### PR TITLE
config/resources: activate agharta on classic 9573000

### DIFF
--- a/config/src/main/resources/classic.json
+++ b/config/src/main/resources/classic.json
@@ -8,6 +8,7 @@
     "gothamBlock": 5000001,
     "ecip1041Block": 5900000,
     "atlantisBlock": 8772000,
+    "aghartaBlock": 9573000,
     "ethash": {
 
     }


### PR DESCRIPTION
activates ecip-1056 on ethereum classic mainnet block 9573000. cc @edwardmack  

Ref https://github.com/ethereumclassic/ECIPs/pull/245