### PR TITLE
Update Code of Conduct and Security

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,74 +1,166 @@
-# Contributor Covenant Code of Conduct
+# Hyperledger Code of Conduct
 
-## Our Pledge
+Hyperledger is a collaborative project at The Linux Foundation. It is an open-source and open
+community project where participants choose to work together, and in that process experience
+differences in language, location, nationality, and experience. In such a diverse environment,
+misunderstandings and disagreements happen, which in most cases can be resolved informally. In rare
+cases, however, behavior can intimidate, harass, or otherwise disrupt one or more people in the
+community, which Hyperledger will not tolerate.
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+A **Code of Conduct** is useful to define accepted and acceptable behaviors and to promote high
+standards of professional practice. It also provides a benchmark for self evaluation and acts as a
+vehicle for better identity of the organization.
 
-## Our Standards
+This code (**CoC**) applies to any member of the Hyperledger community – developers, participants in
+meetings, teleconferences, mailing lists, conferences or functions, etc. Note that this code
+complements rather than replaces legal rights and obligations pertaining to any particular
+situation.
 
-Examples of behavior that contributes to creating a positive environment
-include:
+## Statement of Intent
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+Hyperledger is committed to maintain a **positive** [work environment](#work-environment). This
+commitment calls for a workplace where [participants](#participant) at all levels behave according
+to the rules of the following code. A foundational concept of this code is that we all share
+responsibility for our work environment.
 
-Examples of unacceptable behavior by participants include:
+## Code
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+1. Treat each other with [respect](#respect), professionalism, fairness, and sensitivity to our many
+   differences and strengths, including in situations of high pressure and urgency.
 
-## Our Responsibilities
+2. Never [harass](#harassment) or [bully](#workplace-bullying) anyone verbally, physically or
+   [sexually](#sexual-harassment).
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+3. Never [discriminate](#discrimination) on the basis of personal characteristics or group
+   membership.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+4. Communicate constructively and avoid [demeaning](#demeaning-behavior) or
+   [insulting](#insulting-behavior) behavior or language.
 
-## Scope
+5. Seek, accept, and offer objective work criticism, and [acknowledge](#acknowledgement) properly
+   the contributions of others.
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+6. Be honest about your own qualifications, and about any circumstances that might lead to conflicts
+   of interest.
 
-## Enforcement
+7. Respect the privacy of others and the confidentiality of data you access.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [private@pegasys.tech]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+8. With respect to cultural differences, be conservative in what you do and liberal in what you
+   accept from others, but not to the point of accepting disrespectful, unprofessional or unfair or
+   [unwelcome behavior](#unwelcome-behavior) or [advances](#unwelcome-sexual-advance).
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+9. Promote the rules of this Code and take action (especially if you are in a
+   [leadership position](#leadership-position)) to bring the discussion back to a more civil level
+   whenever inappropriate behaviors are observed.
 
-## Attribution
+10. Stay on topic: Make sure that you are posting to the correct channel and avoid off-topic
+    discussions. Remember when you update an issue or respond to an email you are potentially
+    sending to a large number of people.
 
-This Code of Conduct is adapted from the [Contributor Covenant], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+11. Step down considerately: Members of every project come and go, and the Hyperledger is no
+    different. When you leave or disengage from the project, in whole or in part, we ask that you do
+    so in a way that minimizes disruption to the project. This means you should tell people you are
+    leaving and take the proper steps to ensure that others can pick up where you left off.
 
-[Contributor Covenant]: https://www.contributor-covenant.org
-[private@pegasys.tech]: mailto:private@pegasys.tech
+## Glossary
+
+### Demeaning Behavior
+
+is acting in a way that reduces another person's dignity, sense of self-worth or respect within the
+community.
+
+### Discrimination
+
+is the prejudicial treatment of an individual based on criteria such as: physical appearance, race,
+ethnic origin, genetic differences, national or social origin, name, religion, gender, sexual
+orientation, family or health situation, pregnancy, disability, age, education, wealth, domicile,
+political view, morals, employment, or union activity.
+
+### Insulting Behavior
+
+is treating another person with scorn or disrespect.
+
+### Acknowledgement
+
+is a record of the origin(s) and author(s) of a contribution.
+
+### Harassment
+
+is any conduct, verbal or physical, that has the intent or effect of interfering with an individual,
+or that creates an intimidating, hostile, or offensive environment.
+
+### Leadership Position
+
+includes group Chairs, project maintainers, staff members, and Board members.
+
+### Participant
+
+includes the following persons:
+
+- Developers
+- Member representatives
+- Staff members
+- Anyone from the Public partaking in the Hyperledger work environment (e.g. contribute code,
+  comment on our code or specs, email us, attend our conferences, functions, etc)
+
+### Respect
+
+is the genuine consideration you have for someone (if only because of their status as participant in
+Hyperledger, like yourself), and that you show by treating them in a polite and kind way.
+
+### Sexual Harassment
+
+includes visual displays of degrading sexual images, sexually suggestive conduct, offensive remarks
+of a sexual nature, requests for sexual favors, unwelcome physical contact, and sexual assault.
+
+### Unwelcome Behavior
+
+Hard to define? Some questions to ask yourself are:
+
+- how would I feel if I were in the position of the recipient?
+- would my spouse, parent, child, sibling or friend like to be treated this way?
+- would I like an account of my behavior published in the organization's newsletter?
+- could my behavior offend or hurt other members of the work group?
+- could someone misinterpret my behavior as intentionally harmful or harassing?
+- would I treat my boss or a person I admire at work like that ?
+- Summary: if you are unsure whether something might be welcome or unwelcome, don't do it.
+
+### Unwelcome Sexual Advance
+
+includes requests for sexual favors, and other verbal or physical conduct of a sexual nature, where:
+
+- submission to such conduct is made either explicitly or implicitly a term or condition of an
+  individual's employment,
+- submission to or rejection of such conduct by an individual is used as a basis for employment
+  decisions affecting the individual,
+- such conduct has the purpose or effect of unreasonably interfering with an individual's work
+  performance or creating an intimidating hostile or offensive working environment.
+
+### Workplace Bullying
+
+is a tendency of individuals or groups to use persistent aggressive or unreasonable behavior (e.g.
+verbal or written abuse, offensive conduct or any interference which undermines or impedes work)
+against a co-worker or any professional relations.
+
+### Work Environment
+
+is the set of all available means of collaboration, including, but not limited to messages to
+mailing lists, private correspondence, Web pages, chat channels, phone and video teleconferences,
+and any kind of face-to-face meetings or discussions.
+
+## Incident Procedure
+
+To report incidents or to appeal reports of incidents, send email to Mike Dolan
+(mdolan@linuxfoundation.org) or Angela Brown (angela@linuxfoundation.org). Please include any
+available relevant information, including links to any publicly accessible material relating to the
+matter. Every effort will be taken to ensure a safe and collegial environment in which to
+collaborate on matters relating to the Project. In order to protect the community, the Project
+reserves the right to take appropriate action, potentially including the removal of an individual
+from any and all participation in the project. The Project will work towards an equitable resolution
+in the event of a misunderstanding.
+
+## Credits
+
+This code is based on the
+[W3C’s Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc) with some
+additions from the [Cloud Foundry](https://www.cloudfoundry.org/)‘s Code of Conduct.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,5 +16,5 @@ The other way is to file a confidential security bug in our
 “Security issue”.
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in
-our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our
+our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our
 [wiki](https://wiki.hyperledger.org).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,19 @@
 
 ## Reporting a Security Bug
 
-If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to hear from you. We will take all security bugs seriously and if confirmed upon investigation we will patch it within a reasonable amount of time and release a public security bulletin discussing the impact and credit the discoverer.
+If you think you have discovered a security issue in any of the Hyperledger projects, we'd love to
+hear from you. We will take all security bugs seriously and if confirmed upon investigation we will
+patch it within a reasonable amount of time and release a public security bulletin discussing the
+impact and credit the discoverer.
 
-There are two ways to report a security bug. The easiest is to email a description of the flaw and any related information (e.g. reproduction steps, version) to [security at hyperledger dot org](mailto:security@hyperledger.org).
+There are two ways to report a security bug. The easiest is to email a description of the flaw and
+any related information (e.g. reproduction steps, version) to
+[security at hyperledger dot org](mailto:security@hyperledger.org).
 
-The other way is to file a confidential security bug in our [JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to “Security issue”.
+The other way is to file a confidential security bug in our
+[JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to
+“Security issue”.
 
-The process by which the Hyperledger Security Team handles security bugs is documented further in our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our [wiki](https://wiki.hyperledger.org).
+The process by which the Hyperledger Security Team handles security bugs is documented further in
+our [Defect Response page](https://wiki.hyperledger.org/display/HYP/Defect+Response) on our
+[wiki](https://wiki.hyperledger.org).


### PR DESCRIPTION
This Bring our code of conduct and security file in line with automated
checks.

The changes to `SECURITY.md` are strictly formatting, adding newlines so
it line wraps at 80 lines.

The `CODE_OF_CONDUCT.md` is a more substantial change.  Rather than the
being subject to both the contributor covenant and the Hyperledger CoC
this change makes the project only subject to the Hyperledger CoC.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>