### PR TITLE
LogBloomCache - Do uncached query if EOF is detected

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -590,6 +590,7 @@ public class BlockchainQueries {
         try {
           raf.readFully(bloomBuff);
         } catch (final EOFException e) {
+          results.addAll(matchingLogsUncached(segmentStart + pos, segmentStart + endOffset, query));
           break;
         }
         final LogsBloomFilter logsBloom = new LogsBloomFilter(bytesValue);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionLogBloomCacher.java
@@ -175,12 +175,14 @@ public class TransactionLogBloomCacher {
         try {
           final File currentFile = calculateCacheFileName(CURRENT, cacheDir);
 
-          final long segmentNumber = blockchain.getChainHeadBlockNumber() / BLOCKS_PER_BLOOM_CACHE;
-          long blockNumber = segmentNumber / BLOCKS_PER_BLOOM_CACHE;
+          final long chainHeadBlockNumber = blockchain.getChainHeadBlockNumber();
+          final long segmentNumber = chainHeadBlockNumber / BLOCKS_PER_BLOOM_CACHE;
+          long blockNumber =
+              Math.min((segmentNumber + 1) * BLOCKS_PER_BLOOM_CACHE - 1, chainHeadBlockNumber);
           try (final OutputStream out = new FileOutputStream(currentFile)) {
             fillCacheFile(segmentNumber * BLOCKS_PER_BLOOM_CACHE, blockNumber, out);
           }
-          while (blockNumber <= blockchain.getChainHeadBlockNumber()
+          while (blockNumber <= chainHeadBlockNumber
               && (blockNumber % BLOCKS_PER_BLOOM_CACHE != 0)) {
             cacheSingleBlock(blockchain.getBlockHeader(blockNumber).orElseThrow(), currentFile);
             blockNumber++;


### PR DESCRIPTION
If we detect an EOF for the cache file switch over to an uncached query.

This is typically seen when filling a log filter and the new block has
not yet written out the log bloom cache to disk.  Fixed #473

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

