### PR TITLE
Removed Unused methods in the transaction simulator.

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -131,16 +131,6 @@ public class TransactionSimulator {
     return Optional.of(new TransactionSimulatorResult(transaction, result));
   }
 
-  public Optional<Boolean> doesAddressExist(final Address address, final Hash blockHeaderHash) {
-    final BlockHeader header = blockchain.getBlockHeader(blockHeaderHash).orElse(null);
-    return doesAddressExist(address, header);
-  }
-
-  public Optional<Boolean> doesAddressExist(final Address address, final long blockNumber) {
-    final BlockHeader header = blockchain.getBlockHeader(blockNumber).orElse(null);
-    return doesAddressExist(address, header);
-  }
-
   public Optional<Boolean> doesAddressExistAtHead(final Address address) {
     return doesAddressExist(address, blockchain.getChainHeadHeader());
   }


### PR DESCRIPTION
Narrowed the API on the TransactionSimulator in preparation for some potential generification and use with private transactions.  Given the hash and long overloads of doesAddressExist are unused, remove them.

Signed-off-by: Rob Dawson <robert@rojotek.com>