### PR TITLE
endpoint root path will redirect to /graphql

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceCorsTest.java
@@ -140,7 +140,10 @@ public class GraphQLHttpServiceCorsTest {
   public void requestWithNoOriginShouldSucceedWhenCorsIsSet() throws Exception {
     graphQLHttpService = createGraphQLHttpServiceWithAllowedDomains("http://foo.io");
 
-    final Request request = new Request.Builder().url(graphQLHttpService.url()).build();
+    final Request request =
+        new Request.Builder()
+            .url(graphQLHttpService.url() + "/graphql?query={protocolVersion}")
+            .build();
 
     try (final Response response = client.newCall(request).execute()) {
       Assertions.assertThat(response.isSuccessful()).isTrue();


### PR DESCRIPTION
Signed-off-by: Anthony <anthonybuckle@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
When users hit GraphQL url http://url:port/ they will be redirected to http://url:port/graphql.

## Fixed Issue(s)
[BESU-58](https://jira.hyperledger.org/browse/BESU-58)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
