### PR TITLE
Update web3j dependency to 4.5.8

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -91,10 +91,10 @@ dependencyManagement {
 
     dependency 'org.springframework.security:spring-security-crypto:5.2.0.RELEASE'
 
-    dependency 'org.web3j:abi:4.5.7'
-    dependency 'org.web3j:core:4.5.7'
-    dependency 'org.web3j:crypto:4.5.7'
-    dependency 'org.web3j:besu:4.5.7'
+    dependency 'org.web3j:abi:4.5.8'
+    dependency 'org.web3j:core:4.5.8'
+    dependency 'org.web3j:crypto:4.5.8'
+    dependency 'org.web3j:besu:4.5.8'
 
     dependency 'org.xerial.snappy:snappy-java:1.1.7.3'
 


### PR DESCRIPTION
## PR description
This solves the LPGP license issue around ktlint being imported
by mistake

## Fixed Issue(s)
Fixes https://github.com/web3j/web3j/issues/1105