### PR TITLE
Improving error msg when privacy key doesn't match Orion key

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -147,7 +147,9 @@ public enum JsonRpcError {
   ENCLAVE_UNABLE_PUSH_DELETE_PRIVACY_GROUP(-50200, "PrivacyGroupNotPushed"),
   ENCLAVE_PRIVACY_GROUP_MISSING(-50200, "PrivacyGroupNotFound"),
   ENCLAVE_PRIVACY_QUERY_ERROR(-50200, "PrivacyGroupQueryError"),
+  ENCLAVE_KEYS_CANNOT_DECRYPT_PAYLOAD(-50200, "EnclaveKeysCannotDecryptPayload"),
   METHOD_UNIMPLEMENTED(-50200, "MethodUnimplemented");
+
   private final int code;
   private final String message;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -281,4 +281,21 @@ public class PrivGetTransactionReceiptTest {
 
     assertThat(response.getError()).isEqualTo(JsonRpcError.PRIVACY_NOT_ENABLED);
   }
+
+  @Test
+  public void enclaveKeysCannotDecryptPayloadThrowsRuntimeException() {
+    final String keysCannotDecryptPayloadMsg = "EnclaveKeysCannotDecryptPayload";
+    when(privacyParameters.getEnclave()).thenReturn(enclave);
+    when(enclave.receive(any())).thenThrow(new EnclaveException(keysCannotDecryptPayloadMsg));
+
+    final PrivGetTransactionReceipt privGetTransactionReceipt =
+        new PrivGetTransactionReceipt(blockchainQueries, privacyParameters);
+    final Object[] params = new Object[] {transaction.getHash()};
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(new JsonRpcRequest("1", "priv_getTransactionReceipt", params));
+
+    final Throwable t = catchThrowable(() -> privGetTransactionReceipt.response(request));
+    assertThat(t).isInstanceOf(EnclaveException.class);
+    assertThat(t.getMessage()).isEqualTo(keysCannotDecryptPayloadMsg);
+  }
 }


### PR DESCRIPTION
## PR description

When Besu has been configured to use privacy and the option `privacy-public-key-file` doesn't match the key used in Orion, the priv_getPrivateTransactionReceipt method would fail without providing any info to the system admin on what could be wrong.

This PR adds a warning log message that will help system admins to track down this issue.