### PR TITLE
Plugin error stack traces

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -97,7 +97,7 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
       } catch (final Exception e) {
         LOG.error(
             "Error registering plugin of type "
-                + plugin.getClass()
+                + plugin.getClass().getName()
                 + ", start and stop will not be called.",
             e);
         continue;
@@ -141,7 +141,10 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
         LOG.debug("Started plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
         LOG.error(
-            "Error starting plugin of type " + plugin.getClass() + ", stop will not be called.", e);
+            "Error starting plugin of type "
+                + plugin.getClass().getName()
+                + ", stop will not be called.",
+            e);
         pluginsIterator.remove();
       }
     }
@@ -163,7 +166,7 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
         plugin.stop();
         LOG.debug("Stopped plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
-        LOG.error("Error stopping plugin of type " + plugin.getClass(), e);
+        LOG.error("Error stopping plugin of type " + plugin.getClass().getName(), e);
       }
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -96,8 +96,9 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
         addPluginVersion(plugin);
       } catch (final Exception e) {
         LOG.error(
-            "Error registering plugin of type {}, start and stop will not be called. \n{}",
-            plugin.getClass(),
+            "Error registering plugin of type "
+                + plugin.getClass()
+                + ", start and stop will not be called.",
             e);
         continue;
       }
@@ -140,9 +141,7 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
         LOG.debug("Started plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
         LOG.error(
-            "Error starting plugin of type {}, stop will not be called. \n{}",
-            plugin.getClass(),
-            e);
+            "Error starting plugin of type " + plugin.getClass() + ", stop will not be called.", e);
         pluginsIterator.remove();
       }
     }
@@ -164,7 +163,7 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
         plugin.stop();
         LOG.debug("Stopped plugin of type {}.", plugin.getClass().getName());
       } catch (final Exception e) {
-        LOG.error("Error stopping plugin of type {}. \n{}", plugin.getClass(), e);
+        LOG.error("Error stopping plugin of type " + plugin.getClass(), e);
       }
     }
 


### PR DESCRIPTION
Because of how the Log4J2 api works exception stack traces were not
being printed.  Update to use the explicit "throwable" overloaded
methods.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
