### PR TITLE
Remove the use of JsonRpcParameters from RpcMethods

### DIFF
--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
@@ -29,7 +29,6 @@ import org.hyperledger.besu.consensus.common.VoteTallyUpdater;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -38,8 +37,6 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import java.util.Map;
 
 public class CliqueJsonRpcMethods extends ApiGroupJsonRpcMethods {
-
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final ProtocolContext<CliqueContext> context;
 
   public CliqueJsonRpcMethods(final ProtocolContext<CliqueContext> context) {
@@ -63,12 +60,12 @@ public class CliqueJsonRpcMethods extends ApiGroupJsonRpcMethods {
     final VoteTallyCache voteTallyCache = createVoteTallyCache(context, blockchain);
 
     return mapOf(
-        new CliqueGetSigners(blockchainQueries, voteTallyCache, parameter),
-        new CliqueGetSignersAtHash(blockchainQueries, voteTallyCache, parameter),
-        new Propose(voteProposer, parameter),
-        new Discard(voteProposer, parameter),
+        new CliqueGetSigners(blockchainQueries, voteTallyCache),
+        new CliqueGetSignersAtHash(blockchainQueries, voteTallyCache),
+        new Propose(voteProposer),
+        new Discard(voteProposer),
         new CliqueProposals(voteProposer),
-        new CliqueGetSignerMetrics(new CliqueBlockInterface(), blockchainQueries, parameter));
+        new CliqueGetSignerMetrics(new CliqueBlockInterface(), blockchainQueries));
   }
 
   private VoteTallyCache createVoteTallyCache(

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetrics.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetrics.java
@@ -18,17 +18,14 @@ import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.jsonrpc.AbstractGetSignerMetricsMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 public class CliqueGetSignerMetrics extends AbstractGetSignerMetricsMethod
     implements JsonRpcMethod {
 
   public CliqueGetSignerMetrics(
-      final BlockInterface blockInterface,
-      final BlockchainQueries blockchainQueries,
-      final JsonRpcParameter parameter) {
-    super(blockInterface, blockchainQueries, parameter);
+      final BlockInterface blockInterface, final BlockchainQueries blockchainQueries) {
+    super(blockInterface, blockchainQueries);
   }
 
   @Override

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSigners.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSigners.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -35,15 +34,11 @@ import java.util.stream.Collectors;
 public class CliqueGetSigners implements JsonRpcMethod {
   private final BlockchainQueries blockchainQueries;
   private final VoteTallyCache voteTallyCache;
-  private final JsonRpcParameter parameters;
 
   public CliqueGetSigners(
-      final BlockchainQueries blockchainQueries,
-      final VoteTallyCache voteTallyCache,
-      final JsonRpcParameter parameter) {
+      final BlockchainQueries blockchainQueries, final VoteTallyCache voteTallyCache) {
     this.blockchainQueries = blockchainQueries;
     this.voteTallyCache = voteTallyCache;
-    this.parameters = parameter;
   }
 
   @Override
@@ -63,7 +58,7 @@ public class CliqueGetSigners implements JsonRpcMethod {
 
   private Optional<BlockHeader> determineBlockHeader(final JsonRpcRequest request) {
     final Optional<BlockParameter> blockParameter =
-        parameters.optional(request.getParams(), 0, BlockParameter.class);
+        request.getOptionalParameter(0, BlockParameter.class);
     final long latest = blockchainQueries.headBlockNumber();
     final long blockNumber = blockParameter.map(b -> b.getNumber().orElse(latest)).orElse(latest);
     return blockchainQueries.blockByNumber(blockNumber).map(BlockWithMetadata::getHeader);

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersAtHash.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersAtHash.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -35,15 +34,11 @@ import java.util.stream.Collectors;
 public class CliqueGetSignersAtHash implements JsonRpcMethod {
   private final BlockchainQueries blockchainQueries;
   private final VoteTallyCache voteTallyCache;
-  private final JsonRpcParameter parameters;
 
   public CliqueGetSignersAtHash(
-      final BlockchainQueries blockchainQueries,
-      final VoteTallyCache voteTallyCache,
-      final JsonRpcParameter parameter) {
+      final BlockchainQueries blockchainQueries, final VoteTallyCache voteTallyCache) {
     this.blockchainQueries = blockchainQueries;
     this.voteTallyCache = voteTallyCache;
-    this.parameters = parameter;
   }
 
   @Override
@@ -62,7 +57,7 @@ public class CliqueGetSignersAtHash implements JsonRpcMethod {
   }
 
   private Optional<BlockHeader> determineBlockHeader(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     return blockchainQueries.blockByHash(hash).map(BlockWithMetadata::getHeader);
   }
 }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/Discard.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/Discard.java
@@ -18,18 +18,15 @@ import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
 
 public class Discard implements JsonRpcMethod {
   private final VoteProposer proposer;
-  private final JsonRpcParameter parameters;
 
-  public Discard(final VoteProposer proposer, final JsonRpcParameter parameters) {
+  public Discard(final VoteProposer proposer) {
     this.proposer = proposer;
-    this.parameters = parameters;
   }
 
   @Override
@@ -39,7 +36,7 @@ public class Discard implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Address address = parameters.required(request.getParams(), 0, Address.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
     proposer.discard(address);
     return new JsonRpcSuccessResponse(request.getId(), true);
   }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/Propose.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/Propose.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -28,11 +27,9 @@ import org.hyperledger.besu.ethereum.core.Address;
 
 public class Propose implements JsonRpcMethod {
   private final VoteProposer proposer;
-  private final JsonRpcParameter parameters;
 
-  public Propose(final VoteProposer proposer, final JsonRpcParameter parameters) {
+  public Propose(final VoteProposer proposer) {
     this.proposer = proposer;
-    this.parameters = parameters;
   }
 
   @Override
@@ -42,8 +39,8 @@ public class Propose implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Address address = parameters.required(request.getParams(), 0, Address.class);
-    final Boolean auth = parameters.required(request.getParams(), 1, Boolean.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
+    final Boolean auth = request.getRequiredParameter(1, Boolean.class);
     if (address.equals(CliqueBlockInterface.NO_VOTE_SUBJECT)) {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_REQUEST);
     }

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.SignerMetricResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -49,7 +48,6 @@ public class CliqueGetSignerMetricsTest {
     Address.fromHexString("0x1"), Address.fromHexString("0x2"), Address.fromHexString("0x3"),
   };
 
-  private final JsonRpcParameter jsonRpcParameter = new JsonRpcParameter();
   private final String CLIQUE_METHOD = "clique_getSignerMetrics";
   private final String JSON_RPC_VERSION = "2.0";
   private CliqueGetSignerMetrics method;
@@ -63,7 +61,7 @@ public class CliqueGetSignerMetricsTest {
   public void setup() {
     blockchainQueries = mock(BlockchainQueries.class);
     blockInterface = mock(BlockInterface.class);
-    method = new CliqueGetSignerMetrics(blockInterface, blockchainQueries, jsonRpcParameter);
+    method = new CliqueGetSignerMetrics(blockInterface, blockchainQueries);
   }
 
   @Test

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersAtHashTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersAtHashTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -67,7 +66,7 @@ public class CliqueGetSignersAtHashTest {
 
   @Before
   public void setup() {
-    method = new CliqueGetSignersAtHash(blockchainQueries, voteTallyCache, new JsonRpcParameter());
+    method = new CliqueGetSignersAtHash(blockchainQueries, voteTallyCache);
 
     final byte[] genesisBlockExtraData =
         Hex.decode(

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignersTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -59,7 +58,7 @@ public class CliqueGetSignersTest {
 
   @Before
   public void setup() {
-    method = new CliqueGetSigners(blockchainQueries, voteTallyCache, new JsonRpcParameter());
+    method = new CliqueGetSigners(blockchainQueries, voteTallyCache);
 
     final String genesisBlockExtraData =
         "52657370656374206d7920617574686f7269746168207e452e436172746d616e42eb768f2244c8811c63729a21a3569731535f067ffc57839b00206d1ad20c69a1981b489f772031b279182d99e65703f0076e4812653aab85fca0f00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/DiscardTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/DiscardTest.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -38,7 +37,7 @@ public class DiscardTest {
   @Test
   public void discardEmpty() {
     final VoteProposer proposer = new VoteProposer();
-    final Discard discard = new Discard(proposer, new JsonRpcParameter());
+    final Discard discard = new Discard(proposer);
     final Address a0 = Address.fromHexString("0");
 
     final JsonRpcResponse response = discard.response(requestWithParams(a0));
@@ -52,7 +51,7 @@ public class DiscardTest {
   @Test
   public void discardAuth() {
     final VoteProposer proposer = new VoteProposer();
-    final Discard discard = new Discard(proposer, new JsonRpcParameter());
+    final Discard discard = new Discard(proposer);
     final Address a0 = Address.fromHexString("0");
 
     proposer.auth(a0);
@@ -68,7 +67,7 @@ public class DiscardTest {
   @Test
   public void discardDrop() {
     final VoteProposer proposer = new VoteProposer();
-    final Discard discard = new Discard(proposer, new JsonRpcParameter());
+    final Discard discard = new Discard(proposer);
     final Address a0 = Address.fromHexString("0");
 
     proposer.drop(a0);
@@ -84,7 +83,7 @@ public class DiscardTest {
   @Test
   public void discardIsolation() {
     final VoteProposer proposer = new VoteProposer();
-    final Discard discard = new Discard(proposer, new JsonRpcParameter());
+    final Discard discard = new Discard(proposer);
     final Address a0 = Address.fromHexString("0");
     final Address a1 = Address.fromHexString("1");
 
@@ -103,7 +102,7 @@ public class DiscardTest {
   @Test
   public void discardWithoutAddress() {
     final VoteProposer proposer = new VoteProposer();
-    final Discard discard = new Discard(proposer, new JsonRpcParameter());
+    final Discard discard = new Discard(proposer);
 
     assertThatThrownBy(() -> discard.response(requestWithParams()))
         .hasMessage("Missing required json rpc parameter at index 0")

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/ProposeTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/ProposeTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -38,7 +37,7 @@ public class ProposeTest {
   @Test
   public void testAuth() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a1 = Address.fromHexString("1");
 
     final JsonRpcResponse response = propose.response(requestWithParams(a1, true));
@@ -52,7 +51,7 @@ public class ProposeTest {
   @Test
   public void testAuthWithAddressZeroResultsInError() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a0 = Address.fromHexString("0");
 
     final JsonRpcResponse response = propose.response(requestWithParams(a0, true));
@@ -66,7 +65,7 @@ public class ProposeTest {
   @Test
   public void testDrop() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a1 = Address.fromHexString("1");
 
     final JsonRpcResponse response = propose.response(requestWithParams(a1, false));
@@ -80,7 +79,7 @@ public class ProposeTest {
   @Test
   public void testDropWithAddressZeroResultsInError() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a0 = Address.fromHexString("0");
 
     final JsonRpcResponse response = propose.response(requestWithParams(a0, false));
@@ -94,7 +93,7 @@ public class ProposeTest {
   @Test
   public void testRepeatAuth() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a1 = Address.fromHexString("1");
 
     proposer.auth(a1);
@@ -109,7 +108,7 @@ public class ProposeTest {
   @Test
   public void testRepeatDrop() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a1 = Address.fromHexString("1");
 
     proposer.drop(a1);
@@ -124,7 +123,7 @@ public class ProposeTest {
   @Test
   public void testChangeToAuth() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a1 = Address.fromHexString("1");
 
     proposer.drop(a1);
@@ -139,7 +138,7 @@ public class ProposeTest {
   @Test
   public void testChangeToDrop() {
     final VoteProposer proposer = new VoteProposer();
-    final Propose propose = new Propose(proposer, new JsonRpcParameter());
+    final Propose propose = new Propose(proposer);
     final Address a0 = Address.fromHexString("1");
 
     proposer.auth(a0);

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.consensus.common.jsonrpc;
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -39,23 +38,19 @@ public abstract class AbstractGetSignerMetricsMethod {
 
   private final BlockInterface blockInterface;
   private final BlockchainQueries blockchainQueries;
-  private final JsonRpcParameter parameters;
 
   public AbstractGetSignerMetricsMethod(
-      final BlockInterface blockInterface,
-      final BlockchainQueries blockchainQueries,
-      final JsonRpcParameter parameter) {
+      final BlockInterface blockInterface, final BlockchainQueries blockchainQueries) {
     this.blockInterface = blockInterface;
     this.blockchainQueries = blockchainQueries;
-    this.parameters = parameter;
   }
 
   public JsonRpcResponse response(final JsonRpcRequest request) {
 
     final Optional<BlockParameter> startBlockParameter =
-        parameters.optional(request.getParams(), 0, BlockParameter.class);
+        request.getOptionalParameter(0, BlockParameter.class);
     final Optional<BlockParameter> endBlockParameter =
-        parameters.optional(request.getParams(), 1, BlockParameter.class);
+        request.getOptionalParameter(1, BlockParameter.class);
 
     final long fromBlockNumber = getFromBlockNumber(startBlockParameter);
     final long toBlockNumber = getEndBlockNumber(endBlockParameter);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/IbftJsonRpcMethods.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/IbftJsonRpcMethods.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.consensus.ibft.jsonrpc.methods.IbftProposeValidatorV
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
@@ -35,7 +34,6 @@ import java.util.Map;
 
 public class IbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter jsonRpcParameter = new JsonRpcParameter();
   private final ProtocolContext<IbftContext> context;
 
   public IbftJsonRpcMethods(final ProtocolContext<IbftContext> context) {
@@ -55,11 +53,11 @@ public class IbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
     final BlockInterface blockInterface = new IbftBlockInterface();
 
     return mapOf(
-        new IbftProposeValidatorVote(voteProposer, jsonRpcParameter),
-        new IbftGetValidatorsByBlockNumber(blockchainQueries, blockInterface, jsonRpcParameter),
-        new IbftDiscardValidatorVote(voteProposer, jsonRpcParameter),
-        new IbftGetValidatorsByBlockHash(context.getBlockchain(), blockInterface, jsonRpcParameter),
-        new IbftGetSignerMetrics(blockInterface, blockchainQueries, jsonRpcParameter),
+        new IbftProposeValidatorVote(voteProposer),
+        new IbftGetValidatorsByBlockNumber(blockchainQueries, blockInterface),
+        new IbftDiscardValidatorVote(voteProposer),
+        new IbftGetValidatorsByBlockHash(context.getBlockchain(), blockInterface),
+        new IbftGetSignerMetrics(blockInterface, blockchainQueries),
         new IbftGetPendingVotes(voteProposer));
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftDiscardValidatorVote.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftDiscardValidatorVote.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -29,12 +28,9 @@ import org.apache.logging.log4j.Logger;
 public class IbftDiscardValidatorVote implements JsonRpcMethod {
   private static final Logger LOG = LogManager.getLogger();
   private final VoteProposer voteProposer;
-  private final JsonRpcParameter parameters;
 
-  public IbftDiscardValidatorVote(
-      final VoteProposer voteProposer, final JsonRpcParameter parameters) {
+  public IbftDiscardValidatorVote(final VoteProposer voteProposer) {
     this.voteProposer = voteProposer;
-    this.parameters = parameters;
   }
 
   @Override
@@ -44,7 +40,7 @@ public class IbftDiscardValidatorVote implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
-    final Address validatorAddress = parameters.required(req.getParams(), 0, Address.class);
+    final Address validatorAddress = req.getRequiredParameter(0, Address.class);
     LOG.trace("Received RPC rpcName={} address={}", getName(), validatorAddress);
     voteProposer.discard(validatorAddress);
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetrics.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetrics.java
@@ -18,16 +18,13 @@ import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.jsonrpc.AbstractGetSignerMetricsMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 public class IbftGetSignerMetrics extends AbstractGetSignerMetricsMethod implements JsonRpcMethod {
 
   public IbftGetSignerMetrics(
-      final BlockInterface blockInterface,
-      final BlockchainQueries blockchainQueries,
-      final JsonRpcParameter parameter) {
-    super(blockInterface, blockchainQueries, parameter);
+      final BlockInterface blockInterface, final BlockchainQueries blockchainQueries) {
+    super(blockInterface, blockchainQueries);
   }
 
   @Override

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHash.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -36,15 +35,11 @@ public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
 
   private final Blockchain blockchain;
   private final BlockInterface blockInterface;
-  private final JsonRpcParameter parameters;
 
   public IbftGetValidatorsByBlockHash(
-      final Blockchain blockchain,
-      final BlockInterface blockInterface,
-      final JsonRpcParameter parameters) {
+      final Blockchain blockchain, final BlockInterface blockInterface) {
     this.blockchain = blockchain;
     this.blockInterface = blockInterface;
-    this.parameters = parameters;
   }
 
   @Override
@@ -58,7 +53,7 @@ public class IbftGetValidatorsByBlockHash implements JsonRpcMethod {
   }
 
   private Object blockResult(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     LOG.trace("Received RPC rpcName={} blockHash={}", getName(), hash);
     final Optional<BlockHeader> blockHeader = blockchain.getBlockHeader(hash);
     return blockHeader

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumber.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AbstractBlockParameterMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
@@ -37,16 +36,14 @@ public class IbftGetValidatorsByBlockNumber extends AbstractBlockParameterMethod
   private final BlockInterface blockInterface;
 
   public IbftGetValidatorsByBlockNumber(
-      final BlockchainQueries blockchainQueries,
-      final BlockInterface blockInterface,
-      final JsonRpcParameter parameters) {
-    super(blockchainQueries, parameters);
+      final BlockchainQueries blockchainQueries, final BlockInterface blockInterface) {
+    super(blockchainQueries);
     this.blockInterface = blockInterface;
   }
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftProposeValidatorVote.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftProposeValidatorVote.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.consensus.common.VoteType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -30,12 +29,9 @@ import org.apache.logging.log4j.Logger;
 public class IbftProposeValidatorVote implements JsonRpcMethod {
   private static final Logger LOG = LogManager.getLogger();
   private final VoteProposer voteProposer;
-  private final JsonRpcParameter parameters;
 
-  public IbftProposeValidatorVote(
-      final VoteProposer voteProposer, final JsonRpcParameter parameters) {
+  public IbftProposeValidatorVote(final VoteProposer voteProposer) {
     this.voteProposer = voteProposer;
-    this.parameters = parameters;
   }
 
   @Override
@@ -46,8 +42,8 @@ public class IbftProposeValidatorVote implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
 
-    final Address validatorAddress = parameters.required(req.getParams(), 0, Address.class);
-    final Boolean add = parameters.required(req.getParams(), 1, Boolean.class);
+    final Address validatorAddress = req.getRequiredParameter(0, Address.class);
+    final Boolean add = req.getRequiredParameter(1, Boolean.class);
     LOG.trace(
         "Received RPC rpcName={} voteType={} address={}",
         getName(),

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftDiscardValidatorVoteTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftDiscardValidatorVoteTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -33,7 +32,6 @@ import org.junit.rules.ExpectedException;
 
 public class IbftDiscardValidatorVoteTest {
   private final VoteProposer voteProposer = mock(VoteProposer.class);
-  private final JsonRpcParameter jsonRpcParameter = new JsonRpcParameter();
   private final String IBFT_METHOD = "ibft_discardValidatorVote";
   private final String JSON_RPC_VERSION = "2.0";
   private IbftDiscardValidatorVote method;
@@ -42,7 +40,7 @@ public class IbftDiscardValidatorVoteTest {
 
   @Before
   public void setup() {
-    method = new IbftDiscardValidatorVote(voteProposer, jsonRpcParameter);
+    method = new IbftDiscardValidatorVote(voteProposer);
   }
 
   @Test

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.SignerMetricResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -49,7 +48,6 @@ public class IbftGetSignerMetricsTest {
     Address.fromHexString("0x1"), Address.fromHexString("0x2"), Address.fromHexString("0x3"),
   };
 
-  private final JsonRpcParameter jsonRpcParameter = new JsonRpcParameter();
   private final String IBFT_METHOD = "ibft_getSignerMetrics";
   private final String JSON_RPC_VERSION = "2.0";
   private IbftGetSignerMetrics method;
@@ -63,7 +61,7 @@ public class IbftGetSignerMetricsTest {
   public void setup() {
     blockchainQueries = mock(BlockchainQueries.class);
     blockInterface = mock(BlockInterface.class);
-    method = new IbftGetSignerMetrics(blockInterface, blockchainQueries, jsonRpcParameter);
+    method = new IbftGetSignerMetrics(blockInterface, blockchainQueries);
   }
 
   @Test

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHashTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockHashTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -48,12 +47,11 @@ public class IbftGetValidatorsByBlockHashTest {
   @Mock private IbftBlockInterface ibftBlockInterface;
   @Mock private JsonRpcRequest request;
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private IbftGetValidatorsByBlockHash method;
 
   @Before
   public void setUp() {
-    method = new IbftGetValidatorsByBlockHash(blockchain, ibftBlockInterface, parameters);
+    method = new IbftGetValidatorsByBlockHash(blockchain, ibftBlockInterface);
   }
 
   @Test

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumberTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetValidatorsByBlockNumberTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -43,12 +42,11 @@ public class IbftGetValidatorsByBlockNumberTest {
   @Mock private IbftBlockInterface ibftBlockInterface;
   @Mock private JsonRpcRequest request;
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private IbftGetValidatorsByBlockNumber method;
 
   @Before
   public void setUp() {
-    method = new IbftGetValidatorsByBlockNumber(blockchainQueries, ibftBlockInterface, parameters);
+    method = new IbftGetValidatorsByBlockNumber(blockchainQueries, ibftBlockInterface);
   }
 
   @Test

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftProposeValidatorVoteTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftProposeValidatorVoteTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -33,7 +32,6 @@ import org.junit.rules.ExpectedException;
 
 public class IbftProposeValidatorVoteTest {
   private final VoteProposer voteProposer = mock(VoteProposer.class);
-  private final JsonRpcParameter jsonRpcParameter = new JsonRpcParameter();
   private final String IBFT_METHOD = "ibft_proposeValidatorVote";
   private final String JSON_RPC_VERSION = "2.0";
   private IbftProposeValidatorVote method;
@@ -42,7 +40,7 @@ public class IbftProposeValidatorVoteTest {
 
   @Before
   public void setup() {
-    method = new IbftProposeValidatorVote(voteProposer, jsonRpcParameter);
+    method = new IbftProposeValidatorVote(voteProposer);
   }
 
   @Test

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetFilterChangesIntegrationTest.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterIdGenerat
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterRepository;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetFilterChanges;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -89,7 +88,6 @@ public class EthGetFilterChangesIntegrationTest {
   private static final int MAX_TRANSACTIONS = 5;
   private static final KeyPair keyPair = KeyPair.generate();
   private final Transaction transaction = createTransaction(1);
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private FilterManager filterManager;
   private EthGetFilterChanges method;
   private final SyncState syncState = mock(SyncState.class);
@@ -121,7 +119,7 @@ public class EthGetFilterChangesIntegrationTest {
     filterManager =
         new FilterManager(
             blockchainQueries, transactionPool, new FilterIdGenerator(), new FilterRepository());
-    method = new EthGetFilterChanges(filterManager, parameters);
+    method = new EthGetFilterChanges(filterManager);
   }
 
   @Test

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.enclave.types.SendRequest;
 import org.hyperledger.besu.enclave.types.SendRequestLegacy;
 import org.hyperledger.besu.enclave.types.SendResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivGetPrivateTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionLegacyResult;
@@ -125,8 +124,6 @@ public class PrivGetPrivateTransactionIntegrationTest {
           .restriction(Restriction.RESTRICTED)
           .signAndBuild(KEY_PAIR);
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
 
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
@@ -135,7 +132,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
   public void returnsStoredPrivateTransaction() {
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(blockchain, enclave, parameters, privacyParameters);
+        new PrivGetPrivateTransaction(blockchain, enclave, privacyParameters);
 
     when(blockchain.transactionByHash(any(Hash.class)))
         .thenReturn(Optional.of(returnedTransaction));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
@@ -15,9 +15,11 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -30,6 +32,8 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JsonRpcRequest {
+
+  private final JsonRpcParameter parameterAccessor = new JsonRpcParameter();
 
   private JsonRpcRequestId id;
   private final String method;
@@ -123,5 +127,13 @@ public class JsonRpcRequest {
   @Override
   public int hashCode() {
     return Objects.hash(id, method, Arrays.hashCode(params), version, isNotification);
+  }
+
+  public <T> T getRequiredParameter(final int index, final Class<T> paramClass) {
+    return parameterAccessor.required(params, index, paramClass);
+  }
+
+  public <T> Optional<T> getOptionalParameter(final int index, final Class<T> paramClass) {
+    return parameterAccessor.optional(params, index, paramClass);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterMethod.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -29,17 +28,13 @@ import com.google.common.base.Suppliers;
 public abstract class AbstractBlockParameterMethod implements JsonRpcMethod {
 
   private final Supplier<BlockchainQueries> blockchainQueries;
-  private final JsonRpcParameter parameters;
 
-  protected AbstractBlockParameterMethod(
-      final BlockchainQueries blockchainQueries, final JsonRpcParameter parameters) {
-    this(Suppliers.ofInstance(blockchainQueries), parameters);
+  protected AbstractBlockParameterMethod(final BlockchainQueries blockchainQueries) {
+    this(Suppliers.ofInstance(blockchainQueries));
   }
 
-  protected AbstractBlockParameterMethod(
-      final Supplier<BlockchainQueries> blockchainQueries, final JsonRpcParameter parameters) {
+  protected AbstractBlockParameterMethod(final Supplier<BlockchainQueries> blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
-    this.parameters = parameters;
   }
 
   protected abstract BlockParameter blockParameter(JsonRpcRequest request);
@@ -48,10 +43,6 @@ public abstract class AbstractBlockParameterMethod implements JsonRpcMethod {
 
   protected BlockchainQueries getBlockchainQueries() {
     return blockchainQueries.get();
-  }
-
-  protected JsonRpcParameter getParameters() {
-    return parameters;
   }
 
   protected Object pendingResult(final JsonRpcRequest request) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
@@ -30,8 +29,8 @@ public class AdminAddPeer extends AdminModifyPeer {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  public AdminAddPeer(final P2PNetwork peerNetwork, final JsonRpcParameter parameters) {
-    super(peerNetwork, parameters);
+  public AdminAddPeer(final P2PNetwork peerNetwork) {
+    super(peerNetwork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevel.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevel.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -34,11 +33,6 @@ import org.apache.logging.log4j.core.config.Configurator;
 public class AdminChangeLogLevel implements JsonRpcMethod {
 
   private static final Logger LOG = LogManager.getLogger();
-  private final JsonRpcParameter parameters;
-
-  public AdminChangeLogLevel(final JsonRpcParameter parameters) {
-    this.parameters = parameters;
-  }
 
   @Override
   public String getName() {
@@ -48,9 +42,8 @@ public class AdminChangeLogLevel implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
     try {
-      final Level logLevel = parameters.required(request.getParams(), 0, Level.class);
-      final Optional<String[]> optionalLogFilters =
-          parameters.optional(request.getParams(), 1, String[].class);
+      final Level logLevel = request.getRequiredParameter(0, Level.class);
+      final Optional<String[]> optionalLogFilters = request.getOptionalParameter(1, String[].class);
       optionalLogFilters.ifPresentOrElse(
           logFilters ->
               Arrays.stream(logFilters).forEach(logFilter -> setLogLevel(logFilter, logLevel)),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminModifyPeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminModifyPeer.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -25,12 +24,10 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException
 
 public abstract class AdminModifyPeer implements JsonRpcMethod {
 
-  protected final JsonRpcParameter parameters;
   protected final P2PNetwork peerNetwork;
 
-  public AdminModifyPeer(final P2PNetwork peerNetwork, final JsonRpcParameter parameters) {
+  public AdminModifyPeer(final P2PNetwork peerNetwork) {
     this.peerNetwork = peerNetwork;
-    this.parameters = parameters;
   }
 
   @Override
@@ -39,7 +36,7 @@ public abstract class AdminModifyPeer implements JsonRpcMethod {
       return new JsonRpcErrorResponse(req.getId(), JsonRpcError.INVALID_PARAMS);
     }
     try {
-      final String enodeString = parameters.required(req.getParams(), 0, String.class);
+      final String enodeString = req.getRequiredParameter(0, String.class);
       return performOperation(req.getId(), enodeString);
     } catch (final InvalidJsonRpcParameters e) {
       return new JsonRpcErrorResponse(req.getId(), JsonRpcError.INVALID_PARAMS);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
@@ -29,8 +28,8 @@ public class AdminRemovePeer extends AdminModifyPeer {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  public AdminRemovePeer(final P2PNetwork peerNetwork, final JsonRpcParameter parameters) {
-    super(peerNetwork, parameters);
+  public AdminRemovePeer(final P2PNetwork peerNetwork) {
+    super(peerNetwork);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountRange.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountRange.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameterOrBlockHash;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.DebugAccountRangeAtResult;
@@ -39,17 +38,13 @@ import com.google.common.base.Suppliers;
 
 public class DebugAccountRange implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final Supplier<BlockchainQueries> blockchainQueries;
 
-  public DebugAccountRange(
-      final JsonRpcParameter parameters, final BlockchainQueries blockchainQueries) {
-    this(parameters, Suppliers.ofInstance(blockchainQueries));
+  public DebugAccountRange(final BlockchainQueries blockchainQueries) {
+    this(Suppliers.ofInstance(blockchainQueries));
   }
 
-  public DebugAccountRange(
-      final JsonRpcParameter parameters, final Supplier<BlockchainQueries> blockchainQueries) {
-    this.parameters = parameters;
+  public DebugAccountRange(final Supplier<BlockchainQueries> blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }
 
@@ -62,11 +57,10 @@ public class DebugAccountRange implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Object[] params = request.getParams();
     final BlockParameterOrBlockHash blockParameterOrBlockHash =
-        parameters.required(params, 0, BlockParameterOrBlockHash.class);
-    final String addressHash = parameters.required(params, 2, String.class);
-    final int maxResults = parameters.required(params, 3, Integer.TYPE);
+        request.getRequiredParameter(0, BlockParameterOrBlockHash.class);
+    final String addressHash = request.getRequiredParameter(2, String.class);
+    final int maxResults = request.getRequiredParameter(3, Integer.TYPE);
 
     final Optional<Hash> blockHashOptional = hashFromParameter(blockParameterOrBlockHash);
     if (blockHashOptional.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAt.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameterOrBlockHash;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -42,28 +41,19 @@ import com.google.common.base.Suppliers;
 
 public class DebugStorageRangeAt implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final Supplier<BlockchainQueries> blockchainQueries;
   private final Supplier<BlockReplay> blockReplay;
   private final boolean shortValues;
 
   public DebugStorageRangeAt(
-      final JsonRpcParameter parameters,
-      final BlockchainQueries blockchainQueries,
-      final BlockReplay blockReplay) {
-    this(
-        parameters,
-        Suppliers.ofInstance(blockchainQueries),
-        Suppliers.ofInstance(blockReplay),
-        false);
+      final BlockchainQueries blockchainQueries, final BlockReplay blockReplay) {
+    this(Suppliers.ofInstance(blockchainQueries), Suppliers.ofInstance(blockReplay), false);
   }
 
   public DebugStorageRangeAt(
-      final JsonRpcParameter parameters,
       final Supplier<BlockchainQueries> blockchainQueries,
       final Supplier<BlockReplay> blockReplay,
       final boolean shortValues) {
-    this.parameters = parameters;
     this.blockchainQueries = blockchainQueries;
     this.blockReplay = blockReplay;
     this.shortValues = shortValues;
@@ -77,12 +67,11 @@ public class DebugStorageRangeAt implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
     final BlockParameterOrBlockHash blockParameterOrBlockHash =
-        parameters.required(request.getParams(), 0, BlockParameterOrBlockHash.class);
-    final int transactionIndex = parameters.required(request.getParams(), 1, Integer.class);
-    final Address accountAddress = parameters.required(request.getParams(), 2, Address.class);
-    final Hash startKey =
-        Hash.fromHexStringLenient(parameters.required(request.getParams(), 3, String.class));
-    final int limit = parameters.required(request.getParams(), 4, Integer.class);
+        request.getRequiredParameter(0, BlockParameterOrBlockHash.class);
+    final int transactionIndex = request.getRequiredParameter(1, Integer.class);
+    final Address accountAddress = request.getRequiredParameter(2, Address.class);
+    final Hash startKey = Hash.fromHexStringLenient(request.getRequiredParameter(3, String.class));
+    final int limit = request.getRequiredParameter(4, Integer.class);
 
     final Optional<Hash> blockHashOptional = hashFromParameter(blockParameterOrBlockHash);
     if (blockHashOptional.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TransactionTraceParams;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
@@ -42,17 +41,14 @@ import org.apache.logging.log4j.Logger;
 public class DebugTraceBlock implements JsonRpcMethod {
 
   private static final Logger LOG = LogManager.getLogger();
-  private final JsonRpcParameter parameters;
   private final BlockTracer blockTracer;
   private final BlockHeaderFunctions blockHeaderFunctions;
   private final BlockchainQueries blockchain;
 
   public DebugTraceBlock(
-      final JsonRpcParameter parameters,
       final BlockTracer blockTracer,
       final BlockHeaderFunctions blockHeaderFunctions,
       final BlockchainQueries blockchain) {
-    this.parameters = parameters;
     this.blockTracer = blockTracer;
     this.blockHeaderFunctions = blockHeaderFunctions;
     this.blockchain = blockchain;
@@ -65,7 +61,7 @@ public class DebugTraceBlock implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final String input = parameters.required(request.getParams(), 0, String.class);
+    final String input = request.getRequiredParameter(0, String.class);
     final Block block;
     try {
       block = Block.readFrom(RLP.input(BytesValue.fromHexString(input)), this.blockHeaderFunctions);
@@ -74,8 +70,8 @@ public class DebugTraceBlock implements JsonRpcMethod {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
     }
     final TraceOptions traceOptions =
-        parameters
-            .optional(request.getParams(), 1, TransactionTraceParams.class)
+        request
+            .getOptionalParameter(1, TransactionTraceParams.class)
             .map(TransactionTraceParams::traceOptions)
             .orElse(TraceOptions.DEFAULT);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TransactionTraceParams;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
@@ -31,11 +30,9 @@ import java.util.Collection;
 
 public class DebugTraceBlockByHash implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final BlockTracer blockTracer;
 
-  public DebugTraceBlockByHash(final JsonRpcParameter parameters, final BlockTracer blockTracer) {
-    this.parameters = parameters;
+  public DebugTraceBlockByHash(final BlockTracer blockTracer) {
     this.blockTracer = blockTracer;
   }
 
@@ -46,10 +43,10 @@ public class DebugTraceBlockByHash implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash blockHash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash blockHash = request.getRequiredParameter(0, Hash.class);
     final TraceOptions traceOptions =
-        parameters
-            .optional(request.getParams(), 1, TransactionTraceParams.class)
+        request
+            .getOptionalParameter(1, TransactionTraceParams.class)
             .map(TransactionTraceParams::traceOptions)
             .orElse(TraceOptions.DEFAULT);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TransactionTraceParams;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
@@ -34,10 +33,8 @@ public class DebugTraceBlockByNumber extends AbstractBlockParameterMethod {
   private final BlockTracer blockTracer;
 
   public DebugTraceBlockByNumber(
-      final JsonRpcParameter parameters,
-      final BlockTracer blockTracer,
-      final BlockchainQueries blockchain) {
-    super(blockchain, parameters);
+      final BlockTracer blockTracer, final BlockchainQueries blockchain) {
+    super(blockchain);
     this.blockTracer = blockTracer;
   }
 
@@ -48,15 +45,15 @@ public class DebugTraceBlockByNumber extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override
   protected Object resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
     final Optional<Hash> blockHash = getBlockchainQueries().getBlockHashByNumber(blockNumber);
     final TraceOptions traceOptions =
-        getParameters()
-            .optional(request.getParams(), 1, TransactionTraceParams.class)
+        request
+            .getOptionalParameter(1, TransactionTraceParams.class)
             .map(TransactionTraceParams::traceOptions)
             .orElse(TraceOptions.DEFAULT);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransaction.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TransactionTraceParams;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -32,17 +31,13 @@ import java.util.Optional;
 
 public class DebugTraceTransaction implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final TransactionTracer transactionTracer;
   private final BlockchainQueries blockchain;
 
   public DebugTraceTransaction(
-      final BlockchainQueries blockchain,
-      final TransactionTracer transactionTracer,
-      final JsonRpcParameter parameters) {
+      final BlockchainQueries blockchain, final TransactionTracer transactionTracer) {
     this.blockchain = blockchain;
     this.transactionTracer = transactionTracer;
-    this.parameters = parameters;
   }
 
   @Override
@@ -52,13 +47,13 @@ public class DebugTraceTransaction implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final Optional<TransactionWithMetadata> transactionWithMetadata =
         blockchain.transactionByHash(hash);
     if (transactionWithMetadata.isPresent()) {
       final TraceOptions traceOptions =
-          parameters
-              .optional(request.getParams(), 1, TransactionTraceParams.class)
+          request
+              .getOptionalParameter(1, TransactionTraceParams.class)
               .map(TransactionTraceParams::traceOptions)
               .orElse(TraceOptions.DEFAULT);
       final DebugTraceTransactionResult debugTraceTransactionResult =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -33,10 +32,8 @@ public class EthCall extends AbstractBlockParameterMethod {
   private final TransactionSimulator transactionSimulator;
 
   public EthCall(
-      final BlockchainQueries blockchainQueries,
-      final TransactionSimulator transactionSimulator,
-      final JsonRpcParameter parameters) {
-    super(blockchainQueries, parameters);
+      final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
+    super(blockchainQueries);
     this.transactionSimulator = transactionSimulator;
   }
 
@@ -47,7 +44,7 @@ public class EthCall extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 1, BlockParameter.class);
+    return request.getRequiredParameter(1, BlockParameter.class);
   }
 
   @Override
@@ -81,8 +78,7 @@ public class EthCall extends AbstractBlockParameterMethod {
   }
 
   private CallParameter validateAndGetCallParams(final JsonRpcRequest request) {
-    final JsonCallParameter callParams =
-        getParameters().required(request.getParams(), 0, JsonCallParameter.class);
+    final JsonCallParameter callParams = request.getRequiredParameter(0, JsonCallParameter.class);
     if (callParams.getTo() == null) {
       throw new InvalidJsonRpcParameters("Missing \"to\" field in call arguments");
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -35,15 +34,11 @@ public class EthEstimateGas implements JsonRpcMethod {
 
   private final BlockchainQueries blockchainQueries;
   private final TransactionSimulator transactionSimulator;
-  private final JsonRpcParameter parameters;
 
   public EthEstimateGas(
-      final BlockchainQueries blockchainQueries,
-      final TransactionSimulator transactionSimulator,
-      final JsonRpcParameter parameters) {
+      final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     this.blockchainQueries = blockchainQueries;
     this.transactionSimulator = transactionSimulator;
-    this.parameters = parameters;
   }
 
   @Override
@@ -53,8 +48,7 @@ public class EthEstimateGas implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final JsonCallParameter callParams =
-        parameters.required(request.getParams(), 0, JsonCallParameter.class);
+    final JsonCallParameter callParams = request.getRequiredParameter(0, JsonCallParameter.class);
 
     final BlockHeader blockHeader = blockHeader();
     if (blockHeader == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBalance.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBalance.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -28,13 +27,12 @@ import com.google.common.base.Suppliers;
 
 public class EthGetBalance extends AbstractBlockParameterMethod {
 
-  public EthGetBalance(final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    this(Suppliers.ofInstance(blockchain), parameters);
+  public EthGetBalance(final BlockchainQueries blockchain) {
+    this(Suppliers.ofInstance(blockchain));
   }
 
-  public EthGetBalance(
-      final Supplier<BlockchainQueries> blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetBalance(final Supplier<BlockchainQueries> blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -44,12 +42,12 @@ public class EthGetBalance extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 1, BlockParameter.class);
+    return request.getRequiredParameter(1, BlockParameter.class);
   }
 
   @Override
   protected String resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final Address address = getParameters().required(request.getParams(), 0, Address.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
     return getBlockchainQueries()
         .accountBalance(address, blockNumber)
         .map(Quantity::create)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
@@ -28,15 +27,11 @@ public class EthGetBlockByHash implements JsonRpcMethod {
 
   private final BlockResultFactory blockResult;
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
   public EthGetBlockByHash(
-      final BlockchainQueries blockchain,
-      final BlockResultFactory blockResult,
-      final JsonRpcParameter parameters) {
+      final BlockchainQueries blockchain, final BlockResultFactory blockResult) {
     this.blockchain = blockchain;
     this.blockResult = blockResult;
-    this.parameters = parameters;
   }
 
   @Override
@@ -50,7 +45,7 @@ public class EthGetBlockByHash implements JsonRpcMethod {
   }
 
   private BlockResult blockResult(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
 
     if (isCompleteTransactions(request)) {
       return transactionComplete(hash);
@@ -71,6 +66,6 @@ public class EthGetBlockByHash implements JsonRpcMethod {
   }
 
   private boolean isCompleteTransactions(final JsonRpcRequest request) {
-    return parameters.required(request.getParams(), 1, Boolean.class);
+    return request.getRequiredParameter(1, Boolean.class);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -32,18 +31,15 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
   private final boolean includeCoinbase;
 
   public EthGetBlockByNumber(
-      final BlockchainQueries blockchain,
-      final BlockResultFactory blockResult,
-      final JsonRpcParameter parameters) {
-    this(Suppliers.ofInstance(blockchain), blockResult, parameters, false);
+      final BlockchainQueries blockchain, final BlockResultFactory blockResult) {
+    this(Suppliers.ofInstance(blockchain), blockResult, false);
   }
 
   public EthGetBlockByNumber(
       final Supplier<BlockchainQueries> blockchain,
       final BlockResultFactory blockResult,
-      final JsonRpcParameter parameters,
       final boolean includeCoinbase) {
-    super(blockchain, parameters);
+    super(blockchain);
     this.blockResult = blockResult;
     this.includeCoinbase = includeCoinbase;
   }
@@ -55,7 +51,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override
@@ -82,6 +78,6 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
   }
 
   private boolean isCompleteTransactions(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 1, Boolean.class);
+    return request.getRequiredParameter(1, Boolean.class);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
@@ -26,12 +25,9 @@ import org.hyperledger.besu.ethereum.core.Hash;
 public class EthGetBlockTransactionCountByHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetBlockTransactionCountByHash(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetBlockTransactionCountByHash(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -41,7 +37,7 @@ public class EthGetBlockTransactionCountByHash implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final Integer count = blockchain.getTransactionCount(hash);
 
     if (count == -1) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByNumber.java
@@ -17,15 +17,13 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 public class EthGetBlockTransactionCountByNumber extends AbstractBlockParameterMethod {
 
-  public EthGetBlockTransactionCountByNumber(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetBlockTransactionCountByNumber(final BlockchainQueries blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -35,7 +33,7 @@ public class EthGetBlockTransactionCountByNumber extends AbstractBlockParameterM
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetCode.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.util.bytes.BytesValue;
@@ -28,13 +27,12 @@ import com.google.common.base.Suppliers;
 
 public class EthGetCode extends AbstractBlockParameterMethod {
 
-  public EthGetCode(final BlockchainQueries blockchainQueries, final JsonRpcParameter parameters) {
-    super(Suppliers.ofInstance(blockchainQueries), parameters);
+  public EthGetCode(final BlockchainQueries blockchainQueries) {
+    super(Suppliers.ofInstance(blockchainQueries));
   }
 
-  public EthGetCode(
-      final Supplier<BlockchainQueries> blockchainQueries, final JsonRpcParameter parameters) {
-    super(blockchainQueries, parameters);
+  public EthGetCode(final Supplier<BlockchainQueries> blockchainQueries) {
+    super(blockchainQueries);
   }
 
   @Override
@@ -44,12 +42,12 @@ public class EthGetCode extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 1, BlockParameter.class);
+    return request.getRequiredParameter(1, BlockParameter.class);
   }
 
   @Override
   protected String resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final Address address = getParameters().required(request.getParams(), 0, Address.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
     return getBlockchainQueries()
         .getCode(address, blockNumber)
         .map(BytesValue::toString)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChanges.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChanges.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -32,11 +31,9 @@ import java.util.stream.Collectors;
 public class EthGetFilterChanges implements JsonRpcMethod {
 
   private final FilterManager filterManager;
-  private final JsonRpcParameter parameters;
 
-  public EthGetFilterChanges(final FilterManager filterManager, final JsonRpcParameter parameters) {
+  public EthGetFilterChanges(final FilterManager filterManager) {
     this.filterManager = filterManager;
-    this.parameters = parameters;
   }
 
   @Override
@@ -46,7 +43,7 @@ public class EthGetFilterChanges implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final String filterId = parameters.required(request.getParams(), 0, String.class);
+    final String filterId = request.getRequiredParameter(0, String.class);
 
     final List<Hash> blockHashes = filterManager.blockChanges(filterId);
     if (blockHashes != null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogs.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -30,11 +29,9 @@ import java.util.List;
 public class EthGetFilterLogs implements JsonRpcMethod {
 
   private final FilterManager filterManager;
-  private final JsonRpcParameter parameters;
 
-  public EthGetFilterLogs(final FilterManager filterManager, final JsonRpcParameter parameters) {
+  public EthGetFilterLogs(final FilterManager filterManager) {
     this.filterManager = filterManager;
-    this.parameters = parameters;
   }
 
   @Override
@@ -44,7 +41,7 @@ public class EthGetFilterLogs implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final String filterId = parameters.required(request.getParams(), 0, String.class);
+    final String filterId = request.getRequiredParameter(0, String.class);
 
     final List<LogWithMetadata> logs = filterManager.logs(filterId);
     if (logs != null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -29,11 +28,9 @@ import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 public class EthGetLogs implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetLogs(final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetLogs(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -43,8 +40,7 @@ public class EthGetLogs implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final FilterParameter filter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+    final FilterParameter filter = request.getRequiredParameter(0, FilterParameter.class);
     final LogsQuery query =
         new LogsQuery.Builder().addresses(filter.getAddresses()).topics(filter.getTopics()).build();
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -38,24 +37,24 @@ public class EthGetProof extends AbstractBlockParameterMethod {
 
   private final BlockchainQueries blockchain;
 
-  public EthGetProof(final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetProof(final BlockchainQueries blockchain) {
+    super(blockchain);
     this.blockchain = blockchain;
   }
 
   private Address getAddress(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, Address.class);
+    return request.getRequiredParameter(0, Address.class);
   }
 
   private List<UInt256> getStorageKeys(final JsonRpcRequest request) {
-    return Arrays.stream(getParameters().required(request.getParams(), 1, String[].class))
+    return Arrays.stream(request.getRequiredParameter(1, String[].class))
         .map(UInt256::fromHexString)
         .collect(Collectors.toList());
   }
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 2, BlockParameter.class);
+    return request.getRequiredParameter(2, BlockParameter.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UInt256Parameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -25,8 +24,8 @@ import org.hyperledger.besu.util.uint.UInt256;
 
 public class EthGetStorageAt extends AbstractBlockParameterMethod {
 
-  public EthGetStorageAt(final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetStorageAt(final BlockchainQueries blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -36,14 +35,13 @@ public class EthGetStorageAt extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 2, BlockParameter.class);
+    return request.getRequiredParameter(2, BlockParameter.class);
   }
 
   @Override
   protected String resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final Address address = getParameters().required(request.getParams(), 0, Address.class);
-    final UInt256 position =
-        getParameters().required(request.getParams(), 1, UInt256Parameter.class).getValue();
+    final Address address = request.getRequiredParameter(0, Address.class);
+    final UInt256 position = request.getRequiredParameter(1, UInt256Parameter.class).getValue();
     return getBlockchainQueries()
         .storageAt(address, position, blockNumber)
         .map(UInt256::toHexString)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndex.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedIntParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -31,12 +30,9 @@ import java.util.Optional;
 public class EthGetTransactionByBlockHashAndIndex implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetTransactionByBlockHashAndIndex(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetTransactionByBlockHashAndIndex(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -46,9 +42,8 @@ public class EthGetTransactionByBlockHashAndIndex implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
-    final int index =
-        parameters.required(request.getParams(), 1, UnsignedIntParameter.class).getValue();
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
+    final int index = request.getRequiredParameter(1, UnsignedIntParameter.class).getValue();
     final Optional<TransactionWithMetadata> transactionWithMetadata =
         blockchain.transactionByBlockHashAndIndex(hash, index);
     final TransactionResult result =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockNumberAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockNumberAndIndex.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedIntParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionCompleteResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -27,9 +26,8 @@ import java.util.Optional;
 
 public class EthGetTransactionByBlockNumberAndIndex extends AbstractBlockParameterMethod {
 
-  public EthGetTransactionByBlockNumberAndIndex(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetTransactionByBlockNumberAndIndex(final BlockchainQueries blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -39,13 +37,12 @@ public class EthGetTransactionByBlockNumberAndIndex extends AbstractBlockParamet
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override
   protected Object resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final int index =
-        getParameters().required(request.getParams(), 1, UnsignedIntParameter.class).getValue();
+    final int index = request.getRequiredParameter(1, UnsignedIntParameter.class).getValue();
     final Optional<TransactionWithMetadata> transactionWithMetadata =
         getBlockchainQueries().transactionByBlockNumberAndIndex(blockNumber, index);
     return transactionWithMetadata.map(TransactionCompleteResult::new).orElse(null);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -33,15 +32,11 @@ public class EthGetTransactionByHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
   private final PendingTransactions pendingTransactions;
-  private final JsonRpcParameter parameters;
 
   public EthGetTransactionByHash(
-      final BlockchainQueries blockchain,
-      final PendingTransactions pendingTransactions,
-      final JsonRpcParameter parameters) {
+      final BlockchainQueries blockchain, final PendingTransactions pendingTransactions) {
     this.blockchain = blockchain;
     this.pendingTransactions = pendingTransactions;
-    this.parameters = parameters;
   }
 
   @Override
@@ -54,7 +49,7 @@ public class EthGetTransactionByHash implements JsonRpcMethod {
     if (request.getParamLength() != 1) {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
     }
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final JsonRpcSuccessResponse jsonRpcSuccessResponse =
         new JsonRpcSuccessResponse(request.getId(), getResult(hash));
     return jsonRpcSuccessResponse;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -34,22 +33,15 @@ public class EthGetTransactionCount extends AbstractBlockParameterMethod {
   private final boolean resultAsDecimal;
 
   public EthGetTransactionCount(
-      final BlockchainQueries blockchain,
-      final PendingTransactions pendingTransactions,
-      final JsonRpcParameter parameters) {
-    this(
-        Suppliers.ofInstance(blockchain),
-        Suppliers.ofInstance(pendingTransactions),
-        parameters,
-        false);
+      final BlockchainQueries blockchain, final PendingTransactions pendingTransactions) {
+    this(Suppliers.ofInstance(blockchain), Suppliers.ofInstance(pendingTransactions), false);
   }
 
   public EthGetTransactionCount(
       final Supplier<BlockchainQueries> blockchain,
       final Supplier<PendingTransactions> pendingTransactions,
-      final JsonRpcParameter parameters,
       final boolean resultAsDecimal) {
-    super(blockchain, parameters);
+    super(blockchain);
     this.pendingTransactions = pendingTransactions;
     this.resultAsDecimal = resultAsDecimal;
   }
@@ -61,12 +53,12 @@ public class EthGetTransactionCount extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 1, BlockParameter.class);
+    return request.getRequiredParameter(1, BlockParameter.class);
   }
 
   @Override
   protected Object pendingResult(final JsonRpcRequest request) {
-    final Address address = getParameters().required(request.getParams(), 0, Address.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
     final OptionalLong pendingNonce = pendingTransactions.get().getNextNonceForSender(address);
     if (pendingNonce.isPresent()) {
       return Quantity.create(pendingNonce.getAsLong());
@@ -77,7 +69,7 @@ public class EthGetTransactionCount extends AbstractBlockParameterMethod {
 
   @Override
   protected String resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final Address address = getParameters().required(request.getParams(), 0, Address.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
     if (blockNumber > getBlockchainQueries().headBlockNumber()) {
       return null;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceipt.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionReceiptResult;
@@ -30,12 +29,9 @@ import org.hyperledger.besu.ethereum.mainnet.TransactionReceiptType;
 public class EthGetTransactionReceipt implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetTransactionReceipt(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetTransactionReceipt(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -45,7 +41,7 @@ public class EthGetTransactionReceipt implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final TransactionReceiptResult result =
         blockchain
             .transactionReceiptByTransactionHash(hash)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndex.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedIntParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -28,12 +27,9 @@ import org.hyperledger.besu.ethereum.core.Hash;
 public class EthGetUncleByBlockHashAndIndex implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetUncleByBlockHashAndIndex(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetUncleByBlockHashAndIndex(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -47,9 +43,8 @@ public class EthGetUncleByBlockHashAndIndex implements JsonRpcMethod {
   }
 
   private BlockResult blockResult(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
-    final int index =
-        parameters.required(request.getParams(), 1, UnsignedIntParameter.class).getValue();
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
+    final int index = request.getRequiredParameter(1, UnsignedIntParameter.class).getValue();
 
     return blockchain.getOmmer(hash, index).map(UncleBlockResult::build).orElse(null);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndex.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedIntParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.UncleBlockResult;
@@ -25,9 +24,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 public class EthGetUncleByBlockNumberAndIndex extends AbstractBlockParameterMethod {
 
-  public EthGetUncleByBlockNumberAndIndex(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetUncleByBlockNumberAndIndex(final BlockchainQueries blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -37,13 +35,12 @@ public class EthGetUncleByBlockNumberAndIndex extends AbstractBlockParameterMeth
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override
   protected BlockResult resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
-    final int index =
-        getParameters().required(request.getParams(), 1, UnsignedIntParameter.class).getValue();
+    final int index = request.getRequiredParameter(1, UnsignedIntParameter.class).getValue();
     return getBlockchainQueries()
         .getOmmer(blockNumber, index)
         .map(UncleBlockResult::build)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
@@ -26,12 +25,9 @@ import org.hyperledger.besu.ethereum.core.Hash;
 public class EthGetUncleCountByBlockHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
-  private final JsonRpcParameter parameters;
 
-  public EthGetUncleCountByBlockHash(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
+  public EthGetUncleCountByBlockHash(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
-    this.parameters = parameters;
   }
 
   @Override
@@ -41,7 +37,7 @@ public class EthGetUncleCountByBlockHash implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final String result = blockchain.getOmmerCount(hash).map(Quantity::create).orElse(null);
     return new JsonRpcSuccessResponse(request.getId(), result);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockNumber.java
@@ -17,15 +17,13 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 public class EthGetUncleCountByBlockNumber extends AbstractBlockParameterMethod {
 
-  public EthGetUncleCountByBlockNumber(
-      final BlockchainQueries blockchain, final JsonRpcParameter parameters) {
-    super(blockchain, parameters);
+  public EthGetUncleCountByBlockNumber(final BlockchainQueries blockchain) {
+    super(blockchain);
   }
 
   @Override
@@ -35,7 +33,7 @@ public class EthGetUncleCountByBlockNumber extends AbstractBlockParameterMethod 
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -26,11 +25,9 @@ import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 public class EthNewFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
-  private final JsonRpcParameter parameters;
 
-  public EthNewFilter(final FilterManager filterManager, final JsonRpcParameter parameters) {
+  public EthNewFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
-    this.parameters = parameters;
   }
 
   @Override
@@ -40,8 +37,7 @@ public class EthNewFilter implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final FilterParameter filter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+    final FilterParameter filter = request.getRequiredParameter(0, FilterParameter.class);
     final LogsQuery query =
         new LogsQuery.Builder().addresses(filter.getAddresses()).topics(filter.getTopics()).build();
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -44,19 +43,14 @@ public class EthSendRawTransaction implements JsonRpcMethod {
   private final boolean sendEmptyHashOnInvalidBlock;
 
   private final Supplier<TransactionPool> transactionPool;
-  private final JsonRpcParameter parameters;
 
-  public EthSendRawTransaction(
-      final TransactionPool transactionPool, final JsonRpcParameter parameters) {
-    this(Suppliers.ofInstance(transactionPool), parameters, false);
+  public EthSendRawTransaction(final TransactionPool transactionPool) {
+    this(Suppliers.ofInstance(transactionPool), false);
   }
 
   public EthSendRawTransaction(
-      final Supplier<TransactionPool> transactionPool,
-      final JsonRpcParameter parameters,
-      final boolean sendEmptyHashOnInvalidBlock) {
+      final Supplier<TransactionPool> transactionPool, final boolean sendEmptyHashOnInvalidBlock) {
     this.transactionPool = transactionPool;
-    this.parameters = parameters;
     this.sendEmptyHashOnInvalidBlock = sendEmptyHashOnInvalidBlock;
   }
 
@@ -70,7 +64,7 @@ public class EthSendRawTransaction implements JsonRpcMethod {
     if (request.getParamLength() != 1) {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
     }
-    final String rawTransaction = parameters.required(request.getParams(), 0, String.class);
+    final String rawTransaction = request.getRequiredParameter(0, String.class);
 
     final Transaction transaction;
     try {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWork.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWork.java
@@ -18,7 +18,6 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -36,12 +35,10 @@ import org.apache.logging.log4j.Logger;
 public class EthSubmitWork implements JsonRpcMethod {
 
   private final MiningCoordinator miner;
-  private final JsonRpcParameter parameters;
   private static final Logger LOG = getLogger();
 
-  public EthSubmitWork(final MiningCoordinator miner, final JsonRpcParameter parameters) {
+  public EthSubmitWork(final MiningCoordinator miner) {
     this.miner = miner;
-    this.parameters = parameters;
   }
 
   @Override
@@ -55,11 +52,9 @@ public class EthSubmitWork implements JsonRpcMethod {
     if (solver.isPresent()) {
       final EthHashSolution solution =
           new EthHashSolution(
-              BytesValue.fromHexString(parameters.required(req.getParams(), 0, String.class))
-                  .getLong(0),
-              parameters.required(req.getParams(), 2, Hash.class),
-              BytesValue.fromHexString(parameters.required(req.getParams(), 1, String.class))
-                  .getArrayUnsafe());
+              BytesValue.fromHexString(req.getRequiredParameter(0, String.class)).getLong(0),
+              req.getRequiredParameter(2, Hash.class),
+              BytesValue.fromHexString(req.getRequiredParameter(1, String.class)).getArrayUnsafe());
       final boolean result = miner.submitWork(solution);
       return new JsonRpcSuccessResponse(req.getId(), result);
     } else {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthUninstallFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthUninstallFilter.java
@@ -17,18 +17,15 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
 public class EthUninstallFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
-  private final JsonRpcParameter parameters;
 
-  public EthUninstallFilter(final FilterManager filterManager, final JsonRpcParameter parameters) {
+  public EthUninstallFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
-    this.parameters = parameters;
   }
 
   @Override
@@ -38,7 +35,7 @@ public class EthUninstallFilter implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final String filterId = parameters.required(request.getParams(), 0, String.class);
+    final String filterId = request.getRequiredParameter(0, String.class);
 
     return new JsonRpcSuccessResponse(request.getId(), filterManager.uninstallFilter(filterId));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TraceTypeParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
@@ -51,11 +50,10 @@ public class TraceReplayBlockTransactions extends AbstractBlockParameterMethod {
   private final ProtocolSchedule<?> protocolSchedule;
 
   public TraceReplayBlockTransactions(
-      final JsonRpcParameter parameters,
       final BlockTracer blockTracer,
       final BlockchainQueries queries,
       final ProtocolSchedule<?> protocolSchedule) {
-    super(queries, parameters);
+    super(queries);
     this.blockTracer = blockTracer;
     this.protocolSchedule = protocolSchedule;
   }
@@ -67,13 +65,13 @@ public class TraceReplayBlockTransactions extends AbstractBlockParameterMethod {
 
   @Override
   protected BlockParameter blockParameter(final JsonRpcRequest request) {
-    return getParameters().required(request.getParams(), 0, BlockParameter.class);
+    return request.getRequiredParameter(0, BlockParameter.class);
   }
 
   @Override
   protected Object resultByBlockNumber(final JsonRpcRequest request, final long blockNumber) {
     final TraceTypeParameter traceTypeParameter =
-        getParameters().required(request.getParams(), 1, TraceTypeParameter.class);
+        request.getRequiredParameter(1, TraceTypeParameter.class);
 
     // TODO : method returns an error if any option other than “trace” is supplied.
     // remove when others options are implemented

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3.java
@@ -39,7 +39,7 @@ public class Web3Sha3 implements JsonRpcMethod {
       return new JsonRpcErrorResponse(req.getId(), JsonRpcError.INVALID_PARAMS);
     }
 
-    final String data = req.getParams()[0].toString();
+    final String data = req.getRequiredParameter(0, String.class);
 
     if (!data.isEmpty() && !data.startsWith("0x")) {
       return new JsonRpcErrorResponse(req.getId(), JsonRpcError.INVALID_PARAMS);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbase.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.miner;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -28,12 +27,9 @@ import org.hyperledger.besu.ethereum.core.Address;
 public class MinerSetCoinbase implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
-  private final JsonRpcParameter parameters;
 
-  public MinerSetCoinbase(
-      final MiningCoordinator miningCoordinator, final JsonRpcParameter parameters) {
+  public MinerSetCoinbase(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
-    this.parameters = parameters;
   }
 
   @Override
@@ -44,7 +40,7 @@ public class MinerSetCoinbase implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
     try {
-      final Address coinbase = parameters.required(req.getParams(), 0, Address.class);
+      final Address coinbase = req.getRequiredParameter(0, Address.class);
       miningCoordinator.setCoinbase(coinbase);
       return new JsonRpcSuccessResponse(req.getId(), true);
     } catch (final UnsupportedOperationException ex) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -30,14 +29,11 @@ import java.util.Optional;
 
 public class PermAddAccountsToWhitelist implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final Optional<AccountLocalConfigPermissioningController> whitelistController;
 
   public PermAddAccountsToWhitelist(
-      final Optional<AccountLocalConfigPermissioningController> whitelistController,
-      final JsonRpcParameter parameters) {
+      final Optional<AccountLocalConfigPermissioningController> whitelistController) {
     this.whitelistController = whitelistController;
-    this.parameters = parameters;
   }
 
   @Override
@@ -48,7 +44,7 @@ public class PermAddAccountsToWhitelist implements JsonRpcMethod {
   @Override
   @SuppressWarnings("unchecked")
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final List<String> accountsList = parameters.required(request.getParams(), 0, List.class);
+    final List<String> accountsList = request.getRequiredParameter(0, List.class);
 
     if (whitelistController.isPresent()) {
       final WhitelistOperationResult addResult =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.StringListParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
@@ -33,13 +32,10 @@ public class PermAddNodesToWhitelist implements JsonRpcMethod {
 
   private final Optional<NodeLocalConfigPermissioningController>
       nodeWhitelistPermissioningController;
-  private final JsonRpcParameter parameters;
 
   public PermAddNodesToWhitelist(
-      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController,
-      final JsonRpcParameter parameters) {
+      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController) {
     this.nodeWhitelistPermissioningController = nodeWhitelistPermissioningController;
-    this.parameters = parameters;
   }
 
   @Override
@@ -50,7 +46,7 @@ public class PermAddNodesToWhitelist implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
     final StringListParameter enodeListParam =
-        parameters.required(req.getParams(), 0, StringListParameter.class);
+        req.getRequiredParameter(0, StringListParameter.class);
 
     try {
       if (nodeWhitelistPermissioningController.isPresent()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -30,14 +29,11 @@ import java.util.Optional;
 
 public class PermRemoveAccountsFromWhitelist implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final Optional<AccountLocalConfigPermissioningController> whitelistController;
 
   public PermRemoveAccountsFromWhitelist(
-      final Optional<AccountLocalConfigPermissioningController> whitelistController,
-      final JsonRpcParameter parameters) {
+      final Optional<AccountLocalConfigPermissioningController> whitelistController) {
     this.whitelistController = whitelistController;
-    this.parameters = parameters;
   }
 
   @Override
@@ -48,7 +44,7 @@ public class PermRemoveAccountsFromWhitelist implements JsonRpcMethod {
   @Override
   @SuppressWarnings("unchecked")
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final List<String> accountsList = parameters.required(request.getParams(), 0, List.class);
+    final List<String> accountsList = request.getRequiredParameter(0, List.class);
     if (whitelistController.isPresent()) {
       final WhitelistOperationResult removeResult =
           whitelistController.get().removeAccounts(accountsList);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.StringListParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
@@ -33,13 +32,10 @@ public class PermRemoveNodesFromWhitelist implements JsonRpcMethod {
 
   private final Optional<NodeLocalConfigPermissioningController>
       nodeWhitelistPermissioningController;
-  private final JsonRpcParameter parameters;
 
   public PermRemoveNodesFromWhitelist(
-      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController,
-      final JsonRpcParameter parameters) {
+      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController) {
     this.nodeWhitelistPermissioningController = nodeWhitelistPermissioningController;
-    this.parameters = parameters;
   }
 
   @Override
@@ -50,7 +46,7 @@ public class PermRemoveNodesFromWhitelist implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest req) {
     final StringListParameter enodeListParam =
-        parameters.required(req.getParams(), 0, StringListParameter.class);
+        req.getRequiredParameter(0, StringListParameter.class);
     try {
       if (nodeWhitelistPermissioningController.isPresent()) {
         try {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/AbstractSendTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/AbstractSendTransaction.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -37,15 +36,12 @@ public class AbstractSendTransaction {
   private static final Logger LOG = LogManager.getLogger();
 
   protected final PrivateTransactionHandler privateTransactionHandler;
-  private final JsonRpcParameter parameters;
   protected final TransactionPool transactionPool;
 
   public AbstractSendTransaction(
       final PrivateTransactionHandler privateTransactionHandler,
-      final TransactionPool transactionPool,
-      final JsonRpcParameter parameters) {
+      final TransactionPool transactionPool) {
     this.privateTransactionHandler = privateTransactionHandler;
-    this.parameters = parameters;
     this.transactionPool = transactionPool;
   }
 
@@ -55,7 +51,7 @@ public class AbstractSendTransaction {
       throw new ErrorResponseException(
           new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS));
     }
-    final String rawPrivateTransaction = parameters.required(request.getParams(), 0, String.class);
+    final String rawPrivateTransaction = request.getRequiredParameter(0, String.class);
     final PrivateTransaction privateTransaction;
     try {
       privateTransaction = decodeRawTransaction(rawPrivateTransaction);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.AbstractSendTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -33,9 +32,8 @@ public class EeaSendRawTransaction extends AbstractSendTransaction implements Js
 
   public EeaSendRawTransaction(
       final PrivateTransactionHandler privateTransactionHandler,
-      final TransactionPool transactionPool,
-      final JsonRpcParameter parameters) {
-    super(privateTransactionHandler, transactionPool, parameters);
+      final TransactionPool transactionPool) {
+    super(privateTransactionHandler, transactionPool);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.parameters.CreatePrivacyGroupParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -36,16 +35,11 @@ public class PrivCreatePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
-  private final PrivacyParameters privacyParameters;
-  private final JsonRpcParameter parameters;
+  private PrivacyParameters privacyParameters;
 
-  public PrivCreatePrivacyGroup(
-      final Enclave enclave,
-      final PrivacyParameters privacyParameters,
-      final JsonRpcParameter parameters) {
+  public PrivCreatePrivacyGroup(final Enclave enclave, final PrivacyParameters privacyParameters) {
     this.enclave = enclave;
     this.privacyParameters = privacyParameters;
-    this.parameters = parameters;
   }
 
   @Override
@@ -58,7 +52,7 @@ public class PrivCreatePrivacyGroup implements JsonRpcMethod {
     LOG.trace("Executing {}", RpcMethod.PRIV_CREATE_PRIVACY_GROUP.getMethodName());
 
     final CreatePrivacyGroupParameter parameter =
-        parameters.required(request.getParams(), 0, CreatePrivacyGroupParameter.class);
+        request.getRequiredParameter(0, CreatePrivacyGroupParameter.class);
 
     LOG.trace(
         "Creating a privacy group with name {} and description {}",

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.enclave.types.DeletePrivacyGroupRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -34,15 +33,10 @@ public class PrivDeletePrivacyGroup implements JsonRpcMethod {
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
   private PrivacyParameters privacyParameters;
-  private final JsonRpcParameter parameters;
 
-  public PrivDeletePrivacyGroup(
-      final Enclave enclave,
-      final PrivacyParameters privacyParameters,
-      final JsonRpcParameter parameters) {
+  public PrivDeletePrivacyGroup(final Enclave enclave, final PrivacyParameters privacyParameters) {
     this.enclave = enclave;
     this.privacyParameters = privacyParameters;
-    this.parameters = parameters;
   }
 
   @Override
@@ -54,7 +48,7 @@ public class PrivDeletePrivacyGroup implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequest request) {
     LOG.trace("Executing {}", RpcMethod.PRIV_DELETE_PRIVACY_GROUP.getMethodName());
 
-    final String privacyGroupId = parameters.required(request.getParams(), 0, String.class);
+    final String privacyGroupId = request.getRequiredParameter(0, String.class);
 
     LOG.trace(
         "Deleting a privacy group with privacyGroupId {} and from {}",

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.AbstractSendTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -32,9 +31,8 @@ public class PrivDistributeRawTransaction extends AbstractSendTransaction implem
 
   public PrivDistributeRawTransaction(
       final PrivateTransactionHandler privateTransactionHandler,
-      final TransactionPool transactionPool,
-      final JsonRpcParameter parameters) {
-    super(privateTransactionHandler, transactionPool, parameters);
+      final TransactionPool transactionPool) {
+    super(privateTransactionHandler, transactionPool);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -35,11 +34,9 @@ public class PrivFindPrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
-  private final JsonRpcParameter parameters;
 
-  public PrivFindPrivacyGroup(final Enclave enclave, final JsonRpcParameter parameters) {
+  public PrivFindPrivacyGroup(final Enclave enclave) {
     this.enclave = enclave;
-    this.parameters = parameters;
   }
 
   @Override
@@ -51,7 +48,7 @@ public class PrivFindPrivacyGroup implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequest request) {
     LOG.trace("Executing {}", RpcMethod.PRIV_FIND_PRIVACY_GROUP.getMethodName());
 
-    final String[] addresses = parameters.required(request.getParams(), 0, String[].class);
+    final String[] addresses = request.getRequiredParameter(0, String[].class);
 
     LOG.trace("Finding a privacy group with members {}", Arrays.toString(addresses));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
@@ -19,7 +19,6 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -33,12 +32,9 @@ public class PrivGetEeaTransactionCount implements JsonRpcMethod {
 
   private static final Logger LOG = getLogger();
 
-  private final JsonRpcParameter parameters;
   private final PrivateEeaNonceProvider nonceProvider;
 
-  public PrivGetEeaTransactionCount(
-      final JsonRpcParameter parameters, final PrivateEeaNonceProvider nonceProvider) {
-    this.parameters = parameters;
+  public PrivGetEeaTransactionCount(final PrivateEeaNonceProvider nonceProvider) {
     this.nonceProvider = nonceProvider;
   }
 
@@ -53,9 +49,9 @@ public class PrivGetEeaTransactionCount implements JsonRpcMethod {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
     }
 
-    final Address address = parameters.required(request.getParams(), 0, Address.class);
-    final String privateFrom = parameters.required(request.getParams(), 1, String.class);
-    final String[] privateFor = parameters.required(request.getParams(), 2, String[].class);
+    final Address address = request.getRequiredParameter(0, Address.class);
+    final String privateFrom = request.getRequiredParameter(1, String.class);
+    final String[] privateFor = request.getRequiredParameter(2, String[].class);
 
     try {
       final long nonce = nonceProvider.determineNonce(privateFrom, privateFor, address);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionGroupResult;
@@ -43,17 +42,14 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
   private final Enclave enclave;
-  private final JsonRpcParameter parameters;
   private final PrivacyParameters privacyParameters;
 
   public PrivGetPrivateTransaction(
       final BlockchainQueries blockchain,
       final Enclave enclave,
-      final JsonRpcParameter parameters,
       final PrivacyParameters privacyParameters) {
     this.blockchain = blockchain;
     this.enclave = enclave;
-    this.parameters = parameters;
     this.privacyParameters = privacyParameters;
   }
 
@@ -66,7 +62,7 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequest request) {
     LOG.trace("Executing {}", RpcMethod.PRIV_GET_PRIVATE_TRANSACTION.getMethodName());
 
-    final Hash hash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash hash = request.getRequiredParameter(0, Hash.class);
     final TransactionWithMetadata resultTransaction =
         blockchain.transactionByHash(hash).orElse(null);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -28,13 +27,9 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 
 public class PrivGetTransactionCount implements JsonRpcMethod {
 
-  private final JsonRpcParameter parameters;
   private final PrivateTransactionHandler privateTransactionHandler;
 
-  public PrivGetTransactionCount(
-      final JsonRpcParameter parameters,
-      final PrivateTransactionHandler privateTransactionHandler) {
-    this.parameters = parameters;
+  public PrivGetTransactionCount(final PrivateTransactionHandler privateTransactionHandler) {
     this.privateTransactionHandler = privateTransactionHandler;
   }
 
@@ -49,8 +44,8 @@ public class PrivGetTransactionCount implements JsonRpcMethod {
       return new JsonRpcErrorResponse(request.getId(), JsonRpcError.INVALID_PARAMS);
     }
 
-    final Address address = parameters.required(request.getParams(), 0, Address.class);
-    final String privacyGroupId = parameters.required(request.getParams(), 1, String.class);
+    final Address address = request.getRequiredParameter(0, Address.class);
+    final String privacyGroupId = request.getRequiredParameter(1, String.class);
 
     final long nonce = privateTransactionHandler.getSenderNonce(address, privacyGroupId);
     return new JsonRpcSuccessResponse(request.getId(), Quantity.create(nonce));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -56,17 +55,14 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
   private final Enclave enclave;
-  private final JsonRpcParameter parameters;
   private final PrivacyParameters privacyParameters;
 
   public PrivGetTransactionReceipt(
       final BlockchainQueries blockchain,
       final Enclave enclave,
-      final JsonRpcParameter parameters,
       final PrivacyParameters privacyParameters) {
     this.blockchain = blockchain;
     this.enclave = enclave;
-    this.parameters = parameters;
     this.privacyParameters = privacyParameters;
   }
 
@@ -78,7 +74,7 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
     LOG.trace("Executing {}", RpcMethod.PRIV_GET_TRANSACTION_RECEIPT.getMethodName());
-    final Hash transactionHash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash transactionHash = request.getRequiredParameter(0, Hash.class);
     final Optional<TransactionLocation> maybeLocation =
         blockchain.getBlockchain().getTransactionLocation(transactionHash);
     if (!maybeLocation.isPresent()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AdminNodeInfo;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AdminPeers;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AdminRemovePeer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 
@@ -32,7 +31,6 @@ import java.util.Map;
 
 public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final String clientVersion;
   private final BigInteger networkId;
   private final GenesisConfigOptions genesisConfigOptions;
@@ -60,11 +58,11 @@ public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create() {
     return mapOf(
-        new AdminAddPeer(p2pNetwork, parameter),
-        new AdminRemovePeer(p2pNetwork, parameter),
+        new AdminAddPeer(p2pNetwork),
+        new AdminRemovePeer(p2pNetwork),
         new AdminNodeInfo(
             clientVersion, networkId, genesisConfigOptions, p2pNetwork, blockchainQueries),
         new AdminPeers(p2pNetwork),
-        new AdminChangeLogLevel(parameter));
+        new AdminChangeLogLevel());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceBloc
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceBlockByNumber;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugTraceTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTracer;
@@ -37,7 +36,6 @@ import java.util.Map;
 
 public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final BlockchainQueries blockchainQueries;
   private final ProtocolSchedule<?> protocolSchedule;
   private final ObservableMetricsSystem metricsSystem;
@@ -65,16 +63,15 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
             blockchainQueries.getWorldStateArchive());
 
     return mapOf(
-        new DebugTraceTransaction(blockchainQueries, new TransactionTracer(blockReplay), parameter),
-        new DebugAccountRange(parameter, blockchainQueries),
-        new DebugStorageRangeAt(parameter, blockchainQueries, blockReplay),
+        new DebugTraceTransaction(blockchainQueries, new TransactionTracer(blockReplay)),
+        new DebugAccountRange(blockchainQueries),
+        new DebugStorageRangeAt(blockchainQueries, blockReplay),
         new DebugMetrics(metricsSystem),
         new DebugTraceBlock(
-            parameter,
             new BlockTracer(blockReplay),
             ScheduleBasedBlockHeaderFunctions.create(protocolSchedule),
             blockchainQueries),
-        new DebugTraceBlockByNumber(parameter, new BlockTracer(blockReplay), blockchainQueries),
-        new DebugTraceBlockByHash(parameter, new BlockTracer(blockReplay)));
+        new DebugTraceBlockByNumber(new BlockTracer(blockReplay), blockchainQueries),
+        new DebugTraceBlockByHash(new BlockTracer(blockReplay)));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.eea.EeaSendRawTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivGetEeaTransactionCount;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivateEeaNonceProvider;
@@ -31,8 +30,6 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 import java.util.Map;
 
 public class EeaJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
-
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
 
   public EeaJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
@@ -51,8 +48,8 @@ public class EeaJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create(
       final PrivateTransactionHandler privateTransactionHandler, final Enclave enclave) {
     return mapOf(
-        new EeaSendRawTransaction(privateTransactionHandler, getTransactionPool(), parameter),
+        new EeaSendRawTransaction(privateTransactionHandler, getTransactionPool()),
         new PrivGetEeaTransactionCount(
-            parameter, new PrivateEeaNonceProvider(enclave, privateTransactionHandler)));
+            new PrivateEeaNonceProvider(enclave, privateTransactionHandler)));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -57,7 +57,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthSubmitWork;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthSyncing;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthUninstallFilter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -73,7 +72,6 @@ import java.util.Set;
 public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockResultFactory blockResult = new BlockResultFactory();
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
 
   private final BlockchainQueries blockchainQueries;
   private final Synchronizer synchronizer;
@@ -110,55 +108,51 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
     return mapOf(
         new EthAccounts(),
         new EthBlockNumber(blockchainQueries),
-        new EthGetBalance(blockchainQueries, parameter),
-        new EthGetBlockByHash(blockchainQueries, blockResult, parameter),
-        new EthGetBlockByNumber(blockchainQueries, blockResult, parameter),
-        new EthGetBlockTransactionCountByNumber(blockchainQueries, parameter),
-        new EthGetBlockTransactionCountByHash(blockchainQueries, parameter),
+        new EthGetBalance(blockchainQueries),
+        new EthGetBlockByHash(blockchainQueries, blockResult),
+        new EthGetBlockByNumber(blockchainQueries, blockResult),
+        new EthGetBlockTransactionCountByNumber(blockchainQueries),
+        new EthGetBlockTransactionCountByHash(blockchainQueries),
         new EthCall(
             blockchainQueries,
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule),
-            parameter),
-        new EthGetCode(blockchainQueries, parameter),
-        new EthGetLogs(blockchainQueries, parameter),
-        new EthGetProof(blockchainQueries, parameter),
-        new EthGetUncleCountByBlockHash(blockchainQueries, parameter),
-        new EthGetUncleCountByBlockNumber(blockchainQueries, parameter),
-        new EthGetUncleByBlockNumberAndIndex(blockchainQueries, parameter),
-        new EthGetUncleByBlockHashAndIndex(blockchainQueries, parameter),
+                protocolSchedule)),
+        new EthGetCode(blockchainQueries),
+        new EthGetLogs(blockchainQueries),
+        new EthGetProof(blockchainQueries),
+        new EthGetUncleCountByBlockHash(blockchainQueries),
+        new EthGetUncleCountByBlockNumber(blockchainQueries),
+        new EthGetUncleByBlockNumberAndIndex(blockchainQueries),
+        new EthGetUncleByBlockHashAndIndex(blockchainQueries),
         new EthNewBlockFilter(filterManager),
         new EthNewPendingTransactionFilter(filterManager),
-        new EthNewFilter(filterManager, parameter),
-        new EthGetTransactionByHash(
-            blockchainQueries, transactionPool.getPendingTransactions(), parameter),
-        new EthGetTransactionByBlockHashAndIndex(blockchainQueries, parameter),
-        new EthGetTransactionByBlockNumberAndIndex(blockchainQueries, parameter),
-        new EthGetTransactionCount(
-            blockchainQueries, transactionPool.getPendingTransactions(), parameter),
-        new EthGetTransactionReceipt(blockchainQueries, parameter),
-        new EthUninstallFilter(filterManager, parameter),
-        new EthGetFilterChanges(filterManager, parameter),
-        new EthGetFilterLogs(filterManager, parameter),
+        new EthNewFilter(filterManager),
+        new EthGetTransactionByHash(blockchainQueries, transactionPool.getPendingTransactions()),
+        new EthGetTransactionByBlockHashAndIndex(blockchainQueries),
+        new EthGetTransactionByBlockNumberAndIndex(blockchainQueries),
+        new EthGetTransactionCount(blockchainQueries, transactionPool.getPendingTransactions()),
+        new EthGetTransactionReceipt(blockchainQueries),
+        new EthUninstallFilter(filterManager),
+        new EthGetFilterChanges(filterManager),
+        new EthGetFilterLogs(filterManager),
         new EthSyncing(synchronizer),
-        new EthGetStorageAt(blockchainQueries, parameter),
-        new EthSendRawTransaction(transactionPool, parameter),
+        new EthGetStorageAt(blockchainQueries),
+        new EthSendRawTransaction(transactionPool),
         new EthSendTransaction(),
         new EthEstimateGas(
             blockchainQueries,
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule),
-            parameter),
+                protocolSchedule)),
         new EthMining(miningCoordinator),
         new EthCoinbase(miningCoordinator),
         new EthProtocolVersion(supportedCapabilities),
         new EthGasPrice(miningCoordinator),
         new EthGetWork(miningCoordinator),
-        new EthSubmitWork(miningCoordinator, parameter),
+        new EthSubmitWork(miningCoordinator),
         new EthHashrate(miningCoordinator),
         new EthChainId(protocolSchedule.getChainId()));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/MinerJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/MinerJsonRpcMethods.java
@@ -21,14 +21,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.miner.MinerSet
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.miner.MinerSetEtherbase;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.miner.MinerStart;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.miner.MinerStop;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
 import java.util.Map;
 
 public class MinerJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final MiningCoordinator miningCoordinator;
 
   public MinerJsonRpcMethods(final MiningCoordinator miningCoordinator) {
@@ -42,7 +40,7 @@ public class MinerJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   @Override
   protected Map<String, JsonRpcMethod> create() {
-    final MinerSetCoinbase minerSetCoinbase = new MinerSetCoinbase(miningCoordinator, parameter);
+    final MinerSetCoinbase minerSetCoinbase = new MinerSetCoinbase(miningCoordinator);
     return mapOf(
         new MinerStart(miningCoordinator),
         new MinerStop(miningCoordinator),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethods.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermReloadPermissionsFromFile;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveAccountsFromWhitelist;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveNodesFromWhitelist;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 
@@ -33,7 +32,6 @@ import java.util.Optional;
 
 public class PermJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final Optional<AccountLocalConfigPermissioningController> accountsWhitelistController;
   private final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController;
 
@@ -52,12 +50,12 @@ public class PermJsonRpcMethods extends ApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create() {
     return mapOf(
-        new PermAddNodesToWhitelist(nodeWhitelistController, parameter),
-        new PermRemoveNodesFromWhitelist(nodeWhitelistController, parameter),
+        new PermAddNodesToWhitelist(nodeWhitelistController),
+        new PermRemoveNodesFromWhitelist(nodeWhitelistController),
         new PermGetNodesWhitelist(nodeWhitelistController),
         new PermGetAccountsWhitelist(accountsWhitelistController),
-        new PermAddAccountsToWhitelist(accountsWhitelistController, parameter),
-        new PermRemoveAccountsFromWhitelist(accountsWhitelistController, parameter),
+        new PermAddAccountsToWhitelist(accountsWhitelistController),
+        new PermRemoveAccountsFromWhitelist(accountsWhitelistController),
         new PermReloadPermissionsFromFile(accountsWhitelistController, nodeWhitelistController));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivCreatePrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivDeletePrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivDistributeRawTransaction;
@@ -37,8 +36,6 @@ import java.util.Map;
 
 public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
-
   public PrivJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule<?> protocolSchedule,
@@ -56,18 +53,15 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create(
       final PrivateTransactionHandler privateTransactionHandler, final Enclave enclave) {
     return mapOf(
-        new PrivGetTransactionReceipt(
-            getBlockchainQueries(), enclave, parameter, getPrivacyParameters()),
+        new PrivGetTransactionReceipt(getBlockchainQueries(), enclave, getPrivacyParameters()),
         new PrivCreatePrivacyGroup(
-            new Enclave(getPrivacyParameters().getEnclaveUri()), getPrivacyParameters(), parameter),
+            new Enclave(getPrivacyParameters().getEnclaveUri()), getPrivacyParameters()),
         new PrivDeletePrivacyGroup(
-            new Enclave(getPrivacyParameters().getEnclaveUri()), getPrivacyParameters(), parameter),
-        new PrivFindPrivacyGroup(new Enclave(getPrivacyParameters().getEnclaveUri()), parameter),
+            new Enclave(getPrivacyParameters().getEnclaveUri()), getPrivacyParameters()),
+        new PrivFindPrivacyGroup(new Enclave(getPrivacyParameters().getEnclaveUri())),
         new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
-        new PrivGetTransactionCount(parameter, privateTransactionHandler),
-        new PrivGetPrivateTransaction(
-            getBlockchainQueries(), enclave, parameter, getPrivacyParameters()),
-        new PrivDistributeRawTransaction(
-            privateTransactionHandler, getTransactionPool(), parameter));
+        new PrivGetTransactionCount(privateTransactionHandler),
+        new PrivGetPrivateTransaction(getBlockchainQueries(), enclave, getPrivacyParameters()),
+        new PrivDistributeRawTransaction(privateTransactionHandler, getTransactionPool()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceReplayBlockTransactions;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -27,7 +26,6 @@ import java.util.Map;
 
 public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
   private final BlockchainQueries blockchainQueries;
   private final ProtocolSchedule<?> protocolSchedule;
 
@@ -48,7 +46,6 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create() {
     return mapOf(
         new TraceReplayBlockTransactions(
-            parameter,
             new BlockTracer(
                 new BlockReplay(
                     protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactory.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionRequestMapper;
 
@@ -26,7 +25,6 @@ public class WebSocketMethodsFactory {
 
   private final SubscriptionManager subscriptionManager;
   private final Map<String, JsonRpcMethod> jsonRpcMethods;
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
 
   public WebSocketMethodsFactory(
       final SubscriptionManager subscriptionManager,
@@ -40,8 +38,8 @@ public class WebSocketMethodsFactory {
     websocketMethods.putAll(jsonRpcMethods);
     addMethods(
         websocketMethods,
-        new EthSubscribe(subscriptionManager, new SubscriptionRequestMapper(parameter)),
-        new EthUnsubscribe(subscriptionManager, new SubscriptionRequestMapper(parameter)));
+        new EthSubscribe(subscriptionManager, new SubscriptionRequestMapper()),
+        new EthUnsubscribe(subscriptionManager, new SubscriptionRequestMapper()));
     return websocketMethods;
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcRequest;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -24,11 +23,7 @@ import java.util.Optional;
 
 public class SubscriptionRequestMapper {
 
-  private final JsonRpcParameter parameter;
-
-  public SubscriptionRequestMapper(final JsonRpcParameter parameter) {
-    this.parameter = parameter;
-  }
+  public SubscriptionRequestMapper() {}
 
   public SubscribeRequest mapSubscribeRequest(final JsonRpcRequest jsonRpcRequest)
       throws InvalidSubscriptionRequestException {
@@ -36,7 +31,7 @@ public class SubscriptionRequestMapper {
       final WebSocketRpcRequest webSocketRpcRequest = validateRequest(jsonRpcRequest);
 
       final SubscriptionType subscriptionType =
-          parameter.required(webSocketRpcRequest.getParams(), 0, SubscriptionType.class);
+          webSocketRpcRequest.getRequiredParameter(0, SubscriptionType.class);
       switch (subscriptionType) {
         case NEW_BLOCK_HEADERS:
           {
@@ -45,7 +40,7 @@ public class SubscriptionRequestMapper {
           }
         case LOGS:
           {
-            return parseLogsRequest(webSocketRpcRequest, parameter);
+            return parseLogsRequest(webSocketRpcRequest);
           }
         case NEW_PENDING_TRANSACTIONS:
         case SYNCING:
@@ -61,7 +56,7 @@ public class SubscriptionRequestMapper {
 
   private boolean includeTransactions(final WebSocketRpcRequest webSocketRpcRequest) {
     final Optional<SubscriptionParam> params =
-        parameter.optional(webSocketRpcRequest.getParams(), 1, SubscriptionParam.class);
+        webSocketRpcRequest.getOptionalParameter(1, SubscriptionParam.class);
     return params.isPresent() && params.get().includeTransaction();
   }
 
@@ -71,9 +66,8 @@ public class SubscriptionRequestMapper {
         SubscriptionType.NEW_BLOCK_HEADERS, null, includeTransactions, request.getConnectionId());
   }
 
-  private SubscribeRequest parseLogsRequest(
-      final WebSocketRpcRequest request, final JsonRpcParameter parameter) {
-    final LogsQuery logsQuery = parameter.required(request.getParams(), 1, LogsQuery.class);
+  private SubscribeRequest parseLogsRequest(final WebSocketRpcRequest request) {
+    final LogsQuery logsQuery = request.getRequiredParameter(1, LogsQuery.class);
     return new SubscribeRequest(SubscriptionType.LOGS, logsQuery, null, request.getConnectionId());
   }
 
@@ -83,9 +77,7 @@ public class SubscriptionRequestMapper {
       final WebSocketRpcRequest webSocketRpcRequest = validateRequest(jsonRpcRequest);
 
       final long subscriptionId =
-          parameter
-              .required(webSocketRpcRequest.getParams(), 0, UnsignedLongParameter.class)
-              .getValue();
+          webSocketRpcRequest.getRequiredParameter(0, UnsignedLongParameter.class).getValue();
       return new UnsubscribeRequest(subscriptionId, webSocketRpcRequest.getConnectionId());
     } catch (final Exception e) {
       throw new InvalidSubscriptionRequestException("Error parsing subscribe request", e);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/TraceJsonRpcHttpBySpecTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceReplayBlockTransactions;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -66,10 +65,7 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
     final BlockTracer blockTracer = new BlockTracer(blockReplay);
     final TraceReplayBlockTransactions traceReplayBlockTransactions =
         new TraceReplayBlockTransactions(
-            new JsonRpcParameter(),
-            blockTracer,
-            blockchainQueries,
-            blockchainSetupUtil.getProtocolSchedule());
+            blockTracer, blockchainQueries, blockchainSetupUtil.getProtocolSchedule());
     methods.put(traceReplayBlockTransactions.getName(), traceReplayBlockTransactions);
 
     return methods;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeerTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -37,7 +36,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AdminAddPeerTest {
 
   @Mock private P2PNetwork p2pNetwork;
-  private final JsonRpcParameter parameter = new JsonRpcParameter();
 
   private AdminAddPeer method;
 
@@ -54,7 +52,7 @@ public class AdminAddPeerTest {
 
   @Before
   public void setup() {
-    method = new AdminAddPeer(p2pNetwork, parameter);
+    method = new AdminAddPeer(p2pNetwork);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -34,13 +33,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AdminChangeLogLevelTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   private AdminChangeLogLevel adminChangeLogLevel;
 
   @Before
   public void before() {
-    adminChangeLogLevel = new AdminChangeLogLevel(parameters);
+    adminChangeLogLevel = new AdminChangeLogLevel();
     Configurator.setAllLevels("", Level.INFO);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.DebugStorageRangeAtResult;
@@ -57,12 +56,11 @@ public class DebugStorageRangeAtTest {
 
   private static final int TRANSACTION_INDEX = 2;
   private static final Bytes32 START_KEY_HASH = Bytes32.fromHexString("0x22");
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final Blockchain blockchain = mock(Blockchain.class);
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final BlockReplay blockReplay = mock(BlockReplay.class);
   private final DebugStorageRangeAt debugStorageRangeAt =
-      new DebugStorageRangeAt(parameters, blockchainQueries, blockReplay);
+      new DebugStorageRangeAt(blockchainQueries, blockReplay);
   private final MutableWorldState worldState = mock(MutableWorldState.class);
   private final Account account = mock(Account.class);
   private final TransactionProcessor transactionProcessor = mock(TransactionProcessor.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
@@ -42,10 +41,9 @@ import org.junit.Test;
 
 public class DebugTraceBlockByHashTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final DebugTraceBlockByHash debugTraceBlockByHash =
-      new DebugTraceBlockByHash(parameters, blockTracer);
+      new DebugTraceBlockByHash(blockTracer);
 
   private final Hash blockHash =
       Hash.fromHexString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
@@ -45,11 +44,10 @@ import org.junit.Test;
 
 public class DebugTraceBlockByNumberTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final DebugTraceBlockByNumber debugTraceBlockByNumber =
-      new DebugTraceBlockByNumber(parameters, blockTracer, blockchain);
+      new DebugTraceBlockByNumber(blockTracer, blockchain);
 
   private final Hash blockHash =
       Hash.fromHexString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
@@ -50,12 +49,10 @@ import org.mockito.Mockito;
 
 public class DebugTraceBlockTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final DebugTraceBlock debugTraceBlock =
-      new DebugTraceBlock(
-          parameters, blockTracer, new MainnetBlockHeaderFunctions(), blockchainQueries);
+      new DebugTraceBlock(blockTracer, new MainnetBlockHeaderFunctions(), blockchainQueries);
 
   @Test
   public void nameShouldBeDebugTraceBlock() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -49,11 +48,10 @@ import org.junit.Test;
 
 public class DebugTraceTransactionTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
   private final TransactionTracer transactionTracer = mock(TransactionTracer.class);
   private final DebugTraceTransaction debugTraceTransaction =
-      new DebugTraceTransaction(blockchain, transactionTracer, parameters);
+      new DebugTraceTransaction(blockchain, transactionTracer);
   private final Transaction transaction = mock(Transaction.class);
 
   private final BlockHeader blockHeader = mock(BlockHeader.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
@@ -55,7 +54,7 @@ public class EthCallTest {
 
   @Before
   public void setUp() {
-    method = new EthCall(blockchainQueries, transactionSimulator, new JsonRpcParameter());
+    method = new EthCall(blockchainQueries, transactionSimulator);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -61,7 +60,7 @@ public class EthEstimateGasTest {
     when(blockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
     when(blockHeader.getNumber()).thenReturn(1L);
 
-    method = new EthEstimateGas(blockchainQueries, transactionSimulator, new JsonRpcParameter());
+    method = new EthEstimateGas(blockchainQueries, transactionSimulator);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHashTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -39,7 +38,6 @@ public class EthGetBlockByHashTest {
 
   @Mock private BlockchainQueries blockchainQueries;
   private final BlockResultFactory blockResult = new BlockResultFactory();
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private EthGetBlockByHash method;
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_getBlockByHash";
@@ -47,7 +45,7 @@ public class EthGetBlockByHashTest {
 
   @Before
   public void setUp() {
-    method = new EthGetBlockByHash(blockchainQueries, blockResult, parameters);
+    method = new EthGetBlockByHash(blockchainQueries, blockResult);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -55,7 +54,7 @@ public class EthGetFilterChangesTest {
 
   @Before
   public void setUp() {
-    method = new EthGetFilterChanges(filterManager, new JsonRpcParameter());
+    method = new EthGetFilterChanges(filterManager);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -54,7 +53,7 @@ public class EthGetFilterLogsTest {
 
   @Before
   public void setUp() {
-    method = new EthGetFilterLogs(filterManager, new JsonRpcParameter());
+    method = new EthGetFilterLogs(filterManager);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -56,8 +55,6 @@ public class EthGetProofTest {
 
   @Mock private BlockchainQueries blockchainQueries;
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   private EthGetProof method;
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_getProof";
@@ -70,7 +67,7 @@ public class EthGetProofTest {
 
   @Before
   public void setUp() {
-    method = new EthGetProof(blockchainQueries, parameters);
+    method = new EthGetProof(blockchainQueries);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndexTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -38,7 +37,7 @@ public class EthGetTransactionByBlockHashAndIndexTest {
 
   @Test
   public void shouldReturnNullWhenBlockHashDoesNotExist() {
-    method = new EthGetTransactionByBlockHashAndIndex(blockchain, new JsonRpcParameter());
+    method = new EthGetTransactionByBlockHashAndIndex(blockchain);
     Bytes32 hash = Hash.keccak256(BytesValue.wrap("horse".getBytes(UTF_8)));
     JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request(hash, 1));
     assertThat(response.getResult()).isEqualTo(null);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCountTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCountTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -31,12 +30,11 @@ import org.junit.Test;
 
 public class EthGetTransactionCountTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
   private final PendingTransactions pendingTransactions = mock(PendingTransactions.class);
 
   private final EthGetTransactionCount ethGetTransactionCount =
-      new EthGetTransactionCount(blockchain, pendingTransactions, parameters);
+      new EthGetTransactionCount(blockchain, pendingTransactions);
   private final String pendingTransactionString = "0x00000000000000000000000000000000000000AA";
   private final Object[] pendingParams = new Object[] {pendingTransactionString, "pending"};
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionReceiptRootResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionReceiptStatusResult;
@@ -116,14 +115,12 @@ public class EthGetTransactionReceiptTest {
           false,
           null);
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   @SuppressWarnings("unchecked")
   private final ProtocolSchedule<Void> protocolSchedule = mock(ProtocolSchedule.class);
 
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
   private final EthGetTransactionReceipt ethGetTransactionReceipt =
-      new EthGetTransactionReceipt(blockchain, parameters);
+      new EthGetTransactionReceipt(blockchain);
   private final String receiptString =
       "0xcbef69eaf44af151aa66677ae4b8d8c343a09f667c873a3a6f4558fa4051fa5f";
   private final Hash receiptHash =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
@@ -62,7 +61,7 @@ public class EthGetUncleByBlockHashAndIndexTest {
 
   @Before
   public void before() {
-    this.method = new EthGetUncleByBlockHashAndIndex(blockchainQueries, new JsonRpcParameter());
+    this.method = new EthGetUncleByBlockHashAndIndex(blockchainQueries);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
@@ -61,7 +60,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
 
   @Before
   public void before() {
-    this.method = new EthGetUncleByBlockNumberAndIndex(blockchainQueries, new JsonRpcParameter());
+    this.method = new EthGetUncleByBlockNumberAndIndex(blockchainQueries);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -53,7 +52,7 @@ public class EthNewFilterTest {
 
   @Before
   public void setUp() {
-    method = new EthNewFilter(filterManager, new JsonRpcParameter());
+    method = new EthNewFilter(filterManager);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
@@ -16,12 +16,10 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -44,13 +42,11 @@ public class EthSendRawTransactionTest {
       "0xf86d0485174876e800830222e0945aae326516b4f8fe08074b7e972e40a713048d62880de0b6b3a7640000801ba05d4e7998757264daab67df2ce6f7e7a0ae36910778a406ca73898c9899a32b9ea0674700d5c3d1d27f2e6b4469957dfd1a1c49bf92383d80717afc84eb05695d5b";
   @Mock private TransactionPool transactionPool;
 
-  @Mock private JsonRpcParameter parameter;
-
   private EthSendRawTransaction method;
 
   @Before
   public void before() {
-    method = new EthSendRawTransaction(transactionPool, parameter);
+    method = new EthSendRawTransaction(transactionPool);
   }
 
   @Test
@@ -94,7 +90,6 @@ public class EthSendRawTransactionTest {
   @Test
   public void invalidTransactionRlpDecoding() {
     final String rawTransaction = "0x00";
-    when(parameter.required(any(Object[].class), anyInt(), any())).thenReturn(rawTransaction);
 
     final JsonRpcRequest request =
         new JsonRpcRequest("2.0", "eth_sendRawTransaction", new String[] {rawTransaction});
@@ -109,7 +104,6 @@ public class EthSendRawTransactionTest {
 
   @Test
   public void validTransactionIsSentToTransactionPool() {
-    when(parameter.required(any(Object[].class), anyInt(), any())).thenReturn(VALID_TRANSACTION);
     when(transactionPool.addLocalTransaction(any(Transaction.class)))
         .thenReturn(ValidationResult.valid());
 
@@ -172,7 +166,6 @@ public class EthSendRawTransactionTest {
 
   private void verifyErrorForInvalidTransaction(
       final TransactionInvalidReason transactionInvalidReason, final JsonRpcError expectedError) {
-    when(parameter.required(any(Object[].class), anyInt(), any())).thenReturn(VALID_TRANSACTION);
     when(transactionPool.addLocalTransaction(any(Transaction.class)))
         .thenReturn(ValidationResult.invalid(transactionInvalidReason));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -54,7 +53,7 @@ public class EthSubmitWorkTest {
 
   @Before
   public void setUp() {
-    method = new EthSubmitWork(miningCoordinator, new JsonRpcParameter());
+    method = new EthSubmitWork(miningCoordinator);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbaseTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbaseTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -46,7 +45,7 @@ public class MinerSetCoinbaseTest {
 
   @Before
   public void before() {
-    this.method = new MinerSetCoinbase(miningCoordinator, new JsonRpcParameter());
+    this.method = new MinerSetCoinbase(miningCoordinator);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelistTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -48,9 +47,7 @@ public class PermAddAccountsToWhitelistTest {
 
   @Before
   public void before() {
-    method =
-        new PermAddAccountsToWhitelist(
-            java.util.Optional.of(accountWhitelist), new JsonRpcParameter());
+    method = new PermAddAccountsToWhitelist(java.util.Optional.of(accountWhitelist));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelistTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -60,12 +59,9 @@ public class PermAddNodesToWhitelistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  private JsonRpcParameter params = new JsonRpcParameter();
-
   @Before
   public void setUp() {
-    method =
-        new PermAddNodesToWhitelist(Optional.of(nodeLocalConfigPermissioningController), params);
+    method = new PermAddNodesToWhitelist(Optional.of(nodeLocalConfigPermissioningController));
   }
 
   @Test
@@ -179,7 +175,7 @@ public class PermAddNodesToWhitelistTest {
 
   @Test
   public void shouldFailWhenP2pDisabled() {
-    method = new PermAddNodesToWhitelist(Optional.empty(), params);
+    method = new PermAddNodesToWhitelist(Optional.empty());
 
     final JsonRpcRequest request = buildRequest(Lists.newArrayList(enode1, enode2, enode3));
     ;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelistTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -48,9 +47,7 @@ public class PermRemoveAccountsFromWhitelistTest {
 
   @Before
   public void before() {
-    method =
-        new PermRemoveAccountsFromWhitelist(
-            java.util.Optional.of(accountWhitelist), new JsonRpcParameter());
+    method = new PermRemoveAccountsFromWhitelist(java.util.Optional.of(accountWhitelist));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelistTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -60,13 +59,9 @@ public class PermRemoveNodesFromWhitelistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  private JsonRpcParameter params = new JsonRpcParameter();
-
   @Before
   public void setUp() {
-    method =
-        new PermRemoveNodesFromWhitelist(
-            Optional.of(nodeLocalConfigPermissioningController), params);
+    method = new PermRemoveNodesFromWhitelist(Optional.of(nodeLocalConfigPermissioningController));
   }
 
   @Test
@@ -136,7 +131,7 @@ public class PermRemoveNodesFromWhitelistTest {
 
   @Test
   public void shouldFailWhenP2pDisabled() {
-    method = new PermRemoveNodesFromWhitelist(Optional.empty(), params);
+    method = new PermRemoveNodesFromWhitelist(Optional.empty());
     final JsonRpcRequest request = buildRequest(Lists.newArrayList(enode1, enode2, enode3));
     final JsonRpcResponse expectedResponse =
         new JsonRpcErrorResponse(request.getId(), JsonRpcError.NODE_WHITELIST_NOT_ENABLED);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/privacy/eea/PrivGetEeaTransactionCountTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/privacy/eea/PrivGetEeaTransactionCountTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivGetEeaTransactionCount;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivateEeaNonceProvider;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
@@ -49,8 +48,7 @@ public class PrivGetEeaTransactionCountTest {
   @Test
   public void validRequestProducesExpectedNonce() {
     final long reportedNonce = 8L;
-    final PrivGetEeaTransactionCount method =
-        new PrivGetEeaTransactionCount(new JsonRpcParameter(), nonceProvider);
+    final PrivGetEeaTransactionCount method = new PrivGetEeaTransactionCount(nonceProvider);
 
     when(nonceProvider.determineNonce(privateFrom, privateFor, address)).thenReturn(reportedNonce);
 
@@ -64,8 +62,7 @@ public class PrivGetEeaTransactionCountTest {
 
   @Test
   public void nonceProviderThrowsRuntimeExceptionProducesErrorResponse() {
-    final PrivGetEeaTransactionCount method =
-        new PrivGetEeaTransactionCount(new JsonRpcParameter(), nonceProvider);
+    final PrivGetEeaTransactionCount method = new PrivGetEeaTransactionCount(nonceProvider);
 
     when(nonceProvider.determineNonce(privateFrom, privateFor, address))
         .thenThrow(RuntimeException.class);
@@ -80,8 +77,7 @@ public class PrivGetEeaTransactionCountTest {
 
   @Test
   public void nonceProviderThrowsAnExceptionProducesErrorResponse() {
-    final PrivGetEeaTransactionCount method =
-        new PrivGetEeaTransactionCount(new JsonRpcParameter(), nonceProvider);
+    final PrivGetEeaTransactionCount method = new PrivGetEeaTransactionCount(nonceProvider);
 
     when(nonceProvider.determineNonce(privateFrom, privateFor, address))
         .thenThrow(RuntimeException.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -35,8 +35,6 @@ import org.junit.Test;
 
 public class FilterParameterTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   @Test
   public void jsonWithArrayOfAddressesShouldSerializeSuccessfully() throws Exception {
     final String jsonWithAddressArray =
@@ -45,7 +43,7 @@ public class FilterParameterTest {
     final FilterParameter expectedFilterParameter = filterParameterWithAddresses("0x0", "0x1");
 
     final FilterParameter parsedFilterParameter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+        request.getRequiredParameter(0, FilterParameter.class);
 
     assertThat(parsedFilterParameter)
         .isEqualToComparingFieldByFieldRecursively(expectedFilterParameter);
@@ -59,7 +57,7 @@ public class FilterParameterTest {
     final FilterParameter expectedFilterParameter = filterParameterWithAddresses("0x0");
 
     final FilterParameter parsedFilterParameter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+        request.getRequiredParameter(0, FilterParameter.class);
 
     assertThat(parsedFilterParameter)
         .isEqualToComparingFieldByFieldRecursively(expectedFilterParameter);
@@ -76,7 +74,7 @@ public class FilterParameterTest {
             "0x0", "0x0000000000000000000000000000000000000000000000000000000000000002");
 
     final FilterParameter parsedFilterParameter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+        request.getRequiredParameter(0, FilterParameter.class);
 
     assertThat(parsedFilterParameter)
         .isEqualToComparingFieldByFieldRecursively(expectedFilterParameter);
@@ -95,7 +93,7 @@ public class FilterParameterTest {
             "0x0000000000000000000000000000000000000000000000000000000000000003");
 
     final FilterParameter parsedFilterParameter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+        request.getRequiredParameter(0, FilterParameter.class);
 
     assertThat(parsedFilterParameter)
         .isEqualToComparingFieldByFieldRecursively(expectedFilterParameter);
@@ -115,7 +113,7 @@ public class FilterParameterTest {
             "0x0000000000000000000000000000000000000000000000000000000000000003");
 
     final FilterParameter parsedFilterParameter =
-        parameters.required(request.getParams(), 0, FilterParameter.class);
+        request.getRequiredParameter(0, FilterParameter.class);
 
     assertThat(parsedFilterParameter)
         .isEqualToComparingFieldByFieldRecursively(expectedFilterParameter);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -16,14 +16,12 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.eea;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -111,15 +109,13 @@ public class EeaSendRawTransactionTest {
 
   @Mock private TransactionPool transactionPool;
 
-  @Mock private JsonRpcParameter parameter;
-
   @Mock private EeaSendRawTransaction method;
 
   @Mock private PrivateTransactionHandler privateTxHandler;
 
   @Before
   public void before() {
-    method = new EeaSendRawTransaction(privateTxHandler, transactionPool, parameter);
+    method = new EeaSendRawTransaction(privateTxHandler, transactionPool);
   }
 
   @Test
@@ -163,7 +159,6 @@ public class EeaSendRawTransactionTest {
   @Test
   public void invalidTransactionRlpDecoding() {
     final String rawTransaction = "0x00";
-    when(parameter.required(any(Object[].class), anyInt(), any())).thenReturn(rawTransaction);
 
     final JsonRpcRequest request =
         new JsonRpcRequest("2.0", "eea_sendRawTransaction", new String[] {rawTransaction});
@@ -178,9 +173,6 @@ public class EeaSendRawTransactionTest {
 
   @Test
   public void valueNonZeroTransaction() {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALUE_NON_ZERO_TRANSACTION_RLP);
-
     final JsonRpcRequest request =
         new JsonRpcRequest(
             "2.0", "eea_sendRawTransaction", new String[] {VALUE_NON_ZERO_TRANSACTION_RLP});
@@ -195,8 +187,6 @@ public class EeaSendRawTransactionTest {
 
   @Test
   public void validTransactionIsSentToTransactionPool() throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALID_PRIVATE_TRANSACTION_RLP);
     when(privateTxHandler.sendToOrion(any(PrivateTransaction.class))).thenReturn(MOCK_ORION_KEY);
     when(privateTxHandler.getPrivacyGroup(any(String.class), any(PrivateTransaction.class)))
         .thenReturn(MOCK_PRIVACY_GROUP);
@@ -230,8 +220,6 @@ public class EeaSendRawTransactionTest {
 
   @Test
   public void validTransactionPrivacyGroupIsSentToTransactionPool() throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALID_PRIVATE_TRANSACTION_RLP_PRIVACY_GROUP);
     when(privateTxHandler.sendToOrion(any(PrivateTransaction.class))).thenReturn(MOCK_ORION_KEY);
     when(privateTxHandler.getPrivacyGroup(any(String.class), any(PrivateTransaction.class)))
         .thenReturn(MOCK_PRIVACY_GROUP);
@@ -268,9 +256,6 @@ public class EeaSendRawTransactionTest {
 
   @Test
   public void transactionPrivacyGroupNoPrivateFromReturnsError() throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(PRIVATE_TRANSACTION_RLP_PRIVACY_GROUP_NO_PRIVATE_FROM);
-
     final JsonRpcRequest request =
         new JsonRpcRequest(
             "2.0",
@@ -288,8 +273,6 @@ public class EeaSendRawTransactionTest {
 
   @Test
   public void invalidTransactionIsSentToTransactionPool() throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALID_PRIVATE_TRANSACTION_RLP);
     when(privateTxHandler.sendToOrion(any(PrivateTransaction.class)))
         .thenThrow(new IOException("enclave failed to execute"));
 
@@ -352,8 +335,7 @@ public class EeaSendRawTransactionTest {
   private void verifyErrorForInvalidTransaction(
       final TransactionInvalidReason transactionInvalidReason, final JsonRpcError expectedError)
       throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALID_PRIVATE_TRANSACTION_RLP);
+
     when(privateTxHandler.sendToOrion(any(PrivateTransaction.class))).thenReturn(MOCK_ORION_KEY);
     when(privateTxHandler.getPrivacyGroup(any(String.class), any(PrivateTransaction.class)))
         .thenReturn(MOCK_PRIVACY_GROUP);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.enclave.types.CreatePrivacyGroupRequest;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.parameters.CreatePrivacyGroupParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
@@ -46,7 +45,6 @@ public class PrivCreatePrivacyGroupTest {
   private final Enclave enclave = mock(Enclave.class);
   private final Enclave failingEnclave = mock(Enclave.class);
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
 
   @Before
   public void setUp() {
@@ -63,7 +61,7 @@ public class PrivCreatePrivacyGroupTest {
     when(privacyParameters.getEnclavePublicKey()).thenReturn(FROM);
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final CreatePrivacyGroupParameter param =
         new CreatePrivacyGroupParameter(ADDRESSES, NAME, DESCRIPTION);
@@ -89,7 +87,7 @@ public class PrivCreatePrivacyGroupTest {
     when(privacyParameters.getEnclavePublicKey()).thenReturn(FROM);
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final Object[] params =
         new Object[] {
@@ -123,7 +121,7 @@ public class PrivCreatePrivacyGroupTest {
     when(privacyParameters.getEnclavePublicKey()).thenReturn(FROM);
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final Object[] params =
         new Object[] {
@@ -157,7 +155,7 @@ public class PrivCreatePrivacyGroupTest {
     when(privacyParameters.getEnclavePublicKey()).thenReturn(FROM);
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final Object[] params =
         new Object[] {
@@ -188,7 +186,7 @@ public class PrivCreatePrivacyGroupTest {
     when(privacyParameters.getEnclavePublicKey()).thenReturn(FROM);
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final Object[] params =
         new Object[] {
@@ -216,7 +214,7 @@ public class PrivCreatePrivacyGroupTest {
   public void returnsCorrectExceptionMissingParam() {
 
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(enclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(enclave, privacyParameters);
 
     final Object[] params = new Object[] {};
 
@@ -232,7 +230,7 @@ public class PrivCreatePrivacyGroupTest {
   @Test
   public void returnsCorrectErrorEnclaveError() {
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
-        new PrivCreatePrivacyGroup(failingEnclave, privacyParameters, parameters);
+        new PrivCreatePrivacyGroup(failingEnclave, privacyParameters);
 
     final CreatePrivacyGroupParameter param =
         new CreatePrivacyGroupParameter(ADDRESSES, NAME, DESCRIPTION);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
@@ -16,12 +16,10 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -53,21 +51,17 @@ public class PrivDistributeRawTransactionTest {
 
   @Mock private TransactionPool transactionPool;
 
-  @Mock private JsonRpcParameter parameter;
-
   @Mock private PrivDistributeRawTransaction method;
 
   @Mock private PrivateTransactionHandler privateTxHandler;
 
   @Before
   public void before() {
-    method = new PrivDistributeRawTransaction(privateTxHandler, transactionPool, parameter);
+    method = new PrivDistributeRawTransaction(privateTxHandler, transactionPool);
   }
 
   @Test
   public void validTransactionHashReturnedAfterDistribute() throws Exception {
-    when(parameter.required(any(Object[].class), anyInt(), any()))
-        .thenReturn(VALID_PRIVATE_TRANSACTION_RLP_PRIVACY_GROUP);
     when(privateTxHandler.sendToOrion(any(PrivateTransaction.class))).thenReturn(MOCK_ORION_KEY);
     when(privateTxHandler.getPrivacyGroup(any(String.class), any(PrivateTransaction.class)))
         .thenReturn(MOCK_PRIVACY_GROUP);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.enclave.types.ReceiveRequest;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionGroupResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionLegacyResult;
@@ -91,7 +90,6 @@ public class PrivGetPrivateTransactionTest {
   private final String enclaveKey =
       BytesValues.fromBase64("93Ky7lXwFkMc7+ckoFgUMku5bpr9tz4zhmWmk9RlNng=").toString();
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final Enclave enclave = mock(Enclave.class);
 
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
@@ -119,7 +117,7 @@ public class PrivGetPrivateTransactionTest {
         new PrivateTransactionLegacyResult(privateTransaction);
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(blockchain, enclave, parameters, privacyParameters);
+        new PrivGetPrivateTransaction(blockchain, enclave, privacyParameters);
     final Object[] params = new Object[] {enclaveKey};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getPrivateTransaction", params);
 
@@ -152,7 +150,7 @@ public class PrivGetPrivateTransactionTest {
         new PrivateTransactionGroupResult(privateTransaction);
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(blockchain, enclave, parameters, privacyParameters);
+        new PrivGetPrivateTransaction(blockchain, enclave, privacyParameters);
 
     final Object[] params = new Object[] {enclaveKey};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getPrivateTransaction", params);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
@@ -31,7 +30,6 @@ import org.junit.Test;
 
 public class PrivGetTransactionCountTest {
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
   private final String privacyGroupId =
       BytesValues.asBase64String(BytesValue.wrap("0x123".getBytes(UTF_8)));
 
@@ -46,7 +44,7 @@ public class PrivGetTransactionCountTest {
     when(privateTransactionHandler.getSenderNonce(senderAddress, privacyGroupId)).thenReturn(NONCE);
 
     final PrivGetTransactionCount privGetTransactionCount =
-        new PrivGetTransactionCount(parameters, privateTransactionHandler);
+        new PrivGetTransactionCount(privateTransactionHandler);
 
     final Object[] params = new Object[] {senderAddress, privacyGroupId};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getTransactionCount", params);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.enclave.EnclaveException;
 import org.hyperledger.besu.enclave.types.ReceiveRequest;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionReceiptResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -125,8 +124,6 @@ public class PrivGetTransactionReceiptTest {
           0,
           0);
 
-  private final JsonRpcParameter parameters = new JsonRpcParameter();
-
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final Blockchain blockchain = mock(Blockchain.class);
   private final Enclave enclave = mock(Enclave.class);
@@ -163,7 +160,7 @@ public class PrivGetTransactionReceiptTest {
   @Test
   public void returnReceiptIfTransactionExists() {
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(blockchainQueries, enclave, parameters, privacyParameters);
+        new PrivGetTransactionReceipt(blockchainQueries, enclave, privacyParameters);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getTransactionReceipt", params);
 
@@ -181,8 +178,7 @@ public class PrivGetTransactionReceiptTest {
         .thenThrow(new EnclaveException("EnclavePayloadNotFound"));
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(
-            blockchainQueries, failingEnclave, parameters, privacyParameters);
+        new PrivGetTransactionReceipt(blockchainQueries, failingEnclave, privacyParameters);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getTransactionReceipt", params);
 
@@ -199,7 +195,7 @@ public class PrivGetTransactionReceiptTest {
     when(blockchain.getTransactionLocation(nullable(Hash.class))).thenReturn(Optional.empty());
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(blockchainQueries, enclave, parameters, privacyParameters);
+        new PrivGetTransactionReceipt(blockchainQueries, enclave, privacyParameters);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getTransactionReceipt", params);
 
@@ -214,8 +210,7 @@ public class PrivGetTransactionReceiptTest {
   @Test
   public void enclaveConnectionIssueThrowsRuntimeException() {
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(
-            blockchainQueries, failingEnclave, parameters, privacyParameters);
+        new PrivGetTransactionReceipt(blockchainQueries, failingEnclave, privacyParameters);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequest request = new JsonRpcRequest("1", "priv_getTransactionReceipt", params);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
@@ -25,7 +25,6 @@ import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcRequest;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -50,7 +49,7 @@ public class SubscriptionRequestMapperTest {
 
   @Before
   public void before() {
-    mapper = new SubscriptionRequestMapper(new JsonRpcParameter());
+    mapper = new SubscriptionRequestMapper();
   }
 
   @Test

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetTransact
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthSendRawTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Web3ClientVersion;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestGetLogHash;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestImportRawBlock;
@@ -59,34 +58,28 @@ public class RetestethService {
     vertx = Vertx.vertx();
     retestethContext = new RetestethContext();
 
-    final JsonRpcParameter parameters = new JsonRpcParameter();
     final BlockResultFactory blockResult = new BlockResultFactory();
     final Map<String, JsonRpcMethod> jsonRpcMethods =
         mapOf(
             new Web3ClientVersion(clientVersion),
             new TestSetChainParams(retestethContext),
-            new TestImportRawBlock(retestethContext, parameters),
+            new TestImportRawBlock(retestethContext),
             new EthBlockNumber(retestethContext::getBlockchainQueries, true),
-            new EthGetBlockByNumber(
-                retestethContext::getBlockchainQueries, blockResult, parameters, true),
-            new DebugAccountRange(parameters, retestethContext::getBlockchainQueries),
-            new EthGetBalance(retestethContext::getBlockchainQueries, parameters),
-            new EthGetCode(retestethContext::getBlockchainQueries, parameters),
+            new EthGetBlockByNumber(retestethContext::getBlockchainQueries, blockResult, true),
+            new DebugAccountRange(retestethContext::getBlockchainQueries),
+            new EthGetBalance(retestethContext::getBlockchainQueries),
+            new EthGetCode(retestethContext::getBlockchainQueries),
             new EthGetTransactionCount(
                 retestethContext::getBlockchainQueries,
                 retestethContext::getPendingTransactions,
-                parameters,
                 true),
             new DebugStorageRangeAt(
-                parameters,
-                retestethContext::getBlockchainQueries,
-                retestethContext::getBlockReplay,
-                true),
-            new TestModifyTimestamp(retestethContext, parameters),
-            new EthSendRawTransaction(retestethContext::getTransactionPool, parameters, true),
-            new TestMineBlocks(retestethContext, parameters),
-            new TestGetLogHash(retestethContext, parameters),
-            new TestRewindToBlock(retestethContext, parameters));
+                retestethContext::getBlockchainQueries, retestethContext::getBlockReplay, true),
+            new TestModifyTimestamp(retestethContext),
+            new EthSendRawTransaction(retestethContext::getTransactionPool, true),
+            new TestMineBlocks(retestethContext),
+            new TestGetLogHash(retestethContext),
+            new TestRewindToBlock(retestethContext));
 
     jsonRpcHttpService =
         new JsonRpcHttpService(

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestGetLogHash.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestGetLogHash.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.TransactionReceiptWithMetadata;
@@ -29,11 +28,9 @@ import java.util.Optional;
 
 public class TestGetLogHash implements JsonRpcMethod {
   private final RetestethContext context;
-  private final JsonRpcParameter parameters;
 
-  public TestGetLogHash(final RetestethContext context, final JsonRpcParameter parameters) {
+  public TestGetLogHash(final RetestethContext context) {
     this.context = context;
-    this.parameters = parameters;
   }
 
   @Override
@@ -43,7 +40,7 @@ public class TestGetLogHash implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final Hash txHash = parameters.required(request.getParams(), 0, Hash.class);
+    final Hash txHash = request.getRequiredParameter(0, Hash.class);
 
     final Optional<TransactionReceiptWithMetadata> receipt =
         context.getBlockchainQueries().transactionReceiptByTransactionHash(txHash);

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlock.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlock.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -37,11 +36,9 @@ public class TestImportRawBlock implements JsonRpcMethod {
   private static final String METHOD_NAME = "test_importRawBlock";
 
   private final RetestethContext context;
-  private final JsonRpcParameter parameters;
 
-  public TestImportRawBlock(final RetestethContext context, final JsonRpcParameter parameters) {
+  public TestImportRawBlock(final RetestethContext context) {
     this.context = context;
-    this.parameters = parameters;
   }
 
   @Override
@@ -51,7 +48,7 @@ public class TestImportRawBlock implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final String input = parameters.required(request.getParams(), 0, String.class);
+    final String input = request.getRequiredParameter(0, String.class);
     final ProtocolSpec<Void> protocolSpec = context.getProtocolSpec(context.getBlockHeight());
     final ProtocolContext<Void> protocolContext = this.context.getProtocolContext();
 

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.blockcreation.EthHashBlockCreator;
@@ -35,11 +34,9 @@ import com.google.common.base.Functions;
 
 public class TestMineBlocks implements JsonRpcMethod {
   private final RetestethContext context;
-  private final JsonRpcParameter parameters;
 
-  public TestMineBlocks(final RetestethContext context, final JsonRpcParameter parameters) {
+  public TestMineBlocks(final RetestethContext context) {
     this.context = context;
-    this.parameters = parameters;
   }
 
   @Override
@@ -49,7 +46,7 @@ public class TestMineBlocks implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    long blocksToMine = parameters.required(request.getParams(), 0, Long.class);
+    long blocksToMine = request.getRequiredParameter(0, Long.class);
     while (blocksToMine-- > 0) {
       if (!mineNewBlock()) {
         return new JsonRpcSuccessResponse(request.getId(), false);

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestModifyTimestamp.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestModifyTimestamp.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.retesteth.RetestethContext;
@@ -24,11 +23,9 @@ import org.hyperledger.besu.ethereum.retesteth.RetestethContext;
 public class TestModifyTimestamp implements JsonRpcMethod {
 
   private final RetestethContext context;
-  private final JsonRpcParameter parameters;
 
-  public TestModifyTimestamp(final RetestethContext context, final JsonRpcParameter parameters) {
+  public TestModifyTimestamp(final RetestethContext context) {
     this.context = context;
-    this.parameters = parameters;
   }
 
   @Override
@@ -38,7 +35,7 @@ public class TestModifyTimestamp implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final long epochSeconds = parameters.required(request.getParams(), 0, Long.class);
+    final long epochSeconds = request.getRequiredParameter(0, Long.class);
     context.getRetestethClock().resetTime(epochSeconds);
     return new JsonRpcSuccessResponse(request.getId(), true);
   }

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestRewindToBlock.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestRewindToBlock.java
@@ -16,18 +16,15 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.retesteth.RetestethContext;
 
 public class TestRewindToBlock implements JsonRpcMethod {
   private final RetestethContext context;
-  private final JsonRpcParameter parameters;
 
-  public TestRewindToBlock(final RetestethContext context, final JsonRpcParameter parameters) {
+  public TestRewindToBlock(final RetestethContext context) {
     this.context = context;
-    this.parameters = parameters;
   }
 
   @Override
@@ -37,7 +34,7 @@ public class TestRewindToBlock implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequest request) {
-    final long blockNumber = parameters.required(request.getParams(), 0, Long.TYPE);
+    final long blockNumber = request.getRequiredParameter(0, Long.TYPE);
 
     return new JsonRpcSuccessResponse(
         request.getId(), context.getBlockchain().rewindToBlock(blockNumber));

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.stratum;
 import static org.apache.logging.log4j.LogManager.getLogger;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.mainnet.DirectAcyclicGraphSeed;
@@ -109,14 +108,11 @@ public class Stratum1EthProxyProtocol implements StratumProtocol {
       throws IOException {
     LOG.debug("Miner submitted solution {}", req);
     boolean result = false;
-    JsonRpcParameter parameters = new JsonRpcParameter();
     final EthHashSolution solution =
         new EthHashSolution(
-            BytesValue.fromHexString(parameters.required(req.getParams(), 0, String.class))
-                .getLong(0),
-            parameters.required(req.getParams(), 2, Hash.class),
-            BytesValue.fromHexString(parameters.required(req.getParams(), 1, String.class))
-                .getArrayUnsafe());
+            BytesValue.fromHexString(req.getRequiredParameter(0, String.class)).getLong(0),
+            req.getRequiredParameter(2, Hash.class),
+            BytesValue.fromHexString(req.getRequiredParameter(1, String.class)).getArrayUnsafe());
     if (Arrays.equals(currentInput.getPrePowHash(), solution.getPowHash())) {
       result = submitCallback.apply(solution);
     }

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.stratum;
 import static org.apache.logging.log4j.LogManager.getLogger;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.mainnet.DirectAcyclicGraphSeed;
@@ -165,13 +164,11 @@ public class Stratum1Protocol implements StratumProtocol {
       throws IOException {
     LOG.debug("Miner submitted solution {}", message);
     boolean result = false;
-    JsonRpcParameter parameters = new JsonRpcParameter();
     final EthHashSolution solution =
         new EthHashSolution(
-            BytesValue.fromHexString(parameters.required(message.getParams(), 2, String.class))
-                .getLong(0),
-            Hash.fromHexString(parameters.required(message.getParams(), 4, String.class)),
-            BytesValue.fromHexString(parameters.required(message.getParams(), 3, String.class))
+            BytesValue.fromHexString(message.getRequiredParameter(2, String.class)).getLong(0),
+            Hash.fromHexString(message.getRequiredParameter(4, String.class)),
+            BytesValue.fromHexString(message.getRequiredParameter(3, String.class))
                 .getArrayUnsafe());
     if (Arrays.equals(currentInput.getPrePowHash(), solution.getPowHash())) {
       result = submitCallback.apply(solution);


### PR DESCRIPTION
The JsonRpcParameters are now "hidden" behind the JsonRpcRequest
object.

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>
