### PR TITLE
Repair EthGetLogs returning incorrect results

### DIFF
--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
@@ -475,41 +475,4 @@ public class IbftExtraDataTest {
     }
     return vanity_bytes;
   }
-
-  @Test
-  public void doMyStuff() {
-    final String key1 =
-        "0xb962e52b5e421d1dd73fc2c18b7cf162b2cc8936b3ec7a689365474c7a64c28767c61ff8ef46829dd71fcc52593fdda7a16ff229ffbdbd5108634471700d70d8";
-    final String key2 =
-        "0x71f2f210e9701008a6774015b0806467a446e811f25b1797224a49a27a73037eb2b909e7b293c93a42b4740565f237ccd89b1f285ebad7a5ef876cd1c2e56a4c";
-    final String key3 =
-        "0x3f5acb72b5a8436318c26b014e45caa3477e70d328d87d5dfefb2149c1406715c547dc2d9f29adc73024e95a164d49d71107e3149105defb943807925f4aea35";
-    final String key4 =
-        "0x4cde66c509327f0bea090aad56748c41a2aa6d33c5b4b7e77088cdd0c93f43876512be86fd0c76efaf9b6994b1a6eb5e0ae182a06c2c5dcdfc3f20a537db6169";
-
-    final Address addr1 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key1)));
-    final Address addr2 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key2)));
-    final Address addr3 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key3)));
-    final Address addr4 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key4)));
-
-    OrderedHashSet<Address> addrs = new OrderedHashSet<>();
-    addrs.add(addr1);
-    addrs.add(addr2);
-    addrs.add(addr3);
-    addrs.add(addr4);
-
-    final IbftExtraData ed =
-        new IbftExtraData(
-            BytesValue.wrap(new byte[32]), Collections.emptyList(), Optional.empty(), 0, addrs);
-
-    final String genesisText = ed.encode().toString();
-
-    /*
-    "0x5d301767ae21d29200661a24d9318d57885316fe",
-    "0xaf3aa4810e15eaf71631389e411d53493efe1aac",
-    "0x89fc175f2317a9475f3d0cb3e7de36c968369bb2",
-    "0x1b0265ee954c4bcd2b124ecd597771501ecf1a22"
-     */
-
-  }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
@@ -18,11 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.consensus.common.VoteType;
-import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
@@ -30,13 +28,11 @@ import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
 import com.google.common.collect.Lists;
-import org.antlr.v4.runtime.misc.OrderedHashSet;
 import org.junit.Test;
 
 public class IbftExtraDataTest {

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataTest.java
@@ -18,9 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.consensus.common.VoteType;
+import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
@@ -28,11 +30,13 @@ import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
 import com.google.common.collect.Lists;
+import org.antlr.v4.runtime.misc.OrderedHashSet;
 import org.junit.Test;
 
 public class IbftExtraDataTest {
@@ -470,5 +474,42 @@ public class IbftExtraDataTest {
       vanity_bytes[i] = (byte) (i + 1);
     }
     return vanity_bytes;
+  }
+
+  @Test
+  public void doMyStuff() {
+    final String key1 =
+        "0xb962e52b5e421d1dd73fc2c18b7cf162b2cc8936b3ec7a689365474c7a64c28767c61ff8ef46829dd71fcc52593fdda7a16ff229ffbdbd5108634471700d70d8";
+    final String key2 =
+        "0x71f2f210e9701008a6774015b0806467a446e811f25b1797224a49a27a73037eb2b909e7b293c93a42b4740565f237ccd89b1f285ebad7a5ef876cd1c2e56a4c";
+    final String key3 =
+        "0x3f5acb72b5a8436318c26b014e45caa3477e70d328d87d5dfefb2149c1406715c547dc2d9f29adc73024e95a164d49d71107e3149105defb943807925f4aea35";
+    final String key4 =
+        "0x4cde66c509327f0bea090aad56748c41a2aa6d33c5b4b7e77088cdd0c93f43876512be86fd0c76efaf9b6994b1a6eb5e0ae182a06c2c5dcdfc3f20a537db6169";
+
+    final Address addr1 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key1)));
+    final Address addr2 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key2)));
+    final Address addr3 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key3)));
+    final Address addr4 = Util.publicKeyToAddress(PublicKey.create(BytesValue.fromHexString(key4)));
+
+    OrderedHashSet<Address> addrs = new OrderedHashSet<>();
+    addrs.add(addr1);
+    addrs.add(addr2);
+    addrs.add(addr3);
+    addrs.add(addr4);
+
+    final IbftExtraData ed =
+        new IbftExtraData(
+            BytesValue.wrap(new byte[32]), Collections.emptyList(), Optional.empty(), 0, addrs);
+
+    final String genesisText = ed.encode().toString();
+
+    /*
+    "0x5d301767ae21d29200661a24d9318d57885316fe",
+    "0xaf3aa4810e15eaf71631389e411d53493efe1aac",
+    "0x89fc175f2317a9475f3d0cb3e7de36c968369bb2",
+    "0x1b0265ee954c4bcd2b124ecd597771501ecf1a22"
+     */
+
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TopicsDeserializer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TopicsDeserializer.java
@@ -17,14 +17,14 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import org.hyperledger.besu.ethereum.api.query.TopicsParameter;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.google.common.collect.Lists;
 
 public class TopicsDeserializer extends StdDeserializer<TopicsParameter> {
   public TopicsDeserializer() {
@@ -38,21 +38,25 @@ public class TopicsDeserializer extends StdDeserializer<TopicsParameter> {
   @Override
   public TopicsParameter deserialize(
       final JsonParser jsonparser, final DeserializationContext context) throws IOException {
-    List<String> topicsList = new ArrayList<>();
+    final JsonNode topicsNode = jsonparser.getCodec().readTree(jsonparser);
+    final List<List<String>> topics = Lists.newArrayList();
 
-    try {
-      // parse as list of lists
-      return jsonparser.readValueAs(TopicsParameter.class);
-    } catch (MismatchedInputException mie) {
-      // single list case
-      String topics = jsonparser.getText();
-      jsonparser.nextToken(); // consume end of array character
-      if (topics == null) {
-        return new TopicsParameter(Collections.singletonList(topicsList));
-      } else {
-        // make it list of list
-        return new TopicsParameter(Collections.singletonList(Collections.singletonList(topics)));
+    if (!topicsNode.isArray()) {
+      topics.add(Collections.singletonList(topicsNode.textValue()));
+    } else {
+      for (JsonNode child : topicsNode) {
+        if (child.isArray()) {
+          final List<String> childItems = Lists.newArrayList();
+          for (JsonNode subChild : child) {
+            childItems.add(subChild.textValue());
+          }
+          topics.add(childItems);
+        } else {
+          topics.add(Collections.singletonList(child.textValue()));
+        }
       }
     }
+
+    return new TopicsParameter(topics);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/LogsQuery.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/LogsQuery.java
@@ -59,15 +59,7 @@ public class LogsQuery {
   }
 
   private boolean matchesTopic(final LogTopic topic, final List<LogTopic> matchCriteria) {
-    for (final LogTopic candidate : matchCriteria) {
-      if (candidate == null) {
-        return true;
-      }
-      if (candidate.equals(topic)) {
-        return true;
-      }
-    }
-    return false;
+    return matchCriteria.contains(null) || matchCriteria.contains(topic);
   }
 
   public static class Builder {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TopicsParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TopicsParameter.java
@@ -22,13 +22,10 @@ import org.hyperledger.besu.util.bytes.BytesValue;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 public class TopicsParameter {
 
   private final List<List<LogTopic>> queryTopics = new ArrayList<>();
 
-  @JsonCreator
   public TopicsParameter(final List<List<String>> topics) {
     if (topics != null) {
       for (final List<String> list : topics) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -416,5 +418,25 @@ public class LogsQueryTest {
     final Log log = new Log(address, BytesValue.fromHexString("0x0102"), logTopics);
 
     assertThat(query.matches(log)).isTrue();
+  }
+
+  @Test
+  public void emptySubTopicProducesNoMatches() {
+    final Address address = Address.fromHexString("0x1111111111111111111111111111111111111111");
+
+    final LogTopic topic1 =
+        LogTopic.fromHexString(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    final LogTopic topic2 =
+        LogTopic.fromHexString(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    final List<List<LogTopic>> queryParameter =
+        Lists.newArrayList(singletonList(topic1), emptyList());
+
+    final LogsQuery query = new LogsQuery.Builder().address(address).topics(queryParameter).build();
+    final Log log =
+        new Log(address, BytesValue.fromHexString("0x0102"), Lists.newArrayList(topic1, topic2));
+
+    assertThat(query.matches(log)).isFalse();
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -14,16 +14,22 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.query.TopicsParameter;
+import org.hyperledger.besu.ethereum.core.LogTopic;
 
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.junit.Test;
 
 public class FilterParameterTest {
@@ -126,6 +132,102 @@ public class FilterParameterTest {
         .isEqualToComparingFieldByFieldRecursively(readJsonAsFilterParameter(jsonWithTopicsLast));
   }
 
+  @Test
+  public void whenTopicsParameterIsArrayOfStringsFilterContainsListOfSingletonLists()
+      throws JsonProcessingException {
+    final List<String> topics =
+        Lists.newArrayList(
+            "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d",
+            null,
+            "0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74");
+    final FilterParameter filter = createFilterWithTopics(topics);
+
+    assertThat(filter.getTopics().getTopics())
+        .containsExactly(
+            singletonList(
+                LogTopic.fromHexString(
+                    "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d")),
+            singletonList(null),
+            singletonList(
+                LogTopic.fromHexString(
+                    "0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74")));
+  }
+
+  @Test
+  public void whenTopicsParameterContainsArraysFilterContainsListOfSingletonLists()
+      throws JsonProcessingException {
+    final List<List<String>> topics =
+        Lists.newArrayList(
+            singletonList("0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d"),
+            null,
+            singletonList("0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74"));
+
+    final FilterParameter filter = createFilterWithTopics(topics);
+
+    assertThat(filter.getTopics().getTopics())
+        .containsExactly(
+            singletonList(
+                LogTopic.fromHexString(
+                    "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d")),
+            singletonList(null),
+            singletonList(
+                LogTopic.fromHexString(
+                    "0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74")));
+  }
+
+  @Test
+  public void whenTopicArrayContainsNullFilterContainsSingletonListOfAllTopics()
+      throws JsonProcessingException {
+    final List<List<String>> topics =
+        Lists.newArrayList(
+            singletonList("0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d"),
+            null,
+            singletonList("0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74"));
+    final FilterParameter filter = createFilterWithTopics(topics);
+
+    assertThat(filter.getTopics().getTopics())
+        .containsExactly(
+            singletonList(
+                LogTopic.fromHexString(
+                    "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d")),
+            singletonList(null),
+            singletonList(
+                LogTopic.fromHexString(
+                    "0x000000000000000000000000244a53ab66ea8901c25efc48c8ab84662643cc74")));
+  }
+
+  @Test
+  public void emptyListDecodesCorrectly() throws JsonProcessingException {
+    final List<String> topics = emptyList();
+    final FilterParameter filter = createFilterWithTopics(topics);
+
+    assertThat(filter.getTopics().getTopics().size()).isZero();
+  }
+
+  @Test
+  public void emptyListAsSubTopicDecodesCorrectly() throws JsonProcessingException {
+    final List<List<String>> topics =
+        Lists.newArrayList(
+            singletonList("0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d"),
+            emptyList());
+    final FilterParameter filter = createFilterWithTopics(topics);
+    assertThat(filter.getTopics().getTopics())
+        .containsExactly(
+            singletonList(
+                LogTopic.fromHexString(
+                    "0xce8688f853ffa65c042b72302433c25d7a230c322caba0901587534b6551091d")),
+            emptyList());
+  }
+
+  private <T> FilterParameter createFilterWithTopics(final T inputTopics)
+      throws JsonProcessingException {
+    final Map<String, T> payload = new HashMap<>();
+    payload.put("topics", inputTopics);
+
+    final String json = new ObjectMapper().writeValueAsString(payload);
+    return new ObjectMapper().readValue(json, FilterParameter.class);
+  }
+
   private FilterParameter filterParameterWithAddresses(final String... addresses) {
     return new FilterParameter("latest", "latest", Arrays.asList(addresses), null, null);
   }
@@ -136,7 +238,7 @@ public class FilterParameterTest {
         "latest",
         "latest",
         Arrays.asList(address),
-        new TopicsParameter(Collections.singletonList(Arrays.asList(topics))),
+        new TopicsParameter(singletonList(Arrays.asList(topics))),
         null);
   }
 


### PR DESCRIPTION
An error was detected (PAN-3248) whereby if "Null" appeared in a Log
Topic filter, it and all subsequent filters were lost (and thus
were not used to filter responses) - thus Besu would return too many
results (as the filters were less restrictive than reqeusted).

This was determined to be an issue in the TopicParameterDeserialiser
which is resolved in this commit.

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>