### PR TITLE
Enclave retrieve privacy group enclave method

### DIFF
--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -152,7 +152,7 @@ public class EnclaveTest {
     assertThat(findPrivacyGroupResponse[0].getPrivacyGroupId())
         .isEqualTo(privacyGroupResponse.getPrivacyGroupId());
 
-    String response =
+    final String response =
         enclave.deletePrivacyGroup(privacyGroupResponse.getPrivacyGroupId(), publicKeys.get(0));
 
     assertThat(privacyGroupResponse.getPrivacyGroupId()).isEqualTo(response);
@@ -167,10 +167,9 @@ public class EnclaveTest {
     List<String> publicKeys = testHarness.getPublicKeys();
     String name = "name";
     String description = "desc";
-    final String[] addresses = publicKeys.toArray(new String[0]);
 
     PrivacyGroup privacyGroupResponse =
-        enclave.createPrivacyGroup(addresses, publicKeys.get(0), name, description);
+        enclave.createPrivacyGroup(publicKeys, publicKeys.get(0), name, description);
 
     assertThat(privacyGroupResponse.getPrivacyGroupId()).isNotNull();
     assertThat(privacyGroupResponse.getName()).isEqualTo(name);
@@ -182,7 +181,7 @@ public class EnclaveTest {
 
     assertThat(retrievePrivacyGroup).isEqualToComparingFieldByField(privacyGroupResponse);
 
-    String response =
+    final String response =
         enclave.deletePrivacyGroup(privacyGroupResponse.getPrivacyGroupId(), publicKeys.get(0));
 
     assertThat(privacyGroupResponse.getPrivacyGroupId()).isEqualTo(response);

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -134,11 +134,11 @@ public class EnclaveTest {
 
   @Test
   public void testCreateFindDeleteFindPrivacyGroup() {
-    List<String> publicKeys = testHarness.getPublicKeys();
-    String name = "name";
-    String description = "desc";
+    final List<String> publicKeys = testHarness.getPublicKeys();
+    final String name = "name";
+    final String description = "desc";
 
-    PrivacyGroup privacyGroupResponse =
+    final PrivacyGroup privacyGroupResponse =
         enclave.createPrivacyGroup(publicKeys, publicKeys.get(0), name, description);
 
     assertThat(privacyGroupResponse.getPrivacyGroupId()).isNotNull();
@@ -164,11 +164,11 @@ public class EnclaveTest {
 
   @Test
   public void testCreateDeleteRetrievePrivacyGroup() {
-    List<String> publicKeys = testHarness.getPublicKeys();
-    String name = "name";
-    String description = "desc";
+    final List<String> publicKeys = testHarness.getPublicKeys();
+    final String name = "name";
+    final String description = "desc";
 
-    PrivacyGroup privacyGroupResponse =
+    final PrivacyGroup privacyGroupResponse =
         enclave.createPrivacyGroup(publicKeys, publicKeys.get(0), name, description);
 
     assertThat(privacyGroupResponse.getPrivacyGroupId()).isNotNull();
@@ -176,7 +176,7 @@ public class EnclaveTest {
     assertThat(privacyGroupResponse.getDescription()).isEqualTo(description);
     assertThat(privacyGroupResponse.getType()).isEqualTo(PrivacyGroup.Type.PANTHEON);
 
-    PrivacyGroup retrievePrivacyGroup =
+    final PrivacyGroup retrievePrivacyGroup =
         enclave.retrievePrivacyGroup(privacyGroupResponse.getPrivacyGroupId());
 
     assertThat(retrievePrivacyGroup).isEqualToComparingFieldByField(privacyGroupResponse);

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -163,6 +163,32 @@ public class EnclaveTest {
   }
 
   @Test
+  public void testCreateDeleteRetrievePrivacyGroup() {
+    List<String> publicKeys = testHarness.getPublicKeys();
+    String name = "name";
+    String description = "desc";
+    final String[] addresses = publicKeys.toArray(new String[0]);
+
+    PrivacyGroup privacyGroupResponse =
+        enclave.createPrivacyGroup(addresses, publicKeys.get(0), name, description);
+
+    assertThat(privacyGroupResponse.getPrivacyGroupId()).isNotNull();
+    assertThat(privacyGroupResponse.getName()).isEqualTo(name);
+    assertThat(privacyGroupResponse.getDescription()).isEqualTo(description);
+    assertThat(privacyGroupResponse.getType()).isEqualTo(PrivacyGroup.Type.PANTHEON);
+
+    PrivacyGroup retrievePrivacyGroup =
+        enclave.retrievePrivacyGroup(privacyGroupResponse.getPrivacyGroupId());
+
+    assertThat(retrievePrivacyGroup).isEqualToComparingFieldByField(privacyGroupResponse);
+
+    String response =
+        enclave.deletePrivacyGroup(privacyGroupResponse.getPrivacyGroupId(), publicKeys.get(0));
+
+    assertThat(privacyGroupResponse.getPrivacyGroupId()).isEqualTo(response);
+  }
+
+  @Test
   public void upcheckReturnsFalseIfNoResposneReceived() throws URISyntaxException {
     assertThat(factory.createVertxEnclave(new URI("http://8.8.8.8:65535")).upCheck()).isFalse();
   }

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
@@ -128,8 +128,7 @@ public class Enclave {
   }
 
   public PrivacyGroup retrievePrivacyGroup(final String privacyGroupId) {
-    final RetrievePrivacyGroupRequest request =
-        new RetrievePrivacyGroupRequest(privacyGroupId);
+    final RetrievePrivacyGroupRequest request = new RetrievePrivacyGroupRequest(privacyGroupId);
     return post(
         JSON,
         request,

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
@@ -128,11 +128,11 @@ public class Enclave {
   }
 
   public PrivacyGroup retrievePrivacyGroup(final String privacyGroupId) {
-    final RetrievePrivacyGroupRequest retrievePrivacyGroupRequest =
+    final RetrievePrivacyGroupRequest request =
         new RetrievePrivacyGroupRequest(privacyGroupId);
     return post(
         JSON,
-        retrievePrivacyGroupRequest,
+        request,
         "/retrievePrivacyGroup",
         (statusCode, body) -> handleJsonResponse(statusCode, body, PrivacyGroup.class));
   }

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.enclave.types.FindPrivacyGroupRequest;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveRequest;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
+import org.hyperledger.besu.enclave.types.RetrievePrivacyGroupRequest;
 import org.hyperledger.besu.enclave.types.SendRequestBesu;
 import org.hyperledger.besu.enclave.types.SendRequestLegacy;
 import org.hyperledger.besu.enclave.types.SendResponse;
@@ -124,6 +125,16 @@ public class Enclave {
         request,
         "/findPrivacyGroup",
         (statusCode, body) -> handleJsonResponse(statusCode, body, PrivacyGroup[].class));
+  }
+
+  public PrivacyGroup retrievePrivacyGroup(final String privacyGroupId) {
+    final RetrievePrivacyGroupRequest retrievePrivacyGroupRequest =
+        new RetrievePrivacyGroupRequest(privacyGroupId);
+    return post(
+        JSON,
+        retrievePrivacyGroupRequest,
+        "/retrievePrivacyGroup",
+        (statusCode, body) -> handleJsonResponse(statusCode, body, PrivacyGroup.class));
   }
 
   private <T> T post(

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/types/RetrievePrivacyGroupRequest.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/types/RetrievePrivacyGroupRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.enclave.types;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class RetrievePrivacyGroupRequest {
+  private final String privacyGroupId;
+
+  @JsonCreator
+  public RetrievePrivacyGroupRequest(@JsonProperty("privacyGroupId") final String privacyGroupId) {
+    this.privacyGroupId = privacyGroupId;
+  }
+
+  @JsonProperty("privacyGroupId")
+  public String privacyGroupId() {
+    return privacyGroupId;
+  }
+}


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Add the Orion retrieve privacy group endpoint to the Enclave so that it can be used in Besu for the multi-tenancy privacy validation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
