### PR TITLE
Windows Build Compatibility

### DIFF
--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -37,7 +37,7 @@ class FileStateChecker extends DefaultTask {
   def CheckState() {
     def digestor = MessageDigest.getInstance("SHA-256")
 
-    this.files.sort().each {
+    this.files.toSorted(Comparator.comparing({it.canonicalPath})).each {
       digestor.update(it.readBytes())
     }
     def currentHash = digestor.digest().encodeBase64().toString()


### PR DESCRIPTION
Windows sorts files case insensitively, resulting in a different hash
for the API check because the files are in a different order.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
