### PR TITLE
Clean up BesuConfiguration construction

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -773,7 +773,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     if (pluginCommonConfiguration == null) {
       final Path dataDir = dataDir();
       pluginCommonConfiguration =
-          new BesuConfigurationImpl(dataDir.resolve(DATABASE_PATH), dataDir);
+          new BesuConfigurationImpl(dataDir, dataDir.resolve(DATABASE_PATH));
       besuPluginContext.addService(BesuConfiguration.class, pluginCommonConfiguration);
     }
   }

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuConfigurationImpl.java
@@ -23,11 +23,7 @@ public class BesuConfigurationImpl implements BesuConfiguration {
   private final Path storagePath;
   private final Path dataPath;
 
-  public BesuConfigurationImpl(final Path storagePath) {
-    this(storagePath, storagePath);
-  }
-
-  public BesuConfigurationImpl(final Path storagePath, final Path dataPath) {
+  public BesuConfigurationImpl(final Path dataPath, final Path storagePath) {
     this.storagePath = storagePath;
     this.dataPath = dataPath;
   }

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -59,11 +59,12 @@ public class PrivacyTest {
   @Test
   public void privacyPrecompiled() throws IOException {
     final Path dataDir = folder.newFolder().toPath();
+    final Path dbDir = dataDir.resolve("database");
     final PrivacyParameters privacyParameters =
         new PrivacyParameters.Builder()
             .setPrivacyAddress(ADDRESS)
             .setEnabled(true)
-            .setStorageProvider(createKeyValueStorageProvider(dataDir))
+            .setStorageProvider(createKeyValueStorageProvider(dataDir, dbDir))
             .build();
     final BesuController<?> besuController =
         new BesuController.Builder()
@@ -92,7 +93,7 @@ public class PrivacyTest {
     assertThat(precompiledContract.getName()).isEqualTo("Privacy");
   }
 
-  private StorageProvider createKeyValueStorageProvider(final Path dbAhead) {
+  private StorageProvider createKeyValueStorageProvider(final Path dataDir, final Path dbDir) {
     return new KeyValueStorageProviderBuilder()
         .withStorageFactory(
             new RocksDBKeyValuePrivacyStorageFactory(
@@ -103,7 +104,7 @@ public class PrivacyTest {
                         BACKGROUND_THREAD_COUNT,
                         CACHE_CAPACITY),
                 Arrays.asList(KeyValueSegmentIdentifier.values())))
-        .withCommonConfiguration(new BesuConfigurationImpl(dbAhead))
+        .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))
         .withMetricsSystem(new NoOpMetricsSystem())
         .build();
   }

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -148,7 +148,7 @@ public final class RunnerTest {
             .privacyParameters(PrivacyParameters.DEFAULT)
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
-            .storageProvider(createKeyValueStorageProvider(dbAhead))
+            .storageProvider(createKeyValueStorageProvider(dataDirAhead, dbAhead))
             .build()) {
       setupState(blockCount, controller.getProtocolSchedule(), controller.getProtocolContext());
     }
@@ -167,7 +167,7 @@ public final class RunnerTest {
             .privacyParameters(PrivacyParameters.DEFAULT)
             .clock(TestClock.fixed())
             .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
-            .storageProvider(createKeyValueStorageProvider(dbAhead))
+            .storageProvider(createKeyValueStorageProvider(dataDirAhead, dbAhead))
             .build();
     final String listenHost = InetAddress.getLoopbackAddress().getHostAddress();
     final JsonRpcConfiguration aheadJsonRpcConfiguration = jsonRpcConfiguration();
@@ -355,7 +355,7 @@ public final class RunnerTest {
     return GenesisConfigFile.fromConfig(jsonNode);
   }
 
-  private StorageProvider createKeyValueStorageProvider(final Path dbAhead) {
+  private StorageProvider createKeyValueStorageProvider(final Path dataDir, final Path dbDir) {
     return new KeyValueStorageProviderBuilder()
         .withStorageFactory(
             new RocksDBKeyValueStorageFactory(
@@ -366,7 +366,7 @@ public final class RunnerTest {
                         BACKGROUND_THREAD_COUNT,
                         CACHE_CAPACITY),
                 Arrays.asList(KeyValueSegmentIdentifier.values())))
-        .withCommonConfiguration(new BesuConfigurationImpl(dbAhead))
+        .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))
         .withMetricsSystem(new NoOpMetricsSystem())
         .build();
   }

--- a/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
+++ b/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
@@ -100,7 +100,7 @@ public class WorldStateDownloaderBenchmark {
     final EthContext ethContext = ethProtocolManager.ethContext();
 
     final StorageProvider storageProvider =
-        createKeyValueStorageProvider(tempDir.resolve("database"));
+        createKeyValueStorageProvider(tempDir, tempDir.resolve("database"));
     worldStateStorage = storageProvider.createWorldStateStorage();
 
     pendingRequests =
@@ -158,7 +158,7 @@ public class WorldStateDownloaderBenchmark {
     return rootData;
   }
 
-  private StorageProvider createKeyValueStorageProvider(final Path dbAhead) {
+  private StorageProvider createKeyValueStorageProvider(final Path dataDir, final Path dbDir) {
     return new KeyValueStorageProviderBuilder()
         .withStorageFactory(
             new RocksDBKeyValueStorageFactory(
@@ -169,7 +169,7 @@ public class WorldStateDownloaderBenchmark {
                         DEFAULT_BACKGROUND_THREAD_COUNT,
                         DEFAULT_CACHE_CAPACITY),
                 Arrays.asList(KeyValueSegmentIdentifier.values())))
-        .withCommonConfiguration(new BesuConfigurationImpl(dbAhead))
+        .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))
         .withMetricsSystem(new NoOpMetricsSystem())
         .build();
   }


### PR DESCRIPTION
## PR description
Clean up `BesuConfiguration` construction.  Remove constructor that should never be used in production. Reorder parameters.