### PR TITLE
[PAN-3239] Only set sync targets that have an estimated height value

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ChainState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ChainState.java
@@ -103,8 +103,8 @@ public class ChainState implements ChainHeadEstimate {
 
   public void updateHeightEstimate(final long blockNumber) {
     synchronized (this) {
-      estimatedHeightKnown = true;
       if (blockNumber > estimatedHeight) {
+        estimatedHeightKnown = true;
         estimatedHeight = blockNumber;
         estimatedHeightListeners.forEach(e -> e.onEstimatedHeightChanged(estimatedHeight));
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncTargetManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncTargetManager.java
@@ -61,7 +61,7 @@ class FastSyncTargetManager<C> extends SyncTargetManager<C> {
 
   @Override
   protected CompletableFuture<Optional<EthPeer>> selectBestAvailableSyncTarget() {
-    final Optional<EthPeer> maybeBestPeer = ethContext.getEthPeers().bestPeer();
+    final Optional<EthPeer> maybeBestPeer = ethContext.getEthPeers().bestPeerWithHeightEstimate();
     if (!maybeBestPeer.isPresent()) {
       LOG.info("No sync target, wait for peers.");
       return completedFuture(Optional.empty());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncTargetManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncTargetManager.java
@@ -70,7 +70,7 @@ class FullSyncTargetManager<C> extends SyncTargetManager<C> {
 
   @Override
   protected CompletableFuture<Optional<EthPeer>> selectBestAvailableSyncTarget() {
-    final Optional<EthPeer> maybeBestPeer = ethContext.getEthPeers().bestPeer();
+    final Optional<EthPeer> maybeBestPeer = ethContext.getEthPeers().bestPeerWithHeightEstimate();
     if (!maybeBestPeer.isPresent()) {
       LOG.info("No sync target, wait for peers.");
       return completedFuture(Optional.empty());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ChainStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ChainStateTest.java
@@ -44,6 +44,20 @@ public class ChainStateTest {
   }
 
   @Test
+  public void updateHeightEstimate_toZero() {
+    chainState.updateHeightEstimate(0L);
+    assertThat(chainState.hasEstimatedHeight()).isFalse();
+    assertThat(chainState.getEstimatedHeight()).isEqualTo(0L);
+  }
+
+  @Test
+  public void updateHeightEstimate_toNonZeroValue() {
+    chainState.updateHeightEstimate(1L);
+    assertThat(chainState.hasEstimatedHeight()).isTrue();
+    assertThat(chainState.getEstimatedHeight()).isEqualTo(1L);
+  }
+
+  @Test
   public void updateBestBlockAndHeightFromHashAndHeight() {
     final long blockNumber = 12;
     final BlockHeader bestBlockHeader =


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This updates the `Synchronizer` logic to only set a `SyncTarget` using peers who have a height estimate.  This ensures that the initial `SyncStatus` event emitted from `SyncState` has a non-zero "highestBlock" value.