### PR TITLE
add the binary on ci at build time, dont need it to be in the code base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ jobs:
           name: test image
           command: |
             mkdir -p docker/reports
+            curl -L https://github.com/aelsabbahy/goss/releases/download/v0.3.9/goss-linux-amd64 -o ./docker/tests/goss-linux-amd64
             ./gradlew --no-daemon testDocker
 
   publish:


### PR DESCRIPTION
## PR description
add the binary on ci at build time, dont need it to be in the code base

