### PR TITLE
Fix potential bug in Env default value provider

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
@@ -36,7 +36,7 @@ public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider
 
   @Override
   public String defaultValue(final ArgSpec argSpec) {
-    if (!argSpec.isOption()) {
+    if (argSpec.isPositional()) {
       return null; // skip default for positional params
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/EnvironmentVariableDefaultProvider.java
@@ -36,6 +36,10 @@ public class EnvironmentVariableDefaultProvider implements IDefaultValueProvider
 
   @Override
   public String defaultValue(final ArgSpec argSpec) {
+    if (!argSpec.isOption()) {
+      return null; // skip default for positional params
+    }
+
     return envVarNames((OptionSpec) argSpec)
         .map(environment::get)
         .filter(Objects::nonNull)

--- a/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.junit.Test;
 import picocli.CommandLine.Model.OptionSpec;
 import picocli.CommandLine.Model.PositionalParamSpec;
-import picocli.CommandLine.Model.PositionalParamSpec.Builder;
 
 public class EnvironmentVariableDefaultProviderTest {
 
@@ -82,7 +81,7 @@ public class EnvironmentVariableDefaultProviderTest {
   @Test
   public void shouldReturnNullForPositionalParameter() {
     environment.put("BESU_KEY", "abc");
-    final Builder positional = PositionalParamSpec.builder().descriptionKey("key");
+    final PositionalParamSpec.Builder positional = PositionalParamSpec.builder().descriptionKey("key");
     assertThat(provider.defaultValue(positional.build())).isNull();
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.junit.Test;
 import picocli.CommandLine.Model.OptionSpec;
+import picocli.CommandLine.Model.PositionalParamSpec;
+import picocli.CommandLine.Model.PositionalParamSpec.Builder;
 
 public class EnvironmentVariableDefaultProviderTest {
 
@@ -75,5 +77,12 @@ public class EnvironmentVariableDefaultProviderTest {
     environment.put("PANTHEON_ENV_VAR_SET", "def");
     assertThat(provider.defaultValue(OptionSpec.builder("--env-var", "--env-var-set").build()))
         .isEqualTo("abc");
+  }
+
+  @Test
+  public void shouldReturnNullForPositionalParameter() {
+    environment.put("BESU_KEY", "abc");
+    final Builder positional = PositionalParamSpec.builder().descriptionKey("key");
+    assertThat(provider.defaultValue(positional.build())).isNull();
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/EnvironmentVariableDefaultProviderTest.java
@@ -81,7 +81,8 @@ public class EnvironmentVariableDefaultProviderTest {
   @Test
   public void shouldReturnNullForPositionalParameter() {
     environment.put("BESU_KEY", "abc");
-    final PositionalParamSpec.Builder positional = PositionalParamSpec.builder().descriptionKey("key");
+    final PositionalParamSpec.Builder positional =
+        PositionalParamSpec.builder().descriptionKey("key");
     assertThat(provider.defaultValue(positional.build())).isNull();
   }
 }


### PR DESCRIPTION
Bypass default value from environment variable provider for positional parameter. In case of subcommands such as help this could have thrown class cast exception

Signed-off-by: Usman Saleem <usman@usmans.info>
