### PR TITLE
Fix log level setup during startup

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -629,9 +629,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--logging", "-l"},
       paramLabel = "<LOG VERBOSITY LEVEL>",
-      description =
-          "Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL (default: ${DEFAULT-VALUE})")
-  private final Level logLevel = LogManager.getRootLogger().getLevel();
+      description = "Logging verbosity levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL")
+  private final Level logLevel = null;
 
   @Option(
       names = {"--miner-enabled"},
@@ -2022,7 +2021,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     return new BesuExceptionHandler(this::getLogLevel);
   }
 
-  private Level getLogLevel() {
+  @VisibleForTesting
+  Level getLogLevel() {
     return logLevel;
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -87,6 +87,7 @@ import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.text.StringEscapeUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.toml.Toml;
 import org.apache.tuweni.toml.TomlParseResult;
@@ -3483,5 +3484,19 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString())
         .startsWith("Contents of privacy-public-key-file invalid");
     assertThat(commandErrorOutput.toString()).contains("Illegal base64 character");
+  }
+
+  @Test
+  public void logLevelHasNullAsDefaultValue() {
+    final TestBesuCommand command = parseCommand();
+
+    assertThat(command.getLogLevel()).isNull();
+  }
+
+  @Test
+  public void logLevelIsSetByLoggingOption() {
+    final TestBesuCommand command = parseCommand("--logging", "WARN");
+
+    assertThat(command.getLogLevel()).isEqualTo(Level.WARN);
   }
 }


### PR DESCRIPTION
## PR description
Fixed log level setting that was overriding the setting in log4j.xml file during startup.