### PR TITLE
Fix priv_getCode on multi-tenancy

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyAcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyAcceptanceTestBase.java
@@ -33,6 +33,8 @@ import org.junit.rules.TemporaryFolder;
 public class PrivacyAcceptanceTestBase {
   @ClassRule public static final TemporaryFolder privacy = new TemporaryFolder();
 
+  protected static final long POW_CHAIN_ID = 2018;
+
   protected final PrivacyTransactions privacyTransactions;
   protected final PrivateContractVerifier privateContractVerifier;
   protected final PrivateTransactionVerifier privateTransactionVerifier;

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/PrivacyTransactions.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/PrivacyTransactions.java
@@ -14,8 +14,10 @@
  */
 package org.hyperledger.besu.tests.acceptance.dsl.privacy.transaction;
 
+import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.PrivacyNode;
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.condition.PrivGetTransactionReceiptTransaction;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.privacy.PrivGetCodeTransaction;
 
 import java.util.List;
 
@@ -38,5 +40,10 @@ public class PrivacyTransactions {
   public PrivDistributeTransactionTransaction privDistributeTransaction(
       final String signedPrivateTransaction) {
     return new PrivDistributeTransactionTransaction(signedPrivateTransaction);
+  }
+
+  public PrivGetCodeTransaction privGetCode(
+      final String privacyGroupId, final Address contractAddress, final String blockParameter) {
+    return new PrivGetCodeTransaction(privacyGroupId, contractAddress, blockParameter);
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/privacy/PrivGetCodeTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/privacy/PrivGetCodeTransaction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.dsl.transaction.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
+
+import java.io.IOException;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class PrivGetCodeTransaction implements Transaction<Bytes> {
+
+  private final String privacyGroupId;
+  private final Address contractAddress;
+  private final String blockParameter;
+
+  public PrivGetCodeTransaction(
+      final String privacyGroupId, final Address contractAddress, final String blockParameter) {
+    this.privacyGroupId = privacyGroupId;
+    this.contractAddress = contractAddress;
+    this.blockParameter = blockParameter;
+  }
+
+  @Override
+  public Bytes execute(final NodeRequests node) {
+    try {
+      final PrivacyRequestFactory.GetCodeResponse response =
+          node.privacy()
+              .privGetCode(privacyGroupId, contractAddress.toHexString(), blockParameter)
+              .send();
+      assertThat(response).as("check response is not null").isNotNull();
+      assertThat(response.getResult()).as("check code in response isn't null").isNotNull();
+      return Bytes.fromHexString(response.getResult());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/privacy/PrivacyRequestFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/privacy/PrivacyRequestFactory.java
@@ -51,6 +51,7 @@ public class PrivacyRequestFactory {
   public static class GetTransactionReceiptResponse extends Response<PrivateTransactionReceipt> {}
 
   public static class GetTransactionCountResponse extends Response<Integer> {
+
     final Integer count;
 
     @JsonCreator
@@ -62,6 +63,8 @@ public class PrivacyRequestFactory {
       return count;
     }
   }
+
+  public static class GetCodeResponse extends Response<String> {}
 
   public Request<?, PrivDistributeTransactionResponse> privDistributeTransaction(
       final String signedPrivateTransaction) {
@@ -166,5 +169,14 @@ public class PrivacyRequestFactory {
         List.of(params),
         web3jService,
         GetTransactionCountResponse.class);
+  }
+
+  public Request<?, GetCodeResponse> privGetCode(
+      final String privacyGroupId, final String contractAddress, final String blockParameter) {
+    return new Request<>(
+        "priv_getCode",
+        List.of(privacyGroupId, contractAddress, blockParameter),
+        web3jService,
+        GetCodeResponse.class);
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivGetCodeAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/PrivGetCodeAcceptanceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.web3j.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.tests.acceptance.dsl.privacy.PrivacyAcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.privacy.PrivacyNode;
+import org.hyperledger.besu.tests.web3j.generated.EventEmitter;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.Before;
+import org.junit.Test;
+import org.web3j.protocol.besu.response.privacy.PrivacyGroup;
+import org.web3j.utils.Base64String;
+
+public class PrivGetCodeAcceptanceTest extends PrivacyAcceptanceTestBase {
+
+  private PrivacyNode alice;
+
+  @Before
+  public void setUp() throws Exception {
+    alice =
+        privacyBesu.createPrivateTransactionEnabledMinerNode(
+            "alice", privacyAccountResolver.resolve(0));
+    privacyCluster.start(alice);
+  }
+
+  @Test
+  public void privGetCodeReturnsDeployedContractBytecode() {
+    final String privacyGroupId = createPrivacyGroup();
+    final EventEmitter eventEmitterContract = deployPrivateContract(privacyGroupId);
+
+    final Bytes deployedContractCode =
+        alice.execute(
+            privacyTransactions.privGetCode(
+                privacyGroupId,
+                Address.fromHexString(eventEmitterContract.getContractAddress()),
+                "latest"));
+
+    assertThat(eventEmitterContract.getContractBinary())
+        .contains(deployedContractCode.toUnprefixedHexString());
+  }
+
+  private EventEmitter deployPrivateContract(final String privacyGroupId) {
+    final EventEmitter eventEmitter =
+        alice.execute(
+            privateContractTransactions.createSmartContractWithPrivacyGroupId(
+                EventEmitter.class,
+                alice.getTransactionSigningKey(),
+                POW_CHAIN_ID,
+                alice.getEnclaveKey(),
+                privacyGroupId));
+
+    privateContractVerifier
+        .validPrivateContractDeployed(
+            eventEmitter.getContractAddress(), alice.getAddress().toString())
+        .verify(eventEmitter);
+    return eventEmitter;
+  }
+
+  private String createPrivacyGroup() {
+    final String privacyGroupId =
+        alice.execute(
+            privacyTransactions.createPrivacyGroup("myGroupName", "my group description", alice));
+
+    assertThat(privacyGroupId).isNotNull();
+
+    final PrivacyGroup expected =
+        new PrivacyGroup(
+            privacyGroupId,
+            PrivacyGroup.Type.PANTHEON,
+            "myGroupName",
+            "my group description",
+            Base64String.wrapList(alice.getEnclaveKey()));
+
+    alice.verify(privateTransactionVerifier.validPrivacyGroupCreated(expected));
+
+    return privacyGroupId;
+  }
+}

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -92,7 +92,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
     final EnclaveFactory factory = new EnclaveFactory(vertx);
     enclave = factory.createVertxEnclave(testHarness.clientUrl());
 
-    privacyController = new DefaultPrivacyController(enclave, null, null, null, null);
+    privacyController = new DefaultPrivacyController(enclave, null, null, null, null, null);
   }
 
   @AfterClass

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
@@ -49,6 +49,9 @@ public class PrivGetCode extends AbstractBlockParameterMethod {
     final String privacyGroupId = request.getRequiredParameter(0, String.class);
     final Address address = request.getRequiredParameter(1, Address.class);
 
-    return privacyController.getContractCode(privacyGroupId, address, blockNumber).orElse(null);
+    return getBlockchainQueries()
+        .getBlockHashByNumber(blockNumber)
+        .flatMap(blockHash -> privacyController.getContractCode(privacyGroupId, address, blockHash))
+        .orElse(null);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
@@ -50,7 +50,8 @@ public class PrivGetCode extends AbstractBlockParameterMethod {
   }
 
   @Override
-  protected Bytes resultByBlockNumber(final JsonRpcRequestContext request, final long blockNumber) {
+  protected String resultByBlockNumber(
+      final JsonRpcRequestContext request, final long blockNumber) {
     final String privacyGroupId = request.getRequiredParameter(0, String.class);
     final Address address = request.getRequiredParameter(1, Address.class);
 
@@ -62,6 +63,7 @@ public class PrivGetCode extends AbstractBlockParameterMethod {
             blockHash ->
                 privacyController.getContractCode(
                     privacyGroupId, address, blockHash, enclavePublicKey))
+        .map(Bytes::toString)
         .orElse(null);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -70,6 +70,6 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
             getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
         new PrivDistributeRawTransaction(privacyController, enclavePublicKeyProvider),
         new PrivCall(getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
-        new PrivGetCode(getBlockchainQueries(), privacyController));
+        new PrivGetCode(getBlockchainQueries(), privacyController, enclavePublicKeyProvider));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
-import org.hyperledger.besu.ethereum.privacy.PrivateStateRootResolver;
 
 import java.util.Map;
 
@@ -71,9 +70,6 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
             getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
         new PrivDistributeRawTransaction(privacyController, enclavePublicKeyProvider),
         new PrivCall(getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
-        new PrivGetCode(
-            getBlockchainQueries(),
-            getPrivacyParameters().getPrivateWorldStateArchive(),
-            new PrivateStateRootResolver(getPrivacyParameters().getPrivateStateStorage())));
+        new PrivGetCode(getBlockchainQueries(), privacyController));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivateNonceProvider;
 import org.hyperledger.besu.ethereum.privacy.PrivateStateRootResolver;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionSimulator;
+import org.hyperledger.besu.ethereum.privacy.PrivateWorldStateReader;
 import org.hyperledger.besu.ethereum.privacy.markertransaction.FixedKeySigningPrivateMarkerTransactionFactory;
 import org.hyperledger.besu.ethereum.privacy.markertransaction.PrivateMarkerTransactionFactory;
 import org.hyperledger.besu.ethereum.privacy.markertransaction.RandomSigningPrivateMarkerTransactionFactory;
@@ -49,6 +50,7 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
   private final TransactionPool transactionPool;
   private final PrivacyParameters privacyParameters;
   private final PrivateNonceProvider privateNonceProvider;
+  private final PrivateWorldStateReader privateWorldStateReader;
 
   public PrivacyApiGroupJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
@@ -67,6 +69,10 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
             blockchainQueries.getBlockchain(),
             privateStateRootResolver,
             privacyParameters.getPrivateWorldStateArchive());
+
+    this.privateWorldStateReader =
+        new PrivateWorldStateReader(
+            privateStateRootResolver, privacyParameters.getPrivateWorldStateArchive());
   }
 
   public BlockchainQueries getBlockchainQueries() {
@@ -144,7 +150,8 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
             protocolSchedule.getChainId(),
             markerTransactionFactory,
             createPrivateTransactionSimulator(),
-            privateNonceProvider);
+            privateNonceProvider,
+            privateWorldStateReader);
     return privacyParameters.isMultiTenancyEnabled()
         ? new MultiTenancyPrivacyController(
             defaultPrivacyController, privacyParameters.getEnclave())

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
@@ -15,13 +15,16 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.EnclavePublicKeyProvider;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -43,6 +46,7 @@ public class PrivGetCodeTest {
 
   @Mock private PrivacyController privacyController;
   @Mock private BlockchainQueries mockBlockchainQueries;
+  @Mock private EnclavePublicKeyProvider enclavePublicKeyProvider;
 
   private final Hash latestBlockHash = Hash.ZERO;
   private final String privacyGroupId = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
@@ -55,7 +59,10 @@ public class PrivGetCodeTest {
 
   @Before
   public void before() {
-    method = new PrivGetCode(mockBlockchainQueries, privacyController);
+    when(enclavePublicKeyProvider.getEnclaveKey(any()))
+        .thenReturn("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=");
+
+    method = new PrivGetCode(mockBlockchainQueries, privacyController, enclavePublicKeyProvider);
     privGetCodeRequest = buildPrivGetCodeRequest();
   }
 
@@ -69,7 +76,7 @@ public class PrivGetCodeTest {
     when(mockBlockchainQueries.getBlockHashByNumber(anyLong()))
         .thenReturn(Optional.of(latestBlockHash));
     when(privacyController.getContractCode(
-            eq(privacyGroupId), eq(contractAddress), eq(latestBlockHash)))
+            eq(privacyGroupId), eq(contractAddress), eq(latestBlockHash), anyString()))
         .thenReturn(Optional.of(contractCode));
 
     final JsonRpcResponse response = method.response(privGetCodeRequest);
@@ -83,7 +90,7 @@ public class PrivGetCodeTest {
     when(mockBlockchainQueries.getBlockHashByNumber(anyLong()))
         .thenReturn(Optional.of(latestBlockHash));
     when(privacyController.getContractCode(
-            eq(privacyGroupId), eq(contractAddress), eq(latestBlockHash)))
+            eq(privacyGroupId), eq(contractAddress), eq(latestBlockHash), anyString()))
         .thenReturn(Optional.empty());
 
     final JsonRpcResponse response = method.response(privGetCodeRequest);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
@@ -82,7 +82,8 @@ public class PrivGetCodeTest {
     final JsonRpcResponse response = method.response(privGetCodeRequest);
 
     assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
-    assertThat(((JsonRpcSuccessResponse) response).getResult()).isEqualTo(contractCode);
+    assertThat(((JsonRpcSuccessResponse) response).getResult())
+        .isEqualTo(contractCode.toHexString());
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
@@ -15,33 +15,21 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.core.Wei;
-import org.hyperledger.besu.ethereum.core.WorldState;
-import org.hyperledger.besu.ethereum.privacy.PrivateStateRootResolver;
-import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
-import org.hyperledger.besu.ethereum.privacy.Restriction;
-import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
-import java.math.BigInteger;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,98 +39,55 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PrivGetCodeTest {
 
-  private final Address sender =
-      Address.fromHexString("0x0000000000000000000000000000000000000003");
-  private static final SECP256K1.KeyPair KEY_PAIR =
-      SECP256K1.KeyPair.create(
-          SECP256K1.PrivateKey.create(
-              new BigInteger(
-                  "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63", 16)));
+  @Mock private PrivacyController privacyController;
+  @Mock private BlockchainQueries mockBlockchainQueries;
 
-  private final Bytes privacyGroupId =
-      Bytes.fromBase64String("Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=");
-
-  private final PrivateTransaction.Builder privateTransactionBuilder =
-      PrivateTransaction.builder()
-          .nonce(0)
-          .gasPrice(Wei.of(1000))
-          .gasLimit(3000000)
-          .to(null)
-          .value(Wei.ZERO)
-          .payload(
-              Bytes.fromBase64String(
-                  "0x608060405234801561001057600080fd5b5060d08061001f60003960"
-                      + "00f3fe60806040526004361060485763ffffffff7c01000000"
-                      + "00000000000000000000000000000000000000000000000000"
-                      + "60003504166360fe47b18114604d5780636d4ce63c14607557"
-                      + "5b600080fd5b348015605857600080fd5b5060736004803603"
-                      + "6020811015606d57600080fd5b50356099565b005b34801560"
-                      + "8057600080fd5b506087609e565b6040805191825251908190"
-                      + "0360200190f35b600055565b6000549056fea165627a7a7230"
-                      + "5820cb1d0935d14b589300b12fcd0ab849a7e9019c81da24d6"
-                      + "daa4f6b2f003d1b0180029"))
-          .sender(sender)
-          .chainId(BigInteger.valueOf(2018))
-          .privateFrom(Bytes.fromBase64String("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo="))
-          .restriction(Restriction.RESTRICTED);
+  private final String privacyGroupId = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
+  private final Address contractAddress =
+      Address.fromHexString("f17f52151EbEF6C7334FAD080c5704D77216b732");
+  private final Bytes contractCode = Bytes.fromBase64String("ZXhhbXBsZQ==");
 
   private PrivGetCode method;
-
-  @Mock private BlockchainQueries mockBlockchainQueries;
-  @Mock private Blockchain mockBlockchain;
-  @Mock private Block mockBlock;
-  @Mock private Hash mockHash;
-  @Mock private PrivateStateRootResolver mockResolver;
-  @Mock private WorldStateArchive mockPrivateWorldStateArchive;
-  @Mock private WorldState mockWorldState;
-  @Mock private Account mockAccount;
-
-  private final Hash lastStateRoot =
-      Hash.fromHexString("0x2121b68f1333e93bae8cd717a3ca68c9d7e7003f6b288c36dfc59b0f87be9590");
-
-  private final Bytes contractAccountCode = Bytes.fromBase64String("ZXhhbXBsZQ==");
+  private JsonRpcRequestContext privGetCodeRequest;
 
   @Before
   public void before() {
-    method = new PrivGetCode(mockBlockchainQueries, mockPrivateWorldStateArchive, mockResolver);
+    method = new PrivGetCode(mockBlockchainQueries, privacyController);
+    privGetCodeRequest = buildPrivGetCodeRequest();
+  }
+
+  @Test
+  public void methodHasExpectedName() {
+    assertThat(method.getName()).isEqualTo("priv_getCode");
   }
 
   @Test
   public void returnValidCodeWhenCalledOnValidContract() {
-    final PrivateTransaction transaction =
-        privateTransactionBuilder.privacyGroupId(privacyGroupId).signAndBuild(KEY_PAIR);
-    final Address contractAddress =
-        Address.privateContractAddress(
-            transaction.getSender(), transaction.getNonce(), privacyGroupId);
+    when(privacyController.getContractCode(eq(privacyGroupId), eq(contractAddress), anyLong()))
+        .thenReturn(Optional.of(contractCode));
 
-    mockBlockchainWithContractCode(contractAddress);
-
-    final JsonRpcRequestContext request =
-        new JsonRpcRequestContext(
-            new JsonRpcRequest(
-                "2.0",
-                "priv_getCode",
-                new Object[] {
-                  "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=",
-                  contractAddress.toHexString(),
-                  "latest"
-                }));
-
-    final JsonRpcResponse response = method.response(request);
+    final JsonRpcResponse response = method.response(privGetCodeRequest);
 
     assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
-    assertThat(((JsonRpcSuccessResponse) response).getResult())
-        .isEqualTo(contractAccountCode.toString());
+    assertThat(((JsonRpcSuccessResponse) response).getResult()).isEqualTo(contractCode);
   }
 
-  private void mockBlockchainWithContractCode(final Address resultantContractAddress) {
-    when(mockBlockchainQueries.getBlockchain()).thenReturn(mockBlockchain);
-    when(mockBlockchain.getBlockByNumber(anyLong())).thenReturn(Optional.of(mockBlock));
-    when(mockBlock.getHash()).thenReturn(mockHash);
-    when(mockResolver.resolveLastStateRoot(any(Bytes32.class), any(Hash.class)))
-        .thenReturn(lastStateRoot);
-    when(mockPrivateWorldStateArchive.get(lastStateRoot)).thenReturn(Optional.of(mockWorldState));
-    when(mockWorldState.get(resultantContractAddress)).thenReturn(mockAccount);
-    when(mockAccount.getCode()).thenReturn(contractAccountCode);
+  @Test
+  public void returnEmptyWhenContractDoesNotExist() {
+    when(privacyController.getContractCode(eq(privacyGroupId), eq(contractAddress), anyLong()))
+        .thenReturn(Optional.empty());
+
+    final JsonRpcResponse response = method.response(privGetCodeRequest);
+
+    assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);
+    assertThat(((JsonRpcSuccessResponse) response).getResult()).isNull();
+  }
+
+  private JsonRpcRequestContext buildPrivGetCodeRequest() {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest(
+            "2.0",
+            "priv_getCode",
+            new Object[] {privacyGroupId, contractAddress.toHexString(), "latest"}));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
@@ -49,6 +49,7 @@ public class PrivGetCodeTest {
   @Mock private EnclavePublicKeyProvider enclavePublicKeyProvider;
 
   private final Hash latestBlockHash = Hash.ZERO;
+  private final String enclavePublicKey = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
   private final String privacyGroupId = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
   private final Address contractAddress =
       Address.fromHexString("f17f52151EbEF6C7334FAD080c5704D77216b732");
@@ -59,8 +60,7 @@ public class PrivGetCodeTest {
 
   @Before
   public void before() {
-    when(enclavePublicKeyProvider.getEnclaveKey(any()))
-        .thenReturn("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=");
+    when(enclavePublicKeyProvider.getEnclaveKey(any())).thenReturn(enclavePublicKey);
 
     method = new PrivGetCode(mockBlockchainQueries, privacyController, enclavePublicKeyProvider);
     privGetCodeRequest = buildPrivGetCodeRequest();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.enclave.types.PrivacyGroup.Type;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.enclave.types.SendResponse;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidator;
@@ -181,7 +182,7 @@ public class DefaultPrivacyController implements PrivacyController {
 
   @Override
   public Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final long blockNumber) {
+      final String privacyGroupId, final Address contractAddress, final Hash blockHash) {
     return Optional.empty();
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -50,19 +50,22 @@ public class DefaultPrivacyController implements PrivacyController {
   private final PrivateMarkerTransactionFactory privateMarkerTransactionFactory;
   private final PrivateTransactionSimulator privateTransactionSimulator;
   private final PrivateNonceProvider privateNonceProvider;
+  private final PrivateWorldStateReader privateWorldStateReader;
 
   public DefaultPrivacyController(
       final PrivacyParameters privacyParameters,
       final Optional<BigInteger> chainId,
       final PrivateMarkerTransactionFactory privateMarkerTransactionFactory,
       final PrivateTransactionSimulator privateTransactionSimulator,
-      final PrivateNonceProvider privateNonceProvider) {
+      final PrivateNonceProvider privateNonceProvider,
+      final PrivateWorldStateReader privateWorldStateReader) {
     this(
         privacyParameters.getEnclave(),
         new PrivateTransactionValidator(chainId),
         privateMarkerTransactionFactory,
         privateTransactionSimulator,
-        privateNonceProvider);
+        privateNonceProvider,
+        privateWorldStateReader);
   }
 
   public DefaultPrivacyController(
@@ -70,12 +73,14 @@ public class DefaultPrivacyController implements PrivacyController {
       final PrivateTransactionValidator privateTransactionValidator,
       final PrivateMarkerTransactionFactory privateMarkerTransactionFactory,
       final PrivateTransactionSimulator privateTransactionSimulator,
-      final PrivateNonceProvider privateNonceProvider) {
+      final PrivateNonceProvider privateNonceProvider,
+      final PrivateWorldStateReader privateWorldStateReader) {
     this.enclave = enclave;
     this.privateTransactionValidator = privateTransactionValidator;
     this.privateMarkerTransactionFactory = privateMarkerTransactionFactory;
     this.privateTransactionSimulator = privateTransactionSimulator;
     this.privateNonceProvider = privateNonceProvider;
+    this.privateWorldStateReader = privateWorldStateReader;
   }
 
   @Override
@@ -182,8 +187,11 @@ public class DefaultPrivacyController implements PrivacyController {
 
   @Override
   public Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final Hash blockHash) {
-    return Optional.empty();
+      final String privacyGroupId,
+      final Address contractAddress,
+      final Hash blockHash,
+      final String enclavePublicKey) {
+    return privateWorldStateReader.getContractCode(privacyGroupId, blockHash, contractAddress);
   }
 
   private SendResponse sendRequest(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -179,6 +179,12 @@ public class DefaultPrivacyController implements PrivacyController {
     return result;
   }
 
+  @Override
+  public Optional<Bytes> getContractCode(
+      final String privacyGroupId, final Address contractAddress, final long blockNumber) {
+    return Optional.empty();
+  }
+
   private SendResponse sendRequest(
       final PrivateTransaction privateTransaction, final String enclavePublicKey) {
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -129,8 +129,13 @@ public class MultiTenancyPrivacyController implements PrivacyController {
 
   @Override
   public Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final Hash blockHash) {
-    return Optional.empty();
+      final String privacyGroupId,
+      final Address contractAddress,
+      final Hash blockHash,
+      final String enclavePublicKey) {
+    verifyPrivacyGroupContainsEnclavePublicKey(privacyGroupId, enclavePublicKey);
+    return privacyController.getContractCode(
+        privacyGroupId, contractAddress, blockHash, enclavePublicKey);
   }
 
   private void verifyPrivateFromMatchesEnclavePublicKey(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -26,6 +26,8 @@ import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
+
 public class MultiTenancyPrivacyController implements PrivacyController {
 
   private final PrivacyController privacyController;
@@ -122,6 +124,12 @@ public class MultiTenancyPrivacyController implements PrivacyController {
     verifyPrivacyGroupContainsEnclavePublicKey(privacyGroupId, enclavePublicKey);
     return privacyController.simulatePrivateTransaction(
         privacyGroupId, enclavePublicKey, callParams, blockNumber);
+  }
+
+  @Override
+  public Optional<Bytes> getContractCode(
+      final String privacyGroupId, final Address contractAddress, final long blockNumber) {
+    return Optional.empty();
   }
 
   private void verifyPrivateFromMatchesEnclavePublicKey(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
@@ -128,7 +129,7 @@ public class MultiTenancyPrivacyController implements PrivacyController {
 
   @Override
   public Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final long blockNumber) {
+      final String privacyGroupId, final Address contractAddress, final Hash blockHash) {
     return Optional.empty();
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -25,6 +25,8 @@ import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
+
 public interface PrivacyController {
 
   String sendTransaction(PrivateTransaction privateTransaction, String enclavePublicKey);
@@ -54,4 +56,7 @@ public interface PrivacyController {
       final String enclavePublicKey,
       final CallParameter callParams,
       final long blockNumber);
+
+  Optional<Bytes> getContractCode(
+      final String privacyGroupId, final Address contractAddress, final long blockNumber);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.privacy;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
@@ -58,5 +59,5 @@ public interface PrivacyController {
       final long blockNumber);
 
   Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final long blockNumber);
+      final String privacyGroupId, final Address contractAddress, final Hash blockHash);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -59,5 +59,8 @@ public interface PrivacyController {
       final long blockNumber);
 
   Optional<Bytes> getContractCode(
-      final String privacyGroupId, final Address contractAddress, final Hash blockHash);
+      final String privacyGroupId,
+      final Address contractAddress,
+      final Hash blockHash,
+      final String enclavePublicKey);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateWorldStateReader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateWorldStateReader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.privacy;
+
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class PrivateWorldStateReader {
+
+  private final PrivateStateRootResolver privateStateRootResolver;
+  private final WorldStateArchive privateWorldStateArchive;
+
+  public PrivateWorldStateReader(
+      final PrivateStateRootResolver privateStateRootResolver,
+      final WorldStateArchive privateWorldStateArchive) {
+    this.privateStateRootResolver = privateStateRootResolver;
+    this.privateWorldStateArchive = privateWorldStateArchive;
+  }
+
+  public Optional<Bytes> getContractCode(
+      final String privacyGroupId, final Hash blockHash, final Address contractAddress) {
+    final Hash latestStateRoot =
+        privateStateRootResolver.resolveLastStateRoot(
+            Bytes32.wrap(Bytes.fromBase64String(privacyGroupId)), blockHash);
+
+    return privateWorldStateArchive
+        .get(latestStateRoot)
+        .flatMap(worldState -> Optional.ofNullable(worldState.get(contractAddress)))
+        .flatMap(account -> Optional.ofNullable(account.getCode()));
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateWorldStateReaderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateWorldStateReaderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.ethereum.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.core.Account;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.WorldState;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrivateWorldStateReaderTest {
+
+  private final String PRIVACY_GROUP_ID = "B1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
+  private final Bytes32 privacyGroupBytes = Bytes32.wrap(Bytes.fromBase64String(PRIVACY_GROUP_ID));
+  private final Bytes contractCode = Bytes.fromBase64String("ZXhhbXBsZQ==");
+  private final Address contractAddress = Address.ZERO;
+  private final Hash blockHash = Hash.ZERO;
+  private final Hash stateRootHash = Hash.ZERO;
+
+  @Mock private PrivateStateRootResolver privateStateRootResolver;
+  @Mock private WorldStateArchive privateWorldStateArchive;
+  @Mock private WorldState privateWorldState;
+  @Mock private Account contractAccount;
+
+  private PrivateWorldStateReader privateWorldStateReader;
+
+  @Before
+  public void before() {
+    privateWorldStateReader =
+        new PrivateWorldStateReader(privateStateRootResolver, privateWorldStateArchive);
+  }
+
+  @Test
+  public void absentPrivateWorldStateReturnsEmpty() {
+    final Bytes32 privacyGroupBytes = Bytes32.wrap(Bytes.fromBase64String(PRIVACY_GROUP_ID));
+    final Address contractAddress = Address.ZERO;
+
+    when(privateStateRootResolver.resolveLastStateRoot(eq(privacyGroupBytes), eq(blockHash)))
+        .thenReturn(stateRootHash);
+    when(privateWorldStateArchive.get(eq(stateRootHash))).thenReturn(Optional.empty());
+
+    final Optional<Bytes> maybecontractCode =
+        privateWorldStateReader.getContractCode(PRIVACY_GROUP_ID, blockHash, contractAddress);
+
+    assertThat(maybecontractCode).isNotPresent();
+  }
+
+  @Test
+  public void absentAccountReturnsEmpty() {
+    final Bytes32 privacyGroupBytes = Bytes32.wrap(Bytes.fromBase64String(PRIVACY_GROUP_ID));
+    final Address contractAddress = Address.ZERO;
+
+    when(privateStateRootResolver.resolveLastStateRoot(eq(privacyGroupBytes), eq(blockHash)))
+        .thenReturn(stateRootHash);
+    when(privateWorldStateArchive.get(eq(stateRootHash)))
+        .thenReturn(Optional.of(privateWorldState));
+    when(privateWorldState.get(eq(contractAddress))).thenReturn(null);
+
+    final Optional<Bytes> maybeContractCode =
+        privateWorldStateReader.getContractCode(PRIVACY_GROUP_ID, blockHash, contractAddress);
+
+    assertThat(maybeContractCode).isNotPresent();
+  }
+
+  @Test
+  public void existingAccountWithEmptyCodeReturnsEmpty() {
+    final Bytes32 privacyGroupBytes = Bytes32.wrap(Bytes.fromBase64String(PRIVACY_GROUP_ID));
+    final Address contractAddress = Address.ZERO;
+
+    when(privateStateRootResolver.resolveLastStateRoot(eq(privacyGroupBytes), eq(blockHash)))
+        .thenReturn(stateRootHash);
+    when(privateWorldStateArchive.get(eq(stateRootHash)))
+        .thenReturn(Optional.of(privateWorldState));
+    when(privateWorldState.get(eq(contractAddress))).thenReturn(contractAccount);
+    when(contractAccount.getCode()).thenReturn(null);
+
+    final Optional<Bytes> maybeContractCode =
+        privateWorldStateReader.getContractCode(PRIVACY_GROUP_ID, blockHash, contractAddress);
+
+    assertThat(maybeContractCode).isNotPresent();
+  }
+
+  @Test
+  public void existingAccountWithCodeReturnsExpectedBytes() {
+    when(privateStateRootResolver.resolveLastStateRoot(eq(privacyGroupBytes), eq(blockHash)))
+        .thenReturn(stateRootHash);
+    when(privateWorldStateArchive.get(eq(stateRootHash)))
+        .thenReturn(Optional.of(privateWorldState));
+    when(privateWorldState.get(eq(contractAddress))).thenReturn(contractAccount);
+    when(contractAccount.getCode()).thenReturn(contractCode);
+
+    final Optional<Bytes> maybeContractCode =
+        privateWorldStateReader.getContractCode(PRIVACY_GROUP_ID, blockHash, contractAddress);
+
+    assertThat(maybeContractCode).isPresent().hasValue(contractCode);
+  }
+}


### PR DESCRIPTION
## PR description
• Moved the logic to read the code from the private world state into PrivateWorldStateReader
• Channelling the access from PrivGetCode to PrivateWorldStateReader through the PrivacyController to enforce multi-tenancy rules
• Created an acceptance test for PrivGetCode