### PR TITLE
Support both BESU_ and PANTHEON_ env var prefixes

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
@@ -24,6 +24,7 @@ import picocli.CommandLine.Model.OptionSpec;
 
 public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider {
   private static final String ENV_VAR_PREFIX = "BESU_";
+  private static final String LEGACY_ENV_VAR_PREFIX = "PANTHEON_";
 
   private final Map<String, String> environment;
 
@@ -43,9 +44,13 @@ public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider
   private Stream<String> envVarNames(final OptionSpec spec) {
     return Arrays.stream(spec.names())
         .filter(name -> name.startsWith("--")) // Only long options are allowed
-        .map(
+        .flatMap(
             name ->
-                ENV_VAR_PREFIX
-                    + name.substring("--".length()).replace('-', '_').toUpperCase(Locale.US));
+                Stream.of(ENV_VAR_PREFIX, LEGACY_ENV_VAR_PREFIX)
+                    .map(prefix -> prefix + nameToEnvVarSuffix(name)));
+  }
+
+  private String nameToEnvVarSuffix(final String name) {
+    return name.substring("--".length()).replace('-', '_').toUpperCase(Locale.US);
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
@@ -41,6 +41,12 @@ public class EnvironmentVariableDefaultProviderTest {
   }
 
   @Test
+  public void shouldReturnValueWhenEnvironmentVariableIsSetWithLegacyPrefix() {
+    environment.put("PANTHEON_ENV_VAR_SET", "abc");
+    assertThat(provider.defaultValue(OptionSpec.builder("--env-var-set").build())).isEqualTo("abc");
+  }
+
+  @Test
   public void shouldReturnValueWhenEnvironmentVariableIsSetForAlternateName() {
     environment.put("BESU_ENV_VAR_SET", "abc");
     assertThat(provider.defaultValue(OptionSpec.builder("--env-var", "--env-var-set").build()))
@@ -48,8 +54,24 @@ public class EnvironmentVariableDefaultProviderTest {
   }
 
   @Test
+  public void shouldReturnValueWhenEnvironmentVariableIsSetForAlternateNameAndLegacyPrefix() {
+    environment.put("PANTHEON_ENV_VAR_SET", "abc");
+    assertThat(provider.defaultValue(OptionSpec.builder("--env-var", "--env-var-set").build()))
+        .isEqualTo("abc");
+  }
+
+  @Test
   public void shouldNotReturnValueForShortOptions() {
     environment.put("BESU_H", "abc");
+    environment.put("PANTHEON_H", "abc");
     assertThat(provider.defaultValue(OptionSpec.builder("-h").build())).isNull();
+  }
+
+  @Test
+  public void shouldPreferBesuPrefixOverLegacyPrefix() {
+    environment.put("BESU_ENV_VAR_SET", "abc");
+    environment.put("PANTHEON_ENV_VAR_SET", "def");
+    assertThat(provider.defaultValue(OptionSpec.builder("--env-var", "--env-var-set").build()))
+        .isEqualTo("abc");
   }
 }


### PR DESCRIPTION
## PR description

For backwards compatibility, support both `BESU_` and `PANTHEON_` prefixes for environment variables.  The `BESU_` prefix is used if both are set.