### PR TITLE
[PAN-3240] fix private transaction root mismatch

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractMessageProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractMessageProcessor.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.mainnet;
 
 import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.ModificationNotAllowedException;
 import org.hyperledger.besu.ethereum.vm.EVM;
 import org.hyperledger.besu.ethereum.vm.MessageFrame;
 import org.hyperledger.besu.ethereum.vm.OperationTracer;
@@ -155,6 +156,8 @@ public abstract class AbstractMessageProcessor {
       evm.runToHalt(frame, operationTracer);
     } catch (final ExceptionalHaltException e) {
       frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+    } catch (final ModificationNotAllowedException e) {
+      frame.setState(MessageFrame.State.REVERT);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Ivaylo Kirilov <iikirilov@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Not catching illegal modification inside evm operation caused Besu to abruptly exit private transaction processing. This meant that on some nodes extra gas was not refunded when processing the PMT while on non-participating nodes no private transaction was processed so the PMT was successfully processed and extra gas was refunded. This causes a mismatch in the receipt root as the gas used is recorded in the receipt.

## Fixed Issue(s)
[PAN-3240]
