### PR TITLE
Fix default logging

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -538,8 +538,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       names = {"--logging", "-l"},
       paramLabel = "<LOG VERBOSITY LEVEL>",
       description =
-          "Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL (default: ${DEFAULT-VALUE})")
-  private final Level logLevel = Level.INFO;
+          "Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL (default: INFO)")
+  private final Level logLevel = null;
 
   @Option(
       names = {"--miner-enabled"},
@@ -932,7 +932,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       if (!NetworkUtility.isNetworkInterfaceAvailable(p2pInterface)) {
         throw new ParameterException(commandLine, failMessage);
       }
-    } catch (UnknownHostException | SocketException e) {
+    } catch (final UnknownHostException | SocketException e) {
       throw new ParameterException(commandLine, failMessage, e);
     }
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/RetestethSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/RetestethSubCommand.java
@@ -62,7 +62,7 @@ public class RetestethSubCommand implements Runnable {
       paramLabel = "<LOG VERBOSITY LEVEL>",
       description =
           "Logging verbosity levels: OFF, FATAL, WARN, INFO, DEBUG, TRACE, ALL (default: INFO)")
-  private final Level logLevel = Level.INFO;
+  private final Level logLevel = null;
 
   @SuppressWarnings("FieldMayBeFinal") // Because PicoCLI requires Strings to not be final.
   @Option(


### PR DESCRIPTION
## PR description

Default logging should be 'null' - which means that Besu will do nothing
to the Log4J2 logging levels and rely on the built in or user supplied
log4j2.xml configuration files to set up logging.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>
