### PR TITLE
BESU-146 - check if success and return errorResponse otherwise

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -84,8 +84,8 @@ public class EthEstimateGas implements JsonRpcMethod {
   private Function<TransactionSimulatorResult, JsonRpcResponse> gasEstimateResponse(
       final JsonRpcRequestContext request) {
     return result ->
-        new JsonRpcSuccessResponse(
-            request.getRequest().getId(), Quantity.create(result.getGasEstimate()));
+        result.isSuccessful() ? new JsonRpcSuccessResponse(
+            request.getRequest().getId(), Quantity.create(result.getGasEstimate())) : null;
   }
 
   private JsonRpcErrorResponse errorResponse(final JsonRpcRequestContext request) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -84,8 +84,10 @@ public class EthEstimateGas implements JsonRpcMethod {
   private Function<TransactionSimulatorResult, JsonRpcResponse> gasEstimateResponse(
       final JsonRpcRequestContext request) {
     return result ->
-        result.isSuccessful() ? new JsonRpcSuccessResponse(
-            request.getRequest().getId(), Quantity.create(result.getGasEstimate())) : null;
+        result.isSuccessful()
+            ? new JsonRpcSuccessResponse(
+                request.getRequest().getId(), Quantity.create(result.getGasEstimate()))
+            : null;
   }
 
   private JsonRpcErrorResponse errorResponse(final JsonRpcRequestContext request) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -85,7 +85,7 @@ public class EthEstimateGasTest {
   @Test
   public void shouldReturnGasEstimateWhenTransientTransactionProcessorReturnsResult() {
     final JsonRpcRequestContext request = ethEstimateGasRequest(callParameter());
-    mockTransientProcessorResultGasEstimate(1L);
+    mockTransientProcessorResultGasEstimate(1L, true);
 
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, Quantity.create(1L));
 
@@ -93,11 +93,12 @@ public class EthEstimateGasTest {
         .isEqualToComparingFieldByField(expectedResponse);
   }
 
-  private void mockTransientProcessorResultGasEstimate(final long gasEstimate) {
+  private void mockTransientProcessorResultGasEstimate(final long gasEstimate, final boolean isSuccessful) {
     final TransactionSimulatorResult result = mock(TransactionSimulatorResult.class);
     when(result.getGasEstimate()).thenReturn(gasEstimate);
     when(transactionSimulator.process(eq(modifiedCallParameter()), eq(1L)))
         .thenReturn(Optional.of(result));
+    when(result.isSuccessful()).thenReturn(isSuccessful);
   }
 
   private JsonCallParameter callParameter() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -83,11 +83,23 @@ public class EthEstimateGasTest {
   }
 
   @Test
-  public void shouldReturnGasEstimateWhenTransientTransactionProcessorReturnsResult() {
+  public void shouldReturnGasEstimateWhenTransientTransactionProcessorReturnsResultSuccess() {
     final JsonRpcRequestContext request = ethEstimateGasRequest(callParameter());
     mockTransientProcessorResultGasEstimate(1L, true);
 
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, Quantity.create(1L));
+
+    Assertions.assertThat(method.response(request))
+        .isEqualToComparingFieldByField(expectedResponse);
+  }
+
+  @Test
+  public void shouldReturnGasEstimateErrorWhenTransientTransactionProcessorReturnsResultFailure() {
+    final JsonRpcRequestContext request = ethEstimateGasRequest(callParameter());
+    mockTransientProcessorResultGasEstimate(1L, false);
+
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(null, JsonRpcError.INTERNAL_ERROR);
 
     Assertions.assertThat(method.response(request))
         .isEqualToComparingFieldByField(expectedResponse);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -93,7 +93,8 @@ public class EthEstimateGasTest {
         .isEqualToComparingFieldByField(expectedResponse);
   }
 
-  private void mockTransientProcessorResultGasEstimate(final long gasEstimate, final boolean isSuccessful) {
+  private void mockTransientProcessorResultGasEstimate(
+      final long gasEstimate, final boolean isSuccessful) {
     final TransactionSimulatorResult result = mock(TransactionSimulatorResult.class);
     when(result.getGasEstimate()).thenReturn(gasEstimate);
     when(transactionSimulator.process(eq(modifiedCallParameter()), eq(1L)))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Bug - when calculating eth_estimateGas, we always return a success response even if an error has occurred. 

Solution - We should first check to see if the result is valid and return an error response otherwise.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
