### PR TITLE
[BESU-157] Stop processing private tx when enclave is down

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -18,8 +18,10 @@ import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 
 import org.hyperledger.besu.controller.KeyPairUtil;
 import org.hyperledger.besu.enclave.Enclave;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveClientException;
 import org.hyperledger.besu.enclave.EnclaveFactory;
+import org.hyperledger.besu.enclave.EnclaveIOException;
+import org.hyperledger.besu.enclave.EnclaveServerException;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivacyStorageProvider;
@@ -119,8 +121,10 @@ public class PrivacyNode implements AutoCloseable {
               try {
                 enclaveClient.send(payload, orion.getDefaultPublicKey(), to);
                 return true;
-              } catch (final EnclaveException e) {
-                LOG.info("Waiting for enclave connectivity");
+              } catch (final EnclaveClientException
+                  | EnclaveIOException
+                  | EnclaveServerException e) {
+                LOG.warn("Waiting for enclave connectivity");
                 return false;
               }
             });

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveClientException.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveClientException.java
@@ -14,12 +14,19 @@
  */
 package org.hyperledger.besu.enclave;
 
-public class EnclaveException extends IllegalArgumentException {
-  public EnclaveException(final String message) {
+public class EnclaveClientException extends IllegalArgumentException {
+  private int statusCode;
+
+  public EnclaveClientException(final int statusCode, final String message) {
     super(message);
+    this.statusCode = statusCode;
   }
 
-  public EnclaveException(final String message, final Throwable cause) {
+  public EnclaveClientException(final String message, final Throwable cause) {
     super(message, cause);
+  }
+
+  public int getStatusCode() {
+    return statusCode;
   }
 }

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveFactory.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveFactory.java
@@ -30,7 +30,7 @@ public class EnclaveFactory {
 
   public Enclave createVertxEnclave(final URI enclaveUri) {
     if (enclaveUri.getPort() == -1) {
-      throw new EnclaveException("Illegal URI - no port specified");
+      throw new EnclaveIOException("Illegal URI - no port specified");
     }
 
     final HttpClientOptions clientOptions = new HttpClientOptions();

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveIOException.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveIOException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.enclave;
+
+public class EnclaveIOException extends RuntimeException {
+  public EnclaveIOException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public EnclaveIOException(final String message) {
+    super(message);
+  }
+}

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveServerException.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/EnclaveServerException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.enclave;
+
+public class EnclaveServerException extends RuntimeException {
+  private int statusCode;
+
+  public EnclaveServerException(final int statusCode, final String message) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+
+  public int getStatusCode() {
+    return statusCode;
+  }
+}

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
@@ -71,15 +71,13 @@ public class VertxRequestTransmitter implements RequestTransmitter {
         request.end();
       }
       return result.get();
-    } catch (final ExecutionException e) {
-      if (e.getCause() instanceof EnclaveException) {
-        throw (EnclaveException) e.getCause();
+    } catch (final ExecutionException | InterruptedException e) {
+      if (e.getCause() instanceof EnclaveClientException) {
+        throw (EnclaveClientException) e.getCause();
+      } else if (e.getCause() instanceof EnclaveServerException) {
+        throw (EnclaveServerException) e.getCause();
       }
-      throw new EnclaveException("Failure during reception", e);
-    } catch (final InterruptedException e) {
-      throw new EnclaveException("Task interrupted while waiting for Enclave response.", e);
-    } catch (final Exception e) {
-      throw new EnclaveException("Other error", e);
+      throw new EnclaveIOException("Enclave Communication Failed", e);
     }
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.apache.logging.log4j.LogManager.getLogger;
 
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveClientException;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -101,7 +101,7 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
 
       privateTransaction = PrivateTransaction.readFrom(bytesValueRLPInput);
       privacyGroupId = receiveResponse.getPrivacyGroupId();
-    } catch (final EnclaveException e) {
+    } catch (final EnclaveClientException e) {
       return handleEnclaveException(requestContext, e);
     }
 
@@ -172,7 +172,7 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
   }
 
   private JsonRpcResponse handleEnclaveException(
-      final JsonRpcRequestContext requestContext, final EnclaveException e) {
+      final JsonRpcRequestContext requestContext, final EnclaveClientException e) {
     final JsonRpcError jsonRpcError =
         JsonRpcEnclaveErrorConverter.convertEnclaveInvalidReason(e.getMessage());
     switch (jsonRpcError) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveServerException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
@@ -283,7 +283,7 @@ public class EeaSendRawTransactionTest {
   @Test
   public void invalidTransactionIsNotSentToTransactionPool() {
     when(privacyController.sendTransaction(any(PrivateTransaction.class)))
-        .thenThrow(new EnclaveException("enclave failed to execute"));
+        .thenThrow(new EnclaveServerException(500, "enclave failed to execute"));
 
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.enclave.Enclave;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveServerException;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -242,7 +242,7 @@ public class PrivCreatePrivacyGroupTest {
   @Test
   public void returnsCorrectErrorEnclaveError() {
     when(privacyController.createPrivacyGroup(ADDRESSES, NAME, DESCRIPTION))
-        .thenThrow(new EnclaveException(""));
+        .thenThrow(new EnclaveServerException(500, ""));
     final PrivCreatePrivacyGroup privCreatePrivacyGroup =
         new PrivCreatePrivacyGroup(privacyController);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.enclave.Enclave;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveClientException;
+import org.hyperledger.besu.enclave.EnclaveServerException;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -139,10 +139,8 @@ public class PrivGetTransactionReceiptTest {
 
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final Blockchain blockchain = mock(Blockchain.class);
-  private final Enclave enclave = mock(Enclave.class);
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
   private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
-  private final PrivacyController failingPrivacyController = mock(PrivacyController.class);
   private final PrivacyController privacyController = mock(PrivacyController.class);
 
   @Before
@@ -174,7 +172,6 @@ public class PrivGetTransactionReceiptTest {
 
   @Test
   public void returnReceiptIfTransactionExists() {
-    when(privacyParameters.getEnclave()).thenReturn(enclave);
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(blockchainQueries, privacyParameters, privacyController);
@@ -192,12 +189,11 @@ public class PrivGetTransactionReceiptTest {
 
   @Test
   public void enclavePayloadNotFoundResultsInSuccessButNullResponse() {
-    when(failingPrivacyController.retrieveTransaction(anyString()))
-        .thenThrow(new EnclaveException("EnclavePayloadNotFound"));
+    when(privacyController.retrieveTransaction(anyString()))
+        .thenThrow(new EnclaveClientException(404, "EnclavePayloadNotFound"));
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, failingPrivacyController);
+        new PrivGetTransactionReceipt(blockchainQueries, privacyParameters, privacyController);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(new JsonRpcRequest("1", "priv_getTransactionReceipt", params));
@@ -213,7 +209,6 @@ public class PrivGetTransactionReceiptTest {
   @Test
   public void markerTransactionNotAvailableResultsInNullResponse() {
     when(blockchain.getTransactionLocation(nullable(Hash.class))).thenReturn(Optional.empty());
-    when(privacyParameters.getEnclave()).thenReturn(enclave);
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(blockchainQueries, privacyParameters, privacyController);
@@ -231,11 +226,10 @@ public class PrivGetTransactionReceiptTest {
 
   @Test
   public void enclaveConnectionIssueThrowsRuntimeException() {
-    when(failingPrivacyController.retrieveTransaction(anyString()))
-        .thenThrow(EnclaveException.class);
+    when(privacyController.retrieveTransaction(anyString()))
+        .thenThrow(EnclaveServerException.class);
     final PrivGetTransactionReceipt privGetTransactionReceipt =
-        new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, failingPrivacyController);
+        new PrivGetTransactionReceipt(blockchainQueries, privacyParameters, privacyController);
     final Object[] params = new Object[] {transaction.getHash()};
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(new JsonRpcRequest("1", "priv_getTransactionReceipt", params));
@@ -266,9 +260,8 @@ public class PrivGetTransactionReceiptTest {
   @Test
   public void enclaveKeysCannotDecryptPayloadThrowsRuntimeException() {
     final String keysCannotDecryptPayloadMsg = "EnclaveKeysCannotDecryptPayload";
-    when(privacyParameters.getEnclave()).thenReturn(enclave);
     when(privacyController.retrieveTransaction(any()))
-        .thenThrow(new EnclaveException(keysCannotDecryptPayloadMsg));
+        .thenThrow(new EnclaveClientException(400, keysCannotDecryptPayloadMsg));
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(blockchainQueries, privacyParameters, privacyController);
@@ -277,7 +270,7 @@ public class PrivGetTransactionReceiptTest {
         new JsonRpcRequestContext(new JsonRpcRequest("1", "priv_getTransactionReceipt", params));
 
     final Throwable t = catchThrowable(() -> privGetTransactionReceipt.response(request));
-    assertThat(t).isInstanceOf(EnclaveException.class);
+    assertThat(t).isInstanceOf(EnclaveClientException.class);
     assertThat(t.getMessage()).isEqualTo(keysCannotDecryptPayloadMsg);
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.enclave.Enclave;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveClientException;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -54,10 +54,10 @@ public class PrivacyPrecompiledContractTest {
 
   private final String actual = "Test String";
   private final BytesValue key = BytesValue.wrap(actual.getBytes(UTF_8));
-  private PrivacyPrecompiledContract privacyPrecompiledContract;
-  private PrivacyPrecompiledContract brokenPrivateTransactionHandler;
   private MessageFrame messageFrame;
   private final String DEFAULT_OUTPUT = "0x01";
+  private final WorldStateArchive worldStateArchive = mock(WorldStateArchive.class);
+  final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
 
   private static final byte[] VALID_PRIVATE_TRANSACTION_RLP_BASE64 =
       Base64.getEncoder()
@@ -74,13 +74,6 @@ public class PrivacyPrecompiledContractTest {
                           + "6e766966746a69697a706a52742b4854754642733d8a726573747269637465"
                           + "64")
                   .extractArray());
-
-  private Enclave mockEnclave() {
-    final Enclave mockEnclave = mock(Enclave.class);
-    final ReceiveResponse response = new ReceiveResponse(VALID_PRIVATE_TRANSACTION_RLP_BASE64, "");
-    when(mockEnclave.receive(any())).thenReturn(response);
-    return mockEnclave;
-  }
 
   private PrivateTransactionProcessor mockPrivateTxProcessor() {
     final PrivateTransactionProcessor mockPrivateTransactionProcessor =
@@ -104,22 +97,13 @@ public class PrivacyPrecompiledContractTest {
     return mockPrivateTransactionProcessor;
   }
 
-  private Enclave brokenMockEnclave() {
-    final Enclave mockEnclave = mock(Enclave.class);
-    when(mockEnclave.receive(any())).thenThrow(EnclaveException.class);
-    return mockEnclave;
-  }
-
   @Before
   public void setUp() {
-    final WorldStateArchive worldStateArchive;
-    worldStateArchive = mock(WorldStateArchive.class);
     final MutableWorldState mutableWorldState = mock(MutableWorldState.class);
     when(mutableWorldState.updater()).thenReturn(mock(WorldUpdater.class));
     when(worldStateArchive.getMutable()).thenReturn(mutableWorldState);
     when(worldStateArchive.getMutable(any())).thenReturn(Optional.of(mutableWorldState));
 
-    final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
     final PrivateStateStorage.Updater storageUpdater = mock(PrivateStateStorage.Updater.class);
     when(storageUpdater.putLatestStateRoot(nullable(Bytes32.class), any()))
         .thenReturn(storageUpdater);
@@ -129,33 +113,50 @@ public class PrivacyPrecompiledContractTest {
         .thenReturn(storageUpdater);
     when(privateStateStorage.updater()).thenReturn(storageUpdater);
 
-    privacyPrecompiledContract =
-        new PrivacyPrecompiledContract(
-            new SpuriousDragonGasCalculator(),
-            mockEnclave(),
-            worldStateArchive,
-            privateStateStorage);
-    privacyPrecompiledContract.setPrivateTransactionProcessor(mockPrivateTxProcessor());
-    brokenPrivateTransactionHandler =
-        new PrivacyPrecompiledContract(
-            new SpuriousDragonGasCalculator(),
-            brokenMockEnclave(),
-            worldStateArchive,
-            privateStateStorage);
     messageFrame = mock(MessageFrame.class);
   }
 
   @Test
-  public void testPrivacyPrecompiledContract() {
-    final BytesValue actual = privacyPrecompiledContract.compute(key, messageFrame);
+  public void testPayloadFoundInEnaclave() {
+    Enclave enclave = mock(Enclave.class);
+    PrivacyPrecompiledContract contract =
+        new PrivacyPrecompiledContract(
+            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
+    contract.setPrivateTransactionProcessor(mockPrivateTxProcessor());
+
+    final ReceiveResponse response = new ReceiveResponse(VALID_PRIVATE_TRANSACTION_RLP_BASE64, "");
+    when(enclave.receive(any(String.class))).thenReturn(response);
+
+    final BytesValue actual = contract.compute(key, messageFrame);
 
     assertThat(actual).isEqualTo(BytesValue.fromHexString(DEFAULT_OUTPUT));
   }
 
   @Test
-  public void enclaveIsDownWhileHandling() {
-    final BytesValue expected = brokenPrivateTransactionHandler.compute(key, messageFrame);
+  public void testPayloadNotFoundInEnclave() {
+    Enclave enclave = mock(Enclave.class);
+
+    PrivacyPrecompiledContract contract =
+        new PrivacyPrecompiledContract(
+            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
+
+    when(enclave.receive(any(String.class))).thenThrow(EnclaveClientException.class);
+
+    final BytesValue expected = contract.compute(key, messageFrame);
 
     assertThat(expected).isEqualTo(BytesValue.EMPTY);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testEnclaveDown() {
+    Enclave enclave = mock(Enclave.class);
+
+    PrivacyPrecompiledContract contract =
+        new PrivacyPrecompiledContract(
+            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
+
+    when(enclave.receive(any(String.class))).thenThrow(new RuntimeException());
+
+    contract.compute(key, messageFrame);
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivacyControllerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivacyControllerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.enclave.Enclave;
-import org.hyperledger.besu.enclave.EnclaveException;
+import org.hyperledger.besu.enclave.EnclaveServerException;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.PrivacyGroup.Type;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
@@ -111,7 +111,8 @@ public class PrivacyControllerTest {
 
   private Enclave brokenMockEnclave() {
     Enclave mockEnclave = mock(Enclave.class);
-    when(mockEnclave.send(anyString(), anyString(), anyList())).thenThrow(EnclaveException.class);
+    when(mockEnclave.send(anyString(), anyString(), anyList()))
+        .thenThrow(EnclaveServerException.class);
     return mockEnclave;
   }
 
@@ -207,7 +208,7 @@ public class PrivacyControllerTest {
 
   @Test
   public void sendTransactionWhenEnclaveFailsThrowsEnclaveError() {
-    assertThatExceptionOfType(EnclaveException.class)
+    assertThatExceptionOfType(EnclaveServerException.class)
         .isThrownBy(() -> brokenPrivacyController.sendTransaction(buildLegacyPrivateTransaction()));
   }
 


### PR DESCRIPTION
When a besu node sees a private marker transaction and the enclave is down/unavailable/unreachable block processing should stop until the enclave is available again.

This will stop ALL new blocks from node processed. The node will keep retrying forever until the enclave is available again. 

If the enclave becomes available but does not contain the expected data (i.e the enclave has lost data) then the privacy group may have an inconsistent state. 

Signed-off-by: Antony Denyer <email@antonydenyer.co.uk>