### PR TITLE
Storing private tx receipts indexed by PMT hashes

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
@@ -200,9 +200,8 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
         new PrivateTransactionReceipt(
             txStatus, result.getLogs(), result.getOutput(), result.getRevertReason());
 
-    final Bytes32 txHash = keccak256(RLP.encode(privateTransaction::writeTo));
-
-    privateStateUpdater.putTransactionReceipt(currentBlockHash, txHash, privateTransactionReceipt);
+    privateStateUpdater
+        .putTransactionReceipt(currentBlockHash, commitmentHash, privateTransactionReceipt);
 
     maybeUpdateGroupHeadBlockMap(privacyGroupId, currentBlockHash, privateStateUpdater);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet.precompiles.privacy;
 
-import static org.hyperledger.besu.crypto.Hash.keccak256;
-
 import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.enclave.EnclaveClientException;
 import org.hyperledger.besu.enclave.EnclaveIOException;
@@ -39,7 +37,6 @@ import org.hyperledger.besu.ethereum.privacy.storage.PrivateBlockMetadata;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateTransactionMetadata;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
-import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 import org.hyperledger.besu.ethereum.vm.GasCalculator;
 import org.hyperledger.besu.ethereum.vm.MessageFrame;
@@ -200,8 +197,8 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
         new PrivateTransactionReceipt(
             txStatus, result.getLogs(), result.getOutput(), result.getRevertReason());
 
-    privateStateUpdater
-        .putTransactionReceipt(currentBlockHash, commitmentHash, privateTransactionReceipt);
+    privateStateUpdater.putTransactionReceipt(
+        currentBlockHash, commitmentHash, privateTransactionReceipt);
 
     maybeUpdateGroupHeadBlockMap(privacyGroupId, currentBlockHash, privateStateUpdater);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
@@ -209,8 +209,6 @@ public class PrivateGroupRehydrationBlockProcessor {
         privateStateUpdater,
         privateStateStorage);
 
-    final Bytes32 txHash = keccak256(RLP.encode(privateTransaction::writeTo));
-
     final int txStatus =
         result.getStatus() == PrivateTransactionProcessor.Result.Status.SUCCESSFUL ? 1 : 0;
 
@@ -218,7 +216,8 @@ public class PrivateGroupRehydrationBlockProcessor {
         new PrivateTransactionReceipt(
             txStatus, result.getLogs(), result.getOutput(), result.getRevertReason());
 
-    privateStateUpdater.putTransactionReceipt(currentBlockHash, txHash, privateTransactionReceipt);
+    privateStateUpdater
+        .putTransactionReceipt(currentBlockHash, commitmentHash, privateTransactionReceipt);
     final PrivacyGroupHeadBlockMap privacyGroupHeadBlockMap =
         privateStateStorage.getPrivacyGroupHeadBlockMap(currentBlockHash).get();
     if (!privacyGroupHeadBlockMap.contains(Bytes32.wrap(privacyGroupId), currentBlockHash)) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.privacy;
 
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.hyperledger.besu.ethereum.privacy.PrivateStateRootResolver.EMPTY_ROOT_HASH;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -40,7 +39,6 @@ import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateBlockMetadata;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateTransactionMetadata;
-import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.vm.BlockHashLookup;
 import org.hyperledger.besu.ethereum.vm.OperationTracer;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -216,8 +214,8 @@ public class PrivateGroupRehydrationBlockProcessor {
         new PrivateTransactionReceipt(
             txStatus, result.getLogs(), result.getOutput(), result.getRevertReason());
 
-    privateStateUpdater
-        .putTransactionReceipt(currentBlockHash, commitmentHash, privateTransactionReceipt);
+    privateStateUpdater.putTransactionReceipt(
+        currentBlockHash, commitmentHash, privateTransactionReceipt);
     final PrivacyGroupHeadBlockMap privacyGroupHeadBlockMap =
         privateStateStorage.getPrivacyGroupHeadBlockMap(currentBlockHash).get();
     if (!privacyGroupHeadBlockMap.contains(Bytes32.wrap(privacyGroupId), currentBlockHash)) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/PrivateStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/PrivateStateKeyValueStorage.java
@@ -50,8 +50,8 @@ public class PrivateStateKeyValueStorage implements PrivateStateStorage {
 
   @Override
   public Optional<PrivateTransactionReceipt> getTransactionReceipt(
-      final Bytes32 blockHash, final Bytes32 txHash) {
-    final Bytes blockHashTxHash = Bytes.concatenate(blockHash, txHash);
+      final Bytes32 blockHash, final Bytes32 pmtHash) {
+    final Bytes blockHashTxHash = Bytes.concatenate(blockHash, pmtHash);
     return get(blockHashTxHash, TX_RECEIPT_SUFFIX)
         .map(b -> PrivateTransactionReceipt.readFrom(new BytesValueRLPInput(b, false)));
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -63,13 +63,15 @@ import org.junit.rules.TemporaryFolder;
 public class PrivacyPrecompiledContractTest {
   @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
-  private final String PAYLOAD_TEST_PRIVACY_GROUP_ID = "8lDVI66RZHIrBsolz6Kn88Rd+WsJ4hUjb4hsh29xW/o=";
+  private final String PAYLOAD_TEST_PRIVACY_GROUP_ID =
+      "8lDVI66RZHIrBsolz6Kn88Rd+WsJ4hUjb4hsh29xW/o=";
   private final String DEFAULT_OUTPUT = "0x01";
   private final String actual = "Test String";
   private final Bytes key = Bytes.wrap(actual.getBytes(UTF_8));
   private final WorldStateArchive worldStateArchive = mock(WorldStateArchive.class);
   private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
-  private final PrivateStateStorage.Updater storageUpdater = mock(PrivateStateStorage.Updater.class);
+  private final PrivateStateStorage.Updater storageUpdater =
+      mock(PrivateStateStorage.Updater.class);
   private final Enclave enclave = mock(Enclave.class);
 
   private MessageFrame messageFrame;
@@ -132,7 +134,8 @@ public class PrivacyPrecompiledContractTest {
     when(messageFrame.getBlockchain()).thenReturn(blockchain);
     when(messageFrame.getBlockHeader()).thenReturn(block.getHeader());
 
-    precompiledContract =new PrivacyPrecompiledContract(
+    precompiledContract =
+        new PrivacyPrecompiledContract(
             new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
     precompiledContract.setPrivateTransactionProcessor(mockPrivateTxProcessor());
   }
@@ -172,9 +175,9 @@ public class PrivacyPrecompiledContractTest {
 
     precompiledContract.compute(key, messageFrame);
 
-
-    verify(storageUpdater).putTransactionReceipt(eq(expectedBlockHash), eq(expectedPmtHash), any(
-        PrivateTransactionReceipt.class));
+    verify(storageUpdater)
+        .putTransactionReceipt(
+            eq(expectedBlockHash), eq(expectedPmtHash), any(PrivateTransactionReceipt.class));
   }
 
   private void mockEnclaveWithPrivateTransaction() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -17,8 +17,10 @@ package org.hyperledger.besu.ethereum.mainnet.precompiles.privacy;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.enclave.Enclave;
@@ -28,6 +30,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
@@ -37,6 +40,7 @@ import org.hyperledger.besu.ethereum.core.WorldUpdater;
 import org.hyperledger.besu.ethereum.mainnet.SpuriousDragonGasCalculator;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionProcessor;
+import org.hyperledger.besu.ethereum.privacy.PrivateTransactionReceipt;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
@@ -59,14 +63,18 @@ import org.junit.rules.TemporaryFolder;
 public class PrivacyPrecompiledContractTest {
   @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
+  private final String PAYLOAD_TEST_PRIVACY_GROUP_ID = "8lDVI66RZHIrBsolz6Kn88Rd+WsJ4hUjb4hsh29xW/o=";
+  private final String DEFAULT_OUTPUT = "0x01";
   private final String actual = "Test String";
   private final Bytes key = Bytes.wrap(actual.getBytes(UTF_8));
+  private final WorldStateArchive worldStateArchive = mock(WorldStateArchive.class);
+  private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
+  private final PrivateStateStorage.Updater storageUpdater = mock(PrivateStateStorage.Updater.class);
+  private final Enclave enclave = mock(Enclave.class);
+
   private MessageFrame messageFrame;
   private Blockchain blockchain;
-  private final String DEFAULT_OUTPUT = "0x01";
-  final String PAYLOAD_TEST_PRIVACY_GROUP_ID = "8lDVI66RZHIrBsolz6Kn88Rd+WsJ4hUjb4hsh29xW/o=";
-  private final WorldStateArchive worldStateArchive = mock(WorldStateArchive.class);
-  final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
+  private PrivacyPrecompiledContract precompiledContract;
 
   private PrivateTransactionProcessor mockPrivateTxProcessor() {
     final PrivateTransactionProcessor mockPrivateTransactionProcessor =
@@ -98,7 +106,6 @@ public class PrivacyPrecompiledContractTest {
     when(worldStateArchive.getMutable()).thenReturn(mutableWorldState);
     when(worldStateArchive.getMutable(any())).thenReturn(Optional.of(mutableWorldState));
 
-    final PrivateStateStorage.Updater storageUpdater = mock(PrivateStateStorage.Updater.class);
     when(privateStateStorage.getPrivacyGroupHeadBlockMap(any()))
         .thenReturn(Optional.of(PrivacyGroupHeadBlockMap.EMPTY));
     when(privateStateStorage.getPrivateBlockMetadata(any(), any())).thenReturn(Optional.empty());
@@ -124,17 +131,54 @@ public class PrivacyPrecompiledContractTest {
     when(blockchain.getBlockByHash(genesis.getHash())).thenReturn(Optional.of(genesis));
     when(messageFrame.getBlockchain()).thenReturn(blockchain);
     when(messageFrame.getBlockHeader()).thenReturn(block.getHeader());
+
+    precompiledContract =new PrivacyPrecompiledContract(
+            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
+    precompiledContract.setPrivateTransactionProcessor(mockPrivateTxProcessor());
   }
 
   @Test
   public void testPayloadFoundInEnclave() {
-    final Enclave enclave = mock(Enclave.class);
-    final PrivacyPrecompiledContract contract =
-        new PrivacyPrecompiledContract(
-            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
-    contract.setPrivateTransactionProcessor(mockPrivateTxProcessor());
+    mockEnclaveWithPrivateTransaction();
 
-    BytesValueRLPOutput bytesValueRLPOutput = new BytesValueRLPOutput();
+    final Bytes actual = precompiledContract.compute(key, messageFrame);
+
+    assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
+  }
+
+  @Test
+  public void testPayloadNotFoundInEnclave() {
+    when(enclave.receive(any(String.class))).thenThrow(EnclaveClientException.class);
+
+    final Bytes expected = precompiledContract.compute(key, messageFrame);
+    assertThat(expected).isEqualTo(Bytes.EMPTY);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testEnclaveDown() {
+    when(enclave.receive(any(String.class))).thenThrow(new RuntimeException());
+
+    precompiledContract.compute(key, messageFrame);
+  }
+
+  @Test
+  public void processTransactionPersistingStateCreatesPrivateReceipt() {
+    final Hash expectedPmtHash = Hash.wrap(Bytes32.random());
+    final Hash expectedBlockHash = ((BlockHeader) messageFrame.getBlockHeader()).getHash();
+
+    mockEnclaveWithPrivateTransaction();
+    when(messageFrame.isPersistingPrivateState()).thenReturn(true);
+    when(messageFrame.getTransactionHash()).thenReturn(expectedPmtHash);
+
+    precompiledContract.compute(key, messageFrame);
+
+
+    verify(storageUpdater).putTransactionReceipt(eq(expectedBlockHash), eq(expectedPmtHash), any(
+        PrivateTransactionReceipt.class));
+  }
+
+  private void mockEnclaveWithPrivateTransaction() {
+    final BytesValueRLPOutput bytesValueRLPOutput = new BytesValueRLPOutput();
     PrivateTransactionDataFixture.privateTransactionBesu().writeTo(bytesValueRLPOutput);
 
     final ReceiveResponse response =
@@ -143,36 +187,5 @@ public class PrivacyPrecompiledContractTest {
             PAYLOAD_TEST_PRIVACY_GROUP_ID,
             null);
     when(enclave.receive(any(String.class))).thenReturn(response);
-
-    final Bytes actual = contract.compute(key, messageFrame);
-
-    assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
-  }
-
-  @Test
-  public void testPayloadNotFoundInEnclave() {
-    final Enclave enclave = mock(Enclave.class);
-
-    final PrivacyPrecompiledContract contract =
-        new PrivacyPrecompiledContract(
-            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
-
-    when(enclave.receive(any(String.class))).thenThrow(EnclaveClientException.class);
-
-    final Bytes expected = contract.compute(key, messageFrame);
-    assertThat(expected).isEqualTo(Bytes.EMPTY);
-  }
-
-  @Test(expected = RuntimeException.class)
-  public void testEnclaveDown() {
-    final Enclave enclave = mock(Enclave.class);
-
-    final PrivacyPrecompiledContract contract =
-        new PrivacyPrecompiledContract(
-            new SpuriousDragonGasCalculator(), enclave, worldStateArchive, privateStateStorage);
-
-    when(enclave.receive(any(String.class))).thenThrow(new RuntimeException());
-
-    contract.compute(key, messageFrame);
   }
 }


### PR DESCRIPTION
• Storing private tx receipts indexed by PMT hashes
• Updated priv_getTransactionReceipt to have a fallback method to use the private tx hash for backwards compatibility