### PR TITLE
More specific task metrics names

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
@@ -42,14 +42,15 @@ public abstract class AbstractEthTask<T> implements EthTask<T> {
   private final Collection<CompletableFuture<?>> subTaskFutures = new ConcurrentLinkedDeque<>();
 
   protected AbstractEthTask(final MetricsSystem metricsSystem) {
-    this(buildOperationTimer(metricsSystem));
+    this.taskTimer = buildOperationTimer(metricsSystem, getClass().getSimpleName());
   }
 
   protected AbstractEthTask(final OperationTimer taskTimer) {
     this.taskTimer = taskTimer;
   }
 
-  private static OperationTimer buildOperationTimer(final MetricsSystem metricsSystem) {
+  private static OperationTimer buildOperationTimer(
+      final MetricsSystem metricsSystem, String taskName) {
     final LabelledMetric<OperationTimer> ethTasksTimer =
         metricsSystem.createLabelledTimer(
             BesuMetricCategory.SYNCHRONIZER, "task", "Internal processing tasks", "taskName");
@@ -64,7 +65,7 @@ public abstract class AbstractEthTask<T> implements EthTask<T> {
             }
           };
     } else {
-      return ethTasksTimer.labels(AbstractEthTask.class.getSimpleName());
+      return ethTasksTimer.labels(taskName);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTask.java
@@ -50,7 +50,7 @@ public abstract class AbstractEthTask<T> implements EthTask<T> {
   }
 
   private static OperationTimer buildOperationTimer(
-      final MetricsSystem metricsSystem, String taskName) {
+      final MetricsSystem metricsSystem, final String taskName) {
     final LabelledMetric<OperationTimer> ethTasksTimer =
         metricsSystem.createLabelledTimer(
             BesuMetricCategory.SYNCHRONIZER, "task", "Internal processing tasks", "taskName");

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
@@ -109,7 +109,8 @@ public class AbstractEthTaskTest {
 
   @Test
   public void shouldHaveSpecificMetricsLabels() {
-    final String[] lastLabelNames = new String[1];
+    // seed with a failing value so that a no-op also trips the failure.
+    final String[] lastLabelNames = {"AbstractEthTask"};
     final MetricsSystem instrumentedLabeler =
         new NoOpMetricsSystem() {
           @Override
@@ -124,13 +125,12 @@ public class AbstractEthTaskTest {
             };
           }
         };
-    final AbstractEthTask<?> task =
-        new AbstractEthTask<>(instrumentedLabeler) {
-          @Override
-          protected void executeTask() {
-            // no-op
-          }
-        };
+    new AbstractEthTask<>(instrumentedLabeler) {
+      @Override
+      protected void executeTask() {
+        // no-op
+      }
+    };
     assertThat(lastLabelNames[0]).isNotEqualTo("AbstractEthTask");
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
@@ -124,12 +124,13 @@ public class AbstractEthTaskTest {
             };
           }
         };
-    final AbstractEthTask<?> task = new AbstractEthTask<>(instrumentedLabeler) {
-      @Override
-      protected void executeTask() {
-        // no-op
-      }
-    };
+    final AbstractEthTask<?> task =
+        new AbstractEthTask<>(instrumentedLabeler) {
+          @Override
+          protected void executeTask() {
+            // no-op
+          }
+        };
     assertThat(lastLabelNames[0]).isNotEqualTo("AbstractEthTask");
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractEthTaskTest.java
@@ -19,6 +19,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.Arrays;
@@ -102,6 +105,32 @@ public class AbstractEthTaskTest {
     task.run();
     verify(mockOperationTimer).startTimer();
     verify(mockTimingContext).stopTimer();
+  }
+
+  @Test
+  public void shouldHaveSpecificMetricsLabels() {
+    final String[] lastLabelNames = new String[1];
+    final MetricsSystem instrumentedLabeler =
+        new NoOpMetricsSystem() {
+          @Override
+          public LabelledMetric<OperationTimer> createLabelledTimer(
+              final MetricCategory category,
+              final String name,
+              final String help,
+              final String... labelNames) {
+            return names -> {
+              lastLabelNames[0] = names[0];
+              return null;
+            };
+          }
+        };
+    final AbstractEthTask<?> task = new AbstractEthTask<>(instrumentedLabeler) {
+      @Override
+      protected void executeTask() {
+        // no-op
+      }
+    };
+    assertThat(lastLabelNames[0]).isNotEqualTo("AbstractEthTask");
   }
 
   private class EthTaskWithMultipleSubtasks extends AbstractEthTask<Void> {


### PR DESCRIPTION
A prior refactoring had accidentally removed the specific task names
from the metrics labels.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

