### PR TITLE
Cleanup UnformattedDataWrapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,3 @@
 	path = ethereum/referencetests/src/test/resources
 	url = https://github.com/ethereum/tests.git
 	ignore = all
-	branch = 48142b4ee7a42d081c6eda7b2a57d9b2c958bc81
-	shallow = true

--- a/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
@@ -127,7 +127,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 1
       Block block = blocks.get(0);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.EMPTY);
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.ZERO);
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(2);
@@ -155,8 +155,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 2
       block = blocks.get(1);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData())
-            .isEqualTo(Bytes.fromHexString("0x1234"));
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.fromHexString("0x1234"));
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.fromHexString("0x02"));
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(1);
@@ -174,8 +173,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 3
       block = blocks.get(2);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData())
-            .isEqualTo(Bytes.fromHexString("0x3456"));
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.fromHexString("0x3456"));
         assertThat(block.getHeader().getCoinbase())
             .isEqualTo(Address.fromHexString("f17f52151EbEF6C7334FAD080c5704D77216b732"));
       }
@@ -184,7 +182,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 4
       block = blocks.get(3);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.EMPTY);
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.ZERO);
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(1);
@@ -220,7 +218,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 1
       Block block = blocks.get(0);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.EMPTY);
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.ZERO);
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(2);
@@ -248,8 +246,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 2
       block = blocks.get(1);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData())
-            .isEqualTo(Bytes.fromHexString("0x1234"));
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.fromHexString("0x1234"));
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.fromHexString("0x02"));
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(1);
@@ -267,8 +264,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 3
       block = blocks.get(2);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData())
-            .isEqualTo(Bytes.fromHexString("0x3456"));
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.fromHexString("0x3456"));
         assertThat(block.getHeader().getCoinbase())
             .isEqualTo(Address.fromHexString("f17f52151EbEF6C7334FAD080c5704D77216b732"));
       }
@@ -277,7 +273,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 4
       block = blocks.get(3);
       if (isEthash) {
-        assertThat(block.getHeader().internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.EMPTY);
         assertThat(block.getHeader().getCoinbase()).isEqualTo(Address.ZERO);
       }
       assertThat(block.getBody().getTransactions().size()).isEqualTo(1);
@@ -327,7 +323,7 @@ public abstract class JsonBlockImporterTest {
       // Check block 1
       assertThat(newBlock.getHeader().getParentHash()).isEqualTo(parentBlock.getHash());
       if (isEthash) {
-        assertThat(newBlock.getHeader().internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+        assertThat(newBlock.getHeader().getExtraData()).isEqualTo(Bytes.EMPTY);
         assertThat(newBlock.getHeader().getCoinbase()).isEqualTo(Address.ZERO);
       }
       assertThat(newBlock.getBody().getTransactions().size()).isEqualTo(1);
@@ -379,8 +375,7 @@ public abstract class JsonBlockImporterTest {
         importer.importChain(jsonData);
         final Blockchain blockchain = controller.getProtocolContext().getBlockchain();
         final Block block = getBlockAt(blockchain, 1);
-        assertThat(block.getHeader().internalGetExtraData())
-            .isEqualTo(Bytes.fromHexString("0x0123"));
+        assertThat(block.getHeader().getExtraData()).isEqualTo(Bytes.fromHexString("0x0123"));
         assertThat(block.getHeader().getCoinbase())
             .isEqualTo(Address.fromHexString("627306090abaB3A6e1400e9345bC60c78a8BEf57"));
       } else {

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueExtraData.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueExtraData.java
@@ -80,7 +80,7 @@ public class CliqueExtraData implements ParsedExtraData {
   }
 
   static CliqueExtraData decodeRaw(final BlockHeader header) {
-    final Bytes input = header.internalGetExtraData();
+    final Bytes input = header.getExtraData();
     if (input.size() < EXTRA_VANITY_LENGTH + Signature.BYTES_REQUIRED) {
       throw new IllegalArgumentException(
           "Invalid Bytes supplied - too short to produce a valid Clique Extra Data object.");

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashing.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashing.java
@@ -89,7 +89,7 @@ public class IbftBlockHashing {
 
     // set the extraData field using the supplied extraDataSerializer if the block height is not 0
     if (header.getNumber() == BlockHeader.GENESIS_BLOCK_NUMBER) {
-      builder.extraData(header.internalGetExtraData());
+      builder.extraData(header.getExtraData());
     } else {
       builder.extraData(extraDataSerializer.get());
     }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftBlockHeaderFunctions.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftBlockHeaderFunctions.java
@@ -48,6 +48,6 @@ public class IbftBlockHeaderFunctions implements BlockHeaderFunctions {
 
   @Override
   public IbftExtraData parseExtraData(final BlockHeader header) {
-    return IbftExtraData.decodeRaw(header.internalGetExtraData());
+    return IbftExtraData.decodeRaw(header.getExtraData());
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftExtraData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftExtraData.java
@@ -80,7 +80,7 @@ public class IbftExtraData implements ParsedExtraData {
     LOG.warn(
         "Expected a IbftExtraData instance but got {}. Reparsing required.",
         inputExtraData != null ? inputExtraData.getClass().getName() : "null");
-    return decodeRaw(blockHeader.internalGetExtraData());
+    return decodeRaw(blockHeader.getExtraData());
   }
 
   static IbftExtraData decodeRaw(final Bytes input) {

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
@@ -117,7 +117,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void getRoundNumberThrowsIfBlockIsNotOnTheChain() {
     final NonBesuBlockHeader header =
-        new NonBesuBlockHeader(blockHeader.getHash(), blockHeader.internalGetExtraData());
+        new NonBesuBlockHeader(blockHeader.getHash(), blockHeader.getExtraData());
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =
@@ -142,7 +142,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void getSignersThrowsIfBlockIsNotOnTheChain() {
     final NonBesuBlockHeader header =
-        new NonBesuBlockHeader(blockHeader.getHash(), blockHeader.internalGetExtraData());
+        new NonBesuBlockHeader(blockHeader.getHash(), blockHeader.getExtraData());
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =

--- a/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftBlockHashing.java
+++ b/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftBlockHashing.java
@@ -156,7 +156,7 @@ public class IbftBlockHashing {
     out.writeLongScalar(header.getTimestamp());
     // Cannot decode an IbftExtraData on block 0 due to missing/illegal signatures
     if (header.getNumber() == 0) {
-      out.writeBytes(header.internalGetExtraData());
+      out.writeBytes(header.getExtraData());
     } else {
       out.writeBytes(extraDataSerializer.get());
     }

--- a/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftExtraData.java
+++ b/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/IbftExtraData.java
@@ -69,7 +69,7 @@ public class IbftExtraData implements ParsedExtraData {
     LOG.warn(
         "Expected a IbftExtraData instance but got {}. Reparsing required.",
         inputExtraData != null ? inputExtraData.getClass().getName() : "null");
-    return decodeRaw(header.internalGetExtraData());
+    return decodeRaw(header.getExtraData());
   }
 
   static IbftExtraData decodeRaw(final Bytes input) {

--- a/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/LegacyIbftBlockHeaderFunctions.java
+++ b/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/LegacyIbftBlockHeaderFunctions.java
@@ -27,6 +27,6 @@ public class LegacyIbftBlockHeaderFunctions implements BlockHeaderFunctions {
 
   @Override
   public IbftExtraData parseExtraData(final BlockHeader header) {
-    return IbftExtraData.decodeRaw(header.internalGetExtraData());
+    return IbftExtraData.decodeRaw(header.getExtraData());
   }
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcResponseUtils.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcResponseUtils.java
@@ -48,7 +48,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 
@@ -165,7 +165,7 @@ public class JsonRpcResponseUtils {
     when(transaction.getHash()).thenReturn(hash(hash));
     when(transaction.getTo()).thenReturn(Optional.ofNullable(address(toAddress)));
     when(transaction.getSender()).thenReturn(address(fromAddress));
-    when(transaction.getPayload()).thenReturn(new UnformattedDataWrapper(bytes(input)));
+    when(transaction.getPayload()).thenReturn(new UnformattedDataImpl(bytes(input)));
     when(transaction.getValue()).thenReturn(wei(value));
     when(transaction.getGasLimit()).thenReturn(unsignedLong(gas));
 

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
@@ -161,7 +162,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
     final SendResponse sendResponse = enclave.send(payload, ENCLAVE_PUBLIC_KEY, to);
 
     final Bytes hexKey = Bytes.fromBase64String(sendResponse.getKey());
-    when(justTransaction.getPayloadBytes()).thenReturn(hexKey);
+    when(justTransaction.getPayload()).thenReturn(new UnformattedDataImpl(hexKey));
 
     final Object[] params = new Object[] {Hash.ZERO};
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
@@ -96,7 +96,7 @@ public class BlockAdapterBase extends AdapterBase {
   }
 
   public Optional<Bytes> getExtraData() {
-    return Optional.of(header.internalGetExtraData());
+    return Optional.of(header.getExtraData());
   }
 
   public Optional<Long> getGasLimit() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -99,7 +99,7 @@ public class TransactionAdapter extends AdapterBase {
   }
 
   public Optional<Bytes> getInputData() {
-    return Optional.of(transactionWithMetadata.getTransaction().getPayloadBytes());
+    return Optional.of(transactionWithMetadata.getTransaction().getPayload());
   }
 
   public Optional<NormalBlockAdapter> getBlock(final DataFetchingEnvironment environment) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -68,7 +68,7 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
       LOG.trace("Fetching transaction information");
       final ReceiveResponse receiveResponse =
           privacyController.retrieveTransaction(
-              resultTransaction.getTransaction().getPayloadBytes().toBase64String());
+              resultTransaction.getTransaction().getPayload().toBase64String());
       LOG.trace("Received transaction information");
 
       final BytesValueRLPInput input =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -92,7 +92,7 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
     final String privacyGroupId;
     try {
       final ReceiveResponse receiveResponse =
-          privacyController.retrieveTransaction(transaction.getPayloadBytes().toBase64String());
+          privacyController.retrieveTransaction(transaction.getPayload().toBase64String());
       LOG.trace("Received transaction information");
 
       final BytesValueRLPInput input =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -1797,8 +1797,7 @@ public class JsonRpcHttpServiceTest {
     assertThat(Wei.fromHexString(result.getString("gasPrice")))
         .isEqualTo(transaction.getGasPrice());
     assertThat(Long.decode(result.getString("gas"))).isEqualTo(transaction.getGasLimit());
-    assertThat(Bytes.fromHexString(result.getString("input")))
-        .isEqualTo(transaction.getPayloadBytes());
+    assertThat(Bytes.fromHexString(result.getString("input"))).isEqualTo(transaction.getPayload());
   }
 
   private void assertBlockResultMatchesBlock(final JsonObject result, final Block block) {
@@ -1816,7 +1815,7 @@ public class JsonRpcHttpServiceTest {
     assertThat(Difficulty.fromHexString(result.getString("difficulty")))
         .isEqualTo(header.getDifficulty());
     assertThat(Bytes.fromHexStringLenient(result.getString("extraData")))
-        .isEqualTo(header.internalGetExtraData());
+        .isEqualTo(header.getExtraData());
     assertThat(hexStringToInt(result.getString("size"))).isEqualTo(block.calculateSize());
     assertThat(Long.decode(result.getString("gasLimit"))).isEqualTo(header.getGasLimit());
     assertThat(Long.decode(result.getString("gasUsed"))).isEqualTo(header.getGasUsed());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/SimpleTestTransactionBuilder.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/SimpleTestTransactionBuilder.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 import org.hyperledger.besu.ethereum.core.Wei;
 
 import java.math.BigInteger;
@@ -69,8 +69,7 @@ public class SimpleTestTransactionBuilder {
     when(transaction.getS()).thenReturn(bigInteger(s));
     when(transaction.getTo()).thenReturn(Optional.ofNullable(address(toAddress)));
     when(transaction.getSender()).thenReturn(address(fromAddress));
-    when(transaction.getPayload())
-        .thenReturn(new UnformattedDataWrapper(Bytes.fromHexString(input)));
+    when(transaction.getPayload()).thenReturn(new UnformattedDataImpl(Bytes.fromHexString(input)));
     when(transaction.getValue()).thenReturn(wei(value));
     when(transaction.getGasLimit()).thenReturn(unsignedLong(gas));
     return transaction;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerLogFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerLogFilterTest.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.List;
@@ -200,7 +200,7 @@ public class FilterManagerLogFilterTest {
         Hash.ZERO,
         0,
         Address.fromHexString("0x0"),
-        new UnformattedDataWrapper(Bytes.EMPTY),
+        new UnformattedDataImpl(Bytes.EMPTY),
         Lists.newArrayList(),
         false);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
@@ -23,8 +23,6 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.LogTopic;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
-import org.hyperledger.besu.plugin.data.UnformattedData;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +33,7 @@ import org.junit.Test;
 
 public class LogsQueryTest {
 
-  private static final UnformattedData data =
-      new UnformattedDataWrapper(Bytes.fromHexString("0x0102"));
+  private static final Bytes data = Bytes.fromHexString("0x0102");
 
   @Test
   public void wildcardQueryAddressTopicReturnTrue() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogsResult;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -203,7 +203,7 @@ public class EthGetFilterChangesTest {
         Hash.ZERO,
         0,
         Address.fromHexString("0x0"),
-        new UnformattedDataWrapper(Bytes.EMPTY),
+        new UnformattedDataImpl(Bytes.EMPTY),
         Lists.newArrayList(),
         false);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
@@ -32,7 +32,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogsResult;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -137,7 +137,7 @@ public class EthGetFilterLogsTest {
             Hash.ZERO,
             0,
             Address.fromHexString("0x0"),
-            new UnformattedDataWrapper(Bytes.EMPTY),
+            new UnformattedDataImpl(Bytes.EMPTY),
             Lists.newArrayList(),
             false));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.UnformattedDataImpl;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
@@ -110,7 +111,8 @@ public class PrivGetPrivateTransactionTest {
     when(blockchain.transactionByHash(any(Hash.class)))
         .thenReturn(Optional.of(returnedTransaction));
     when(returnedTransaction.getTransaction()).thenReturn(justTransaction);
-    when(justTransaction.getPayloadBytes()).thenReturn(Bytes.fromBase64String(""));
+    when(justTransaction.getPayload())
+        .thenReturn(new UnformattedDataImpl(Bytes.fromBase64String("")));
 
     final PrivateTransaction privateTransaction =
         privateTransactionBuilder
@@ -145,7 +147,8 @@ public class PrivGetPrivateTransactionTest {
     when(blockchain.transactionByHash(any(Hash.class)))
         .thenReturn(Optional.of(returnedTransaction));
     when(returnedTransaction.getTransaction()).thenReturn(justTransaction);
-    when(justTransaction.getPayloadBytes()).thenReturn(Bytes.fromBase64String(""));
+    when(justTransaction.getPayload())
+        .thenReturn(new UnformattedDataImpl(Bytes.fromBase64String("")));
 
     final PrivateTransaction privateTransaction =
         privateTransactionBuilder

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -32,7 +32,6 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -70,8 +69,7 @@ public class BlockchainQueriesLogCacheTest {
   @BeforeClass
   public static void setupClass() throws IOException {
     final Address testAddress = Address.fromHexString("0x123456");
-    final UnformattedDataWrapper testMessage =
-        new UnformattedDataWrapper(Bytes.fromHexString("0x9876"));
+    final Bytes testMessage = Bytes.fromHexString("0x9876");
     final Log testLog = new Log(testAddress, testMessage, List.of());
     testLogsBloomFilter = new LogsBloomFilter();
     testLogsBloomFilter.insertLog(testLog);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -78,7 +78,7 @@ public class BlockHeaderBuilder {
         .gasLimit(header.getGasLimit())
         .gasUsed(header.getGasUsed())
         .timestamp(header.getTimestamp())
-        .extraData(header.internalGetExtraData())
+        .extraData(header.getExtraData())
         .mixHash(header.getMixHash())
         .nonce(header.getNonce());
   }
@@ -205,7 +205,7 @@ public class BlockHeaderBuilder {
     gasLimit(sealableBlockHeader.getGasLimit());
     gasUsed(sealableBlockHeader.getGasUsed());
     timestamp(sealableBlockHeader.getTimestamp());
-    extraData(sealableBlockHeader.internalGetExtraData());
+    extraData(sealableBlockHeader.getExtraData());
     return this;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Log.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Log.java
@@ -40,7 +40,11 @@ public class Log implements org.hyperledger.besu.plugin.data.Log {
    * @param data Data associated with this log.
    * @param topics Indexable topics associated with this log.
    */
-  public Log(final Address logger, final UnformattedData data, final List<LogTopic> topics) {
+  public Log(final Address logger, final Bytes data, final List<LogTopic> topics) {
+    this(logger, (UnformattedData) new UnformattedDataImpl(data), topics);
+  }
+
+  protected Log(final Address logger, final UnformattedData data, final List<LogTopic> topics) {
     this.logger = logger;
     this.data = data;
     this.topics = ImmutableList.copyOf(topics);
@@ -71,7 +75,7 @@ public class Log implements org.hyperledger.besu.plugin.data.Log {
     final List<LogTopic> topics = in.readList(listIn -> LogTopic.wrap(listIn.readBytes32()));
     final Bytes data = in.readBytes();
     in.leaveList();
-    return new Log(logger, new UnformattedDataWrapper(data), topics);
+    return new Log(logger, data, topics);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
-import org.hyperledger.besu.plugin.data.UnformattedData;
-
 import org.apache.tuweni.bytes.Bytes;
 
 /** A block header capable of being sealed. */
@@ -32,7 +30,7 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
 
   protected final long gasUsed;
 
-  protected final Bytes extraData;
+  protected final UnformattedDataImpl extraData;
 
   protected SealableBlockHeader(
       final Hash parentHash,
@@ -55,7 +53,7 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
     this.receiptsRoot = receiptsRoot;
     this.logsBloom = logsBloom;
     this.gasUsed = gasUsed;
-    this.extraData = extraData;
+    this.extraData = new UnformattedDataImpl(extraData);
   }
 
   /**
@@ -117,11 +115,7 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
    *
    * @return the raw bytes of the extra data field
    */
-  public UnformattedData getExtraData() {
-    return new UnformattedDataWrapper(extraData);
-  }
-
-  public Bytes internalGetExtraData() {
+  public UnformattedDataImpl getExtraData() {
     return extraData;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -60,7 +60,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
 
   private final SECP256K1.Signature signature;
 
-  private final Bytes payload;
+  private final UnformattedDataImpl payload;
 
   private final Optional<BigInteger> chainId;
 
@@ -147,7 +147,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
     this.to = to;
     this.value = value;
     this.signature = signature;
-    this.payload = payload;
+    this.payload = new UnformattedDataImpl(payload);
     this.sender = sender;
     this.chainId = chainId;
   }
@@ -220,11 +220,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
    * @return the transaction payload
    */
   @Override
-  public UnformattedData getPayload() {
-    return new UnformattedDataWrapper(payload);
-  }
-
-  public Bytes getPayloadBytes() {
+  public UnformattedDataImpl getPayload() {
     return payload;
   }
 
@@ -235,9 +231,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
    */
   @Override
   public Optional<UnformattedData> getInit() {
-    return getTo().isPresent()
-        ? Optional.empty()
-        : Optional.of(new UnformattedDataWrapper(payload));
+    return getTo().isPresent() ? Optional.empty() : Optional.of(payload);
   }
 
   /**
@@ -247,9 +241,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
    */
   @Override
   public Optional<UnformattedData> getData() {
-    return getTo().isPresent()
-        ? Optional.of(new UnformattedDataWrapper(payload))
-        : Optional.empty();
+    return getTo().isPresent() ? Optional.of(payload) : Optional.empty();
   }
 
   /**
@@ -306,7 +298,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
     out.writeLongScalar(getGasLimit());
     out.writeBytes(getTo().isPresent() ? getTo().get() : Bytes.EMPTY);
     out.writeUInt256Scalar(getValue());
-    out.writeBytes(getPayloadBytes());
+    out.writeBytes(getPayload());
     writeSignature(out);
 
     out.endList();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UnformattedDataImpl.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UnformattedDataImpl.java
@@ -18,49 +18,23 @@ package org.hyperledger.besu.ethereum.core;
 
 import org.hyperledger.besu.plugin.data.UnformattedData;
 
-import java.util.Objects;
-
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.DelegatingBytes;
 
 /** Wrapper for a Bytes value to be exposed as UnformattedData. */
-public class UnformattedDataWrapper implements UnformattedData {
+public class UnformattedDataImpl extends DelegatingBytes implements UnformattedData {
 
-  private final Bytes value;
-
-  public UnformattedDataWrapper(final Bytes value) {
-    this.value = value;
+  public UnformattedDataImpl(final Bytes value) {
+    super(value);
   }
 
   @Override
   public byte[] getByteArray() {
-    return value.toArray();
+    return toArray();
   }
 
   @Override
   public String getHexString() {
-    return value.toHexString();
-  }
-
-  @Override
-  public int size() {
-    return value.size();
-  }
-
-  @Override
-  public String toString() {
-    return getHexString();
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    UnformattedDataWrapper that = (UnformattedDataWrapper) o;
-    return Objects.equals(value, that.value);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(value);
+    return toHexString();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/EthHash.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/EthHash.java
@@ -177,7 +177,7 @@ public final class EthHash {
     out.writeLongScalar(header.getGasLimit());
     out.writeLongScalar(header.getGasUsed());
     out.writeLongScalar(header.getTimestamp());
-    out.writeBytes(header.internalGetExtraData());
+    out.writeBytes(header.getExtraData());
     out.endList();
     return DirectAcyclicGraphSeed.KECCAK_256.get().digest(out.encoded().toArray());
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/FrontierGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/FrontierGasCalculator.java
@@ -113,7 +113,7 @@ public class FrontierGasCalculator implements GasCalculator {
 
   @Override
   public Gas transactionIntrinsicGasCost(final Transaction transaction) {
-    final Bytes payload = transaction.getPayloadBytes();
+    final Bytes payload = transaction.getPayload();
     int zeros = 0;
     for (int i = 0; i < payload.size(); i++) {
       if (payload.get(i) == 0) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
@@ -41,7 +41,7 @@ public class IstanbulGasCalculator extends ConstantinopleFixGasCalculator {
 
   @Override
   public Gas transactionIntrinsicGasCost(final Transaction transaction) {
-    final Bytes payload = transaction.getPayloadBytes();
+    final Bytes payload = transaction.getPayload();
     int zeros = 0;
     for (int i = 0; i < payload.size(); i++) {
       if (payload.get(i) == 0) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -47,7 +47,7 @@ public final class MainnetBlockHeaderValidator {
     return createValidator(difficultyCalculator)
         .addRule(
             new ConstantFieldValidationRule<>(
-                "extraData", BlockHeader::internalGetExtraData, DAO_EXTRA_DATA))
+                "extraData", BlockHeader::getExtraData, DAO_EXTRA_DATA))
         .build();
   }
 
@@ -63,7 +63,7 @@ public final class MainnetBlockHeaderValidator {
   }
 
   public static boolean validateHeaderForDaoFork(final BlockHeader header) {
-    return header.internalGetExtraData().equals(DAO_EXTRA_DATA);
+    return DAO_EXTRA_DATA.equals(header.getExtraData());
   }
 
   public static boolean validateHeaderForClassicFork(final BlockHeader header) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -238,7 +238,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
               .sender(senderAddress)
               .value(transaction.getValue())
               .apparentValue(transaction.getValue())
-              .code(new Code(transaction.getPayloadBytes()))
+              .code(new Code(transaction.getPayload()))
               .blockHeader(blockHeader)
               .depth(0)
               .completer(c -> {})
@@ -265,7 +265,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
               .contractAccountVersion(
                   contract != null ? contract.getVersion() : Account.DEFAULT_VERSION)
               .gasPrice(transaction.getGasPrice())
-              .inputData(transaction.getPayloadBytes())
+              .inputData(transaction.getPayload())
               .sender(senderAddress)
               .value(transaction.getValue())
               .apparentValue(transaction.getValue())

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ExtraDataMaxLengthValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ExtraDataMaxLengthValidationRule.java
@@ -36,7 +36,7 @@ public class ExtraDataMaxLengthValidationRule implements DetachedBlockHeaderVali
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {
-    return validateExtraData(header.internalGetExtraData());
+    return validateExtraData(header.getExtraData());
   }
 
   private boolean validateExtraData(final Bytes extraData) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
@@ -94,7 +94,7 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
     out.writeLongScalar(header.getGasLimit());
     out.writeLongScalar(header.getGasUsed());
     out.writeLongScalar(header.getTimestamp());
-    out.writeBytes(header.internalGetExtraData());
+    out.writeBytes(header.getExtraData());
     out.endList();
 
     return Hash.hash(out.encoded());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/operations/LogOperation.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/operations/LogOperation.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.LogTopic;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
 import org.hyperledger.besu.ethereum.vm.AbstractOperation;
 import org.hyperledger.besu.ethereum.vm.EVM;
 import org.hyperledger.besu.ethereum.vm.ExceptionalHaltReason;
@@ -63,7 +62,7 @@ public class LogOperation extends AbstractOperation {
       builder.add(LogTopic.create(frame.popStackItem()));
     }
 
-    frame.addLog(new Log(address, new UnformattedDataWrapper(data), builder.build()));
+    frame.addLog(new Log(address, data, builder.build()));
   }
 
   @Override

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -386,7 +386,7 @@ public class BlockDataGenerator {
   public Log log(final int topicCount) {
     final List<LogTopic> topics =
         Stream.generate(this::logTopic).limit(topicCount).collect(Collectors.toList());
-    return new Log(address(), new UnformattedDataWrapper(bytesValue(5, 15)), topics);
+    return new Log(address(), bytesValue(5, 15), topics);
   }
 
   private LogTopic logTopic() {

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/NonBesuBlockHeader.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/NonBesuBlockHeader.java
@@ -20,14 +20,12 @@ import org.hyperledger.besu.plugin.data.Hash;
 import org.hyperledger.besu.plugin.data.Quantity;
 import org.hyperledger.besu.plugin.data.UnformattedData;
 
-import org.apache.tuweni.bytes.Bytes;
-
 public class NonBesuBlockHeader implements BlockHeader {
 
   final Hash blockHash;
-  final Bytes extraData;
+  final UnformattedData extraData;
 
-  public NonBesuBlockHeader(final Hash blockHash, final Bytes extraData) {
+  public NonBesuBlockHeader(final Hash blockHash, final UnformattedData extraData) {
     this.blockHash = blockHash;
     this.extraData = extraData;
   }
@@ -94,7 +92,7 @@ public class NonBesuBlockHeader implements BlockHeader {
 
   @Override
   public UnformattedData getExtraData() {
-    return new UnformattedDataWrapper(extraData);
+    return extraData;
   }
 
   @Override

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TestCodeExecutor.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TestCodeExecutor.java
@@ -76,7 +76,7 @@ public class TestCodeExecutor {
             .contract(SENDER_ADDRESS)
             .contractAccountVersion(accountVersion)
             .gasPrice(transaction.getGasPrice())
-            .inputData(transaction.getPayloadBytes())
+            .inputData(transaction.getPayload())
             .sender(SENDER_ADDRESS)
             .value(transaction.getValue())
             .code(new Code(Bytes.fromHexString(code)))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
@@ -59,7 +59,7 @@ public final class GenesisStateTest {
     assertThat(header.getTransactionsRoot()).isEqualTo(Hash.EMPTY_TRIE_HASH);
     assertThat(header.getReceiptsRoot()).isEqualTo(Hash.EMPTY_TRIE_HASH);
     assertThat(header.getOmmersHash()).isEqualTo(Hash.EMPTY_LIST_HASH);
-    assertThat(header.internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+    assertThat(header.getExtraData()).isEqualTo(Bytes.EMPTY);
     assertThat(header.getParentHash()).isEqualTo(Hash.ZERO);
     final MutableWorldState worldState = InMemoryStorageProvider.createInMemoryWorldState();
     genesisState.writeStateTo(worldState);
@@ -84,7 +84,7 @@ public final class GenesisStateTest {
     assertThat(header.getTransactionsRoot()).isEqualTo(Hash.EMPTY_TRIE_HASH);
     assertThat(header.getReceiptsRoot()).isEqualTo(Hash.EMPTY_TRIE_HASH);
     assertThat(header.getOmmersHash()).isEqualTo(Hash.EMPTY_LIST_HASH);
-    assertThat(header.internalGetExtraData()).isEqualTo(Bytes.EMPTY);
+    assertThat(header.getExtraData()).isEqualTo(Bytes.EMPTY);
     assertThat(header.getParentHash()).isEqualTo(Hash.ZERO);
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/LogsBloomFilterTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/LogsBloomFilterTest.java
@@ -33,7 +33,7 @@ public class LogsBloomFilterTest {
         LogTopic.fromHexString(
             "0x0000000000000000000000000000000000000000000000000000000000000000"));
 
-    final Log log = new Log(address, new UnformattedDataWrapper(data), topics);
+    final Log log = new Log(address, data, topics);
     final LogsBloomFilter bloom = LogsBloomFilter.empty();
     bloom.insertLog(log);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/markertransaction/FixedKeySigningPrivateMarkerTransactionFactoryTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/markertransaction/FixedKeySigningPrivateMarkerTransactionFactoryTest.java
@@ -68,7 +68,7 @@ public class FixedKeySigningPrivateMarkerTransactionFactoryTest {
     assertThat(transaction.getSender())
         .isEqualTo(Util.publicKeyToAddress(signingKeys.getPublicKey()));
     assertThat(transaction.getTo()).isEqualTo(Optional.of(precompiledAddress));
-    assertThat(transaction.getPayloadBytes())
+    assertThat(transaction.getPayload())
         .isEqualTo(Bytes.wrap(Base64.getDecoder().decode(enclaveKey)));
 
     final Transaction nextTransaction = factory.create("enclaveKey", privTransaction);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/markertransaction/RandomSigningPrivateMarkerTransactionFactoryTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/markertransaction/RandomSigningPrivateMarkerTransactionFactoryTest.java
@@ -60,7 +60,7 @@ public class RandomSigningPrivateMarkerTransactionFactoryTest {
     assertThat(transaction.getGasPrice()).isEqualTo(privTransaction.getGasPrice());
     assertThat(transaction.getValue()).isEqualTo(privTransaction.getValue());
     assertThat(transaction.getTo()).isEqualTo(Optional.of(precompiledAddress));
-    assertThat(transaction.getPayloadBytes())
+    assertThat(transaction.getPayload())
         .isEqualTo(Bytes.wrap(Base64.getDecoder().decode(enclaveKey)));
 
     final Transaction nextTransaction = factory.create("enclaveKey", privTransaction);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/LogMock.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/LogMock.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.vm;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.LogTopic;
-import org.hyperledger.besu.ethereum.core.UnformattedDataWrapper;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -42,7 +41,7 @@ public class LogMock extends Log {
       @JsonProperty("topics") final String[] topics) {
     super(
         Address.fromHexString(address),
-        new UnformattedDataWrapper(Bytes.fromHexString(data)),
+        Bytes.fromHexString(data),
         Arrays.stream(topics).map(LogTopic::fromHexString).collect(Collectors.toList()));
   }
 }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
@@ -196,7 +196,7 @@ public class TransactionSmartContractPermissioningController
         transaction.getValue().toBytes(),
         transaction.getGasPrice().toBytes(),
         encodeLong(transaction.getGasLimit()),
-        encodeBytes(transaction.getPayloadBytes()));
+        encodeBytes(transaction.getPayload()));
   }
 
   // Case for empty address


### PR DESCRIPTION
Keep UnformattedDataWrapper, but rename it UnformattedDataImpl as extending DelegatingBytes, thus removing the need to create a wrapper every time.