### PR TITLE
Change CustomForks -> Transitions

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -233,7 +233,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder<IbftContext
     final EpochManager epochManager = new EpochManager(ibftConfig.getEpochLength());
 
     final Map<Long, List<Address>> ibftValidatorForkMap =
-        convertIbftForks(configOptions.getCustomForks().getIbftForks());
+        convertIbftForks(configOptions.getTransitions().getIbftForks());
 
     return new IbftContext(
         new ForkingVoteTallyCache(

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -133,5 +133,5 @@ public interface GenesisConfigOptions {
 
   Map<String, Object> asMap();
 
-  CustomForksConfigOptions getCustomForks();
+  TransitionsConfigOptions getTransitions();
 }

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -35,10 +35,10 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   private static final String IBFT_LEGACY_CONFIG_KEY = "ibft";
   private static final String IBFT2_CONFIG_KEY = "ibft2";
   private static final String CLIQUE_CONFIG_KEY = "clique";
-  private static final String CUSTOM_FORKS_CONFIG_KEY = "customforks";
+  private static final String TRANSITIONS_CONFIG_KEY = "transitions";
   private final ObjectNode configRoot;
   private final Map<String, String> configOverrides = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-  private final CustomForksConfigOptions customForks;
+  private final TransitionsConfigOptions transitions;
 
   public static JsonGenesisConfigOptions fromJsonObject(final ObjectNode configRoot) {
     return fromJsonObjectWithOverrides(configRoot, emptyMap());
@@ -46,41 +46,41 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
 
   static JsonGenesisConfigOptions fromJsonObjectWithOverrides(
       final ObjectNode configRoot, final Map<String, String> configOverrides) {
-    final CustomForksConfigOptions customForksConfigOptions;
+    final TransitionsConfigOptions transitionsConfigOptions;
     try {
-      customForksConfigOptions = loadCustomForksFrom(configRoot);
+      transitionsConfigOptions = loadTransitionsFrom(configRoot);
     } catch (final JsonProcessingException e) {
-      throw new RuntimeException("CustomForks section of genesis file failed to decode.", e);
+      throw new RuntimeException("Transitions section of genesis file failed to decode.", e);
     }
-    return new JsonGenesisConfigOptions(configRoot, configOverrides, customForksConfigOptions);
+    return new JsonGenesisConfigOptions(configRoot, configOverrides, transitionsConfigOptions);
   }
 
-  private static CustomForksConfigOptions loadCustomForksFrom(final ObjectNode parentNode)
+  private static TransitionsConfigOptions loadTransitionsFrom(final ObjectNode parentNode)
       throws JsonProcessingException {
 
-    final Optional<ObjectNode> customForksNode =
-        JsonUtil.getObjectNode(parentNode, CUSTOM_FORKS_CONFIG_KEY);
-    if (customForksNode.isEmpty()) {
-      return new CustomForksConfigOptions(JsonUtil.createEmptyObjectNode());
+    final Optional<ObjectNode> transitionsNode =
+        JsonUtil.getObjectNode(parentNode, TRANSITIONS_CONFIG_KEY);
+    if (transitionsNode.isEmpty()) {
+      return new TransitionsConfigOptions(JsonUtil.createEmptyObjectNode());
     }
 
-    return new CustomForksConfigOptions(customForksNode.get());
+    return new TransitionsConfigOptions(transitionsNode.get());
   }
 
   private JsonGenesisConfigOptions(
-      final ObjectNode maybeConfig, final CustomForksConfigOptions customForksConfig) {
-    this(maybeConfig, Collections.emptyMap(), customForksConfig);
+      final ObjectNode maybeConfig, final TransitionsConfigOptions transitionsConfig) {
+    this(maybeConfig, Collections.emptyMap(), transitionsConfig);
   }
 
   JsonGenesisConfigOptions(
       final ObjectNode maybeConfig,
       final Map<String, String> configOverrides,
-      final CustomForksConfigOptions customForksConfig) {
+      final TransitionsConfigOptions transitionsConfig) {
     this.configRoot = isNull(maybeConfig) ? JsonUtil.createEmptyObjectNode() : maybeConfig;
     if (configOverrides != null) {
       this.configOverrides.putAll(configOverrides);
     }
-    this.customForks = customForksConfig;
+    this.transitions = transitionsConfig;
   }
 
   @Override
@@ -147,8 +147,8 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
-  public CustomForksConfigOptions getCustomForks() {
-    return customForks;
+  public TransitionsConfigOptions getTransitions() {
+    return transitions;
   }
 
   @Override

--- a/config/src/main/java/org/hyperledger/besu/config/TransitionsConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/TransitionsConfigOptions.java
@@ -25,17 +25,17 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
-public class CustomForksConfigOptions {
+public class TransitionsConfigOptions {
 
   public static final String IBFT2_FORKS = "ibft2";
 
-  public static final CustomForksConfigOptions DEFAULT =
-      new CustomForksConfigOptions(JsonUtil.createEmptyObjectNode());
+  public static final TransitionsConfigOptions DEFAULT =
+      new TransitionsConfigOptions(JsonUtil.createEmptyObjectNode());
 
   private final ObjectNode customForkConfigRoot;
 
   @JsonCreator
-  public CustomForksConfigOptions(final ObjectNode customForkConfigRoot) {
+  public TransitionsConfigOptions(final ObjectNode customForkConfigRoot) {
     this.customForkConfigRoot = customForkConfigRoot;
   }
 

--- a/config/src/test-support/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
+++ b/config/src/test-support/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
@@ -212,8 +212,8 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
-  public CustomForksConfigOptions getCustomForks() {
-    return CustomForksConfigOptions.DEFAULT;
+  public TransitionsConfigOptions getTransitions() {
+    return TransitionsConfigOptions.DEFAULT;
   }
 
   public StubGenesisConfigOptions homesteadBlock(final long blockNumber) {

--- a/config/src/test/java/org/hyperledger/besu/config/JsonGenesisConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonGenesisConfigOptionsTest.java
@@ -37,61 +37,61 @@ public class JsonGenesisConfigOptionsTest {
     }
   }
 
-  private ObjectNode loadConfigWithNoCustomForks() {
+  private ObjectNode loadConfigWithNoTransitions() {
     final ObjectNode configNode = loadCompleteDataSet();
-    configNode.remove("customforks");
+    configNode.remove("transitions");
     return configNode;
   }
 
   private ObjectNode loadConfigWithNoIbft2Forks() {
     final ObjectNode configNode = loadCompleteDataSet();
-    final ObjectNode customForksNode = JsonUtil.getObjectNode(configNode, "customforks").get();
-    customForksNode.remove("ibft2");
+    final ObjectNode transitionsNode = JsonUtil.getObjectNode(configNode, "transitions").get();
+    transitionsNode.remove("ibft2");
 
     return configNode;
   }
 
   private ObjectNode loadConfigWithAnIbft2ForkWithMissingValidators() {
     final ObjectNode configNode = loadCompleteDataSet();
-    final ObjectNode customForksNode = JsonUtil.getObjectNode(configNode, "customforks").get();
-    final ArrayNode ibftNode = JsonUtil.getArrayNode(customForksNode, "ibft2").get();
+    final ObjectNode transitionsNode = JsonUtil.getObjectNode(configNode, "transitions").get();
+    final ArrayNode ibftNode = JsonUtil.getArrayNode(transitionsNode, "ibft2").get();
     ((ObjectNode) ibftNode.get(0)).remove("validators");
 
     return configNode;
   }
 
   @Test
-  public void customForksDecodesCorrectlyFromFile() {
+  public void transitionsDecodesCorrectlyFromFile() {
     final ObjectNode configNode = loadCompleteDataSet();
 
     final JsonGenesisConfigOptions configOptions =
         JsonGenesisConfigOptions.fromJsonObject(configNode);
 
-    assertThat(configOptions.getCustomForks()).isNotNull();
-    assertThat(configOptions.getCustomForks().getIbftForks().size()).isEqualTo(2);
-    assertThat(configOptions.getCustomForks().getIbftForks().get(0).getForkBlock()).isEqualTo(20);
-    assertThat(configOptions.getCustomForks().getIbftForks().get(0).getValidators()).isNotEmpty();
-    assertThat(configOptions.getCustomForks().getIbftForks().get(0).getValidators().get())
+    assertThat(configOptions.getTransitions()).isNotNull();
+    assertThat(configOptions.getTransitions().getIbftForks().size()).isEqualTo(2);
+    assertThat(configOptions.getTransitions().getIbftForks().get(0).getForkBlock()).isEqualTo(20);
+    assertThat(configOptions.getTransitions().getIbftForks().get(0).getValidators()).isNotEmpty();
+    assertThat(configOptions.getTransitions().getIbftForks().get(0).getValidators().get())
         .containsExactly(
             "0x12345678901234567890123456789012345678900x1234567890123456789012345678901234567890",
             "0x98765432109876543210987654321098765432100x9876543210987654321098765432109876543210");
 
-    assertThat(configOptions.getCustomForks().getIbftForks().get(1).getForkBlock()).isEqualTo(25);
-    assertThat(configOptions.getCustomForks().getIbftForks().get(1).getValidators()).isNotEmpty();
-    assertThat(configOptions.getCustomForks().getIbftForks().get(1).getValidators().get())
+    assertThat(configOptions.getTransitions().getIbftForks().get(1).getForkBlock()).isEqualTo(25);
+    assertThat(configOptions.getTransitions().getIbftForks().get(1).getValidators()).isNotEmpty();
+    assertThat(configOptions.getTransitions().getIbftForks().get(1).getValidators().get())
         .containsExactly(
             "0x12345678901234567890123456789012345678900x1234567890123456789012345678901234567890");
   }
 
   @Test
-  public void configWithMissingCustomForksIsValid() {
-    final ObjectNode configNode = loadConfigWithNoCustomForks();
+  public void configWithMissingTransitionsIsValid() {
+    final ObjectNode configNode = loadConfigWithNoTransitions();
 
     final JsonGenesisConfigOptions configOptions =
         JsonGenesisConfigOptions.fromJsonObject(configNode);
 
-    assertThat(configOptions.getCustomForks()).isNotNull();
-    assertThat(configOptions.getCustomForks().getIbftForks().size()).isZero();
+    assertThat(configOptions.getTransitions()).isNotNull();
+    assertThat(configOptions.getTransitions().getIbftForks().size()).isZero();
   }
 
   @Test
@@ -101,8 +101,8 @@ public class JsonGenesisConfigOptionsTest {
     final JsonGenesisConfigOptions configOptions =
         JsonGenesisConfigOptions.fromJsonObject(configNode);
 
-    assertThat(configOptions.getCustomForks()).isNotNull();
-    assertThat(configOptions.getCustomForks().getIbftForks().size()).isZero();
+    assertThat(configOptions.getTransitions()).isNotNull();
+    assertThat(configOptions.getTransitions().getIbftForks().size()).isZero();
   }
 
   @Test
@@ -112,9 +112,9 @@ public class JsonGenesisConfigOptionsTest {
     final JsonGenesisConfigOptions configOptions =
         JsonGenesisConfigOptions.fromJsonObject(configNode);
 
-    assertThat(configOptions.getCustomForks().getIbftForks().get(0).getValidators().isPresent())
+    assertThat(configOptions.getTransitions().getIbftForks().get(0).getValidators().isPresent())
         .isFalse();
-    assertThat(configOptions.getCustomForks().getIbftForks().get(1).getValidators().get().size())
+    assertThat(configOptions.getTransitions().getIbftForks().get(1).getValidators().get().size())
         .isEqualTo(1);
   }
 }

--- a/config/src/test/resources/valid_config_with_custom_forks.json
+++ b/config/src/test/resources/valid_config_with_custom_forks.json
@@ -11,7 +11,7 @@
     "epochlength": 30000,
     "requesttimeoutseconds": 10
   },
-  "customforks": {
+  "transitions": {
     "ibft2": [
       {
         "block": 20,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -57,7 +57,9 @@ public final class MainnetBlockHeaderValidator {
     return createValidator(difficultyCalculator)
         .addRule(
             new ConstantFieldValidationRule<>(
-                "hash", BlockHeader::getBlockHash, CLASSIC_FORK_BLOCK_HEADER))
+                "hash",
+                h -> h.getNumber() == 1920000 ? h.getBlockHash() : CLASSIC_FORK_BLOCK_HEADER,
+                CLASSIC_FORK_BLOCK_HEADER))
         .build();
   }
 


### PR DESCRIPTION
Change the configuration name of "CustomForks" to "Transitions."  This
will better reflect that this is a list of blocks where transition
events might happen.  These may be more than forks, and mainnet is also
moving away from the name forks to "network upgrades."  Transitions is
more general purpose.

Signed-off-by: Danno Ferrin \<danno.ferrin@gmail.com\>

