### PR TITLE
[PIE-2031] Rework sync status events

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -125,7 +125,7 @@ public class BesuEventsImplTest {
   @Test
   public void syncStatusEventFiresAfterSubscribe() {
     final AtomicReference<Optional<SyncStatus>> result = new AtomicReference<>();
-    serviceImpl.addSyncStatusListener(newValue -> result.set(newValue));
+    serviceImpl.addSyncStatusListener(result::set);
 
     assertThat(result.get()).isNull();
     setSyncTarget();
@@ -141,7 +141,7 @@ public class BesuEventsImplTest {
   @Test
   public void syncStatusEventDoesNotFireAfterUnsubscribe() {
     final AtomicReference<Optional<SyncStatus>> result = new AtomicReference<>();
-    final long id = serviceImpl.addSyncStatusListener(newValue -> result.set(newValue));
+    final long id = serviceImpl.addSyncStatusListener(result::set);
 
     assertThat(result.get()).isNull();
     setSyncTarget();

--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
@@ -30,6 +31,7 @@ import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.WorldState;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.sync.BlockBroadcaster;
@@ -122,24 +124,44 @@ public class BesuEventsImplTest {
 
   @Test
   public void syncStatusEventFiresAfterSubscribe() {
-    final AtomicReference<SyncStatus> result = new AtomicReference<>();
-    serviceImpl.addSyncStatusListener(result::set);
+    final AtomicReference<Optional<SyncStatus>> result = new AtomicReference<>();
+    serviceImpl.addSyncStatusListener(newValue -> result.set(newValue));
 
     assertThat(result.get()).isNull();
-    syncState.publishSyncStatus();
+    setSyncTarget();
+    assertThat(result.get()).isNotNull();
+
+    // Reset result for next event
+    result.set(null);
+
+    clearSyncTarget();
     assertThat(result.get()).isNotNull();
   }
 
   @Test
   public void syncStatusEventDoesNotFireAfterUnsubscribe() {
-    final AtomicReference<SyncStatus> result = new AtomicReference<>();
-    final long id = serviceImpl.addSyncStatusListener(result::set);
-    syncState.publishSyncStatus();
-    assertThat(result.get()).isNotNull();
-    result.set(null);
-    serviceImpl.removeSyncStatusListener(id);
-    syncState.publishSyncStatus();
+    final AtomicReference<Optional<SyncStatus>> result = new AtomicReference<>();
+    final long id = serviceImpl.addSyncStatusListener(newValue -> result.set(newValue));
+
     assertThat(result.get()).isNull();
+    setSyncTarget();
+    assertThat(result.get()).isNotNull();
+
+    // Reset result for next event
+    result.set(null);
+    // And remove listener
+    serviceImpl.removeSyncStatusListener(id);
+
+    clearSyncTarget();
+    assertThat(result.get()).isNull();
+  }
+
+  private void setSyncTarget() {
+    syncState.setSyncTarget(mock(EthPeer.class), fakeBlockHeader);
+  }
+
+  private void clearSyncTarget() {
+    syncState.clearSyncTarget();
   }
 
   @Test

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
@@ -31,7 +31,7 @@ public class SyncingSubscriptionService {
   public SyncingSubscriptionService(
       final SubscriptionManager subscriptionManager, final Synchronizer synchronizer) {
     this.subscriptionManager = subscriptionManager;
-    synchronizer.subscribeSyncStatus(syncStatus -> sendSyncingToMatchingSubscriptions(syncStatus));
+    synchronizer.subscribeSyncStatus(this::sendSyncingToMatchingSubscriptions);
   }
 
   private void sendSyncingToMatchingSubscriptions(final Optional<SyncStatus> syncStatus) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.JsonRpcResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.SyncingResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
@@ -26,36 +27,24 @@ import java.util.Optional;
 public class SyncingSubscriptionService {
 
   private final SubscriptionManager subscriptionManager;
-  private Optional<Boolean> lastMessageWasInSync = Optional.empty();
 
   public SyncingSubscriptionService(
       final SubscriptionManager subscriptionManager, final Synchronizer synchronizer) {
     this.subscriptionManager = subscriptionManager;
-    synchronizer.subscribeSyncStatus(this::sendSyncingToMatchingSubscriptions);
+    synchronizer.subscribeSyncStatus(syncStatus -> sendSyncingToMatchingSubscriptions(syncStatus));
   }
 
-  private void sendSyncingToMatchingSubscriptions(final SyncStatus syncStatus) {
+  private void sendSyncingToMatchingSubscriptions(final Optional<SyncStatus> syncStatus) {
     subscriptionManager.notifySubscribersOnWorkerThread(
         SubscriptionType.SYNCING,
         Subscription.class,
         syncingSubscriptions -> {
-          if (syncStatus.inSync()) {
-            if (!lastMessageWasInSync.orElse(Boolean.FALSE)) {
-              syncingSubscriptions.forEach(
-                  s ->
-                      subscriptionManager.sendMessage(
-                          s.getSubscriptionId(), new NotSynchronisingResult()));
-              lastMessageWasInSync = Optional.of(Boolean.TRUE);
-            }
-          } else {
-            if (lastMessageWasInSync.orElse(Boolean.TRUE)) {
-              syncingSubscriptions.forEach(
-                  s ->
-                      subscriptionManager.sendMessage(
-                          s.getSubscriptionId(), new SyncingResult(syncStatus)));
-              lastMessageWasInSync = Optional.of(Boolean.FALSE);
-            }
-          }
+          final JsonRpcResult result =
+              syncStatus.isPresent()
+                  ? new SyncingResult(syncStatus.get())
+                  : new NotSynchronisingResult();
+          syncingSubscriptions.forEach(
+              s -> subscriptionManager.sendMessage(s.getSubscriptionId(), result));
         });
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -21,8 +21,8 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
+import org.hyperledger.besu.ethereum.core.DefaultSyncStatus;
 import org.hyperledger.besu.ethereum.core.InMemoryStorageProvider;
-import org.hyperledger.besu.ethereum.core.SyncStatus;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.util.RawBlockIterator;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.net.URL;
@@ -120,7 +121,7 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
   @Before
   public void setupTest() throws Exception {
     final Synchronizer synchronizerMock = Mockito.mock(Synchronizer.class);
-    final SyncStatus status = new SyncStatus(1, 2, 3);
+    final SyncStatus status = new DefaultSyncStatus(1, 2, 3);
     Mockito.when(synchronizerMock.getSyncStatus()).thenReturn(Optional.of(status));
 
     final EthHashMiningCoordinator miningCoordinatorMock =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -38,10 +38,10 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.DefaultSyncStatus;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
-import org.hyperledger.besu.ethereum.core.SyncStatus;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
@@ -54,6 +54,7 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.bytes.BytesValues;
 import org.hyperledger.besu.util.uint.UInt256;
@@ -1855,7 +1856,7 @@ public class JsonRpcHttpServiceTest {
 
   @Test
   public void ethSyncingResultIsPresent() throws Exception {
-    final SyncStatus testResult = new SyncStatus(1L, 8L, 7L);
+    final SyncStatus testResult = new DefaultSyncStatus(1L, 8L, 7L);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.of(testResult));
     final String id = "999";
     final RequestBody body =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.core.DefaultSyncStatus;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.plugin.data.SyncStatus;
@@ -142,7 +143,6 @@ public class ReadinessCheckTest {
   }
 
   private Optional<SyncStatus> createSyncStatus(final int currentBlock, final int highestBlock) {
-    return Optional.of(
-        new org.hyperledger.besu.ethereum.core.SyncStatus(0, currentBlock, highestBlock));
+    return Optional.of(new DefaultSyncStatus(0, currentBlock, highestBlock));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncingTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncingTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.SyncingResult;
+import org.hyperledger.besu.ethereum.core.DefaultSyncStatus;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 
@@ -68,8 +69,7 @@ public class EthSyncingTest {
   @Test
   public void shouldReturnExpectedValueWhenSyncStatusIsNotEmpty() {
     final JsonRpcRequest request = requestWithParams();
-    final SyncStatus expectedSyncStatus =
-        new org.hyperledger.besu.ethereum.core.SyncStatus(0, 1, 2);
+    final SyncStatus expectedSyncStatus = new DefaultSyncStatus(0, 1, 2);
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getId(), new SyncingResult(expectedSyncStatus));
     final Optional<SyncStatus> optionalSyncStatus = Optional.of(expectedSyncStatus);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/DefaultSyncStatus.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/DefaultSyncStatus.java
@@ -16,26 +16,17 @@ package org.hyperledger.besu.ethereum.core;
 
 import java.util.Objects;
 
-public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncStatus {
+public final class DefaultSyncStatus implements org.hyperledger.besu.plugin.data.SyncStatus {
 
   private final long startingBlock;
   private final long currentBlock;
   private final long highestBlock;
-  private final boolean inSync;
 
-  public SyncStatus(final long startingBlock, final long currentBlock, final long highestBlock) {
-    this(startingBlock, currentBlock, highestBlock, currentBlock == highestBlock);
-  }
-
-  public SyncStatus(
-      final long startingBlock,
-      final long currentBlock,
-      final long highestBlock,
-      final boolean inSync) {
+  public DefaultSyncStatus(
+      final long startingBlock, final long currentBlock, final long highestBlock) {
     this.startingBlock = startingBlock;
     this.currentBlock = currentBlock;
     this.highestBlock = highestBlock;
-    this.inSync = inSync;
   }
 
   @Override
@@ -54,11 +45,6 @@ public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncSt
   }
 
   @Override
-  public boolean inSync() {
-    return inSync;
-  }
-
-  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -66,15 +52,14 @@ public final class SyncStatus implements org.hyperledger.besu.plugin.data.SyncSt
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final SyncStatus that = (SyncStatus) o;
+    final DefaultSyncStatus that = (DefaultSyncStatus) o;
     return startingBlock == that.startingBlock
         && currentBlock == that.currentBlock
-        && highestBlock == that.highestBlock
-        && inSync == that.inSync;
+        && highestBlock == that.highestBlock;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startingBlock, currentBlock, highestBlock, inSync);
+    return Objects.hash(startingBlock, currentBlock, highestBlock);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -106,7 +106,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
         BesuMetricCategory.ETHEREUM,
         "best_known_block_number",
         "The estimated highest block available",
-        () -> syncState.syncStatus().getHighestBlock());
+        syncState::bestChainHeight);
     metricsSystem.createIntegerGauge(
         BesuMetricCategory.SYNCHRONIZER,
         "in_sync",
@@ -176,11 +176,7 @@ public class DefaultSynchronizer<C> implements Synchronizer {
     if (!running.get()) {
       return Optional.empty();
     }
-    final SyncStatus syncStatus = syncState.syncStatus();
-    if (syncStatus.inSync()) {
-      return Optional.empty();
-    }
-    return Optional.of(syncStatus);
+    return syncState.syncStatus();
   }
 
   @Override

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -56,7 +56,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'XMBMdVNS2VAa+WN3lyEAKmXznu4ExSIHA2arYUeo0eo='
+  knownHash = 'zaoahMUhnC3tj6nhjrXTMhIDeN4HnhqmM4x9Lqz28T0='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/SyncStatus.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/SyncStatus.java
@@ -39,11 +39,4 @@ public interface SyncStatus {
    * @return the height of the highest known block.
    */
   long getHighestBlock();
-
-  /**
-   * Checks if the synchronizer is within a default sync tolerance of the highest known block
-   *
-   * @return true if it is within the tolerance, false otherwise
-   */
-  boolean inSync();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuEvents.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuEvents.java
@@ -19,6 +19,8 @@ import org.hyperledger.besu.plugin.data.PropagatedBlockContext;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.plugin.data.Transaction;
 
+import java.util.Optional;
+
 /**
  * This service allows plugins to attach to various events during the normal operation of Besu.
  *
@@ -144,6 +146,6 @@ public interface BesuEvents {
      *
      * @param syncStatus the sync status
      */
-    void onSyncStatusChanged(SyncStatus syncStatus);
+    void onSyncStatusChanged(Optional<SyncStatus> syncStatus);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->
## PR description
Simplify sync status events.

Summary:
* Update when `syncStatus` events fire.  They now fire when:
    * The `Synchronizer` sets a target (starts syncing)
    * The `Synchronizer` clears a target (stops syncing)
* Update `SyncStatus` fields:
    *  The `inSync` field has been removed since this is a separate concern from the `Synchronizer`'s status
    * The `startingBlock` value is being set to the common ancestor with the sync target, to provide more meaningful information on the status of the `Synchronizer`
* Update `BesuEvents.SyncStatusListener` to accept an `Optional<SyncStatus>`, where an empty value means that the `Synchronizer` is not currently syncing
* Rename class `SyncStatus` to `DefaultSyncStatus` to disambiguate between the implementation and the interface

This PR builds off of https://github.com/hyperledger/besu/pull/100.  