### PR TITLE
[minor] add openjdk to platform detector

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/util/PlatformDetector.java
+++ b/besu/src/main/java/org/hyperledger/besu/util/PlatformDetector.java
@@ -186,6 +186,9 @@ public class PlatformDetector {
     if (javaVendor.contains("amazoncominc")) {
       return "corretto";
     }
+    if (javaVmName.contains("openjdk")) {
+      return "openjdk";
+    }
 
     return "-" + javaVendor + "-" + javaVmName;
   }


### PR DESCRIPTION
## PR description

Add an openjdk case to platform detector, changes client info from
`besu/v1.2.4/linux-x86_64/-ubuntu-openjdk64bitservervm-java-11`
to
`besu/v1.2.4/linux-x86_64/openjdk-java-11`
while preserving adoptopenjdk and oracle_openjdk cases.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
