### PR TITLE
BESU-134: Prevent execution of PRIV/EEA methods when privacy is disabled

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1384,9 +1384,19 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       privacyParametersBuilder.setStorageProvider(
           privacyKeyStorageProvider(keyValueStorageName + "-privacy"));
       privacyParametersBuilder.setEnclaveFactory(new EnclaveFactory(vertx));
+    } else {
+      if (anyPrivacyApiEnabled()) {
+        logger.warn(
+            "Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+      }
     }
 
     return privacyParametersBuilder.build();
+  }
+
+  private boolean anyPrivacyApiEnabled() {
+    return rpcHttpApis.contains(RpcApis.EEA) || rpcWsApis.contains(RpcApis.EEA) ||
+        rpcHttpApis.contains(RpcApis.PRIV) || rpcWsApis.contains(RpcApis.PRIV);
   }
 
   private PrivacyKeyValueStorageProvider privacyKeyStorageProvider(final String name) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1386,8 +1386,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       privacyParametersBuilder.setEnclaveFactory(new EnclaveFactory(vertx));
     } else {
       if (anyPrivacyApiEnabled()) {
-        logger.warn(
-            "Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+        logger.warn("Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
       }
     }
 
@@ -1395,8 +1394,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private boolean anyPrivacyApiEnabled() {
-    return rpcHttpApis.contains(RpcApis.EEA) || rpcWsApis.contains(RpcApis.EEA) ||
-        rpcHttpApis.contains(RpcApis.PRIV) || rpcWsApis.contains(RpcApis.PRIV);
+    return rpcHttpApis.contains(RpcApis.EEA)
+        || rpcWsApis.contains(RpcApis.EEA)
+        || rpcHttpApis.contains(RpcApis.PRIV)
+        || rpcWsApis.contains(RpcApis.PRIV);
   }
 
   private PrivacyKeyValueStorageProvider privacyKeyStorageProvider(final String name) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3090,4 +3090,52 @@ public class BesuCommandTest extends CommandTestAbstract {
         .contains(
             "Unable to authenticate JSON-RPC WebSocket endpoint without a supplied credentials file or authentication public key file");
   }
+
+  @Test
+  public void privHttpApisWithPrivacyDisabledLogsWarning() {
+    parseCommand("--privacy-enabled=false", "--rpc-http-api", "PRIV", "--rpc-http-enabled");
+
+    verify(mockRunnerBuilder).build();
+    verify(mockLogger)
+        .warn("Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void privWsApisWithPrivacyDisabledLogsWarning() {
+    parseCommand("--privacy-enabled=false", "--rpc-ws-api", "PRIV", "--rpc-ws-enabled");
+
+    verify(mockRunnerBuilder).build();
+    verify(mockLogger)
+        .warn("Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void eeaHttpApisWithPrivacyDisabledLogsWarning() {
+    parseCommand("--privacy-enabled=false", "--rpc-http-api", "EEA", "--rpc-http-enabled");
+
+    verify(mockRunnerBuilder).build();
+    verify(mockLogger)
+        .warn("Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void eeaWsApisWithPrivacyDisabledLogsWarning() {
+    parseCommand("--privacy-enabled=false", "--rpc-ws-api", "EEA", "--rpc-ws-enabled");
+
+    verify(mockRunnerBuilder).build();
+    verify(mockLogger)
+        .warn("Privacy is disabled. Cannot use EEA/PRIV API methods when not using Privacy.");
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -134,11 +135,16 @@ public class PrivGetPrivateTransactionIntegrationTest {
 
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
 
+  @Before
+  public void before() {
+    when(privacyParameters.getEnclave()).thenReturn(enclave);
+  }
+
   @Test
   public void returnsStoredPrivateTransaction() {
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(blockchain, enclave, privacyParameters);
+        new PrivGetPrivateTransaction(blockchain, privacyParameters);
 
     when(blockchain.transactionByHash(any(Hash.class)))
         .thenReturn(Optional.of(returnedTransaction));

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -137,6 +137,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
 
   @Before
   public void before() {
+    when(privacyParameters.isEnabled()).thenReturn(true);
     when(privacyParameters.getEnclave()).thenReturn(enclave);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/AbstractSendTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/AbstractSendTransaction.java
@@ -17,9 +17,11 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivacyApiMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
@@ -31,7 +33,7 @@ import org.hyperledger.besu.util.bytes.BytesValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class AbstractSendTransaction {
+public abstract class AbstractSendTransaction extends PrivacyApiMethod {
 
   private static final Logger LOG = LogManager.getLogger();
 
@@ -39,8 +41,10 @@ public class AbstractSendTransaction {
   protected final TransactionPool transactionPool;
 
   public AbstractSendTransaction(
+      final PrivacyParameters privacyParameters,
       final PrivateTransactionHandler privateTransactionHandler,
       final TransactionPool transactionPool) {
+    super(privacyParameters);
     this.privateTransactionHandler = privateTransactionHandler;
     this.transactionPool = transactionPool;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacySendTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacySendTransaction.java
@@ -33,14 +33,14 @@ import org.hyperledger.besu.util.bytes.BytesValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public abstract class AbstractSendTransaction extends PrivacyApiMethod {
+public abstract class PrivacySendTransaction extends PrivacyApiMethod {
 
   private static final Logger LOG = LogManager.getLogger();
 
   protected final PrivateTransactionHandler privateTransactionHandler;
   protected final TransactionPool transactionPool;
 
-  public AbstractSendTransaction(
+  public PrivacySendTransaction(
       final PrivacyParameters privacyParameters,
       final PrivateTransactionHandler privateTransactionHandler,
       final TransactionPool transactionPool) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.Abstra
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
@@ -31,9 +32,10 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 public class EeaSendRawTransaction extends AbstractSendTransaction implements JsonRpcMethod {
 
   public EeaSendRawTransaction(
+      final PrivacyParameters privacyParameters,
       final PrivateTransactionHandler privateTransactionHandler,
       final TransactionPool transactionPool) {
-    super(privateTransactionHandler, transactionPool);
+    super(privacyParameters, privateTransactionHandler, transactionPool);
   }
 
   @Override
@@ -42,7 +44,7 @@ public class EeaSendRawTransaction extends AbstractSendTransaction implements Js
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     PrivateTransaction privateTransaction;
     try {
       privateTransaction = validateAndDecodeRequest(requestContext);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
@@ -18,8 +18,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.AbstractSendTransaction;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacySendTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -29,7 +28,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 
-public class EeaSendRawTransaction extends AbstractSendTransaction implements JsonRpcMethod {
+public class EeaSendRawTransaction extends PrivacySendTransaction {
 
   public EeaSendRawTransaction(
       final PrivacyParameters privacyParameters,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.parameters.CreatePrivacyGroupParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -31,15 +30,14 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivCreatePrivacyGroup implements JsonRpcMethod {
+public class PrivCreatePrivacyGroup extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
-  private PrivacyParameters privacyParameters;
 
   public PrivCreatePrivacyGroup(final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
     this.enclave = privacyParameters.getEnclave();
-    this.privacyParameters = privacyParameters;
   }
 
   @Override
@@ -48,7 +46,7 @@ public class PrivCreatePrivacyGroup implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     LOG.trace("Executing {}", RpcMethod.PRIV_CREATE_PRIVACY_GROUP.getMethodName());
 
     final CreatePrivacyGroupParameter parameter =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.enclave.types.DeletePrivacyGroupRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -28,15 +27,14 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivDeletePrivacyGroup implements JsonRpcMethod {
+public class PrivDeletePrivacyGroup extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
-  private PrivacyParameters privacyParameters;
 
   public PrivDeletePrivacyGroup(final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
     this.enclave = privacyParameters.getEnclave();
-    this.privacyParameters = privacyParameters;
   }
 
   @Override
@@ -45,7 +43,7 @@ public class PrivDeletePrivacyGroup implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     LOG.trace("Executing {}", RpcMethod.PRIV_DELETE_PRIVACY_GROUP.getMethodName());
 
     final String privacyGroupId = requestContext.getRequiredParameter(0, String.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.Abstra
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
@@ -30,9 +31,10 @@ import org.hyperledger.besu.util.bytes.BytesValues;
 public class PrivDistributeRawTransaction extends AbstractSendTransaction implements JsonRpcMethod {
 
   public PrivDistributeRawTransaction(
+      final PrivacyParameters privacyParameters,
       final PrivateTransactionHandler privateTransactionHandler,
       final TransactionPool transactionPool) {
-    super(privateTransactionHandler, transactionPool);
+    super(privacyParameters, privateTransactionHandler, transactionPool);
   }
 
   @Override
@@ -41,7 +43,7 @@ public class PrivDistributeRawTransaction extends AbstractSendTransaction implem
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     PrivateTransaction privateTransaction;
     try {
       privateTransaction = validateAndDecodeRequest(requestContext);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
@@ -17,8 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.AbstractSendTransaction;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacySendTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -28,7 +27,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 import org.hyperledger.besu.util.bytes.BytesValues;
 
-public class PrivDistributeRawTransaction extends AbstractSendTransaction implements JsonRpcMethod {
+public class PrivDistributeRawTransaction extends PrivacySendTransaction {
 
   public PrivDistributeRawTransaction(
       final PrivacyParameters privacyParameters,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
@@ -21,22 +21,23 @@ import org.hyperledger.besu.enclave.types.FindPrivacyGroupRequest;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import java.util.Arrays;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivFindPrivacyGroup implements JsonRpcMethod {
+public class PrivFindPrivacyGroup extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
   private final Enclave enclave;
 
-  public PrivFindPrivacyGroup(final Enclave enclave) {
-    this.enclave = enclave;
+  public PrivFindPrivacyGroup(final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
+    this.enclave = privacyParameters.getEnclave();
   }
 
   @Override
@@ -45,7 +46,7 @@ public class PrivFindPrivacyGroup implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     LOG.trace("Executing {}", RpcMethod.PRIV_FIND_PRIVACY_GROUP.getMethodName());
 
     final String[] addresses = requestContext.getRequiredParameter(0, String[].class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
@@ -18,23 +18,25 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivGetEeaTransactionCount implements JsonRpcMethod {
+public class PrivGetEeaTransactionCount extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
 
   private final PrivateEeaNonceProvider nonceProvider;
 
-  public PrivGetEeaTransactionCount(final PrivateEeaNonceProvider nonceProvider) {
+  public PrivGetEeaTransactionCount(
+      final PrivacyParameters privacyParameters, final PrivateEeaNonceProvider nonceProvider) {
+    super(privacyParameters);
     this.nonceProvider = nonceProvider;
   }
 
@@ -44,7 +46,7 @@ public class PrivGetEeaTransactionCount implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     if (requestContext.getRequest().getParamLength() != 3) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
@@ -16,22 +16,18 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
-public class PrivGetPrivacyPrecompileAddress implements JsonRpcMethod {
+public class PrivGetPrivacyPrecompileAddress extends PrivacyApiMethod {
 
   private final Integer privacyAddress;
-  private final Boolean privacyEnabled;
 
   public PrivGetPrivacyPrecompileAddress(final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
     privacyAddress = privacyParameters.getPrivacyAddress();
-    privacyEnabled = privacyParameters.isEnabled();
   }
 
   @Override
@@ -40,15 +36,8 @@ public class PrivGetPrivacyPrecompileAddress implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-
-    if (privacyEnabled) {
-      return new JsonRpcSuccessResponse(
-          requestContext.getRequest().getId(),
-          Address.privacyPrecompiled(privacyAddress).toString());
-    } else {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.PRIVACY_NOT_ENABLED);
-    }
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(), Address.privacyPrecompiled(privacyAddress).toString());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.enclave.types.ReceiveRequest;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionGroupResult;
@@ -36,21 +35,18 @@ import org.hyperledger.besu.util.bytes.BytesValues;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivGetPrivateTransaction implements JsonRpcMethod {
+public class PrivGetPrivateTransaction extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
 
   private final BlockchainQueries blockchain;
   private final Enclave enclave;
-  private final PrivacyParameters privacyParameters;
 
   public PrivGetPrivateTransaction(
-      final BlockchainQueries blockchain,
-      final Enclave enclave,
-      final PrivacyParameters privacyParameters) {
+      final BlockchainQueries blockchain, final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
     this.blockchain = blockchain;
-    this.enclave = enclave;
-    this.privacyParameters = privacyParameters;
+    this.enclave = privacyParameters.getEnclave();
   }
 
   @Override
@@ -59,7 +55,7 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     LOG.trace("Executing {}", RpcMethod.PRIV_GET_PRIVATE_TRANSACTION.getMethodName());
 
     final Hash hash = requestContext.getRequiredParameter(0, Hash.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
@@ -16,20 +16,23 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 
-public class PrivGetTransactionCount implements JsonRpcMethod {
+public class PrivGetTransactionCount extends PrivacyApiMethod {
 
   private final PrivateTransactionHandler privateTransactionHandler;
 
-  public PrivGetTransactionCount(final PrivateTransactionHandler privateTransactionHandler) {
+  public PrivGetTransactionCount(
+      final PrivacyParameters privacyParameters,
+      final PrivateTransactionHandler privateTransactionHandler) {
+    super(privacyParameters);
     this.privateTransactionHandler = privateTransactionHandler;
   }
 
@@ -39,7 +42,7 @@ public class PrivGetTransactionCount implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     if (requestContext.getRequest().getParamLength() != 2) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -50,21 +49,18 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
-public class PrivGetTransactionReceipt implements JsonRpcMethod {
+public class PrivGetTransactionReceipt extends PrivacyApiMethod {
 
   private static final Logger LOG = getLogger();
 
   private final BlockchainQueries blockchain;
   private final Enclave enclave;
-  private final PrivacyParameters privacyParameters;
 
   public PrivGetTransactionReceipt(
-      final BlockchainQueries blockchain,
-      final Enclave enclave,
-      final PrivacyParameters privacyParameters) {
+      final BlockchainQueries blockchain, final PrivacyParameters privacyParameters) {
+    super(privacyParameters);
     this.blockchain = blockchain;
-    this.enclave = enclave;
-    this.privacyParameters = privacyParameters;
+    this.enclave = privacyParameters.getEnclave();
   }
 
   @Override
@@ -73,7 +69,7 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public JsonRpcResponse doResponse(final JsonRpcRequestContext requestContext) {
     LOG.trace("Executing {}", RpcMethod.PRIV_GET_TRANSACTION_RECEIPT.getMethodName());
     final Hash transactionHash = requestContext.getRequiredParameter(0, Hash.class);
     final Optional<TransactionLocation> maybeLocation =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
@@ -16,7 +16,7 @@ public abstract class PrivacyApiMethod implements JsonRpcMethod {
   }
 
   @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+  public final JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
     if (privacyParameters.isEnabled()) {
       return doResponse(requestContext);
     } else {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivacyApiMethod.java
@@ -1,0 +1,29 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+
+public abstract class PrivacyApiMethod implements JsonRpcMethod {
+
+  protected final PrivacyParameters privacyParameters;
+
+  protected PrivacyApiMethod(final PrivacyParameters privacyParameters) {
+    this.privacyParameters = privacyParameters;
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    if (privacyParameters.isEnabled()) {
+      return doResponse(requestContext);
+    } else {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.PRIVACY_NOT_ENABLED);
+    }
+  }
+
+  public abstract JsonRpcResponse doResponse(final JsonRpcRequestContext request);
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -107,7 +107,7 @@ public enum JsonRpcError {
   // Private transaction errors
   ENCLAVE_ERROR(-50100, "Error communicating with enclave"),
   UNIMPLEMENTED_PRIVATE_TRANSACTION_TYPE(-50100, "Unimplemented private transaction type"),
-  PRIVACY_NOT_ENABLED(-50100, "Privacy is not enabled to get the precompiled address"),
+  PRIVACY_NOT_ENABLED(-50100, "Privacy is not enabled"),
   CREATE_PRIVACY_GROUP_ERROR(-50100, "Error creating privacy group"),
   DELETE_PRIVACY_GROUP_ERROR(-50100, "Error deleting privacy group"),
   FIND_PRIVACY_GROUP_ERROR(-50100, "Error finding privacy group"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
@@ -47,8 +47,10 @@ public class EeaJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create(
       final PrivateTransactionHandler privateTransactionHandler) {
     return mapOf(
-        new EeaSendRawTransaction(privateTransactionHandler, getTransactionPool()),
+        new EeaSendRawTransaction(
+            getPrivacyParameters(), privateTransactionHandler, getTransactionPool()),
         new PrivGetEeaTransactionCount(
+            getPrivacyParameters(),
             new PrivateEeaNonceProvider(
                 getPrivacyParameters().getEnclave(), privateTransactionHandler)));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
-import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
@@ -52,15 +51,15 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create(
       final PrivateTransactionHandler privateTransactionHandler) {
-    final Enclave enclave = getPrivacyParameters().getEnclave();
     return mapOf(
-        new PrivGetTransactionReceipt(getBlockchainQueries(), enclave, getPrivacyParameters()),
+        new PrivGetTransactionReceipt(getBlockchainQueries(), getPrivacyParameters()),
         new PrivCreatePrivacyGroup(getPrivacyParameters()),
         new PrivDeletePrivacyGroup(getPrivacyParameters()),
-        new PrivFindPrivacyGroup(getPrivacyParameters().getEnclave()),
+        new PrivFindPrivacyGroup(getPrivacyParameters()),
         new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
-        new PrivGetTransactionCount(privateTransactionHandler),
-        new PrivGetPrivateTransaction(getBlockchainQueries(), enclave, getPrivacyParameters()),
-        new PrivDistributeRawTransaction(privateTransactionHandler, getTransactionPool()));
+        new PrivGetTransactionCount(getPrivacyParameters(), privateTransactionHandler),
+        new PrivGetPrivateTransaction(getBlockchainQueries(), getPrivacyParameters()),
+        new PrivDistributeRawTransaction(
+            getPrivacyParameters(), privateTransactionHandler, getTransactionPool()));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
@@ -52,6 +52,7 @@ public class PrivCreatePrivacyGroupTest {
     when(failingEnclave.createPrivacyGroup(any(CreatePrivacyGroupRequest.class)))
         .thenThrow(new EnclaveException(""));
     when(privacyParameters.getEnclave()).thenReturn(enclave);
+    when(privacyParameters.isEnabled()).thenReturn(true);
   }
 
   @Test
@@ -255,5 +256,20 @@ public class PrivCreatePrivacyGroupTest {
     final JsonRpcError result = response.getError();
 
     assertThat(result).isEqualTo(JsonRpcError.ENCLAVE_ERROR);
+  }
+
+  @Test
+  public void returnPrivacyDisabledErrorWhenPrivacyIsDisabled() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+    final PrivCreatePrivacyGroup privCreatePrivacyGroup =
+        new PrivCreatePrivacyGroup(privacyParameters);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("1", "priv_createPrivacyGroup", new Object[] {}));
+    final JsonRpcErrorResponse response =
+        (JsonRpcErrorResponse) privCreatePrivacyGroup.response(request);
+
+    assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
@@ -1,0 +1,43 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.enclave.Enclave;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrivDeletePrivacyGroupTest {
+
+  private Enclave enclave;
+  private PrivacyParameters privacyParameters;
+  private PrivDeletePrivacyGroup privDeletePrivacyGroup;
+
+  @Before
+  public void before() {
+    enclave = mock(Enclave.class);
+    privacyParameters = mock(PrivacyParameters.class);
+    when(privacyParameters.getEnclave()).thenReturn(enclave);
+    privDeletePrivacyGroup = new PrivDeletePrivacyGroup(privacyParameters);
+  }
+
+  @Test
+  public void returnPrivacyDisabledErrorWhenPrivacyIsDisabled() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("1", "priv_deletePrivacyGroup", new Object[] {}));
+    final JsonRpcErrorResponse response =
+        (JsonRpcErrorResponse) privDeletePrivacyGroup.response(request);
+
+    assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
@@ -1,7 +1,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.enclave.Enclave;
@@ -13,17 +12,19 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PrivDeletePrivacyGroupTest {
 
-  private Enclave enclave;
-  private PrivacyParameters privacyParameters;
+  @Mock private Enclave enclave;
+  @Mock private PrivacyParameters privacyParameters;
   private PrivDeletePrivacyGroup privDeletePrivacyGroup;
 
   @Before
   public void before() {
-    enclave = mock(Enclave.class);
-    privacyParameters = mock(PrivacyParameters.class);
     when(privacyParameters.getEnclave()).thenReturn(enclave);
     privDeletePrivacyGroup = new PrivDeletePrivacyGroup(privacyParameters);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
@@ -21,8 +21,11 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
@@ -56,9 +59,12 @@ public class PrivDistributeRawTransactionTest {
 
   @Mock private PrivateTransactionHandler privateTxHandler;
 
+  @Mock private PrivacyParameters privacyParameters;
+
   @Before
   public void before() {
-    method = new PrivDistributeRawTransaction(privateTxHandler, transactionPool);
+    when(privacyParameters.isEnabled()).thenReturn(true);
+    method = new PrivDistributeRawTransaction(privacyParameters, privateTxHandler, transactionPool);
   }
 
   @Test
@@ -88,5 +94,17 @@ public class PrivDistributeRawTransactionTest {
     verify(privateTxHandler).getPrivacyGroup(any(String.class), any(PrivateTransaction.class));
     verify(privateTxHandler)
         .validatePrivateTransaction(any(PrivateTransaction.class), any(String.class));
+  }
+
+  @Test
+  public void returnPrivacyDisabledErrorWhenPrivacyIsDisabled() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("1", "priv_distributeRawTransaction", new Object[] {}));
+    final JsonRpcErrorResponse response = (JsonRpcErrorResponse) method.response(request);
+
+    assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
@@ -1,0 +1,42 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.enclave.Enclave;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class PrivFindPrivacyGroupTest {
+
+  private Enclave enclave;
+  private PrivacyParameters privacyParameters;
+  private PrivFindPrivacyGroup privFindPrivacyGroup;
+
+  @Before
+  public void before() {
+    enclave = mock(Enclave.class);
+    privacyParameters = mock(PrivacyParameters.class);
+    when(privacyParameters.getEnclave()).thenReturn(enclave);
+    privFindPrivacyGroup = new PrivFindPrivacyGroup(privacyParameters);
+  }
+
+  @Test
+  public void returnPrivacyDisabledErrorWhenPrivacyIsDisabled() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(new JsonRpcRequest("1", "findPrivacyGroup", new Object[] {}));
+    final JsonRpcErrorResponse response =
+        (JsonRpcErrorResponse) privFindPrivacyGroup.response(request);
+
+    assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
@@ -1,7 +1,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.enclave.Enclave;
@@ -13,17 +12,19 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PrivFindPrivacyGroupTest {
 
-  private Enclave enclave;
-  private PrivacyParameters privacyParameters;
+  @Mock private Enclave enclave;
+  @Mock private PrivacyParameters privacyParameters;
   private PrivFindPrivacyGroup privFindPrivacyGroup;
 
   @Before
   public void before() {
-    enclave = mock(Enclave.class);
-    privacyParameters = mock(PrivacyParameters.class);
     when(privacyParameters.getEnclave()).thenReturn(enclave);
     privFindPrivacyGroup = new PrivFindPrivacyGroup(privacyParameters);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
@@ -21,15 +21,23 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionHandler;
 import org.hyperledger.besu.util.bytes.BytesValue;
 import org.hyperledger.besu.util.bytes.BytesValues;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class PrivGetTransactionCountTest {
+
+  private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
+  private final PrivateTransactionHandler privateTransactionHandler =
+      mock(PrivateTransactionHandler.class);
 
   private final String privacyGroupId =
       BytesValues.asBase64String(BytesValue.wrap("0x123".getBytes(UTF_8)));
@@ -38,14 +46,16 @@ public class PrivGetTransactionCountTest {
       Address.fromHexString("0x627306090abab3a6e1400e9345bc60c78a8bef57");
   private final long NONCE = 5;
 
+  @Before
+  public void before() {
+    when(privacyParameters.isEnabled()).thenReturn(true);
+    when(privateTransactionHandler.getSenderNonce(senderAddress, privacyGroupId)).thenReturn(NONCE);
+  }
+
   @Test
   public void verifyTransactionCount() {
-    final PrivateTransactionHandler privateTransactionHandler =
-        mock(PrivateTransactionHandler.class);
-    when(privateTransactionHandler.getSenderNonce(senderAddress, privacyGroupId)).thenReturn(NONCE);
-
     final PrivGetTransactionCount privGetTransactionCount =
-        new PrivGetTransactionCount(privateTransactionHandler);
+        new PrivGetTransactionCount(privacyParameters, privateTransactionHandler);
 
     final Object[] params = new Object[] {senderAddress, privacyGroupId};
     final JsonRpcRequestContext request =
@@ -55,5 +65,20 @@ public class PrivGetTransactionCountTest {
         (JsonRpcSuccessResponse) privGetTransactionCount.response(request);
 
     assertThat(response.getResult()).isEqualTo(String.format("0x%X", NONCE));
+  }
+
+  @Test
+  public void returnPrivacyDisabledErrorWhenPrivacyIsDisabled() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+    final PrivGetTransactionCount privGetTransactionCount =
+        new PrivGetTransactionCount(privacyParameters, privateTransactionHandler);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest("1", "priv_getTransactionCount", new Object[] {}));
+    final JsonRpcErrorResponse response =
+        (JsonRpcErrorResponse) privGetTransactionCount.response(request);
+
+    assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
   }
 }


### PR DESCRIPTION
This is to be done similar to what is done for the permissioning API methods.

When privay is disabled, but the user specifies PRIV or EEA api groups in the cmd line, Besu should give a warning about not being able to use the methods.

If the user tries to execute the methods, Besu should give back a nice response saying that they aren't available because privacy is disabled.

* Updated `BesuCommand` to give warning if privacy is disabled and user tries to enable PRIV or EEA methods
* Created `PrivacyApiMethod` abstract class that has the logic of checking if privacy is enabled and returning a nice error when it is not
* Updated all Priv/Eea method objects to extend `PrivacyApiMethod`
* Updated unit tests