### PR TITLE
Check for duplicate Maven coordinates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,9 +268,26 @@ allprojects {
 
 task deploy() {}
 
+task checkMavenCoordianteCollisions {
+  doLast {
+    def coordinates = [:]
+    getAllprojects().forEach {
+      if (it.properties.containsKey('publishing')) {
+        def coordinate = it.publishing?.publications[0].coordinates
+        if (coordinates.containsKey(coordinate)) {
+          throw new GradleException("Duplicate maven coordinates detected, ${coordinate} is used by " +
+              "both ${coordinates[coordinate]} and ${it.path}.\n" +
+              "Please add a `publishing` script block to one or both subprojects.")
+        }
+        coordinates[coordinate] = it.path
+      }
+    }
+  }
+}
+
 tasks.register('checkPluginAPIChanges', DefaultTask) { }
 checkPluginAPIChanges.dependsOn(':plugin-api:checkAPIChanges')
-check.dependsOn('checkPluginAPIChanges')
+check.dependsOn('checkPluginAPIChanges', 'checkMavenCoordianteCollisions')
 
 subprojects {
 


### PR DESCRIPTION
## PR description

Add a build task that will enumerate all the maven publications and fail
the build if it detects that a duplicate maven coordinate would be used.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
