### PR TITLE
Make logic in PersistBlockTask more explicit to fix a LGTM warning

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -67,22 +68,20 @@ public class PersistBlockTask<C> extends AbstractEthTask<Block> {
       final List<Block> blocks,
       final HeaderValidationMode headerValidationMode,
       final MetricsSystem metricsSystem) {
-    checkArgument(blocks.size() > 0);
+    checkArgument(!blocks.isEmpty());
     return () -> {
       final List<Block> successfulImports = new ArrayList<>();
-      CompletableFuture<Block> future = null;
-      for (final Block block : blocks) {
-        if (future == null) {
-          future =
-              importBlockAndAddToList(
-                  protocolSchedule,
-                  protocolContext,
-                  block,
-                  successfulImports,
-                  headerValidationMode,
-                  metricsSystem);
-          continue;
-        }
+      final Iterator<Block> blockIterator = blocks.iterator();
+      CompletableFuture<Block> future =
+          importBlockAndAddToList(
+              protocolSchedule,
+              protocolContext,
+              blockIterator.next(),
+              successfulImports,
+              headerValidationMode,
+              metricsSystem);
+      while (blockIterator.hasNext()) {
+        final Block block = blockIterator.next();
         future =
             future.thenCompose(
                 b ->
@@ -122,34 +121,34 @@ public class PersistBlockTask<C> extends AbstractEthTask<Block> {
       final List<Block> blocks,
       final HeaderValidationMode headerValidationMode,
       final MetricsSystem metricsSystem) {
-    checkArgument(blocks.size() > 0);
+    checkArgument(!blocks.isEmpty());
     return () -> {
       final CompletableFuture<List<Block>> finalResult = new CompletableFuture<>();
       final List<Block> successfulImports = new ArrayList<>();
-      CompletableFuture<Block> future = null;
-      for (final Block block : blocks) {
-        if (future == null) {
-          future =
-              PersistBlockTask.create(
-                      protocolSchedule, protocolContext, block, headerValidationMode, metricsSystem)
-                  .run();
-          continue;
-        }
+      final Iterator<PersistBlockTask<C>> tasks =
+          blocks.stream()
+              .map(
+                  block ->
+                      PersistBlockTask.create(
+                          protocolSchedule,
+                          protocolContext,
+                          block,
+                          headerValidationMode,
+                          metricsSystem))
+              .iterator();
+
+      CompletableFuture<Block> future = tasks.next().run();
+      while (tasks.hasNext()) {
+        final PersistBlockTask<C> task = tasks.next();
         future =
             future
                 .handle((r, t) -> r)
                 .thenCompose(
-                    (r) -> {
+                    r -> {
                       if (r != null) {
                         successfulImports.add(r);
                       }
-                      return PersistBlockTask.create(
-                              protocolSchedule,
-                              protocolContext,
-                              block,
-                              headerValidationMode,
-                              metricsSystem)
-                          .run();
+                      return task.run();
                     });
       }
       future.whenComplete(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
@@ -68,7 +68,7 @@ public class PersistBlockTask<C> extends AbstractEthTask<Block> {
       final List<Block> blocks,
       final HeaderValidationMode headerValidationMode,
       final MetricsSystem metricsSystem) {
-    checkArgument(!blocks.isEmpty());
+    checkArgument(!blocks.isEmpty(), "No blocks to import provided");
     return () -> {
       final List<Block> successfulImports = new ArrayList<>();
       final Iterator<Block> blockIterator = blocks.iterator();
@@ -121,7 +121,7 @@ public class PersistBlockTask<C> extends AbstractEthTask<Block> {
       final List<Block> blocks,
       final HeaderValidationMode headerValidationMode,
       final MetricsSystem metricsSystem) {
-    checkArgument(!blocks.isEmpty());
+    checkArgument(!blocks.isEmpty(), "No blocks to import provided");
     return () -> {
       final CompletableFuture<List<Block>> finalResult = new CompletableFuture<>();
       final List<Block> successfulImports = new ArrayList<>();


### PR DESCRIPTION
## PR description
Make the logic for iterating through blocks and importing in `PersistBlockTask` simpler and clearer. The different behaviour for the first block is now handled before the loop instead of as an if condition within the loop.  This makes it clearer to both humans and LGTM that `future` is never null (https://lgtm.com/projects/g/hyperledger/besu/snapshot/72b95dc86ce4d94aba338c45522656af3116c67e/files/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java?sort=name&dir=ASC&mode=heatmap#x57078a84215a57eb:1).