### PR TITLE
[BESU-179] getSignerMetrics doesn't return missing signers

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -243,6 +243,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder<IbftContext
             new IbftBlockInterface(),
             new IbftValidatorOverrides(ibftValidatorForkMap)),
         new VoteProposer(),
+        epochManager,
         blockInterface);
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftLegacyBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftLegacyBesuControllerBuilder.java
@@ -89,7 +89,7 @@ public class IbftLegacyBesuControllerBuilder extends BesuControllerBuilder<IbftC
             blockInterface);
 
     final VoteProposer voteProposer = new VoteProposer();
-    return new IbftContext(voteTallyCache, voteProposer, blockInterface);
+    return new IbftContext(voteTallyCache, voteProposer, epochManager, blockInterface);
   }
 
   @Override

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
@@ -65,15 +65,15 @@ public class CliqueJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new Propose(voteProposer),
         new Discard(voteProposer),
         new CliqueProposals(voteProposer),
-        new CliqueGetSignerMetrics(new CliqueBlockInterface(), blockchainQueries));
+        new CliqueGetSignerMetrics(voteTallyCache, new CliqueBlockInterface(), blockchainQueries));
   }
 
   private VoteTallyCache createVoteTallyCache(
       final ProtocolContext<CliqueContext> context, final MutableBlockchain blockchain) {
     final EpochManager epochManager = context.getConsensusState().getEpochManager();
+    final CliqueBlockInterface cliqueBlockInterface = new CliqueBlockInterface();
     final VoteTallyUpdater voteTallyUpdater =
-        new VoteTallyUpdater(epochManager, new CliqueBlockInterface());
-    return new VoteTallyCache(
-        blockchain, voteTallyUpdater, epochManager, new CliqueBlockInterface());
+        new VoteTallyUpdater(epochManager, cliqueBlockInterface);
+    return new VoteTallyCache(blockchain, voteTallyUpdater, epochManager, cliqueBlockInterface);
   }
 }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetrics.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetrics.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.clique.jsonrpc.methods;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.consensus.common.jsonrpc.AbstractGetSignerMetricsMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
@@ -24,8 +25,10 @@ public class CliqueGetSignerMetrics extends AbstractGetSignerMetricsMethod
     implements JsonRpcMethod {
 
   public CliqueGetSignerMetrics(
-      final BlockInterface blockInterface, final BlockchainQueries blockchainQueries) {
-    super(blockInterface, blockchainQueries);
+      final VoteTallyCache voteTallyCache,
+      final BlockInterface blockInterface,
+      final BlockchainQueries blockchainQueries) {
+    super(voteTallyCache, blockInterface, blockchainQueries);
   }
 
   @Override

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
@@ -235,6 +235,8 @@ public class CliqueGetSignerMetricsTest {
 
     final List<SignerMetricResult> signerMetricResultList = new ArrayList<>();
 
+    when(blockchainQueries.headBlockNumber()).thenReturn(endBlock);
+
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/CliqueGetSignerMetricsTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.VoteTally;
+import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -33,6 +35,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -46,13 +49,14 @@ import org.junit.rules.ExpectedException;
 public class CliqueGetSignerMetricsTest {
 
   private static final Address[] VALIDATORS = {
-    Address.fromHexString("0x1"), Address.fromHexString("0x2"), Address.fromHexString("0x3"),
+    Address.fromHexString("0x1"), Address.fromHexString("0x2"), Address.fromHexString("0x3")
   };
 
   private final String CLIQUE_METHOD = "clique_getSignerMetrics";
   private final String JSON_RPC_VERSION = "2.0";
   private CliqueGetSignerMetrics method;
 
+  private VoteTallyCache voteTallyCache;
   private BlockchainQueries blockchainQueries;
   private BlockInterface blockInterface;
 
@@ -60,9 +64,10 @@ public class CliqueGetSignerMetricsTest {
 
   @Before
   public void setup() {
+    voteTallyCache = mock(VoteTallyCache.class);
     blockchainQueries = mock(BlockchainQueries.class);
     blockInterface = mock(BlockInterface.class);
-    method = new CliqueGetSignerMetrics(blockInterface, blockchainQueries);
+    method = new CliqueGetSignerMetrics(voteTallyCache, blockInterface, blockchainQueries);
   }
 
   @Test
@@ -103,6 +108,8 @@ public class CliqueGetSignerMetricsTest {
 
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
+
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
 
     final JsonRpcRequestContext request = requestWithParams();
 
@@ -158,6 +165,8 @@ public class CliqueGetSignerMetricsTest {
     LongStream.range(startBlock, headBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[2])); // missing validator
+
     final JsonRpcRequestContext request = requestWithParams();
 
     final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
@@ -183,6 +192,8 @@ public class CliqueGetSignerMetricsTest {
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
+
     final JsonRpcRequestContext request = requestWithParams(String.valueOf(startBlock), "latest");
 
     final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
@@ -204,6 +215,8 @@ public class CliqueGetSignerMetricsTest {
 
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
+
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
 
     final JsonRpcRequestContext request = requestWithParams(String.valueOf(startBlock), "pending");
 
@@ -245,6 +258,9 @@ public class CliqueGetSignerMetricsTest {
 
     when(blockchainQueries.getBlockHeaderByNumber(number)).thenReturn(Optional.of(header));
     when(blockInterface.getProposerOfBlock(header)).thenReturn(proposerAddressBlock);
+
+    when(voteTallyCache.getVoteTallyAfterBlock(header))
+        .thenReturn(new VoteTally(Arrays.asList(VALIDATORS)));
 
     final SignerMetricResult signerMetricResult = new SignerMetricResult(proposerAddressBlock);
     signerMetricResult.incrementeNbBlock();

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
@@ -109,9 +109,11 @@ public abstract class AbstractGetSignerMetricsMethod {
   }
 
   private long getEndBlockNumber(final Optional<BlockParameter> endBlockParameter) {
+    final long headBlockNumber = blockchainQueries.headBlockNumber();
     return endBlockParameter
         .map(this::resolveBlockNumber)
-        .orElseGet(blockchainQueries::headBlockNumber);
+        .filter(blockNumber -> blockNumber <= headBlockNumber)
+        .orElse(headBlockNumber);
   }
 
   private boolean isValidParameters(final long startBlock, final long endBlock) {

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/jsonrpc/AbstractGetSignerMetricsMethod.java
@@ -33,8 +33,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.LongStream;
 
-import org.apache.logging.log4j.LogManager;
-
 public abstract class AbstractGetSignerMetricsMethod {
 
   private static final long DEFAULT_RANGE_BLOCK = 100;
@@ -94,10 +92,8 @@ public abstract class AbstractGetSignerMetricsMethod {
                           .getVoteTallyAfterBlock(header)
                           .getValidators()
                           .forEach(
-                              address -> {
-                                LogManager.getLogger().info("--> " + address);
-                                proposersMap.computeIfAbsent(address, SignerMetricResult::new);
-                              });
+                              address ->
+                                  proposersMap.computeIfAbsent(address, SignerMetricResult::new));
                     }
                   });
             });

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -296,7 +296,7 @@ public class TestContextBuilder {
         new ProtocolContext<>(
             blockChain,
             worldStateArchive,
-            new IbftContext(voteTallyCache, voteProposer, blockInterface));
+            new IbftContext(voteTallyCache, voteProposer, epochManager, blockInterface));
 
     final PendingTransactions pendingTransactions =
         new PendingTransactions(

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftContext.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftContext.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.PoaContext;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
@@ -24,14 +25,17 @@ public class IbftContext implements PoaContext {
 
   private final VoteTallyCache voteTallyCache;
   private final VoteProposer voteProposer;
+  private final EpochManager epochManager;
   private final BlockInterface blockInterface;
 
   public IbftContext(
       final VoteTallyCache voteTallyCache,
       final VoteProposer voteProposer,
+      final EpochManager epochManager,
       final BlockInterface blockInterface) {
     this.voteTallyCache = voteTallyCache;
     this.voteProposer = voteProposer;
+    this.epochManager = epochManager;
     this.blockInterface = blockInterface;
   }
 
@@ -41,6 +45,10 @@ public class IbftContext implements PoaContext {
 
   public VoteProposer getVoteProposer() {
     return voteProposer;
+  }
+
+  public EpochManager getEpochManager() {
+    return epochManager;
   }
 
   @Override

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetrics.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetrics.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.jsonrpc.methods;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.consensus.common.jsonrpc.AbstractGetSignerMetricsMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
@@ -23,8 +24,10 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 public class IbftGetSignerMetrics extends AbstractGetSignerMetricsMethod implements JsonRpcMethod {
 
   public IbftGetSignerMetrics(
-      final BlockInterface blockInterface, final BlockchainQueries blockchainQueries) {
-    super(blockInterface, blockchainQueries);
+      final VoteTallyCache voteTallyCache,
+      final BlockInterface blockInterface,
+      final BlockchainQueries blockchainQueries) {
+    super(voteTallyCache, blockInterface, blockchainQueries);
   }
 
   @Override

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.VoteTally;
+import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
@@ -33,6 +35,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -53,6 +56,7 @@ public class IbftGetSignerMetricsTest {
   private final String JSON_RPC_VERSION = "2.0";
   private IbftGetSignerMetrics method;
 
+  private VoteTallyCache voteTallyCache;
   private BlockchainQueries blockchainQueries;
   private BlockInterface blockInterface;
 
@@ -60,9 +64,10 @@ public class IbftGetSignerMetricsTest {
 
   @Before
   public void setup() {
+    voteTallyCache = mock(VoteTallyCache.class);
     blockchainQueries = mock(BlockchainQueries.class);
     blockInterface = mock(BlockInterface.class);
-    method = new IbftGetSignerMetrics(blockInterface, blockchainQueries);
+    method = new IbftGetSignerMetrics(voteTallyCache, blockInterface, blockchainQueries);
   }
 
   @Test
@@ -103,6 +108,8 @@ public class IbftGetSignerMetricsTest {
 
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
+
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
 
     final JsonRpcRequestContext request = requestWithParams();
 
@@ -158,6 +165,8 @@ public class IbftGetSignerMetricsTest {
     LongStream.range(startBlock, headBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[2])); // missing validator
+
     final JsonRpcRequestContext request = requestWithParams();
 
     final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
@@ -183,6 +192,8 @@ public class IbftGetSignerMetricsTest {
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
+
     final JsonRpcRequestContext request = requestWithParams(String.valueOf(startBlock), "latest");
 
     final JsonRpcSuccessResponse response = (JsonRpcSuccessResponse) method.response(request);
@@ -204,6 +215,8 @@ public class IbftGetSignerMetricsTest {
 
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
+
+    signerMetricResultList.add(new SignerMetricResult(VALIDATORS[0])); // missing validator
 
     final JsonRpcRequestContext request = requestWithParams(String.valueOf(startBlock), "pending");
 
@@ -244,6 +257,8 @@ public class IbftGetSignerMetricsTest {
 
     when(blockchainQueries.getBlockHeaderByNumber(number)).thenReturn(Optional.of(header));
     when(blockInterface.getProposerOfBlock(header)).thenReturn(proposerAddressBlock);
+    when(voteTallyCache.getVoteTallyAfterBlock(header))
+        .thenReturn(new VoteTally(Arrays.asList(VALIDATORS)));
 
     final SignerMetricResult signerMetricResult = new SignerMetricResult(proposerAddressBlock);
     signerMetricResult.incrementeNbBlock();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
@@ -235,6 +235,8 @@ public class IbftGetSignerMetricsTest {
 
     final List<SignerMetricResult> signerMetricResultList = new ArrayList<>();
 
+    when(blockchainQueries.headBlockNumber()).thenReturn(endBlock);
+
     LongStream.range(startBlock, endBlock)
         .forEach(value -> signerMetricResultList.add(generateBlock(value)));
 


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description
getSignerMetrics doesn't return missing signers (validators who never proposed a block are not displayed).  This means to find missing signers you have to use getSigners followed by getSignerMetrics and manually figure out which ones are missing. 

## Fixed Issue(s)
getSignerMetrics returns now missing signers

Example with `0x12eb759f2222d7711c63729a45c3585731521d02`
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": [
    {
      "address": "0x6639adb0e64884dc4cd9d686c15ba1ca1885c24e",
      "proposedBlockCount": "0x22",
      "lastProposedBlockNumber": "0xb8"
    },
    {
      "address": "0x12eb759f2222d7711c63729a45c3585731521d02",
      "proposedBlockCount": "0x0",
      "lastProposedBlockNumber": "0x0"
    },
    {
      "address": "0x187ec8a86cdd7e71e2c0e72affe48b727f894877",
      "proposedBlockCount": "0x21",
      "lastProposedBlockNumber": "0xb7"
    },
    {
      "address": "0x9cd90ee9290637030073f2b32884b9fa1fc0c06b",
      "proposedBlockCount": "0x21",
      "lastProposedBlockNumber": "0xb6"
    }
  ]
}
```