### PR TITLE
[PAN-3242] Programatically enforce plugin CLI variable names

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
@@ -32,48 +33,40 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class PicoCLIOptionsPluginTest extends AcceptanceTestBase {
+public class BadCLIOptionsPluginTest extends AcceptanceTestBase {
   private BesuNode node;
-
-  // context: https://en.wikipedia.org/wiki/The_Magic_Words_are_Squeamish_Ossifrage
-  private static final String MAGIC_WORDS = "Squemish Ossifrage";
 
   @Before
   public void setUp() throws Exception {
     node =
         besu.createPluginsNode(
-            "node1",
-            Collections.singletonList("testPlugins"),
-            Collections.singletonList("--Xplugin-test-option=" + MAGIC_WORDS));
+            "node1", Collections.singletonList("testPlugins"), Collections.emptyList());
     cluster.start(node);
   }
 
   @Test
-  public void shouldRegister() throws IOException {
-    final Path registrationFile =
-        node.homeDirectory().resolve("plugins/pluginLifecycle.registered");
+  public void shouldNotRegister() {
+    final Path registrationFile = node.homeDirectory().resolve("plugins/badCLIOptions.init");
     waitForFile(registrationFile);
-
-    // this assert is false as CLI will not be parsed at this point
-    assertThat(Files.readAllLines(registrationFile).stream().anyMatch(s -> s.contains(MAGIC_WORDS)))
-        .isFalse();
+    assertThat(node.homeDirectory().resolve("plugins/badCliOptions.register")).doesNotExist();
   }
 
   @Test
-  public void shouldStart() throws IOException {
+  public void shouldNotStart() {
+    // depend on the good PicoCLIOptions to tell us when it should be up
     final Path registrationFile = node.homeDirectory().resolve("plugins/pluginLifecycle.started");
     waitForFile(registrationFile);
 
-    // this assert is true as CLI will be parsed at this point
-    assertThat(Files.readAllLines(registrationFile).stream().anyMatch(s -> s.contains(MAGIC_WORDS)))
-        .isTrue();
+    assertThat(node.homeDirectory().resolve("plugins/badCliOptions.start")).doesNotExist();
   }
 
   @Test
   @Ignore("No way to do a graceful shutdown of Besu at the moment.")
-  public void shouldStop() {
+  public void shouldNotStop() {
     cluster.stopNode(node);
     waitForFile(node.homeDirectory().resolve("plugins/pluginLifecycle.stopped"));
+    assertThat(node.homeDirectory().resolve("plugins/badCliOptions.start")).doesNotExist();
+    assertThat(node.homeDirectory().resolve("plugins/badCliOptions.stop")).doesNotExist();
   }
 
   private void waitForFile(final Path path) {

--- a/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
@@ -16,9 +16,15 @@ package org.hyperledger.besu.services;
 
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Model.OptionSpec;
 
 public class PicoCLIOptionsImpl implements PicoCLIOptions {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   private final CommandLine commandLine;
 
@@ -28,6 +34,24 @@ public class PicoCLIOptionsImpl implements PicoCLIOptions {
 
   @Override
   public void addPicoCLIOptions(final String namespace, final Object optionObject) {
-    commandLine.addMixin("Plugin " + namespace, optionObject);
+    final String pluginPrefix = "--plugin-" + namespace + "-";
+    final String unstablePrefix = "--Xplugin-" + namespace + "-";
+    final CommandSpec mixin = CommandSpec.forAnnotatedObject(optionObject);
+    boolean badOptionName = false;
+
+    for (final OptionSpec optionSpec : mixin.options()) {
+      for (final String optionName : optionSpec.names()) {
+        if (!optionName.startsWith(pluginPrefix) && !optionName.startsWith(unstablePrefix)) {
+          badOptionName = true;
+          LOG.error(
+              "Plugin option {} did not have the expected prefix of {}", optionName, pluginPrefix);
+        }
+      }
+    }
+    if (badOptionName) {
+      throw new RuntimeException("Error loading CLI options");
+    } else {
+      commandLine.getCommandSpec().addMixin("Plugin " + namespace, mixin);
+    }
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
+++ b/besu/src/test/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.plugins;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.hyperledger.besu.plugin.BesuContext;
+import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import com.google.auto.service.AutoService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import picocli.CommandLine.Option;
+
+@AutoService(BesuPlugin.class)
+public class BadCLIOptionsPlugin implements BesuPlugin {
+  private static final Logger LOG = LogManager.getLogger();
+
+  @Option(names = "--poorly-named-option")
+  String poorlyNamedOption = "nothing";
+
+  private File callbackDir;
+
+  @Override
+  public void register(final BesuContext context) {
+    LOG.info("Registering BadCliOptionsPlugin");
+    callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
+    writeStatus("init");
+
+    context
+        .getService(PicoCLIOptions.class)
+        .ifPresent(
+            picoCLIOptions ->
+                picoCLIOptions.addPicoCLIOptions("bad-cli", BadCLIOptionsPlugin.this));
+
+    writeStatus("register");
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Starting BadCliOptionsPlugin");
+    writeStatus("start");
+  }
+
+  @Override
+  public void stop() {
+    LOG.info("Stopping BadCliOptionsPlugin");
+    writeStatus("stop");
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  private void writeStatus(final String status) {
+    try {
+      final File callbackFile = new File(callbackDir, "badCLIOptions." + status);
+      if (!callbackFile.getParentFile().exists()) {
+        callbackFile.getParentFile().mkdirs();
+        callbackFile.getParentFile().deleteOnExit();
+      }
+      Files.write(callbackFile.toPath(), status.getBytes(UTF_8));
+      callbackFile.deleteOnExit();
+      LOG.info("Write status " + status);
+    } catch (final IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+  }
+}

--- a/besu/src/test/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
+++ b/besu/src/test/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
@@ -32,8 +32,17 @@ import picocli.CommandLine.Option;
 public class TestPicoCLIPlugin implements BesuPlugin {
   private static final Logger LOG = LogManager.getLogger();
 
-  @Option(names = "--Xtest-option", hidden = true, defaultValue = "UNSET")
+  @Option(
+      names = {"--Xplugin-test-option"},
+      hidden = true,
+      defaultValue = "UNSET")
   String testOption = System.getProperty("testPicoCLIPlugin.testOption");
+
+  @Option(
+      names = {"--plugin-test-stable-option"},
+      hidden = true,
+      defaultValue = "UNSET")
+  String stableOption = "";
 
   private String state = "uninited";
   private File callbackDir;
@@ -51,8 +60,7 @@ public class TestPicoCLIPlugin implements BesuPlugin {
     context
         .getService(PicoCLIOptions.class)
         .ifPresent(
-            picoCLIOptions ->
-                picoCLIOptions.addPicoCLIOptions("Test PicoCLI Plugin", TestPicoCLIPlugin.this));
+            picoCLIOptions -> picoCLIOptions.addPicoCLIOptions("test", TestPicoCLIPlugin.this));
 
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeSignal("registered");
@@ -93,6 +101,7 @@ public class TestPicoCLIPlugin implements BesuPlugin {
   }
 
   /** This is used to signal to the acceptance test that certain tasks were completed. */
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   private void writeSignal(final String signal) {
     try {
       final File callbackFile = new File(callbackDir, "pluginLifecycle." + signal);

--- a/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
@@ -34,7 +34,7 @@ public class PicoCLIOptionsImplTest {
   }
 
   static final class MixinOptions {
-    @Option(names = "--mixin")
+    @Option(names = "--plugin-Test1-mixin")
     String mixinOption = "defaultmixin";
   }
 
@@ -44,18 +44,18 @@ public class PicoCLIOptionsImplTest {
   private PicoCLIOptionsImpl serviceImpl;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     command = new SimpleCommand();
     mixin = new MixinOptions();
     commandLine = new CommandLine(command);
     serviceImpl = new PicoCLIOptionsImpl(commandLine);
 
-    serviceImpl.addPicoCLIOptions("Test 1", mixin);
+    serviceImpl.addPicoCLIOptions("Test1", mixin);
   }
 
   @Test
   public void testSimpleOptionParse() {
-    commandLine.parseArgs("--existing", "1", "--mixin", "2");
+    commandLine.parseArgs("--existing", "1", "--plugin-Test1-mixin", "2");
     assertThat(command.existingOption).isEqualTo("1");
     assertThat(mixin.mixinOption).isEqualTo("2");
   }
@@ -69,7 +69,7 @@ public class PicoCLIOptionsImplTest {
 
   @Test
   public void testMixinOptionOnly() {
-    commandLine.parseArgs("--mixin", "2");
+    commandLine.parseArgs("--plugin-Test1-mixin", "2");
     assertThat(command.existingOption).isEqualTo("defaultexisting");
     assertThat(mixin.mixinOption).isEqualTo("2");
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -24,11 +24,12 @@ public class RocksDBCLIOptions {
   public static final int DEFAULT_MAX_BACKGROUND_COMPACTIONS = 4;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 4;
 
-  private static final String MAX_OPEN_FILES_FLAG = "--Xrocksdb-max-open-files";
-  private static final String CACHE_CAPACITY_FLAG = "--Xrocksdb-cache-capacity";
+  private static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
+  private static final String CACHE_CAPACITY_FLAG = "--Xplugin-rocksdb-cache-capacity";
   private static final String MAX_BACKGROUND_COMPACTIONS_FLAG =
-      "--Xrocksdb-max-background-compactions";
-  private static final String BACKGROUND_THREAD_COUNT_FLAG = "--Xrocksdb-background-thread-count";
+      "--Xplugin-rocksdb-max-background-compactions";
+  private static final String BACKGROUND_THREAD_COUNT_FLAG =
+      "--Xplugin-rocksdb-background-thread-count";
 
   @CommandLine.Option(
       names = {MAX_OPEN_FILES_FLAG},

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -28,11 +28,12 @@ import picocli.CommandLine;
 
 public class RocksDBCLIOptionsTest {
 
-  private static final String MAX_OPEN_FILES_FLAG = "--Xrocksdb-max-open-files";
-  private static final String CACHE_CAPACITY_FLAG = "--Xrocksdb-cache-capacity";
+  private static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
+  private static final String CACHE_CAPACITY_FLAG = "--Xplugin-rocksdb-cache-capacity";
   private static final String MAX_BACKGROUND_COMPACTIONS_FLAG =
-      "--Xrocksdb-max-background-compactions";
-  private static final String BACKGROUND_THREAD_COUNT_FLAG = "--Xrocksdb-background-thread-count";
+      "--Xplugin-rocksdb-max-background-compactions";
+  private static final String BACKGROUND_THREAD_COUNT_FLAG =
+      "--Xplugin-rocksdb-background-thread-count";
 
   @Test
   public void defaultValues() {


### PR DESCRIPTION
## PR description

Enforce that plugin variable names are either `--plugin-<namespace>-`
or `--Xplugin-<namespace>-` when registered with the
PicoCLIOptionsService.  If the names don't match a RuntimeException is
thrown, and unless that exception is caught the plugin will not have
start or stop lifecycle messages called.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## Fixed Issue(s)
PAN-3242