### PR TITLE
Fix private transaction chainId validation

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
@@ -28,6 +28,8 @@ public class JsonRpcErrorConverter {
       case INCORRECT_NONCE:
       case INCORRECT_PRIVATE_NONCE:
         return JsonRpcError.INCORRECT_NONCE;
+      case WRONG_CHAIN_ID:
+        return JsonRpcError.WRONG_CHAIN_ID;
       case INVALID_SIGNATURE:
         return JsonRpcError.INVALID_TRANSACTION_SIGNATURE;
       case INTRINSIC_GAS_EXCEEDS_GAS_LIMIT:

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -54,6 +54,7 @@ public enum JsonRpcError {
   TX_SENDER_NOT_AUTHORIZED(-32007, "Sender account not authorized to send transactions"),
   CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE(-32008, "Initial sync is still in progress"),
   GAS_PRICE_TOO_LOW(-32009, "Gas price below configured minimum gas price"),
+  WRONG_CHAIN_ID(-32012, "Invalid chainId"),
 
   // Miner failures
   COINBASE_NOT_SET(-32010, "Coinbase not set. Unable to start mining without a coinbase"),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidator.java
@@ -78,16 +78,13 @@ public class PrivateTransactionValidator {
 
   private ValidationResult<TransactionValidator.TransactionInvalidReason>
       validateTransactionSignature(final PrivateTransaction transaction) {
-    if (chainId.isPresent()
-        && (transaction.getChainId().isPresent() && !transaction.getChainId().equals(chainId))) {
+    if (chainId.isPresent() && !chainId.equals(transaction.getChainId())) {
       return ValidationResult.invalid(
           TransactionValidator.TransactionInvalidReason.WRONG_CHAIN_ID,
-          String.format(
-              "Transaction was meant for chain id %s, not this chain id %s",
-              transaction.getChainId().get(), chainId.get()));
+          String.format("Transaction has wrong chainId. Expected chainId is %s.", chainId.get()));
     }
 
-    if (!chainId.isPresent() && transaction.getChainId().isPresent()) {
+    if (chainId.isEmpty() && transaction.getChainId().isPresent()) {
       return ValidationResult.invalid(
           TransactionValidator.TransactionInvalidReason.REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED,
           "Replay protection (chainId) is not supported");

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidatorTest.java
@@ -74,7 +74,17 @@ public class PrivateTransactionValidatorTest {
     validator = new PrivateTransactionValidator(Optional.of(BigInteger.ONE));
 
     ValidationResult<TransactionInvalidReason> validationResult =
-        validator.validate(privateTransactionWithChainId(999), 0L);
+        validator.validate(privateTransactionWithChainId(Optional.of(BigInteger.TWO)), 0L);
+
+    assertThat(validationResult).isEqualTo(ValidationResult.invalid(WRONG_CHAIN_ID));
+  }
+
+  @Test
+  public void transactionWithoutChainIdWithValidatorUsingChainIdShouldReturnWrongChainId() {
+    validator = new PrivateTransactionValidator(Optional.of(BigInteger.ONE));
+
+    ValidationResult<TransactionInvalidReason> validationResult =
+        validator.validate(privateTransactionWithChainId(Optional.empty()), 0L);
 
     assertThat(validationResult).isEqualTo(ValidationResult.invalid(WRONG_CHAIN_ID));
   }
@@ -85,7 +95,7 @@ public class PrivateTransactionValidatorTest {
     validator = new PrivateTransactionValidator(Optional.empty());
 
     ValidationResult<TransactionInvalidReason> validationResult =
-        validator.validate(privateTransactionWithChainId(999), 0L);
+        validator.validate(privateTransactionWithChainId(Optional.of(BigInteger.ONE)), 0L);
 
     assertThat(validationResult)
         .isEqualTo(ValidationResult.invalid(REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED));
@@ -111,10 +121,10 @@ public class PrivateTransactionValidatorTest {
     return privateTransactionTestFixture.createTransaction(senderKeys);
   }
 
-  private PrivateTransaction privateTransactionWithChainId(final int chainId) {
+  private PrivateTransaction privateTransactionWithChainId(final Optional<BigInteger> chainId) {
     PrivateTransactionTestFixture privateTransactionTestFixture =
         new PrivateTransactionTestFixture();
-    privateTransactionTestFixture.chainId(Optional.of(BigInteger.valueOf(chainId)));
+    privateTransactionTestFixture.chainId(chainId);
     return privateTransactionTestFixture.createTransaction(senderKeys);
   }
 }


### PR DESCRIPTION
## PR description
• Fixes the scenario when a private transaction doesn't have a chainId and the validator expects a chainId
• Added wrong chain id error msg in JSON-RPC response