### PR TITLE
Fix acceptance test logging, Besu subprocess killing, misc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,12 @@ jobs:
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             ./gradlew --no-daemon --parallel acceptanceTest $GRADLE_ARGS
       - capture_test_results
+      - store_artifacts:
+          path: acceptance-tests/build/reports
+          destination: acceptance-tests-reports
+      - store_artifacts:
+          path: acceptance-tests/build/acceptanceTestLogs
+          destination: acceptance-tests-logs
 
   buildDocker:
     executor: besu_executor_med

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -39,7 +39,11 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.net.NetTransactions
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.perm.PermissioningTransactions;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.web3.Web3Transactions;
 
+import org.apache.logging.log4j.ThreadContext;
 import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 public class AcceptanceTestBase {
 
@@ -90,6 +94,17 @@ public class AcceptanceTestBase {
     besu = new BesuNodeFactory();
     contractVerifier = new ContractVerifier(accounts.getPrimaryBenefactor());
     permissionedNodeBuilder = new PermissionedNodeBuilder();
+  }
+
+  static {
+    System.setProperty("log4j2.isThreadContextMapInheritable", "true");
+  }
+
+  @Rule public final TestName name = new TestName();
+
+  @Before
+  public void setUpAcceptanceTestBase() {
+    ThreadContext.put("test", name.getMethodName());
   }
 
   @After

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -53,9 +53,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
@@ -67,8 +64,8 @@ import picocli.CommandLine.Model.CommandSpec;
 public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
   private final Logger LOG = LogManager.getLogger();
+
   private final Map<String, Runner> besuRunners = new HashMap<>();
-  private ExecutorService nodeExecutor = Executors.newCachedThreadPool();
 
   private final Map<Node, BesuPluginContextImpl> besuPluginContextMap = new HashMap<>();
 
@@ -102,9 +99,6 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
   @Override
   public void startNode(final BesuNode node) {
-    if (nodeExecutor == null || nodeExecutor.isShutdown()) {
-      nodeExecutor = Executors.newCachedThreadPool();
-    }
 
     final StorageServiceImpl storageService = new StorageServiceImpl();
     final Path dataDir = node.homeDirectory();
@@ -220,14 +214,6 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
     // iterate over a copy of the set so that besuRunner can be updated when a runner is killed
     new HashSet<>(besuRunners.keySet()).forEach(this::killRunner);
-    try {
-      nodeExecutor.shutdownNow();
-      if (!nodeExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
-        throw new IllegalStateException("Failed to shut down node executor");
-      }
-    } catch (final InterruptedException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   @Override

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 import io.vertx.core.Vertx;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
@@ -99,6 +100,9 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
   @Override
   public void startNode(final BesuNode node) {
+
+    assert (!ThreadContext.containsKey("node"));
+    ThreadContext.put("node", node.getName());
 
     final StorageServiceImpl storageService = new StorageServiceImpl();
     final Path dataDir = node.homeDirectory();
@@ -194,6 +198,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
     runner.start();
 
     besuRunners.put(node.getName(), runner);
+    ThreadContext.remove("node");
   }
 
   @Override

--- a/acceptance-tests/tests/src/test/resources/log4j2.xml
+++ b/acceptance-tests/tests/src/test/resources/log4j2.xml
@@ -5,18 +5,49 @@
   </Properties>
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} | %t | %-5level | %c{1} | %msg%n" />
+      <PatternLayout pattern="%X{test} | %d{HH:mm:ss.SSS} | %t | %-5level | %c{1} | %msg%n" />
     </Console>
     <Console name="SubProcessConsole" target="SYSTEM_OUT">
-      <PatternLayout pattern="Process %msg%n" />
+      <PatternLayout pattern="%X{test} | %X{node} | %msg%n" />
     </Console>
+    <Routing name="PerTestFile">
+      <Routes pattern="${ctx:test}">
+        <Route>
+          <File
+                  name="Test-${ctx:test}"
+                  filename="build/acceptanceTestLogs/${ctx:test}.log"
+                  append="false"
+                  createOnDemand="true"
+          >
+            <PatternLayout pattern="%X{test} | %d{HH:mm:ss.SSS} | %t | %-5level | %c{1} | %msg%n" />
+          </File>
+        </Route>
+      </Routes>
+    </Routing>
+    <Routing name="PerTestSubprocessFile">
+      <Routes pattern="${ctx:test}">
+        <Route>
+          <File
+                  name="TestSubprocess-${ctx:test}"
+                  filename="build/acceptanceTestLogs/${ctx:test}.log"
+                  append="true"
+                  createOnDemand="true"
+          >
+            <PatternLayout pattern="%X{test} | %X{node} | %msg%n" />
+          </File>
+        </Route>
+      </Routes>
+    </Routing>
+
   </Appenders>
   <Loggers>
     <Logger name="org.hyperledger.besu.SubProcessLog" level="INFO" additivity="false">
       <AppenderRef ref="SubProcessConsole" />
+      <AppenderRef ref="PerTestSubprocessFile" />
     </Logger>
     <Root level="${sys:root.log.level}">
       <AppenderRef ref="Console" />
+      <AppenderRef ref="PerTestFile" />
     </Root>
   </Loggers>
 </Configuration>

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -98,7 +98,7 @@ public class Runner implements AutoCloseable {
               besuController.getTransactionPool().getPendingTransactions().evictOldTransactions());
       jsonRpc.ifPresent(service -> waitForServiceToStart("jsonRpc", service.start()));
       graphQLHttp.ifPresent(service -> waitForServiceToStart("graphQLHttp", service.start()));
-      websocketRpc.ifPresent(service -> waitForServiceToStop("websocketRpc", service.start()));
+      websocketRpc.ifPresent(service -> waitForServiceToStart("websocketRpc", service.start()));
       metrics.ifPresent(service -> waitForServiceToStart("metrics", service.start()));
       LOG.info("Ethereum main loop is up.");
       writeBesuPortsToFile();


### PR DESCRIPTION
## PR description
Acceptance test logs contain now information about test and subprocess that generated them,
and are separated accordingly.
Besu subprocesses in acceptance tests are now killed correctly.
Minor misc fixes.

