### PR TITLE
[BOUNTY-2] Explicit Configuration & General internal NAT API

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -81,6 +81,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private final Path homeDirectory;
   private final KeyPair keyPair;
   private final Properties portsProperties = new Properties();
+  private final Properties networksProperties = new Properties();
   private final Boolean p2pEnabled;
   private final NetworkingConfiguration networkingConfiguration;
   private final boolean revertReasonEnabled;
@@ -444,10 +445,10 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private void loadNetworksFile() {
     try (final FileInputStream fis =
         new FileInputStream(new File(homeDirectory.toFile(), "besu.networks"))) {
-      portsProperties.load(fis);
-      LOG.info("IP Addresses for node {}: {}", name, portsProperties);
+      networksProperties.load(fis);
+      LOG.info("IP Addresses for node {}: {}", name, networksProperties);
     } catch (final IOException e) {
-      throw new RuntimeException("Error reading Besu ports file", e);
+      throw new RuntimeException("Error reading Besu networks file", e);
     }
   }
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -416,6 +416,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   public void start(final BesuNodeRunner runner) {
     runner.startNode(this);
     loadPortsFile();
+    loadNetworksFile();
   }
 
   @Override
@@ -435,6 +436,16 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
         new FileInputStream(new File(homeDirectory.toFile(), "besu.ports"))) {
       portsProperties.load(fis);
       LOG.info("Ports for node {}: {}", name, portsProperties);
+    } catch (final IOException e) {
+      throw new RuntimeException("Error reading Besu ports file", e);
+    }
+  }
+
+  private void loadNetworksFile() {
+    try (final FileInputStream fis =
+        new FileInputStream(new File(homeDirectory.toFile(), "besu.networks"))) {
+      portsProperties.load(fis);
+      LOG.info("IP Addresses for node {}: {}", name, portsProperties);
     } catch (final IOException e) {
       throw new RuntimeException("Error reading Besu ports file", e);
     }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNodeRunner.java
@@ -40,8 +40,8 @@ public interface BesuNodeRunner {
 
   boolean isActive(String nodeName);
 
-  default void waitForPortsFile(final Path dataDir) {
-    final File file = new File(dataDir.toFile(), "besu.ports");
+  default void waitForFile(final Path dataDir, final String fileName) {
+    final File file = new File(dataDir.toFile(), fileName);
     Awaitility.waitAtMost(30, TimeUnit.SECONDS)
         .until(
             () -> {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -262,7 +262,8 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
       LOG.error("Error starting BesuNode process", e);
     }
 
-    waitForPortsFile(dataDir);
+    waitForFile(dataDir, "besu.ports");
+    waitForFile(dataDir, "besu.networks");
   }
 
   private void printOutput(final BesuNode node, final Process process) {

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -241,12 +241,12 @@ public class Runner implements AutoCloseable {
                 final String localIp = natManager.getLocalIp().orElseGet(enode::getIpAsString);
                 properties.setProperty("local-ip", localIp);
               });
-      // create besu.networks file
-      createBesuFile(
-          properties,
-          "networks",
-          "This file contains the IP Addresses (global and local) used by the running instance of Besu");
     }
+    // create besu.networks file
+    createBesuFile(
+        properties,
+        "networks",
+        "This file contains the IP Addresses (global and local) used by the running instance of Besu");
   }
 
   public Optional<Integer> getJsonRpcPort() {

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -227,26 +227,25 @@ public class Runner implements AutoCloseable {
   }
 
   private void writeBesuNetworksToFile() {
+    final Properties properties = new Properties();
     if (networkRunner.getNetwork().isP2pEnabled()) {
       networkRunner
           .getNetwork()
           .getLocalEnode()
           .ifPresent(
               enode -> {
-                final Properties properties = new Properties();
                 final String globalIp =
                     natManager.getAdvertisedIp().orElseGet(enode::getIpAsString);
                 properties.setProperty("global-ip", globalIp);
 
                 final String localIp = natManager.getLocalIp().orElseGet(enode::getIpAsString);
                 properties.setProperty("local-ip", localIp);
-
-                // create besu.networks file
-                createBesuFile(
-                    properties,
-                    "networks",
-                    "This file contains the IP Addresses (global and local) used by the running instance of Besu");
               });
+      // create besu.networks file
+      createBesuFile(
+          properties,
+          "networks",
+          "This file contains the IP Addresses (global and local) used by the running instance of Besu");
     }
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -120,6 +120,8 @@ public class RunnerBuilder {
   private String p2pListenInterface = NetworkUtility.INADDR_ANY;
   private int p2pListenPort;
   private NATMethod natMethod = NATMethod.NONE;
+  private boolean natExternalIpUsageEnabled = true;
+
   private int maxPeers;
   private boolean limitRemoteWireConnectionsEnabled = false;
   private float fractionRemoteConnectionsAllowed;
@@ -184,6 +186,11 @@ public class RunnerBuilder {
 
   public RunnerBuilder natMethod(final NATMethod natMethod) {
     this.natMethod = natMethod;
+    return this;
+  }
+
+  public RunnerBuilder natExternalIpUsageEnabled(final boolean natExternalIpUsageEnabled) {
+    this.natExternalIpUsageEnabled = natExternalIpUsageEnabled;
     return this;
   }
 
@@ -325,7 +332,7 @@ public class RunnerBuilder {
             .map(nodePerms -> PeerPermissions.combine(nodePerms, bannedNodes))
             .orElse(bannedNodes);
 
-    final NATManager natManager = new NATManager(natMethod);
+    final NATManager natManager = new NATManager(natMethod, natExternalIpUsageEnabled);
 
     NetworkBuilder inactiveNetwork = (caps) -> new NoopP2PNetwork();
     NetworkBuilder activeNetwork =

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -94,7 +94,7 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.metrics.vertx.VertxMetricsAdapterFactory;
-import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -363,7 +363,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       description =
           "Specify the NAT circumvention method to be used, possible values are ${COMPLETION-CANDIDATES}."
               + " NONE disables NAT functionality. (default: ${DEFAULT-VALUE})")
-  private final NatMethod natMethod = DEFAULT_NAT_METHOD;
+  private final NATMethod natMethod = DEFAULT_NAT_METHOD;
 
   @Option(
       names = {"--network-id"},

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -366,6 +366,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final NATMethod natMethod = DEFAULT_NAT_METHOD;
 
   @Option(
+      names = {"--nat-external-ip-usage-enabled"},
+      description = "Set to use the detected NAT external IP (default: ${DEFAULT-VALUE})")
+  private final Boolean natExternalIpUsageEnabled = true;
+
+  @Option(
       names = {"--network-id"},
       paramLabel = "<BIG INTEGER>",
       description =
@@ -929,6 +934,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         jsonRpcConfiguration,
         webSocketConfiguration,
         metricsConfiguration,
+        natMethod,
+        natExternalIpUsageEnabled,
         permissioningConfiguration,
         staticNodes);
   }
@@ -1026,6 +1033,13 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         "--sync-mode",
         !SyncMode.FAST.equals(syncMode),
         singletonList("--fast-sync-min-peers"));
+
+    CommandLineUtils.checkOptionDependencies(
+        logger,
+        commandLine,
+        "--nat-method",
+        NATMethod.NONE.equals(natMethod),
+        singletonList("--nat-external-ip-usage-enabled"));
   }
 
   private BesuCommand configure() throws Exception {
@@ -1417,6 +1431,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,
       final MetricsConfiguration metricsConfiguration,
+      final NATMethod natMethod,
+      final boolean natExternalIpUsageEnabled,
       final Optional<PermissioningConfiguration> permissioningConfiguration,
       final Collection<EnodeURL> staticNodes) {
 
@@ -1431,6 +1447,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .besuController(controller)
             .p2pEnabled(p2pEnabled)
             .natMethod(natMethod)
+            .natExternalIpUsageEnabled(natExternalIpUsageEnabled)
             .discovery(peerDiscoveryEnabled)
             .ethNetworkConfig(ethNetworkConfig)
             .p2pAdvertisedHost(p2pAdvertisedHost)

--- a/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.io.File;
@@ -61,7 +61,7 @@ public interface DefaultCommandValues {
   String MANDATORY_HOST_FORMAT_HELP = "<HOST>";
   String MANDATORY_PORT_FORMAT_HELP = "<PORT>";
   SyncMode DEFAULT_SYNC_MODE = SyncMode.FULL;
-  NatMethod DEFAULT_NAT_METHOD = NatMethod.NONE;
+  NATMethod DEFAULT_NAT_METHOD = NATMethod.NONE;
   int FAST_SYNC_MIN_PEER_COUNT = 5;
   int DEFAULT_MAX_PEERS = 25;
   float DEFAULT_FRACTION_REMOTE_WIRE_CONNECTIONS_ALLOWED =

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -59,7 +59,7 @@ import org.hyperledger.besu.ethereum.permissioning.SmartContractPermissioningCon
 import org.hyperledger.besu.ethereum.worldstate.PrunerConfiguration;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
-import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
@@ -1379,10 +1379,10 @@ public class BesuCommandTest extends CommandTestAbstract {
   public void natMethodOptionIsParsedCorrectly() {
 
     parseCommand("--nat-method", "NONE");
-    verify(mockRunnerBuilder).natMethod(eq(NatMethod.NONE));
+    verify(mockRunnerBuilder).natMethod(eq(NATMethod.NONE));
 
     parseCommand("--nat-method", "UPNP");
-    verify(mockRunnerBuilder).natMethod(eq(NatMethod.UPNP));
+    verify(mockRunnerBuilder).natMethod(eq(NATMethod.UPNP));
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
@@ -1413,7 +1413,7 @@ public class BesuCommandTest extends CommandTestAbstract {
   public void natMethodPropertyDefaultIsNone() {
     parseCommand();
 
-    verify(mockRunnerBuilder).natMethod(eq(NatMethod.NONE));
+    verify(mockRunnerBuilder).natMethod(eq(NATMethod.NONE));
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1396,7 +1396,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--nat-method': expected one of [UPNP, NONE] (case-insensitive) but was 'invalid'");
+            "Invalid value for option '--nat-method': expected one of [UPNP, DOCKER, KUBERNETES, NONE] (case-insensitive) but was 'invalid'");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -200,6 +200,7 @@ public abstract class CommandTestAbstract {
         .thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethod(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.natExternalIpUsageEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.jsonRpcConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.graphQLConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.webSocketConfiguration(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -17,6 +17,7 @@ node-private-key-file="./path/to/privateKey"
 identity="PegaSysEng"
 p2p-enabled=true
 nat-method="NONE"
+nat-external-ip-usage-enabled=false
 discovery-enabled=false
 bootnodes=[
   "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567",

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -45,6 +45,8 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.math.BigInteger;
 import java.util.HashSet;
@@ -97,6 +99,7 @@ public class JsonRpcTestMethodsFactory {
     final JsonRpcConfiguration jsonRpcConfiguration = mock(JsonRpcConfiguration.class);
     final WebSocketConfiguration webSocketConfiguration = mock(WebSocketConfiguration.class);
     final MetricsConfiguration metricsConfiguration = mock(MetricsConfiguration.class);
+    final NATManager natManager = new NATManager(NATMethod.NONE);
 
     return new JsonRpcMethodsFactory()
         .methods(
@@ -118,6 +121,7 @@ public class JsonRpcTestMethodsFactory {
             privacyParameters,
             jsonRpcConfiguration,
             webSocketConfiguration,
-            metricsConfiguration);
+            metricsConfiguration,
+            natManager);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -88,7 +88,7 @@ public class AdminNodeInfo implements JsonRpcMethod {
     response.put("enode", enode.toString());
     response.put("ip", ip);
     if (enode.isListening()) {
-      int listeningPort = getListeningPort(enode);
+      final int listeningPort = getListeningPort(enode);
       response.put("listenAddr", ip + ":" + listeningPort);
       ports.put("listener", listeningPort);
     }
@@ -120,8 +120,8 @@ public class AdminNodeInfo implements JsonRpcMethod {
     return new JsonRpcSuccessResponse(req.getId(), response);
   }
 
-  private String getIp(EnodeURL enode) {
-    Optional<NATSystem> natSystem = natManager.getNatSystem();
+  private String getIp(final EnodeURL enode) {
+    final Optional<NATSystem> natSystem = natManager.getNatSystem();
     if (natSystem.isPresent()) {
       try {
         return natSystem
@@ -136,8 +136,8 @@ public class AdminNodeInfo implements JsonRpcMethod {
     }
   }
 
-  private int getDiscoveryPort(EnodeURL enode) {
-    AtomicInteger discoveryPort = new AtomicInteger();
+  private int getDiscoveryPort(final EnodeURL enode) {
+    final AtomicInteger discoveryPort = new AtomicInteger();
     natManager
         .getNatSystem()
         .ifPresentOrElse(
@@ -150,8 +150,8 @@ public class AdminNodeInfo implements JsonRpcMethod {
     return discoveryPort.intValue();
   }
 
-  private int getListeningPort(EnodeURL enode) {
-    AtomicInteger listeningPort = new AtomicInteger();
+  private int getListeningPort(final EnodeURL enode) {
+    final AtomicInteger listeningPort = new AtomicInteger();
     natManager
         .getNatSystem()
         .ifPresentOrElse(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -122,7 +122,7 @@ public class AdminNodeInfo implements JsonRpcMethod {
 
   private String getIp(final EnodeURL enode) {
     final Optional<NATSystem> natSystem = natManager.getNatSystem();
-    if (natSystem.isPresent()) {
+    if (natSystem.isPresent() && natManager.isNatExternalIpUsageEnabled()) {
       try {
         return natSystem
             .get()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AdminRemovePee
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
+import org.hyperledger.besu.nat.core.NATManager;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -36,18 +37,21 @@ public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final GenesisConfigOptions genesisConfigOptions;
   private final P2PNetwork p2pNetwork;
   private final BlockchainQueries blockchainQueries;
+  private final NATManager natManager;
 
   public AdminJsonRpcMethods(
       final String clientVersion,
       final BigInteger networkId,
       final GenesisConfigOptions genesisConfigOptions,
       final P2PNetwork p2pNetwork,
-      final BlockchainQueries blockchainQueries) {
+      final BlockchainQueries blockchainQueries,
+      final NATManager natManager) {
     this.clientVersion = clientVersion;
     this.networkId = networkId;
     this.genesisConfigOptions = genesisConfigOptions;
     this.p2pNetwork = p2pNetwork;
     this.blockchainQueries = blockchainQueries;
+    this.natManager = natManager;
   }
 
   @Override
@@ -61,7 +65,12 @@ public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new AdminAddPeer(p2pNetwork),
         new AdminRemovePeer(p2pNetwork),
         new AdminNodeInfo(
-            clientVersion, networkId, genesisConfigOptions, p2pNetwork, blockchainQueries),
+            clientVersion,
+            networkId,
+            genesisConfigOptions,
+            p2pNetwork,
+            blockchainQueries,
+            natManager),
         new AdminPeers(p2pNetwork),
         new AdminChangeLogLevel());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
 
 import java.math.BigInteger;
 import java.util.Collection;
@@ -66,7 +67,8 @@ public class JsonRpcMethodsFactory {
       final PrivacyParameters privacyParameters,
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,
-      final MetricsConfiguration metricsConfiguration) {
+      final MetricsConfiguration metricsConfiguration,
+      final NATManager natManager) {
     final BlockchainQueries blockchainQueries =
         new BlockchainQueries(blockchain, worldStateArchive);
     return methods(
@@ -88,7 +90,8 @@ public class JsonRpcMethodsFactory {
         privacyParameters,
         jsonRpcConfiguration,
         webSocketConfiguration,
-        metricsConfiguration);
+        metricsConfiguration,
+        natManager);
   }
 
   public Map<String, JsonRpcMethod> methods(
@@ -110,7 +113,8 @@ public class JsonRpcMethodsFactory {
       final PrivacyParameters privacyParameters,
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,
-      final MetricsConfiguration metricsConfiguration) {
+      final MetricsConfiguration metricsConfiguration,
+      final NATManager natManager) {
     final Map<String, JsonRpcMethod> enabled = new HashMap<>();
 
     if (!rpcApis.isEmpty()) {
@@ -120,7 +124,12 @@ public class JsonRpcMethodsFactory {
       final List<JsonRpcMethods> availableApiGroups =
           List.of(
               new AdminJsonRpcMethods(
-                  clientVersion, networkId, genesisConfigOptions, p2pNetwork, blockchainQueries),
+                  clientVersion,
+                  networkId,
+                  genesisConfigOptions,
+                  p2pNetwork,
+                  blockchainQueries,
+                  natManager),
               new DebugJsonRpcMethods(blockchainQueries, protocolSchedule, metricsSystem),
               new EeaJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -44,6 +44,8 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.testutil.BlockTestUtil.ChainResources;
 
 import java.math.BigInteger;
@@ -158,7 +160,8 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             privacyParameters,
             config,
             mock(WebSocketConfiguration.class),
-            mock(MetricsConfiguration.class));
+            mock(MetricsConfiguration.class),
+            new NATManager(NATMethod.NONE));
   }
 
   protected void startService() throws Exception {
@@ -177,7 +180,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NATManager(NATMethod.NONE),
             methods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -18,9 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.util.HashMap;
-import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
@@ -196,7 +197,7 @@ public class JsonRpcHttpServiceCorsTest {
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NATManager(NATMethod.NONE),
             new HashMap<>(),
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostWhitelistTest.java
@@ -37,6 +37,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -112,7 +114,8 @@ public class JsonRpcHttpServiceHostWhitelistTest {
                     mock(PrivacyParameters.class),
                     mock(JsonRpcConfiguration.class),
                     mock(WebSocketConfiguration.class),
-                    mock(MetricsConfiguration.class)));
+                    mock(MetricsConfiguration.class),
+                    new NATManager(NATMethod.NONE)));
     service = createJsonRpcHttpService();
     service.start().join();
 
@@ -126,7 +129,7 @@ public class JsonRpcHttpServiceHostWhitelistTest {
         folder.newFolder().toPath(),
         jsonRpcConfig,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NATManager(NATMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -41,6 +41,8 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -143,7 +145,8 @@ public class JsonRpcHttpServiceLoginTest {
                     mock(PrivacyParameters.class),
                     mock(JsonRpcConfiguration.class),
                     mock(WebSocketConfiguration.class),
-                    mock(MetricsConfiguration.class)));
+                    mock(MetricsConfiguration.class),
+                    new NATManager(NATMethod.NONE)));
     service = createJsonRpcHttpService();
     jwtAuth = service.authenticationService.get().getJwtAuthProvider();
     service.start().join();
@@ -168,7 +171,7 @@ public class JsonRpcHttpServiceLoginTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NATManager(NATMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -255,7 +255,6 @@ public class JsonRpcHttpServiceRpcApisTest {
             .vertx(vertx)
             .config(config)
             .metricsSystem(new NoOpMetricsSystem())
-            .natManager(new NATManager(NATMethod.NONE))
             .build();
 
     p2pNetwork.start();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -44,6 +44,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -206,14 +208,15 @@ public class JsonRpcHttpServiceRpcApisTest {
                     mock(PrivacyParameters.class),
                     mock(JsonRpcConfiguration.class),
                     mock(WebSocketConfiguration.class),
-                    mock(MetricsConfiguration.class)));
+                    mock(MetricsConfiguration.class),
+                    new NATManager(NATMethod.NONE)));
     final JsonRpcHttpService jsonRpcHttpService =
         new JsonRpcHttpService(
             vertx,
             folder.newFolder().toPath(),
             config,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NATManager(NATMethod.NONE),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);
@@ -266,7 +269,8 @@ public class JsonRpcHttpServiceRpcApisTest {
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,
       final P2PNetwork p2pNetwork,
-      final MetricsConfiguration metricsConfiguration)
+      final MetricsConfiguration metricsConfiguration,
+      final NATManager natManager)
       throws Exception {
     final Set<Capability> supportedCapabilities = new HashSet<>();
     supportedCapabilities.add(EthProtocol.ETH62);
@@ -296,14 +300,15 @@ public class JsonRpcHttpServiceRpcApisTest {
                     mock(PrivacyParameters.class),
                     jsonRpcConfiguration,
                     webSocketConfiguration,
-                    metricsConfiguration));
+                    metricsConfiguration,
+                    natManager));
     final JsonRpcHttpService jsonRpcHttpService =
         new JsonRpcHttpService(
             vertx,
             folder.newFolder().toPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NATManager(NATMethod.NONE),
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
             HealthService.ALWAYS_HEALTHY);
@@ -387,6 +392,7 @@ public class JsonRpcHttpServiceRpcApisTest {
     WebSocketConfiguration webSocketConfiguration = WebSocketConfiguration.createDefault();
     P2PNetwork p2pNetwork = mock(P2PNetwork.class);
     MetricsConfiguration metricsConfiguration = MetricsConfiguration.builder().build();
+    NATManager natManager = new NATManager(NATMethod.NONE);
 
     if (enabledNetServices[netServices.indexOf("jsonrpc")]) {
       jsonRpcConfiguration = createJsonRpcConfiguration();
@@ -403,7 +409,7 @@ public class JsonRpcHttpServiceRpcApisTest {
     }
 
     return createJsonRpcHttpService(
-        jsonRpcConfiguration, webSocketConfiguration, p2pNetwork, metricsConfiguration);
+        jsonRpcConfiguration, webSocketConfiguration, p2pNetwork, metricsConfiguration, natManager);
   }
 
   @Test
@@ -414,7 +420,8 @@ public class JsonRpcHttpServiceRpcApisTest {
             JsonRpcConfiguration.createDefault(),
             WebSocketConfiguration.createDefault(),
             mock(P2PNetwork.class),
-            MetricsConfiguration.builder().build());
+            MetricsConfiguration.builder().build(),
+            new NATManager(NATMethod.NONE));
     final RequestBody body = createNetServicesRequestBody();
 
     try (final Response resp = client.newCall(buildRequest(body)).execute()) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -255,6 +255,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             .vertx(vertx)
             .config(config)
             .metricsSystem(new NoOpMetricsSystem())
+            .natManager(new NATManager(NATMethod.NONE))
             .build();
 
     p2pNetwork.start();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -55,6 +55,8 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.bytes.BytesValues;
@@ -159,7 +161,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         config,
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NATManager(NATMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);
@@ -171,7 +173,7 @@ public class JsonRpcHttpServiceTest {
         folder.newFolder().toPath(),
         createJsonRpcConfig(),
         new NoOpMetricsSystem(),
-        Optional.empty(),
+        new NATManager(NATMethod.NONE),
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
         HealthService.ALWAYS_HEALTHY);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -145,7 +145,8 @@ public class JsonRpcHttpServiceTest {
                     mock(PrivacyParameters.class),
                     mock(JsonRpcConfiguration.class),
                     mock(WebSocketConfiguration.class),
-                    mock(MetricsConfiguration.class)));
+                    mock(MetricsConfiguration.class),
+                    new NATManager(NATMethod.NONE)));
     service = createJsonRpcHttpService();
     service.start().join();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -56,6 +56,7 @@ public class AdminNodeInfoTest {
   @Mock private P2PNetwork p2pNetwork;
   @Mock private Blockchain blockchain;
   @Mock private BlockchainQueries blockchainQueries;
+  @Mock private NATManager natManager;
 
   private AdminNodeInfo method;
 
@@ -79,6 +80,10 @@ public class AdminNodeInfoTest {
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchainQueries.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(Hash.EMPTY));
     when(blockchain.getChainHead()).thenReturn(testChainHead);
+    when(natManager.isNATEnvironment()).thenReturn(true);
+    when(natManager.isNatExternalIpUsageEnabled()).thenReturn(true);
+    when(natManager.getNatSystem()).thenReturn(Optional.empty());
+    when(natManager.getNatMethod()).thenReturn(NATMethod.UPNP);
 
     method =
         new AdminNodeInfo(
@@ -87,7 +92,7 @@ public class AdminNodeInfoTest {
             genesisConfigOptions,
             p2pNetwork,
             blockchainQueries,
-            new NATManager(NATMethod.NONE));
+            natManager);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.uint.UInt256;
 
@@ -84,7 +86,8 @@ public class AdminNodeInfoTest {
             BigInteger.valueOf(2018),
             genesisConfigOptions,
             p2pNetwork,
-            blockchainQueries);
+            blockchainQueries,
+            new NATManager(NATMethod.NONE));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.nat.core.NATManager;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.uint.UInt256;
 
@@ -80,10 +79,6 @@ public class AdminNodeInfoTest {
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchainQueries.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(Hash.EMPTY));
     when(blockchain.getChainHead()).thenReturn(testChainHead);
-    when(natManager.isNATEnvironment()).thenReturn(true);
-    when(natManager.isNatExternalIpUsageEnabled()).thenReturn(true);
-    when(natManager.getNatSystem()).thenReturn(Optional.empty());
-    when(natManager.getNatMethod()).thenReturn(NATMethod.UPNP);
 
     method =
         new AdminNodeInfo(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -50,6 +50,8 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 import org.hyperledger.besu.util.bytes.BytesValue;
@@ -135,6 +137,7 @@ public class TestNode implements Closeable {
                         .keyPair(this.kp)
                         .config(networkingConfiguration)
                         .metricsSystem(new NoOpMetricsSystem())
+                        .natManager(new NATManager(NATMethod.NONE))
                         .supportedCapabilities(capabilities)
                         .build())
             .metricsSystem(new NoOpMetricsSystem())

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -50,8 +50,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.core.NATManager;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 import org.hyperledger.besu.util.bytes.BytesValue;
@@ -137,7 +135,6 @@ public class TestNode implements Closeable {
                         .keyPair(this.kp)
                         .config(networkingConfiguration)
                         .metricsSystem(new NoOpMetricsSystem())
-                        .natManager(new NATManager(NATMethod.NONE))
                         .supportedCapabilities(capabilities)
                         .build())
             .metricsSystem(new NoOpMetricsSystem())

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -25,7 +25,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.VertxTimerUtil;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.nat.core.NATManager;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.NetworkUtility;
 
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.IntSupplier;
@@ -62,7 +61,7 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Optional<UpnpNatManager> natManager,
+      final NATManager natManager,
       final MetricsSystem metricsSystem) {
     super(keyPair, config, peerPermissions, natManager, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -421,7 +421,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private MaintainedPeers maintainedPeers = new MaintainedPeers();
     private PeerPermissions peerPermissions = PeerPermissions.noop();
 
-    private NATManager natManager;
+    private NATManager natManager = new NATManager(NATMethod.NONE);
     private MetricsSystem metricsSystem;
 
     public P2PNetwork build() {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
@@ -27,6 +27,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.util.Arrays;
@@ -186,6 +188,7 @@ public class PeerDiscoveryTestHelper {
     private String advertisedHost = "127.0.0.1";
     private OptionalInt bindPort = OptionalInt.empty();
     private KeyPair keyPair = SECP256K1.KeyPair.generate();
+    private NATManager natManager = new NATManager(NATMethod.NONE);
 
     private AgentBuilder(
         final Map<BytesValue, MockPeerDiscoveryAgent> agents,
@@ -214,6 +217,11 @@ public class PeerDiscoveryTestHelper {
 
     public AgentBuilder peerPermissions(final PeerPermissions peerPermissions) {
       this.peerPermissions = peerPermissions;
+      return this;
+    }
+
+    public AgentBuilder natManager(final NATManager natManager) {
+      this.natManager = natManager;
       return this;
     }
 
@@ -252,7 +260,7 @@ public class PeerDiscoveryTestHelper {
       config.setBindPort(port);
       config.setActive(active);
 
-      return new MockPeerDiscoveryAgent(keyPair, config, peerPermissions, agents);
+      return new MockPeerDiscoveryAgent(keyPair, config, peerPermissions, agents, natManager);
     }
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController.AsyncExecutor;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
@@ -29,7 +31,6 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
@@ -43,7 +44,8 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final Map<BytesValue, MockPeerDiscoveryAgent> agentNetwork) {
-    super(keyPair, config, peerPermissions, Optional.empty(), new NoOpMetricsSystem());
+    super(
+        keyPair, config, peerPermissions, new NATManager(NATMethod.NONE), new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryControl
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.nat.core.NATManager;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetSocketAddress;
@@ -43,9 +42,9 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final KeyPair keyPair,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
-      final Map<BytesValue, MockPeerDiscoveryAgent> agentNetwork) {
-    super(
-        keyPair, config, peerPermissions, new NATManager(NATMethod.NONE), new NoOpMetricsSystem());
+      final Map<BytesValue, MockPeerDiscoveryAgent> agentNetwork,
+      final NATManager natManager) {
+    super(keyPair, config, peerPermissions, natManager, new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.Di
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.nat.core.NATManager;
 import org.hyperledger.besu.nat.core.NATSystem;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
 import org.hyperledger.besu.nat.upnp.UpnpNatSystem;
 
@@ -350,6 +351,7 @@ public final class DefaultP2PNetworkTest {
         .keyPair(keyPair)
         .maintainedPeers(maintainedPeers)
         .metricsSystem(new NoOpMetricsSystem())
+        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Capability.create("eth", 63));
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -46,7 +46,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.Di
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.nat.core.NATManager;
 import org.hyperledger.besu.nat.core.NATSystem;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
 import org.hyperledger.besu.nat.upnp.UpnpNatSystem;
 
@@ -351,7 +350,6 @@ public final class DefaultP2PNetworkTest {
         .keyPair(keyPair)
         .maintainedPeers(maintainedPeers)
         .metricsSystem(new NoOpMetricsSystem())
-        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Capability.create("eth", 63));
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
@@ -25,8 +25,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryServiceException
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.core.NATManager;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -159,7 +157,6 @@ public class NetworkingServiceLifecycleTest {
         .keyPair(keyPair)
         .config(config)
         .metricsSystem(new NoOpMetricsSystem())
-        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
@@ -25,6 +25,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryServiceException
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -157,6 +159,7 @@ public class NetworkingServiceLifecycleTest {
         .keyPair(keyPair)
         .config(config)
         .metricsSystem(new NoOpMetricsSystem())
+        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
@@ -37,8 +37,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.nat.core.NATManager;
-import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetAddress;
@@ -334,7 +332,6 @@ public class P2PNetworkTest {
         .config(config)
         .keyPair(KeyPair.generate())
         .metricsSystem(new NoOpMetricsSystem())
-        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
@@ -37,6 +37,8 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.util.bytes.BytesValue;
 
 import java.net.InetAddress;
@@ -332,6 +334,7 @@ public class P2PNetworkTest {
         .config(config)
         .keyPair(KeyPair.generate())
         .metricsSystem(new NoOpMetricsSystem())
+        .natManager(new NATManager(NATMethod.NONE))
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));
   }
 }

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -36,10 +36,11 @@ import org.hyperledger.besu.ethereum.retesteth.methods.TestModifyTimestamp;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestRewindToBlock;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestSetChainParams;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.nat.core.NATManager;
+import org.hyperledger.besu.nat.core.domain.NATMethod;
 
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
@@ -87,7 +88,7 @@ public class RetestethService {
             retestethConfiguration.getDataPath(),
             jsonRpcConfiguration,
             new NoOpMetricsSystem(),
-            Optional.empty(),
+            new NATManager(NATMethod.NONE),
             jsonRpcMethods,
             new HealthService(new LivenessCheck()),
             HealthService.ALWAYS_HEALTHY);

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNATSystem.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNATSystem.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core;
+
+import org.hyperledger.besu.nat.core.domain.NATMethod;
+import org.hyperledger.besu.nat.core.domain.NATPortMapping;
+import org.hyperledger.besu.nat.core.domain.NATServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public abstract class AbstractNATSystem implements NATSystem {
+  protected static final Logger LOG = LogManager.getLogger();
+
+  protected final NATMethod natMethod;
+  protected final AtomicBoolean started = new AtomicBoolean();
+
+  protected AbstractNATSystem(final NATMethod natMethod) {
+    this.natMethod = natMethod;
+  }
+
+  public abstract void doStart();
+
+  public abstract void doStop();
+
+  @Override
+  public NATMethod getNatMethod() {
+    return natMethod;
+  }
+
+  @Override
+  public boolean isStarted() {
+    return started.get();
+  }
+
+  @Override
+  public CompletableFuture<String> getLocalIPAddress() {
+    final CompletableFuture<String> future = new CompletableFuture<>();
+    Executors.newCachedThreadPool()
+        .submit(
+            () -> {
+              try {
+                future.complete(InetAddress.getLocalHost().getHostAddress());
+              } catch (UnknownHostException e) {
+                future.completeExceptionally(e);
+              }
+            });
+    return future;
+  }
+
+  @Override
+  public void start() {
+    if (started.compareAndSet(false, true)) {
+      doStart();
+    } else {
+      LOG.warn("Attempt to start an already-started {}", getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void stop() {
+    if (started.compareAndSet(true, false)) {
+      doStop();
+    } else {
+      LOG.warn("Attempt to stop an already-stopped {}", getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public NATPortMapping getPortMapping(
+      final NATServiceType serviceType, final NetworkProtocol networkProtocol) {
+    try {
+      final List<NATPortMapping> natPortMappings =
+          getPortMappings().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      final Optional<NATPortMapping> foundPortMapping =
+          natPortMappings.stream()
+              .filter(
+                  c ->
+                      c.getNatServiceType().equals(serviceType)
+                          && c.getProtocol().equals(networkProtocol))
+              .findFirst();
+      return foundPortMapping.orElseThrow();
+    } catch (NoSuchElementException e) {
+      throw new IllegalArgumentException(
+          String.format("Required service type not found : %s %s", serviceType, networkProtocol));
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(
+          String.format("Unable to retrieve the service type : %s", serviceType.toString()));
+    }
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNATSystem.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNATSystem.java
@@ -38,15 +38,18 @@ public abstract class AbstractNATSystem implements NATSystem {
   protected static final Logger LOG = LogManager.getLogger();
 
   protected final NATMethod natMethod;
+
   protected final AtomicBoolean started = new AtomicBoolean();
 
   protected AbstractNATSystem(final NATMethod natMethod) {
     this.natMethod = natMethod;
   }
 
-  public abstract void doStart();
+  protected abstract void doStart();
 
-  public abstract void doStop();
+  protected abstract void doStop();
+
+  protected abstract CompletableFuture<String> retrieveExternalIPAddress();
 
   @Override
   public NATMethod getNatMethod() {
@@ -56,6 +59,14 @@ public abstract class AbstractNATSystem implements NATSystem {
   @Override
   public boolean isStarted() {
     return started.get();
+  }
+
+  @Override
+  public CompletableFuture<String> getExternalIPAddress() {
+    if (!isStarted()) {
+      throw new IllegalStateException("Cannot call getExternalIPAddress() when in stopped state");
+    }
+    return retrieveExternalIPAddress();
   }
 
   @Override

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/NATManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/NATManager.java
@@ -28,17 +28,16 @@ public class NATManager {
 
   private final NATMethod currentNatMethod;
   private final Optional<NATSystem> currentNatSystem;
+  private final boolean natExternalIpUsageEnabled;
 
   public NATManager(final NATMethod natMethod) {
+    this(natMethod, true);
+  }
+
+  public NATManager(final NATMethod natMethod, final boolean natExternalIpUsageEnabled) {
     this.currentNatMethod = natMethod;
-    switch (currentNatMethod) {
-      case UPNP:
-        currentNatSystem = Optional.of(new UpnpNatSystem());
-        break;
-      case NONE:
-      default:
-        currentNatSystem = Optional.empty();
-    }
+    this.currentNatSystem = buildNatSystem();
+    this.natExternalIpUsageEnabled = natExternalIpUsageEnabled;
   }
 
   /**
@@ -48,6 +47,15 @@ public class NATManager {
    */
   public boolean isNATEnvironment() {
     return currentNatMethod != NATMethod.NONE;
+  }
+
+  /**
+   * Returns whether or not the nat external IP usage is enabled.
+   *
+   * @return true if the usage of the nat external ip is enabled, false otherwise.
+   */
+  public boolean isNatExternalIpUsageEnabled() {
+    return natExternalIpUsageEnabled;
   }
 
   /**
@@ -66,5 +74,20 @@ public class NATManager {
    */
   public Optional<NATSystem> getNatSystem() {
     return currentNatSystem;
+  }
+
+  /**
+   * Build the NAT system associated to the current NAT method.
+   *
+   * @return an {@link Optional} wrapping the {@link NATSystem} or empty if not found.
+   */
+  private Optional<NATSystem> buildNatSystem() {
+    switch (currentNatMethod) {
+      case UPNP:
+        return Optional.of(new UpnpNatSystem());
+      case NONE:
+      default:
+        return Optional.empty();
+    }
   }
 }

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/NATManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/NATManager.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core;
+
+import org.hyperledger.besu.nat.core.domain.NATMethod;
+import org.hyperledger.besu.nat.upnp.UpnpNatSystem;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Utility class to help interacting with various {@link NATSystem}. */
+public class NATManager {
+  protected static final Logger LOG = LogManager.getLogger();
+
+  private final NATMethod currentNatMethod;
+  private final Optional<NATSystem> currentNatSystem;
+
+  public NATManager(final NATMethod natMethod) {
+    this.currentNatMethod = natMethod;
+    switch (currentNatMethod) {
+      case UPNP:
+        currentNatSystem = Optional.of(new UpnpNatSystem());
+        break;
+      case NONE:
+      default:
+        currentNatSystem = Optional.empty();
+    }
+  }
+
+  /**
+   * Returns whether or not the Besu node is running under a NAT environment.
+   *
+   * @return true if Besu node is running under NAT environment, false otherwise.
+   */
+  public boolean isNATEnvironment() {
+    return currentNatMethod != NATMethod.NONE;
+  }
+
+  /**
+   * Returns the NAT method.
+   *
+   * @return an {@link Optional} wrapping the {@link NATMethod} or empty if not found.
+   */
+  public NATMethod getNatMethod() {
+    return currentNatMethod;
+  }
+
+  /**
+   * Returns the NAT system associated to the current NAT method.
+   *
+   * @return an {@link Optional} wrapping the {@link NATSystem} or empty if not found.
+   */
+  public Optional<NATSystem> getNatSystem() {
+    return currentNatSystem;
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/NATSystem.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/NATSystem.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core;
+
+import org.hyperledger.besu.nat.core.domain.NATMethod;
+import org.hyperledger.besu.nat.core.domain.NATPortMapping;
+import org.hyperledger.besu.nat.core.domain.NATServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This class describes the behaviour of any supported NAT system. Internal API to support Network
+ * Address Translation (NAT) technologies in Besu.
+ */
+public interface NATSystem {
+
+  int TIMEOUT_SECONDS = 60;
+
+  /**
+   * Returns the NAT method associated to this system.
+   *
+   * @return the {@link NATMethod}
+   */
+  NATMethod getNatMethod();
+
+  /** Starts the system or service. */
+  void start();
+
+  /** Stops the system or service. */
+  void stop();
+
+  /**
+   * Returns whether or not the system is started.
+   *
+   * @return true if started, false otherwise.
+   */
+  boolean isStarted();
+
+  /**
+   * Checks if the system is started and throws an {@link IllegalStateException} in case it is not
+   * started. Convenient method to perform actions only if service is started.
+   */
+  default void requireSystemStarted() {
+    if (!isStarted()) {
+      throw new IllegalStateException("NAT system must be started.");
+    }
+  }
+
+  /**
+   * Returns a {@link java.util.concurrent.Future} wrapping the local IP address.
+   *
+   * @return The local IP address wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<String> getLocalIPAddress();
+
+  /**
+   * Returns a {@link java.util.concurrent.Future} wrapping the external IP address.
+   *
+   * @return The external IP address wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<String> getExternalIPAddress();
+
+  /**
+   * Returns all known port mappings.
+   *
+   * @return The known port mappings wrapped in a {@link java.util.concurrent.Future}.
+   */
+  CompletableFuture<List<NATPortMapping>> getPortMappings();
+
+  /**
+   * Returns the port mapping associated to the passed service type.
+   *
+   * @param serviceType The service type {@link NATServiceType}.
+   * @param networkProtocol The network protocol {@link NetworkProtocol}.
+   * @return The port mapping {@link NATPortMapping}
+   */
+  NATPortMapping getPortMapping(
+      final NATServiceType serviceType, final NetworkProtocol networkProtocol);
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/NATSystem.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/NATSystem.java
@@ -90,4 +90,8 @@ public interface NATSystem {
    */
   NATPortMapping getPortMapping(
       final NATServiceType serviceType, final NetworkProtocol networkProtocol);
+
+  default boolean isRunningOn() {
+    return false;
+  }
 }

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATMethod.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATMethod.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.core.domain;
+
+/**
+ * This enum describes all supported NAT methods in Besu.
+ *
+ * <ul>
+ *   <li><b>UPNP:</b> Universal Plug and Play is used to perform NAT tasks.
+ *   <li><b>DOCKER:</b> Besu node is running inside a Docker container.
+ *   <li><b>KUBERNETES:</b> Besu node is running inside a Kubernetes pod.
+ * </ul>
+ */
+public enum NATMethod {
+  UPNP,
+  DOCKER,
+  KUBERNETES,
+  NONE;
+
+  /**
+   * Parses and returns corresponding enum value to the passed method name. This method throws an
+   * {@link IllegalStateException} if the method name is invalid.
+   *
+   * @param natMethodName The name of the NAT method.
+   * @return The corresponding {@link NATMethod}
+   */
+  public static NATMethod fromString(final String natMethodName) {
+    for (final NATMethod mode : NATMethod.values()) {
+      if (mode.name().equalsIgnoreCase(natMethodName)) {
+        return mode;
+      }
+    }
+    throw new IllegalStateException(String.format("Invalid NAT type provided: %s", natMethodName));
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATPortMapping.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATPortMapping.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core.domain;
+
+/** This class describes a NAT configuration. */
+public class NATPortMapping {
+
+  private final NATServiceType natServiceType;
+  private final NetworkProtocol protocol;
+  private final String internalHost;
+  private final String remoteHost;
+  private final int externalPort;
+  private final int internalPort;
+
+  public NATPortMapping(
+      final NATServiceType natServiceType,
+      final NetworkProtocol protocol,
+      final String internalHost,
+      final String remoteHost,
+      final int externalPort,
+      final int internalPort) {
+    this.natServiceType = natServiceType;
+    this.protocol = protocol;
+    this.internalHost = internalHost;
+    this.remoteHost = remoteHost;
+    this.externalPort = externalPort;
+    this.internalPort = internalPort;
+  }
+
+  /**
+   * Builds an empty representation of a {@link NATPortMapping}
+   *
+   * @param protocol the {@link NetworkProtocol} associated to the representation.
+   * @return the built {@link NATPortMapping}
+   */
+  public static NATPortMapping emptyPortMapping(final NetworkProtocol protocol) {
+    return new NATPortMapping(null, protocol, "", "", 0, 0);
+  }
+
+  public NATServiceType getNatServiceType() {
+    return natServiceType;
+  }
+
+  public NetworkProtocol getProtocol() {
+    return protocol;
+  }
+
+  public String getInternalHost() {
+    return internalHost;
+  }
+
+  public String getRemoteHost() {
+    return remoteHost;
+  }
+
+  public int getExternalPort() {
+    return externalPort;
+  }
+
+  public int getInternalPort() {
+    return internalPort;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[%s - %s] %s:%d ==> %s:%d",
+        natServiceType, protocol, internalHost, internalPort, remoteHost, externalPort);
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATServiceType.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NATServiceType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core.domain;
+
+/**
+ * This enum describes the types of services that could be impacted by the {@link NATMethod} used by
+ * the Besu node.
+ *
+ * <ul>
+ *   <li><b>JSON_RPC:</b> Ethereum JSON-RPC HTTP service.
+ *   <li><b>RLPX:</b> Peer to Peer network layer.
+ *   <li><b>DISCOVERY:</b> Peer to Peer discovery layer.
+ * </ul>
+ */
+public enum NATServiceType {
+  JSON_RPC("json-rpc"),
+  RLPX("rlpx"),
+  DISCOVERY("discovery");
+
+  private final String value;
+
+  NATServiceType(final String value) {
+    this.value = value;
+  }
+
+  /**
+   * Parses and returns corresponding enum value to the passed method name. This method throws an
+   * {@link IllegalStateException} if the method name is invalid.
+   *
+   * @param natServiceTypeName The name of the NAT service type.
+   * @return The corresponding {@link NATServiceType}
+   */
+  public static NATServiceType fromString(final String natServiceTypeName) {
+    for (final NATServiceType mode : NATServiceType.values()) {
+      if (mode.getValue().equalsIgnoreCase(natServiceTypeName)) {
+        return mode;
+      }
+    }
+    throw new IllegalStateException(
+        String.format("Invalid NAT service type provided: %s", natServiceTypeName));
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NetworkProtocol.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/domain/NetworkProtocol.java
@@ -12,18 +12,18 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.nat;
 
-public enum NatMethod {
-  UPNP,
-  NONE;
+package org.hyperledger.besu.nat.core.domain;
 
-  public static NatMethod fromString(final String str) {
-    for (final NatMethod mode : NatMethod.values()) {
-      if (mode.name().equalsIgnoreCase(str)) {
-        return mode;
-      }
-    }
-    return null;
-  }
+/**
+ * This enum describes all supported NAT methods in Besu.
+ *
+ * <ul>
+ *   <li><b>TCP:</b> Transmission Control Protocol.
+ *   <li><b>UDP:</b> User Datagram Protocol.
+ * </ul>
+ */
+public enum NetworkProtocol {
+  TCP,
+  UDP
 }

--- a/nat/src/main/java/org/hyperledger/besu/nat/upnp/BesuUpnpServiceConfiguration.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/upnp/BesuUpnpServiceConfiguration.java
@@ -80,7 +80,7 @@ class BesuUpnpServiceConfiguration implements UpnpServiceConfiguration {
               public void rejectedExecution(
                   final Runnable runnable, final ThreadPoolExecutor threadPoolExecutor) {
                 // Log and discard
-                UpnpNatManager.LOG.warn("Thread pool rejected execution of " + runnable.getClass());
+                UpnpNatSystem.LOG.warn("Thread pool rejected execution of " + runnable.getClass());
                 super.rejectedExecution(runnable, threadPoolExecutor);
               }
             });

--- a/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatSystem.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatSystem.java
@@ -145,6 +145,16 @@ public class UpnpNatSystem extends AbstractNATSystem implements NATSystem {
   }
 
   /**
+   * Sends a UPnP request to the discovered IGD for the external ip address.
+   *
+   * @return A CompletableFuture that can be used to query the result (or error).
+   */
+  @Override
+  public CompletableFuture<String> retrieveExternalIPAddress() {
+    return externalIpQueryFuture.thenApply(x -> x);
+  }
+
+  /**
    * Convenience function to call {@link #requestPortForward(PortMapping)} with the following
    * defaults:
    *
@@ -176,18 +186,10 @@ public class UpnpNatSystem extends AbstractNATSystem implements NATSystem {
   }
 
   /**
-   * Sends a UPnP request to the discovered IGD for the external ip address.
+   * Returns all known port mappings.
    *
-   * @return A CompletableFuture that can be used to query the result (or error).
+   * @return The known port mappings wrapped in a {@link java.util.concurrent.Future}.
    */
-  @Override
-  public CompletableFuture<String> getExternalIPAddress() {
-    if (!isStarted()) {
-      throw new IllegalStateException("Cannot call queryExternalIPAddress() when in stopped state");
-    }
-    return externalIpQueryFuture.thenApply(x -> x);
-  }
-
   @Override
   public CompletableFuture<List<NATPortMapping>> getPortMappings() {
     if (!isStarted()) {

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -104,7 +104,7 @@ public class AbstractNATSystemTest {
       public void doStop() {}
 
       @Override
-      public CompletableFuture<String> getExternalIPAddress() {
+      protected CompletableFuture<String> retrieveExternalIPAddress() {
         return new CompletableFuture<>();
       }
 

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.nat.core.domain.NATPortMapping;
 import org.hyperledger.besu.nat.core.domain.NATServiceType;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -95,7 +96,7 @@ public class AbstractNATSystemTest {
       }
 
       @Override
-      public CompletableFuture<Map<NATServiceType, NATPortMapping>> getPortMappings() {
+      public CompletableFuture<List<NATPortMapping>> getPortMappings() {
         return new CompletableFuture<>();
       }
     };

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.hyperledger.besu.nat.core.domain.NATMethod;
+import org.hyperledger.besu.nat.core.domain.NATPortMapping;
+import org.hyperledger.besu.nat.core.domain.NATServiceType;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractNATSystemTest {
+
+  @Test
+  public void assertThatSystemIsStartedAfterStart() {
+    final AbstractNATSystem natSystem = buildNATSystem(NATMethod.DOCKER);
+    assertThat(natSystem.isStarted()).isFalse();
+    natSystem.start();
+    assertThat(natSystem.isStarted()).isTrue();
+  }
+
+  @Test
+  public void assertThatSystemIsStoppedAfterStopped() {
+    final AbstractNATSystem natSystem = buildNATSystem(NATMethod.DOCKER);
+    assertThat(natSystem.isStarted()).isFalse();
+    natSystem.start();
+    assertThat(natSystem.isStarted()).isTrue();
+    natSystem.stop();
+    assertThat(natSystem.isStarted()).isFalse();
+  }
+
+  @Test
+  public void assertThatDoStartIsCalledOnlyOnce() {
+    final AbstractNATSystem natSystem = Mockito.spy(buildNATSystem(NATMethod.DOCKER));
+    natSystem.start();
+    natSystem.start();
+    verify(natSystem, times(2)).start();
+    verify(natSystem).doStart();
+  }
+
+  @Test
+  public void assertThatDoStopIsCalledOnlyOnce() {
+    final AbstractNATSystem natSystem = Mockito.spy(buildNATSystem(NATMethod.DOCKER));
+    natSystem.start();
+    natSystem.stop();
+    natSystem.stop();
+    verify(natSystem).start();
+    verify(natSystem).doStart();
+    verify(natSystem, times(2)).stop();
+    verify(natSystem).doStop();
+  }
+
+  @Test
+  public void assertThatRequireSystemStartedThrowExceptionIfNotStarted() {
+    assertThatThrownBy(() -> buildNATSystem(NATMethod.DOCKER).requireSystemStarted())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("NAT system must be started.");
+  }
+
+  private static AbstractNATSystem buildNATSystem(final NATMethod natMethod) {
+    return new AbstractNATSystem(natMethod) {
+      @Override
+      public void doStart() {}
+
+      @Override
+      public void doStop() {}
+
+      @Override
+      public CompletableFuture<String> getExternalIPAddress() {
+        return new CompletableFuture<>();
+      }
+
+      @Override
+      public CompletableFuture<Map<NATServiceType, NATPortMapping>> getPortMappings() {
+        return new CompletableFuture<>();
+      }
+    };
+  }
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -22,10 +22,8 @@ import static org.mockito.Mockito.verify;
 
 import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.nat.core.domain.NATPortMapping;
-import org.hyperledger.besu.nat.core.domain.NATServiceType;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.Test;

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/AbstractNATSystemTest.java
@@ -23,8 +23,11 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.nat.core.domain.NATMethod;
 import org.hyperledger.besu.nat.core.domain.NATPortMapping;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,6 +81,18 @@ public class AbstractNATSystemTest {
     assertThatThrownBy(() -> buildNATSystem(NATMethod.DOCKER).requireSystemStarted())
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("NAT system must be started.");
+  }
+
+  @Test
+  public void assertThatSystemReturnValidNatMethod() {
+    assertThat(buildNATSystem(NATMethod.DOCKER).getNatMethod()).isEqualTo(NATMethod.DOCKER);
+  }
+
+  @Test
+  public void assertThatSystemReturnValidLocalIpAddress()
+      throws UnknownHostException, ExecutionException, InterruptedException {
+    final String hostAddress = InetAddress.getLocalHost().getHostAddress();
+    assertThat(buildNATSystem(NATMethod.DOCKER).getLocalIPAddress().get()).isEqualTo(hostAddress);
   }
 
   private static AbstractNATSystem buildNATSystem(final NATMethod natMethod) {

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/NATManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/NATManagerTest.java
@@ -18,7 +18,6 @@ package org.hyperledger.besu.nat.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.nat.core.domain.NATMethod;
@@ -69,11 +68,12 @@ public class NATManagerTest {
     final NATSystem natSystem = mock(NATSystem.class);
     when(natSystem.getPortMapping(natPortMapping.getNatServiceType(), natPortMapping.getProtocol()))
         .thenReturn(natPortMapping);
+    when(natSystem.getNatMethod()).thenReturn(NATMethod.UPNP);
 
     final NATManager natManager = new NATManager(NATMethod.UPNP);
-    natManager.setNatSystem(Optional.of(natSystem));
+    natManager.setNatSystem(natSystem);
 
-    Optional<NATPortMapping> portMapping =
+    final Optional<NATPortMapping> portMapping =
         natManager.getPortMapping(natPortMapping.getNatServiceType(), natPortMapping.getProtocol());
 
     verify(natSystem)
@@ -86,15 +86,10 @@ public class NATManagerTest {
   @Test
   public void assertThatGetPortMappingWorksProperlyWithoutNat() {
 
-    final NATSystem natSystem = mock(NATSystem.class);
-
     final NATManager natManager = new NATManager(NATMethod.NONE);
-    natManager.setNatSystem(Optional.of(natSystem));
 
-    Optional<NATPortMapping> portMapping =
+    final Optional<NATPortMapping> portMapping =
         natManager.getPortMapping(NATServiceType.DISCOVERY, NetworkProtocol.TCP);
-
-    verifyNoInteractions(natSystem);
 
     Assertions.assertThat(portMapping).isNotPresent();
   }

--- a/nat/src/test/java/org/hyperledger/besu/nat/core/NATManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/core/NATManagerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.nat.core.domain.NATMethod;
+import org.hyperledger.besu.nat.upnp.UpnpNatSystem;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NATManagerTest {
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  public void assertThatGetNatSystemReturnValidSystem() {
+    final NATManager natManager = new NATManager(NATMethod.UPNP);
+    assertThat(natManager.getNatSystem().get()).isInstanceOf(UpnpNatSystem.class);
+  }
+
+  @Test
+  public void assertThatGetNatSystemNotReturnSystemWhenNatMethodIsNone() {
+    final NATManager natManager = new NATManager(NATMethod.NONE);
+    assertThat(natManager.getNatSystem()).isNotPresent();
+  }
+
+  @Test
+  public void assertThatIsNatEnvironmentReturnCorrectStatus() {
+    final NATManager nonNatManager = new NATManager(NATMethod.NONE);
+    assertThat(nonNatManager.isNATEnvironment()).isFalse();
+
+    final NATManager upnpNatManager = new NATManager(NATMethod.UPNP);
+    assertThat(upnpNatManager.isNATEnvironment()).isTrue();
+  }
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.nat.core.domain.NATServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URL;
@@ -48,7 +51,7 @@ public final class UpnpNatManagerTest {
   private Registry mockedRegistry;
   private ControlPoint mockedControlPoint;
 
-  private UpnpNatManager upnpManager;
+  private UpnpNatSystem upnpManager;
 
   @Before
   public void initialize() {
@@ -60,7 +63,7 @@ public final class UpnpNatManagerTest {
     when(mockedService.getRegistry()).thenReturn(mockedRegistry);
     when(mockedService.getControlPoint()).thenReturn(mockedControlPoint);
 
-    upnpManager = new UpnpNatManager(mockedService);
+    upnpManager = new UpnpNatSystem(mockedService);
   }
 
   @Test
@@ -104,7 +107,7 @@ public final class UpnpNatManagerTest {
 
     assertThatThrownBy(
             () -> {
-              upnpManager.requestPortForward(80, UpnpNatManager.Protocol.TCP, "");
+              upnpManager.requestPortForward(80, NetworkProtocol.TCP, NATServiceType.JSON_RPC);
             })
         .isInstanceOf(IllegalStateException.class);
   }
@@ -113,7 +116,8 @@ public final class UpnpNatManagerTest {
   public void requestPortForwardThrowsWhenPortIsZero() {
     upnpManager.start();
 
-    assertThatThrownBy(() -> upnpManager.requestPortForward(0, UpnpNatManager.Protocol.TCP, ""))
+    assertThatThrownBy(
+            () -> upnpManager.requestPortForward(0, NetworkProtocol.TCP, NATServiceType.JSON_RPC))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -122,7 +126,7 @@ public final class UpnpNatManagerTest {
 
     assertThatThrownBy(
             () -> {
-              upnpManager.queryExternalIPAddress();
+              upnpManager.getExternalIPAddress();
             })
         .isInstanceOf(IllegalStateException.class);
   }
@@ -131,7 +135,7 @@ public final class UpnpNatManagerTest {
   public void queryIpDoesNotThrowWhenStarted() throws Exception {
     upnpManager.start();
 
-    upnpManager.queryExternalIPAddress();
+    upnpManager.getExternalIPAddress();
   }
 
   @Test
@@ -144,7 +148,7 @@ public final class UpnpNatManagerTest {
 
     assertThat(listener).isNotNull();
 
-    // create a remote device that matches the WANIPConnection service that UpnpNatManager
+    // create a remote device that matches the WANIPConnection service that UpnpNatSystem
     // is looking for and directly call the registry listener
     RemoteService wanIpConnectionService =
         new RemoteService(
@@ -159,7 +163,7 @@ public final class UpnpNatManagerTest {
     RemoteDevice device =
         new RemoteDevice(
             new RemoteDeviceIdentity(
-                UDN.valueOf(UpnpNatManager.SERVICE_TYPE_WAN_IP_CONNECTION),
+                UDN.valueOf(UpnpNatSystem.SERVICE_TYPE_WAN_IP_CONNECTION),
                 3600,
                 new URL("http://127.63.31.15/"),
                 null,

--- a/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/upnp/UpnpNatManagerTest.java
@@ -122,7 +122,7 @@ public final class UpnpNatManagerTest {
   }
 
   @Test
-  public void queryIpThrowsWhenStopped() throws Exception {
+  public void getExternalIPAddressThrowsWhenStopped() throws Exception {
 
     assertThatThrownBy(
             () -> {
@@ -132,7 +132,7 @@ public final class UpnpNatManagerTest {
   }
 
   @Test
-  public void queryIpDoesNotThrowWhenStarted() throws Exception {
+  public void getExternalIPAddressDoesNotThrowWhenStarted() throws Exception {
     upnpManager.start();
 
     upnpManager.getExternalIPAddress();
@@ -175,5 +175,19 @@ public final class UpnpNatManagerTest {
     listener.remoteDeviceAdded(mockedRegistry, device);
 
     assertThat(upnpManager.getWANIPConnectionService().join()).isEqualTo(wanIpConnectionService);
+  }
+
+  @Test
+  public void getPortMappingsThrowsWhenStopped() throws Exception {
+
+    assertThatThrownBy(() -> upnpManager.getPortMappings())
+        .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void getPortMappingsNotThrowWhenStarted() throws Exception {
+    upnpManager.start();
+
+    upnpManager.getPortMappings();
   }
 }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

Create a general internal API to support Network Address Translation (NAT) technologies in Besu. The goal of this work is to offer developers a consistent API for performing NAT tasks so that I can abstractly add support for new NAT systems (e.g. Docker, Kubernetes, etc.) with a minimum amount of code changes. As a second NAT style, explicit configuration for all ports and IP addresses would be available.

### A few comments

Java APIs to determine if a node is in a NAT environment, and then identify the kind of NAT environment
>The method is passed using the `--nat-method` parameter. If the method is not passed in argument the client will try to detect it automatically. Automatic detection is being developed. 
it is possible to call `isNATEnvironment` to get the result 

Java APIs to enable/disable the NAT port forwarding if the environment requires it, as well as APIs to determine if such calls are needed or making the enable/disable calls a no-op when it is unneeded.  

>As requested, the generic API does not allow to enable or disable the port forwading.  `requestPortForward` and `releasePortForward` are only available in the UPNP implementation

Ability to explicitly configure the external IP to broadcast without regards to NAT or other considerations.

>A new command-line parameter `--nat-external-ip-usage-enabled` has been added to allow the user to force the usage of the external ip addresss, otherwise the `p2pAdvertisedHost`  is used. The default value is `true`
