### PR TITLE
Shutdown vertx instance created within BesuCommand

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1453,7 +1453,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     final ObservableMetricsSystem metricsSystem = this.metricsSystem.get();
     final Runner runner =
         runnerBuilder
-            .vertx(Vertx.vertx(createVertxOptions(metricsSystem)))
+            .vertx(createVertx(createVertxOptions(metricsSystem)))
             .besuController(controller)
             .p2pEnabled(p2pEnabled)
             .natMethod(natMethod)
@@ -1481,6 +1481,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     addShutdownHook(runner);
     runner.start();
     runner.awaitStop();
+  }
+
+  protected Vertx createVertx(final VertxOptions vertxOptions) {
+    return Vertx.vertx(vertxOptions);
   }
 
   private VertxOptions createVertxOptions(final MetricsSystem metricsSystem) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -67,13 +67,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,6 +106,8 @@ public abstract class CommandTestAbstract {
   protected final ByteArrayOutputStream commandErrorOutput = new ByteArrayOutputStream();
   private final PrintStream errPrintStream = new PrintStream(commandErrorOutput);
   private final HashMap<String, String> environment = new HashMap<>();
+
+  private final List<TestBesuCommand> besuCommands = new ArrayList<>();
 
   @Mock protected RunnerBuilder mockRunnerBuilder;
   @Mock protected Runner mockRunner;
@@ -229,6 +238,7 @@ public abstract class CommandTestAbstract {
 
     errPrintStream.close();
     commandErrorOutput.close();
+    besuCommands.forEach(TestBesuCommand::close);
   }
 
   protected void setEnvironemntVariable(final String name, final String value) {
@@ -270,6 +280,7 @@ public abstract class CommandTestAbstract {
             mockBesuPluginContext,
             environment,
             storageService);
+    besuCommands.add(besuCommand);
 
     besuCommand.setBesuConfiguration(commonPluginConfiguration);
 
@@ -287,6 +298,7 @@ public abstract class CommandTestAbstract {
 
     @CommandLine.Spec CommandLine.Model.CommandSpec spec;
     private final PublicKeySubCommand.KeyLoader keyLoader;
+    private Vertx vertx;
 
     @Override
     protected PublicKeySubCommand.KeyLoader getKeyLoader() {
@@ -322,6 +334,12 @@ public abstract class CommandTestAbstract {
       // For testing, don't actually query for networking interfaces to validate this option
     }
 
+    @Override
+    protected Vertx createVertx(final VertxOptions vertxOptions) {
+      vertx = super.createVertx(vertxOptions);
+      return vertx;
+    }
+
     public CommandSpec getSpec() {
       return spec;
     }
@@ -348,6 +366,14 @@ public abstract class CommandTestAbstract {
 
     public MetricsCLIOptions getMetricsCLIOptions() {
       return metricsCLIOptions;
+    }
+
+    public void close() {
+      if (vertx != null) {
+        final AtomicBoolean closed = new AtomicBoolean(false);
+        vertx.close(event -> closed.set(true));
+        Awaitility.waitAtMost(30, TimeUnit.SECONDS).until(closed::get);
+      }
     }
   }
 }


### PR DESCRIPTION
## PR description
`BesuCommandTest` and probably anything else that extends `CommandTestAbstract` leaked about 50 file descriptors per test that successfully parsed the CLI args. `BesuCommand` creates a `Vertx` instance which is never shutdown.

This is the root cause of newer Macs failing tests with "Failed to create a child event loop". They have more cores so run more processes in parallel which increases the number of file descriptors validly being used (each process needs around 200 file descriptors) and increases the chance that two of these tests will run at the same time and hit the resource limits.

This is a fairly brute-force approach to getting hold of that vertx instance and shutting it down but it solves the immediate issue.

Signed-off-by: Adrian Sutton <adrian.sutton@consensys.net>
