### PR TITLE
Adding onchain privacy groups flag

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -113,6 +113,10 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
       params.add(String.valueOf(node.getPrivacyParameters().getPrivacyAddress()));
       params.add("--privacy-marker-transaction-signing-key-file");
       params.add(node.homeDirectory().resolve("key").toString());
+
+      if (node.getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
+        params.add("--privacy-onchain-groups-enabled");
+      }
     }
 
     params.add("--bootnodes");

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/privacy/PrivacyNodeConfiguration.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/privacy/PrivacyNodeConfiguration.java
@@ -20,6 +20,7 @@ import org.hyperledger.orion.testutil.OrionKeyConfiguration;
 public class PrivacyNodeConfiguration {
 
   private final int privacyAddress;
+  private final boolean isOnchainPrivacyGroupEnabled;
   private final BesuNodeConfiguration besuConfig;
   private final OrionKeyConfiguration orionConfig;
 
@@ -27,13 +28,26 @@ public class PrivacyNodeConfiguration {
       final int privacyAddress,
       final BesuNodeConfiguration besuConfig,
       final OrionKeyConfiguration orionConfig) {
+    this(privacyAddress, false, besuConfig, orionConfig);
+  }
+
+  PrivacyNodeConfiguration(
+      final int privacyAddress,
+      final boolean isOnchainPrivacyGroupEnabled,
+      final BesuNodeConfiguration besuConfig,
+      final OrionKeyConfiguration orionConfig) {
     this.privacyAddress = privacyAddress;
+    this.isOnchainPrivacyGroupEnabled = isOnchainPrivacyGroupEnabled;
     this.besuConfig = besuConfig;
     this.orionConfig = orionConfig;
   }
 
   public int getPrivacyAddress() {
     return privacyAddress;
+  }
+
+  public boolean isOnchainPrivacyGroupEnabled() {
+    return isOnchainPrivacyGroupEnabled;
   }
 
   public BesuNodeConfiguration getBesuConfig() {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/privacy/PrivacyNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/privacy/PrivacyNodeFactory.java
@@ -109,4 +109,41 @@ public class PrivacyNodeFactory {
             new OrionKeyConfiguration(
                 privacyAccount.getEnclaveKeyPath(), privacyAccount.getEnclavePrivateKeyPath())));
   }
+
+  public PrivacyNode createOnChainPrivacyGroupEnabledMinerNode(
+      final String name, final PrivacyAccount privacyAccount, final int privacyAddress)
+      throws IOException {
+    return create(
+        new PrivacyNodeConfiguration(
+            privacyAddress,
+            true,
+            new BesuNodeConfigurationBuilder()
+                .name(name)
+                .miningEnabled()
+                .jsonRpcEnabled()
+                .webSocketEnabled()
+                .enablePrivateTransactions()
+                .keyFilePath(privacyAccount.getPrivateKeyPath())
+                .build(),
+            new OrionKeyConfiguration(
+                privacyAccount.getEnclaveKeyPath(), privacyAccount.getEnclavePrivateKeyPath())));
+  }
+
+  public PrivacyNode createOnChainPrivacyGroupEnabledNode(
+      final String name, final PrivacyAccount privacyAccount, final int privacyAddress)
+      throws IOException {
+    return create(
+        new PrivacyNodeConfiguration(
+            privacyAddress,
+            true,
+            new BesuNodeConfigurationBuilder()
+                .name(name)
+                .jsonRpcEnabled()
+                .keyFilePath(privacyAccount.getPrivateKeyPath())
+                .enablePrivateTransactions()
+                .webSocketEnabled()
+                .build(),
+            new OrionKeyConfiguration(
+                privacyAccount.getEnclaveKeyPath(), privacyAccount.getEnclavePrivateKeyPath())));
+  }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -70,6 +70,7 @@ public class PrivacyNode implements AutoCloseable {
   private final BesuNode besu;
   private final Vertx vertx;
   private final Integer privacyAddress;
+  private final boolean isOnchainPrivacyEnabled;
 
   public PrivacyNode(final PrivacyNodeConfiguration privacyConfiguration, final Vertx vertx)
       throws IOException {
@@ -80,6 +81,7 @@ public class PrivacyNode implements AutoCloseable {
     final BesuNodeConfiguration besuConfig = privacyConfiguration.getBesuConfig();
 
     privacyAddress = privacyConfiguration.getPrivacyAddress();
+    isOnchainPrivacyEnabled = privacyConfiguration.isOnchainPrivacyGroupEnabled();
 
     this.besu =
         new BesuNode(
@@ -172,6 +174,7 @@ public class PrivacyNode implements AutoCloseable {
               .setPrivateKeyPath(KeyPairUtil.getDefaultKeyFile(besu.homeDirectory()).toPath())
               .setEnclaveFactory(new EnclaveFactory(vertx))
               .setPrivacyAddress(privacyAddress)
+              .setOnchainPrivacyGroupsEnabled(isOnchainPrivacyEnabled)
               .build();
     } catch (IOException e) {
       throw new RuntimeException();

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/RemoveFromOnChainPrivacyGroupTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/RemoveFromOnChainPrivacyGroupTransaction.java
@@ -29,9 +29,9 @@ public class RemoveFromOnChainPrivacyGroupTransaction implements Transaction<Str
   private final String toRemove;
 
   public RemoveFromOnChainPrivacyGroupTransaction(
-      final String privacyGroupId, final PrivacyNode remove, final PrivacyNode toRemove) {
+      final String privacyGroupId, final PrivacyNode remover, final PrivacyNode toRemove) {
     this.privacyGroupId = Base64String.wrap(privacyGroupId);
-    this.remover = remove;
+    this.remover = remover;
     this.toRemove = toRemove.getOrion().getDefaultPublicKey();
   }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/OnChainPrivacyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/web3j/privacy/OnChainPrivacyAcceptanceTest.java
@@ -61,13 +61,13 @@ public class OnChainPrivacyAcceptanceTest extends PrivacyAcceptanceTestBase {
   @Before
   public void setUp() throws Exception {
     alice =
-        privacyBesu.createPrivateTransactionEnabledMinerNode(
+        privacyBesu.createOnChainPrivacyGroupEnabledMinerNode(
             "node1", privacyAccountResolver.resolve(0), Address.PRIVACY);
     bob =
-        privacyBesu.createPrivateTransactionEnabledNode(
+        privacyBesu.createOnChainPrivacyGroupEnabledNode(
             "node2", privacyAccountResolver.resolve(1), Address.PRIVACY);
     charlie =
-        privacyBesu.createPrivateTransactionEnabledNode(
+        privacyBesu.createOnChainPrivacyGroupEnabledNode(
             "node3", privacyAccountResolver.resolve(2), Address.PRIVACY);
     privacyCluster.start(alice, bob, charlie);
   }
@@ -261,7 +261,7 @@ public class OnChainPrivacyAcceptanceTest extends PrivacyAcceptanceTestBase {
         privateTransactionVerifier.validPrivateTransactionReceipt(
             aliceStoreHash, expectedStoreReceipt));
 
-    bob.execute(privacyTransactions.removeFromPrivacyGroup(privacyGroupId, bob, charlie));
+    removeFromPrivacyGroup(privacyGroupId, bob, charlie);
 
     checkOnChainPrivacyGroupExists(privacyGroupId, alice, bob);
   }
@@ -328,7 +328,14 @@ public class OnChainPrivacyAcceptanceTest extends PrivacyAcceptanceTestBase {
         privacyTransactions.addToPrivacyGroup(privacyGroupId, nodeAddingMember, newMembers));
   }
 
-  // TODO remove from privacy group method
+  private String removeFromPrivacyGroup(
+      final String privacyGroupId,
+      final PrivacyNode nodeRemovingMember,
+      final PrivacyNode memberBeingRemoved) {
+    return nodeRemovingMember.execute(
+        privacyTransactions.removeFromPrivacyGroup(
+            privacyGroupId, nodeRemovingMember, memberBeingRemoved));
+  }
 
   private String calculateAddParticipantPMTHash(
       final String privacyGroupId, final PrivacyNode groupCreator) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -769,6 +769,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final Boolean migratePrivateDatabase = false;
 
   @Option(
+      names = {"--privacy-onchain-groups-enabled"},
+      description = "Enable onchain privacy groups (default: ${DEFAULT-VALUE})")
+  private final Boolean isOnchainPrivacyGroupEnabled = false;
+
+  @Option(
       names = {"--target-gas-limit"},
       description =
           "Sets target gas limit per block. If set each blocks gas limit will approach this setting over time if the current gas limit is different.")
@@ -1591,6 +1596,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       privacyParametersBuilder.setEnabled(true);
       privacyParametersBuilder.setEnclaveUrl(privacyUrl);
       privacyParametersBuilder.setMultiTenancyEnabled(isPrivacyMultiTenancyEnabled);
+      privacyParametersBuilder.setOnchainPrivacyGroupsEnabled(isOnchainPrivacyGroupEnabled);
 
       final boolean hasPrivacyPublicKey = privacyPublicKeyFile() != null;
       if (hasPrivacyPublicKey && !isPrivacyMultiTenancyEnabled) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2996,6 +2996,44 @@ public class BesuCommandTest extends CommandTestAbstract {
         .startsWith("Privacy multi-tenancy and privacy public key cannot be used together");
   }
 
+  @Test
+  public void onChainPrivacyGroupEnabledFlagDefaultValueIsFalse() {
+    parseCommand("--privacy-enabled", "--privacy-public-key-file", ENCLAVE_PUBLIC_KEY_PATH);
+
+    final ArgumentCaptor<PrivacyParameters> privacyParametersArgumentCaptor =
+        ArgumentCaptor.forClass(PrivacyParameters.class);
+
+    verify(mockControllerBuilder).privacyParameters(privacyParametersArgumentCaptor.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    final PrivacyParameters privacyParameters = privacyParametersArgumentCaptor.getValue();
+    assertThat(privacyParameters.isOnchainPrivacyGroupsEnabled()).isEqualTo(false);
+  }
+
+  @Test
+  public void onChainPrivacyGroupEnabledFlagValueIsSet() {
+    parseCommand(
+        "--privacy-enabled",
+        "--privacy-public-key-file",
+        ENCLAVE_PUBLIC_KEY_PATH,
+        "--privacy-onchain-groups-enabled");
+
+    final ArgumentCaptor<PrivacyParameters> privacyParametersArgumentCaptor =
+        ArgumentCaptor.forClass(PrivacyParameters.class);
+
+    verify(mockControllerBuilder).privacyParameters(privacyParametersArgumentCaptor.capture());
+    verify(mockControllerBuilder).build();
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+
+    final PrivacyParameters privacyParameters = privacyParametersArgumentCaptor.getValue();
+    assertThat(privacyParameters.isOnchainPrivacyGroupsEnabled()).isEqualTo(true);
+  }
+
   private Path createFakeGenesisFile(final JsonObject jsonGenesis) throws IOException {
     final Path genesisFile = Files.createTempFile("genesisFile", "");
     Files.write(genesisFile, encodeJsonGenesis(jsonGenesis).getBytes(UTF_8));

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -123,6 +123,7 @@ privacy-multi-tenancy-enabled=true
 privacy-precompiled-address=9
 privacy-marker-transaction-signing-key-file="./signerKey"
 privacy-enable-database-migration=false
+privacy-onchain-groups-enabled=false
 
 # Transaction Pool
 tx-pool-retention-hours=999

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -116,6 +116,9 @@ public enum JsonRpcError {
   GET_PRIVATE_TRANSACTION_NONCE_ERROR(-50100, "Unable to determine nonce for account in group."),
   PRIV_CALL_ONLY_SUPPORTED_ON_CHAIN_HEAD(-50100, "priv_call is only supported on chain head."),
   PRIVACY_GROUP_DOES_NOT_EXIST(-50100, "Privacy group does not exist."),
+  ONCHAIN_PRIVACY_GROUP_NOT_ENABLED(-50100, "Onchain privacy groups not enabled."),
+  OFFCHAIN_PRIVACY_GROUP_NOT_ENABLED(
+      -50100, "Offchain privacy group can't be used with Onchain privacy groups enabled."),
 
   CANT_CONNECT_TO_LOCAL_PEER(-32100, "Cannot add local node as peer."),
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
@@ -44,7 +44,10 @@ public class EeaJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
       final EnclavePublicKeyProvider enclavePublicKeyProvider) {
     return mapOf(
         new EeaSendRawTransaction(
-            getTransactionPool(), privacyController, enclavePublicKeyProvider),
+            getTransactionPool(),
+            privacyController,
+            enclavePublicKeyProvider,
+            getPrivacyParameters().isOnchainPrivacyGroupsEnabled()),
         new PrivGetEeaTransactionCount(privacyController, enclavePublicKeyProvider));
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -55,24 +55,43 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create(
       final PrivacyController privacyController,
       final EnclavePublicKeyProvider enclavePublicKeyProvider) {
-    return mapOf(
-        new PrivGetTransactionReceipt(
-            getBlockchainQueries(),
-            getPrivacyParameters(),
-            privacyController,
-            enclavePublicKeyProvider),
-        new PrivCreatePrivacyGroup(privacyController, enclavePublicKeyProvider),
-        new PrivDeletePrivacyGroup(privacyController, enclavePublicKeyProvider),
-        new PrivFindPrivacyGroup(privacyController, enclavePublicKeyProvider),
-        new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
-        new PrivGetTransactionCount(privacyController, enclavePublicKeyProvider),
-        new PrivGetPrivateTransaction(
-            getBlockchainQueries(),
-            privacyController,
-            getPrivacyParameters().getPrivateStateStorage(),
-            enclavePublicKeyProvider),
-        new PrivDistributeRawTransaction(privacyController, enclavePublicKeyProvider),
-        new PrivCall(getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
-        new PrivGetCode(getBlockchainQueries(), privacyController, enclavePublicKeyProvider));
+    if (getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
+      return mapOf(
+          new PrivGetTransactionReceipt(
+              getBlockchainQueries(),
+              getPrivacyParameters(),
+              privacyController,
+              enclavePublicKeyProvider),
+          new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
+          new PrivGetTransactionCount(privacyController, enclavePublicKeyProvider),
+          new PrivGetPrivateTransaction(
+              getBlockchainQueries(),
+              privacyController,
+              getPrivacyParameters().getPrivateStateStorage(),
+              enclavePublicKeyProvider),
+          new PrivDistributeRawTransaction(privacyController, enclavePublicKeyProvider),
+          new PrivCall(getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
+          new PrivGetCode(getBlockchainQueries(), privacyController, enclavePublicKeyProvider));
+    } else {
+      return mapOf(
+          new PrivGetTransactionReceipt(
+              getBlockchainQueries(),
+              getPrivacyParameters(),
+              privacyController,
+              enclavePublicKeyProvider),
+          new PrivCreatePrivacyGroup(privacyController, enclavePublicKeyProvider),
+          new PrivDeletePrivacyGroup(privacyController, enclavePublicKeyProvider),
+          new PrivFindPrivacyGroup(privacyController, enclavePublicKeyProvider),
+          new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
+          new PrivGetTransactionCount(privacyController, enclavePublicKeyProvider),
+          new PrivGetPrivateTransaction(
+              getBlockchainQueries(),
+              privacyController,
+              getPrivacyParameters().getPrivateStateStorage(),
+              enclavePublicKeyProvider),
+          new PrivDistributeRawTransaction(privacyController, enclavePublicKeyProvider),
+          new PrivCall(getBlockchainQueries(), privacyController, enclavePublicKeyProvider),
+          new PrivGetCode(getBlockchainQueries(), privacyController, enclavePublicKeyProvider));
+    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethods.java
@@ -46,6 +46,10 @@ public class PrivxJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create(
       final PrivacyController privacyController,
       final EnclavePublicKeyProvider enclavePublicKeyProvider) {
-    return mapOf(new PrivxFindOnChainPrivacyGroup(privacyController, enclavePublicKeyProvider));
+    if (getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
+      return mapOf(new PrivxFindOnChainPrivacyGroup(privacyController, enclavePublicKeyProvider));
+    } else {
+      return Map.of();
+    }
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethodsTest.java
@@ -15,12 +15,13 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PRIVX_FIND_PRIVACY_GROUP;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PRIV_CREATE_PRIVACY_GROUP;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PRIV_DELETE_PRIVACY_GROUP;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PRIV_FIND_PRIVACY_GROUP;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.privx.PrivxFindOnChainPrivacyGroup;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -35,40 +36,41 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PrivxJsonRpcMethodsTest {
+public class PrivJsonRpcMethodsTest {
 
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private ProtocolSchedule<?> protocolSchedule;
   @Mock private TransactionPool transactionPool;
   @Mock private PrivacyParameters privacyParameters;
 
-  private PrivxJsonRpcMethods privxJsonRpcMethods;
+  private PrivJsonRpcMethods privJsonRpcMethods;
 
   @Before
   public void setup() {
-    privxJsonRpcMethods =
-        new PrivxJsonRpcMethods(
+    privJsonRpcMethods =
+        new PrivJsonRpcMethods(
             blockchainQueries, protocolSchedule, transactionPool, privacyParameters);
 
     lenient().when(privacyParameters.isEnabled()).thenReturn(true);
   }
 
   @Test
-  public void privxFindPrivacyGroupMethodIsDisabledWhenOnchainPrivacyGroupIsDisabled() {
-    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(false);
-    final Map<String, JsonRpcMethod> rpcMethods = privxJsonRpcMethods.create();
-    final JsonRpcMethod method = rpcMethods.get(PRIVX_FIND_PRIVACY_GROUP.getMethodName());
+  public void offchainPrivacyGroupMethodsAreDisabledWhenOnchainPrivacyGroupIsEnabled() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(true);
+    final Map<String, JsonRpcMethod> rpcMethods = privJsonRpcMethods.create();
 
-    assertThat(method).isNull();
+    assertThat(rpcMethods.get(PRIV_CREATE_PRIVACY_GROUP.getMethodName())).isNull();
+    assertThat(rpcMethods.get(PRIV_DELETE_PRIVACY_GROUP.getMethodName())).isNull();
+    assertThat(rpcMethods.get(PRIV_FIND_PRIVACY_GROUP.getMethodName())).isNull();
   }
 
   @Test
-  public void privxFindPrivacyGroupMethodIsEnabledWhenOnchainPrivacyGroupIsEnabled() {
-    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(true);
-    final Map<String, JsonRpcMethod> rpcMethods = privxJsonRpcMethods.create();
-    final JsonRpcMethod method = rpcMethods.get(PRIVX_FIND_PRIVACY_GROUP.getMethodName());
+  public void offchainPrivacyGroupMethodsAreEnabledWhenOnchainPrivacyGroupIsDisabled() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(false);
+    final Map<String, JsonRpcMethod> rpcMethods = privJsonRpcMethods.create();
 
-    assertThat(method).isNotNull();
-    assertThat(method).isInstanceOf(PrivxFindOnChainPrivacyGroup.class);
+    assertThat(rpcMethods.get(PRIV_CREATE_PRIVACY_GROUP.getMethodName())).isNotNull();
+    assertThat(rpcMethods.get(PRIV_DELETE_PRIVACY_GROUP.getMethodName())).isNotNull();
+    assertThat(rpcMethods.get(PRIV_FIND_PRIVACY_GROUP.getMethodName())).isNotNull();
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethodsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PRIVX_FIND_PRIVACY_GROUP;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.privx.PrivxFindOnChainPrivacyGroup;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrivxJsonRpcMethodsTest {
+
+  @Mock private BlockchainQueries blockchainQueries;
+  @Mock private ProtocolSchedule<?> protocolSchedule;
+  @Mock private TransactionPool transactionPool;
+  @Mock private PrivacyParameters privacyParameters;
+
+  private PrivxJsonRpcMethods privxJsonRpcMethods;
+
+  @Before
+  public void setup() {
+    privxJsonRpcMethods =
+        new PrivxJsonRpcMethods(
+            blockchainQueries, protocolSchedule, transactionPool, privacyParameters);
+
+    lenient().when(privacyParameters.isEnabled()).thenReturn(true);
+  }
+
+  @Test
+  public void privxFindPrivacyGroupMethodsIsDisabledWhenOnchainPrivacyGroupIsDisabled() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(false);
+    final Map<String, JsonRpcMethod> rpcMethods = privxJsonRpcMethods.create();
+    final JsonRpcMethod method = rpcMethods.get(PRIVX_FIND_PRIVACY_GROUP.getMethodName());
+
+    assertThat(method).isNull();
+  }
+
+  @Test
+  public void privxFindPrivacyGroupMethodsIsEnabledWhenOnchainPrivacyGroupIsEnabled() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(true);
+    final Map<String, JsonRpcMethod> rpcMethods = privxJsonRpcMethods.create();
+    final JsonRpcMethod method = rpcMethods.get(PRIVX_FIND_PRIVACY_GROUP.getMethodName());
+
+    assertThat(method).isNotNull();
+    assertThat(method).isInstanceOf(PrivxFindOnChainPrivacyGroup.class);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
@@ -52,6 +52,7 @@ public class PrivacyParameters {
   private WorldStateArchive privateWorldStateArchive;
   private PrivateStateStorage privateStateStorage;
   private boolean multiTenancyEnabled;
+  private boolean onchainPrivacyGroupsEnabled;
 
   public Integer getPrivacyAddress() {
     return privacyAddress;
@@ -141,6 +142,14 @@ public class PrivacyParameters {
     return multiTenancyEnabled;
   }
 
+  public void setOnchainPrivacyGroupsEnabled(final boolean onchainPrivacyGroupsEnabled) {
+    this.onchainPrivacyGroupsEnabled = onchainPrivacyGroupsEnabled;
+  }
+
+  public boolean isOnchainPrivacyGroupsEnabled() {
+    return onchainPrivacyGroupsEnabled;
+  }
+
   @Override
   public String toString() {
     return "PrivacyParameters{"
@@ -148,6 +157,8 @@ public class PrivacyParameters {
         + enabled
         + ", multiTenancyEnabled = "
         + multiTenancyEnabled
+        + ", onchainPrivacyGroupsEnabled = "
+        + onchainPrivacyGroupsEnabled
         + ", enclaveUri='"
         + enclaveUri
         + '\''
@@ -168,6 +179,7 @@ public class PrivacyParameters {
     private Path privacyKeyStoreFile;
     private Path privacyKeyStorePasswordFile;
     private Path privacyTlsKnownEnclaveFile;
+    private boolean onchainPrivacyGroupsEnabled;
 
     public Builder setPrivacyAddress(final Integer privacyAddress) {
       this.privacyAddress = privacyAddress;
@@ -219,6 +231,11 @@ public class PrivacyParameters {
       return this;
     }
 
+    public Builder setOnchainPrivacyGroupsEnabled(final boolean onchainPrivacyGroupsEnabled) {
+      this.onchainPrivacyGroupsEnabled = onchainPrivacyGroupsEnabled;
+      return this;
+    }
+
     public PrivacyParameters build() {
       final PrivacyParameters config = new PrivacyParameters();
       if (enabled) {
@@ -256,6 +273,7 @@ public class PrivacyParameters {
       config.setEnclaveUri(enclaveUrl);
       config.setPrivacyAddress(privacyAddress);
       config.setMultiTenancyEnabled(multiTenancyEnabled);
+      config.setOnchainPrivacyGroupsEnabled(onchainPrivacyGroupsEnabled);
       return config;
     }
 


### PR DESCRIPTION
## PR description

This PR adds a flag for using onchain privacy groups (`--privacy-onchain-groups-enabled`). This is used to ensure that offchain privacy groups can't be used at the same time as offchain privacy groups.
