### PR TITLE
Store db metadata file in the root data directory.

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -106,8 +106,8 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
     }
 
     final StorageServiceImpl storageService = new StorageServiceImpl();
-    final BesuConfiguration commonPluginConfiguration =
-        new BesuConfigurationImpl(Files.createTempDir().toPath());
+    final Path path = Files.createTempDir().toPath();
+    final BesuConfiguration commonPluginConfiguration = new BesuConfigurationImpl(path, path);
     final BesuPluginContextImpl besuPluginContext =
         besuPluginContextMap.computeIfAbsent(
             node, n -> buildPluginContext(node, storageService, commonPluginConfiguration));

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -771,7 +771,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private void addConfigurationService() {
     if (pluginCommonConfiguration == null) {
-      pluginCommonConfiguration = new BesuConfigurationImpl(dataDir().resolve(DATABASE_PATH));
+      final Path dataDir = dataDir();
+      pluginCommonConfiguration =
+          new BesuConfigurationImpl(dataDir.resolve(DATABASE_PATH), dataDir);
       besuPluginContext.addService(BesuConfiguration.class, pluginCommonConfiguration);
     }
   }

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
@@ -21,13 +21,24 @@ import java.nio.file.Path;
 public class BesuConfigurationImpl implements BesuConfiguration {
 
   private final Path storagePath;
+  private final Path dataPath;
 
   public BesuConfigurationImpl(final Path storagePath) {
+    this(storagePath, storagePath);
+  }
+
+  public BesuConfigurationImpl(final Path storagePath, final Path dataPath) {
     this.storagePath = storagePath;
+    this.dataPath = dataPath;
   }
 
   @Override
   public Path getStoragePath() {
     return storagePath;
+  }
+
+  @Override
+  public Path getDataPath() {
+    return dataPath;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -164,9 +164,7 @@ allprojects {
     }
 
     // Below this line are currently only license header tasks
-    format 'groovy', {
-      target '**/src/*/grovy/**/*.groovy'
-    }
+    format 'groovy', { target '**/src/*/grovy/**/*.groovy' }
 
     // Currently disabled due to referencetest issues
     //  format 'bash', {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.jvmargs=-Xmx1g
-version=1.2.4
+version=1.2.5-SNAPSHOT

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -56,7 +56,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '7GpOlkPAtanchkveLlCKOTmafqC8cAa19/s/eLLGFyE='
+  knownHash = 'f0SPUj4/aLZKyjAGcDYai021dO8pg5xLaNvALEWxoIg='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuConfiguration.java
@@ -25,4 +25,11 @@ public interface BesuConfiguration {
    * @return location of the storage in the file system of the client.
    */
   Path getStoragePath();
+
+  /**
+   * Location of the data directory in the file system running the client.
+   *
+   * @return location of the data directory in the file system of the client.
+   */
+  Path getDataPath();
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -156,6 +156,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
     } else {
       databaseVersion = DEFAULT_VERSION;
       LOG.info("No existing database detected at {}. Using version {}", dataDir, databaseVersion);
+      Files.createDirectories(databaseDir);
       Files.createDirectories(dataDir);
       new DatabaseMetadata(databaseVersion).writeToDirectory(dataDir);
     }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -147,17 +147,17 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
 
   private int readDatabaseVersion(final BesuConfiguration commonConfiguration) throws IOException {
     final Path databaseDir = commonConfiguration.getStoragePath();
+    final Path dataDir = commonConfiguration.getDataPath();
     final boolean databaseExists = databaseDir.resolve("IDENTITY").toFile().exists();
     final int databaseVersion;
     if (databaseExists) {
-      databaseVersion = DatabaseMetadata.fromDirectory(databaseDir).getVersion();
-      LOG.info("Existing database detected at {}. Version {}", databaseDir, databaseVersion);
+      databaseVersion = DatabaseMetadata.lookUpFrom(databaseDir, dataDir).getVersion();
+      LOG.info("Existing database detected at {}. Version {}", dataDir, databaseVersion);
     } else {
       databaseVersion = DEFAULT_VERSION;
-      LOG.info(
-          "No existing database detected at {}. Using version {}", databaseDir, databaseVersion);
-      Files.createDirectories(databaseDir);
-      new DatabaseMetadata(databaseVersion).writeToDirectory(databaseDir);
+      LOG.info("No existing database detected at {}. Using version {}", dataDir, databaseVersion);
+      Files.createDirectories(dataDir);
+      new DatabaseMetadata(databaseVersion).writeToDirectory(dataDir);
     }
 
     if (!SUPPORTED_VERSIONS.contains(databaseVersion)) {

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/DatabaseMetadata.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/DatabaseMetadata.java
@@ -23,8 +23,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class DatabaseMetadata {
+  private static final Logger LOG = LogManager.getLogger();
+
   private static final String METADATA_FILENAME = "DATABASE_METADATA.json";
   private static ObjectMapper MAPPER = new ObjectMapper();
   private final int version;
@@ -40,9 +44,13 @@ public class DatabaseMetadata {
 
   public static DatabaseMetadata lookUpFrom(final Path databaseDir, final Path dataDir)
       throws IOException {
+    LOG.info("Lookup database metadata file in data directory: {}", dataDir.toString());
     File metadataFile = getDefaultMetadataFile(dataDir);
     final boolean shouldLookupInDatabaseDir = !metadataFile.exists();
     if (shouldLookupInDatabaseDir) {
+      LOG.info(
+          "Database metadata file not found in data directory. Lookup in database directory: {}",
+          databaseDir.toString());
       metadataFile = getDefaultMetadataFile(databaseDir);
     }
     DatabaseMetadata databaseMetadata;
@@ -55,6 +63,8 @@ public class DatabaseMetadata {
           String.format("Invalid metadata file %s", metadataFile.getAbsolutePath()), jpe);
     }
     if (shouldLookupInDatabaseDir) {
+      LOG.warn(
+          "Database metadata file has been copied from old location (database directory). Be aware that the old file might be removed in future release.");
       writeToDirectory(databaseMetadata, dataDir);
     }
     return databaseMetadata;

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/helper/Conditions.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/helper/Conditions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.plugin.services.helper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Condition;
+
+public class Conditions {
+  public static final Condition<Path> FILE_EXISTS =
+      new Condition<>(path -> path != null && path.toFile().exists(), "File must exist.");
+  public static final Condition<Path> FILE_DOES_NOT_EXIST =
+      new Condition<>(path -> path == null || !path.toFile().exists(), "File must not exist.");
+
+  public static Condition<Path> shouldContain(final String content) {
+    return new Condition<>(
+        path -> {
+          try {
+            return content.equals(Files.readString(path));
+          } catch (IOException e) {
+            return false;
+          }
+        },
+        "File should contain specified content.");
+  }
+}

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/DatabaseMetadataTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/DatabaseMetadataTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.plugin.services.storage.rocksdb.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.plugin.services.helper.Conditions.FILE_DOES_NOT_EXIST;
+import static org.hyperledger.besu.plugin.services.helper.Conditions.FILE_EXISTS;
+import static org.hyperledger.besu.plugin.services.helper.Conditions.shouldContain;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DatabaseMetadataTest {
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void getVersion() {
+    final DatabaseMetadata databaseMetadata = new DatabaseMetadata(42);
+    assertThat(databaseMetadata).isNotNull();
+    assertThat(databaseMetadata.getVersion()).isEqualTo(42);
+  }
+
+  @Test
+  public void metaFileShouldBeSoughtIntoDataDirFirst() throws Exception {
+    final Path tempDataDir = createAndWrite("data", "DATABASE_METADATA.json", "{\"version\":42}");
+    final Path tempDatabaseDir = createAndWrite("db", "DATABASE_METADATA.json", "{\"version\":99}");
+    final DatabaseMetadata databaseMetadata =
+        DatabaseMetadata.lookUpFrom(tempDatabaseDir, tempDataDir);
+    assertThat(databaseMetadata).isNotNull();
+    assertThat(databaseMetadata.getVersion()).isEqualTo(42);
+  }
+
+  @Test
+  public void metaFileNotFoundInDataDirShouldLookupIntoDbDir() throws Exception {
+    final Path tempDataDir = temporaryFolder.newFolder().toPath().resolve("data");
+    Files.createDirectories(tempDataDir);
+    final Path tempDatabaseDir = createAndWrite("db", "DATABASE_METADATA.json", "{\"version\":42}");
+    final Path metadataPathInDataDir = tempDataDir.resolve("DATABASE_METADATA.json");
+    assertThat(metadataPathInDataDir).is(FILE_DOES_NOT_EXIST);
+    final DatabaseMetadata databaseMetadata =
+        DatabaseMetadata.lookUpFrom(tempDatabaseDir, tempDataDir);
+    assertThat(databaseMetadata).isNotNull();
+    assertThat(databaseMetadata.getVersion()).isEqualTo(42);
+    assertThat(metadataPathInDataDir).is(FILE_EXISTS);
+    assertThat(metadataPathInDataDir).is(shouldContain("{\"version\":42}"));
+  }
+
+  private Path createAndWrite(final String dir, final String file, final String content)
+      throws IOException {
+    return createAndWrite(temporaryFolder, dir, file, content);
+  }
+
+  private Path createAndWrite(
+      final TemporaryFolder temporaryFolder,
+      final String dir,
+      final String file,
+      final String content)
+      throws IOException {
+    final Path tmpDir = temporaryFolder.newFolder().toPath().resolve(dir);
+    Files.createDirectories(tmpDir);
+    createAndWrite(tmpDir.resolve(file), content);
+    return tmpDir;
+  }
+
+  private void createAndWrite(final Path path, final String content) throws IOException {
+    path.toFile().createNewFile();
+    Files.writeString(path, content);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
The database metadata file should be stored in the root data directory rather than the database subdirectory. The database subdirectory is owned by the database itself and should not be directly manipulated by the node.
- first look in the data directory for the metadata file
- if the metadata file is found there, process it as normal
- if no metadata file is found in the root directory, look in the database subdirectory 
- if the file is found here, copy it to the root directory, and run based on the root directory version
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
