### PR TITLE
check enclave public key and improve error messages

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/chainimport/internal/TransactionData.java
+++ b/besu/src/main/java/org/hyperledger/besu/chainimport/internal/TransactionData.java
@@ -56,7 +56,7 @@ public class TransactionData {
   }
 
   public Transaction getSignedTransaction(final NonceProvider nonceProvider) {
-    KeyPair keyPair = KeyPair.create(privateKey);
+    final KeyPair keyPair = KeyPair.create(privateKey);
 
     final Address fromAddress = Address.extract(keyPair.getPublicKey());
     final long nonce = nonceProvider.get(fromAddress);

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1374,7 +1374,15 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       privacyParametersBuilder.setEnabled(true);
       privacyParametersBuilder.setEnclaveUrl(privacyUrl);
       if (privacyPublicKeyFile() != null) {
-        privacyParametersBuilder.setEnclavePublicKeyUsingFile(privacyPublicKeyFile());
+        try {
+          privacyParametersBuilder.setEnclavePublicKeyUsingFile(privacyPublicKeyFile());
+        } catch (final IOException e) {
+          throw new ParameterException(
+              commandLine, "Problem with privacy-public-key-file: " + e.getMessage(), e);
+        } catch (final IllegalArgumentException e) {
+          throw new ParameterException(
+              commandLine, "Contents of privacy-public-key-file invalid: " + e.getMessage(), e);
+        }
       } else {
         throw new ParameterException(
             commandLine, "Please specify Enclave public key file path to enable privacy");

--- a/besu/src/main/java/org/hyperledger/besu/cli/converter/FractionConverter.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/converter/FractionConverter.java
@@ -25,7 +25,7 @@ public class FractionConverter implements CommandLine.ITypeConverter<Float> {
   public Float convert(final String value) throws FractionConversionException {
     try {
       return Fraction.fromString(value).getValue();
-    } catch (NullPointerException | IllegalArgumentException e) {
+    } catch (final NullPointerException | IllegalArgumentException e) {
       throw new FractionConversionException(value);
     }
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/CommandLineUtils.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/CommandLineUtils.java
@@ -48,7 +48,7 @@ public class CommandLineUtils {
       final boolean isMainOptionCondition,
       final List<String> dependentOptionsNames) {
     if (isMainOptionCondition) {
-      String affectedOptions =
+      final String affectedOptions =
           commandLine.getCommandSpec().options().stream()
               .filter(
                   option ->

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3138,4 +3138,35 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
+
+  @Test
+  public void privEnclaveKeyFileDoesNotExist() {
+    parseCommand("--privacy-enabled=true", "--privacy-public-key-file", "/non/existent/file");
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).startsWith("Problem with privacy-public-key-file");
+    assertThat(commandErrorOutput.toString()).contains("No such file");
+  }
+
+  @Test
+  public void privEnclaveKeyFileInvalidContentTooShort() throws IOException {
+    final Path file = createTempFile("privacy.key", "lkjashdfiluhwelrk");
+    parseCommand("--privacy-enabled=true", "--privacy-public-key-file", file.toString());
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString())
+        .startsWith("Contents of privacy-public-key-file invalid");
+    assertThat(commandErrorOutput.toString()).contains("needs to be 44 characters long");
+  }
+
+  @Test
+  public void privEnclaveKeyFileInvalidContentNotValidBase64() throws IOException {
+    final Path file = createTempFile("privacy.key", "l*jashdfillk9ashdfillkjashdfillkjashdfilrtg=");
+    parseCommand("--privacy-enabled=true", "--privacy-public-key-file", file.toString());
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString())
+        .startsWith("Contents of privacy-public-key-file invalid");
+    assertThat(commandErrorOutput.toString()).contains("Illegal base64 character");
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
@@ -210,14 +210,17 @@ public class PrivacyParameters {
     public Builder setEnclavePublicKeyUsingFile(final File publicKeyFile) throws IOException {
       this.enclavePublicKeyFile = publicKeyFile;
       this.enclavePublicKey = Files.asCharSource(publicKeyFile, UTF_8).read();
-      // check that the length of the Sting is 44, which base 64 decodes to 32 Byte
+      validatePublicKey(publicKeyFile);
+      return this;
+    }
+
+    private void validatePublicKey(final File publicKeyFile) {
       if (publicKeyFile.length() != 44) {
         throw new IllegalArgumentException(
             "Contents of enclave public key file needs to be 44 characters long to decode to a valid 32 byte public key.");
       }
-      // base 64 decode to see whether the value is a valid base64 String
+      // throws exception if invalid base 64
       Base64.getDecoder().decode(this.enclavePublicKey);
-      return this;
     }
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Optional;
 
 import com.google.common.io.Files;
@@ -209,6 +210,13 @@ public class PrivacyParameters {
     public Builder setEnclavePublicKeyUsingFile(final File publicKeyFile) throws IOException {
       this.enclavePublicKeyFile = publicKeyFile;
       this.enclavePublicKey = Files.asCharSource(publicKeyFile, UTF_8).read();
+      // check that the length of the Sting is 44, which base 64 decodes to 32 Byte
+      if (publicKeyFile.length() != 44) {
+        throw new IllegalArgumentException(
+            "Contents of enclave public key file needs to be 44 characters long to decode to a valid 32 byte public key.");
+      }
+      // base 64 decode to see whether the value is a valid base64 String
+      Base64.getDecoder().decode(this.enclavePublicKey);
       return this;
     }
   }


### PR DESCRIPTION
Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>

Check the --privacy-public-key-file parameter on the besu command line and return meaningful error messages. 