### PR TITLE
Automatically cache Transaction Log Bloom Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ A migration will be performed when starting v1.4 for the first time to reprocess
 and re-create the private state data in the v1.4 format. 
 If you have existing private transactions, see [migration details](docs/Private-Txns-Migration.md).
 
+### Additions and Improvements 
+
+-  Automatic Transaction Log Bloom Filter Caching
+
+Add a new option `--auto-logs-bloom-indexing-enabled` which defaults to true. This performs the equivalent of the `operator generate-log-bloom-cache` CLI task or `admin_generateLogBloomCache` RPC call for each block as it arrives, in addition to caching older logs on first startup.  
+
 ## 1.4.0 RC-1 
 
 ### Additions and Improvements 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -257,6 +257,9 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     params.add("--key-value-storage");
     params.add("rocksdb");
 
+    params.add("--auto-logs-bloom-indexing-enabled");
+    params.add("false");
+
     LOG.info("Creating besu process with params {}", params);
     final ProcessBuilder processBuilder =
         new ProcessBuilder(params)

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -257,7 +257,7 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     params.add("--key-value-storage");
     params.add("rocksdb");
 
-    params.add("--auto-logs-bloom-indexing-enabled");
+    params.add("--auto-log-bloom-caching-enabled");
     params.add("false");
 
     LOG.info("Creating besu process with params {}", params);

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -195,6 +195,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
                     .map(EnodeURL::fromString)
                     .collect(Collectors.toList()))
             .besuPluginContext(new BesuPluginContextImpl())
+            .autoLogsBloomIndexing(false)
             .build();
 
     runner.start();

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -195,7 +195,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
                     .map(EnodeURL::fromString)
                     .collect(Collectors.toList()))
             .besuPluginContext(new BesuPluginContextImpl())
-            .autoLogsBloomIndexing(false)
+            .autoLogBloomCaching(false)
             .build();
 
     runner.start();

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -18,8 +18,8 @@ import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLHttpService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcHttpService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketService;
-import org.hyperledger.besu.ethereum.api.query.AutoTransactionLogsIndexingService;
-import org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer;
+import org.hyperledger.besu.ethereum.api.query.AutoTransactionLogBloomCachingService;
+import org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.p2p.network.NetworkRunner;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
@@ -61,7 +61,8 @@ public class Runner implements AutoCloseable {
   private final BesuController<?> besuController;
   private final Path dataDir;
   private final Optional<StratumServer> stratumServer;
-  private final Optional<AutoTransactionLogsIndexingService> autoTransactionLogsIndexingService;
+  private final Optional<AutoTransactionLogBloomCachingService>
+      autoTransactionLogBloomCachingService;
 
   Runner(
       final Vertx vertx,
@@ -74,7 +75,7 @@ public class Runner implements AutoCloseable {
       final Optional<MetricsService> metrics,
       final BesuController<?> besuController,
       final Path dataDir,
-      final Optional<TransactionLogsIndexer> transactionLogsIndexer,
+      final Optional<TransactionLogBloomCacher> transactionLogBloomCacher,
       final Blockchain blockchain) {
     this.vertx = vertx;
     this.networkRunner = networkRunner;
@@ -86,9 +87,9 @@ public class Runner implements AutoCloseable {
     this.besuController = besuController;
     this.dataDir = dataDir;
     this.stratumServer = stratumServer;
-    this.autoTransactionLogsIndexingService =
-        transactionLogsIndexer.map(
-            indexer -> new AutoTransactionLogsIndexingService(blockchain, indexer));
+    this.autoTransactionLogBloomCachingService =
+        transactionLogBloomCacher.map(
+            cacher -> new AutoTransactionLogBloomCachingService(blockchain, cacher));
   }
 
   public void start() {
@@ -112,7 +113,7 @@ public class Runner implements AutoCloseable {
       LOG.info("Ethereum main loop is up.");
       writeBesuPortsToFile();
       writeBesuNetworksToFile();
-      autoTransactionLogsIndexingService.ifPresent(AutoTransactionLogsIndexingService::start);
+      autoTransactionLogBloomCachingService.ifPresent(AutoTransactionLogBloomCachingService::start);
     } catch (final Exception ex) {
       LOG.error("Startup failed", ex);
       throw new IllegalStateException(ex);
@@ -135,7 +136,7 @@ public class Runner implements AutoCloseable {
 
     networkRunner.stop();
     waitForServiceToStop("Network", networkRunner::awaitStop);
-    autoTransactionLogsIndexingService.ifPresent(AutoTransactionLogsIndexingService::stop);
+    autoTransactionLogBloomCachingService.ifPresent(AutoTransactionLogBloomCachingService::stop);
     natService.stop();
     besuController.close();
     vertx.close((res) -> vertxShutdownLatch.countDown());

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -144,7 +144,7 @@ public class RunnerBuilder {
   private Collection<EnodeURL> staticNodes = Collections.emptyList();
   private Optional<String> identityString = Optional.empty();
   private BesuPluginContextImpl besuPluginContext;
-  private boolean autoLogsBloomIndexing = true;
+  private boolean autoLogBloomCaching = true;
 
   public RunnerBuilder vertx(final Vertx vertx) {
     this.vertx = vertx;
@@ -271,8 +271,8 @@ public class RunnerBuilder {
     return this;
   }
 
-  public RunnerBuilder autoLogsBloomIndexing(final boolean autoLogsBloomIndexing) {
-    this.autoLogsBloomIndexing = autoLogsBloomIndexing;
+  public RunnerBuilder autoLogBloomCaching(final boolean autoLogBloomCaching) {
+    this.autoLogBloomCaching = autoLogBloomCaching;
     return this;
   }
 
@@ -534,7 +534,7 @@ public class RunnerBuilder {
         metricsService,
         besuController,
         dataDir,
-        autoLogsBloomIndexing ? blockchainQueries.getTransactionLogsIndexer() : Optional.empty(),
+        autoLogBloomCaching ? blockchainQueries.getTransactionLogBloomCacher() : Optional.empty(),
         context.getBlockchain());
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -144,6 +144,7 @@ public class RunnerBuilder {
   private Collection<EnodeURL> staticNodes = Collections.emptyList();
   private Optional<String> identityString = Optional.empty();
   private BesuPluginContextImpl besuPluginContext;
+  private boolean autoLogsBloomIndexing = true;
 
   public RunnerBuilder vertx(final Vertx vertx) {
     this.vertx = vertx;
@@ -267,6 +268,11 @@ public class RunnerBuilder {
 
   public RunnerBuilder besuPluginContext(final BesuPluginContextImpl besuPluginContext) {
     this.besuPluginContext = besuPluginContext;
+    return this;
+  }
+
+  public RunnerBuilder autoLogsBloomIndexing(final boolean autoLogsBloomIndexing) {
+    this.autoLogsBloomIndexing = autoLogsBloomIndexing;
     return this;
   }
 
@@ -527,7 +533,9 @@ public class RunnerBuilder {
         stratumServer,
         metricsService,
         besuController,
-        dataDir);
+        dataDir,
+        autoLogsBloomIndexing ? blockchainQueries.getTransactionLogsIndexer() : Optional.empty(),
+        context.getBlockchain());
   }
 
   private Optional<NodePermissioningController> buildNodePermissioningController(

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -801,10 +801,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private String keyValueStorageName = DEFAULT_KEY_VALUE_STORAGE_NAME;
 
   @Option(
-      names = {"--auto-logs-bloom-indexing-enabled"},
-      description = "Enable Automatic logs bloom indexing (default: ${DEFAULT-VALUE})",
+      names = {"--auto-log-bloom-caching-enabled"},
+      description = "Enable automatic log bloom caching (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Boolean autoLogsBloomIndexingEnabled = true;
+  private final Boolean autoLogBloomCachingEnabled = true;
 
   @Option(
       names = {"--override-genesis-config"},
@@ -1723,7 +1723,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .staticNodes(staticNodes)
             .identityString(identityString)
             .besuPluginContext(besuPluginContext)
-            .autoLogsBloomIndexing(autoLogsBloomIndexingEnabled)
+            .autoLogBloomCaching(autoLogBloomCachingEnabled)
             .build();
 
     addShutdownHook(runner);

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -801,6 +801,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private String keyValueStorageName = DEFAULT_KEY_VALUE_STORAGE_NAME;
 
   @Option(
+      names = {"--auto-logs-bloom-indexing-enabled"},
+      description = "Enable Automatic logs bloom indexing (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final Boolean autoLogsBloomIndexingEnabled = true;
+
+  @Option(
       names = {"--override-genesis-config"},
       paramLabel = "NAME=VALUE",
       description = "Overrides configuration values in the genesis file.  Use with care.",
@@ -1717,6 +1723,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .staticNodes(staticNodes)
             .identityString(identityString)
             .besuPluginContext(besuPluginContext)
+            .autoLogsBloomIndexing(autoLogsBloomIndexingEnabled)
             .build();
 
     addShutdownHook(runner);

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
@@ -19,10 +19,10 @@ package org.hyperledger.besu.cli.subcommands.operator;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
-import static org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer.BLOCKS_PER_BLOOM_CACHE;
+import static org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher.BLOCKS_PER_BLOOM_CACHE;
 
 import org.hyperledger.besu.controller.BesuController;
-import org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer;
+import org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -43,7 +43,7 @@ public class GenerateLogBloomCache implements Runnable {
       names = "--start-block",
       paramLabel = MANDATORY_LONG_FORMAT_HELP,
       description =
-          "The block to start generating indexes.  Must be an increment of "
+          "The block to start generating the cache.  Must be an increment of "
               + BLOCKS_PER_BLOOM_CACHE
               + " (default: ${DEFAULT-VALUE})",
       arity = "1..1")
@@ -52,7 +52,7 @@ public class GenerateLogBloomCache implements Runnable {
   @Option(
       names = "--end-block",
       paramLabel = MANDATORY_LONG_FORMAT_HELP,
-      description = "The block to stop generating indexes (default is last block of the chain).",
+      description = "The block to stop generating the cache (default is last block of the chain).",
       arity = "1..1")
   private final Long endBlock = Long.MAX_VALUE;
 
@@ -69,9 +69,9 @@ public class GenerateLogBloomCache implements Runnable {
     final EthScheduler scheduler = new EthScheduler(1, 1, 1, 1, new NoOpMetricsSystem());
     try {
       final long finalBlock = Math.min(blockchain.getChainHeadBlockNumber(), endBlock);
-      final TransactionLogsIndexer indexer =
-          new TransactionLogsIndexer(blockchain, cacheDir, scheduler);
-      indexer.generateLogBloomCache(startBlock, finalBlock);
+      final TransactionLogBloomCacher cacher =
+          new TransactionLogBloomCacher(blockchain, cacheDir, scheduler);
+      cacher.generateLogBloomCache(startBlock, finalBlock);
     } finally {
       scheduler.stop();
       try {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -175,6 +175,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).webSocketConfiguration(eq(DEFAULT_WEB_SOCKET_CONFIGURATION));
     verify(mockRunnerBuilder).metricsConfiguration(eq(DEFAULT_METRICS_CONFIGURATION));
     verify(mockRunnerBuilder).ethNetworkConfig(ethNetworkArg.capture());
+    verify(mockRunnerBuilder).autoLogsBloomIndexing(eq(true));
     verify(mockRunnerBuilder).build();
 
     verify(mockControllerBuilderFactory).fromEthNetworkConfig(ethNetworkArg.capture(), any());

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -175,7 +175,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).webSocketConfiguration(eq(DEFAULT_WEB_SOCKET_CONFIGURATION));
     verify(mockRunnerBuilder).metricsConfiguration(eq(DEFAULT_METRICS_CONFIGURATION));
     verify(mockRunnerBuilder).ethNetworkConfig(ethNetworkArg.capture());
-    verify(mockRunnerBuilder).autoLogsBloomIndexing(eq(true));
+    verify(mockRunnerBuilder).autoLogBloomCaching(eq(true));
     verify(mockRunnerBuilder).build();
 
     verify(mockControllerBuilderFactory).fromEthNetworkConfig(ethNetworkArg.capture(), any());

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -223,7 +223,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.staticNodes(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.identityString(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.besuPluginContext(any())).thenReturn(mockRunnerBuilder);
-    when(mockRunnerBuilder.autoLogsBloomIndexing(anyBoolean())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.autoLogBloomCaching(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.build()).thenReturn(mockRunner);
 
     lenient()

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -223,6 +223,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.staticNodes(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.identityString(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.besuPluginContext(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.autoLogsBloomIndexing(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.build()).thenReturn(mockRunner);
 
     lenient()

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -137,4 +137,5 @@ key-value-storage="rocksdb"
 # Gas limit
 target-gas-limit=8000000
 
-auto-logs-bloom-indexing-enabled=true
+# transaction log bloom filter caching
+auto-log-bloom-caching-enabled=true

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -136,3 +136,5 @@ key-value-storage="rocksdb"
 
 # Gas limit
 target-gas-limit=8000000
+
+auto-logs-bloom-indexing-enabled=true

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCache.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCache.java
@@ -73,8 +73,8 @@ public class AdminGenerateLogBloomCache implements JsonRpcMethod {
     return new JsonRpcSuccessResponse(
         requestContext.getRequest().getId(),
         blockchainQueries
-            .getTransactionLogsIndexer()
-            .map(indexer -> indexer.requestIndexing(startBlock, stopBlock))
+            .getTransactionLogBloomCacher()
+            .map(cacher -> cacher.requestCaching(startBlock, stopBlock))
             .orElse(null));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import org.apache.logging.log4j.LogManager;
@@ -51,13 +52,15 @@ public class AutoTransactionLogBloomCachingService {
                   (event, __) -> {
                     if (event.isNewCanonicalHead()) {
                       transactionLogBloomCacher.cacheLogsBloomForBlockHeader(
-                          event.getBlock().getHeader());
+                          event.getBlock().getHeader(), Optional.empty(), true);
                     }
                   }));
       chainReorgSubscriptionId =
           OptionalLong.of(
               blockchain.observeChainReorg(
-                  (header, __) -> transactionLogBloomCacher.cacheLogsBloomForBlockHeader(header)));
+                  (header, __) ->
+                      transactionLogBloomCacher.cacheLogsBloomForBlockHeader(
+                          header, Optional.empty(), true)));
 
       transactionLogBloomCacher
           .getScheduler()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogsIndexingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogsIndexingService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.query;
+
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.OptionalLong;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AutoTransactionLogsIndexingService {
+  protected static final Logger LOG = LogManager.getLogger();
+  private final Blockchain blockchain;
+  private final TransactionLogsIndexer transactionLogsIndexer;
+  private OptionalLong blockAddedSubscriptionId = OptionalLong.empty();
+  private OptionalLong chainReorgSubscriptionId = OptionalLong.empty();
+
+  public AutoTransactionLogsIndexingService(
+      final Blockchain blockchain, final TransactionLogsIndexer transactionLogsIndexer) {
+    this.blockchain = blockchain;
+    this.transactionLogsIndexer = transactionLogsIndexer;
+  }
+
+  public void start() {
+    try {
+      LOG.info("Starting Auto transaction logs indexing service.");
+      final Path cacheDir = transactionLogsIndexer.getCacheDir();
+      if (!cacheDir.toFile().exists() || !cacheDir.toFile().isDirectory()) {
+        Files.createDirectory(cacheDir);
+      }
+      blockAddedSubscriptionId =
+          OptionalLong.of(
+              blockchain.observeBlockAdded(
+                  (event, __) -> {
+                    if (event.isNewCanonicalHead()) {
+                      transactionLogsIndexer.cacheLogsBloomForBlockHeader(
+                          event.getBlock().getHeader());
+                    }
+                  }));
+      chainReorgSubscriptionId =
+          OptionalLong.of(
+              blockchain.observeChainReorg(
+                  (header, __) -> transactionLogsIndexer.cacheLogsBloomForBlockHeader(header)));
+
+      transactionLogsIndexer
+          .getScheduler()
+          .scheduleFutureTask(transactionLogsIndexer::indexAll, Duration.ofMinutes(1));
+    } catch (IOException e) {
+      LOG.error("Unhandled indexing exception.", e);
+    }
+  }
+
+  public void stop() {
+    LOG.info("Shutting down Auto transaction logs indexing service.");
+    blockAddedSubscriptionId.ifPresent(blockchain::removeObserver);
+    chainReorgSubscriptionId.ifPresent(blockchain::removeChainReorgObserver);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.ethereum.api.query;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer.BLOCKS_PER_BLOOM_CACHE;
+import static org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher.BLOCKS_PER_BLOOM_CACHE;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.TransactionLocation;
@@ -61,7 +61,7 @@ public class BlockchainQueries {
   private final WorldStateArchive worldStateArchive;
   private final Blockchain blockchain;
   private final Optional<Path> cachePath;
-  private final Optional<TransactionLogsIndexer> transactionLogsIndexer;
+  private final Optional<TransactionLogBloomCacher> transactionLogBloomCacher;
 
   public BlockchainQueries(final Blockchain blockchain, final WorldStateArchive worldStateArchive) {
     this(blockchain, worldStateArchive, Optional.empty(), Optional.empty());
@@ -82,9 +82,10 @@ public class BlockchainQueries {
     this.blockchain = blockchain;
     this.worldStateArchive = worldStateArchive;
     this.cachePath = cachePath;
-    this.transactionLogsIndexer =
+    this.transactionLogBloomCacher =
         (cachePath.isPresent() && scheduler.isPresent())
-            ? Optional.of(new TransactionLogsIndexer(blockchain, cachePath.get(), scheduler.get()))
+            ? Optional.of(
+                new TransactionLogBloomCacher(blockchain, cachePath.get(), scheduler.get()))
             : Optional.empty();
   }
 
@@ -96,8 +97,8 @@ public class BlockchainQueries {
     return worldStateArchive;
   }
 
-  public Optional<TransactionLogsIndexer> getTransactionLogsIndexer() {
-    return transactionLogsIndexer;
+  public Optional<TransactionLogBloomCacher> getTransactionLogBloomCacher() {
+    return transactionLogBloomCacher;
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -49,7 +48,6 @@ public class TransactionLogBloomCacher {
 
   public static final int BLOCKS_PER_BLOOM_CACHE = 100_000;
   private static final int BLOOM_BITS_LENGTH = 256;
-  public static final String PENDING = "pending";
   private final Map<Long, Boolean> cachedSegments;
 
   private final Lock submissionLock = new ReentrantLock();
@@ -95,22 +93,16 @@ public class TransactionLogBloomCacher {
         LOG.error("Cache directory '{}' does not exist and could not be made.", cacheDir);
         return cachingStatus;
       }
-
-      final File pendingFile = calculateCacheFileName(PENDING, cacheDir);
       for (long blockNum = start; blockNum < stop; blockNum += BLOCKS_PER_BLOOM_CACHE) {
         LOG.info("Caching segment at {}", blockNum);
-        try (final FileOutputStream fos = new FileOutputStream(pendingFile)) {
-          final long blockCount = fillCacheFile(blockNum, blockNum + BLOCKS_PER_BLOOM_CACHE, fos);
-          if (blockCount == BLOCKS_PER_BLOOM_CACHE) {
-            Files.move(
-                pendingFile.toPath(),
-                calculateCacheFileName(blockNum, cacheDir).toPath(),
-                StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE);
-          } else {
-            LOG.info("Partial segment at {}, only {} blocks cached", blockNum, blockCount);
-            break;
-          }
+        final File cacheFile = calculateCacheFileName(blockNum, cacheDir);
+        blockchain
+            .getBlockHeader(blockNum)
+            .ifPresent(
+                blockHeader ->
+                    cacheLogsBloomForBlockHeader(blockHeader, Optional.of(cacheFile), false));
+        try (final FileOutputStream fos = new FileOutputStream(cacheFile)) {
+          fillCacheFile(blockNum, blockNum + BLOCKS_PER_BLOOM_CACHE, fos);
         }
       }
     } catch (final Exception e) {
@@ -122,7 +114,7 @@ public class TransactionLogBloomCacher {
     return cachingStatus;
   }
 
-  private long fillCacheFile(
+  private void fillCacheFile(
       final long startBlock, final long stopBlock, final FileOutputStream fos) throws IOException {
     long blockNum = startBlock;
     while (blockNum < stopBlock) {
@@ -134,15 +126,19 @@ public class TransactionLogBloomCacher {
       cachingStatus.currentBlock = blockNum;
       blockNum++;
     }
-    return blockNum - startBlock;
   }
 
-  public void cacheLogsBloomForBlockHeader(final BlockHeader blockHeader) {
+  public void cacheLogsBloomForBlockHeader(
+      final BlockHeader blockHeader,
+      final Optional<File> reusedCacheFile,
+      final boolean ensureChecks) {
     try {
       final long blockNumber = blockHeader.getNumber();
       LOG.debug("Caching logs bloom for block {}.", "0x" + Long.toHexString(blockNumber));
-      ensurePreviousSegmentsArePresent(blockNumber);
-      final File cacheFile = calculateCacheFileName(blockNumber, cacheDir);
+      if (ensureChecks) {
+        ensurePreviousSegmentsArePresent(blockNumber);
+      }
+      final File cacheFile = reusedCacheFile.orElse(calculateCacheFileName(blockNumber, cacheDir));
       if (!cacheFile.exists()) {
         Files.createFile(cacheFile.toPath());
       }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCacheTest.java
@@ -23,8 +23,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer;
-import org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer.IndexingStatus;
+import org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher;
+import org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher.CachingStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +41,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AdminGenerateLogBloomCacheTest {
 
   @Mock private BlockchainQueries blockchainQueries;
-  @Mock private TransactionLogsIndexer transactionLogsIndexer;
+  @Mock private TransactionLogBloomCacher transactionLogBloomCacher;
   @Captor private ArgumentCaptor<Long> fromBlock;
   @Captor private ArgumentCaptor<Long> toBlock;
 
@@ -53,12 +53,12 @@ public class AdminGenerateLogBloomCacheTest {
   }
 
   @Test
-  public void requestWithZeroParameters_NoIndexer_returnsNull() {
+  public void requestWithZeroParameters_NoCacher_returnsNull() {
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(
             new JsonRpcRequest("2.0", "admin_generateLogBloomCache", new String[] {}));
 
-    when(blockchainQueries.getTransactionLogsIndexer()).thenReturn(Optional.empty());
+    when(blockchainQueries.getTransactionLogBloomCacher()).thenReturn(Optional.empty());
 
     final JsonRpcResponse actualResponse = method.response(request);
 
@@ -109,11 +109,11 @@ public class AdminGenerateLogBloomCacheTest {
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", "admin_generateLogBloomCache", args));
 
-    final IndexingStatus expectedStatus = new IndexingStatus();
+    final CachingStatus expectedStatus = new CachingStatus();
 
-    when(blockchainQueries.getTransactionLogsIndexer())
-        .thenReturn(Optional.of(transactionLogsIndexer));
-    when(transactionLogsIndexer.requestIndexing(fromBlock.capture(), toBlock.capture()))
+    when(blockchainQueries.getTransactionLogBloomCacher())
+        .thenReturn(Optional.of(transactionLogBloomCacher));
+    when(transactionLogBloomCacher.requestCaching(fromBlock.capture(), toBlock.capture()))
         .thenReturn(expectedStatus);
 
     final JsonRpcResponse actualResponse = method.response(request);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -16,7 +16,7 @@
 
 package org.hyperledger.besu.ethereum.api.query;
 
-import static org.hyperledger.besu.ethereum.api.query.TransactionLogsIndexer.BLOCKS_PER_BLOOM_CACHE;
+import static org.hyperledger.besu.ethereum.api.query.TransactionLogBloomCacher.BLOCKS_PER_BLOOM_CACHE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
@@ -206,4 +206,22 @@ public interface Blockchain {
    * @return {@code true} if the observer was removed; otherwise {@code false}
    */
   boolean removeObserver(long observerId);
+
+  /**
+   * Adds an observer that will get called when a new block is added after reorg.
+   *
+   * <p><i>No guarantees are made about the order in which observers are invoked.</i>
+   *
+   * @param observer the observer to call
+   * @return the observer ID that can be used to remove it later.
+   */
+  long observeChainReorg(ChainReorgObserver observer);
+
+  /**
+   * Removes a previously added {@link ChainReorgObserver}.
+   *
+   * @param observerId the ID of the observer to remove
+   * @return {@code true} if the observer was removed; otherwise {@code false}
+   */
+  boolean removeChainReorgObserver(long observerId);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainReorgObserver.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainReorgObserver.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.chain;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+public interface ChainReorgObserver {
+
+  void onBlockAdded(BlockHeader blockHeader, Blockchain blockchain);
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/TestBlockchain.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/TestBlockchain.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
+import org.hyperledger.besu.ethereum.chain.ChainReorgObserver;
 import org.hyperledger.besu.ethereum.chain.TransactionLocation;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -147,6 +148,16 @@ public class TestBlockchain implements Blockchain {
   @Override
   public boolean removeObserver(final long observerId) {
     throw new NonDeterministicOperationException("Listening for new blocks is not deterministic");
+  }
+
+  @Override
+  public long observeChainReorg(final ChainReorgObserver observer) {
+    throw new NonDeterministicOperationException("Listening for chain reorg is not deterministic");
+  }
+
+  @Override
+  public boolean removeChainReorgObserver(final long observerId) {
+    throw new NonDeterministicOperationException("Listening for chain reorg is not deterministic");
   }
 
   public static class NonDeterministicOperationException extends RuntimeException {


### PR DESCRIPTION
Add a new option `--auto-logs-bloom-indexing-enabled` which defaults to true. This performs the equivalent of the `operator generate-log-bloom-cache` CLI task or `admin_generateLogBloomCache` RPC call for each block as it arrives, in addition to caching older logs on first startup.  
