### PR TITLE
DSL precondition to avoid creating orphan processes - Invalid

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -282,7 +282,7 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
 
   private boolean isNotAliveOrphan(final String name) {
     final Process orphan = besuProcesses.get(name);
-    return orphan != null && orphan.isAlive();
+    return orphan == null || !orphan.isAlive();
   }
 
   private void printOutput(final BesuNode node, final Process process) {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -267,7 +267,7 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     try {
       checkState(
           isNotAliveOrphan(node.getName()),
-          "A live process with name: %s already exists, cannot create another with the same name as it orphans the first",
+          "A live process with name: %s, already exists. Cannot create another with the same name as it would orphan the first",
           node.getName());
 
       final Process process = processBuilder.start();

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.tests.acceptance.dsl.node;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.hyperledger.besu.cli.options.NetworkingOptions;
@@ -264,6 +265,11 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     }
 
     try {
+      checkState(
+          isNotAliveOrphan(node.getName()),
+          "A live process with name: %s already exists, cannot create another with the same name as it orphans the first",
+          node.getName());
+
       final Process process = processBuilder.start();
       outputProcessorExecutor.execute(() -> printOutput(node, process));
       besuProcesses.put(node.getName(), process);
@@ -272,6 +278,11 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     }
 
     waitForPortsFile(dataDir);
+  }
+
+  private boolean isNotAliveOrphan(final String name) {
+    final Process orphan = besuProcesses.get(name);
+    return orphan != null && orphan.isAlive();
   }
 
   private void printOutput(final BesuNode node, final Process process) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Sanity check to ensure that the non-unique node name (the is being used as a key in a map) does not inadvertently orphan an existing process sharing the same name

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
