### PR TITLE
Add missing bouncy castle library required by JSON-RPC HTTP TLS 

### DIFF
--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -56,6 +56,8 @@ dependencies {
   implementation 'org.bouncycastle:bcprov-jdk15on'
   implementation 'org.springframework.security:spring-security-crypto'
 
+  runtimeOnly 'org.bouncycastle:bcpkix-jdk15on'
+
   testImplementation project(':config')
   testImplementation project(path: ':config', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:core', configuration: 'testArtifacts')

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -76,6 +76,7 @@ dependencyManagement {
 
     dependency 'org.awaitility:awaitility:4.0.1'
 
+    dependency 'org.bouncycastle:bcpkix-jdk15on:1.64'
     dependency 'org.bouncycastle:bcprov-jdk15on:1.64'
 
     dependency 'org.java-websocket:Java-WebSocket:1.4.0'


### PR DESCRIPTION
-- This jar is required by Tuweni API handling of known clients fingerprints at runtime

Signed-off-by: Usman Saleem <usman@usmans.info>
