### PR TITLE
[PIE-2003] Make SyncState variables thread-safe

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -140,7 +140,7 @@ public class SyncState {
     replaceSyncTarget(Optional.empty());
   }
 
-  private void replaceSyncTarget(final Optional<SyncTarget> newTarget) {
+  private synchronized void replaceSyncTarget(final Optional<SyncTarget> newTarget) {
     syncTarget.ifPresent(this::removeEstimatedHeightListener);
     syncTarget = newTarget;
     newTarget.ifPresent(this::addEstimatedHeightListener);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.plugin.services.BesuEvents.SyncStatusListener;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -33,12 +34,12 @@ public class SyncState {
   private final Blockchain blockchain;
   private final EthPeers ethPeers;
 
-  private long startingBlock;
-  private boolean lastInSync = true;
   private final Subscribers<InSyncListener> inSyncListeners = Subscribers.create();
   private final Subscribers<SyncStatusListener> syncStatusListeners = Subscribers.create();
-  private Optional<SyncTarget> syncTarget = Optional.empty();
-  private long chainHeightListenerId;
+  private volatile long chainHeightListenerId;
+  private volatile Optional<SyncTarget> syncTarget = Optional.empty();
+  private volatile long startingBlock;
+  private AtomicBoolean lastInSync = new AtomicBoolean(true);
 
   public SyncState(final Blockchain blockchain, final EthPeers ethPeers) {
     this.blockchain = blockchain;
@@ -166,8 +167,7 @@ public class SyncState {
 
   private synchronized void checkInSync() {
     final boolean currentInSync = isInSync();
-    if (lastInSync != currentInSync) {
-      lastInSync = currentInSync;
+    if (lastInSync.compareAndSet(!currentInSync, currentInSync)) {
       if (!currentInSync) {
         // when we fall out of sync change our starting block
         startingBlock = blockchain.getChainHeadBlockNumber();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -39,7 +39,7 @@ public class SyncState {
   private volatile long chainHeightListenerId;
   private volatile Optional<SyncTarget> syncTarget = Optional.empty();
   private volatile long startingBlock;
-  private AtomicBoolean lastInSync = new AtomicBoolean(true);
+  private final AtomicBoolean lastInSync = new AtomicBoolean(true);
 
   public SyncState(final Blockchain blockchain, final EthPeers ethPeers) {
     this.blockchain = blockchain;


### PR DESCRIPTION
## PR description
Make `SyncState` variables visible across threads.