### PR TITLE
Trace APIs - fix reused blocktracer

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,15 +42,15 @@ import org.apache.tuweni.bytes.Bytes;
 public class DebugTraceBlock implements JsonRpcMethod {
 
   private static final Logger LOG = LogManager.getLogger();
-  private final BlockTracer blockTracer;
+  private final Supplier<BlockTracer> blockTracerSupplier;
   private final BlockHeaderFunctions blockHeaderFunctions;
   private final BlockchainQueries blockchain;
 
   public DebugTraceBlock(
-      final BlockTracer blockTracer,
+      final Supplier<BlockTracer> blockTracerSupplier,
       final BlockHeaderFunctions blockHeaderFunctions,
       final BlockchainQueries blockchain) {
-    this.blockTracer = blockTracer;
+    this.blockTracerSupplier = blockTracerSupplier;
     this.blockHeaderFunctions = blockHeaderFunctions;
     this.blockchain = blockchain;
   }
@@ -78,7 +79,8 @@ public class DebugTraceBlock implements JsonRpcMethod {
 
     if (this.blockchain.blockByHash(block.getHeader().getParentHash()).isPresent()) {
       final Collection<DebugTraceTransactionResult> results =
-          blockTracer
+          blockTracerSupplier
+              .get()
               .trace(block, new DebugOperationTracer(traceOptions))
               .map(BlockTrace::getTransactionTraces)
               .map(DebugTraceTransactionResult::of)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
@@ -27,13 +27,14 @@ import org.hyperledger.besu.ethereum.debug.TraceOptions;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 
 import java.util.Collection;
+import java.util.function.Supplier;
 
 public class DebugTraceBlockByHash implements JsonRpcMethod {
 
-  private final BlockTracer blockTracer;
+  private final Supplier<BlockTracer> blockTracerSupplier;
 
-  public DebugTraceBlockByHash(final BlockTracer blockTracer) {
-    this.blockTracer = blockTracer;
+  public DebugTraceBlockByHash(final Supplier<BlockTracer> blockTracerSupplier) {
+    this.blockTracerSupplier = blockTracerSupplier;
   }
 
   @Override
@@ -51,7 +52,8 @@ public class DebugTraceBlockByHash implements JsonRpcMethod {
             .orElse(TraceOptions.DEFAULT);
 
     final Collection<DebugTraceTransactionResult> results =
-        blockTracer
+        blockTracerSupplier
+            .get()
             .trace(blockHash, new DebugOperationTracer(traceOptions))
             .map(BlockTrace::getTransactionTraces)
             .map(DebugTraceTransactionResult::of)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
@@ -27,15 +27,16 @@ import org.hyperledger.besu.ethereum.debug.TraceOptions;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class DebugTraceBlockByNumber extends AbstractBlockParameterMethod {
 
-  private final BlockTracer blockTracer;
+  private final Supplier<BlockTracer> blockTracerSupplier;
 
   public DebugTraceBlockByNumber(
-      final BlockTracer blockTracer, final BlockchainQueries blockchain) {
+      final Supplier<BlockTracer> blockTracerSupplier, final BlockchainQueries blockchain) {
     super(blockchain);
-    this.blockTracer = blockTracer;
+    this.blockTracerSupplier = blockTracerSupplier;
   }
 
   @Override
@@ -61,7 +62,8 @@ public class DebugTraceBlockByNumber extends AbstractBlockParameterMethod {
     return blockHash
         .flatMap(
             hash ->
-                blockTracer
+                blockTracerSupplier
+                    .get()
                     .trace(hash, new DebugOperationTracer(traceOptions))
                     .map(BlockTrace::getTransactionTraces)
                     .map(DebugTraceTransactionResult::of))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
@@ -38,23 +38,23 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 
 public class TraceReplayBlockTransactions extends AbstractBlockParameterMethod {
-  private final BlockTracer blockTracer;
+  private final Supplier<BlockTracer> blockTracerSupplier;
   private final Supplier<StateDiffGenerator> stateDiffGenerator =
       Suppliers.memoize(StateDiffGenerator::new);
 
   public TraceReplayBlockTransactions(
-      final BlockTracer blockTracer, final BlockchainQueries queries) {
+      final Supplier<BlockTracer> blockTracerSupplier, final BlockchainQueries queries) {
     super(queries);
-    this.blockTracer = blockTracer;
+    this.blockTracerSupplier = blockTracerSupplier;
   }
 
   @Override
@@ -92,7 +92,8 @@ public class TraceReplayBlockTransactions extends AbstractBlockParameterMethod {
     // TODO: generate options based on traceTypeParameter
     final TraceOptions traceOptions = TraceOptions.DEFAULT;
 
-    return blockTracer
+    return blockTracerSupplier
+        .get()
         .trace(block, new DebugOperationTracer(traceOptions))
         .map(BlockTrace::getTransactionTraces)
         .map((traces) -> generateTracesFromTransactionTrace(traces, traceTypeParameter))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -40,7 +40,7 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ProtocolSchedule<?> protocolSchedule;
   private final ObservableMetricsSystem metricsSystem;
 
-  public DebugJsonRpcMethods(
+  DebugJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule<?> protocolSchedule,
       final ObservableMetricsSystem metricsSystem) {
@@ -68,10 +68,10 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new DebugStorageRangeAt(blockchainQueries, blockReplay),
         new DebugMetrics(metricsSystem),
         new DebugTraceBlock(
-            new BlockTracer(blockReplay),
+            () -> new BlockTracer(blockReplay),
             ScheduleBasedBlockHeaderFunctions.create(protocolSchedule),
             blockchainQueries),
-        new DebugTraceBlockByNumber(new BlockTracer(blockReplay), blockchainQueries),
-        new DebugTraceBlockByHash(new BlockTracer(blockReplay)));
+        new DebugTraceBlockByNumber(() -> new BlockTracer(blockReplay), blockchainQueries),
+        new DebugTraceBlockByHash(() -> new BlockTracer(blockReplay)));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -30,7 +30,7 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final BlockchainQueries blockchainQueries;
   private final ProtocolSchedule<?> protocolSchedule;
 
-  public TraceJsonRpcMethods(
+  TraceJsonRpcMethods(
       final BlockchainQueries blockchainQueries, final ProtocolSchedule<?> protocolSchedule) {
     this.blockchainQueries = blockchainQueries;
     this.protocolSchedule = protocolSchedule;
@@ -44,13 +44,12 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   @Override
   protected Map<String, JsonRpcMethod> create() {
+    final BlockReplay blockReplay =
+        new BlockReplay(
+            protocolSchedule,
+            blockchainQueries.getBlockchain(),
+            blockchainQueries.getWorldStateArchive());
     return mapOf(
-        new TraceReplayBlockTransactions(
-            new BlockTracer(
-                new BlockReplay(
-                    protocolSchedule,
-                    blockchainQueries.getBlockchain(),
-                    blockchainQueries.getWorldStateArchive())),
-            blockchainQueries));
+        new TraceReplayBlockTransactions(() -> new BlockTracer(blockReplay), blockchainQueries));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -135,8 +135,7 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
         }
         for (int i = 0; i < ((ArrayNode) expectedResponse).size(); i++) {
           checkResponse(
-              (ObjectNode) responseBody.get(i),
-              (ObjectNode) ((ArrayNode) expectedResponse).get(i));
+              (ObjectNode) responseBody.get(i), (ObjectNode) ((ArrayNode) expectedResponse).get(i));
         }
       }
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -37,7 +37,6 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
@@ -73,7 +72,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
   protected static String CLIENT_VERSION = "TestClientVersion/0.1.0";
   protected static final BigInteger NETWORK_ID = BigInteger.valueOf(123);
   protected static final Collection<RpcApi> JSON_RPC_APIS =
-      Arrays.asList(RpcApis.ETH, RpcApis.NET, RpcApis.WEB3, RpcApis.DEBUG);
+      Arrays.asList(RpcApis.ETH, RpcApis.NET, RpcApis.WEB3, RpcApis.DEBUG, RpcApis.TRACE);
 
   protected final Vertx vertx = Vertx.vertx();
   protected JsonRpcHttpService service;
@@ -150,7 +149,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             peerDiscoveryMock,
             blockchainQueries,
             synchronizerMock,
-            MainnetProtocolSchedule.create(),
+            blockchainSetupUtil.getProtocolSchedule(),
             filterManager,
             transactionPoolMock,
             miningCoordinatorMock,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/TraceJsonRpcHttpBySpecTest.java
@@ -14,15 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc;
 
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceReplayBlockTransactions;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
-import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 
 import java.net.URL;
-import java.util.Map;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -45,31 +39,6 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
   protected BlockchainSetupUtil<Void> getBlockchainSetupUtil() {
     return createBlockchainSetupUtil(
         "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin");
-  }
-
-  @Override
-  protected Map<String, JsonRpcMethod> getRpcMethods(
-      final JsonRpcConfiguration config, final BlockchainSetupUtil<Void> blockchainSetupUtil) {
-    final Map<String, JsonRpcMethod> methods = super.getRpcMethods(config, blockchainSetupUtil);
-
-    // Add trace_replayBlockTransactions
-    // TODO: Once this method is generally enabled, we won't need to add this here
-    final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(
-            blockchainSetupUtil.getBlockchain(),
-            blockchainSetupUtil.getWorldArchive(),
-            blockchainSetupUtil.getScheduler());
-    final BlockReplay blockReplay =
-        new BlockReplay(
-            blockchainSetupUtil.getProtocolSchedule(),
-            blockchainSetupUtil.getBlockchain(),
-            blockchainSetupUtil.getWorldArchive());
-    final BlockTracer blockTracer = new BlockTracer(blockReplay);
-    final TraceReplayBlockTransactions traceReplayBlockTransactions =
-        new TraceReplayBlockTransactions(blockTracer, blockchainQueries);
-    methods.put(traceReplayBlockTransactions.getName(), traceReplayBlockTransactions);
-
-    return methods;
   }
 
   @Parameters(name = "{index}: {0}")

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
@@ -44,7 +44,7 @@ public class DebugTraceBlockByHashTest {
 
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final DebugTraceBlockByHash debugTraceBlockByHash =
-      new DebugTraceBlockByHash(blockTracer);
+      new DebugTraceBlockByHash(() -> blockTracer);
 
   private final Hash blockHash =
       Hash.fromHexString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
@@ -48,7 +48,7 @@ public class DebugTraceBlockByNumberTest {
   private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final DebugTraceBlockByNumber debugTraceBlockByNumber =
-      new DebugTraceBlockByNumber(blockTracer, blockchain);
+      new DebugTraceBlockByNumber(() -> blockTracer, blockchain);
 
   private final Hash blockHash =
       Hash.fromHexString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
@@ -53,7 +53,7 @@ public class DebugTraceBlockTest {
   private final BlockTracer blockTracer = mock(BlockTracer.class);
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final DebugTraceBlock debugTraceBlock =
-      new DebugTraceBlock(blockTracer, new MainnetBlockHeaderFunctions(), blockchainQueries);
+      new DebugTraceBlock(() -> blockTracer, new MainnetBlockHeaderFunctions(), blockchainQueries);
 
   @Test
   public void nameShouldBeDebugTraceBlock() {

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/statediff/trace_replayBlockTransactions_diffOnly_0x2_twice.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/statediff/trace_replayBlockTransactions_diffOnly_0x2_twice.json
@@ -1,0 +1,135 @@
+{
+  "request": [
+    {
+      "jsonrpc": "2.0",
+      "method": "trace_replayBlockTransactions",
+      "params": [
+        "0x2",
+        [
+          "stateDiff"
+        ]
+      ],
+      "id": 415
+    },
+    {
+      "jsonrpc": "2.0",
+      "method": "trace_replayBlockTransactions",
+      "params": [
+        "0x2",
+        [
+          "stateDiff"
+        ]
+      ],
+      "id": 416
+    }
+  ],
+  "response": [
+    {
+      "jsonrpc": "2.0",
+      "result": [
+        {
+          "output": "0x",
+          "stateDiff": {
+            "0x0000000000000000000000000000000000000000": {
+              "balance": {
+                "*": {
+                  "from": "0x1bc16d674ec80000",
+                  "to": "0x1bc16d674f149578"
+                }
+              },
+              "code": "=",
+              "nonce": "=",
+              "storage": {}
+            },
+            "0x0000000000000000000000000000000000000999": {
+              "balance": {
+                "+": "0x1"
+              },
+              "code": {
+                "+": "0x"
+              },
+              "nonce": {
+                "+": "0x0"
+              },
+              "storage": {}
+            },
+            "0x627306090abab3a6e1400e9345bc60c78a8bef57": {
+              "balance": {
+                "*": {
+                  "from": "0xf0000000000000000000000",
+                  "to": "0xeffffffffffffffffb36a87"
+                }
+              },
+              "code": "=",
+              "nonce": {
+                "*": {
+                  "from": "0x0",
+                  "to": "0x1"
+                }
+              },
+              "storage": {}
+            }
+          },
+          "trace": [],
+          "transactionHash": "0x28fa8042c7b5835f4f91fc20937f3e70dcf3585c1afe31202bb6075185f9abfe",
+          "vmTrace": null
+        }
+      ],
+      "id": 415
+    },
+    {
+      "jsonrpc": "2.0",
+      "result": [
+        {
+          "output": "0x",
+          "stateDiff": {
+            "0x0000000000000000000000000000000000000000": {
+              "balance": {
+                "*": {
+                  "from": "0x1bc16d674ec80000",
+                  "to": "0x1bc16d674f149578"
+                }
+              },
+              "code": "=",
+              "nonce": "=",
+              "storage": {}
+            },
+            "0x0000000000000000000000000000000000000999": {
+              "balance": {
+                "+": "0x1"
+              },
+              "code": {
+                "+": "0x"
+              },
+              "nonce": {
+                "+": "0x0"
+              },
+              "storage": {}
+            },
+            "0x627306090abab3a6e1400e9345bc60c78a8bef57": {
+              "balance": {
+                "*": {
+                  "from": "0xf0000000000000000000000",
+                  "to": "0xeffffffffffffffffb36a87"
+                }
+              },
+              "code": "=",
+              "nonce": {
+                "*": {
+                  "from": "0x0",
+                  "to": "0x1"
+                }
+              },
+              "storage": {}
+            }
+          },
+          "trace": [],
+          "transactionHash": "0x28fa8042c7b5835f4f91fc20937f3e70dcf3585c1afe31202bb6075185f9abfe",
+          "vmTrace": null
+        }
+      ],
+      "id": 416
+    }
+  ],
+  "statusCode": 200
+}


### PR DESCRIPTION
Now that BlockTracer has mutable state we cannot re-use it across
requests, instead we need to create a new one for each call.

To support this spec tests were upgraded to allow batched requests and
responses, which are processed sequentially.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

