### PR TITLE
specify that pruning options are minimums

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -591,7 +591,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       names = {"--pruning-blocks-retained"},
       hidden = true,
       description =
-          "Number of recent blocks for which to keep entire world state (default: ${DEFAULT-VALUE})",
+          "Minimum number of recent blocks for which to keep entire world state (default: ${DEFAULT-VALUE})",
       arity = "1")
   private final Long pruningBlocksRetained = DEFAULT_PRUNING_BLOCKS_RETAINED;
 
@@ -599,7 +599,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       names = {"--pruning-block-confirmations"},
       hidden = true,
       description =
-          "Number of confirmations on a block before marking begins (default: ${DEFAULT-VALUE})",
+          "Minimum number of confirmations on a block before marking begins (default: ${DEFAULT-VALUE})",
       arity = "1")
   private final Long pruningBlockConfirmations = DEFAULT_PRUNING_BLOCK_CONFIRMATIONS;
 


### PR DESCRIPTION
Marking can take longer than the time it takes to accumulate the blocks to satisfy these options. We make no guarantees that exactly the number of blocks in the options will be awaited/kept.