### PR TITLE
[PAN-3222] Fix private transactions breaking evm

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivacyClusterAcceptanceTest.java
@@ -98,7 +98,29 @@ public class PrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
     bob.verify(
         privateTransactionVerifier.validPrivateTransactionReceipt(
             transactionHash, expectedReceipt));
+
     charlie.verify(privateTransactionVerifier.noPrivateTransactionReceipt(transactionHash));
+
+    // When Alice executes a contract call in the wrong privacy group the transaction should pass
+    // but it should return any output
+    final String transactionHash2 =
+        alice.execute(
+            privateContractTransactions.callSmartContract(
+                eventEmitter.getContractAddress(),
+                eventEmitter.value().encodeFunctionCall(),
+                alice.getTransactionSigningKey(),
+                POW_CHAIN_ID,
+                alice.getEnclaveKey(),
+                charlie.getEnclaveKey()));
+
+    final PrivateTransactionReceipt expectedReceipt2 =
+        alice.execute(privacyTransactions.getPrivateTransactionReceipt(transactionHash2));
+
+    assertThat(expectedReceipt2.getOutput()).isEqualTo("0x");
+
+    charlie.verify(
+        privateTransactionVerifier.validPrivateTransactionReceipt(
+            transactionHash2, expectedReceipt2));
   }
 
   @Test

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivacyClusterAcceptanceTest.java
@@ -102,7 +102,7 @@ public class PrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
     charlie.verify(privateTransactionVerifier.noPrivateTransactionReceipt(transactionHash));
 
     // When Alice executes a contract call in the wrong privacy group the transaction should pass
-    // but it should return any output
+    // but it should NOT return any output
     final String transactionHash2 =
         alice.execute(
             privateContractTransactions.callSmartContract(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutablePrivateWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutablePrivateWorldStateUpdater.java
@@ -60,7 +60,7 @@ public class DefaultMutablePrivateWorldStateUpdater implements WorldUpdater {
       publicAccount.setImmutable(true);
       return publicAccount;
     }
-    return null;
+    return privateAccount;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Fixes an edge case which causes the evm to break. If a private account does not exist (i.e. it is empty) we should return the public account. If the public account does not account (i.e. it is empty) there is no useful information that can be read from the private transaction processor - so it is ok to return the empty private account instead of null.

The AT update covers this edge.

## Fixed Issue(s)
[PAN-3222]
