### PR TITLE
Downgrade some RocksDBPlugin Logging Levels

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -151,7 +151,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
     final int databaseVersion;
     if (databaseExists) {
       databaseVersion = DatabaseMetadata.fromDirectory(databaseDir).getVersion();
-      LOG.info("Existing database detected at {}. Version {}", databaseDir, databaseVersion);
+      LOG.debug("Existing database detected at {}. Version {}", databaseDir, databaseVersion);
     } else {
       databaseVersion = DEFAULT_VERSION;
       LOG.info(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -47,7 +47,7 @@ public class RocksDBPlugin implements BesuPlugin {
 
   @Override
   public void register(final BesuContext context) {
-    LOG.info("Registering plugin");
+    LOG.debug("Registering plugin");
     this.context = context;
 
     final Optional<PicoCLIOptions> cmdlineOptions = context.getService(PicoCLIOptions.class);
@@ -60,21 +60,21 @@ public class RocksDBPlugin implements BesuPlugin {
     cmdlineOptions.get().addPicoCLIOptions(NAME, options);
     createFactoriesAndRegisterWithStorageService();
 
-    LOG.info("Plugin registered.");
+    LOG.debug("Plugin registered.");
   }
 
   @Override
   public void start() {
-    LOG.info("Starting plugin.");
+    LOG.debug("Starting plugin.");
     if (factory == null) {
-      LOG.debug("Applied configuration: {}", options.toString());
+      LOG.trace("Applied configuration: {}", options.toString());
       createFactoriesAndRegisterWithStorageService();
     }
   }
 
   @Override
   public void stop() {
-    LOG.info("Stopping plugin.");
+    LOG.debug("Stopping plugin.");
 
     try {
       if (factory != null) {


### PR DESCRIPTION
## PR description

Some of the logging levels produce surprising results, for example the
call to `--help` spits out info about rocksdb starting, which we don't
need.  Turn down plugin start/stop to debug and using an existing DB to
debug.  Config options are only developer relevant, so down to trace.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

