### PR TITLE
Undo "Add CODEOWNERS to match MAINTAINERS"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,0 @@
-# See https://help.github.com/articles/about-codeowners/
-# for more info about CODEOWNERS file
-
-**/* @abdelhamidbakhta @ajsutton @bgravenorst @CjHare @EdJoJob @jframe @joshuafernandes @lucassaldanha @macfarla @MadelineMurray @mark-terry @mbaxter @NicolasMassart @rain-on @RatanRSur @rojotek @shemnon @timbeiko @usmansaleem 
-


### PR DESCRIPTION
The functional reason to change this is now all PRs wind up adding every maintainer to the reviewers list.  This reduces the value on requesting a specific review from a specific maintainer.  If all the reviewers were not auto-added I would be neutral on this change.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>