### PR TITLE
[PAN-3183] Less verbose synching subscriptions

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/NotSynchronisingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/NotSynchronisingResult.java
@@ -24,4 +24,14 @@ public class NotSynchronisingResult implements JsonRpcResult {
   public boolean getResult() {
     return false;
   }
+
+  @Override
+  public boolean equals(final Object o) {
+    return (this == o) || (o != null && getClass() == o.getClass());
+  }
+
+  @Override
+  public int hashCode() {
+    return "NotSyncingResult".hashCode();
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SyncStatus.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SyncStatus.java
@@ -21,11 +21,21 @@ public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncSt
   private final long startingBlock;
   private final long currentBlock;
   private final long highestBlock;
+  private final boolean inSync;
 
   public SyncStatus(final long startingBlock, final long currentBlock, final long highestBlock) {
+    this(startingBlock, currentBlock, highestBlock, currentBlock == highestBlock);
+  }
+
+  public SyncStatus(
+      final long startingBlock,
+      final long currentBlock,
+      final long highestBlock,
+      final boolean inSync) {
     this.startingBlock = startingBlock;
     this.currentBlock = currentBlock;
     this.highestBlock = highestBlock;
+    this.inSync = inSync;
   }
 
   @Override
@@ -45,7 +55,7 @@ public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncSt
 
   @Override
   public boolean inSync() {
-    return currentBlock == highestBlock;
+    return inSync;
   }
 
   @Override
@@ -56,14 +66,15 @@ public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncSt
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SyncStatus that = (SyncStatus) o;
+    final SyncStatus that = (SyncStatus) o;
     return startingBlock == that.startingBlock
         && currentBlock == that.currentBlock
-        && highestBlock == that.highestBlock;
+        && highestBlock == that.highestBlock
+        && inSync == that.inSync;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startingBlock, currentBlock, highestBlock);
+    return Objects.hash(startingBlock, currentBlock, highestBlock, inSync);
   }
 }


### PR DESCRIPTION
## PR description

We should not send a sync status for every forking block state update.
Yes, we send status updates for detected forks as well as new canonical
heads.

Instead we should send a synching message for status changes as well as
when we reorg the chain.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>

## Fixed Issue(s)

PAN-3183