### PR TITLE
[PAN-3203] add --required-block flag to deal with chainsplits

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
@@ -34,6 +35,7 @@ import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.peervalidation.DaoForkPeerValidator;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.peervalidation.RequiredBlocksPeerValidator;
 import org.hyperledger.besu.ethereum.eth.sync.DefaultSynchronizer;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
@@ -72,9 +74,8 @@ public abstract class BesuControllerBuilder<C> {
   private static final Logger LOG = LogManager.getLogger();
 
   protected GenesisConfigFile genesisConfig;
-  protected SynchronizerConfiguration syncConfig;
-  protected EthProtocolManager ethProtocolManager;
-  protected EthProtocolConfiguration ethereumWireProtocolConfiguration;
+  SynchronizerConfiguration syncConfig;
+  EthProtocolConfiguration ethereumWireProtocolConfiguration;
   protected TransactionPoolConfiguration transactionPoolConfiguration;
   protected BigInteger networkId;
   protected MiningParameters miningParameters;
@@ -82,14 +83,15 @@ public abstract class BesuControllerBuilder<C> {
   protected PrivacyParameters privacyParameters;
   protected Path dataDirectory;
   protected Clock clock;
-  protected KeyPair nodeKeys;
+  KeyPair nodeKeys;
   protected boolean isRevertReasonEnabled;
-  protected GasLimitCalculator gasLimitCalculator;
+  GasLimitCalculator gasLimitCalculator;
   private StorageProvider storageProvider;
   private final List<Runnable> shutdownActions = new ArrayList<>();
   private boolean isPruningEnabled;
   private PruningConfiguration pruningConfiguration;
   Map<String, String> genesisConfigOverrides;
+  private Map<Long, Hash> requiredBlocks;
 
   public BesuControllerBuilder<C> storageProvider(final StorageProvider storageProvider) {
     this.storageProvider = storageProvider;
@@ -187,6 +189,11 @@ public abstract class BesuControllerBuilder<C> {
     return this;
   }
 
+  public BesuControllerBuilder<C> requiredBlocks(final Map<Long, Hash> requiredBlocks) {
+    this.requiredBlocks = requiredBlocks;
+    return this;
+  }
+
   public BesuController<C> build() {
     checkNotNull(genesisConfig, "Missing genesis config");
     checkNotNull(syncConfig, "Missing sync config");
@@ -253,7 +260,7 @@ public abstract class BesuControllerBuilder<C> {
                 }));
 
     final boolean fastSyncEnabled = syncConfig.getSyncMode().equals(SyncMode.FAST);
-    ethProtocolManager =
+    final EthProtocolManager ethProtocolManager =
         createEthProtocolManager(
             protocolContext, fastSyncEnabled, createPeerValidators(protocolSchedule));
     final SyncState syncState =
@@ -335,7 +342,7 @@ public abstract class BesuControllerBuilder<C> {
     return new SubProtocolConfiguration().withSubProtocol(EthProtocol.get(), ethProtocolManager);
   }
 
-  protected final void addShutdownAction(final Runnable action) {
+  final void addShutdownAction(final Runnable action) {
     shutdownActions.add(action);
   }
 
@@ -372,7 +379,7 @@ public abstract class BesuControllerBuilder<C> {
         ethereumWireProtocolConfiguration);
   }
 
-  protected List<PeerValidator> createPeerValidators(final ProtocolSchedule<C> protocolSchedule) {
+  private List<PeerValidator> createPeerValidators(final ProtocolSchedule<C> protocolSchedule) {
     final List<PeerValidator> validators = new ArrayList<>();
 
     final OptionalLong daoBlock =
@@ -381,6 +388,12 @@ public abstract class BesuControllerBuilder<C> {
       // Setup dao validator
       validators.add(
           new DaoForkPeerValidator(protocolSchedule, metricsSystem, daoBlock.getAsLong()));
+    }
+
+    for (final Map.Entry<Long, Hash> requiredBlock : requiredBlocks.entrySet()) {
+      validators.add(
+          new RequiredBlocksPeerValidator(
+              protocolSchedule, metricsSystem, requiredBlock.getKey(), requiredBlock.getValue()));
     }
 
     return validators;

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -91,7 +91,7 @@ public abstract class BesuControllerBuilder<C> {
   private boolean isPruningEnabled;
   private PruningConfiguration pruningConfiguration;
   Map<String, String> genesisConfigOverrides;
-  private Map<Long, Hash> requiredBlocks;
+  private Map<Long, Hash> requiredBlocks = Collections.emptyMap();
 
   public BesuControllerBuilder<C> storageProvider(final StorageProvider storageProvider) {
     this.storageProvider = storageProvider;

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2827,4 +2827,55 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     assertThat(requiredBlocksArg.getValue()).isEmpty();
   }
+
+  @Test
+  public void requiredBlocksMulpleBlocksOneArg() {
+    final long block1 = 8675309L;
+    final long block2 = 5551212L;
+    final String hash1 = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    final String hash2 = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    parseCommand("--required-block=" + block1 + "=" + hash1 + "," + block2 + "=" + hash2);
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<Long, Hash>> requiredBlocksArg = ArgumentCaptor.forClass(Map.class);
+
+    verify(mockControllerBuilder).requiredBlocks(requiredBlocksArg.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    assertThat(requiredBlocksArg.getValue()).containsOnlyKeys(block1, block2);
+    assertThat(requiredBlocksArg.getValue())
+        .containsEntry(block1, Hash.fromHexStringLenient(hash1));
+    assertThat(requiredBlocksArg.getValue())
+        .containsEntry(block2, Hash.fromHexStringLenient(hash2));
+  }
+
+  @Test
+  public void requiredBlocksMulpleBlocksTwoArgs() {
+    final long block1 = 8675309L;
+    final long block2 = 5551212L;
+    final String hash1 = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+    final String hash2 = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    parseCommand(
+        "--required-block=" + block1 + "=" + hash1, "--required-block=" + block2 + "=" + hash2);
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<Long, Hash>> requiredBlocksArg = ArgumentCaptor.forClass(Map.class);
+
+    verify(mockControllerBuilder).requiredBlocks(requiredBlocksArg.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    assertThat(requiredBlocksArg.getValue()).containsOnlyKeys(block1, block2);
+    assertThat(requiredBlocksArg.getValue())
+        .containsEntry(block1, Hash.fromHexStringLenient(hash1));
+    assertThat(requiredBlocksArg.getValue())
+        .containsEntry(block2, Hash.fromHexStringLenient(hash2));
+  }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Wei;
@@ -73,6 +74,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -2787,5 +2789,42 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString()).isEmpty();
 
     assertThat(targetGasLimitArg.getValue()).isEqualTo(Optional.empty());
+  }
+
+  @Test
+  public void requiredBlocksSetWhenSpecified() {
+    final long blockNumber = 8675309L;
+    final String hash = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+
+    parseCommand("--required-block=" + blockNumber + "=" + hash);
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<Long, Hash>> requiredBlocksArg = ArgumentCaptor.forClass(Map.class);
+
+    verify(mockControllerBuilder).requiredBlocks(requiredBlocksArg.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    assertThat(requiredBlocksArg.getValue()).containsOnlyKeys(blockNumber);
+    assertThat(requiredBlocksArg.getValue())
+        .containsEntry(blockNumber, Hash.fromHexStringLenient(hash));
+  }
+
+  @Test
+  public void requiredBlocksEmptyWhenNotSpecified() {
+    parseCommand();
+
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<Map<Long, Hash>> requiredBlocksArg = ArgumentCaptor.forClass(Map.class);
+
+    verify(mockControllerBuilder).requiredBlocks(requiredBlocksArg.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    assertThat(requiredBlocksArg.getValue()).isEmpty();
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -170,6 +170,7 @@ public abstract class CommandTestAbstract {
     when(mockControllerBuilder.pruningConfiguration(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.genesisConfigOverrides(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.targetGasLimit(any())).thenReturn(mockControllerBuilder);
+    when(mockControllerBuilder.requiredBlocks(any())).thenReturn(mockControllerBuilder);
 
     // doReturn used because of generic BesuController
     doReturn(mockController).when(mockControllerBuilder).build();

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -31,6 +31,7 @@ max-peers=42
 remote-connections-limit-enabled=true
 remote-connections-max-percentage=60
 host-whitelist=["all"]
+required-blocks=["8675309=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
 
 # chain
 network="MAINNET"

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidator.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidator.java
@@ -1,0 +1,120 @@
+/*
+ *
+ *  * Copyright 2019 ConsenSys AG.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  * specific language governing permissions and limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.eth.peervalidation;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByNumberTask;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+abstract class AbstractPeerBlockValidator implements PeerValidator {
+  private static final Logger LOG = LogManager.getLogger();
+  static long DEFAULT_CHAIN_HEIGHT_ESTIMATION_BUFFER = 10L;
+
+  private final ProtocolSchedule<?> protocolSchedule;
+  private final MetricsSystem metricsSystem;
+
+  final long blockNumber;
+  // Wait for peer's chainhead to advance some distance beyond blockNumber before validating
+  private final long chainHeightEstimationBuffer;
+
+  AbstractPeerBlockValidator(
+      final ProtocolSchedule<?> protocolSchedule,
+      final MetricsSystem metricsSystem,
+      final long blockNumber,
+      final long chainHeightEstimationBuffer) {
+    checkArgument(chainHeightEstimationBuffer >= 0);
+    this.protocolSchedule = protocolSchedule;
+    this.metricsSystem = metricsSystem;
+    this.blockNumber = blockNumber;
+    this.chainHeightEstimationBuffer = chainHeightEstimationBuffer;
+  }
+
+  public AbstractPeerBlockValidator(
+      final ProtocolSchedule<?> protocolSchedule,
+      final MetricsSystem metricsSystem,
+      final long blockNumber) {
+    this(protocolSchedule, metricsSystem, blockNumber, DEFAULT_CHAIN_HEIGHT_ESTIMATION_BUFFER);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> validatePeer(
+      final EthContext ethContext, final EthPeer ethPeer) {
+    final AbstractPeerTask<List<BlockHeader>> getHeaderTask =
+        GetHeadersFromPeerByNumberTask.forSingleNumber(
+                protocolSchedule, ethContext, blockNumber, metricsSystem)
+            .setTimeout(Duration.ofSeconds(20))
+            .assignPeer(ethPeer);
+    return getHeaderTask
+        .run()
+        .handle(
+            (res, err) -> {
+              if (err != null) {
+                // Mark peer as invalid on error
+                LOG.debug(
+                    "Peer {} is invalid because required block block ({}) is unavailable: {}",
+                    ethPeer,
+                    blockNumber,
+                    err.toString());
+                return false;
+              }
+              final List<BlockHeader> headers = res.getResult();
+              if (headers.size() == 0) {
+                // If no headers are returned, fail
+                LOG.debug(
+                    "Peer {} is invalid because required block ({}) is unavailable.",
+                    ethPeer,
+                    blockNumber);
+                return false;
+              }
+              final BlockHeader header = headers.get(0);
+              return validateBlockHeader(ethPeer, header);
+            });
+  }
+
+  abstract boolean validateBlockHeader(EthPeer ethPeer, BlockHeader header);
+
+  @Override
+  public boolean canBeValidated(final EthPeer ethPeer) {
+    return ethPeer.chainState().getEstimatedHeight() >= (blockNumber + chainHeightEstimationBuffer);
+  }
+
+  @Override
+  public Duration nextValidationCheckTimeout(final EthPeer ethPeer) {
+    if (!ethPeer.chainState().hasEstimatedHeight()) {
+      return Duration.ofSeconds(30);
+    }
+    final long distanceToBlock = blockNumber - ethPeer.chainState().getEstimatedHeight();
+    if (distanceToBlock < 100_000L) {
+      return Duration.ofMinutes(1);
+    }
+    // If the peer is trailing behind, give it some time to catch up before trying again.
+    return Duration.ofMinutes(10);
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidator.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidator.java
@@ -1,0 +1,132 @@
+/*
+ *
+ *  * Copyright ConsenSys AG.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  * specific language governing permissions and limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.eth.peervalidation;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByNumberTask;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class RequiredBlocksPeerValidator implements PeerValidator {
+  private static final Logger LOG = LogManager.getLogger();
+  private static long DEFAULT_CHAIN_HEIGHT_ESTIMATION_BUFFER = 10L;
+
+  private final ProtocolSchedule<?> protocolSchedule;
+  private final MetricsSystem metricsSystem;
+
+  private final long blockNumber;
+  private final Hash hash;
+  // Wait for peer's chainhead to advance some distance beyond blockNumber before validating
+  private final long chainHeightEstimationBuffer;
+
+  RequiredBlocksPeerValidator(
+      final ProtocolSchedule<?> protocolSchedule,
+      final MetricsSystem metricsSystem,
+      final long blockNumber,
+      final Hash hash,
+      final long chainHeightEstimationBuffer) {
+    checkArgument(chainHeightEstimationBuffer >= 0);
+    this.protocolSchedule = protocolSchedule;
+    this.metricsSystem = metricsSystem;
+    this.blockNumber = blockNumber;
+    this.hash = hash;
+    this.chainHeightEstimationBuffer = chainHeightEstimationBuffer;
+  }
+
+  public RequiredBlocksPeerValidator(
+      final ProtocolSchedule<?> protocolSchedule,
+      final MetricsSystem metricsSystem,
+      final long blockNumber,
+      final Hash hash) {
+    this(
+        protocolSchedule, metricsSystem, blockNumber, hash, DEFAULT_CHAIN_HEIGHT_ESTIMATION_BUFFER);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> validatePeer(
+      final EthContext ethContext, final EthPeer ethPeer) {
+    final AbstractPeerTask<List<BlockHeader>> getHeaderTask =
+        GetHeadersFromPeerByNumberTask.forSingleNumber(
+                protocolSchedule, ethContext, blockNumber, metricsSystem)
+            .setTimeout(Duration.ofSeconds(20))
+            .assignPeer(ethPeer);
+    return getHeaderTask
+        .run()
+        .handle(
+            (res, err) -> {
+              if (err != null) {
+                // Mark peer as invalid on error
+                LOG.debug(
+                    "Peer {} is invalid because required block block ({}) is unavailable: {}",
+                    ethPeer,
+                    blockNumber,
+                    err.toString());
+                return false;
+              }
+              final List<BlockHeader> headers = res.getResult();
+              if (headers.size() == 0) {
+                // If no headers are returned, fail
+                LOG.debug(
+                    "Peer {} is invalid because required block ({}) is unavailable.",
+                    ethPeer,
+                    blockNumber);
+                return false;
+              }
+              final BlockHeader header = headers.get(0);
+              final boolean validBlock = hash.equals(header.getHash());
+              if (!validBlock) {
+                LOG.debug(
+                    "Peer {} is invalid because required block ({}) does not match required hash ({}).",
+                    ethPeer,
+                    blockNumber,
+                    hash);
+              }
+              return validBlock;
+            });
+  }
+
+  @Override
+  public boolean canBeValidated(final EthPeer ethPeer) {
+    return ethPeer.chainState().getEstimatedHeight() >= (blockNumber + chainHeightEstimationBuffer);
+  }
+
+  @Override
+  public Duration nextValidationCheckTimeout(final EthPeer ethPeer) {
+    if (!ethPeer.chainState().hasEstimatedHeight()) {
+      return Duration.ofSeconds(30);
+    }
+    final long distanceToBlock = blockNumber - ethPeer.chainState().getEstimatedHeight();
+    if (distanceToBlock < 100_000L) {
+      return Duration.ofMinutes(1);
+    }
+    // If the peer is trailing behind, give it some time to catch up before trying again.
+    return Duration.ofMinutes(10);
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
@@ -1,0 +1,170 @@
+/*
+ *
+ *  * Copyright 2019 ConsenSys AG.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  * specific language governing permissions and limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.eth.peervalidation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.eth.manager.DeterministicEthScheduler;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
+import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
+import org.hyperledger.besu.ethereum.eth.messages.GetBlockHeadersMessage;
+import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+public abstract class AbstractPeerBlockValidatorTest {
+
+  abstract AbstractPeerBlockValidator getSampleValidator(long blockNumber);
+
+  @Test
+  public void validatePeer_unresponsivePeer() {
+    final EthProtocolManager ethProtocolManager =
+        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
+    final long blockNumber = 500;
+
+    final PeerValidator validator = getSampleValidator(blockNumber);
+
+    final RespondingEthPeer peer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, blockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
+
+    // Request should timeout immediately
+    assertThat(result).isDone();
+    assertThat(result).isCompletedWithValue(false);
+  }
+
+  @Test
+  public void validatePeer_requestBlockFromPeerBeingTested() {
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long requiredBlockNumber = 500;
+    final Block requiredBlock =
+        gen.block(BlockOptions.create().setBlockNumber(requiredBlockNumber));
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            0);
+
+    final int peerCount = 1000;
+    final List<RespondingEthPeer> otherPeers =
+        Stream.generate(
+                () ->
+                    EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber))
+            .limit(peerCount)
+            .collect(Collectors.toList());
+    final RespondingEthPeer targetPeer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), targetPeer.getEthPeer());
+
+    assertThat(result).isNotDone();
+
+    // Other peers should not receive request for required block
+    for (final RespondingEthPeer otherPeer : otherPeers) {
+      final AtomicBoolean requiredBlockRequestedForOtherPeer =
+          respondToBlockRequest(otherPeer, requiredBlock);
+      assertThat(requiredBlockRequestedForOtherPeer).isFalse();
+    }
+
+    // Target peer should receive request for required block
+    final AtomicBoolean requiredBlockRequested = respondToBlockRequest(targetPeer, requiredBlock);
+    assertThat(requiredBlockRequested).isTrue();
+  }
+
+  @Test
+  public void canBeValidated() {
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final EthProtocolManager ethProtocolManager =
+        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
+    final long requiredBlockNumber = 500;
+    final long buffer = 10;
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            buffer);
+
+    final EthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0).getEthPeer();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber - 10);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer - 1);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer);
+    assertThat(validator.canBeValidated(peer)).isTrue();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer + 10);
+    assertThat(validator.canBeValidated(peer)).isTrue();
+  }
+
+  AtomicBoolean respondToBlockRequest(final RespondingEthPeer peer, final Block block) {
+    final AtomicBoolean blockRequested = new AtomicBoolean(false);
+
+    final RespondingEthPeer.Responder responder =
+        RespondingEthPeer.targetedResponder(
+            (cap, msg) -> {
+              if (msg.getCode() != EthPV62.GET_BLOCK_HEADERS) {
+                return false;
+              }
+              final GetBlockHeadersMessage headersRequest = GetBlockHeadersMessage.readFrom(msg);
+              final boolean isTargetedBlockRequest =
+                  headersRequest.blockNumber().isPresent()
+                      && headersRequest.blockNumber().getAsLong() == block.getHeader().getNumber();
+              if (isTargetedBlockRequest) {
+                blockRequested.set(true);
+              }
+              return isTargetedBlockRequest;
+            },
+            (cap, msg) -> BlockHeadersMessage.create(block.getHeader()));
+
+    // Respond
+    peer.respond(responder);
+
+    return blockRequested;
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 public abstract class AbstractPeerBlockValidatorTest {
 
-  abstract AbstractPeerBlockValidator createValidator(long blockNumber);
+  abstract AbstractPeerBlockValidator createValidator(long blockNumber, long buffer);
 
   @Test
   public void validatePeer_unresponsivePeer() {
@@ -49,7 +49,7 @@ public abstract class AbstractPeerBlockValidatorTest {
         EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
     final long blockNumber = 500;
 
-    final PeerValidator validator = createValidator(blockNumber);
+    final PeerValidator validator = createValidator(blockNumber, 0);
 
     final RespondingEthPeer peer =
         EthProtocolManagerTestUtil.createPeer(ethProtocolManager, blockNumber);
@@ -69,7 +69,7 @@ public abstract class AbstractPeerBlockValidatorTest {
     final long blockNumber = 500;
     final Block block = gen.block(BlockOptions.create().setBlockNumber(blockNumber));
 
-    final PeerValidator validator = createValidator(blockNumber);
+    final PeerValidator validator = createValidator(blockNumber, 0);
 
     final int peerCount = 1000;
     final List<RespondingEthPeer> otherPeers =
@@ -104,7 +104,7 @@ public abstract class AbstractPeerBlockValidatorTest {
     final long blockNumber = 500;
     final long buffer = 10;
 
-    final PeerValidator validator = createValidator(blockNumber);
+    final PeerValidator validator = createValidator(blockNumber, buffer);
     final EthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0).getEthPeer();
 
     peer.chainState().update(gen.hash(), blockNumber - 10);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
@@ -35,9 +35,9 @@ import org.junit.Test;
 public class DaoForkPeerValidatorTest extends AbstractPeerBlockValidatorTest {
 
   @Override
-  AbstractPeerBlockValidator createValidator(final long blockNumber) {
+  AbstractPeerBlockValidator createValidator(final long blockNumber, final long buffer) {
     return new DaoForkPeerValidator(
-        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, 0);
+        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, buffer);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 public class DaoForkPeerValidatorTest extends AbstractPeerBlockValidatorTest {
 
   @Override
-  AbstractPeerBlockValidator getSampleValidator(final long blockNumber) {
+  AbstractPeerBlockValidator createValidator(final long blockNumber) {
     return new DaoForkPeerValidator(
         MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, 0);
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/DaoForkPeerValidatorTest.java
@@ -19,54 +19,52 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
-import org.hyperledger.besu.ethereum.eth.manager.DeterministicEthScheduler;
-import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
-import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
-import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
-import org.hyperledger.besu.ethereum.eth.messages.GetBlockHeadersMessage;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 
-public class DaoForkPeerValidatorTest {
+public class DaoForkPeerValidatorTest extends AbstractPeerBlockValidatorTest {
+
+  @Override
+  AbstractPeerBlockValidator getSampleValidator(final long blockNumber) {
+    return new DaoForkPeerValidator(
+        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, 0);
+  }
 
   @Test
   public void validatePeer_responsivePeerOnRightSideOfFork() {
-    EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
-    BlockDataGenerator gen = new BlockDataGenerator(1);
-    long daoBlockNumber = 500;
-    Block daoBlock =
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long daoBlockNumber = 500;
+    final Block daoBlock =
         gen.block(
             BlockOptions.create()
                 .setBlockNumber(daoBlockNumber)
                 .setExtraData(MainnetBlockHeaderValidator.DAO_EXTRA_DATA));
 
-    PeerValidator validator =
+    final PeerValidator validator =
         new DaoForkPeerValidator(
             MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), daoBlockNumber, 0);
 
-    RespondingEthPeer peer =
+    final RespondingEthPeer peer =
         EthProtocolManagerTestUtil.createPeer(ethProtocolManager, daoBlockNumber);
 
-    CompletableFuture<Boolean> result =
+    final CompletableFuture<Boolean> result =
         validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
 
     assertThat(result).isNotDone();
 
     // Send response for dao block
-    AtomicBoolean daoBlockRequested = respondToDaoBlockRequest(peer, daoBlock);
+    final AtomicBoolean daoBlockRequested = respondToBlockRequest(peer, daoBlock);
 
     assertThat(daoBlockRequested).isTrue();
     assertThat(result).isDone();
@@ -75,149 +73,30 @@ public class DaoForkPeerValidatorTest {
 
   @Test
   public void validatePeer_responsivePeerOnWrongSideOfFork() {
-    EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
-    BlockDataGenerator gen = new BlockDataGenerator(1);
-    long daoBlockNumber = 500;
-    Block daoBlock =
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long daoBlockNumber = 500;
+    final Block daoBlock =
         gen.block(
             BlockOptions.create().setBlockNumber(daoBlockNumber).setExtraData(BytesValue.EMPTY));
 
-    PeerValidator validator =
+    final PeerValidator validator =
         new DaoForkPeerValidator(
             MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), daoBlockNumber, 0);
 
-    RespondingEthPeer peer =
+    final RespondingEthPeer peer =
         EthProtocolManagerTestUtil.createPeer(ethProtocolManager, daoBlockNumber);
 
-    CompletableFuture<Boolean> result =
+    final CompletableFuture<Boolean> result =
         validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
 
     assertThat(result).isNotDone();
 
     // Send response for dao block
-    AtomicBoolean daoBlockRequested = respondToDaoBlockRequest(peer, daoBlock);
+    final AtomicBoolean daoBlockRequested = respondToBlockRequest(peer, daoBlock);
 
     assertThat(daoBlockRequested).isTrue();
     assertThat(result).isDone();
     assertThat(result).isCompletedWithValue(false);
-  }
-
-  @Test
-  public void validatePeer_unresponsivePeer() {
-    EthProtocolManager ethProtocolManager =
-        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
-    long daoBlockNumber = 500;
-
-    PeerValidator validator =
-        new DaoForkPeerValidator(
-            MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), daoBlockNumber, 0);
-
-    RespondingEthPeer peer =
-        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, daoBlockNumber);
-
-    CompletableFuture<Boolean> result =
-        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
-
-    // Request should timeout immediately
-    assertThat(result).isDone();
-    assertThat(result).isCompletedWithValue(false);
-  }
-
-  @Test
-  public void validatePeer_requestBlockFromPeerBeingTested() {
-    EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
-    BlockDataGenerator gen = new BlockDataGenerator(1);
-    long daoBlockNumber = 500;
-    Block daoBlock =
-        gen.block(
-            BlockOptions.create()
-                .setBlockNumber(daoBlockNumber)
-                .setExtraData(MainnetBlockHeaderValidator.DAO_EXTRA_DATA));
-
-    PeerValidator validator =
-        new DaoForkPeerValidator(
-            MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), daoBlockNumber, 0);
-
-    int peerCount = 1000;
-    List<RespondingEthPeer> otherPeers =
-        Stream.generate(
-                () -> EthProtocolManagerTestUtil.createPeer(ethProtocolManager, daoBlockNumber))
-            .limit(peerCount)
-            .collect(Collectors.toList());
-    RespondingEthPeer targetPeer =
-        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, daoBlockNumber);
-
-    CompletableFuture<Boolean> result =
-        validator.validatePeer(ethProtocolManager.ethContext(), targetPeer.getEthPeer());
-
-    assertThat(result).isNotDone();
-
-    // Other peers should not receive request for dao block
-    for (RespondingEthPeer otherPeer : otherPeers) {
-      AtomicBoolean daoBlockRequestedForOtherPeer = respondToDaoBlockRequest(otherPeer, daoBlock);
-      assertThat(daoBlockRequestedForOtherPeer).isFalse();
-    }
-
-    // Target peer should receive request for dao block
-    final AtomicBoolean daoBlockRequested = respondToDaoBlockRequest(targetPeer, daoBlock);
-    assertThat(daoBlockRequested).isTrue();
-  }
-
-  @Test
-  public void canBeValidated() {
-    BlockDataGenerator gen = new BlockDataGenerator(1);
-    EthProtocolManager ethProtocolManager =
-        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
-    long daoBlockNumber = 500;
-    long buffer = 10;
-
-    PeerValidator validator =
-        new DaoForkPeerValidator(
-            MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), daoBlockNumber, buffer);
-
-    EthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0).getEthPeer();
-
-    peer.chainState().update(gen.hash(), daoBlockNumber - 10);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), daoBlockNumber);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), daoBlockNumber + buffer - 1);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), daoBlockNumber + buffer);
-    assertThat(validator.canBeValidated(peer)).isTrue();
-
-    peer.chainState().update(gen.hash(), daoBlockNumber + buffer + 10);
-    assertThat(validator.canBeValidated(peer)).isTrue();
-  }
-
-  private AtomicBoolean respondToDaoBlockRequest(
-      final RespondingEthPeer peer, final Block daoBlock) {
-    AtomicBoolean daoBlockRequested = new AtomicBoolean(false);
-
-    RespondingEthPeer.Responder responder =
-        RespondingEthPeer.targetedResponder(
-            (cap, msg) -> {
-              if (msg.getCode() != EthPV62.GET_BLOCK_HEADERS) {
-                return false;
-              }
-              GetBlockHeadersMessage headersRequest = GetBlockHeadersMessage.readFrom(msg);
-              boolean isDaoBlockRequest =
-                  headersRequest.blockNumber().isPresent()
-                      && headersRequest.blockNumber().getAsLong()
-                          == daoBlock.getHeader().getNumber();
-              if (isDaoBlockRequest) {
-                daoBlockRequested.set(true);
-              }
-              return isDaoBlockRequest;
-            },
-            (cap, msg) -> BlockHeadersMessage.create(daoBlock.getHeader()));
-
-    // Respond
-    peer.respond(responder);
-
-    return daoBlockRequested;
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
@@ -1,0 +1,248 @@
+/*
+ *
+ *  * Copyright ConsenSys AG.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  * specific language governing permissions and limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.eth.peervalidation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.eth.manager.DeterministicEthScheduler;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
+import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
+import org.hyperledger.besu.ethereum.eth.messages.GetBlockHeadersMessage;
+import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.util.bytes.BytesValue;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+public class RequiredBlocksPeerValidatorTest {
+
+  private BytesValue goodExtraData =
+      BytesValue.fromHexString("0x100f0e0d0c0b0a09080706050403020100");
+  private BytesValue badExtraData = BytesValue.fromHexString("0x1009080706050403020100");
+
+  @Test
+  public void validatePeer_responsivePeerWithRequiredBlock() {
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long requiredBlockNumber = 500;
+    final Block requiredBlock =
+        gen.block(
+            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(goodExtraData));
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            requiredBlock.getHash(),
+            0);
+
+    final RespondingEthPeer peer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
+
+    assertThat(result).isNotDone();
+
+    // Send response for dao block
+    final AtomicBoolean requiredBlockRequested = respondToRequiredBlockRequest(peer, requiredBlock);
+
+    assertThat(requiredBlockRequested).isTrue();
+    assertThat(result).isDone();
+    assertThat(result).isCompletedWithValue(true);
+  }
+
+  @Test
+  public void validatePeer_responsivePeerWithBadRequiredBlock() {
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long requiredBlockNumber = 500;
+    final Block requiredBlock =
+        gen.block(
+            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(badExtraData));
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            0);
+
+    final RespondingEthPeer peer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
+
+    assertThat(result).isNotDone();
+
+    // Send response for dao block
+    final AtomicBoolean requiredBlockRequested = respondToRequiredBlockRequest(peer, requiredBlock);
+
+    assertThat(requiredBlockRequested).isTrue();
+    assertThat(result).isDone();
+    assertThat(result).isCompletedWithValue(false);
+  }
+
+  @Test
+  public void validatePeer_unresponsivePeer() {
+    final EthProtocolManager ethProtocolManager =
+        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
+    final long requiredBlockNumber = 500;
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            0);
+
+    final RespondingEthPeer peer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
+
+    // Request should timeout immediately
+    assertThat(result).isDone();
+    assertThat(result).isCompletedWithValue(false);
+  }
+
+  @Test
+  public void validatePeer_requestBlockFromPeerBeingTested() {
+    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final long requiredBlockNumber = 500;
+    final Block requiredBlock =
+        gen.block(
+            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(goodExtraData));
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            0);
+
+    final int peerCount = 1000;
+    final List<RespondingEthPeer> otherPeers =
+        Stream.generate(
+                () ->
+                    EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber))
+            .limit(peerCount)
+            .collect(Collectors.toList());
+    final RespondingEthPeer targetPeer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
+
+    final CompletableFuture<Boolean> result =
+        validator.validatePeer(ethProtocolManager.ethContext(), targetPeer.getEthPeer());
+
+    assertThat(result).isNotDone();
+
+    // Other peers should not receive request for dao block
+    for (final RespondingEthPeer otherPeer : otherPeers) {
+      final AtomicBoolean requiredBlockRequestedForOtherPeer =
+          respondToRequiredBlockRequest(otherPeer, requiredBlock);
+      assertThat(requiredBlockRequestedForOtherPeer).isFalse();
+    }
+
+    // Target peer should receive request for dao block
+    final AtomicBoolean requiredBlockRequested =
+        respondToRequiredBlockRequest(targetPeer, requiredBlock);
+    assertThat(requiredBlockRequested).isTrue();
+  }
+
+  @Test
+  public void canBeValidated() {
+    final BlockDataGenerator gen = new BlockDataGenerator(1);
+    final EthProtocolManager ethProtocolManager =
+        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
+    final long requiredBlockNumber = 500;
+    final long buffer = 10;
+
+    final PeerValidator validator =
+        new RequiredBlocksPeerValidator(
+            MainnetProtocolSchedule.create(),
+            new NoOpMetricsSystem(),
+            requiredBlockNumber,
+            Hash.ZERO,
+            buffer);
+
+    final EthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0).getEthPeer();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber - 10);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer - 1);
+    assertThat(validator.canBeValidated(peer)).isFalse();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer);
+    assertThat(validator.canBeValidated(peer)).isTrue();
+
+    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer + 10);
+    assertThat(validator.canBeValidated(peer)).isTrue();
+  }
+
+  private AtomicBoolean respondToRequiredBlockRequest(
+      final RespondingEthPeer peer, final Block requiredBlock) {
+    final AtomicBoolean requiredBlockRequested = new AtomicBoolean(false);
+
+    final RespondingEthPeer.Responder responder =
+        RespondingEthPeer.targetedResponder(
+            (cap, msg) -> {
+              if (msg.getCode() != EthPV62.GET_BLOCK_HEADERS) {
+                return false;
+              }
+              final GetBlockHeadersMessage headersRequest = GetBlockHeadersMessage.readFrom(msg);
+              final boolean isRequiredBlockRequest =
+                  headersRequest.blockNumber().isPresent()
+                      && headersRequest.blockNumber().getAsLong()
+                          == requiredBlock.getHeader().getNumber();
+              if (isRequiredBlockRequest) {
+                requiredBlockRequested.set(true);
+              }
+              return isRequiredBlockRequest;
+            },
+            (cap, msg) -> BlockHeadersMessage.create(requiredBlock.getHeader()));
+
+    // Respond
+    peer.respond(responder);
+
+    return requiredBlockRequested;
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
@@ -36,9 +36,9 @@ import org.junit.Test;
 public class RequiredBlocksPeerValidatorTest extends AbstractPeerBlockValidatorTest {
 
   @Override
-  AbstractPeerBlockValidator createValidator(final long blockNumber) {
+  AbstractPeerBlockValidator createValidator(final long blockNumber, final long buffer) {
     return new RequiredBlocksPeerValidator(
-        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, Hash.ZERO, 0);
+        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, Hash.ZERO, buffer);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
@@ -22,31 +22,24 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.eth.manager.DeterministicEthScheduler;
-import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
-import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
-import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
-import org.hyperledger.besu.ethereum.eth.messages.GetBlockHeadersMessage;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.util.bytes.BytesValue;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 
-public class RequiredBlocksPeerValidatorTest {
+public class RequiredBlocksPeerValidatorTest extends AbstractPeerBlockValidatorTest {
 
-  private BytesValue goodExtraData =
-      BytesValue.fromHexString("0x100f0e0d0c0b0a09080706050403020100");
-  private BytesValue badExtraData = BytesValue.fromHexString("0x1009080706050403020100");
+  @Override
+  AbstractPeerBlockValidator getSampleValidator(final long blockNumber) {
+    return new RequiredBlocksPeerValidator(
+        MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, Hash.ZERO, 0);
+  }
 
   @Test
   public void validatePeer_responsivePeerWithRequiredBlock() {
@@ -54,8 +47,7 @@ public class RequiredBlocksPeerValidatorTest {
     final BlockDataGenerator gen = new BlockDataGenerator(1);
     final long requiredBlockNumber = 500;
     final Block requiredBlock =
-        gen.block(
-            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(goodExtraData));
+        gen.block(BlockOptions.create().setBlockNumber(requiredBlockNumber));
 
     final PeerValidator validator =
         new RequiredBlocksPeerValidator(
@@ -73,8 +65,8 @@ public class RequiredBlocksPeerValidatorTest {
 
     assertThat(result).isNotDone();
 
-    // Send response for dao block
-    final AtomicBoolean requiredBlockRequested = respondToRequiredBlockRequest(peer, requiredBlock);
+    // Send response for block
+    final AtomicBoolean requiredBlockRequested = respondToBlockRequest(peer, requiredBlock);
 
     assertThat(requiredBlockRequested).isTrue();
     assertThat(result).isDone();
@@ -87,8 +79,7 @@ public class RequiredBlocksPeerValidatorTest {
     final BlockDataGenerator gen = new BlockDataGenerator(1);
     final long requiredBlockNumber = 500;
     final Block requiredBlock =
-        gen.block(
-            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(badExtraData));
+        gen.block(BlockOptions.create().setBlockNumber(requiredBlockNumber));
 
     final PeerValidator validator =
         new RequiredBlocksPeerValidator(
@@ -106,143 +97,11 @@ public class RequiredBlocksPeerValidatorTest {
 
     assertThat(result).isNotDone();
 
-    // Send response for dao block
-    final AtomicBoolean requiredBlockRequested = respondToRequiredBlockRequest(peer, requiredBlock);
+    // Send response for required block
+    final AtomicBoolean requiredBlockRequested = respondToBlockRequest(peer, requiredBlock);
 
     assertThat(requiredBlockRequested).isTrue();
     assertThat(result).isDone();
     assertThat(result).isCompletedWithValue(false);
-  }
-
-  @Test
-  public void validatePeer_unresponsivePeer() {
-    final EthProtocolManager ethProtocolManager =
-        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
-    final long requiredBlockNumber = 500;
-
-    final PeerValidator validator =
-        new RequiredBlocksPeerValidator(
-            MainnetProtocolSchedule.create(),
-            new NoOpMetricsSystem(),
-            requiredBlockNumber,
-            Hash.ZERO,
-            0);
-
-    final RespondingEthPeer peer =
-        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
-
-    final CompletableFuture<Boolean> result =
-        validator.validatePeer(ethProtocolManager.ethContext(), peer.getEthPeer());
-
-    // Request should timeout immediately
-    assertThat(result).isDone();
-    assertThat(result).isCompletedWithValue(false);
-  }
-
-  @Test
-  public void validatePeer_requestBlockFromPeerBeingTested() {
-    final EthProtocolManager ethProtocolManager = EthProtocolManagerTestUtil.create();
-    final BlockDataGenerator gen = new BlockDataGenerator(1);
-    final long requiredBlockNumber = 500;
-    final Block requiredBlock =
-        gen.block(
-            BlockOptions.create().setBlockNumber(requiredBlockNumber).setExtraData(goodExtraData));
-
-    final PeerValidator validator =
-        new RequiredBlocksPeerValidator(
-            MainnetProtocolSchedule.create(),
-            new NoOpMetricsSystem(),
-            requiredBlockNumber,
-            Hash.ZERO,
-            0);
-
-    final int peerCount = 1000;
-    final List<RespondingEthPeer> otherPeers =
-        Stream.generate(
-                () ->
-                    EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber))
-            .limit(peerCount)
-            .collect(Collectors.toList());
-    final RespondingEthPeer targetPeer =
-        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, requiredBlockNumber);
-
-    final CompletableFuture<Boolean> result =
-        validator.validatePeer(ethProtocolManager.ethContext(), targetPeer.getEthPeer());
-
-    assertThat(result).isNotDone();
-
-    // Other peers should not receive request for dao block
-    for (final RespondingEthPeer otherPeer : otherPeers) {
-      final AtomicBoolean requiredBlockRequestedForOtherPeer =
-          respondToRequiredBlockRequest(otherPeer, requiredBlock);
-      assertThat(requiredBlockRequestedForOtherPeer).isFalse();
-    }
-
-    // Target peer should receive request for dao block
-    final AtomicBoolean requiredBlockRequested =
-        respondToRequiredBlockRequest(targetPeer, requiredBlock);
-    assertThat(requiredBlockRequested).isTrue();
-  }
-
-  @Test
-  public void canBeValidated() {
-    final BlockDataGenerator gen = new BlockDataGenerator(1);
-    final EthProtocolManager ethProtocolManager =
-        EthProtocolManagerTestUtil.create(DeterministicEthScheduler.TimeoutPolicy.ALWAYS_TIMEOUT);
-    final long requiredBlockNumber = 500;
-    final long buffer = 10;
-
-    final PeerValidator validator =
-        new RequiredBlocksPeerValidator(
-            MainnetProtocolSchedule.create(),
-            new NoOpMetricsSystem(),
-            requiredBlockNumber,
-            Hash.ZERO,
-            buffer);
-
-    final EthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 0).getEthPeer();
-
-    peer.chainState().update(gen.hash(), requiredBlockNumber - 10);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), requiredBlockNumber);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer - 1);
-    assertThat(validator.canBeValidated(peer)).isFalse();
-
-    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer);
-    assertThat(validator.canBeValidated(peer)).isTrue();
-
-    peer.chainState().update(gen.hash(), requiredBlockNumber + buffer + 10);
-    assertThat(validator.canBeValidated(peer)).isTrue();
-  }
-
-  private AtomicBoolean respondToRequiredBlockRequest(
-      final RespondingEthPeer peer, final Block requiredBlock) {
-    final AtomicBoolean requiredBlockRequested = new AtomicBoolean(false);
-
-    final RespondingEthPeer.Responder responder =
-        RespondingEthPeer.targetedResponder(
-            (cap, msg) -> {
-              if (msg.getCode() != EthPV62.GET_BLOCK_HEADERS) {
-                return false;
-              }
-              final GetBlockHeadersMessage headersRequest = GetBlockHeadersMessage.readFrom(msg);
-              final boolean isRequiredBlockRequest =
-                  headersRequest.blockNumber().isPresent()
-                      && headersRequest.blockNumber().getAsLong()
-                          == requiredBlock.getHeader().getNumber();
-              if (isRequiredBlockRequest) {
-                requiredBlockRequested.set(true);
-              }
-              return isRequiredBlockRequest;
-            },
-            (cap, msg) -> BlockHeadersMessage.create(requiredBlock.getHeader()));
-
-    // Respond
-    peer.respond(responder);
-
-    return requiredBlockRequested;
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/RequiredBlocksPeerValidatorTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 public class RequiredBlocksPeerValidatorTest extends AbstractPeerBlockValidatorTest {
 
   @Override
-  AbstractPeerBlockValidator getSampleValidator(final long blockNumber) {
+  AbstractPeerBlockValidator createValidator(final long blockNumber) {
     return new RequiredBlocksPeerValidator(
         MainnetProtocolSchedule.create(), new NoOpMetricsSystem(), blockNumber, Hash.ZERO, 0);
   }


### PR DESCRIPTION
## PR description

Add a new CLI flag `--required-block` that takes a block number and a
block hash.  Before using a peer for syncing we validate that the block
exists with the spcified hash at the peer.

For example `--required-block=6485846=0x43f0cd1e5b1f9c4d5cda26c240b59ee4f1b510d0a185aa8fd476d091b0097a80`
deals with the current Istanbul Ropsten chainsplit.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>
