### PR TITLE
Additional unit test for selecting replaced pending transactions

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
@@ -277,7 +277,7 @@ public class PendingTransactionsTest {
   }
 
   @Test
-  public void shouldNotSelectReplacedTransactionWithSameSenderAndNonceButGreaterGas() {
+  public void shouldNotSelectReplacedTransaction() {
     final Transaction transaction1 = transactionWithNonceSenderAndGasPrice(1, KEYS1, 1);
     final Transaction transaction2 = transactionWithNonceSenderAndGasPrice(1, KEYS1, 2);
 
@@ -292,7 +292,7 @@ public class PendingTransactionsTest {
         });
 
     assertThat(parsedTransactions.size()).isEqualTo(1);
-    assertThat(parsedTransactions.get(0)).isEqualTo(transaction2);
+    assertThat(parsedTransactions).containsExactly(transaction2);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
@@ -277,6 +277,25 @@ public class PendingTransactionsTest {
   }
 
   @Test
+  public void shouldNotSelectReplacedTransactionWithSameSenderAndNonceButGreaterGas() {
+    final Transaction transaction1 = transactionWithNonceSenderAndGasPrice(1, KEYS1, 1);
+    final Transaction transaction2 = transactionWithNonceSenderAndGasPrice(1, KEYS1, 2);
+
+    transactions.addRemoteTransaction(transaction1);
+    transactions.addRemoteTransaction(transaction2);
+
+    final List<Transaction> parsedTransactions = Lists.newArrayList();
+    transactions.selectTransactions(
+        transaction -> {
+          parsedTransactions.add(transaction);
+          return PendingTransactions.TransactionSelectionResult.CONTINUE;
+        });
+
+    assertThat(parsedTransactions.size()).isEqualTo(1);
+    assertThat(parsedTransactions.get(0)).isEqualTo(transaction2);
+  }
+
+  @Test
   public void invalidTransactionIsDeletedFromPendingTransactions() {
     transactions.addRemoteTransaction(transaction1);
     transactions.addRemoteTransaction(transaction2);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
@@ -291,7 +291,6 @@ public class PendingTransactionsTest {
           return PendingTransactions.TransactionSelectionResult.CONTINUE;
         });
 
-    assertThat(parsedTransactions.size()).isEqualTo(1);
     assertThat(parsedTransactions).containsExactly(transaction2);
   }
 


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This adds an additional unit test around pending transactions when transactions are replaced and then selected for mining.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
