### PR TITLE
[PIE-2303] Automatic log bloom caching - Remove usage of pending file.

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import org.apache.logging.log4j.LogManager;
@@ -51,13 +52,15 @@ public class AutoTransactionLogBloomCachingService {
                   (event, __) -> {
                     if (event.isNewCanonicalHead()) {
                       transactionLogBloomCacher.cacheLogsBloomForBlockHeader(
-                          event.getBlock().getHeader());
+                          event.getBlock().getHeader(), Optional.empty(), true);
                     }
                   }));
       chainReorgSubscriptionId =
           OptionalLong.of(
               blockchain.observeChainReorg(
-                  (header, __) -> transactionLogBloomCacher.cacheLogsBloomForBlockHeader(header)));
+                  (header, __) ->
+                      transactionLogBloomCacher.cacheLogsBloomForBlockHeader(
+                          header, Optional.empty(), true)));
 
       transactionLogBloomCacher
           .getScheduler()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
@@ -16,9 +16,10 @@
 
 package org.hyperledger.besu.ethereum.api.query;
 
-import com.fasterxml.jackson.annotation.JsonGetter;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
@@ -37,9 +38,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
+import com.fasterxml.jackson.annotation.JsonGetter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class TransactionLogBloomCacher {
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Since we use mutable files for the cache we can directly cache log blooms in the proper cache file.
The location of the cache file is deterministic based on the cache directory and the block number.
The block number is used to get the index in the binary file to write to.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
[PIE-2303](https://pegasys1.atlassian.net/browse/PIE-2303)

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>