### PR TITLE
Increase timeout to 5s

### DIFF
--- a/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
@@ -27,7 +27,7 @@ import io.vertx.core.http.HttpMethod;
 public class VertxRequestTransmitter implements RequestTransmitter {
 
   private final HttpClient client;
-  private static final long REQUEST_TIMEOUT_MS = 1000L;
+  private static final long REQUEST_TIMEOUT_MS = 5000L;
 
   public VertxRequestTransmitter(final HttpClient httpClient) {
     this.client = httpClient;


### PR DESCRIPTION
Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>

Increase the request timeout from 1s to 5s.
Some integration test started failing intermittently because of the 1s timeout.