### PR TITLE
Upgrade junit to 4.13

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -51,7 +51,7 @@ dependencyManagement {
     dependency 'io.vertx:vertx-unit:3.8.0'
     dependency 'io.vertx:vertx-web:3.8.0'
 
-    dependency 'junit:junit:4.12'
+    dependency 'junit:junit:4.13'
 
     dependency 'net.consensys:orion:1.5.0-SNAPSHOT'
 


### PR DESCRIPTION
Signed-off-by: Horacio Mijail Anton Quiles <hmijail@gmail.com>

## PR description
Upgrade junit to 4.13, which allows junit's MultipleExceptions to display the individual exceptions they contain and where they appeared.
