### PR TITLE
Upgrade to ethsign 0.4.0

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerConfig.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerConfig.java
@@ -14,30 +14,28 @@
  */
 package org.hyperledger.besu.tests.acceptance.dsl.ethsigner.testutil;
 
-import java.net.InetAddress;
 import java.nio.file.Path;
 import java.time.Duration;
-
 import org.apache.logging.log4j.Level;
 import tech.pegasys.ethsigner.core.Config;
 import tech.pegasys.ethsigner.core.signing.ChainIdProvider;
 
 public class EthSignerConfig implements Config {
   private final Level logLevel;
-  private final InetAddress downstreamHttpHost;
+  private final String downstreamHttpHost;
   private final Integer downStreamHttpPort;
   private Duration downstreamHttpRequestTimeout;
-  private final InetAddress httpListenHost;
+  private final String httpListenHost;
   private final Integer httpListenPort;
   private final ChainIdProvider chainId;
   private final Path dataDirectory;
 
   public EthSignerConfig(
       final Level logLevel,
-      final InetAddress downstreamHttpHost,
+      final String downstreamHttpHost,
       final Integer downStreamHttpPort,
       final Duration downstreamHttpRequestTimeout,
-      final InetAddress httpListenHost,
+      final String httpListenHost,
       final Integer httpListenPort,
       final ChainIdProvider chainId,
       final Path dataDirectory) {
@@ -58,7 +56,7 @@ public class EthSignerConfig implements Config {
   }
 
   @Override
-  public InetAddress getDownstreamHttpHost() {
+  public String getDownstreamHttpHost() {
     return downstreamHttpHost;
   }
 
@@ -73,7 +71,7 @@ public class EthSignerConfig implements Config {
   }
 
   @Override
-  public InetAddress getHttpListenHost() {
+  public String getHttpListenHost() {
     return httpListenHost;
   }
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerConfig.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerConfig.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.ethsigner.testutil;
 
 import java.nio.file.Path;
 import java.time.Duration;
+
 import org.apache.logging.log4j.Level;
 import tech.pegasys.ethsigner.core.Config;
 import tech.pegasys.ethsigner.core.signing.ChainIdProvider;

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarness.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarness.java
@@ -29,7 +29,7 @@ public class EthSignerTestHarness {
   public URI getHttpListeningUrl() {
     return URI.create(
         "http://"
-            + config.getHttpListenHost().getHostAddress()
+            + config.getHttpListenHost()
             + ":"
             + portsProperties.getProperty("http-jsonrpc"));
   }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarness.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarness.java
@@ -28,9 +28,6 @@ public class EthSignerTestHarness {
 
   public URI getHttpListeningUrl() {
     return URI.create(
-        "http://"
-            + config.getHttpListenHost()
-            + ":"
-            + portsProperties.getProperty("http-jsonrpc"));
+        "http://" + config.getHttpListenHost() + ":" + portsProperties.getProperty("http-jsonrpc"));
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarnessFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarnessFactory.java
@@ -35,6 +35,7 @@ import org.web3j.crypto.CipherException;
 import org.web3j.crypto.WalletUtils;
 import tech.pegasys.ethsigner.core.EthSigner;
 import tech.pegasys.ethsigner.core.signing.ConfigurationChainId;
+import tech.pegasys.ethsigner.core.signing.SingleTransactionSignerProvider;
 import tech.pegasys.ethsigner.signer.filebased.CredentialTransactionSigner;
 
 public class EthSignerTestHarnessFactory {
@@ -51,10 +52,10 @@ public class EthSignerTestHarnessFactory {
     final EthSignerConfig config =
         new EthSignerConfig(
             Level.DEBUG,
-            InetAddress.getByName(HOST),
+            HOST,
             besuPort,
             Duration.ofSeconds(10),
-            InetAddress.getByName(HOST),
+            HOST,
             0,
             new ConfigurationChainId(chainId),
             tempDir);
@@ -62,8 +63,8 @@ public class EthSignerTestHarnessFactory {
     final EthSigner ethSigner =
         new EthSigner(
             config,
-            new CredentialTransactionSigner(
-                WalletUtils.loadCredentials("", keyFilePath.toAbsolutePath().toFile())));
+            new SingleTransactionSignerProvider(new CredentialTransactionSigner(
+                WalletUtils.loadCredentials("", keyFilePath.toAbsolutePath().toFile()))));
     ethSigner.run();
 
     waitForPortFile(tempDir);

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarnessFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/ethsigner/testutil/EthSignerTestHarnessFactory.java
@@ -19,7 +19,6 @@ import static org.apache.tuweni.io.file.Files.copyResource;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -63,8 +62,9 @@ public class EthSignerTestHarnessFactory {
     final EthSigner ethSigner =
         new EthSigner(
             config,
-            new SingleTransactionSignerProvider(new CredentialTransactionSigner(
-                WalletUtils.loadCredentials("", keyFilePath.toAbsolutePath().toFile()))));
+            new SingleTransactionSignerProvider(
+                new CredentialTransactionSigner(
+                    WalletUtils.loadCredentials("", keyFilePath.toAbsolutePath().toFile()))));
     ethSigner.run();
 
     waitForPortFile(tempDir);

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -98,8 +98,8 @@ dependencyManagement {
 
     dependency 'org.xerial.snappy:snappy-java:1.1.7.3'
 
-    dependency "tech.pegasys.ethsigner.internal:core:0.3.0"
-    dependency "tech.pegasys.ethsigner.internal:file-based:0.3.0"
-    dependency "tech.pegasys.ethsigner.internal:signing-api:0.3.0"
+    dependency "tech.pegasys.ethsigner.internal:core:0.4.0"
+    dependency "tech.pegasys.ethsigner.internal:file-based:0.4.0"
+    dependency "tech.pegasys.ethsigner.internal:signing-api:0.4.0"
   }
 }


### PR DESCRIPTION
This upgrade removes the intermittent failure in
NewPendingTransactionAcceptanceTest (due to prior Ethsigner
affecting the leniency of the global json parser (making it
more strict than Besu demands)).

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
