### PR TITLE
Rename method

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -172,7 +172,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
       final Address miningBeneficiary,
       final OperationTracer operationTracer,
       final BlockHashLookup blockHashLookup,
-      final Boolean isPersistingState,
+      final Boolean isPersistingPrivateState,
       final TransactionValidationParams transactionValidationParams) {
     LOG.trace("Starting execution of {}", transaction);
 
@@ -246,7 +246,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
               .completer(c -> {})
               .miningBeneficiary(miningBeneficiary)
               .blockHashLookup(blockHashLookup)
-              .isPersistingState(isPersistingState)
+              .isPersistingPrivateState(isPersistingPrivateState)
               .maxStackSize(maxStackSize)
               .transactionHash(transaction.getHash())
               .build();
@@ -279,7 +279,7 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
               .miningBeneficiary(miningBeneficiary)
               .blockHashLookup(blockHashLookup)
               .maxStackSize(maxStackSize)
-              .isPersistingState(isPersistingState)
+              .isPersistingPrivateState(isPersistingPrivateState)
               .transactionHash(transaction.getHash())
               .build();
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
@@ -116,7 +116,7 @@ public interface TransactionProcessor {
    * @param transaction The transaction to process
    * @param miningBeneficiary The address which is to receive the transaction fee
    * @param blockHashLookup The {@link BlockHashLookup} to use for BLOCKHASH operations
-   * @param isPersistingPrivateState Whether the state will be modified by this process
+   * @param isPersistingPrivateState Whether the resulting private state will be persisted
    * @param transactionValidationParams Validation parameters that will be used by the {@link
    *     TransactionValidator}
    * @return the transaction result
@@ -154,7 +154,7 @@ public interface TransactionProcessor {
    * @param operationTracer The tracer to record results of each EVM operation
    * @param miningBeneficiary The address which is to receive the transaction fee
    * @param blockHashLookup The {@link BlockHashLookup} to use for BLOCKHASH operations
-   * @param isPersistingPrivateState Whether the state will be modified by this process
+   * @param isPersistingPrivateState Whether the resulting private state will be persisted
    * @return the transaction result
    */
   default Result processTransaction(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionProcessor.java
@@ -116,7 +116,7 @@ public interface TransactionProcessor {
    * @param transaction The transaction to process
    * @param miningBeneficiary The address which is to receive the transaction fee
    * @param blockHashLookup The {@link BlockHashLookup} to use for BLOCKHASH operations
-   * @param isPersistingState Whether the state will be modified by this process
+   * @param isPersistingPrivateState Whether the state will be modified by this process
    * @param transactionValidationParams Validation parameters that will be used by the {@link
    *     TransactionValidator}
    * @return the transaction result
@@ -130,7 +130,7 @@ public interface TransactionProcessor {
       final Transaction transaction,
       final Address miningBeneficiary,
       final BlockHashLookup blockHashLookup,
-      final Boolean isPersistingState,
+      final Boolean isPersistingPrivateState,
       final TransactionValidationParams transactionValidationParams) {
     return processTransaction(
         blockchain,
@@ -140,7 +140,7 @@ public interface TransactionProcessor {
         miningBeneficiary,
         OperationTracer.NO_TRACING,
         blockHashLookup,
-        isPersistingState,
+        isPersistingPrivateState,
         transactionValidationParams);
   }
 
@@ -154,7 +154,7 @@ public interface TransactionProcessor {
    * @param operationTracer The tracer to record results of each EVM operation
    * @param miningBeneficiary The address which is to receive the transaction fee
    * @param blockHashLookup The {@link BlockHashLookup} to use for BLOCKHASH operations
-   * @param isPersistingState Whether the state will be modified by this process
+   * @param isPersistingPrivateState Whether the state will be modified by this process
    * @return the transaction result
    */
   default Result processTransaction(
@@ -165,7 +165,7 @@ public interface TransactionProcessor {
       final Address miningBeneficiary,
       final OperationTracer operationTracer,
       final BlockHashLookup blockHashLookup,
-      final Boolean isPersistingState) {
+      final Boolean isPersistingPrivateState) {
     return processTransaction(
         blockchain,
         worldState,
@@ -174,7 +174,7 @@ public interface TransactionProcessor {
         miningBeneficiary,
         operationTracer,
         blockHashLookup,
-        isPersistingState,
+        isPersistingPrivateState,
         new TransactionValidationParams.Builder().build());
   }
 
@@ -186,6 +186,6 @@ public interface TransactionProcessor {
       Address miningBeneficiary,
       OperationTracer operationTracer,
       BlockHashLookup blockHashLookup,
-      Boolean isPersistingState,
+      Boolean isPersistingPrivateState,
       TransactionValidationParams transactionValidationParams);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
@@ -97,7 +97,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
   public Bytes compute(final Bytes input, final MessageFrame messageFrame) {
     final ProcessableBlockHeader currentBlockHeader = messageFrame.getBlockHeader();
     if (!BlockHeader.class.isAssignableFrom(currentBlockHeader.getClass())) {
-      if (!messageFrame.isPersistingState()) {
+      if (!messageFrame.isPersistingPrivateState()) {
         // We get in here from block mining.
         return Bytes.EMPTY;
       } else {
@@ -168,7 +168,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
       return Bytes.EMPTY;
     }
 
-    if (messageFrame.isPersistingState()) {
+    if (messageFrame.isPersistingPrivateState()) {
       LOG.trace(
           "Persisting private state {} for privacyGroup {}",
           disposablePrivateState.rootHash(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
@@ -1199,7 +1199,7 @@ public class MessageFrame {
           completer,
           miningBeneficiary,
           blockHashLookup,
-              isPersistingPrivateState,
+          isPersistingPrivateState,
           transactionHash,
           reason,
           maxStackSize);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
@@ -227,7 +227,7 @@ public class MessageFrame {
   private final int depth;
   private final Deque<MessageFrame> messageFrameStack;
   private final Address miningBeneficiary;
-  private final Boolean isPersistingState;
+  private final Boolean isPersistingPrivateState;
   private Optional<Bytes> revertReason;
 
   // Privacy Execution Environment fields.
@@ -267,7 +267,7 @@ public class MessageFrame {
       final Consumer<MessageFrame> completer,
       final Address miningBeneficiary,
       final BlockHashLookup blockHashLookup,
-      final Boolean isPersistingState,
+      final Boolean isPersistingPrivateState,
       final Hash transactionHash,
       final Optional<Bytes> revertReason,
       final int maxStackSize) {
@@ -303,7 +303,7 @@ public class MessageFrame {
     this.isStatic = isStatic;
     this.completer = completer;
     this.miningBeneficiary = miningBeneficiary;
-    this.isPersistingState = isPersistingState;
+    this.isPersistingPrivateState = isPersistingPrivateState;
     this.transactionHash = transactionHash;
     this.revertReason = revertReason;
   }
@@ -962,8 +962,8 @@ public class MessageFrame {
    *
    * @return whether Message calls will be persisted
    */
-  public Boolean isPersistingState() {
-    return isPersistingState;
+  public Boolean isPersistingPrivateState() {
+    return isPersistingPrivateState;
   }
 
   /**
@@ -1020,7 +1020,7 @@ public class MessageFrame {
     private Consumer<MessageFrame> completer;
     private Address miningBeneficiary;
     private BlockHashLookup blockHashLookup;
-    private Boolean isPersistingState = false;
+    private Boolean isPersistingPrivateState = false;
     private Hash transactionHash;
     private Optional<Bytes> reason = Optional.empty();
 
@@ -1135,8 +1135,8 @@ public class MessageFrame {
       return this;
     }
 
-    public Builder isPersistingState(final Boolean isPersistingState) {
-      this.isPersistingState = isPersistingState;
+    public Builder isPersistingPrivateState(final Boolean isPersistingPrivateState) {
+      this.isPersistingPrivateState = isPersistingPrivateState;
       return this;
     }
 
@@ -1170,7 +1170,7 @@ public class MessageFrame {
       checkState(completer != null, "Missing message frame completer");
       checkState(miningBeneficiary != null, "Missing mining beneficiary");
       checkState(blockHashLookup != null, "Missing block hash lookup");
-      checkState(isPersistingState != null, "Missing isPersistingState");
+      checkState(isPersistingPrivateState != null, "Missing isPersistingPrivateState");
       checkState(contractAccountVersion != -1, "Missing contractAccountVersion");
     }
 
@@ -1199,7 +1199,7 @@ public class MessageFrame {
           completer,
           miningBeneficiary,
           blockHashLookup,
-          isPersistingState,
+              isPersistingPrivateState,
           transactionHash,
           reason,
           maxStackSize);


### PR DESCRIPTION
This is renaming the method isPersistingState() on the MessageFrame class to isPersistingPrivateState(), as this is what it is used for. 
