### PR TITLE
Adding whitespace to separate words in log message

### DIFF
--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidator.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidator.java
@@ -42,8 +42,7 @@ public class RoundChangeMessageValidator {
 
     if (msg.getPreparedCertificate().isPresent() != msg.getProposedBlock().isPresent()) {
       LOG.info(
-          "Invalid RoundChange message, availability of certificate does not correlate with"
-              + "availability of block.");
+          "Invalid RoundChange message, availability of certificate does not correlate with availability of block.");
       return false;
     }
 


### PR DESCRIPTION
Signed-off-by: Christopher Hare <chris.hare@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
LGTM recommended correcting the log line to have separate words i.e. add a space.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
