### PR TITLE
[Pan 3238] Fix rlpx startup

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -125,7 +125,19 @@ public class RlpxAgent {
     }
 
     setupListeners();
-    return connectionInitializer.start();
+    return connectionInitializer
+        .start()
+        .thenApply(
+            (socketAddress) -> {
+              LOG.info("P2P RLPx agent started and listening on {}.", socketAddress);
+              return socketAddress.getPort();
+            })
+        .whenComplete(
+            (res, err) -> {
+              if (err != null) {
+                LOG.error("Failed to start P2P RLPx agent.", err);
+              }
+            });
   }
 
   public CompletableFuture<Void> stop() {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/ConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/ConnectionInitializer.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.connections;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 
+import java.net.InetSocketAddress;
 import java.util.concurrent.CompletableFuture;
 
 public interface ConnectionInitializer {
@@ -27,7 +28,7 @@ public interface ConnectionInitializer {
    *
    * @return The port on which we're listening for incoming connections.
    */
-  CompletableFuture<Integer> start();
+  CompletableFuture<InetSocketAddress> start();
 
   /**
    * Shutdown the connection initializer. Stop listening for incoming connections and stop

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/ConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/ConnectionInitializer.java
@@ -26,7 +26,7 @@ public interface ConnectionInitializer {
    * Start the connection initializer. Begins listening for incoming connections. Start allowing
    * outbound connections.
    *
-   * @return The port on which we're listening for incoming connections.
+   * @return The address on which we're listening for incoming connections.
    */
   CompletableFuture<InetSocketAddress> start();
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/MockConnectionInitializer.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/MockConnectionInitializer.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,8 +53,10 @@ public class MockConnectionInitializer implements ConnectionInitializer {
   }
 
   @Override
-  public CompletableFuture<Integer> start() {
-    return CompletableFuture.completedFuture(NEXT_PORT.incrementAndGet());
+  public CompletableFuture<InetSocketAddress> start() {
+    InetSocketAddress socketAddress =
+        new InetSocketAddress("127.0.0.1", NEXT_PORT.incrementAndGet());
+    return CompletableFuture.completedFuture(socketAddress);
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This PR fixes an issue where the `RlpxAgent` could fail to start up, but never return a failed `CompletableFuture`, causing the node to hang. 
