### PR TITLE
[Minor] Rework balance checks to use stronger types

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.condition.account.ExpectAccount
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthTransactions;
 import org.hyperledger.besu.util.bytes.Bytes32;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.web3j.crypto.Credentials;
@@ -66,12 +67,8 @@ public class Account {
     return Address.extract(Hash.hash(keyPair.getPublicKey().getEncodedBytes())).toString();
   }
 
-  public Condition balanceEquals(final String expectedBalance, final Unit balanceUnit) {
-    return new ExpectAccountBalance(eth, this, expectedBalance, balanceUnit);
-  }
-
   public Condition balanceEquals(final int expectedBalance) {
-    return balanceEquals(String.valueOf(expectedBalance), Unit.ETHER);
+    return new ExpectAccountBalance(eth, this, BigDecimal.valueOf(expectedBalance), Unit.ETHER);
   }
 
   public Condition balanceEquals(final Amount expectedBalance) {
@@ -79,12 +76,9 @@ public class Account {
         eth, this, expectedBalance.getValue(), expectedBalance.getUnit());
   }
 
-  public Condition balanceDoesNotChange(final String startingBalance, final Unit balanceUnit) {
-    return new ExpectAccountBalanceNotChanging(eth, this, startingBalance, balanceUnit);
-  }
-
   public Condition balanceDoesNotChange(final int startingBalance) {
-    return balanceDoesNotChange(String.valueOf(startingBalance), Unit.ETHER);
+    return new ExpectAccountBalanceNotChanging(
+        eth, this, BigDecimal.valueOf(startingBalance), Unit.ETHER);
   }
 
   @Override

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/blockchain/Amount.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/blockchain/Amount.java
@@ -17,6 +17,9 @@ package org.hyperledger.besu.tests.acceptance.dsl.blockchain;
 import static org.web3j.utils.Convert.Unit.ETHER;
 import static org.web3j.utils.Convert.Unit.WEI;
 
+import org.hyperledger.besu.ethereum.core.Wei;
+
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import org.web3j.utils.Convert;
@@ -24,20 +27,27 @@ import org.web3j.utils.Convert.Unit;
 
 public class Amount {
 
-  private String value;
+  private BigDecimal value;
   private Unit unit;
 
-  private Amount(final long value, final Unit unit) {
-    this.value = String.valueOf(value);
+  private Amount(final BigDecimal value, final Unit unit) {
+    this.value = value;
     this.unit = unit;
   }
 
-  private Amount(final BigInteger value, final Unit unit) {
-    this.value = value.toString();
-    this.unit = unit;
+  public static Amount ether(final long value) {
+    return new Amount(BigDecimal.valueOf(value), ETHER);
   }
 
-  public String getValue() {
+  public static Amount wei(final BigInteger value) {
+    return new Amount(new BigDecimal(value), WEI);
+  }
+
+  public static Amount wei(final Wei wei) {
+    return wei(new BigInteger(wei.toUnprefixedHexString(), 16));
+  }
+
+  public BigDecimal getValue() {
     return value;
   }
 
@@ -54,21 +64,11 @@ public class Amount {
       denominator = subtracting.unit;
     }
 
-    final BigInteger result =
+    final BigDecimal result =
         Convert.fromWei(
-                Convert.toWei(value, unit)
-                    .subtract(Convert.toWei(subtracting.value, subtracting.unit)),
-                denominator)
-            .toBigInteger();
+            Convert.toWei(value, unit).subtract(Convert.toWei(subtracting.value, subtracting.unit)),
+            denominator);
 
     return new Amount(result, denominator);
-  }
-
-  public static Amount ether(final long value) {
-    return new Amount(value, ETHER);
-  }
-
-  public static Amount wei(final BigInteger value) {
-    return new Amount(value, WEI);
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/account/ExpectAccountBalance.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/account/ExpectAccountBalance.java
@@ -23,31 +23,30 @@ import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthTransactions;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import org.web3j.utils.Convert.Unit;
 
 public class ExpectAccountBalance implements Condition {
 
   private final EthTransactions eth;
   private final Account account;
-  private final String expectedBalance;
-  private final Unit balanceUnit;
+  private final BigInteger expectedBalance;
 
   public ExpectAccountBalance(
       final EthTransactions eth,
       final Account account,
-      final String expectedBalance,
+      final BigDecimal expectedBalance,
       final Unit balanceUnit) {
-    this.expectedBalance = expectedBalance;
-    this.balanceUnit = balanceUnit;
     this.account = account;
     this.eth = eth;
+    this.expectedBalance = toWei(expectedBalance, balanceUnit).toBigIntegerExact();
   }
 
   @Override
   public void verify(final Node node) {
     WaitUtils.waitFor(
-        () ->
-            assertThat(node.execute(eth.getBalance((account))))
-                .isEqualTo(toWei(expectedBalance, balanceUnit).toBigIntegerExact()));
+        () -> assertThat(node.execute(eth.getBalance((account)))).isEqualTo(expectedBalance));
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/account/ExpectAccountBalanceNotChanging.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/account/ExpectAccountBalanceNotChanging.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthTransactions;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -31,18 +33,16 @@ public class ExpectAccountBalanceNotChanging implements Condition {
 
   private final EthTransactions eth;
   private final Account account;
-  private final String startBalance;
-  private final Unit balanceUnit;
+  private final BigInteger startBalance;
 
   public ExpectAccountBalanceNotChanging(
       final EthTransactions eth,
       final Account account,
-      final String startBalance,
+      final BigDecimal startBalance,
       final Unit balanceUnit) {
-    this.startBalance = startBalance;
-    this.balanceUnit = balanceUnit;
     this.account = account;
     this.eth = eth;
+    this.startBalance = toWei(startBalance, balanceUnit).toBigIntegerExact();
   }
 
   @Override
@@ -51,8 +51,6 @@ public class ExpectAccountBalanceNotChanging implements Condition {
         .ignoreExceptions()
         .pollDelay(5, TimeUnit.SECONDS)
         .untilAsserted(
-            () ->
-                assertThat(node.execute(eth.getBalance((account))))
-                    .isEqualTo(toWei(startBalance, balanceUnit).toBigIntegerExact()));
+            () -> assertThat(node.execute(eth.getBalance((account)))).isEqualTo(startBalance));
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/account/TransferTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/account/TransferTransaction.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
 
@@ -41,7 +42,7 @@ public class TransferTransaction implements Transaction<Hash> {
 
   private final Account sender;
   private final Account recipient;
-  private final String transferAmount;
+  private final BigDecimal transferAmount;
   private final Unit transferUnit;
   private final BigInteger gasPrice;
   private final BigInteger nonce;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/AccountLocalConfigPermissioningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/AccountLocalConfigPermissioningAcceptanceTest.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.tests.acceptance.permissioning;
 
-import static org.web3j.utils.Convert.Unit.ETHER;
-
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
@@ -52,7 +50,7 @@ public class AccountLocalConfigPermissioningAcceptanceTest extends AcceptanceTes
     Account beneficiary = accounts.createAccount("beneficiary");
 
     node.execute(accountTransactions.createTransfer(senderA, beneficiary, 1));
-    node.verify(beneficiary.balanceEquals("1", ETHER));
+    node.verify(beneficiary.balanceEquals(1));
 
     verifyTransferForbidden(senderB, beneficiary);
   }
@@ -60,7 +58,7 @@ public class AccountLocalConfigPermissioningAcceptanceTest extends AcceptanceTes
   @Test
   public void manipulatingAccountsWhitelistViaJsonRpc() {
     Account beneficiary = accounts.createAccount("beneficiary");
-    node.verify(beneficiary.balanceEquals("0", ETHER));
+    node.verify(beneficiary.balanceEquals(0));
 
     verifyTransferForbidden(senderB, beneficiary);
 
@@ -68,7 +66,7 @@ public class AccountLocalConfigPermissioningAcceptanceTest extends AcceptanceTes
     node.verify(perm.expectAccountsWhitelist(senderA.getAddress(), senderB.getAddress()));
 
     node.execute(accountTransactions.createTransfer(senderB, beneficiary, 1));
-    node.verify(beneficiary.balanceEquals("1", ETHER));
+    node.verify(beneficiary.balanceEquals(1));
 
     node.execute(permissioningTransactions.removeAccountsFromWhitelist(senderB.getAddress()));
     node.verify(perm.expectAccountsWhitelist(senderA.getAddress()));


### PR DESCRIPTION
## PR description
Rework acceptance test balance checks to use stronger, clearer types.

Previously you could set an expectation for a balance with a decimal string value, but not a hex string value.  This was an error-prone approach.

