### PR TITLE
StateTrieAccountValue:Version should be written as an int, not a long

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValue.java
@@ -100,7 +100,7 @@ public class StateTrieAccountValue {
 
     if (version != Account.DEFAULT_VERSION) {
       // version of zero is never written out.
-      out.writeLongScalar(version);
+      out.writeIntScalar(version);
     }
 
     out.endList();


### PR DESCRIPTION
Signed-off-by: Peter Robinson <drinkcoffee@eml.cc>

The version field is an integer. It is read in as an integer. Mistakenly, it is written as a long.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
