### PR TITLE
Abstract node private key with NodeKey interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.4.3 
 
+### Additions and Improvements
+- Private Transaction `hash` field and `getHash()` method have been deprecated. They will be removed 
+in 1.5.0 release. 
+
 ### Critical Issue for Privacy Users 
 
 A critical issue for privacy users with private transactions created using Hyperledger Besu v1.3.4 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -19,7 +19,7 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.apache.tuweni.io.file.Files.copyResource;
 
 import org.hyperledger.besu.crypto.KeyPairUtil;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -80,7 +80,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private static final Logger LOG = getLogger();
 
   private final Path homeDirectory;
-  private final KeyPair keyPair;
+  private final NodeKey nodeKey;
   private final Properties portsProperties = new Properties();
   private final Boolean p2pEnabled;
   private final NetworkingConfiguration networkingConfiguration;
@@ -139,7 +139,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
             LOG.error("Could not find key file \"{}\" in resources", path);
           }
         });
-    this.keyPair = KeyPairUtil.loadKeyPair(homeDirectory);
+    this.nodeKey = KeyPairUtil.loadKeyPair(homeDirectory);
     this.name = name;
     this.miningParameters = miningParameters;
     this.jsonRpcConfiguration = jsonRpcConfiguration;
@@ -196,7 +196,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
 
   @Override
   public String getNodeId() {
-    return keyPair.getPublicKey().toString().substring(2);
+    return nodeKey.getPublicKey().toString().substring(2);
   }
 
   @Override
@@ -455,11 +455,11 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
 
   @Override
   public Address getAddress() {
-    return Util.publicKeyToAddress(keyPair.getPublicKey());
+    return Util.publicKeyToAddress(nodeKey.getPublicKey());
   }
 
-  public KeyPair keyPair() {
-    return keyPair;
+  public NodeKey nodeKey() {
+    return nodeKey;
   }
 
   public Path homeDirectory() {
@@ -588,7 +588,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
     return MoreObjects.toStringHelper(this)
         .add("name", name)
         .add("homeDirectory", homeDirectory)
-        .add("keyPair", keyPair)
+        .add("keyPair", nodeKey)
         .add("p2pEnabled", p2pEnabled)
         .add("discoveryEnabled", discoveryEnabled)
         .add("privacyEnabled", privacyParameters.isEnabled())

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -46,7 +46,6 @@ import org.hyperledger.besu.services.PicoCLIOptionsImpl;
 import org.hyperledger.besu.services.StorageServiceImpl;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.HashMap;
@@ -134,26 +133,21 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
             .withMetricsSystem(metricsSystem)
             .build();
 
-    final BesuController<?> besuController;
-    try {
-      besuController =
-          builder
-              .synchronizerConfiguration(new SynchronizerConfiguration.Builder().build())
-              .dataDirectory(node.homeDirectory())
-              .miningParameters(node.getMiningParameters())
-              .privacyParameters(node.getPrivacyParameters())
-              .nodePrivateKeyFile(KeyPairUtil.getDefaultKeyFile(node.homeDirectory()))
-              .metricsSystem(metricsSystem)
-              .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
-              .ethProtocolConfiguration(EthProtocolConfiguration.defaultConfig())
-              .clock(Clock.systemUTC())
-              .isRevertReasonEnabled(node.isRevertReasonEnabled())
-              .storageProvider(storageProvider)
-              .targetGasLimit(GasLimitCalculator.DEFAULT)
-              .build();
-    } catch (final IOException e) {
-      throw new RuntimeException("Error building BesuController", e);
-    }
+    final BesuController<?> besuController =
+        builder
+            .synchronizerConfiguration(new SynchronizerConfiguration.Builder().build())
+            .dataDirectory(node.homeDirectory())
+            .miningParameters(node.getMiningParameters())
+            .privacyParameters(node.getPrivacyParameters())
+            .nodePrivateKeyFile(KeyPairUtil.getDefaultKeyFile(node.homeDirectory()))
+            .metricsSystem(metricsSystem)
+            .transactionPoolConfiguration(TransactionPoolConfiguration.builder().build())
+            .ethProtocolConfiguration(EthProtocolConfiguration.defaultConfig())
+            .clock(Clock.systemUTC())
+            .isRevertReasonEnabled(node.isRevertReasonEnabled())
+            .storageProvider(storageProvider)
+            .targetGasLimit(GasLimitCalculator.DEFAULT)
+            .build();
 
     final RunnerBuilder runnerBuilder = new RunnerBuilder();
     if (node.getPermissioningConfiguration().isPresent()) {

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -22,6 +22,8 @@ import static org.hyperledger.besu.controller.BesuController.CACHE_PATH;
 
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.controller.BesuController;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
@@ -305,6 +307,7 @@ public class RunnerBuilder {
     }
 
     final KeyPair keyPair = besuController.getLocalNodeKeyPair();
+    final NodeKey nodeKey = new BouncyCastleNodeKey(keyPair);
 
     final SubProtocolConfiguration subProtocolConfiguration =
         besuController.getSubProtocolConfiguration();
@@ -341,7 +344,7 @@ public class RunnerBuilder {
         new TransactionSimulator(
             context.getBlockchain(), context.getWorldStateArchive(), protocolSchedule);
 
-    final Bytes localNodeId = keyPair.getPublicKey().getEncodedBytes();
+    final Bytes localNodeId = nodeKey.getPublicKey().getEncodedBytes();
     final Optional<NodePermissioningController> nodePermissioningController =
         buildNodePermissioningController(
             bootnodes, synchronizer, transactionSimulator, localNodeId);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -22,9 +22,7 @@ import static org.hyperledger.besu.controller.BesuController.CACHE_PATH;
 
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.controller.BesuController;
-import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetcherContext;
@@ -306,8 +304,7 @@ public class RunnerBuilder {
       discoveryConfiguration = DiscoveryConfiguration.create().setActive(false);
     }
 
-    final KeyPair keyPair = besuController.getLocalNodeKeyPair();
-    final NodeKey nodeKey = new BouncyCastleNodeKey(keyPair);
+    final NodeKey nodeKey = besuController.getNodeKey();
 
     final SubProtocolConfiguration subProtocolConfiguration =
         besuController.getSubProtocolConfiguration();
@@ -362,7 +359,7 @@ public class RunnerBuilder {
         (caps) ->
             DefaultP2PNetwork.builder()
                 .vertx(vertx)
-                .keyPair(keyPair)
+                .nodeKey(nodeKey)
                 .config(networkingConfiguration)
                 .peerPermissions(peerPermissions)
                 .metricsSystem(metricsSystem)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1224,40 +1224,36 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   public BesuControllerBuilder<?> getControllerBuilder() {
-    try {
-      addConfigurationService();
-      return controllerBuilderFactory
-          .fromEthNetworkConfig(updateNetworkConfig(getNetwork()), genesisConfigOverrides)
-          .synchronizerConfiguration(buildSyncConfig())
-          .ethProtocolConfiguration(ethProtocolOptions.toDomainObject())
-          .dataDirectory(dataDir())
-          .miningParameters(
-              new MiningParameters(
-                  coinbase,
-                  minTransactionGasPrice,
-                  extraData,
-                  isMiningEnabled,
-                  iStratumMiningEnabled,
-                  stratumNetworkInterface,
-                  stratumPort,
-                  stratumExtranonce,
-                  Optional.empty()))
-          .transactionPoolConfiguration(buildTransactionPoolConfiguration())
-          .nodePrivateKeyFile(nodePrivateKeyFile())
-          .metricsSystem(metricsSystem.get())
-          .privacyParameters(privacyParameters())
-          .clock(Clock.systemUTC())
-          .isRevertReasonEnabled(isRevertReasonEnabled)
-          .storageProvider(keyStorageProvider(keyValueStorageName))
-          .isPruningEnabled(isPruningEnabled())
-          .pruningConfiguration(
-              new PrunerConfiguration(pruningBlockConfirmations, pruningBlocksRetained))
-          .genesisConfigOverrides(genesisConfigOverrides)
-          .targetGasLimit(targetGasLimit == null ? Optional.empty() : Optional.of(targetGasLimit))
-          .requiredBlocks(requiredBlocks);
-    } catch (final IOException e) {
-      throw new ExecutionException(this.commandLine, "Invalid path", e);
-    }
+    addConfigurationService();
+    return controllerBuilderFactory
+        .fromEthNetworkConfig(updateNetworkConfig(getNetwork()), genesisConfigOverrides)
+        .synchronizerConfiguration(buildSyncConfig())
+        .ethProtocolConfiguration(ethProtocolOptions.toDomainObject())
+        .dataDirectory(dataDir())
+        .miningParameters(
+            new MiningParameters(
+                coinbase,
+                minTransactionGasPrice,
+                extraData,
+                isMiningEnabled,
+                iStratumMiningEnabled,
+                stratumNetworkInterface,
+                stratumPort,
+                stratumExtranonce,
+                Optional.empty()))
+        .transactionPoolConfiguration(buildTransactionPoolConfiguration())
+        .nodePrivateKeyFile(nodePrivateKeyFile())
+        .metricsSystem(metricsSystem.get())
+        .privacyParameters(privacyParameters())
+        .clock(Clock.systemUTC())
+        .isRevertReasonEnabled(isRevertReasonEnabled)
+        .storageProvider(keyStorageProvider(keyValueStorageName))
+        .isPruningEnabled(isPruningEnabled())
+        .pruningConfiguration(
+            new PrunerConfiguration(pruningBlockConfirmations, pruningBlocksRetained))
+        .genesisConfigOverrides(genesisConfigOverrides)
+        .targetGasLimit(targetGasLimit == null ? Optional.empty() : Optional.of(targetGasLimit))
+        .requiredBlocks(requiredBlocks);
   }
 
   private GraphQLConfiguration graphQLConfiguration() {

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/PublicKeySubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/PublicKeySubCommand.java
@@ -22,8 +22,7 @@ import org.hyperledger.besu.cli.BesuCommand;
 import org.hyperledger.besu.cli.DefaultCommandValues;
 import org.hyperledger.besu.cli.subcommands.PublicKeySubCommand.AddressSubCommand;
 import org.hyperledger.besu.cli.subcommands.PublicKeySubCommand.ExportSubCommand;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Util;
 
@@ -75,7 +74,7 @@ public class PublicKeySubCommand implements Runnable {
     spec.commandLine().usage(out);
   }
 
-  private Optional<KeyPair> getKeyPair() {
+  private Optional<NodeKey> getNodeKey() {
     try {
       return Optional.of(keyLoader.load(parentCommand.nodePrivateKeyFile()));
     } catch (IOException e) {
@@ -114,10 +113,10 @@ public class PublicKeySubCommand implements Runnable {
       checkNotNull(parentCommand);
       checkNotNull(parentCommand.parentCommand);
 
-      parentCommand.getKeyPair().ifPresent(this::outputPublicKey);
+      parentCommand.getNodeKey().ifPresent(this::outputPublicKey);
     }
 
-    private void outputPublicKey(final KeyPair keyPair) {
+    private void outputPublicKey(final NodeKey keyPair) {
       // if we have an output file defined, print to it
       // otherwise print to standard output.
       if (publicKeyExportFile != null) {
@@ -166,10 +165,10 @@ public class PublicKeySubCommand implements Runnable {
       checkNotNull(parentCommand);
       checkNotNull(parentCommand.parentCommand);
 
-      parentCommand.getKeyPair().ifPresent(this::outputAddress);
+      parentCommand.getNodeKey().ifPresent(this::outputAddress);
     }
 
-    private void outputAddress(final KeyPair keyPair) {
+    private void outputAddress(final NodeKey keyPair) {
       final Address address = Util.publicKeyToAddress(keyPair.getPublicKey());
 
       // if we have an output file defined, print to it
@@ -190,6 +189,6 @@ public class PublicKeySubCommand implements Runnable {
 
   @FunctionalInterface
   public interface KeyLoader {
-    SECP256K1.KeyPair load(final File keyFile) throws IOException;
+    NodeKey load(final File keyFile) throws IOException;
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.controller;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
@@ -52,7 +52,7 @@ public class BesuController<C> implements java.io.Closeable {
   private final EthProtocolManager ethProtocolManager;
   private final GenesisConfigOptions genesisConfigOptions;
   private final SubProtocolConfiguration subProtocolConfiguration;
-  private final KeyPair keyPair;
+  private final NodeKey nodeKey;
   private final Synchronizer synchronizer;
   private final JsonRpcMethods additionalJsonRpcMethodsFactory;
 
@@ -77,7 +77,7 @@ public class BesuController<C> implements java.io.Closeable {
       final PrivacyParameters privacyParameters,
       final MiningParameters miningParameters,
       final JsonRpcMethods additionalJsonRpcMethodsFactory,
-      final KeyPair keyPair,
+      final NodeKey nodeKey,
       final List<Closeable> closeables,
       final PluginServiceFactory additionalPluginServices) {
     this.protocolSchedule = protocolSchedule;
@@ -88,7 +88,7 @@ public class BesuController<C> implements java.io.Closeable {
     this.synchronizer = synchronizer;
     this.syncState = syncState;
     this.additionalJsonRpcMethodsFactory = additionalJsonRpcMethodsFactory;
-    this.keyPair = keyPair;
+    this.nodeKey = nodeKey;
     this.transactionPool = transactionPool;
     this.miningCoordinator = miningCoordinator;
     this.privacyParameters = privacyParameters;
@@ -121,8 +121,8 @@ public class BesuController<C> implements java.io.Closeable {
     return subProtocolConfiguration;
   }
 
-  public KeyPair getLocalNodeKeyPair() {
-    return keyPair;
+  public NodeKey getNodeKey() {
+    return nodeKey;
   }
 
   public TransactionPool getTransactionPool() {

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hyperledger.besu.crypto.KeyPairUtil.loadKeyPair;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -58,7 +58,6 @@ import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 
 import java.io.Closeable;
 import java.io.File;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Path;
 import java.time.Clock;
@@ -85,7 +84,7 @@ public abstract class BesuControllerBuilder<C> {
   protected PrivacyParameters privacyParameters;
   protected Path dataDirectory;
   protected Clock clock;
-  KeyPair nodeKeys;
+  NodeKey nodeKey;
   protected boolean isRevertReasonEnabled;
   GasLimitCalculator gasLimitCalculator;
   private StorageProvider storageProvider;
@@ -126,14 +125,13 @@ public abstract class BesuControllerBuilder<C> {
     return this;
   }
 
-  public BesuControllerBuilder<C> nodePrivateKeyFile(final File nodePrivateKeyFile)
-      throws IOException {
-    this.nodeKeys = loadKeyPair(nodePrivateKeyFile);
+  public BesuControllerBuilder<C> nodePrivateKeyFile(final File nodePrivateKeyFile) {
+    this.nodeKey = loadKeyPair(nodePrivateKeyFile);
     return this;
   }
 
-  public BesuControllerBuilder<C> nodeKeys(final KeyPair nodeKeys) {
-    this.nodeKeys = nodeKeys;
+  public BesuControllerBuilder<C> nodeKeys(final NodeKey nodeKeys) {
+    this.nodeKey = nodeKeys;
     return this;
   }
 
@@ -206,7 +204,7 @@ public abstract class BesuControllerBuilder<C> {
     checkNotNull(dataDirectory, "Missing data directory"); // Why do we need this?
     checkNotNull(clock, "Missing clock");
     checkNotNull(transactionPoolConfiguration, "Missing transaction pool configuration");
-    checkNotNull(nodeKeys, "Missing node keys");
+    checkNotNull(nodeKey, "Missing node keys");
     checkNotNull(storageProvider, "Must supply a storage provider");
     checkNotNull(gasLimitCalculator, "Missing gas limit calculator");
 
@@ -331,7 +329,7 @@ public abstract class BesuControllerBuilder<C> {
         privacyParameters,
         miningParameters,
         additionalJsonRpcMethodFactory,
-        nodeKeys,
+        nodeKey,
         closeables,
         additionalPluginServices);
   }

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.consensus.common.VoteTallyUpdater;
-import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -57,7 +56,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
 
   @Override
   protected void prepForBuild() {
-    localAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
+    localAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
     final CliqueConfigOptions cliqueConfig =
         genesisConfig.getConfigOptions(genesisConfigOverrides).getCliqueConfigOptions();
     final long blocksPerEpoch = cliqueConfig.getEpochLength();
@@ -85,7 +84,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
             protocolContext,
             protocolSchedule,
             transactionPool.getPendingTransactions(),
-            nodeKeys,
+            nodeKey,
             miningParameters,
             new CliqueBlockScheduler(
                 clock,
@@ -111,7 +110,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
   protected ProtocolSchedule<CliqueContext> createProtocolSchedule() {
     return CliqueProtocolSchedule.create(
         genesisConfig.getConfigOptions(genesisConfigOverrides),
-        nodeKeys,
+        nodeKey,
         privacyParameters,
         isRevertReasonEnabled);
   }
@@ -127,7 +126,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
 
   @Override
   protected PluginServiceFactory createAdditionalPluginServices(final Blockchain blockchain) {
-    return new CliqueQueryPluginServiceFactory(blockchain, new BouncyCastleNodeKey(nodeKeys));
+    return new CliqueQueryPluginServiceFactory(blockchain, nodeKey);
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
 import org.hyperledger.besu.consensus.common.VoteTallyUpdater;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -46,6 +47,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueContext> {
+
   private static final Logger LOG = LogManager.getLogger();
 
   private Address localAddress;
@@ -125,7 +127,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
 
   @Override
   protected PluginServiceFactory createAdditionalPluginServices(final Blockchain blockchain) {
-    return new CliqueQueryPluginServiceFactory(blockchain, nodeKeys);
+    return new CliqueQueryPluginServiceFactory(blockchain, new BouncyCastleNodeKey(nodeKeys));
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueQueryPluginServiceFactory.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueQueryPluginServiceFactory.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.controller;
 import org.hyperledger.besu.consensus.clique.CliqueBlockInterface;
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.PoaQueryServiceImpl;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.plugin.services.metrics.PoAMetricsService;
 import org.hyperledger.besu.plugin.services.query.PoaQueryService;
@@ -26,19 +26,18 @@ import org.hyperledger.besu.services.BesuPluginContextImpl;
 public class CliqueQueryPluginServiceFactory implements PluginServiceFactory {
 
   private final Blockchain blockchain;
-  private final KeyPair localNodeKeypair;
+  private final NodeKey nodeKey;
 
-  public CliqueQueryPluginServiceFactory(
-      final Blockchain blockchain, final KeyPair localNodeKeypair) {
+  public CliqueQueryPluginServiceFactory(final Blockchain blockchain, final NodeKey nodeKey) {
     this.blockchain = blockchain;
-    this.localNodeKeypair = localNodeKeypair;
+    this.nodeKey = nodeKey;
   }
 
   @Override
   public void appendPluginServices(final BesuPluginContextImpl besuContext) {
     final BlockInterface blockInterface = new CliqueBlockInterface();
     final PoaQueryServiceImpl service =
-        new PoaQueryServiceImpl(blockInterface, blockchain, localNodeKeypair);
+        new PoaQueryServiceImpl(blockInterface, blockchain, nodeKey);
     besuContext.addService(PoaQueryService.class, service);
     besuContext.addService(PoAMetricsService.class, service);
   }

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -51,8 +51,6 @@ import org.hyperledger.besu.consensus.ibft.statemachine.IbftController;
 import org.hyperledger.besu.consensus.ibft.statemachine.IbftFinalState;
 import org.hyperledger.besu.consensus.ibft.statemachine.IbftRoundFactory;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
-import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -118,8 +116,6 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder<IbftContext
       final EthProtocolManager ethProtocolManager) {
     final MutableBlockchain blockchain = protocolContext.getBlockchain();
     final IbftExecutors ibftExecutors = IbftExecutors.create(metricsSystem);
-
-    final NodeKey nodeKey = new BouncyCastleNodeKey(nodeKeys);
 
     final IbftBlockCreatorFactory blockCreatorFactory =
         new IbftBlockCreatorFactory(
@@ -208,7 +204,6 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder<IbftContext
 
   @Override
   protected PluginServiceFactory createAdditionalPluginServices(final Blockchain blockchain) {
-    final NodeKey nodeKey = new BouncyCastleNodeKey(nodeKeys);
     return new IbftQueryPluginServiceFactory(blockchain, nodeKey);
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftQueryPluginServiceFactory.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftQueryPluginServiceFactory.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.controller;
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.consensus.ibft.queries.IbftQueryServiceImpl;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.plugin.services.metrics.PoAMetricsService;
 import org.hyperledger.besu.plugin.services.query.IbftQueryService;
@@ -27,12 +27,11 @@ import org.hyperledger.besu.services.BesuPluginContextImpl;
 public class IbftQueryPluginServiceFactory implements PluginServiceFactory {
 
   private final Blockchain blockchain;
-  private final KeyPair localNodeKeypair;
+  private final NodeKey nodeKey;
 
-  public IbftQueryPluginServiceFactory(
-      final Blockchain blockchain, final KeyPair localNodeKeypair) {
+  public IbftQueryPluginServiceFactory(final Blockchain blockchain, final NodeKey nodeKey) {
     this.blockchain = blockchain;
-    this.localNodeKeypair = localNodeKeypair;
+    this.nodeKey = nodeKey;
   }
 
   @Override
@@ -40,7 +39,7 @@ public class IbftQueryPluginServiceFactory implements PluginServiceFactory {
     final BlockInterface blockInterface = new IbftBlockInterface();
 
     final IbftQueryServiceImpl service =
-        new IbftQueryServiceImpl(blockInterface, blockchain, localNodeKeypair);
+        new IbftQueryServiceImpl(blockInterface, blockchain, nodeKey);
     besuContext.addService(IbftQueryService.class, service);
     besuContext.addService(PoaQueryService.class, service);
     besuContext.addService(PoAMetricsService.class, service);

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -20,6 +20,7 @@ import static org.hyperledger.besu.ethereum.privacy.PrivateStateRootResolver.EMP
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.enclave.Enclave;
 import org.hyperledger.besu.enclave.EnclaveFactory;
@@ -164,7 +165,7 @@ public class PrivacyReorgTest {
             .storageProvider(new InMemoryStorageProvider())
             .networkId(BigInteger.ONE)
             .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-            .nodeKeys(SECP256K1.KeyPair.generate())
+            .nodeKeys(BouncyCastleNodeKey.generate())
             .metricsSystem(new NoOpMetricsSystem())
             .dataDirectory(dataDir)
             .clock(TestClock.fixed())

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.enclave.EnclaveFactory;
 import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -114,7 +114,7 @@ public class PrivacyTest {
         .storageProvider(new InMemoryStorageProvider())
         .networkId(BigInteger.ONE)
         .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-        .nodeKeys(KeyPair.generate())
+        .nodeKeys(BouncyCastleNodeKey.generate())
         .metricsSystem(new NoOpMetricsSystem())
         .dataDirectory(dataDir)
         .clock(TestClock.fixed())

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -25,8 +25,9 @@ import org.hyperledger.besu.config.JsonUtil;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
 import org.hyperledger.besu.controller.MainnetBesuControllerBuilder;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.KeyPairUtil;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
@@ -144,7 +145,7 @@ public final class RunnerTest {
     final Path dataDirAhead = temp.newFolder().toPath();
     final Path dbAhead = dataDirAhead.resolve("database");
     final int blockCount = 500;
-    final KeyPair aheadDbNodeKeys = KeyPairUtil.loadKeyPair(dbAhead);
+    final NodeKey aheadDbNodeKey = KeyPairUtil.loadKeyPair(dbAhead);
     final SynchronizerConfiguration syncConfigAhead =
         SynchronizerConfiguration.builder().syncMode(SyncMode.FULL).build();
     final ObservableMetricsSystem noOpMetricsSystem = new NoOpMetricsSystem();
@@ -159,7 +160,7 @@ public final class RunnerTest {
             .dataDirectory(dataDirAhead)
             .networkId(networkId)
             .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-            .nodeKeys(aheadDbNodeKeys)
+            .nodeKeys(aheadDbNodeKey)
             .metricsSystem(noOpMetricsSystem)
             .privacyParameters(PrivacyParameters.DEFAULT)
             .clock(TestClock.fixed())
@@ -179,7 +180,7 @@ public final class RunnerTest {
             .dataDirectory(dataDirAhead)
             .networkId(networkId)
             .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-            .nodeKeys(aheadDbNodeKeys)
+            .nodeKeys(aheadDbNodeKey)
             .metricsSystem(noOpMetricsSystem)
             .privacyParameters(PrivacyParameters.DEFAULT)
             .clock(TestClock.fixed())
@@ -239,7 +240,7 @@ public final class RunnerTest {
               .dataDirectory(dataDirBehind)
               .networkId(networkId)
               .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-              .nodeKeys(KeyPair.generate())
+              .nodeKeys(BouncyCastleNodeKey.generate())
               .storageProvider(new InMemoryStorageProvider())
               .metricsSystem(noOpMetricsSystem)
               .privacyParameters(PrivacyParameters.DEFAULT)

--- a/besu/src/test/java/org/hyperledger/besu/chainexport/RlpBlockExporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainexport/RlpBlockExporterTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.chainimport.RlpBlockImporter;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -85,7 +85,7 @@ public final class RlpBlockExporterTest {
         .storageProvider(new InMemoryStorageProvider())
         .networkId(BigInteger.ONE)
         .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-        .nodeKeys(KeyPair.generate())
+        .nodeKeys(BouncyCastleNodeKey.generate())
         .metricsSystem(new NoOpMetricsSystem())
         .privacyParameters(PrivacyParameters.DEFAULT)
         .dataDirectory(dataDir)

--- a/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.JsonUtil;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -422,7 +422,7 @@ public abstract class JsonBlockImporterTest {
                 .minTransactionGasPrice(Wei.ZERO)
                 .enabled(true)
                 .build())
-        .nodeKeys(KeyPair.generate())
+        .nodeKeys(BouncyCastleNodeKey.generate())
         .metricsSystem(new NoOpMetricsSystem())
         .privacyParameters(PrivacyParameters.DEFAULT)
         .dataDirectory(dataDir)

--- a/besu/src/test/java/org/hyperledger/besu/chainimport/RlpBlockImporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainimport/RlpBlockImporterTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.GasLimitCalculator;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.core.InMemoryStorageProvider;
 import org.hyperledger.besu.ethereum.core.MiningParametersTestBuilder;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
@@ -63,7 +63,7 @@ public final class RlpBlockImporterTest {
             .storageProvider(new InMemoryStorageProvider())
             .networkId(BigInteger.ONE)
             .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-            .nodeKeys(KeyPair.generate())
+            .nodeKeys(BouncyCastleNodeKey.generate())
             .metricsSystem(new NoOpMetricsSystem())
             .privacyParameters(PrivacyParameters.DEFAULT)
             .dataDirectory(dataDir)
@@ -103,7 +103,7 @@ public final class RlpBlockImporterTest {
             .storageProvider(new InMemoryStorageProvider())
             .networkId(BigInteger.valueOf(10))
             .miningParameters(new MiningParametersTestBuilder().enabled(false).build())
-            .nodeKeys(KeyPair.generate())
+            .nodeKeys(BouncyCastleNodeKey.generate())
             .metricsSystem(new NoOpMetricsSystem())
             .privacyParameters(PrivacyParameters.DEFAULT)
             .dataDirectory(dataDir)

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -40,7 +40,7 @@ import org.hyperledger.besu.cli.subcommands.blocks.BlocksSubCommand;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.controller.NoopPluginServiceFactory;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
@@ -271,7 +271,7 @@ public abstract class CommandTestAbstract {
   }
 
   protected TestBesuCommand parseCommand(final InputStream in, final String... args) {
-    return parseCommand(f -> KeyPair.generate(), in, args);
+    return parseCommand(f -> BouncyCastleNodeKey.generate(), in, args);
   }
 
   @SuppressWarnings("unchecked")

--- a/besu/src/test/java/org/hyperledger/besu/cli/PublicKeySubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/PublicKeySubCommandTest.java
@@ -17,7 +17,8 @@ package org.hyperledger.besu.cli;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Util;
 
 import java.io.File;
@@ -113,11 +114,11 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
 
   @Test
   public void callingPublicKeyExportSubCommandWithoutPathMustWriteKeyToStandardOutput() {
-    final KeyPair keyPair = KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
-    parseCommand(f -> keyPair, PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_SUBCOMMAND_NAME);
+    parseCommand(f -> nodeKey, PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_SUBCOMMAND_NAME);
 
-    final String expectedOutputStart = keyPair.getPublicKey().toString();
+    final String expectedOutputStart = nodeKey.getPublicKey().toString();
     assertThat(commandOutput.toString()).startsWith(expectedOutputStart);
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
@@ -126,20 +127,20 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
   public void callingPublicKeyExportSubCommandWithFilePathMustWritePublicKeyInThisFile()
       throws Exception {
 
-    final KeyPair keyPair = KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     final File file = File.createTempFile("public", "key");
 
     parseCommand(
-        f -> keyPair,
+        f -> nodeKey,
         PUBLIC_KEY_SUBCOMMAND_NAME,
         PUBLIC_KEY_EXPORT_SUBCOMMAND_NAME,
         "--to",
         file.getPath());
 
     assertThat(contentOf(file))
-        .startsWith(keyPair.getPublicKey().toString())
-        .endsWith(keyPair.getPublicKey().toString());
+        .startsWith(nodeKey.getPublicKey().toString())
+        .endsWith(nodeKey.getPublicKey().toString());
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
@@ -155,12 +156,12 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
 
   @Test
   public void callingPublicKeyExportAddressSubCommandWithoutPathMustWriteAddressToStandardOutput() {
-    final KeyPair keyPair = KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     parseCommand(
-        f -> keyPair, PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_ADDRESS_SUBCOMMAND_NAME);
+        f -> nodeKey, PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_ADDRESS_SUBCOMMAND_NAME);
 
-    final String expectedOutputStart = Util.publicKeyToAddress(keyPair.getPublicKey()).toString();
+    final String expectedOutputStart = Util.publicKeyToAddress(nodeKey.getPublicKey()).toString();
     assertThat(commandOutput.toString()).startsWith(expectedOutputStart);
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
@@ -169,20 +170,20 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
   public void callingPublicKeyExportAddressSubCommandWithFilePathMustWriteAddressInThisFile()
       throws Exception {
 
-    final KeyPair keyPair = KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     final File file = File.createTempFile("public", "address");
 
     parseCommand(
-        f -> keyPair,
+        f -> nodeKey,
         PUBLIC_KEY_SUBCOMMAND_NAME,
         PUBLIC_KEY_EXPORT_ADDRESS_SUBCOMMAND_NAME,
         "--to",
         file.getPath());
 
     assertThat(contentOf(file))
-        .startsWith(Util.publicKeyToAddress(keyPair.getPublicKey()).toString())
-        .endsWith(Util.publicKeyToAddress(keyPair.getPublicKey()).toString());
+        .startsWith(Util.publicKeyToAddress(nodeKey.getPublicKey()).toString())
+        .endsWith(Util.publicKeyToAddress(nodeKey.getPublicKey()).toString());
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.consensus.clique;
 import org.hyperledger.besu.config.CliqueConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.common.EpochManager;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.MainnetBlockValidator;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
@@ -38,13 +38,13 @@ public class CliqueProtocolSchedule {
 
   public static ProtocolSchedule<CliqueContext> create(
       final GenesisConfigOptions config,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final PrivacyParameters privacyParameters,
       final boolean isRevertReasonEnabled) {
 
     final CliqueConfigOptions cliqueConfig = config.getCliqueConfigOptions();
 
-    final Address localNodeAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
+    final Address localNodeAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
 
     final EpochManager epochManager = new EpochManager(cliqueConfig.getEpochLength());
     return new ProtocolScheduleBuilder<>(
@@ -60,9 +60,9 @@ public class CliqueProtocolSchedule {
 
   public static ProtocolSchedule<CliqueContext> create(
       final GenesisConfigOptions config,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final boolean isRevertReasonEnabled) {
-    return create(config, nodeKeys, PrivacyParameters.DEFAULT, isRevertReasonEnabled);
+    return create(config, nodeKey, PrivacyParameters.DEFAULT, isRevertReasonEnabled);
   }
 
   private static ProtocolSpecBuilder<CliqueContext> applyCliqueSpecificModifications(

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.consensus.clique.CliqueExtraData;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.ValidatorVote;
 import org.hyperledger.besu.consensus.common.VoteTally;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -42,7 +41,7 @@ import java.util.function.Function;
 
 public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
 
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final EpochManager epochManager;
 
   public CliqueBlockCreator(
@@ -52,7 +51,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
       final ProtocolContext<CliqueContext> protocolContext,
       final ProtocolSchedule<CliqueContext> protocolSchedule,
       final Function<Long, Long> gasLimitCalculator,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final Wei minTransactionGasPrice,
       final BlockHeader parentHeader,
       final EpochManager epochManager) {
@@ -64,9 +63,9 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
         protocolSchedule,
         gasLimitCalculator,
         minTransactionGasPrice,
-        Util.publicKeyToAddress(nodeKeys.getPublicKey()),
+        Util.publicKeyToAddress(nodeKey.getPublicKey()),
         parentHeader);
-    this.nodeKeys = nodeKeys;
+    this.nodeKey = nodeKey;
     this.epochManager = epochManager;
   }
 
@@ -109,7 +108,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
           cliqueContext.getVoteTallyCache().getVoteTallyAfterBlock(parentHeader);
       return cliqueContext
           .getVoteProposer()
-          .getVote(Util.publicKeyToAddress(nodeKeys.getPublicKey()), voteTally);
+          .getVote(Util.publicKeyToAddress(nodeKey.getPublicKey()), voteTally);
     }
   }
 
@@ -127,7 +126,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
         CliqueBlockHashing.calculateDataHashForProposerSeal(headerToSign, extraData);
     return new CliqueExtraData(
         extraData.getVanityData(),
-        SECP256K1.sign(hashToSign, nodeKeys),
+        nodeKey.sign(hashToSign),
         extraData.getValidators(),
         headerToSign);
   }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutor.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutor.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.consensus.clique.CliqueExtraData;
 import org.hyperledger.besu.consensus.common.ConsensusHelpers;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteTally;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockScheduler;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractMinerExecutor;
@@ -44,14 +44,14 @@ import org.apache.tuweni.bytes.Bytes;
 public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, CliqueBlockMiner> {
 
   private final Address localAddress;
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final EpochManager epochManager;
 
   public CliqueMinerExecutor(
       final ProtocolContext<CliqueContext> protocolContext,
       final ProtocolSchedule<CliqueContext> protocolSchedule,
       final PendingTransactions pendingTransactions,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final MiningParameters miningParams,
       final AbstractBlockScheduler blockScheduler,
       final EpochManager epochManager,
@@ -63,8 +63,8 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
         miningParams,
         blockScheduler,
         gasLimitCalculator);
-    this.nodeKeys = nodeKeys;
-    this.localAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
+    this.nodeKey = nodeKey;
+    this.localAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
     this.epochManager = epochManager;
   }
 
@@ -82,7 +82,7 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
                 protocolContext,
                 protocolSchedule,
                 gasLimitCalculator,
-                nodeKeys,
+                nodeKey,
                 minTransactionGasPrice,
                 header,
                 epochManager);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
@@ -18,7 +18,8 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -27,7 +28,7 @@ import org.junit.Test;
 
 public class CliqueProtocolScheduleTest {
 
-  private static final KeyPair NODE_KEYS = KeyPair.generate();
+  private static final NodeKey NODE_KEY = BouncyCastleNodeKey.generate();
 
   @Test
   public void protocolSpecsAreCreatedAtBlockDefinedInJson() {
@@ -43,7 +44,7 @@ public class CliqueProtocolScheduleTest {
 
     final GenesisConfigOptions config = GenesisConfigFile.fromConfig(jsonInput).getConfigOptions();
     final ProtocolSchedule<CliqueContext> protocolSchedule =
-        CliqueProtocolSchedule.create(config, NODE_KEYS, false);
+        CliqueProtocolSchedule.create(config, NODE_KEY, false);
 
     final ProtocolSpec<CliqueContext> homesteadSpec = protocolSchedule.getByBlockNumber(1);
     final ProtocolSpec<CliqueContext> tangerineWhistleSpec = protocolSchedule.getByBlockNumber(2);
@@ -58,8 +59,7 @@ public class CliqueProtocolScheduleTest {
   @Test
   public void parametersAlignWithMainnetWithAdjustments() {
     final ProtocolSpec<CliqueContext> homestead =
-        CliqueProtocolSchedule.create(
-                GenesisConfigFile.DEFAULT.getConfigOptions(), NODE_KEYS, false)
+        CliqueProtocolSchedule.create(GenesisConfigFile.DEFAULT.getConfigOptions(), NODE_KEY, false)
             .getByBlockNumber(0);
 
     assertThat(homestead.getName()).isEqualTo("Frontier");

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
@@ -61,8 +63,8 @@ import org.junit.Test;
 
 public class CliqueBlockCreatorTest {
 
-  private final KeyPair proposerKeyPair = KeyPair.generate();
-  private final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+  private final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+  private final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
   private final KeyPair otherKeyPair = KeyPair.generate();
   private final List<Address> validatorList = Lists.newArrayList();
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
@@ -80,7 +82,7 @@ public class CliqueBlockCreatorTest {
   public void setup() {
     protocolSchedule =
         CliqueProtocolSchedule.create(
-            GenesisConfigFile.DEFAULT.getConfigOptions(), proposerKeyPair, false);
+            GenesisConfigFile.DEFAULT.getConfigOptions(), proposerNodeKey, false);
 
     final Address otherAddress = Util.publicKeyToAddress(otherKeyPair.getPublicKey());
     validatorList.add(otherAddress);
@@ -128,7 +130,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -160,7 +162,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -191,7 +193,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -225,7 +227,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -30,7 +30,8 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
@@ -59,7 +60,7 @@ public class CliqueMinerExecutorTest {
   private static final int EPOCH_LENGTH = 10;
   private static final GenesisConfigOptions GENESIS_CONFIG_OPTIONS =
       GenesisConfigFile.fromConfig("{}").getConfigOptions();
-  private final KeyPair proposerKeyPair = KeyPair.generate();
+  private final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
   private final Random random = new Random(21341234L);
   private Address localAddress;
   private final List<Address> validatorList = Lists.newArrayList();
@@ -70,7 +71,7 @@ public class CliqueMinerExecutorTest {
 
   @Before
   public void setup() {
-    localAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    localAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
     validatorList.add(localAddress);
     validatorList.add(AddressHelpers.calculateAddressWithRespectTo(localAddress, 1));
     validatorList.add(AddressHelpers.calculateAddressWithRespectTo(localAddress, 2));
@@ -93,14 +94,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),
@@ -131,14 +132,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),
@@ -169,14 +170,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, initialVanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/PoaQueryServiceImpl.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/PoaQueryServiceImpl.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.consensus.common;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.plugin.data.Address;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -28,15 +28,13 @@ public class PoaQueryServiceImpl implements PoaQueryService, PoAMetricsService {
 
   private final BlockInterface blockInterface;
   private final Blockchain blockchain;
-  private final KeyPair localNodeKeypair;
+  private final NodeKey nodeKey;
 
   public PoaQueryServiceImpl(
-      final BlockInterface blockInterface,
-      final Blockchain blockchain,
-      final KeyPair localNodeKeypair) {
+      final BlockInterface blockInterface, final Blockchain blockchain, final NodeKey nodeKey) {
     this.blockInterface = blockInterface;
     this.blockchain = blockchain;
-    this.localNodeKeypair = localNodeKeypair;
+    this.nodeKey = nodeKey;
   }
 
   @Override
@@ -55,6 +53,6 @@ public class PoaQueryServiceImpl implements PoaQueryService, PoAMetricsService {
 
   @Override
   public Address getLocalSignerAddress() {
-    return org.hyperledger.besu.ethereum.core.Address.extract(localNodeKeypair.getPublicKey());
+    return org.hyperledger.besu.ethereum.core.Address.extract(nodeKey.getPublicKey());
   }
 }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/IntegrationTestHelpers.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/IntegrationTestHelpers.java
@@ -22,8 +22,7 @@ import org.hyperledger.besu.consensus.ibft.payload.CommitPayload;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Block;
 
@@ -33,16 +32,15 @@ import java.util.stream.Collectors;
 public class IntegrationTestHelpers {
 
   public static SignedData<CommitPayload> createSignedCommitPayload(
-      final ConsensusRoundIdentifier roundId, final Block block, final KeyPair signingKeyPair) {
+      final ConsensusRoundIdentifier roundId, final Block block, final NodeKey nodeKey) {
 
     final IbftExtraData extraData = IbftExtraData.decode(block.getHeader());
 
     final Signature commitSeal =
-        SECP256K1.sign(
-            IbftBlockHashing.calculateDataHashForCommittedSeal(block.getHeader(), extraData),
-            signingKeyPair);
+        nodeKey.sign(
+            IbftBlockHashing.calculateDataHashForCommittedSeal(block.getHeader(), extraData));
 
-    final MessageFactory messageFactory = new MessageFactory(signingKeyPair);
+    final MessageFactory messageFactory = new MessageFactory(nodeKey);
 
     return messageFactory.createCommit(roundId, block.getHash(), commitSeal).getSignedPayload();
   }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
@@ -54,9 +54,9 @@ public class NetworkLayout {
     final TreeMap<Address, NodeParams> addressKeyMap = new TreeMap<>();
 
     for (int i = 0; i < validatorCount; i++) {
-      final NodeKey newKeyPair = BouncyCastleNodeKey.generate();
-      final Address nodeAddress = Util.publicKeyToAddress(newKeyPair.getPublicKey());
-      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newKeyPair));
+      final NodeKey newNodeKey = BouncyCastleNodeKey.generate();
+      final Address nodeAddress = Util.publicKeyToAddress(newNodeKey.getPublicKey());
+      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newNodeKey));
     }
 
     return addressKeyMap;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.support;
 
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -54,10 +55,9 @@ public class NetworkLayout {
     final TreeMap<Address, NodeParams> addressKeyMap = new TreeMap<>();
 
     for (int i = 0; i < validatorCount; i++) {
-      final KeyPair newKeyPair = KeyPair.generate();
+      final NodeKey newKeyPair = BouncyCastleNodeKey.generate();
       final Address nodeAddress = Util.publicKeyToAddress(newKeyPair.getPublicKey());
-      addressKeyMap.put(
-          nodeAddress, new NodeParams(nodeAddress, new BouncyCastleNodeKey(newKeyPair)));
+      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newKeyPair);
     }
 
     return addressKeyMap;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.consensus.ibft.support;
 
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Util;
 
@@ -57,7 +56,7 @@ public class NetworkLayout {
     for (int i = 0; i < validatorCount; i++) {
       final NodeKey newKeyPair = BouncyCastleNodeKey.generate();
       final Address nodeAddress = Util.publicKeyToAddress(newKeyPair.getPublicKey());
-      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newKeyPair);
+      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newKeyPair));
     }
 
     return addressKeyMap;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NetworkLayout.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.support;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -55,7 +56,8 @@ public class NetworkLayout {
     for (int i = 0; i < validatorCount; i++) {
       final KeyPair newKeyPair = KeyPair.generate();
       final Address nodeAddress = Util.publicKeyToAddress(newKeyPair.getPublicKey());
-      addressKeyMap.put(nodeAddress, new NodeParams(nodeAddress, newKeyPair));
+      addressKeyMap.put(
+          nodeAddress, new NodeParams(nodeAddress, new BouncyCastleNodeKey(newKeyPair)));
     }
 
     return addressKeyMap;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NodeParams.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/NodeParams.java
@@ -30,7 +30,7 @@ public class NodeParams {
     return address;
   }
 
-  public NodeKey getnodeKey() {
+  public NodeKey getNodeKey() {
     return nodeKey;
   }
 }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContext.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContext.java
@@ -103,7 +103,7 @@ public class TestContext {
   }
 
   public NodeParams getLocalNodeParams() {
-    return new NodeParams(finalState.getLocalAddress(), finalState.getNodeKeys());
+    return new NodeParams(finalState.getLocalAddress(), finalState.getnodeKey());
   }
 
   public long getCurrentChainHeight() {

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContext.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContext.java
@@ -103,7 +103,7 @@ public class TestContext {
   }
 
   public NodeParams getLocalNodeParams() {
-    return new NodeParams(finalState.getLocalAddress(), finalState.getnodeKey());
+    return new NodeParams(finalState.getLocalAddress(), finalState.getNodeKey());
   }
 
   public long getCurrentChainHeight() {

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -50,7 +50,7 @@ import org.hyperledger.besu.consensus.ibft.statemachine.IbftController;
 import org.hyperledger.besu.consensus.ibft.statemachine.IbftFinalState;
 import org.hyperledger.besu.consensus.ibft.statemachine.IbftRoundFactory;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -175,8 +175,6 @@ public class TestContextBuilder {
     final MutableBlockchain blockChain =
         createInMemoryBlockchain(genesisBlock, IbftBlockHeaderFunctions.forOnChainBlock());
 
-    final KeyPair nodeKeys = networkNodes.getLocalNode().getNodeKeyPair();
-
     // Use a stubbed version of the multicaster, to prevent creating PeerConnections etc.
     final StubValidatorMulticaster multicaster = new StubValidatorMulticaster();
     final UniqueMessageMulticaster uniqueMulticaster =
@@ -190,7 +188,7 @@ public class TestContextBuilder {
         createControllerAndFinalState(
             blockChain,
             multicaster,
-            nodeKeys,
+            networkNodes.getLocalNode().getnodeKey(),
             clock,
             ibftEventQueue,
             gossiper,
@@ -207,7 +205,7 @@ public class TestContextBuilder {
                     nodeParams ->
                         new ValidatorPeer(
                             nodeParams,
-                            new MessageFactory(nodeParams.getNodeKeyPair()),
+                            new MessageFactory(nodeParams.getnodeKey()),
                             controllerAndState.getEventMultiplexer()),
                     (u, v) -> {
                       throw new IllegalStateException(String.format("Duplicate key %s", u));
@@ -256,7 +254,7 @@ public class TestContextBuilder {
   private static ControllerAndState createControllerAndFinalState(
       final MutableBlockchain blockChain,
       final StubValidatorMulticaster multicaster,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final Clock clock,
       final IbftEventQueue ibftEventQueue,
       final Gossiper gossiper,
@@ -309,7 +307,7 @@ public class TestContextBuilder {
             protocolContext,
             protocolSchedule,
             miningParams,
-            Util.publicKeyToAddress(nodeKeys.getPublicKey()));
+            Util.publicKeyToAddress(nodeKey.getPublicKey()));
 
     final ProposerSelector proposerSelector =
         new ProposerSelector(blockChain, blockInterface, true, voteTallyCache);
@@ -318,15 +316,15 @@ public class TestContextBuilder {
     final IbftFinalState finalState =
         new IbftFinalState(
             protocolContext.getConsensusState().getVoteTallyCache(),
-            nodeKeys,
-            Util.publicKeyToAddress(nodeKeys.getPublicKey()),
+            nodeKey,
+            Util.publicKeyToAddress(nodeKey.getPublicKey()),
             proposerSelector,
             multicaster,
             new RoundTimer(ibftEventQueue, ROUND_TIMER_SEC * 1000, ibftExecutors),
             new BlockTimer(
                 ibftEventQueue, BLOCK_TIMER_SEC * 1000, ibftExecutors, TestClock.fixed()),
             blockCreatorFactory,
-            new MessageFactory(nodeKeys),
+            new MessageFactory(nodeKey),
             clock);
 
     final MessageValidatorFactory messageValidatorFactory =

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -188,7 +188,7 @@ public class TestContextBuilder {
         createControllerAndFinalState(
             blockChain,
             multicaster,
-            networkNodes.getLocalNode().getnodeKey(),
+            networkNodes.getLocalNode().getNodeKey(),
             clock,
             ibftEventQueue,
             gossiper,
@@ -205,7 +205,7 @@ public class TestContextBuilder {
                     nodeParams ->
                         new ValidatorPeer(
                             nodeParams,
-                            new MessageFactory(nodeParams.getnodeKey()),
+                            new MessageFactory(nodeParams.getNodeKey()),
                             controllerAndState.getEventMultiplexer()),
                     (u, v) -> {
                       throw new IllegalStateException(String.format("Duplicate key %s", u));

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/ValidatorPeer.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/ValidatorPeer.java
@@ -62,7 +62,7 @@ public class ValidatorPeer {
       final NodeParams nodeParams,
       final MessageFactory messageFactory,
       final EventMultiplexer localEventMultiplexer) {
-    this.nodeKey = nodeParams.getnodeKey();
+    this.nodeKey = nodeParams.getNodeKey();
     this.nodeAddress = nodeParams.getAddress();
     this.messageFactory = messageFactory;
     final Bytes nodeId = nodeKey.getPublicKey().getEncodedBytes();

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/ValidatorPeer.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/ValidatorPeer.java
@@ -30,8 +30,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -51,7 +50,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class ValidatorPeer {
 
   private final Address nodeAddress;
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final MessageFactory messageFactory;
   private final PeerConnection peerConnection;
   private final List<MessageData> receivedMessages = Lists.newArrayList();
@@ -63,10 +62,10 @@ public class ValidatorPeer {
       final NodeParams nodeParams,
       final MessageFactory messageFactory,
       final EventMultiplexer localEventMultiplexer) {
-    this.nodeKeys = nodeParams.getNodeKeyPair();
+    this.nodeKey = nodeParams.getnodeKey();
     this.nodeAddress = nodeParams.getAddress();
     this.messageFactory = messageFactory;
-    final Bytes nodeId = nodeKeys.getPublicKey().getEncodedBytes();
+    final Bytes nodeId = nodeKey.getPublicKey().getEncodedBytes();
     this.peerConnection = StubbedPeerConnection.create(nodeId);
     this.localEventMultiplexer = localEventMultiplexer;
   }
@@ -75,8 +74,8 @@ public class ValidatorPeer {
     return nodeAddress;
   }
 
-  public KeyPair getNodeKeys() {
-    return nodeKeys;
+  public NodeKey getnodeKey() {
+    return nodeKey;
   }
 
   public PeerConnection getPeerConnection() {
@@ -97,11 +96,11 @@ public class ValidatorPeer {
   }
 
   public Signature getBlockSignature(final Hash digest) {
-    return SECP256K1.sign(digest, nodeKeys);
+    return nodeKey.sign(digest);
   }
 
   public Commit injectCommit(final ConsensusRoundIdentifier rId, final Hash digest) {
-    final Signature commitSeal = SECP256K1.sign(digest, nodeKeys);
+    final Signature commitSeal = nodeKey.sign(digest);
 
     return injectCommit(rId, digest, commitSeal);
   }
@@ -151,10 +150,6 @@ public class ValidatorPeer {
 
   public MessageFactory getMessageFactory() {
     return messageFactory;
-  }
-
-  public KeyPair getNodeKeyPair() {
-    return nodeKeys;
   }
 
   public void updateEstimatedChainHeight(final long estimatedChainHeight) {

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
@@ -99,7 +99,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getnodeKey()));
+                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getNodeKey()));
 
     peers.verifyMessagesReceived(expectedPrepareMessage, expectedCommitMessage);
     assertThat(context.getCurrentChainHeight()).isEqualTo(2);
@@ -155,7 +155,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                roundId, currentHeightBlock, context.getLocalNodeParams().getnodeKey()));
+                roundId, currentHeightBlock, context.getLocalNodeParams().getNodeKey()));
     peers.verifyMessagesReceived(expectedCommitMessage);
   }
 
@@ -212,7 +212,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getnodeKey()));
+                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getNodeKey()));
 
     // Assert ONLY a prepare message was received, not any commits (i.e. futureHeightRoundId
     // messages have not been used.

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
@@ -99,9 +99,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                futureHeightRoundId,
-                futureHeightBlock,
-                context.getLocalNodeParams().getNodeKeyPair()));
+                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getnodeKey()));
 
     peers.verifyMessagesReceived(expectedPrepareMessage, expectedCommitMessage);
     assertThat(context.getCurrentChainHeight()).isEqualTo(2);
@@ -157,7 +155,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                roundId, currentHeightBlock, context.getLocalNodeParams().getNodeKeyPair()));
+                roundId, currentHeightBlock, context.getLocalNodeParams().getnodeKey()));
     peers.verifyMessagesReceived(expectedCommitMessage);
   }
 
@@ -214,9 +212,7 @@ public class FutureHeightTest {
     final Commit expectedCommitMessage =
         new Commit(
             createSignedCommitPayload(
-                futureHeightRoundId,
-                futureHeightBlock,
-                context.getLocalNodeParams().getNodeKeyPair()));
+                futureHeightRoundId, futureHeightBlock, context.getLocalNodeParams().getnodeKey()));
 
     // Assert ONLY a prepare message was received, not any commits (i.e. futureHeightRoundId
     // messages have not been used.

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.support.RoundSpecificPeers;
 import org.hyperledger.besu.consensus.ibft.support.TestContext;
 import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
-import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.core.Block;
 
 import java.time.Clock;
@@ -107,7 +106,7 @@ public class FutureRoundTest {
         localNodeMessageFactory.createCommit(
             futureRoundId,
             futureBlock.getHash(),
-            SECP256K1.sign(futureBlock.getHash(), context.getLocalNodeParams().getNodeKeyPair()));
+            context.getLocalNodeParams().getnodeKey().sign(futureBlock.getHash()));
     peers.verifyMessagesReceived(expectedCommit);
 
     // requires 1 more commit and the blockchain will progress

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
@@ -106,7 +106,7 @@ public class FutureRoundTest {
         localNodeMessageFactory.createCommit(
             futureRoundId,
             futureBlock.getHash(),
-            context.getLocalNodeParams().getnodeKey().sign(futureBlock.getHash()));
+            context.getLocalNodeParams().getNodeKey().sign(futureBlock.getHash()));
     peers.verifyMessagesReceived(expectedCommit);
 
     // requires 1 more commit and the blockchain will progress

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
@@ -17,10 +17,6 @@ package org.hyperledger.besu.consensus.ibft.tests;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Optional;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftHelpers;
 import org.hyperledger.besu.consensus.ibft.ibftevent.NewChainHead;
@@ -37,6 +33,12 @@ import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
 import org.hyperledger.besu.consensus.ibft.support.ValidatorPeer;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.ethereum.core.Block;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+
 import org.junit.Before;
 import org.junit.Test;
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
@@ -17,6 +17,10 @@ package org.hyperledger.besu.consensus.ibft.tests;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftHelpers;
 import org.hyperledger.besu.consensus.ibft.ibftevent.NewChainHead;
@@ -32,14 +36,7 @@ import org.hyperledger.besu.consensus.ibft.support.TestContext;
 import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
 import org.hyperledger.besu.consensus.ibft.support.ValidatorPeer;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.Optional;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -119,8 +116,7 @@ public class GossipTest {
 
   @Test
   public void messageWithUnknownValidatorIsNotGossiped() {
-    final MessageFactory unknownMsgFactory =
-        new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
+    final MessageFactory unknownMsgFactory = new MessageFactory(BouncyCastleNodeKey.generate());
     final Proposal unknownProposal =
         unknownMsgFactory.createProposal(roundId, block, Optional.empty());
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.consensus.ibft.support.RoundSpecificPeers;
 import org.hyperledger.besu.consensus.ibft.support.TestContext;
 import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
 import org.hyperledger.besu.consensus.ibft.support.ValidatorPeer;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
@@ -118,8 +119,8 @@ public class GossipTest {
 
   @Test
   public void messageWithUnknownValidatorIsNotGossiped() {
-    final KeyPair unknownKeyPair = KeyPair.generate();
-    final MessageFactory unknownMsgFactory = new MessageFactory(unknownKeyPair);
+    final MessageFactory unknownMsgFactory =
+        new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
     final Proposal unknownProposal =
         unknownMsgFactory.createProposal(roundId, block, Optional.empty());
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
@@ -72,7 +72,7 @@ public class LocalNodeIsProposerTest {
     expectedTxCommit =
         new Commit(
             createSignedCommitPayload(
-                roundId, expectedProposedBlock, context.getLocalNodeParams().getNodeKeyPair()));
+                roundId, expectedProposedBlock, context.getLocalNodeParams().getnodeKey()));
 
     // Trigger "block timer" to send proposal.
     context.getController().handleBlockTimerExpiry(new BlockTimerExpiry(roundId));

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
@@ -72,7 +72,7 @@ public class LocalNodeIsProposerTest {
     expectedTxCommit =
         new Commit(
             createSignedCommitPayload(
-                roundId, expectedProposedBlock, context.getLocalNodeParams().getnodeKey()));
+                roundId, expectedProposedBlock, context.getLocalNodeParams().getNodeKey()));
 
     // Trigger "block timer" to send proposal.
     context.getController().handleBlockTimerExpiry(new BlockTimerExpiry(roundId));

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
@@ -57,7 +57,7 @@ public class LocalNodeNotProposerTest {
     expectedTxCommit =
         new Commit(
             createSignedCommitPayload(
-                roundId, blockToPropose, context.getLocalNodeParams().getNodeKeyPair()));
+                roundId, blockToPropose, context.getLocalNodeParams().getnodeKey()));
   }
 
   @Test

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
@@ -57,7 +57,7 @@ public class LocalNodeNotProposerTest {
     expectedTxCommit =
         new Commit(
             createSignedCommitPayload(
-                roundId, blockToPropose, context.getLocalNodeParams().getnodeKey()));
+                roundId, blockToPropose, context.getLocalNodeParams().getNodeKey()));
   }
 
   @Test

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
@@ -171,7 +171,7 @@ public class ReceivedFutureProposalTest {
     final Commit expectedCommit =
         new Commit(
             IntegrationTestHelpers.createSignedCommitPayload(
-                nextRoundId, reproposedBlock, context.getLocalNodeParams().getNodeKeyPair()));
+                nextRoundId, reproposedBlock, context.getLocalNodeParams().getnodeKey()));
 
     peers.verifyMessagesReceived(expectedCommit);
   }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
@@ -171,7 +171,7 @@ public class ReceivedFutureProposalTest {
     final Commit expectedCommit =
         new Commit(
             IntegrationTestHelpers.createSignedCommitPayload(
-                nextRoundId, reproposedBlock, context.getLocalNodeParams().getnodeKey()));
+                nextRoundId, reproposedBlock, context.getLocalNodeParams().getNodeKey()));
 
     peers.verifyMessagesReceived(expectedCommit);
   }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
@@ -75,7 +75,7 @@ public class SpuriousBehaviourTest {
     expectedCommit =
         new Commit(
             createSignedCommitPayload(
-                roundId, proposedBlock, context.getLocalNodeParams().getnodeKey()));
+                roundId, proposedBlock, context.getLocalNodeParams().getNodeKey()));
   }
 
   @Test
@@ -106,7 +106,7 @@ public class SpuriousBehaviourTest {
     final ValidatorPeer nonvalidator =
         new ValidatorPeer(
             nonValidatorParams,
-            new MessageFactory(nonValidatorParams.getnodeKey()),
+            new MessageFactory(nonValidatorParams.getNodeKey()),
             context.getEventMultiplexer());
 
     nonvalidator.injectProposal(new ConsensusRoundIdentifier(1, 0), proposedBlock);

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
@@ -17,6 +17,10 @@ package org.hyperledger.besu.consensus.ibft.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.consensus.ibft.support.IntegrationTestHelpers.createSignedCommitPayload;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.messagedata.IbftV2;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
@@ -28,19 +32,13 @@ import org.hyperledger.besu.consensus.ibft.support.TestContext;
 import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
 import org.hyperledger.besu.consensus.ibft.support.ValidatorPeer;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
-
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-
-import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -98,11 +96,11 @@ public class SpuriousBehaviourTest {
 
   @Test
   public void nonValidatorsCannotTriggerResponses() {
-    final KeyPair nonValidatorKeys = KeyPair.generate();
+    final NodeKey nonValidatorNodeKey = BouncyCastleNodeKey.generate();
     final NodeParams nonValidatorParams =
         new NodeParams(
-            Util.publicKeyToAddress(nonValidatorKeys.getPublicKey()),
-            new BouncyCastleNodeKey(nonValidatorKeys));
+            Util.publicKeyToAddress(nonValidatorNodeKey.getPublicKey()),
+            nonValidatorNodeKey);
 
     final ValidatorPeer nonvalidator =
         new ValidatorPeer(

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
@@ -17,10 +17,6 @@ package org.hyperledger.besu.consensus.ibft.tests;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.consensus.ibft.support.IntegrationTestHelpers.createSignedCommitPayload;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneId;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.messagedata.IbftV2;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
@@ -39,6 +35,12 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,8 +101,7 @@ public class SpuriousBehaviourTest {
     final NodeKey nonValidatorNodeKey = BouncyCastleNodeKey.generate();
     final NodeParams nonValidatorParams =
         new NodeParams(
-            Util.publicKeyToAddress(nonValidatorNodeKey.getPublicKey()),
-            nonValidatorNodeKey);
+            Util.publicKeyToAddress(nonValidatorNodeKey.getPublicKey()), nonValidatorNodeKey);
 
     final ValidatorPeer nonvalidator =
         new ValidatorPeer(

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/MessageFactory.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/MessageFactory.java
@@ -20,8 +20,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -33,10 +32,10 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class MessageFactory {
 
-  private final KeyPair validatorKeyPair;
+  private final NodeKey nodeKey;
 
-  public MessageFactory(final KeyPair validatorKeyPair) {
-    this.validatorKeyPair = validatorKeyPair;
+  public MessageFactory(final NodeKey nodeKey) {
+    this.nodeKey = nodeKey;
   }
 
   public Proposal createProposal(
@@ -79,19 +78,14 @@ public class MessageFactory {
   }
 
   private <M extends Payload> SignedData<M> createSignedMessage(final M payload) {
-    final Signature signature = sign(payload, validatorKeyPair);
+    final Signature signature = nodeKey.sign(hashForSignature(payload));
 
-    return new SignedData<>(
-        payload, Util.publicKeyToAddress(validatorKeyPair.getPublicKey()), signature);
+    return new SignedData<>(payload, Util.publicKeyToAddress(nodeKey.getPublicKey()), signature);
   }
 
   public static Hash hashForSignature(final Payload unsignedMessageData) {
     return Hash.hash(
         Bytes.concatenate(
             Bytes.of(unsignedMessageData.getMessageType()), unsignedMessageData.encoded()));
-  }
-
-  private static Signature sign(final Payload unsignedMessageData, final KeyPair nodeKeys) {
-    return SECP256K1.sign(hashForSignature(unsignedMessageData), nodeKeys);
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImpl.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImpl.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.PoaQueryServiceImpl;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHashing;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -33,8 +33,8 @@ import org.apache.tuweni.bytes.Bytes32;
 public class IbftQueryServiceImpl extends PoaQueryServiceImpl implements IbftQueryService {
 
   public IbftQueryServiceImpl(
-      final BlockInterface blockInterface, final Blockchain blockchain, final KeyPair keyPair) {
-    super(blockInterface, blockchain, keyPair);
+      final BlockInterface blockInterface, final Blockchain blockchain, final NodeKey nodeKey) {
+    super(blockInterface, blockchain, nodeKey);
   }
 
   @Override

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftFinalState.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftFinalState.java
@@ -24,7 +24,7 @@ import org.hyperledger.besu.consensus.ibft.blockcreation.ProposerSelector;
 import org.hyperledger.besu.consensus.ibft.network.IbftMessageTransmitter;
 import org.hyperledger.besu.consensus.ibft.network.ValidatorMulticaster;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 
 import java.time.Clock;
@@ -33,7 +33,7 @@ import java.util.Collection;
 /** This is the full data set, or context, required for many of the aspects of the IBFT workflow. */
 public class IbftFinalState {
   private final VoteTallyCache voteTallyCache;
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final Address localAddress;
   private final ProposerSelector proposerSelector;
   private final RoundTimer roundTimer;
@@ -45,7 +45,7 @@ public class IbftFinalState {
 
   public IbftFinalState(
       final VoteTallyCache voteTallyCache,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final Address localAddress,
       final ProposerSelector proposerSelector,
       final ValidatorMulticaster validatorMulticaster,
@@ -55,7 +55,7 @@ public class IbftFinalState {
       final MessageFactory messageFactory,
       final Clock clock) {
     this.voteTallyCache = voteTallyCache;
-    this.nodeKeys = nodeKeys;
+    this.nodeKey = nodeKey;
     this.localAddress = localAddress;
     this.proposerSelector = proposerSelector;
     this.roundTimer = roundTimer;
@@ -74,8 +74,8 @@ public class IbftFinalState {
     return voteTallyCache.getVoteTallyAtHead().getValidators();
   }
 
-  public KeyPair getNodeKeys() {
-    return nodeKeys;
+  public NodeKey getnodeKey() {
+    return nodeKey;
   }
 
   public Address getLocalAddress() {

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftFinalState.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftFinalState.java
@@ -74,7 +74,7 @@ public class IbftFinalState {
     return voteTallyCache.getVoteTallyAtHead().getValidators();
   }
 
-  public NodeKey getnodeKey() {
+  public NodeKey getNodeKey() {
     return nodeKey;
   }
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
@@ -29,8 +29,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.network.IbftMessageTransmitter;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
@@ -55,7 +54,7 @@ public class IbftRound {
   private final IbftBlockCreator blockCreator;
   private final ProtocolContext<IbftContext> protocolContext;
   private final BlockImporter<IbftContext> blockImporter;
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final MessageFactory messageFactory; // used only to create stored local msgs
   private final IbftMessageTransmitter transmitter;
 
@@ -65,7 +64,7 @@ public class IbftRound {
       final ProtocolContext<IbftContext> protocolContext,
       final BlockImporter<IbftContext> blockImporter,
       final Subscribers<MinedBlockObserver> observers,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final MessageFactory messageFactory,
       final IbftMessageTransmitter transmitter,
       final RoundTimer roundTimer) {
@@ -74,7 +73,7 @@ public class IbftRound {
     this.protocolContext = protocolContext;
     this.blockImporter = blockImporter;
     this.observers = observers;
-    this.nodeKeys = nodeKeys;
+    this.nodeKey = nodeKey;
     this.messageFactory = messageFactory;
     this.transmitter = transmitter;
 
@@ -229,7 +228,7 @@ public class IbftRound {
     final IbftExtraData extraData = IbftExtraData.decode(proposedHeader);
     final Hash commitHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(proposedHeader, extraData);
-    return SECP256K1.sign(commitHash, nodeKeys);
+    return nodeKey.sign(commitHash);
   }
 
   private void notifyNewBlockListeners(final Block block) {

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
@@ -73,7 +73,7 @@ public class IbftRoundFactory {
         protocolContext,
         protocolSchedule.getByBlockNumber(roundIdentifier.getSequenceNumber()).getBlockImporter(),
         minedBlockObservers,
-        finalState.getNodeKeys(),
+        finalState.getnodeKey(),
         finalState.getMessageFactory(),
         finalState.getTransmitter(),
         finalState.getRoundTimer());

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
@@ -73,7 +73,7 @@ public class IbftRoundFactory {
         protocolContext,
         protocolSchedule.getByBlockNumber(roundIdentifier.getSequenceNumber()).getBlockImporter(),
         minedBlockObservers,
-        finalState.getnodeKey(),
+        finalState.getNodeKey(),
         finalState.getMessageFactory(),
         finalState.getTransmitter(),
         finalState.getRoundTimer());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashingTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashingTest.java
@@ -17,13 +17,6 @@ package org.hyperledger.besu.consensus.ibft;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
@@ -37,6 +30,15 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.Test;
 
 public class IbftBlockHashingTest {

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashingTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHashingTest.java
@@ -17,6 +17,13 @@ package org.hyperledger.besu.consensus.ibft;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
@@ -30,20 +37,11 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.Test;
 
 public class IbftBlockHashingTest {
 
-  private static final List<NodeKey> COMMITTERS_KEY_PAIRS = committersNodeKeys();
+  private static final List<NodeKey> COMMITTERS_NODE_KEYS = committersNodeKeys();
   private static final List<Address> VALIDATORS =
       Arrays.asList(Address.fromHexString("1"), Address.fromHexString("2"));
   private static final Optional<Vote> VOTE = Optional.of(Vote.authVote(Address.fromHexString("3")));
@@ -66,8 +64,8 @@ public class IbftBlockHashingTest {
             HEADER_TO_BE_HASHED, IbftExtraData.decode(HEADER_TO_BE_HASHED));
 
     List<Address> expectedCommitterAddresses =
-        COMMITTERS_KEY_PAIRS.stream()
-            .map(keyPair -> Util.publicKeyToAddress(keyPair.getPublicKey()))
+        COMMITTERS_NODE_KEYS.stream()
+            .map(nodeKey -> Util.publicKeyToAddress(nodeKey.getPublicKey()))
             .collect(Collectors.toList());
 
     assertThat(actualCommitterAddresses).isEqualTo(expectedCommitterAddresses);
@@ -82,7 +80,7 @@ public class IbftBlockHashingTest {
     BlockHeaderBuilder builder = setHeaderFieldsExceptForExtraData();
 
     List<Signature> commitSeals =
-        COMMITTERS_KEY_PAIRS.stream()
+        COMMITTERS_NODE_KEYS.stream()
             .map(nodeKey -> nodeKey.sign(dataHahsForCommittedSeal))
             .collect(Collectors.toList());
 
@@ -156,7 +154,7 @@ public class IbftBlockHashingTest {
     builder.buildBlockHeader().writeTo(rlpForHeaderFroCommittersSigning);
 
     List<Signature> commitSeals =
-        COMMITTERS_KEY_PAIRS.stream()
+        COMMITTERS_NODE_KEYS.stream()
             .map(nodeKey -> nodeKey.sign(Hash.hash(rlpForHeaderFroCommittersSigning.encoded())))
             .collect(Collectors.toList());
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHeaderValidationRulesetFactoryTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftBlockHeaderValidationRulesetFactoryTest.java
@@ -19,7 +19,8 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.consensus.ibft.IbftContextBuilder.setupContextWithValidators;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -45,15 +46,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderPasses() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader).buildHeader();
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader).buildHeader();
 
     final BlockHeaderValidator<IbftContext> validator =
         IbftBlockHeaderValidationRulesetFactory.ibftBlockHeaderValidator(5);
@@ -66,15 +67,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnExtraData() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, emptyList(), parentHeader).buildHeader();
+        getPresetHeaderBuilder(2, proposerNodeKey, emptyList(), parentHeader).buildHeader();
 
     final BlockHeaderValidator<IbftContext> validator =
         IbftBlockHeaderValidationRulesetFactory.ibftBlockHeaderValidator(5);
@@ -87,17 +88,18 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnCoinbaseData() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
-    final Address nonProposerAddress = Util.publicKeyToAddress(KeyPair.generate().getPublicKey());
+    final Address nonProposerAddress =
+        Util.publicKeyToAddress(BouncyCastleNodeKey.generate().getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .coinbase(nonProposerAddress)
             .buildHeader();
 
@@ -112,15 +114,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnNonce() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader).nonce(3).buildHeader();
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader).nonce(3).buildHeader();
 
     final BlockHeaderValidator<IbftContext> validator =
         IbftBlockHeaderValidationRulesetFactory.ibftBlockHeaderValidator(5);
@@ -133,15 +135,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnTimestamp() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .timestamp(100)
             .buildHeader();
 
@@ -156,15 +158,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnMixHash() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .mixHash(Hash.EMPTY_TRIE_HASH)
             .buildHeader();
 
@@ -179,15 +181,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnOmmers() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .ommersHash(Hash.EMPTY_TRIE_HASH)
             .buildHeader();
 
@@ -202,15 +204,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnDifficulty() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .difficulty(Difficulty.of(5))
             .buildHeader();
 
@@ -225,15 +227,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnAncestor() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, null).buildHeader();
 
     final BlockHeaderValidator<IbftContext> validator =
         IbftBlockHeaderValidationRulesetFactory.ibftBlockHeaderValidator(5);
@@ -246,15 +248,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnGasUsage() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .gasLimit(5_000)
             .gasUsed(6_000)
             .buildHeader();
@@ -270,15 +272,15 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   @Test
   public void ibftValidateHeaderFailsOnGasLimitRange() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
-    final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+    final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(proposerAddress);
 
     final BlockHeader parentHeader =
-        getPresetHeaderBuilder(1, proposerKeyPair, validators, null).buildHeader();
+        getPresetHeaderBuilder(1, proposerNodeKey, validators, null).buildHeader();
     final BlockHeader blockHeader =
-        getPresetHeaderBuilder(2, proposerKeyPair, validators, parentHeader)
+        getPresetHeaderBuilder(2, proposerNodeKey, validators, parentHeader)
             .gasLimit(4999)
             .buildHeader();
 
@@ -293,7 +295,7 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
 
   private BlockHeaderTestFixture getPresetHeaderBuilder(
       final long number,
-      final KeyPair proposerKeyPair,
+      final NodeKey proposerNodeKey,
       final List<Address> validators,
       final BlockHeader parent) {
     final BlockHeaderTestFixture builder = new BlockHeaderTestFixture();
@@ -309,7 +311,7 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
     builder.ommersHash(Hash.EMPTY_LIST_HASH);
     builder.nonce(0);
     builder.difficulty(Difficulty.ONE);
-    builder.coinbase(Util.publicKeyToAddress(proposerKeyPair.getPublicKey()));
+    builder.coinbase(Util.publicKeyToAddress(proposerNodeKey.getPublicKey()));
 
     final IbftExtraData ibftExtraData =
         IbftExtraDataFixture.createExtraData(
@@ -317,7 +319,7 @@ public class IbftBlockHeaderValidationRulesetFactoryTest {
             Bytes.wrap(new byte[IbftExtraData.EXTRA_VANITY_LENGTH]),
             Optional.of(Vote.authVote(Address.fromHexString("1"))),
             validators,
-            singletonList(proposerKeyPair),
+            singletonList(proposerNodeKey),
             0xDEADBEEF);
 
     builder.extraData(ibftExtraData.encode());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataFixture.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftExtraDataFixture.java
@@ -16,8 +16,7 @@ package org.hyperledger.besu.consensus.ibft;
 
 import static java.util.Collections.emptyList;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -37,9 +36,9 @@ public class IbftExtraDataFixture {
       final Bytes vanityData,
       final Optional<Vote> vote,
       final List<Address> validators,
-      final List<KeyPair> committerKeyPairs) {
+      final List<NodeKey> committerNodeKeys) {
 
-    return createExtraData(header, vanityData, vote, validators, committerKeyPairs, 0);
+    return createExtraData(header, vanityData, vote, validators, committerNodeKeys, 0);
   }
 
   public static IbftExtraData createExtraData(
@@ -47,11 +46,11 @@ public class IbftExtraDataFixture {
       final Bytes vanityData,
       final Optional<Vote> vote,
       final List<Address> validators,
-      final List<KeyPair> committerKeyPairs,
+      final List<NodeKey> committerNodeKeys,
       final int roundNumber) {
 
     return createExtraData(
-        header, vanityData, vote, validators, committerKeyPairs, roundNumber, false);
+        header, vanityData, vote, validators, committerNodeKeys, roundNumber, false);
   }
 
   public static IbftExtraData createExtraData(
@@ -59,7 +58,7 @@ public class IbftExtraDataFixture {
       final Bytes vanityData,
       final Optional<Vote> vote,
       final List<Address> validators,
-      final List<KeyPair> committerKeyPairs,
+      final List<NodeKey> committerNodeKeys,
       final int baseRoundNumber,
       final boolean useDifferentRoundNumbersForCommittedSeals) {
 
@@ -69,7 +68,7 @@ public class IbftExtraDataFixture {
     // if useDifferentRoundNumbersForCommittedSeals is true then each committed seal will be
     // calculated for an extraData field with a different round number
     List<Signature> commitSeals =
-        IntStream.range(0, committerKeyPairs.size())
+        IntStream.range(0, committerNodeKeys.size())
             .mapToObj(
                 i -> {
                   final int round =
@@ -89,7 +88,7 @@ public class IbftExtraDataFixture {
                       IbftBlockHashing.calculateDataHashForCommittedSeal(
                           header, extraDataForCommittedSealCalculation);
 
-                  return SECP256K1.sign(headerHashForCommitters, committerKeyPairs.get(i));
+                  return committerNodeKeys.get(i).sign(headerHashForCommitters);
                 })
             .collect(Collectors.toList());
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
@@ -22,7 +22,8 @@ import org.hyperledger.besu.consensus.ibft.messagedata.RoundChangeMessageData;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.IbftMessage;
 import org.hyperledger.besu.consensus.ibft.network.MockPeerFactory;
 import org.hyperledger.besu.consensus.ibft.network.ValidatorMulticaster;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
@@ -52,8 +53,8 @@ public class IbftGossipTest {
   }
 
   private <P extends IbftMessage<?>> void assertRebroadcastToAllExceptSignerAndSender(
-      final Function<KeyPair, P> createPayload, final Function<P, MessageData> createMessageData) {
-    final KeyPair keypair = KeyPair.generate();
+      final Function<NodeKey, P> createPayload, final Function<P, MessageData> createMessageData) {
+    final NodeKey keypair = BouncyCastleNodeKey.generate();
     final P payload = createPayload.apply(keypair);
     final MessageData messageData = createMessageData.apply(payload);
     final Message message = new DefaultMessage(peerConnection, messageData);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
@@ -54,8 +54,8 @@ public class IbftGossipTest {
 
   private <P extends IbftMessage<?>> void assertRebroadcastToAllExceptSignerAndSender(
       final Function<NodeKey, P> createPayload, final Function<P, MessageData> createMessageData) {
-    final NodeKey keypair = BouncyCastleNodeKey.generate();
-    final P payload = createPayload.apply(keypair);
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
+    final P payload = createPayload.apply(nodeKey);
     final MessageData messageData = createMessageData.apply(payload);
     final Message message = new DefaultMessage(peerConnection, messageData);
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -86,9 +87,8 @@ public class IbftHelpersTest {
     // sources, it is only responsible for determine which of the list or RoundChange messages
     // contains the newest
     // NOTE: This capability is tested as part of the NewRoundMessageValidationTests.
-    final KeyPair proposerKey = KeyPair.generate();
-    final MessageFactory proposerMessageFactory =
-        new MessageFactory(new BouncyCastleNodeKey(proposerKey));
+    final NodeKey proposerKey = BouncyCastleNodeKey.generate();
+    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
     final Block proposedBlock = mock(Block.class);
     when(proposedBlock.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
@@ -139,9 +139,8 @@ public class IbftHelpersTest {
 
   @Test
   public void allRoundChangeHaveNoPreparedReturnsEmptyOptional() {
-    final KeyPair proposerKey = KeyPair.generate();
-    final MessageFactory proposerMessageFactory =
-        new MessageFactory(new BouncyCastleNodeKey(proposerKey));
+    final NodeKey proposerKey = BouncyCastleNodeKey.generate();
+    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
 
     final Optional<PreparedCertificate> newestCert =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftHelpersTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -86,7 +87,8 @@ public class IbftHelpersTest {
     // contains the newest
     // NOTE: This capability is tested as part of the NewRoundMessageValidationTests.
     final KeyPair proposerKey = KeyPair.generate();
-    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+    final MessageFactory proposerMessageFactory =
+        new MessageFactory(new BouncyCastleNodeKey(proposerKey));
     final Block proposedBlock = mock(Block.class);
     when(proposedBlock.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
@@ -138,7 +140,8 @@ public class IbftHelpersTest {
   @Test
   public void allRoundChangeHaveNoPreparedReturnsEmptyOptional() {
     final KeyPair proposerKey = KeyPair.generate();
-    final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+    final MessageFactory proposerMessageFactory =
+        new MessageFactory(new BouncyCastleNodeKey(proposerKey));
     final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 4);
 
     final Optional<PreparedCertificate> newestCert =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/TestHelpers.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/TestHelpers.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
-import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
@@ -64,13 +63,13 @@ public class TestHelpers {
     return new BlockDataGenerator().block(blockOptions);
   }
 
-  public static Proposal createSignedProposalPayload(final KeyPair signerKeys) {
-    return createSignedProposalPayloadWithRound(signerKeys, 0xFEDCBA98);
+  public static Proposal createSignedProposalPayload(final NodeKey signerNodeKey) {
+    return createSignedProposalPayloadWithRound(signerNodeKey, 0xFEDCBA98);
   }
 
   public static Proposal createSignedProposalPayloadWithRound(
-      final KeyPair signerKeys, final int round) {
-    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
+      final NodeKey signerNodeKey, final int round) {
+    final MessageFactory messageFactory = new MessageFactory(signerNodeKey);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, round);
     final Block block =
@@ -78,15 +77,15 @@ public class TestHelpers {
     return messageFactory.createProposal(roundIdentifier, block, Optional.empty());
   }
 
-  public static Prepare createSignedPreparePayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
+  public static Prepare createSignedPreparePayload(final NodeKey signerKeys) {
+    final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createPrepare(roundIdentifier, Hash.fromHexStringLenient("0"));
   }
 
-  public static Commit createSignedCommitPayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
+  public static Commit createSignedCommitPayload(final NodeKey signerKeys) {
+    final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createCommit(
@@ -95,8 +94,8 @@ public class TestHelpers {
         Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0));
   }
 
-  public static RoundChange createSignedRoundChangePayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
+  public static RoundChange createSignedRoundChangePayload(final NodeKey signerKeys) {
+    final MessageFactory messageFactory = new MessageFactory(signerKeys);
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createRoundChange(roundIdentifier, Optional.empty());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/TestHelpers.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/TestHelpers.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -69,7 +70,7 @@ public class TestHelpers {
 
   public static Proposal createSignedProposalPayloadWithRound(
       final KeyPair signerKeys, final int round) {
-    final MessageFactory messageFactory = new MessageFactory(signerKeys);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, round);
     final Block block =
@@ -78,14 +79,14 @@ public class TestHelpers {
   }
 
   public static Prepare createSignedPreparePayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(signerKeys);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createPrepare(roundIdentifier, Hash.fromHexStringLenient("0"));
   }
 
   public static Commit createSignedCommitPayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(signerKeys);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createCommit(
@@ -95,7 +96,7 @@ public class TestHelpers {
   }
 
   public static RoundChange createSignedRoundChangePayload(final KeyPair signerKeys) {
-    final MessageFactory messageFactory = new MessageFactory(signerKeys);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(signerKeys));
     final ConsensusRoundIdentifier roundIdentifier =
         new ConsensusRoundIdentifier(0x1234567890ABCDEFL, 0xFEDCBA98);
     return messageFactory.createRoundChange(roundIdentifier, Optional.empty());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/HeaderValidationTestHelpers.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/HeaderValidationTestHelpers.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.consensus.ibft.headervalidationrules;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
 import org.hyperledger.besu.consensus.ibft.IbftExtraDataFixture;
 import org.hyperledger.besu.consensus.ibft.Vote;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -31,7 +31,7 @@ public class HeaderValidationTestHelpers {
 
   public static BlockHeader createProposedBlockHeader(
       final List<Address> validators,
-      final List<KeyPair> committerKeyPairs,
+      final List<NodeKey> committerNodeKeys,
       final boolean useDifferentRoundNumbersForCommittedSeals) {
     final int BASE_ROUND_NUMBER = 5;
     final BlockHeaderTestFixture builder = new BlockHeaderTestFixture();
@@ -45,7 +45,7 @@ public class HeaderValidationTestHelpers {
             Bytes.wrap(new byte[IbftExtraData.EXTRA_VANITY_LENGTH]),
             Optional.of(Vote.authVote(Address.fromHexString("1"))),
             validators,
-            committerKeyPairs,
+            committerNodeKeys,
             BASE_ROUND_NUMBER,
             useDifferentRoundNumbersForCommittedSeals);
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCoinbaseValidationRuleTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCoinbaseValidationRuleTest.java
@@ -21,7 +21,8 @@ import org.hyperledger.besu.consensus.ibft.IbftContext;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
 import org.hyperledger.besu.consensus.ibft.IbftExtraDataFixture;
 import org.hyperledger.besu.consensus.ibft.Vote;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -39,13 +40,13 @@ import org.junit.Test;
 public class IbftCoinbaseValidationRuleTest {
 
   public static BlockHeader createProposedBlockHeader(
-      final KeyPair proposerKeyPair,
+      final NodeKey proposerNodeKey,
       final List<Address> validators,
-      final List<KeyPair> committerKeyPairs) {
+      final List<NodeKey> committerNodeKeys) {
 
     final BlockHeaderTestFixture builder = new BlockHeaderTestFixture();
     builder.number(1); // must NOT be block 0, as that should not contain seals at all
-    builder.coinbase(Util.publicKeyToAddress(proposerKeyPair.getPublicKey()));
+    builder.coinbase(Util.publicKeyToAddress(proposerNodeKey.getPublicKey()));
     final BlockHeader header = builder.buildHeader();
 
     final IbftExtraData ibftExtraData =
@@ -54,7 +55,7 @@ public class IbftCoinbaseValidationRuleTest {
             Bytes.wrap(new byte[IbftExtraData.EXTRA_VANITY_LENGTH]),
             Optional.of(Vote.authVote(Address.fromHexString("1"))),
             validators,
-            committerKeyPairs);
+            committerNodeKeys);
 
     builder.extraData(ibftExtraData.encode());
     return builder.buildHeader();
@@ -62,42 +63,42 @@ public class IbftCoinbaseValidationRuleTest {
 
   @Test
   public void proposerInValidatorListPassesValidation() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
     final Address proposerAddress =
-        Address.extract(Hash.hash(proposerKeyPair.getPublicKey().getEncodedBytes()));
+        Address.extract(Hash.hash(proposerNodeKey.getPublicKey().getEncodedBytes()));
 
     final List<Address> validators = Lists.newArrayList(proposerAddress);
 
-    final List<KeyPair> committers = Lists.newArrayList(proposerKeyPair);
+    final List<NodeKey> committers = Lists.newArrayList(proposerNodeKey);
 
     final ProtocolContext<IbftContext> context =
         new ProtocolContext<>(null, null, setupContextWithValidators(validators));
 
     final IbftCoinbaseValidationRule coinbaseValidationRule = new IbftCoinbaseValidationRule();
 
-    BlockHeader header = createProposedBlockHeader(proposerKeyPair, validators, committers);
+    BlockHeader header = createProposedBlockHeader(proposerNodeKey, validators, committers);
 
     assertThat(coinbaseValidationRule.validate(header, null, context)).isTrue();
   }
 
   @Test
   public void proposerNotInValidatorListFailsValidation() {
-    final KeyPair proposerKeyPair = KeyPair.generate();
+    final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
 
-    final KeyPair otherValidatorKeyPair = KeyPair.generate();
+    final NodeKey otherValidatorNodeKey = BouncyCastleNodeKey.generate();
     final Address otherValidatorNodeAddress =
-        Address.extract(Hash.hash(otherValidatorKeyPair.getPublicKey().getEncodedBytes()));
+        Address.extract(Hash.hash(otherValidatorNodeKey.getPublicKey().getEncodedBytes()));
 
     final List<Address> validators = Lists.newArrayList(otherValidatorNodeAddress);
 
-    final List<KeyPair> committers = Lists.newArrayList(otherValidatorKeyPair);
+    final List<NodeKey> committers = Lists.newArrayList(otherValidatorNodeKey);
 
     final ProtocolContext<IbftContext> context =
         new ProtocolContext<>(null, null, setupContextWithValidators(validators));
 
     final IbftCoinbaseValidationRule coinbaseValidationRule = new IbftCoinbaseValidationRule();
 
-    BlockHeader header = createProposedBlockHeader(proposerKeyPair, validators, committers);
+    BlockHeader header = createProposedBlockHeader(proposerNodeKey, validators, committers);
 
     assertThat(coinbaseValidationRule.validate(header, null, context)).isFalse();
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCommitSealsValidationRuleTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCommitSealsValidationRuleTest.java
@@ -22,7 +22,8 @@ import static org.hyperledger.besu.consensus.ibft.headervalidationrules.HeaderVa
 
 import org.hyperledger.besu.consensus.ibft.IbftContext;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -44,11 +45,13 @@ public class IbftCommitSealsValidationRuleTest {
 
   @Test
   public void correctlyConstructedHeaderPassesValidation() {
-    final List<KeyPair> committerKeyPairs =
-        IntStream.range(0, 2).mapToObj(i -> KeyPair.generate()).collect(Collectors.toList());
+    final List<NodeKey> committerNodeKeys =
+        IntStream.range(0, 2)
+            .mapToObj(i -> BouncyCastleNodeKey.generate())
+            .collect(Collectors.toList());
 
     final List<Address> committerAddresses =
-        committerKeyPairs.stream()
+        committerNodeKeys.stream()
             .map(keyPair -> Util.publicKeyToAddress(keyPair.getPublicKey()))
             .sorted()
             .collect(Collectors.toList());
@@ -56,16 +59,16 @@ public class IbftCommitSealsValidationRuleTest {
     final ProtocolContext<IbftContext> context =
         new ProtocolContext<>(null, null, setupContextWithValidators(committerAddresses));
 
-    BlockHeader header = createProposedBlockHeader(committerAddresses, committerKeyPairs, false);
+    BlockHeader header = createProposedBlockHeader(committerAddresses, committerNodeKeys, false);
 
     assertThat(commitSealsValidationRule.validate(header, null, context)).isTrue();
   }
 
   @Test
   public void insufficientCommitSealsFailsValidation() {
-    final KeyPair committerKeyPair = KeyPair.generate();
+    final NodeKey committerNodeKey = BouncyCastleNodeKey.generate();
     final Address committerAddress =
-        Address.extract(Hash.hash(committerKeyPair.getPublicKey().getEncodedBytes()));
+        Address.extract(Hash.hash(committerNodeKey.getPublicKey().getEncodedBytes()));
 
     final List<Address> validators = singletonList(committerAddress);
     final ProtocolContext<IbftContext> context =
@@ -82,16 +85,16 @@ public class IbftCommitSealsValidationRuleTest {
 
   @Test
   public void committerNotInValidatorListFailsValidation() {
-    final KeyPair committerKeyPair = KeyPair.generate();
-    final Address committerAddress = Util.publicKeyToAddress(committerKeyPair.getPublicKey());
+    final NodeKey committerNodeKey = BouncyCastleNodeKey.generate();
+    final Address committerAddress = Util.publicKeyToAddress(committerNodeKey.getPublicKey());
 
     final List<Address> validators = singletonList(committerAddress);
 
     // Insert an extraData block with committer seals.
-    final KeyPair nonValidatorKeyPair = KeyPair.generate();
+    final NodeKey nonValidatorNodeKey = BouncyCastleNodeKey.generate();
 
     final BlockHeader header =
-        createProposedBlockHeader(validators, singletonList(nonValidatorKeyPair), false);
+        createProposedBlockHeader(validators, singletonList(nonValidatorNodeKey), false);
 
     final ProtocolContext<IbftContext> context =
         new ProtocolContext<>(null, null, setupContextWithValidators(validators));
@@ -140,12 +143,12 @@ public class IbftCommitSealsValidationRuleTest {
 
   @Test
   public void headerContainsDuplicateSealsFailsValidation() {
-    final KeyPair committerKeyPair = KeyPair.generate();
+    final NodeKey committerNodeKey = BouncyCastleNodeKey.generate();
     final List<Address> validators =
-        singletonList(Util.publicKeyToAddress(committerKeyPair.getPublicKey()));
+        singletonList(Util.publicKeyToAddress(committerNodeKey.getPublicKey()));
     final BlockHeader header =
         createProposedBlockHeader(
-            validators, Lists.newArrayList(committerKeyPair, committerKeyPair), false);
+            validators, Lists.newArrayList(committerNodeKey, committerNodeKey), false);
 
     final ProtocolContext<IbftContext> context =
         new ProtocolContext<>(null, null, setupContextWithValidators(validators));
@@ -159,12 +162,12 @@ public class IbftCommitSealsValidationRuleTest {
       final boolean useDifferentRoundNumbersForCommittedSeals) {
 
     final List<Address> validators = Lists.newArrayList();
-    final List<KeyPair> committerKeys = Lists.newArrayList();
+    final List<NodeKey> committerKeys = Lists.newArrayList();
 
     for (int i = 0; i < validatorCount; i++) { // need -1 to account for proposer
-      final KeyPair committerKeyPair = KeyPair.generate();
-      committerKeys.add(committerKeyPair);
-      validators.add(Address.extract(Hash.hash(committerKeyPair.getPublicKey().getEncodedBytes())));
+      final NodeKey committerNodeKey = BouncyCastleNodeKey.generate();
+      committerKeys.add(committerNodeKey);
+      validators.add(Address.extract(Hash.hash(committerNodeKey.getPublicKey().getEncodedBytes())));
     }
 
     Collections.sort(validators);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCommitSealsValidationRuleTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/headervalidationrules/IbftCommitSealsValidationRuleTest.java
@@ -52,7 +52,7 @@ public class IbftCommitSealsValidationRuleTest {
 
     final List<Address> committerAddresses =
         committerNodeKeys.stream()
-            .map(keyPair -> Util.publicKeyToAddress(keyPair.getPublicKey()))
+            .map(nodeKey -> Util.publicKeyToAddress(nodeKey.getPublicKey()))
             .sorted()
             .collect(Collectors.toList());
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
@@ -131,18 +131,18 @@ public class IbftGetSignerMetricsTest {
     final List<SignerMetricResult> signerMetricResultList = new ArrayList<>();
 
     // sign a first block with keypairs number 1
-    final SignerMetricResult signerMetricResultFirstKeyPairs = generateBlock(startBlock);
-    signerMetricResultList.add(signerMetricResultFirstKeyPairs);
+    final SignerMetricResult signerMetricResultFirstNodeKeys = generateBlock(startBlock);
+    signerMetricResultList.add(signerMetricResultFirstNodeKeys);
     // sign a second block with keypairs number 2
-    final SignerMetricResult signerMetricResultSecondKeyPairs = generateBlock(startBlock + 1);
-    signerMetricResultList.add(signerMetricResultSecondKeyPairs);
+    final SignerMetricResult signerMetricResultSecondNodeKeys = generateBlock(startBlock + 1);
+    signerMetricResultList.add(signerMetricResultSecondNodeKeys);
     // sign a third block with keypairs number 3
-    final SignerMetricResult signerMetricResultThirdKeyPairs = generateBlock(startBlock + 2);
-    signerMetricResultList.add(signerMetricResultThirdKeyPairs);
+    final SignerMetricResult signerMetricResultThirdNodeKeys = generateBlock(startBlock + 2);
+    signerMetricResultList.add(signerMetricResultThirdNodeKeys);
     // sign the last block with the keypairs number 1
     generateBlock(startBlock + 3);
-    signerMetricResultFirstKeyPairs.setLastProposedBlockNumber(startBlock + 3);
-    signerMetricResultFirstKeyPairs.incrementeNbBlock();
+    signerMetricResultFirstNodeKeys.setLastProposedBlockNumber(startBlock + 3);
+    signerMetricResultFirstNodeKeys.incrementeNbBlock();
 
     final JsonRpcRequestContext request = requestWithParams();
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/jsonrpc/methods/IbftGetSignerMetricsTest.java
@@ -130,16 +130,16 @@ public class IbftGetSignerMetricsTest {
 
     final List<SignerMetricResult> signerMetricResultList = new ArrayList<>();
 
-    // sign a first block with keypairs number 1
+    // sign a first block with nodekey number 1
     final SignerMetricResult signerMetricResultFirstNodeKeys = generateBlock(startBlock);
     signerMetricResultList.add(signerMetricResultFirstNodeKeys);
-    // sign a second block with keypairs number 2
+    // sign a second block with nodekey number 2
     final SignerMetricResult signerMetricResultSecondNodeKeys = generateBlock(startBlock + 1);
     signerMetricResultList.add(signerMetricResultSecondNodeKeys);
-    // sign a third block with keypairs number 3
+    // sign a third block with nodekey number 3
     final SignerMetricResult signerMetricResultThirdNodeKeys = generateBlock(startBlock + 2);
     signerMetricResultList.add(signerMetricResultThirdNodeKeys);
-    // sign the last block with the keypairs number 1
+    // sign the last block with the nodekey number 1
     generateBlock(startBlock + 3);
     signerMetricResultFirstNodeKeys.setLastProposedBlockNumber(startBlock + 3);
     signerMetricResultFirstNodeKeys.incrementeNbBlock();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.consensus.ibft.IbftBlockHashing;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
@@ -51,7 +52,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftQueryServiceImplTest {
 
   @Mock private Blockchain blockchain;
-  @Mock private KeyPair keyPair;
+  @Mock private NodeKey nodeKey;
 
   private final List<KeyPair> validatorKeys =
       Lists.newArrayList(KeyPair.generate(), KeyPair.generate());
@@ -109,7 +110,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void roundNumberFromBlockIsReturned() {
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, keyPair);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
 
     assertThat(service.getRoundNumberFrom(blockHeader)).isEqualTo(ROUND_NUMBER_IN_BLOCK);
   }
@@ -121,7 +122,7 @@ public class IbftQueryServiceImplTest {
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, keyPair);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> service.getRoundNumberFrom(header));
   }
@@ -129,7 +130,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void getSignersReturnsAddressesOfSignersInBlock() {
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, keyPair);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
 
     final List<Address> signers =
         signingKeys.stream()
@@ -146,7 +147,7 @@ public class IbftQueryServiceImplTest {
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, keyPair);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> service.getSignersFrom(header));
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
@@ -131,7 +131,7 @@ public class IbftQueryServiceImplTest {
 
     final List<Address> signers =
         signingKeys.stream()
-            .map(keyPair -> Util.publicKeyToAddress(keyPair.getPublicKey()))
+            .map(nodeKey -> Util.publicKeyToAddress(nodeKey.getPublicKey()))
             .collect(Collectors.toList());
 
     assertThat(service.getSignersFrom(blockHeader)).containsExactlyElementsOf(signers);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
@@ -22,9 +22,8 @@ import org.hyperledger.besu.consensus.ibft.IbftBlockHashing;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.consensus.ibft.IbftExtraData;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -52,12 +51,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftQueryServiceImplTest {
 
   @Mock private Blockchain blockchain;
-  @Mock private NodeKey nodeKey;
+  
+  private final List<NodeKey> validatorKeys =
+      Lists.newArrayList(BouncyCastleNodeKey.generate(), BouncyCastleNodeKey.generate());
 
-  private final List<KeyPair> validatorKeys =
-      Lists.newArrayList(KeyPair.generate(), KeyPair.generate());
-
-  private final List<KeyPair> signingKeys = Lists.newArrayList(validatorKeys.get(0));
+  private final List<NodeKey> signingKeys = Lists.newArrayList(validatorKeys.get(0));
   private final int ROUND_NUMBER_IN_BLOCK = 5;
 
   private IbftExtraData signedExtraData;
@@ -89,10 +87,9 @@ public class IbftQueryServiceImplTest {
     final Collection<Signature> validatorSignatures =
         signingKeys.stream()
             .map(
-                keyPair ->
-                    SECP256K1.sign(
-                        IbftBlockHashing.calculateDataHashForCommittedSeal(unsignedBlockHeader),
-                        keyPair))
+                nodeKey ->
+                    nodeKey.sign(
+                        IbftBlockHashing.calculateDataHashForCommittedSeal(unsignedBlockHeader)))
             .collect(Collectors.toList());
 
     signedExtraData =
@@ -110,7 +107,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void roundNumberFromBlockIsReturned() {
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, null);
 
     assertThat(service.getRoundNumberFrom(blockHeader)).isEqualTo(ROUND_NUMBER_IN_BLOCK);
   }
@@ -122,7 +119,7 @@ public class IbftQueryServiceImplTest {
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, null);
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> service.getRoundNumberFrom(header));
   }
@@ -130,7 +127,7 @@ public class IbftQueryServiceImplTest {
   @Test
   public void getSignersReturnsAddressesOfSignersInBlock() {
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, null);
 
     final List<Address> signers =
         signingKeys.stream()
@@ -147,7 +144,7 @@ public class IbftQueryServiceImplTest {
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.empty());
 
     final IbftQueryService service =
-        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, nodeKey);
+        new IbftQueryServiceImpl(new IbftBlockInterface(), blockchain, null);
     assertThatExceptionOfType(RuntimeException.class)
         .isThrownBy(() -> service.getSignersFrom(header));
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/queries/IbftQueryServiceImplTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftQueryServiceImplTest {
 
   @Mock private Blockchain blockchain;
-  
+
   private final List<NodeKey> validatorKeys =
       Lists.newArrayList(BouncyCastleNodeKey.generate(), BouncyCastleNodeKey.generate());
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -82,8 +82,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class IbftBlockHeightManagerTest {
 
-  private final KeyPair localNodeKeys = KeyPair.generate();
-  private final NodeKey nodeKey = new BouncyCastleNodeKey(localNodeKeys);
+  private final NodeKey nodeKey = BouncyCastleNodeKey.generate();
   private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final BlockHeaderTestFixture headerTestFixture = new BlockHeaderTestFixture();
 
@@ -121,9 +120,9 @@ public class IbftBlockHeightManagerTest {
   @Before
   public void setup() {
     for (int i = 0; i < 3; i++) {
-      final KeyPair key = KeyPair.generate();
-      validators.add(Util.publicKeyToAddress(key.getPublicKey()));
-      validatorMessageFactory.add(new MessageFactory(new BouncyCastleNodeKey(key)));
+      final BouncyCastleNodeKey nodeKey = BouncyCastleNodeKey.generate();
+      validators.add(Util.publicKeyToAddress(nodeKey.getPublicKey()));
+      validatorMessageFactory.add(new MessageFactory(nodeKey));
     }
 
     buildCreatedBlock();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -49,7 +49,6 @@ import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -47,6 +47,8 @@ import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -81,7 +83,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftBlockHeightManagerTest {
 
   private final KeyPair localNodeKeys = KeyPair.generate();
-  private final MessageFactory messageFactory = new MessageFactory(localNodeKeys);
+  private final NodeKey nodeKey = new BouncyCastleNodeKey(localNodeKeys);
+  private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final BlockHeaderTestFixture headerTestFixture = new BlockHeaderTestFixture();
 
   @Mock private IbftFinalState finalState;
@@ -120,7 +123,7 @@ public class IbftBlockHeightManagerTest {
     for (int i = 0; i < 3; i++) {
       final KeyPair key = KeyPair.generate();
       validators.add(Util.publicKeyToAddress(key.getPublicKey()));
-      validatorMessageFactory.add(new MessageFactory(key));
+      validatorMessageFactory.add(new MessageFactory(new BouncyCastleNodeKey(key)));
     }
 
     buildCreatedBlock();
@@ -156,7 +159,7 @@ public class IbftBlockHeightManagerTest {
                   protocolContext,
                   blockImporter,
                   Subscribers.create(),
-                  localNodeKeys,
+                  nodeKey,
                   messageFactory,
                   messageTransmitter,
                   roundTimer);
@@ -172,7 +175,7 @@ public class IbftBlockHeightManagerTest {
                   protocolContext,
                   blockImporter,
                   Subscribers.create(),
-                  localNodeKeys,
+                  nodeKey,
                   messageFactory,
                   messageTransmitter,
                   roundTimer);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -36,7 +36,8 @@ import org.hyperledger.besu.consensus.ibft.network.IbftMessageTransmitter;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
@@ -68,8 +69,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftRoundTest {
 
   private final KeyPair localNodeKeys = KeyPair.generate();
+  private final NodeKey nodeKey = new BouncyCastleNodeKey(localNodeKeys);
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
-  private final MessageFactory messageFactory = new MessageFactory(localNodeKeys);
+  private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();
   private ProtocolContext<IbftContext> protocolContext;
 
@@ -125,7 +127,7 @@ public class IbftRoundTest {
         protocolContext,
         blockImporter,
         subscribers,
-        localNodeKeys,
+        nodeKey,
         messageFactory,
         transmitter,
         roundTimer);
@@ -142,7 +144,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -163,7 +165,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -185,7 +187,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -207,7 +209,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -215,7 +217,7 @@ public class IbftRoundTest {
     final Hash commitSealHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(
             proposedBlock.getHeader(), proposedExtraData);
-    final Signature localCommitSeal = SECP256K1.sign(commitSealHash, localNodeKeys);
+    final Signature localCommitSeal = nodeKey.sign(commitSealHash);
 
     // Receive Proposal Message
     round.handleProposalMessage(
@@ -250,7 +252,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -258,7 +260,7 @@ public class IbftRoundTest {
     final Hash commitSealHash =
         IbftBlockHashing.calculateDataHashForCommittedSeal(
             proposedBlock.getHeader(), proposedExtraData);
-    final Signature localCommitSeal = SECP256K1.sign(commitSealHash, localNodeKeys);
+    final Signature localCommitSeal = nodeKey.sign(commitSealHash);
 
     round.createAndSendProposalMessage(15);
     verify(transmitter, never()).multicastCommit(any(), any(), any());
@@ -286,7 +288,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -309,7 +311,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -355,7 +357,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -388,7 +390,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -408,7 +410,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);
@@ -433,7 +435,7 @@ public class IbftRoundTest {
             protocolContext,
             blockImporter,
             subscribers,
-            localNodeKeys,
+            nodeKey,
             messageFactory,
             transmitter,
             roundTimer);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -26,10 +26,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Optional;
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHashing;
 import org.hyperledger.besu.consensus.ibft.IbftContext;
@@ -54,6 +50,12 @@ import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.util.Subscribers;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -26,6 +26,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHashing;
 import org.hyperledger.besu.consensus.ibft.IbftContext;
@@ -38,7 +42,6 @@ import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
@@ -51,12 +54,6 @@ import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.util.Subscribers;
-
-import java.math.BigInteger;
-import java.util.Collections;
-import java.util.Optional;
-
-import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,8 +65,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class IbftRoundTest {
 
-  private final KeyPair localNodeKeys = KeyPair.generate();
-  private final NodeKey nodeKey = new BouncyCastleNodeKey(localNodeKeys);
+  private final NodeKey nodeKey = BouncyCastleNodeKey.generate();
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
   private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
 import java.util.List;

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
@@ -44,8 +45,8 @@ public class RoundChangeArtifactsTest {
   @Before
   public void setup() {
     for (int i = 0; i < 4; i++) {
-      final KeyPair keyPair = KeyPair.generate();
-      final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(keyPair));
+      final NodeKey keyPair = BouncyCastleNodeKey.generate();
+      final MessageFactory messageFactory = new MessageFactory(keyPair);
       messageFactories.add(messageFactory);
     }
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
@@ -44,7 +45,7 @@ public class RoundChangeArtifactsTest {
   public void setup() {
     for (int i = 0; i < 4; i++) {
       final KeyPair keyPair = KeyPair.generate();
-      final MessageFactory messageFactory = new MessageFactory(keyPair);
+      final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(keyPair));
       messageFactories.add(messageFactory);
     }
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeArtifactsTest.java
@@ -44,8 +44,8 @@ public class RoundChangeArtifactsTest {
   @Before
   public void setup() {
     for (int i = 0; i < 4; i++) {
-      final NodeKey keyPair = BouncyCastleNodeKey.generate();
-      final MessageFactory messageFactory = new MessageFactory(keyPair);
+      final NodeKey nodeKey = BouncyCastleNodeKey.generate();
+      final MessageFactory messageFactory = new MessageFactory(nodeKey);
       messageFactories.add(messageFactory);
     }
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.consensus.ibft.validation.ProposalBlockConsistencyVa
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangeMessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator;
 import org.hyperledger.besu.consensus.ibft.validation.SignedDataValidator;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
@@ -112,7 +113,7 @@ public class RoundChangeManagerTest {
 
   private RoundChange makeRoundChangeMessage(
       final KeyPair key, final ConsensusRoundIdentifier round) {
-    final MessageFactory messageFactory = new MessageFactory(key);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(key));
     return messageFactory.createRoundChange(round, Optional.empty());
   }
 
@@ -122,7 +123,7 @@ public class RoundChangeManagerTest {
       final List<KeyPair> prepareProviders) {
     Preconditions.checkArgument(!prepareProviders.contains(key));
 
-    final MessageFactory messageFactory = new MessageFactory(key);
+    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(key));
 
     final ConsensusRoundIdentifier proposalRound = TestHelpers.createFrom(round, 0, -1);
     final Block block = TestHelpers.createProposalBlock(validators, proposalRound);
@@ -133,7 +134,8 @@ public class RoundChangeManagerTest {
         prepareProviders.stream()
             .map(
                 k -> {
-                  final MessageFactory prepareFactory = new MessageFactory(k);
+                  final MessageFactory prepareFactory =
+                      new MessageFactory(new BouncyCastleNodeKey(k));
                   return prepareFactory.createPrepare(proposalRound, block.getHash());
                 })
             .collect(Collectors.toList());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -19,12 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftContext;
 import org.hyperledger.besu.consensus.ibft.IbftHelpers;
@@ -44,6 +38,14 @@ import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -121,7 +123,7 @@ public class RoundChangeManagerTest {
       final List<NodeKey> prepareProviders) {
     Preconditions.checkArgument(!prepareProviders.contains(key));
 
-    final MessageFactory messageFactory = new MessageFactory(new BouncyCastleNodeKey(key));
+    final MessageFactory messageFactory = new MessageFactory(key);
 
     final ConsensusRoundIdentifier proposalRound = TestHelpers.createFrom(round, 0, -1);
     final Block block = TestHelpers.createProposalBlock(validators, proposalRound);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundStateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundStateTest.java
@@ -27,7 +27,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -48,7 +48,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class RoundStateTest {
 
-  private final List<KeyPair> validatorKeys = Lists.newArrayList();
+  private final List<NodeKey> validatorKeys = Lists.newArrayList();
   private final List<MessageFactory> validatorMessageFactories = Lists.newArrayList();
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
 
@@ -61,10 +61,10 @@ public class RoundStateTest {
   @Before
   public void setup() {
     for (int i = 0; i < 3; i++) {
-      final KeyPair newKeyPair = KeyPair.generate();
-      validatorKeys.add(newKeyPair);
-      validators.add(Util.publicKeyToAddress(newKeyPair.getPublicKey()));
-      validatorMessageFactories.add(new MessageFactory(new BouncyCastleNodeKey(newKeyPair)));
+      final NodeKey newNodeKey = BouncyCastleNodeKey.generate();
+      validatorKeys.add(newNodeKey);
+      validators.add(Util.publicKeyToAddress(newNodeKey.getPublicKey()));
+      validatorMessageFactories.add(new MessageFactory(newNodeKey));
     }
     when(block.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundStateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundStateTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidator;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -63,7 +64,7 @@ public class RoundStateTest {
       final KeyPair newKeyPair = KeyPair.generate();
       validatorKeys.add(newKeyPair);
       validators.add(Util.publicKeyToAddress(newKeyPair.getPublicKey()));
-      validatorMessageFactories.add(new MessageFactory(newKeyPair));
+      validatorMessageFactories.add(new MessageFactory(new BouncyCastleNodeKey(newKeyPair)));
     }
     when(block.getHash()).thenReturn(Hash.fromHexStringLenient("1"));
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/FutureRoundProposalMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/FutureRoundProposalMessageValidatorTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -38,8 +39,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class FutureRoundProposalMessageValidatorTest {
 
-  private final KeyPair proposerKey = KeyPair.generate();
-  private final MessageFactory messageFactoy = new MessageFactory(proposerKey);
+  private final MessageFactory messageFactoy =
+      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
   private final Block proposedBlock = TestHelpers.createProposalBlock(emptyList(), roundIdentifier);
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/FutureRoundProposalMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/FutureRoundProposalMessageValidatorTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
@@ -39,8 +38,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class FutureRoundProposalMessageValidatorTest {
 
-  private final MessageFactory messageFactoy =
-      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
+  private final MessageFactory messageFactoy = new MessageFactory(BouncyCastleNodeKey.generate());
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
   private final Block proposedBlock = TestHelpers.createProposalBlock(emptyList(), roundIdentifier);
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
@@ -31,7 +31,8 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
@@ -55,8 +56,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class MessageValidatorTest {
 
-  private final KeyPair keyPair = KeyPair.generate();
-  private final MessageFactory messageFactory = new MessageFactory(keyPair);
+  private final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
+  private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
 
   private final SignedDataValidator signedDataValidator = mock(SignedDataValidator.class);
@@ -120,7 +121,7 @@ public class MessageValidatorTest {
 
     final Commit commit =
         messageFactory.createCommit(
-            roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), keyPair));
+            roundIdentifier, block.getHash(), nodeKey.sign(block.getHash()));
 
     assertThat(messageValidator.validateProposal(proposal)).isTrue();
     verify(signedDataValidator, times(1)).validateProposal(proposal.getSignedPayload());

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.ProtocolContext;

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
@@ -56,7 +56,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class MessageValidatorTest {
 
-  private final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
+  private final NodeKey nodeKey = BouncyCastleNodeKey.generate();
   private final MessageFactory messageFactory = new MessageFactory(nodeKey);
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
 import java.util.Collections;
@@ -65,8 +64,8 @@ public class ProposalBlockConsistencyValidatorTest {
             IbftBlockHeaderFunctions.forCommittedSeal());
 
     assertThat(
-        consistencyChecker.validateProposalMatchesBlock(
-            proposalMsg.getSignedPayload(), misMatchedBlock))
+            consistencyChecker.validateProposalMatchesBlock(
+                proposalMsg.getSignedPayload(), misMatchedBlock))
         .isFalse();
   }
 
@@ -77,7 +76,7 @@ public class ProposalBlockConsistencyValidatorTest {
         proposerMessageFactory.createProposal(futureRound, block, Optional.empty());
 
     assertThat(
-        consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
+            consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
         .isFalse();
   }
 
@@ -88,7 +87,7 @@ public class ProposalBlockConsistencyValidatorTest {
         proposerMessageFactory.createProposal(futureHeight, block, Optional.empty());
 
     assertThat(
-        consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
+            consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
         .isFalse();
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
@@ -38,7 +38,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ProposalBlockConsistencyValidatorTest {
 
   private final MessageFactory proposerMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
+      new MessageFactory(BouncyCastleNodeKey.generate());
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier roundIdentifier =
       new ConsensusRoundIdentifier(chainHeight, 4);
@@ -65,8 +65,8 @@ public class ProposalBlockConsistencyValidatorTest {
             IbftBlockHeaderFunctions.forCommittedSeal());
 
     assertThat(
-            consistencyChecker.validateProposalMatchesBlock(
-                proposalMsg.getSignedPayload(), misMatchedBlock))
+        consistencyChecker.validateProposalMatchesBlock(
+            proposalMsg.getSignedPayload(), misMatchedBlock))
         .isFalse();
   }
 
@@ -77,7 +77,7 @@ public class ProposalBlockConsistencyValidatorTest {
         proposerMessageFactory.createProposal(futureRound, block, Optional.empty());
 
     assertThat(
-            consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
+        consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
         .isFalse();
   }
 
@@ -88,7 +88,7 @@ public class ProposalBlockConsistencyValidatorTest {
         proposerMessageFactory.createProposal(futureHeight, block, Optional.empty());
 
     assertThat(
-            consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
+        consistencyChecker.validateProposalMatchesBlock(proposalMsg.getSignedPayload(), block))
         .isFalse();
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/ProposalBlockConsistencyValidatorTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.consensus.ibft.IbftBlockInterface;
 import org.hyperledger.besu.consensus.ibft.TestHelpers;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Block;
 
@@ -36,8 +37,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ProposalBlockConsistencyValidatorTest {
 
-  private final KeyPair proposerKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+  private final MessageFactory proposerMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier roundIdentifier =
       new ConsensusRoundIdentifier(chainHeight, 4);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator.MessageValidatorForHeightFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -48,7 +47,7 @@ public class RoundChangeCertificateValidatorTest {
   private final NodeKey proposerKey = BouncyCastleNodeKey.generate();
   private final NodeKey validatorKey = BouncyCastleNodeKey.generate();
   private final NodeKey otherValidatorKey = BouncyCastleNodeKey.generate();
-  private final MessageFactory proposerMessageFactory =new MessageFactory(proposerKey);
+  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
   private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
   private final List<Address> validators = Lists.newArrayList();
   private final long chainHeight = 2;

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator.MessageValidatorForHeightFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -46,8 +47,10 @@ public class RoundChangeCertificateValidatorTest {
   private final KeyPair proposerKey = KeyPair.generate();
   private final KeyPair validatorKey = KeyPair.generate();
   private final KeyPair otherValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
-  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
+  private final MessageFactory proposerMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
+  private final MessageFactory validatorMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
   private final List<Address> validators = Lists.newArrayList();
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier roundIdentifier =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeCertificateValidatorTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator.MessageValidatorForHeightFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -44,13 +45,11 @@ import org.junit.Test;
 
 public class RoundChangeCertificateValidatorTest {
 
-  private final KeyPair proposerKey = KeyPair.generate();
-  private final KeyPair validatorKey = KeyPair.generate();
-  private final KeyPair otherValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
-  private final MessageFactory validatorMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
+  private final NodeKey proposerKey = BouncyCastleNodeKey.generate();
+  private final NodeKey validatorKey = BouncyCastleNodeKey.generate();
+  private final NodeKey otherValidatorKey = BouncyCastleNodeKey.generate();
+  private final MessageFactory proposerMessageFactory =new MessageFactory(proposerKey);
+  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
   private final List<Address> validators = Lists.newArrayList();
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier roundIdentifier =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 
 import org.junit.Test;
 
@@ -31,8 +30,7 @@ public class RoundChangeMessageValidatorTest {
 
   private final RoundChangePayloadValidator payloadValidator =
       mock(RoundChangePayloadValidator.class);
-  private final MessageFactory messageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
+  private final MessageFactory messageFactory = new MessageFactory(BouncyCastleNodeKey.generate());
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
 
   private final ProposalBlockConsistencyValidator proposalBlockConsistencyValidator =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeMessageValidatorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.consensus.ibft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 
 import org.junit.Test;
@@ -30,8 +31,8 @@ public class RoundChangeMessageValidatorTest {
 
   private final RoundChangePayloadValidator payloadValidator =
       mock(RoundChangePayloadValidator.class);
-  private final KeyPair keyPair = KeyPair.generate();
-  private final MessageFactory messageFactory = new MessageFactory(keyPair);
+  private final MessageFactory messageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(KeyPair.generate()));
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 1);
 
   private final ProposalBlockConsistencyValidator proposalBlockConsistencyValidator =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator.MessageValidatorForHeightFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -46,15 +46,12 @@ import org.junit.Test;
 
 public class RoundChangeSignedDataValidatorTest {
 
-  private final KeyPair proposerKey = KeyPair.generate();
-  private final KeyPair validatorKey = KeyPair.generate();
-  private final KeyPair nonValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
-  private final MessageFactory validatorMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
-  private final MessageFactory nonValidatorMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(nonValidatorKey));
+  private final NodeKey proposerKey = BouncyCastleNodeKey.generate();
+  private final NodeKey validatorKey = BouncyCastleNodeKey.generate();
+  private final NodeKey nonValidatorKey = BouncyCastleNodeKey.generate();
+  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
+  private final MessageFactory nonValidatorMessageFactory = new MessageFactory(nonValidatorKey);
 
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier currentRound =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/RoundChangeSignedDataValidatorTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.statemachine.PreparedRoundArtifacts;
 import org.hyperledger.besu.consensus.ibft.validation.RoundChangePayloadValidator.MessageValidatorForHeightFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -48,9 +49,12 @@ public class RoundChangeSignedDataValidatorTest {
   private final KeyPair proposerKey = KeyPair.generate();
   private final KeyPair validatorKey = KeyPair.generate();
   private final KeyPair nonValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
-  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
-  private final MessageFactory nonValidatorMessageFactory = new MessageFactory(nonValidatorKey);
+  private final MessageFactory proposerMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
+  private final MessageFactory validatorMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
+  private final MessageFactory nonValidatorMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(nonValidatorKey));
 
   private final long chainHeight = 2;
   private final ConsensusRoundIdentifier currentRound =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -26,8 +26,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -45,15 +44,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SignedDataValidatorTest {
 
-  private final KeyPair proposerKey = KeyPair.generate();
-  private final KeyPair validatorKey = KeyPair.generate();
-  private final KeyPair nonValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
-  private final MessageFactory validatorMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
-  private final MessageFactory nonValidatorMessageFactory =
-      new MessageFactory(new BouncyCastleNodeKey(nonValidatorKey));
+  private final NodeKey proposerKey = BouncyCastleNodeKey.generate();
+  private final NodeKey validatorKey = BouncyCastleNodeKey.generate();
+  private final NodeKey nonValidatorKey = BouncyCastleNodeKey.generate();
+  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
+  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
+  private final MessageFactory nonValidatorMessageFactory = new MessageFactory(nonValidatorKey);
 
   private final List<Address> validators = Lists.newArrayList();
 
@@ -85,7 +81,7 @@ public class SignedDataValidatorTest {
   public void receivingACommitMessageBeforeProposalFails() {
     final Commit commitMsg =
         proposerMessageFactory.createCommit(
-            roundIdentifier, Hash.ZERO, SECP256K1.sign(block.getHash(), proposerKey));
+            roundIdentifier, Hash.ZERO, proposerKey.sign(block.getHash()));
 
     assertThat(validator.validateCommit(commitMsg.getSignedPayload())).isFalse();
   }
@@ -135,7 +131,7 @@ public class SignedDataValidatorTest {
         validatorMessageFactory.createPrepare(invalidRoundIdentifier, block.getHash());
     final Commit commitMsg =
         validatorMessageFactory.createCommit(
-            invalidRoundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), proposerKey));
+            invalidRoundIdentifier, block.getHash(), proposerKey.sign(block.getHash()));
 
     assertThat(validator.validateProposal(proposalMsg.getSignedPayload())).isTrue();
     assertThat(validator.validatePrepare(prepareMsg.getSignedPayload())).isFalse();
@@ -160,7 +156,7 @@ public class SignedDataValidatorTest {
 
     final Commit commitMsg =
         proposerMessageFactory.createCommit(
-            roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), nonValidatorKey));
+            roundIdentifier, block.getHash(), nonValidatorKey.sign(block.getHash()));
 
     assertThat(validator.validateProposal(proposalMsg.getSignedPayload())).isTrue();
     assertThat(validator.validateCommit(commitMsg.getSignedPayload())).isFalse();
@@ -173,11 +169,11 @@ public class SignedDataValidatorTest {
 
     final Commit proposerCommitMsg =
         proposerMessageFactory.createCommit(
-            roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), proposerKey));
+            roundIdentifier, block.getHash(), proposerKey.sign(block.getHash()));
 
     final Commit validatorCommitMsg =
         validatorMessageFactory.createCommit(
-            roundIdentifier, block.getHash(), SECP256K1.sign(block.getHash(), validatorKey));
+            roundIdentifier, block.getHash(), validatorKey.sign(block.getHash()));
 
     assertThat(validator.validateProposal(proposalMsg.getSignedPayload())).isTrue();
     assertThat(validator.validateCommit(proposerCommitMsg.getSignedPayload())).isTrue();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/SignedDataValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/SignedDataValidatorTest.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -47,9 +48,12 @@ public class SignedDataValidatorTest {
   private final KeyPair proposerKey = KeyPair.generate();
   private final KeyPair validatorKey = KeyPair.generate();
   private final KeyPair nonValidatorKey = KeyPair.generate();
-  private final MessageFactory proposerMessageFactory = new MessageFactory(proposerKey);
-  private final MessageFactory validatorMessageFactory = new MessageFactory(validatorKey);
-  private final MessageFactory nonValidatorMessageFactory = new MessageFactory(nonValidatorKey);
+  private final MessageFactory proposerMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(proposerKey));
+  private final MessageFactory validatorMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(validatorKey));
+  private final MessageFactory nonValidatorMessageFactory =
+      new MessageFactory(new BouncyCastleNodeKey(nonValidatorKey));
 
   private final List<Address> validators = Lists.newArrayList();
 

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
@@ -12,25 +12,29 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.ibft.support;
+package org.hyperledger.besu.crypto;
 
-import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
+import org.hyperledger.besu.crypto.SECP256K1.Signature;
 
-public class NodeParams {
-  private final Address address;
-  private final NodeKey nodeKey;
+import org.apache.tuweni.bytes.Bytes32;
 
-  public NodeParams(final Address address, final NodeKey nodeKey) {
-    this.address = address;
-    this.nodeKey = nodeKey;
+public class BouncyCastleNodeKey implements NodeKey {
+
+  private final KeyPair nodeKeys;
+
+  public BouncyCastleNodeKey(final KeyPair nodeKeys) {
+    this.nodeKeys = nodeKeys;
   }
 
-  public Address getAddress() {
-    return address;
+  @Override
+  public Signature sign(final Bytes32 dataHash) {
+    return SECP256K1.sign(dataHash, nodeKeys);
   }
 
-  public NodeKey getnodeKey() {
-    return nodeKey;
+  @Override
+  public PublicKey getPublicKey() {
+    return nodeKeys.getPublicKey();
   }
 }

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
@@ -28,6 +28,10 @@ public class BouncyCastleNodeKey implements NodeKey {
     this.nodeKeys = nodeKeys;
   }
 
+  public static BouncyCastleNodeKey generate() {
+    return new BouncyCastleNodeKey(KeyPair.generate());
+  }
+
   @Override
   public Signature sign(final Bytes32 dataHash) {
     return SECP256K1.sign(dataHash, nodeKeys);

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
@@ -42,7 +42,7 @@ public class KeyPairUtil {
     }
   }
 
-  public static SECP256K1.KeyPair loadKeyPairFromResource(final String resourcePath) {
+  public static NodeKey loadKeyPairFromResource(final String resourcePath) {
     final SECP256K1.KeyPair keyPair;
     String keyData = loadResourceFile(resourcePath);
     if (keyData == null || keyData.isEmpty()) {
@@ -52,10 +52,10 @@ public class KeyPairUtil {
     keyPair = SECP256K1.KeyPair.create(privateKey);
 
     LOG.info("Loaded keyPair {} from {}", keyPair.getPublicKey().toString(), resourcePath);
-    return keyPair;
+    return new BouncyCastleNodeKey(keyPair);
   }
 
-  public static SECP256K1.KeyPair loadKeyPair(final File keyFile) {
+  public static NodeKey loadKeyPair(final File keyFile) {
 
     final SECP256K1.KeyPair key;
     if (keyFile.exists()) {
@@ -74,10 +74,10 @@ public class KeyPairUtil {
           key.getPublicKey().toString(),
           keyFile.getAbsolutePath());
     }
-    return key;
+    return new BouncyCastleNodeKey(key);
   }
 
-  public static SECP256K1.KeyPair loadKeyPair(final Path homeDirectory) {
+  public static NodeKey loadKeyPair(final Path homeDirectory) {
     return loadKeyPair(getDefaultKeyFile(homeDirectory));
   }
 

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
@@ -12,25 +12,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.ibft.support;
+package org.hyperledger.besu.crypto;
 
-import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
+import org.hyperledger.besu.crypto.SECP256K1.Signature;
 
-public class NodeParams {
-  private final Address address;
-  private final NodeKey nodeKey;
+import org.apache.tuweni.bytes.Bytes32;
 
-  public NodeParams(final Address address, final NodeKey nodeKey) {
-    this.address = address;
-    this.nodeKey = nodeKey;
-  }
+public interface NodeKey {
 
-  public Address getAddress() {
-    return address;
-  }
+  Signature sign(Bytes32 dataHash);
 
-  public NodeKey getnodeKey() {
-    return nodeKey;
-  }
+  PublicKey getPublicKey();
 }

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.crypto;
 import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public interface NodeKey {
@@ -24,4 +25,8 @@ public interface NodeKey {
   Signature sign(Bytes32 dataHash);
 
   PublicKey getPublicKey();
+
+  Bytes32 calculateKeyAgreement(final PublicKey partyKey);
+
+  Bytes calculateECIESAgreement(final SECP256K1.PublicKey ephPubKey);
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
@@ -253,7 +254,7 @@ public class JsonRpcHttpServiceRpcApisTest {
     final P2PNetwork p2pNetwork =
         DefaultP2PNetwork.builder()
             .supportedCapabilities(Capability.create("eth", 63))
-            .keyPair(SECP256K1.KeyPair.generate())
+            .nodeKey(new BouncyCastleNodeKey(SECP256K1.KeyPair.generate()))
             .vertx(vertx)
             .config(config)
             .metricsSystem(new NoOpMetricsSystem())

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractIntegrationTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
@@ -96,6 +97,7 @@ public class PrivacyPrecompiledContractIntegrationTest {
             nullable(WorldUpdater.class),
             nullable(WorldUpdater.class),
             nullable(ProcessableBlockHeader.class),
+            nullable(Hash.class),
             nullable(PrivateTransaction.class),
             nullable(Address.class),
             nullable(OperationTracer.class),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/OnChainPrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/OnChainPrivacyPrecompiledContract.java
@@ -85,6 +85,8 @@ public class OnChainPrivacyPrecompiledContract extends PrivacyPrecompiledContrac
       return Bytes.EMPTY;
     }
 
+    final Hash pmtHash = messageFrame.getTransactionHash();
+
     final String key = input.slice(0, 32).toBase64String();
 
     final ReceiveResponse receiveResponse;
@@ -111,10 +113,7 @@ public class OnChainPrivacyPrecompiledContract extends PrivacyPrecompiledContrac
 
     final Bytes32 privacyGroupId = Bytes32.wrap(maybeGroupId.get());
 
-    LOG.debug(
-        "Processing private transaction {} in privacy group {}",
-        privateTransaction.getHash(),
-        privacyGroupId);
+    LOG.debug("Processing private transaction {} in privacy group {}", pmtHash, privacyGroupId);
 
     final ProcessableBlockHeader currentBlockHeader = messageFrame.getBlockHeader();
     final Hash currentBlockHash = ((BlockHeader) currentBlockHeader).getHash();
@@ -153,14 +152,14 @@ public class OnChainPrivacyPrecompiledContract extends PrivacyPrecompiledContrac
     if (result.isInvalid() || !result.isSuccessful()) {
       LOG.error(
           "Failed to process private transaction {}: {}",
-          privateTransaction.getHash(),
+          pmtHash,
           result.getValidationResult().getErrorMessage());
       return Bytes.EMPTY;
     }
 
     if (messageFrame.isPersistingPrivateState()) {
       persistPrivateState(
-          messageFrame.getTransactionHash(),
+          pmtHash,
           currentBlockHash,
           privateTransaction,
           privacyGroupId,
@@ -272,6 +271,7 @@ public class OnChainPrivacyPrecompiledContract extends PrivacyPrecompiledContrac
         publicWorldState,
         canExecuteUpdater,
         currentBlockHeader,
+        messageFrame.getTransactionHash(),
         buildSimulationTransaction(
             privacyGroupId, privateWorldStateUpdater, canExecuteMethodSignature),
         messageFrame.getMiningBeneficiary(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
@@ -109,6 +109,8 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
       return Bytes.EMPTY;
     }
 
+    final Hash pmtHash = messageFrame.getTransactionHash();
+
     final String key = input.toBase64String();
     final ReceiveResponse receiveResponse;
     try {
@@ -127,10 +129,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
     final Bytes32 privacyGroupId =
         Bytes32.wrap(Bytes.fromBase64String(receiveResponse.getPrivacyGroupId()));
 
-    LOG.debug(
-        "Processing private transaction {} in privacy group {}",
-        privateTransaction.getHash(),
-        privacyGroupId);
+    LOG.debug("Processing private transaction {} in privacy group {}", pmtHash, privacyGroupId);
 
     final Hash currentBlockHash = ((BlockHeader) messageFrame.getBlockHeader()).getHash();
 
@@ -149,15 +148,14 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
     if (result.isInvalid() || !result.isSuccessful()) {
       LOG.error(
           "Failed to process private transaction {}: {}",
-          privateTransaction.getHash(),
+          pmtHash,
           result.getValidationResult().getErrorMessage());
       return Bytes.EMPTY;
     }
 
     if (messageFrame.isPersistingPrivateState()) {
-
       persistPrivateState(
-          messageFrame.getTransactionHash(),
+          pmtHash,
           currentBlockHash,
           privateTransaction,
           privacyGroupId,
@@ -237,6 +235,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
         messageFrame.getWorldState(),
         privateWorldStateUpdater,
         messageFrame.getBlockHeader(),
+        messageFrame.getTransactionHash(),
         privateTransaction,
         messageFrame.getMiningBeneficiary(),
         new DebugOperationTracer(TraceOptions.DEFAULT),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateGroupRehydrationBlockProcessor.java
@@ -128,7 +128,7 @@ public class PrivateGroupRehydrationBlockProcessor {
         LOG.debug(
             "Pre-rehydrate root hash: {} for tx {}",
             disposablePrivateState.rootHash(),
-            privateTransaction.getHash());
+            transaction.getHash());
 
         final PrivateTransactionProcessor.Result privateResult =
             privateTransactionProcessor.processTransaction(
@@ -136,6 +136,7 @@ public class PrivateGroupRehydrationBlockProcessor {
                 worldStateUpdater.updater(),
                 privateStateUpdater,
                 blockHeader,
+                transaction.getHash(),
                 privateTransaction,
                 miningBeneficiary,
                 OperationTracer.NO_TRACING,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
@@ -87,6 +87,8 @@ public class PrivateTransaction {
   protected volatile Address sender;
 
   // Caches the hash used to uniquely identify the transaction.
+  // This field will be removed in 1.5.0
+  @Deprecated(since = "1.4.3")
   protected volatile Hash hash;
 
   public static Builder builder() {
@@ -414,8 +416,11 @@ public class PrivateTransaction {
   /**
    * Returns the transaction hash.
    *
+   * @deprecated All private transactions should be identified by their corresponding PMT hash.
    * @return the transaction hash
    */
+  // This field will be removed in 1.5.0
+  @Deprecated(since = "1.4.3")
   public Hash getHash() {
     if (hash == null) {
       final Bytes rlp = RLP.encode(this::writeTo);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.DefaultEvmAccount;
 import org.hyperledger.besu.ethereum.core.Gas;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.MutableAccount;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
@@ -181,6 +182,7 @@ public class PrivateTransactionProcessor {
       final WorldUpdater publicWorldState,
       final WorldUpdater privateWorldState,
       final ProcessableBlockHeader blockHeader,
+      final Hash pmtHash,
       final PrivateTransaction transaction,
       final Address miningBeneficiary,
       final OperationTracer operationTracer,
@@ -248,7 +250,7 @@ public class PrivateTransactionProcessor {
               .miningBeneficiary(miningBeneficiary)
               .blockHashLookup(blockHashLookup)
               .maxStackSize(maxStackSize)
-              .transactionHash(transaction.getHash())
+              .transactionHash(pmtHash)
               .build();
 
     } else {
@@ -279,7 +281,7 @@ public class PrivateTransactionProcessor {
               .miningBeneficiary(miningBeneficiary)
               .blockHashLookup(blockHashLookup)
               .maxStackSize(maxStackSize)
-              .transactionHash(transaction.getHash())
+              .transactionHash(pmtHash)
               .build();
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionSimulator.java
@@ -122,6 +122,8 @@ public class PrivateTransactionSimulator {
             publicWorldState.updater(),
             disposablePrivateState.updater(),
             header,
+            Hash.ZERO, // Corresponding PMT hash not needed as this private transaction doesn't
+            // exist
             transaction,
             protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(header),
             new DebugOperationTracer(TraceOptions.DEFAULT),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionValidator.java
@@ -38,25 +38,21 @@ public class PrivateTransactionValidator {
       final PrivateTransaction transaction,
       final Long accountNonce,
       final boolean allowFutureNonces) {
-    LOG.debug("Validating private transaction fields of {}", transaction.getHash());
+    LOG.debug("Validating private transaction {}", transaction);
     final ValidationResult<TransactionInvalidReason> privateFieldsValidationResult =
         validatePrivateTransactionFields(transaction);
     if (!privateFieldsValidationResult.isValid()) {
       LOG.debug(
-          "Private Transaction fields are invalid {}, {}",
-          transaction.getHash(),
+          "Private Transaction fields are invalid {}",
           privateFieldsValidationResult.getErrorMessage());
       return privateFieldsValidationResult;
     }
-
-    LOG.debug("Validating the signature of Private Transaction {} ", transaction.getHash());
 
     final ValidationResult<TransactionValidator.TransactionInvalidReason>
         signatureValidationResult = validateTransactionSignature(transaction);
     if (!signatureValidationResult.isValid()) {
       LOG.debug(
-          "Private Transaction {}, failed validation {}, {}",
-          transaction.getHash(),
+          "Private Transaction failed signature validation {}, {}",
           signatureValidationResult.getInvalidReason(),
           signatureValidationResult.getErrorMessage());
       return signatureValidationResult;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessorTest.java
@@ -194,7 +194,7 @@ public class PrivacyBlockProcessorTest {
     final PrivateTransactionProcessor mockPrivateTransactionProcessor =
         mock(PrivateTransactionProcessor.class);
     when(mockPrivateTransactionProcessor.processTransaction(
-            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(
             PrivateTransactionProcessor.Result.successful(
                 Collections.emptyList(), 0, Bytes.EMPTY, ValidationResult.valid()));

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Log;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture;
@@ -79,6 +80,7 @@ public class PrivacyPrecompiledContractTest {
             nullable(WorldUpdater.class),
             nullable(WorldUpdater.class),
             nullable(ProcessableBlockHeader.class),
+            nullable((Hash.class)),
             nullable(PrivateTransaction.class),
             nullable(Address.class),
             nullable(OperationTracer.class),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
@@ -74,7 +76,7 @@ public class TestNode implements Closeable {
   private static final Logger LOG = LogManager.getLogger();
   private static final MetricsSystem metricsSystem = new NoOpMetricsSystem();
 
-  protected final SECP256K1.KeyPair kp;
+  protected final NodeKey nodeKey;
   protected final P2PNetwork network;
   protected final Peer selfPeer;
   protected final Map<PeerConnection, DisconnectReason> disconnections = new HashMap<>();
@@ -89,7 +91,7 @@ public class TestNode implements Closeable {
     checkNotNull(discoveryCfg);
 
     final int listenPort = port != null ? port : 0;
-    this.kp = kp != null ? kp : SECP256K1.KeyPair.generate();
+    this.nodeKey = new BouncyCastleNodeKey(kp != null ? kp : SECP256K1.KeyPair.generate());
 
     final NetworkingConfiguration networkingConfiguration =
         NetworkingConfiguration.create()
@@ -157,7 +159,7 @@ public class TestNode implements Closeable {
                 capabilities ->
                     DefaultP2PNetwork.builder()
                         .vertx(vertx)
-                        .keyPair(this.kp)
+                        .nodeKey(nodeKey)
                         .config(networkingConfiguration)
                         .metricsSystem(new NoOpMetricsSystem())
                         .supportedCapabilities(capabilities)
@@ -173,7 +175,7 @@ public class TestNode implements Closeable {
   }
 
   public Bytes id() {
-    return kp.getPublicKey().getEncodedBytes();
+    return nodeKey.getPublicKey().getEncodedBytes();
   }
 
   public static String shortId(final Bytes id) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.tuweni.bytes.Bytes.wrapBuffer;
 
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController;
@@ -70,7 +70,7 @@ public abstract class PeerDiscoveryAgent {
   protected Optional<PeerDiscoveryController> controller = Optional.empty();
 
   /* The keypair used to sign messages. */
-  protected final SECP256K1.KeyPair keyPair;
+  protected final NodeKey nodeKey;
   private final Bytes id;
   protected final DiscoveryConfiguration config;
 
@@ -84,13 +84,13 @@ public abstract class PeerDiscoveryAgent {
   protected final Subscribers<PeerBondedObserver> peerBondedObservers = Subscribers.create();
 
   public PeerDiscoveryAgent(
-      final SECP256K1.KeyPair keyPair,
+      final NodeKey nodeKey,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final NatService natService,
       final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
-    checkArgument(keyPair != null, "keypair cannot be null");
+    checkArgument(nodeKey != null, "cryptoOps cannot be null");
     checkArgument(config != null, "provided configuration cannot be null");
 
     validateConfiguration(config);
@@ -101,9 +101,9 @@ public abstract class PeerDiscoveryAgent {
         config.getBootnodes().stream().map(DiscoveryPeer::fromEnode).collect(Collectors.toList());
 
     this.config = config;
-    this.keyPair = keyPair;
+    this.nodeKey = nodeKey;
 
-    id = keyPair.getPublicKey().getEncodedBytes();
+    id = nodeKey.getPublicKey().getEncodedBytes();
   }
 
   protected abstract TimerUtil createTimer();
@@ -164,7 +164,7 @@ public abstract class PeerDiscoveryAgent {
 
   private PeerDiscoveryController createController(final DiscoveryPeer localNode) {
     return PeerDiscoveryController.builder()
-        .keypair(keyPair)
+        .nodeKey(nodeKey)
         .localPeer(localNode)
         .bootstrapNodes(bootstrapPeers)
         .outboundMessageHandler(this::handleOutgoingPacket)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -90,7 +90,7 @@ public abstract class PeerDiscoveryAgent {
       final NatService natService,
       final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
-    checkArgument(nodeKey != null, "cryptoOps cannot be null");
+    checkArgument(nodeKey != null, "nodeKey cannot be null");
     checkArgument(config != null, "provided configuration cannot be null");
 
     validateConfiguration(config);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.discovery;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController;
@@ -58,12 +58,12 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
 
   public VertxPeerDiscoveryAgent(
       final Vertx vertx,
-      final KeyPair keyPair,
+      final NodeKey nodeKey,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final NatService natService,
       final MetricsSystem metricsSystem) {
-    super(keyPair, config, peerPermissions, natService, metricsSystem);
+    super(nodeKey, config, peerPermissions, natService, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");
     this.vertx = vertx;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -20,8 +20,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerBondedObserver;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryEvent;
@@ -115,7 +114,7 @@ public class PeerDiscoveryController {
 
   private final AtomicBoolean started = new AtomicBoolean(false);
 
-  private final SECP256K1.KeyPair keypair;
+  private final NodeKey nodeKey;
   // The peer representation of this node
   private final DiscoveryPeer localPeer;
   private final OutboundMessageHandler outboundMessageHandler;
@@ -143,7 +142,7 @@ public class PeerDiscoveryController {
   private RecursivePeerRefreshState recursivePeerRefreshState;
 
   private PeerDiscoveryController(
-      final KeyPair keypair,
+      final NodeKey nodeKey,
       final DiscoveryPeer localPeer,
       final PeerTable peerTable,
       final Collection<DiscoveryPeer> bootstrapNodes,
@@ -157,7 +156,7 @@ public class PeerDiscoveryController {
       final Subscribers<PeerBondedObserver> peerBondedObservers,
       final MetricsSystem metricsSystem) {
     this.timerUtil = timerUtil;
-    this.keypair = keypair;
+    this.nodeKey = nodeKey;
     this.localPeer = localPeer;
     this.bootstrapNodes = bootstrapNodes;
     this.peerTable = peerTable;
@@ -489,7 +488,7 @@ public class PeerDiscoveryController {
     // Creating packets is quite expensive because they have to be cryptographically signed
     // So ensure the work is done on a worker thread to avoid blocking the vertx event thread.
     workerExecutor
-        .execute(() -> Packet.create(type, data, keypair))
+        .execute(() -> Packet.create(type, data, nodeKey))
         .thenAccept(handler)
         .exceptionally(
             error -> {
@@ -660,7 +659,7 @@ public class PeerDiscoveryController {
     private Subscribers<PeerBondedObserver> peerBondedObservers = Subscribers.create();
 
     // Required dependencies
-    private KeyPair keypair;
+    private NodeKey nodeKey;
     private DiscoveryPeer localPeer;
     private TimerUtil timerUtil;
     private AsyncExecutor workerExecutor;
@@ -672,11 +671,11 @@ public class PeerDiscoveryController {
       validate();
 
       if (peerTable == null) {
-        peerTable = new PeerTable(this.keypair.getPublicKey().getEncodedBytes(), 16);
+        peerTable = new PeerTable(this.nodeKey.getPublicKey().getEncodedBytes(), 16);
       }
 
       return new PeerDiscoveryController(
-          keypair,
+          nodeKey,
           localPeer,
           peerTable,
           bootstrapNodes,
@@ -692,7 +691,7 @@ public class PeerDiscoveryController {
     }
 
     private void validate() {
-      validateRequiredDependency(keypair, "KeyPair");
+      validateRequiredDependency(nodeKey, "KeyPair");
       validateRequiredDependency(localPeer, "LocalPeer");
       validateRequiredDependency(timerUtil, "TimerUtil");
       validateRequiredDependency(workerExecutor, "AsyncExecutor");
@@ -704,9 +703,9 @@ public class PeerDiscoveryController {
       checkState(object != null, name + " must be configured.");
     }
 
-    public Builder keypair(final KeyPair keypair) {
-      checkNotNull(keypair);
-      this.keypair = keypair;
+    public Builder nodeKey(final NodeKey nodeKey) {
+      checkNotNull(nodeKey);
+      this.nodeKey = nodeKey;
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -17,7 +17,8 @@ package org.hyperledger.besu.ethereum.p2p.network;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
@@ -145,7 +146,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
    *
    * @param localNode A representation of the local node
    * @param peerDiscoveryAgent The agent responsible for discovering peers on the network.
-   * @param keyPair This node's keypair.
+   * @param nodeKey The key through which cryptographic operations can be performed
    * @param config The network configuration to use.
    * @param peerPermissions An object that determines whether peers are allowed to connect
    * @param natService The NAT environment manager.
@@ -157,7 +158,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
       final MutableLocalNode localNode,
       final PeerDiscoveryAgent peerDiscoveryAgent,
       final RlpxAgent rlpxAgent,
-      final SECP256K1.KeyPair keyPair,
+      final NodeKey nodeKey,
       final NetworkingConfiguration config,
       final PeerPermissions peerPermissions,
       final NatService natService,
@@ -171,7 +172,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     this.natService = natService;
     this.maintainedPeers = maintainedPeers;
 
-    this.nodeId = keyPair.getPublicKey().getEncodedBytes();
+    this.nodeId = nodeKey.getPublicKey().getEncodedBytes();
     this.peerPermissions = peerPermissions;
 
     final int maxPeers = config.getRlpx().getMaxPeers();
@@ -421,7 +422,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
           localNode,
           peerDiscoveryAgent,
           rlpxAgent,
-          keyPair,
+          new BouncyCastleNodeKey(keyPair),
           config,
           peerPermissions,
           natService,
@@ -442,7 +443,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private PeerDiscoveryAgent createDiscoveryAgent() {
 
       return new VertxPeerDiscoveryAgent(
-          vertx, keyPair, config.getDiscovery(), peerPermissions, natService, metricsSystem);
+          vertx,
+          new BouncyCastleNodeKey(keyPair),
+          config.getDiscovery(),
+          peerPermissions,
+          natService,
+          metricsSystem);
     }
 
     private RlpxAgent createRlpxAgent(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -17,9 +17,7 @@ package org.hyperledger.besu.ethereum.p2p.network;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.NodeKey;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
@@ -391,7 +389,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
 
     private NetworkingConfiguration config = NetworkingConfiguration.create();
     private List<Capability> supportedCapabilities;
-    private KeyPair keyPair;
+    private NodeKey nodeKey;
 
     private MaintainedPeers maintainedPeers = new MaintainedPeers();
     private PeerPermissions peerPermissions = PeerPermissions.noop();
@@ -422,7 +420,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
           localNode,
           peerDiscoveryAgent,
           rlpxAgent,
-          new BouncyCastleNodeKey(keyPair),
+          nodeKey,
           config,
           peerPermissions,
           natService,
@@ -431,7 +429,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     }
 
     private void validate() {
-      checkState(keyPair != null, "KeyPair must be set.");
+      checkState(nodeKey != null, "KeyPair must be set.");
       checkState(config != null, "NetworkingConfiguration must be set.");
       checkState(
           supportedCapabilities != null && supportedCapabilities.size() > 0,
@@ -443,18 +441,13 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private PeerDiscoveryAgent createDiscoveryAgent() {
 
       return new VertxPeerDiscoveryAgent(
-          vertx,
-          new BouncyCastleNodeKey(keyPair),
-          config.getDiscovery(),
-          peerPermissions,
-          natService,
-          metricsSystem);
+          vertx, nodeKey, config.getDiscovery(), peerPermissions, natService, metricsSystem);
     }
 
     private RlpxAgent createRlpxAgent(
         final LocalNode localNode, final PeerPrivileges peerPrivileges) {
       return RlpxAgent.builder()
-          .keyPair(keyPair)
+          .nodeKey(nodeKey)
           .config(config.getRlpx())
           .peerPermissions(peerPermissions)
           .peerPrivileges(peerPrivileges)
@@ -481,9 +474,9 @@ public class DefaultP2PNetwork implements P2PNetwork {
       return this;
     }
 
-    public Builder keyPair(final KeyPair keyPair) {
-      checkNotNull(keyPair);
-      this.keyPair = keyPair;
+    public Builder nodeKey(final NodeKey nodeKey) {
+      checkNotNull(nodeKey);
+      this.nodeKey = nodeKey;
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
@@ -526,7 +526,7 @@ public class RlpxAgent {
   }
 
   public static class Builder {
-    private KeyPair keyPair;
+    private NodeKey nodeKey;
     private LocalNode localNode;
     private RlpxConfiguration config;
     private PeerPrivileges peerPrivileges;
@@ -546,7 +546,7 @@ public class RlpxAgent {
       if (connectionInitializer == null) {
         connectionInitializer =
             new NettyConnectionInitializer(
-                keyPair, config, localNode, connectionEvents, metricsSystem);
+                nodeKey, config, localNode, connectionEvents, metricsSystem);
       }
 
       final PeerRlpxPermissions rlpxPermissions =
@@ -563,7 +563,7 @@ public class RlpxAgent {
     }
 
     private void validate() {
-      checkState(keyPair != null, "KeyPair must be configured");
+      checkState(nodeKey != null, "CryptoOps must be configured");
       checkState(localNode != null, "LocalNode must be configured");
       checkState(config != null, "RlpxConfiguration must be set");
       checkState(peerPrivileges != null, "PeerPrivileges must be configured");
@@ -571,9 +571,9 @@ public class RlpxAgent {
       checkState(metricsSystem != null, "MetricsSystem must be configured");
     }
 
-    public Builder keyPair(final KeyPair keyPair) {
-      checkNotNull(keyPair);
-      this.keyPair = keyPair;
+    public Builder nodeKey(final NodeKey nodeKey) {
+      checkNotNull(nodeKey);
+      this.nodeKey = nodeKey;
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerInbound.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerInbound.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnectionEventDispatcher;
@@ -31,7 +31,7 @@ import io.netty.buffer.ByteBuf;
 final class HandshakeHandlerInbound extends AbstractHandshakeHandler {
 
   public HandshakeHandlerInbound(
-      final SECP256K1.KeyPair kp,
+      final NodeKey nodeKey,
       final List<SubProtocol> subProtocols,
       final LocalNode localNode,
       final CompletableFuture<PeerConnection> connectionFuture,
@@ -44,7 +44,7 @@ final class HandshakeHandlerInbound extends AbstractHandshakeHandler {
         connectionFuture,
         connectionEventDispatcher,
         metricsSystem);
-    handshaker.prepareResponder(kp);
+    handshaker.prepareResponder(nodeKey);
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerOutbound.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/HandshakeHandlerOutbound.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
@@ -39,7 +40,7 @@ final class HandshakeHandlerOutbound extends AbstractHandshakeHandler {
   private final ByteBuf first;
 
   public HandshakeHandlerOutbound(
-      final SECP256K1.KeyPair kp,
+      final NodeKey nodeKey,
       final Peer peer,
       final List<SubProtocol> subProtocols,
       final LocalNode localNode,
@@ -53,7 +54,7 @@ final class HandshakeHandlerOutbound extends AbstractHandshakeHandler {
         connectionFuture,
         connectionEventDispatcher,
         metricsSystem);
-    handshaker.prepareInitiator(kp, SECP256K1.PublicKey.create(peer.getId()));
+    handshaker.prepareInitiator(nodeKey, SECP256K1.PublicKey.create(peer.getId()));
     this.first = handshaker.firstMessage();
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
@@ -51,7 +51,7 @@ public class NettyConnectionInitializer implements ConnectionInitializer {
 
   private static final int TIMEOUT_SECONDS = 10;
 
-  private final KeyPair keyPair;
+  private final NodeKey nodeKey;
   private final RlpxConfiguration config;
   private final LocalNode localNode;
   private final PeerConnectionEventDispatcher eventDispatcher;
@@ -65,12 +65,12 @@ public class NettyConnectionInitializer implements ConnectionInitializer {
   private final AtomicBoolean stopped = new AtomicBoolean(false);
 
   public NettyConnectionInitializer(
-      final KeyPair keyPair,
+      final NodeKey nodeKey,
       final RlpxConfiguration config,
       final LocalNode localNode,
       final PeerConnectionEventDispatcher eventDispatcher,
       final MetricsSystem metricsSystem) {
-    this.keyPair = keyPair;
+    this.nodeKey = nodeKey;
     this.config = config;
     this.localNode = localNode;
     this.eventDispatcher = eventDispatcher;
@@ -185,7 +185,7 @@ public class NettyConnectionInitializer implements ConnectionInitializer {
                                         "Timed out waiting to establish connection with peer: "
                                             + peer.getId()))),
                         new HandshakeHandlerOutbound(
-                            keyPair,
+                            nodeKey,
                             peer,
                             config.getSupportedProtocols(),
                             localNode,
@@ -224,7 +224,7 @@ public class NettyConnectionInitializer implements ConnectionInitializer {
                             new TimeoutException(
                                 "Timed out waiting to fully establish incoming connection"))),
                 new HandshakeHandlerInbound(
-                    keyPair,
+                    nodeKey,
                     config.getSupportedProtocols(),
                     localNode,
                     connectionFuture,

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/Handshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/Handshaker.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake;
 
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies.ECIESHandshaker;
 
@@ -76,11 +77,11 @@ public interface Handshaker {
    * <p>This method must throw an {@link IllegalStateException} exception if the handshake had
    * already been prepared before, no matter if under the initiator or the responder role.
    *
-   * @param ourKeypair The keypair for our node identity.
+   * @param nodeKey An object which represents our identity
    * @param theirPubKey The public key of the node we're handshaking with.
    * @throws IllegalStateException Indicates that preparation had already occured.
    */
-  void prepareInitiator(SECP256K1.KeyPair ourKeypair, SECP256K1.PublicKey theirPubKey);
+  void prepareInitiator(final NodeKey nodeKey, SECP256K1.PublicKey theirPubKey);
 
   /**
    * This method must be called by the <em>responding side</em> of the handshake to prepare the
@@ -89,10 +90,10 @@ public interface Handshaker {
    * <p>This method must throw an {@link IllegalStateException} exception if the handshake had
    * already been prepared before, whether with the initiator or the responder role.
    *
-   * @param ourKeypair The keypair for our node identity.
+   * @param nodeKey An object which represents our identity
    * @throws IllegalStateException Indicates that preparation had already occured.
    */
-  void prepareResponder(SECP256K1.KeyPair ourKeypair);
+  void prepareResponder(final NodeKey nodeKey);
 
   /**
    * Retrieves the first message to dispatch in the handshake ceremony.

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESEncryptionEngine.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESEncryptionEngine.java
@@ -16,14 +16,12 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 
-import java.math.BigInteger;
-
 import org.apache.tuweni.bytes.Bytes;
-import org.bouncycastle.crypto.BasicAgreement;
 import org.bouncycastle.crypto.BufferedBlockCipher;
-import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.DataLengthException;
 import org.bouncycastle.crypto.DerivationFunction;
 import org.bouncycastle.crypto.DerivationParameters;
@@ -31,20 +29,15 @@ import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.DigestDerivationFunction;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.Mac;
-import org.bouncycastle.crypto.agreement.ECDHBasicAgreement;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.engines.AESEngine;
 import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.modes.SICBlockCipher;
-import org.bouncycastle.crypto.params.ECDomainParameters;
-import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
-import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.params.IESWithCipherParameters;
 import org.bouncycastle.crypto.params.KDFParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
 import org.bouncycastle.crypto.params.ParametersWithIV;
 import org.bouncycastle.util.Arrays;
-import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.Pack;
 
 /**
@@ -58,6 +51,7 @@ import org.bouncycastle.util.Pack;
  * the IV.
  */
 public class ECIESEncryptionEngine {
+
   public static final int ENCRYPTION_OVERHEAD = 113;
 
   private static final byte[] IES_DERIVATION = new byte[0];
@@ -82,41 +76,30 @@ public class ECIESEncryptionEngine {
   private final byte[] iv;
 
   private ECIESEncryptionEngine(
-      final CipherParameters pubParam,
-      final CipherParameters privParam,
-      final SECP256K1.PublicKey ephPubKey,
-      final byte[] iv) {
+      final Bytes Z, final SECP256K1.PublicKey ephPubKey, final byte[] iv) {
     this.ephPubKey = ephPubKey;
     this.iv = iv;
 
-    // Compute the common value and convert to byte array.
-    final BasicAgreement agree = new ECDHBasicAgreement();
-    agree.init(privParam);
-    final BigInteger z = agree.calculateAgreement(pubParam);
-    final byte[] Z = BigIntegers.asUnsignedByteArray(agree.getFieldSize(), z);
-
     // Initialise the KDF.
-    this.kdf.init(new KDFParameters(Z, PARAM.getDerivationV()));
+    this.kdf.init(new KDFParameters(Z.toArrayUnsafe(), PARAM.getDerivationV()));
   }
 
   /**
    * Creates a new engine for decryption.
    *
-   * @param privKey The private key of the deciphering end.
+   * @param nodeKey An abstraction of the decrypting private key
    * @param ephPubKey The ephemeral public key extracted from the raw message.
    * @param iv The initialization vector extracted from the raw message.
    * @return An engine prepared for decryption.
    */
   public static ECIESEncryptionEngine forDecryption(
-      final SECP256K1.PrivateKey privKey, final SECP256K1.PublicKey ephPubKey, final Bytes iv) {
+      final NodeKey nodeKey, final SECP256K1.PublicKey ephPubKey, final Bytes iv) {
     final byte[] ivb = iv.toArray();
 
     // Create parameters.
-    final ECDomainParameters dp = SECP256K1.CURVE;
-    final CipherParameters pubParam = new ECPublicKeyParameters(ephPubKey.asEcPoint(), dp);
-    final CipherParameters privParam = new ECPrivateKeyParameters(privKey.getD(), dp);
+    final Bytes Z = nodeKey.calculateKeyAgreement(ephPubKey);
 
-    return new ECIESEncryptionEngine(pubParam, privParam, ephPubKey, ivb);
+    return new ECIESEncryptionEngine(Z, ephPubKey, ivb);
   }
 
   /**
@@ -135,13 +118,10 @@ public class ECIESEncryptionEngine {
     // Create random iv.
     final byte[] ivb = ECIESHandshaker.random(CIPHER_BLOCK_SIZE).toArray();
 
-    // Create parameters.
-    final CipherParameters pubParam =
-        new ECPublicKeyParameters(pubKey.asEcPoint(), SECP256K1.CURVE);
-    final CipherParameters privParam =
-        new ECPrivateKeyParameters(ephKeyPair.getPrivateKey().getD(), SECP256K1.CURVE);
+    final BouncyCastleNodeKey nodeKey = new BouncyCastleNodeKey(ephKeyPair);
 
-    return new ECIESEncryptionEngine(pubParam, privParam, ephKeyPair.getPublicKey(), ivb);
+    return new ECIESEncryptionEngine(
+        nodeKey.calculateECIESAgreement(pubKey), ephKeyPair.getPublicKey(), ivb);
   }
 
   /**
@@ -329,6 +309,7 @@ public class ECIESEncryptionEngine {
    * Bouncy Castle.
    */
   private static class ECIESHandshakeKDFFunction implements DigestDerivationFunction {
+
     private static final int COUNTER_START = 1;
     private final Digest digest = new SHA256Digest();
     private final int digestSize = digest.getDigestSize();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static org.apache.tuweni.bytes.Bytes.concatenate;
 import static org.hyperledger.besu.crypto.Hash.keccak256;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SecureRandomProvider;
@@ -56,7 +58,7 @@ public class ECIESHandshaker implements Handshaker {
   static final int TOKEN_FLAG_LENGTH = 1;
 
   // Keypairs under our control.
-  private SECP256K1.KeyPair identityKeyPair;
+  private NodeKey ourCryptoOps;
   private SECP256K1.KeyPair ephKeyPair;
 
   // Party's material, only public keys.
@@ -84,14 +86,14 @@ public class ECIESHandshaker implements Handshaker {
   private boolean version4 = true;
 
   @Override
-  public void prepareInitiator(final SECP256K1.KeyPair ourKeypair, final PublicKey theirPubKey) {
+  public void prepareInitiator(final NodeKey ourCryptoOps, final PublicKey theirPubKey) {
     checkState(
         status.compareAndSet(
             Handshaker.HandshakeStatus.UNINITIALIZED, Handshaker.HandshakeStatus.PREPARED),
         "handshake was already prepared");
 
     this.initiator = true;
-    this.identityKeyPair = ourKeypair;
+    this.ourCryptoOps = ourCryptoOps;
     this.ephKeyPair = SECP256K1.KeyPair.generate();
     this.partyPubKey = theirPubKey;
     this.initiatorNonce = Bytes32.wrap(random(32), 0);
@@ -101,14 +103,14 @@ public class ECIESHandshaker implements Handshaker {
   }
 
   @Override
-  public void prepareResponder(final SECP256K1.KeyPair ourKeypair) {
+  public void prepareResponder(final NodeKey ourCryptoOps) {
     checkState(
         status.compareAndSet(
             Handshaker.HandshakeStatus.UNINITIALIZED, Handshaker.HandshakeStatus.IN_PROGRESS),
         "handshake was already prepared");
 
     this.initiator = false;
-    this.identityKeyPair = ourKeypair;
+    this.ourCryptoOps = ourCryptoOps;
     this.ephKeyPair = SECP256K1.KeyPair.generate();
     this.responderNonce = Bytes32.wrap(random(32), 0);
     LOG.trace("Prepared ECIES handshake under RESPONDER role");
@@ -122,20 +124,15 @@ public class ECIESHandshaker implements Handshaker {
             Handshaker.HandshakeStatus.PREPARED, Handshaker.HandshakeStatus.IN_PROGRESS),
         "illegal invocation of firstMessage, handshake had already started");
 
-    final Bytes32 staticSharedSecret =
-        SECP256K1.calculateKeyAgreement(identityKeyPair.getPrivateKey(), partyPubKey);
+    final Bytes32 staticSharedSecret = ourCryptoOps.calculateKeyAgreement(partyPubKey);
     if (version4) {
       initiatorMsg =
           InitiatorHandshakeMessageV4.create(
-              identityKeyPair.getPublicKey(), ephKeyPair, staticSharedSecret, initiatorNonce);
+              ourCryptoOps.getPublicKey(), ephKeyPair, staticSharedSecret, initiatorNonce);
     } else {
       initiatorMsg =
           InitiatorHandshakeMessageV1.create(
-              identityKeyPair.getPublicKey(),
-              ephKeyPair,
-              staticSharedSecret,
-              initiatorNonce,
-              false);
+              ourCryptoOps.getPublicKey(), ephKeyPair, staticSharedSecret, initiatorNonce, false);
     }
     try {
       if (version4) {
@@ -187,7 +184,7 @@ public class ECIESHandshaker implements Handshaker {
     try {
       // Decrypt the message with our private key.
       try {
-        bytes = EncryptedMessage.decryptMsg(bytes, identityKeyPair.getPrivateKey());
+        bytes = EncryptedMessage.decryptMsg(bytes, ourCryptoOps);
         version4 = false;
       } catch (final Exception ex) {
         // Assume new format
@@ -198,7 +195,7 @@ public class ECIESHandshaker implements Handshaker {
           bufferedBytes.readBytes(fullMessage, 0, expectedLength);
           buf.readBytes(fullMessage, expectedLength, size - expectedLength + 2);
           encryptedMsg = Bytes.wrap(fullMessage);
-          bytes = EncryptedMessage.decryptMsgEIP8(encryptedMsg, identityKeyPair.getPrivateKey());
+          bytes = EncryptedMessage.decryptMsgEIP8(encryptedMsg, ourCryptoOps);
           version4 = true;
         } else {
           throw new HandshakeException("Failed to decrypt handshake message", ex);
@@ -247,14 +244,14 @@ public class ECIESHandshaker implements Handshaker {
       // Store the message, as we need it to generating our ingress and egress MACs.
       initiatorMsgEnc = encryptedMsg;
       if (version4) {
-        initiatorMsg = InitiatorHandshakeMessageV4.decode(bytes, identityKeyPair);
+        initiatorMsg = InitiatorHandshakeMessageV4.decode(bytes, ourCryptoOps);
       } else {
-        initiatorMsg = InitiatorHandshakeMessageV1.decode(bytes, identityKeyPair);
+        initiatorMsg = InitiatorHandshakeMessageV1.decode(bytes, ourCryptoOps);
       }
 
       LOG.trace(
           "[{}] Received initiator's ECIES handshake message: {}",
-          identityKeyPair.getPublicKey().getEncodedBytes(),
+          ourCryptoOps.getPublicKey().getEncodedBytes(),
           initiatorMsg);
 
       // Extract the initiator's data.
@@ -339,8 +336,9 @@ public class ECIESHandshaker implements Handshaker {
 
   /** Computes the secrets from the two exchanged messages. */
   void computeSecrets() {
-    final Bytes agreedSecret =
-        SECP256K1.calculateKeyAgreement(ephKeyPair.getPrivateKey(), partyEphPubKey);
+    final NodeKey nodeKey = new BouncyCastleNodeKey(ephKeyPair);
+    final Bytes agreedSecret = nodeKey.calculateKeyAgreement(partyEphPubKey);
+
     final Bytes sharedSecret =
         keccak256(
             concatenate(agreedSecret, keccak256(concatenate(responderNonce, initiatorNonce))));
@@ -377,8 +375,8 @@ public class ECIESHandshaker implements Handshaker {
   // ---------------------------------------------
 
   @VisibleForTesting
-  SECP256K1.KeyPair getIdentityKeyPair() {
-    return identityKeyPair;
+  NodeKey getOurCryptoOps() {
+    return ourCryptoOps;
   }
 
   @VisibleForTesting

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessage.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SecureRandomProvider;
 
@@ -38,11 +39,11 @@ final class EncryptedMessage {
    * Decrypts the ciphertext using our private key.
    *
    * @param msgBytes The ciphertext.
-   * @param ourKey Our private key.
+   * @param nodeKey Abstraction of this nodes private key & associated crypto operations
    * @return The plaintext.
    * @throws InvalidCipherTextException Thrown if decryption failed.
    */
-  public static Bytes decryptMsg(final Bytes msgBytes, final SECP256K1.PrivateKey ourKey)
+  public static Bytes decryptMsg(final Bytes msgBytes, final NodeKey nodeKey)
       throws InvalidCipherTextException {
 
     // Extract the ephemeral public key, stripping off the first byte (0x04), which designates it's
@@ -57,7 +58,7 @@ final class EncryptedMessage {
 
     // Perform the decryption.
     final ECIESEncryptionEngine decryptor =
-        ECIESEncryptionEngine.forDecryption(ourKey, ephPubKey, iv);
+        ECIESEncryptionEngine.forDecryption(nodeKey, ephPubKey, iv);
     return decryptor.decrypt(encrypted);
   }
 
@@ -65,11 +66,11 @@ final class EncryptedMessage {
    * Decrypts the ciphertext using our private key.
    *
    * @param msgBytes The ciphertext.
-   * @param ourKey Our private key.
+   * @param nodeKey Abstraction of this nodes private key & associated crypto operations
    * @return The plaintext.
    * @throws InvalidCipherTextException Thrown if decryption failed.
    */
-  public static Bytes decryptMsgEIP8(final Bytes msgBytes, final SECP256K1.PrivateKey ourKey)
+  public static Bytes decryptMsgEIP8(final Bytes msgBytes, final NodeKey nodeKey)
       throws InvalidCipherTextException {
     final SECP256K1.PublicKey ephPubKey = SECP256K1.PublicKey.create(msgBytes.slice(3, 64));
 
@@ -81,7 +82,7 @@ final class EncryptedMessage {
 
     // Perform the decryption.
     final ECIESEncryptionEngine decryptor =
-        ECIESEncryptionEngine.forDecryption(ourKey, ephPubKey, iv);
+        ECIESEncryptionEngine.forDecryption(nodeKey, ephPubKey, iv);
     return decryptor.decrypt(encrypted, msgBytes.slice(0, 2).toArray());
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV1.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV1.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.hyperledger.besu.crypto.SECP256K1.calculateKeyAgreement;
 
 import org.hyperledger.besu.crypto.Hash;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -95,11 +95,10 @@ public final class InitiatorHandshakeMessageV1 implements InitiatorHandshakeMess
    * Decodes this message.
    *
    * @param bytes The raw bytes.
-   * @param keyPair Our keypair to calculat ECDH key agreements.
+   * @param nodeKey Our keypair to calculat ECDH key agreements.
    * @return The decoded message.
    */
-  public static InitiatorHandshakeMessageV1 decode(
-      final Bytes bytes, final SECP256K1.KeyPair keyPair) {
+  public static InitiatorHandshakeMessageV1 decode(final Bytes bytes, final NodeKey nodeKey) {
     checkState(bytes.size() == MESSAGE_LENGTH);
 
     int offset = 0;
@@ -119,7 +118,7 @@ public final class InitiatorHandshakeMessageV1 implements InitiatorHandshakeMess
             bytes.slice(offset += ECIESHandshaker.PUBKEY_LENGTH, ECIESHandshaker.NONCE_LENGTH), 0);
     final boolean token = bytes.get(offset) == 0x01;
 
-    final Bytes32 staticSharedSecret = calculateKeyAgreement(keyPair.getPrivateKey(), pubKey);
+    final Bytes32 staticSharedSecret = nodeKey.calculateKeyAgreement(pubKey);
     final SECP256K1.PublicKey ephPubKey =
         SECP256K1.PublicKey.recoverFromSignature(staticSharedSecret.xor(nonce), signature)
             .orElseThrow(() -> new RuntimeException("Could not recover public key from signature"));

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
 import org.hyperledger.besu.crypto.Hash;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
@@ -49,18 +50,16 @@ public final class InitiatorHandshakeMessageV4 implements InitiatorHandshakeMess
    * Decodes this message.
    *
    * @param bytes The raw bytes.
-   * @param keyPair Our keypair to calculat ECDH key agreements.
+   * @param nodeKey Abstraction of the local nodes keys and associated crypto operations
    * @return The decoded message.
    */
-  public static InitiatorHandshakeMessageV4 decode(
-      final Bytes bytes, final SECP256K1.KeyPair keyPair) {
+  public static InitiatorHandshakeMessageV4 decode(final Bytes bytes, final NodeKey nodeKey) {
     final RLPInput input = new BytesValueRLPInput(bytes, true);
     input.enterList();
     final SECP256K1.Signature signature = SECP256K1.Signature.decode(input.readBytes());
     final SECP256K1.PublicKey pubKey = SECP256K1.PublicKey.create(input.readBytes());
     final Bytes32 nonce = input.readBytes32();
-    final Bytes32 staticSharedSecret =
-        SECP256K1.calculateKeyAgreement(keyPair.getPrivateKey(), pubKey);
+    final Bytes32 staticSharedSecret = nodeKey.calculateKeyAgreement(pubKey);
     final SECP256K1.PublicKey ephPubKey =
         SECP256K1.PublicKey.recoverFromSignature(staticSharedSecret.xor(nonce), signature)
             .orElseThrow(() -> new RuntimeException("Could not recover public key from signature"));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -22,8 +22,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper.AgentBuilder;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.FindNeighborsPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.MockPeerDiscoveryAgent;
@@ -78,7 +78,7 @@ public class PeerDiscoveryAgentTest {
     // Generate an out-of-band NEIGHBORS message.
     final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(5);
     final NeighborsPacketData data = NeighborsPacketData.create(peers);
-    final Packet packet = Packet.create(PacketType.NEIGHBORS, data, otherNode.getKeyPair());
+    final Packet packet = Packet.create(PacketType.NEIGHBORS, data, otherNode.getNodeKey());
     helper.sendMessageBetweenAgents(otherNode, agent, packet);
 
     assertThat(agent.streamDiscoveredPeers()).isEmpty();
@@ -117,7 +117,7 @@ public class PeerDiscoveryAgentTest {
         Packet.create(
             PacketType.FIND_NEIGHBORS,
             FindNeighborsPacketData.create(otherAgents.get(0).getAdvertisedPeer().get().getId()),
-            testAgent.getKeyPair());
+            testAgent.getNodeKey());
     helper.sendMessageBetweenAgents(testAgent, agent, packet);
 
     // Check response packet
@@ -337,13 +337,13 @@ public class PeerDiscoveryAgentTest {
     final MockPeerDiscoveryAgent agent = helper.startDiscoveryAgent();
     final DiscoveryPeer agentPeer = agent.getAdvertisedPeer().get();
 
-    final KeyPair remoteKeyPair = SECP256K1.KeyPair.generate();
+    final NodeKey remoteKeyPair = BouncyCastleNodeKey.generate();
     final String remoteIp = "1.2.3.4";
     final MockPeerDiscoveryAgent remoteAgent =
         helper.createDiscoveryAgent(
             helper
                 .agentBuilder()
-                .keyPair(remoteKeyPair)
+                .nodeKey(remoteKeyPair)
                 .advertisedHost(remoteIp)
                 .bootstrapPeers(agentPeer));
 
@@ -363,7 +363,7 @@ public class PeerDiscoveryAgentTest {
         helper.createDiscoveryAgent(
             helper
                 .agentBuilder()
-                .keyPair(remoteKeyPair)
+                .nodeKey(remoteKeyPair)
                 .advertisedHost(newIp)
                 .bindPort(newPort)
                 .bootstrapPeers(agentPeer));
@@ -575,7 +575,7 @@ public class PeerDiscoveryAgentTest {
   protected void requestNeighbors(
       final MockPeerDiscoveryAgent fromAgent, final MockPeerDiscoveryAgent toAgent) {
     final FindNeighborsPacketData data = FindNeighborsPacketData.create(Peer.randomId());
-    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, fromAgent.getKeyPair());
+    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, fromAgent.getNodeKey());
     helper.sendMessageBetweenAgents(fromAgent, toAgent, packet);
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBondingTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBondingTest.java
@@ -70,7 +70,7 @@ public class PeerDiscoveryBondingTest {
     // we haven't bonded.
     final MockPeerDiscoveryAgent otherNode = helper.startDiscoveryAgent();
     final FindNeighborsPacketData data = FindNeighborsPacketData.create(otherNode.getId());
-    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, otherNode.getKeyPair());
+    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, otherNode.getNodeKey());
     helper.sendMessageBetweenAgents(otherNode, agent, packet);
 
     // No responses received

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
@@ -17,7 +17,8 @@ package org.hyperledger.besu.ethereum.p2p.discovery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.FindNeighborsPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.NeighborsPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
@@ -42,16 +43,16 @@ public class PeerDiscoveryPacketSedesTest {
     final byte[] r = new byte[64];
     new Random().nextBytes(r);
     final Bytes target = Bytes.wrap(r);
-    final SECP256K1.KeyPair kp = SECP256K1.KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     final FindNeighborsPacketData packetData = FindNeighborsPacketData.create(target);
-    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, packetData, kp);
+    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, packetData, nodeKey);
     final Buffer encoded = packet.encode();
     assertThat(encoded).isNotNull();
 
     final Packet decoded = Packet.decode(encoded);
     assertThat(decoded.getType()).isEqualTo(PacketType.FIND_NEIGHBORS);
-    assertThat(decoded.getNodeId()).isEqualTo(kp.getPublicKey().getEncodedBytes());
+    assertThat(decoded.getNodeId()).isEqualTo(nodeKey.getPublicKey().getEncodedBytes());
     assertThat(decoded.getPacketData(NeighborsPacketData.class)).isNotPresent();
     assertThat(decoded.getPacketData(FindNeighborsPacketData.class)).isPresent();
   }
@@ -112,10 +113,10 @@ public class PeerDiscoveryPacketSedesTest {
     new Random().nextBytes(r);
     final Bytes target = Bytes.wrap(r);
 
-    final SECP256K1.KeyPair kp = SECP256K1.KeyPair.generate();
+    final NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     final FindNeighborsPacketData data = FindNeighborsPacketData.create(target);
-    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, kp);
+    final Packet packet = Packet.create(PacketType.FIND_NEIGHBORS, data, nodeKey);
 
     final Bytes encoded = Bytes.wrapBuffer(packet.encode());
     final MutableBytes garbled = encoded.mutableCopy();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.ethereum.p2p.discovery;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Arrays.asList;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.MockPeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
@@ -48,8 +48,8 @@ public class PeerDiscoveryTestHelper {
   private final AtomicInteger nextAvailablePort = new AtomicInteger(1);
   Map<Bytes, MockPeerDiscoveryAgent> agents = new HashMap<>();
 
-  public static List<SECP256K1.KeyPair> generateKeyPairs(final int count) {
-    return Stream.generate(SECP256K1.KeyPair::generate).limit(count).collect(Collectors.toList());
+  public static List<NodeKey> generateNodeKeys(final int count) {
+    return Stream.generate(BouncyCastleNodeKey::generate).limit(count).collect(Collectors.toList());
   }
 
   /**
@@ -62,16 +62,16 @@ public class PeerDiscoveryTestHelper {
     return Stream.generate(this::createDiscoveryPeer).limit(count).collect(Collectors.toList());
   }
 
-  public List<DiscoveryPeer> createDiscoveryPeers(final List<KeyPair> keyPairs) {
-    return keyPairs.stream().map(this::createDiscoveryPeer).collect(Collectors.toList());
+  public List<DiscoveryPeer> createDiscoveryPeers(final List<NodeKey> nodeKeys) {
+    return nodeKeys.stream().map(this::createDiscoveryPeer).collect(Collectors.toList());
   }
 
   public DiscoveryPeer createDiscoveryPeer() {
-    return createDiscoveryPeer(KeyPair.generate());
+    return createDiscoveryPeer(BouncyCastleNodeKey.generate());
   }
 
-  public DiscoveryPeer createDiscoveryPeer(final KeyPair keyPair) {
-    final Bytes peerId = keyPair.getPublicKey().getEncodedBytes();
+  public DiscoveryPeer createDiscoveryPeer(final NodeKey nodeKey) {
+    final Bytes peerId = nodeKey.getPublicKey().getEncodedBytes();
     final int port = nextAvailablePort.incrementAndGet();
     return DiscoveryPeer.fromEnode(
         EnodeURL.builder()
@@ -88,7 +88,7 @@ public class PeerDiscoveryTestHelper {
         PingPacketData.create(
             fromAgent.getAdvertisedPeer().get().getEndpoint(),
             toAgent.getAdvertisedPeer().get().getEndpoint()),
-        fromAgent.getKeyPair());
+        fromAgent.getNodeKey());
   }
 
   public AgentBuilder agentBuilder() {
@@ -180,6 +180,7 @@ public class PeerDiscoveryTestHelper {
   }
 
   public static class AgentBuilder {
+
     private final Map<Bytes, MockPeerDiscoveryAgent> agents;
     private final AtomicInteger nextAvailablePort;
 
@@ -188,7 +189,7 @@ public class PeerDiscoveryTestHelper {
     private PeerPermissions peerPermissions = PeerPermissions.noop();
     private String advertisedHost = "127.0.0.1";
     private OptionalInt bindPort = OptionalInt.empty();
-    private KeyPair keyPair = SECP256K1.KeyPair.generate();
+    private NodeKey nodeKey = BouncyCastleNodeKey.generate();
 
     private AgentBuilder(
         final Map<Bytes, MockPeerDiscoveryAgent> agents, final AtomicInteger nextAvailablePort) {
@@ -240,9 +241,9 @@ public class PeerDiscoveryTestHelper {
       return this;
     }
 
-    public AgentBuilder keyPair(final KeyPair keyPair) {
-      checkNotNull(keyPair);
-      this.keyPair = keyPair;
+    public AgentBuilder nodeKey(final NodeKey nodeKey) {
+      checkNotNull(nodeKey);
+      this.nodeKey = nodeKey;
       return this;
     }
 
@@ -255,7 +256,7 @@ public class PeerDiscoveryTestHelper {
       config.setBindPort(port);
       config.setActive(active);
 
-      return new MockPeerDiscoveryAgent(keyPair, config, peerPermissions, agents, natService);
+      return new MockPeerDiscoveryAgent(nodeKey, config, peerPermissions, agents, natService);
     }
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.BlockingAsyncExecutor;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.MockPeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.MockTimerUtil;
@@ -44,17 +44,17 @@ public class PeerDiscoveryTimestampsTest {
   @Test
   public void lastSeenAndFirstDiscoveredTimestampsUpdatedOnMessage() {
     // peer[0] => controller // peer[1] => sender
-    final List<KeyPair> keypairs = PeerDiscoveryTestHelper.generateKeyPairs(2);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keypairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(2);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final MockPeerDiscoveryAgent agent = mock(MockPeerDiscoveryAgent.class);
     when(agent.getAdvertisedPeer()).thenReturn(Optional.of(peers.get(0)));
     final DiscoveryPeer localPeer = peers.get(0);
-    final KeyPair localKeyPair = keypairs.get(0);
+    final NodeKey localNodeKey = nodeKeys.get(0);
 
     final PeerDiscoveryController controller =
         PeerDiscoveryController.builder()
-            .keypair(localKeyPair)
+            .nodeKey(localNodeKey)
             .localPeer(localPeer)
             .peerTable(new PeerTable(agent.getAdvertisedPeer().get().getId()))
             .timerUtil(new MockTimerUtil())
@@ -67,7 +67,7 @@ public class PeerDiscoveryTimestampsTest {
 
     final PingPacketData ping =
         PingPacketData.create(peers.get(1).getEndpoint(), peers.get(0).getEndpoint());
-    final Packet packet = Packet.create(PacketType.PING, ping, keypairs.get(1));
+    final Packet packet = Packet.create(PacketType.PING, ping, nodeKeys.get(1));
 
     controller.onMessage(packet, peers.get(1));
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.internal;
 
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
@@ -40,12 +40,12 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
   private boolean isRunning = false;
 
   public MockPeerDiscoveryAgent(
-      final KeyPair keyPair,
+      final NodeKey nodeKey,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final Map<Bytes, MockPeerDiscoveryAgent> agentNetwork,
       final NatService natService) {
-    super(keyPair, config, peerPermissions, natService, new NoOpMetricsSystem());
+    super(nodeKey, config, peerPermissions, natService, new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 
@@ -128,8 +128,8 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
     return CompletableFuture.completedFuture(null);
   }
 
-  public KeyPair getKeyPair() {
-    return keyPair;
+  public NodeKey getNodeKey() {
+    return nodeKey;
   }
 
   public static class IncomingPacket {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -30,8 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerBondedObserver;
@@ -76,15 +75,15 @@ public class PeerDiscoveryControllerTest {
   private PeerDiscoveryController controller;
   private DiscoveryPeer localPeer;
   private PeerTable peerTable;
-  private KeyPair localKeyPair;
+  private NodeKey localNodeKey;
   private final AtomicInteger counter = new AtomicInteger(1);
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();
 
   @Before
   public void initializeMocks() {
-    final List<KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
-    localKeyPair = keyPairs.get(0);
-    localPeer = helper.createDiscoveryPeer(localKeyPair);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
+    localNodeKey = nodeKeys.get(0);
+    localPeer = helper.createDiscoveryPeer(localNodeKey);
     peerTable = new PeerTable(localPeer.getId());
   }
 
@@ -99,8 +98,8 @@ public class PeerDiscoveryControllerTest {
   public void bootstrapPeersRetriesSent() {
     // Create peers.
     final int peerCount = 3;
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(peerCount);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(peerCount);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final MockTimerUtil timer = spy(new MockTimerUtil());
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -116,7 +115,7 @@ public class PeerDiscoveryControllerTest {
     // which gets validated when receiving the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
 
     controller.start();
@@ -170,8 +169,8 @@ public class PeerDiscoveryControllerTest {
   @Test
   public void bootstrapPeersRetriesStoppedUponResponse() {
     // Create peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(3);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(3);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final MockTimerUtil timer = new MockTimerUtil();
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -186,7 +185,7 @@ public class PeerDiscoveryControllerTest {
     // which gets validated when receiving the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
 
     controller.start();
@@ -204,7 +203,7 @@ public class PeerDiscoveryControllerTest {
     // Simulate a PONG message from peer 0.
     final PongPacketData packetData =
         PongPacketData.create(localPeer.getEndpoint(), mockPacket.getHash());
-    final Packet packet = Packet.create(PacketType.PONG, packetData, keyPairs.get(0));
+    final Packet packet = Packet.create(PacketType.PONG, packetData, nodeKeys.get(0));
     controller.onMessage(packet, peers.get(0));
 
     // Invoke timers again
@@ -224,8 +223,8 @@ public class PeerDiscoveryControllerTest {
   @Test
   public void shouldStopRetryingInteractionWhenLimitIsReached() {
     // Create peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(3);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(3);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final MockTimerUtil timer = new MockTimerUtil();
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -240,7 +239,7 @@ public class PeerDiscoveryControllerTest {
     // which gets validated when receiving the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
 
     controller.start();
@@ -259,8 +258,8 @@ public class PeerDiscoveryControllerTest {
   @Test
   public void bootstrapPeersPongReceived_HashMatched() {
     // Create peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(3);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(3);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final MockTimerUtil timer = new MockTimerUtil();
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -275,7 +274,7 @@ public class PeerDiscoveryControllerTest {
     // when receiving the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
 
     controller.start();
@@ -290,7 +289,7 @@ public class PeerDiscoveryControllerTest {
     for (int i = 0; i < 3; i++) {
       final PongPacketData packetData =
           PongPacketData.create(localPeer.getEndpoint(), mockPacket.getHash());
-      final Packet packet0 = Packet.create(PacketType.PONG, packetData, keyPairs.get(i));
+      final Packet packet0 = Packet.create(PacketType.PONG, packetData, nodeKeys.get(i));
       controller.onMessage(packet0, peers.get(i));
     }
 
@@ -322,8 +321,8 @@ public class PeerDiscoveryControllerTest {
   @Test
   public void bootstrapPeersPongReceived_HashUnmatched() {
     // Create peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(3);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(3);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
     controller =
@@ -335,7 +334,7 @@ public class PeerDiscoveryControllerTest {
     // processing the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
 
     controller.start();
@@ -349,7 +348,7 @@ public class PeerDiscoveryControllerTest {
     // Send a PONG packet from peer 1, with an incorrect hash.
     final PongPacketData packetData =
         PongPacketData.create(localPeer.getEndpoint(), Bytes.fromHexString("1212"));
-    final Packet packet = Packet.create(PacketType.PONG, packetData, keyPairs.get(1));
+    final Packet packet = Packet.create(PacketType.PONG, packetData, nodeKeys.get(1));
     controller.onMessage(packet, peers.get(1));
 
     // No FIND_NEIGHBORS packet was sent for peer 1.
@@ -366,8 +365,8 @@ public class PeerDiscoveryControllerTest {
   @Test
   public void findNeighborsSentAfterBondingFinished() {
     // Create three peers, out of which the first two are bootstrap peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     // Initialize the peer controller, setting a high controller refresh interval and a high timeout
     // threshold,
@@ -384,7 +383,7 @@ public class PeerDiscoveryControllerTest {
     // processing the PONG.
     final PingPacketData mockPing =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, keyPairs.get(0));
+    final Packet mockPacket = Packet.create(PacketType.PING, mockPing, nodeKeys.get(0));
     mockPingPacketCreation(mockPacket);
     controller.setRetryDelayFunction((prev) -> 999999999L);
     controller.start();
@@ -394,7 +393,7 @@ public class PeerDiscoveryControllerTest {
         .send(eq(peers.get(0)), matchPacketOfType(PacketType.PING));
 
     // Simulate a PONG message from peer[0].
-    respondWithPong(peers.get(0), keyPairs.get(0), mockPacket.getHash());
+    respondWithPong(peers.get(0), nodeKeys.get(0), mockPacket.getHash());
 
     // Verify that the FIND_NEIGHBORS packet was sent with target == localPeer.
     final ArgumentCaptor<Packet> captor = ArgumentCaptor.forClass(Packet.class);
@@ -418,23 +417,23 @@ public class PeerDiscoveryControllerTest {
 
   private ControllerBuilder getControllerBuilder() {
     return ControllerBuilder.create()
-        .keyPair(localKeyPair)
+        .nodeKey(localNodeKey)
         .localPeer(localPeer)
         .peerTable(peerTable);
   }
 
   private void respondWithPong(
-      final DiscoveryPeer discoveryPeer, final KeyPair keyPair, final Bytes hash) {
+      final DiscoveryPeer discoveryPeer, final NodeKey nodeKey, final Bytes hash) {
     final PongPacketData packetData0 = PongPacketData.create(localPeer.getEndpoint(), hash);
-    final Packet pongPacket0 = Packet.create(PacketType.PONG, packetData0, keyPair);
+    final Packet pongPacket0 = Packet.create(PacketType.PONG, packetData0, nodeKey);
     controller.onMessage(pongPacket0, discoveryPeer);
   }
 
   @Test
   public void peerSeenTwice() throws InterruptedException {
     // Create three peers, out of which the first two are bootstrap peers.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(3);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keyPairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(3);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
 
     // Initialize the peer controller
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -448,7 +447,7 @@ public class PeerDiscoveryControllerTest {
     // when processing the PONG.
     final PingPacketData pingPacketData =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
 
     mockPingPacketCreation(pingPacket);
 
@@ -461,7 +460,7 @@ public class PeerDiscoveryControllerTest {
         .send(eq(peers.get(1)), matchPacketOfType(PacketType.PING));
 
     // Simulate a PONG message from peer[0].
-    respondWithPong(peers.get(0), keyPairs.get(0), pingPacket.getHash());
+    respondWithPong(peers.get(0), nodeKeys.get(0), pingPacket.getHash());
 
     // Assert that we're bonding with the third peer.
     assertThat(controller.streamDiscoveredPeers()).hasSize(2);
@@ -474,7 +473,7 @@ public class PeerDiscoveryControllerTest {
 
     final PongPacketData pongPacketData =
         PongPacketData.create(localPeer.getEndpoint(), pingPacket.getHash());
-    final Packet pongPacket = Packet.create(PacketType.PONG, pongPacketData, keyPairs.get(1));
+    final Packet pongPacket = Packet.create(PacketType.PONG, pongPacketData, nodeKeys.get(1));
     controller.onMessage(pongPacket, peers.get(1));
 
     // Now after we got that pong we should have sent a find neighbours message...
@@ -485,7 +484,7 @@ public class PeerDiscoveryControllerTest {
     final NeighborsPacketData neighbors0 =
         NeighborsPacketData.create(Collections.singletonList(peers.get(2)));
     final Packet neighborsPacket0 =
-        Packet.create(PacketType.NEIGHBORS, neighbors0, keyPairs.get(0));
+        Packet.create(PacketType.NEIGHBORS, neighbors0, nodeKeys.get(0));
     controller.onMessage(neighborsPacket0, peers.get(0));
 
     // Assert that we're bonded with the third peer.
@@ -499,7 +498,7 @@ public class PeerDiscoveryControllerTest {
     final NeighborsPacketData neighbors1 =
         NeighborsPacketData.create(Collections.singletonList(peers.get(2)));
     final Packet neighborsPacket1 =
-        Packet.create(PacketType.NEIGHBORS, neighbors1, keyPairs.get(1));
+        Packet.create(PacketType.NEIGHBORS, neighbors1, nodeKeys.get(1));
     controller.onMessage(neighborsPacket1, peers.get(1));
 
     verify(outboundMessageHandler, times(1))
@@ -508,7 +507,7 @@ public class PeerDiscoveryControllerTest {
     // Send a PONG packet from peer[2], to transition it to the BONDED state.
     final PongPacketData packetData2 =
         PongPacketData.create(localPeer.getEndpoint(), pingPacket.getHash());
-    final Packet pongPacket2 = Packet.create(PacketType.PONG, packetData2, keyPairs.get(2));
+    final Packet pongPacket2 = Packet.create(PacketType.PONG, packetData2, nodeKeys.get(2));
     controller.onMessage(pongPacket2, peers.get(2));
 
     // Assert we're now bonded with peer[2].
@@ -606,9 +605,9 @@ public class PeerDiscoveryControllerTest {
     final Endpoint localEndpoint = localPeer.getEndpoint();
 
     // Setup ping to be sent to discoPeer
-    List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     PingPacketData pingPacketData = PingPacketData.create(localEndpoint, discoPeer.getEndpoint());
-    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 
     controller.start();
@@ -623,15 +622,15 @@ public class PeerDiscoveryControllerTest {
         .send(eq(discoPeer), matchPacketOfType(PacketType.FIND_NEIGHBORS));
 
     // Setup ping to be sent to otherPeer after neighbors packet is received
-    keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     pingPacketData = PingPacketData.create(localEndpoint, otherPeer.getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, otherPeer, pingPacket);
 
     // Setup ping to be sent to otherPeer2 after neighbors packet is received
-    keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     pingPacketData = PingPacketData.create(localEndpoint, otherPeer2.getEndpoint());
-    final Packet pingPacket2 = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket2 = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, otherPeer2, pingPacket2);
 
     final Packet neighborsPacket =
@@ -684,9 +683,9 @@ public class PeerDiscoveryControllerTest {
     final Endpoint localEndpoint = localPeer.getEndpoint();
 
     // Setup ping to be sent to discoPeer
-    List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     PingPacketData pingPacketData = PingPacketData.create(localEndpoint, discoPeer.getEndpoint());
-    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 
     controller.start();
@@ -700,15 +699,15 @@ public class PeerDiscoveryControllerTest {
         .send(eq(discoPeer), matchPacketOfType(PacketType.FIND_NEIGHBORS));
 
     // Setup ping to be sent to otherPeer after neighbors packet is received
-    keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     pingPacketData = PingPacketData.create(localEndpoint, otherPeer.getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, otherPeer, pingPacket);
 
     // Setup ping to be sent to otherPeer2 after neighbors packet is received
-    keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     pingPacketData = PingPacketData.create(localEndpoint, otherPeer2.getEndpoint());
-    final Packet pingPacket2 = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket2 = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, otherPeer2, pingPacket2);
 
     // Blacklist peer
@@ -738,10 +737,10 @@ public class PeerDiscoveryControllerTest {
     final Endpoint localEndpoint = localPeer.getEndpoint();
 
     // Setup ping to be sent to discoPeer
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localEndpoint, discoPeer.getEndpoint());
-    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 
     controller.start();
@@ -778,10 +777,10 @@ public class PeerDiscoveryControllerTest {
     final Endpoint localEndpoint = localPeer.getEndpoint();
 
     // Setup ping to be sent to discoPeer
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localEndpoint, discoPeer.getEndpoint());
-    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 
     controller.start();
@@ -819,10 +818,10 @@ public class PeerDiscoveryControllerTest {
     final Endpoint localEndpoint = localPeer.getEndpoint();
 
     // Setup ping to be sent to discoPeer
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localEndpoint, discoPeer.getEndpoint());
-    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 
     controller.start();
@@ -848,10 +847,10 @@ public class PeerDiscoveryControllerTest {
     final List<DiscoveryPeer> peers = createPeersInLastBucket(localPeer, 1);
 
     // Mock the creation of the PING packet to control hash for PONG.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
 
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
     controller =
@@ -887,10 +886,10 @@ public class PeerDiscoveryControllerTest {
     controller.setRetryDelayFunction(LONG_DELAY_FUNCTION);
 
     // Mock the creation of PING packets to control hash PONG packets.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPingPacketCreation(pingPacket);
 
     controller.start();
@@ -946,10 +945,10 @@ public class PeerDiscoveryControllerTest {
     final List<DiscoveryPeer> peers = createPeersInLastBucket(localPeer, 2);
 
     // Mock the creation of the PING packet to control hash for PONG.
-    final List<SECP256K1.KeyPair> keyPairs = PeerDiscoveryTestHelper.generateKeyPairs(1);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(localPeer.getEndpoint(), peers.get(0).getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, keyPairs.get(0));
+    final Packet pingPacket = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
 
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
     controller =
@@ -1237,7 +1236,7 @@ public class PeerDiscoveryControllerTest {
   static class ControllerBuilder {
     private Collection<DiscoveryPeer> discoPeers = Collections.emptyList();
     private MockTimerUtil timerUtil = new MockTimerUtil();
-    private KeyPair keypair;
+    private NodeKey nodeKey;
     private DiscoveryPeer localPeer;
     private PeerTable peerTable;
     private OutboundMessageHandler outboundMessageHandler = OutboundMessageHandler.NOOP;
@@ -1269,8 +1268,8 @@ public class PeerDiscoveryControllerTest {
       return this;
     }
 
-    ControllerBuilder keyPair(final KeyPair keypair) {
-      this.keypair = keypair;
+    ControllerBuilder nodeKey(final NodeKey nodeKey) {
+      this.nodeKey = nodeKey;
       return this;
     }
 
@@ -1290,16 +1289,16 @@ public class PeerDiscoveryControllerTest {
     }
 
     PeerDiscoveryController build() {
-      checkNotNull(keypair);
+      checkNotNull(nodeKey);
       if (localPeer == null) {
-        localPeer = helper.createDiscoveryPeer(keypair);
+        localPeer = helper.createDiscoveryPeer(nodeKey);
       }
       if (peerTable == null) {
         peerTable = new PeerTable(localPeer.getId());
       }
       return spy(
           PeerDiscoveryController.builder()
-              .keypair(keypair)
+              .nodeKey(nodeKey)
               .localPeer(localPeer)
               .peerTable(peerTable)
               .bootstrapNodes(discoPeers)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryTableRefreshTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryTableRefreshTest.java
@@ -21,8 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper;
@@ -45,10 +44,10 @@ public class PeerDiscoveryTableRefreshTest {
 
   @Test
   public void tableRefreshSingleNode() {
-    final List<SECP256K1.KeyPair> keypairs = PeerDiscoveryTestHelper.generateKeyPairs(2);
-    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(keypairs);
+    final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(2);
+    final List<DiscoveryPeer> peers = helper.createDiscoveryPeers(nodeKeys);
     final DiscoveryPeer localPeer = peers.get(0);
-    final KeyPair localKeyPair = keypairs.get(0);
+    final NodeKey localKeyPair = nodeKeys.get(0);
 
     // Create and start the PeerDiscoveryController
     final OutboundMessageHandler outboundMessageHandler = mock(OutboundMessageHandler.class);
@@ -56,7 +55,7 @@ public class PeerDiscoveryTableRefreshTest {
     final PeerDiscoveryController controller =
         spy(
             PeerDiscoveryController.builder()
-                .keypair(localKeyPair)
+                .nodeKey(localKeyPair)
                 .localPeer(localPeer)
                 .peerTable(new PeerTable(localPeer.getId()))
                 .outboundMessageHandler(outboundMessageHandler)
@@ -71,7 +70,7 @@ public class PeerDiscoveryTableRefreshTest {
     // Send a PING, so as to add a Peer in the controller.
     final PingPacketData ping =
         PingPacketData.create(peers.get(1).getEndpoint(), peers.get(0).getEndpoint());
-    final Packet pingPacket = Packet.create(PacketType.PING, ping, keypairs.get(1));
+    final Packet pingPacket = Packet.create(PacketType.PING, ping, nodeKeys.get(1));
     controller.onMessage(pingPacket, peers.get(1));
 
     // Wait until the controller has added the newly found peer.
@@ -80,7 +79,7 @@ public class PeerDiscoveryTableRefreshTest {
     // Simulate a PONG message from peer 0.
     final PongPacketData pongPacketData =
         PongPacketData.create(localPeer.getEndpoint(), pingPacket.getHash());
-    final Packet pongPacket = Packet.create(PacketType.PONG, pongPacketData, keypairs.get(0));
+    final Packet pongPacket = Packet.create(PacketType.PONG, pongPacketData, nodeKeys.get(0));
 
     final ArgumentCaptor<Packet> captor = ArgumentCaptor.forClass(Packet.class);
     for (int i = 0; i < 5; i++) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
@@ -324,13 +326,13 @@ public final class DefaultP2PNetworkTest {
 
   private DefaultP2PNetwork.Builder builder() {
 
-    final KeyPair keyPair = KeyPair.generate();
+    final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
 
     return DefaultP2PNetwork.builder()
         .config(config)
         .peerDiscoveryAgent(discoveryAgent)
         .rlpxAgent(rlpxAgent)
-        .keyPair(keyPair)
+        .nodeKey(nodeKey)
         .maintainedPeers(maintainedPeers)
         .metricsSystem(new NoOpMetricsSystem())
         .supportedCapabilities(Capability.create("eth", 63));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
@@ -18,6 +18,8 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.p2p.NetworkingTestHelper.configWithRandomPorts;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
@@ -37,7 +39,7 @@ import org.junit.Test;
 public class NetworkingServiceLifecycleTest {
 
   private final Vertx vertx = Vertx.vertx();
-  private final SECP256K1.KeyPair keyPair = SECP256K1.KeyPair.generate();
+  private final NodeKey nodeKey = new BouncyCastleNodeKey(SECP256K1.KeyPair.generate());
   private final NetworkingConfiguration config = configWithRandomPorts();
 
   @After
@@ -93,7 +95,7 @@ public class NetworkingServiceLifecycleTest {
 
   @Test(expected = NullPointerException.class)
   public void createP2PNetwork_NullKeyPair() throws IOException {
-    try (final P2PNetwork broken = builder().config(config).keyPair(null).build()) {
+    try (final P2PNetwork broken = builder().config(config).nodeKey(null).build()) {
       Assertions.fail("Expected Exception");
     }
   }
@@ -154,7 +156,7 @@ public class NetworkingServiceLifecycleTest {
   private DefaultP2PNetwork.Builder builder() {
     return DefaultP2PNetwork.builder()
         .vertx(vertx)
-        .keyPair(keyPair)
+        .nodeKey(nodeKey)
         .config(config)
         .metricsSystem(new NoOpMetricsSystem())
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
@@ -21,7 +21,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
@@ -66,8 +67,8 @@ public class P2PNetworkTest {
 
   @Test
   public void handshaking() throws Exception {
-    final SECP256K1.KeyPair listenKp = SECP256K1.KeyPair.generate();
-    try (final P2PNetwork listener = builder().keyPair(listenKp).build();
+    final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
+    try (final P2PNetwork listener = builder().nodeKey(nodeKey).build();
         final P2PNetwork connector = builder().build()) {
 
       listener.start();
@@ -88,8 +89,8 @@ public class P2PNetworkTest {
 
   @Test
   public void preventMultipleConnections() throws Exception {
-    final SECP256K1.KeyPair listenKp = SECP256K1.KeyPair.generate();
-    try (final P2PNetwork listener = builder().keyPair(listenKp).build();
+    final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
+    try (final P2PNetwork listener = builder().nodeKey(nodeKey).build();
         final P2PNetwork connector = builder().build()) {
 
       listener.start();
@@ -121,7 +122,7 @@ public class P2PNetworkTest {
    */
   @Test
   public void limitMaxPeers() throws Exception {
-    final SECP256K1.KeyPair listenKp = SECP256K1.KeyPair.generate();
+    final NodeKey nodeKey = new BouncyCastleNodeKey(KeyPair.generate());
     final int maxPeers = 1;
     final NetworkingConfiguration listenerConfig =
         NetworkingConfiguration.create()
@@ -131,7 +132,7 @@ public class P2PNetworkTest {
                     .setBindPort(0)
                     .setMaxPeers(maxPeers)
                     .setSupportedProtocols(subProtocol()));
-    try (final P2PNetwork listener = builder().keyPair(listenKp).config(listenerConfig).build();
+    try (final P2PNetwork listener = builder().nodeKey(nodeKey).config(listenerConfig).build();
         final P2PNetwork connector1 = builder().build();
         final P2PNetwork connector2 = builder().build()) {
 
@@ -176,16 +177,17 @@ public class P2PNetworkTest {
 
   @Test
   public void rejectPeerWithNoSharedCaps() throws Exception {
-    final SECP256K1.KeyPair listenKp = SECP256K1.KeyPair.generate();
+    final NodeKey listenerCryptoOps = new BouncyCastleNodeKey(KeyPair.generate());
+    final NodeKey connectorCryptoOps = new BouncyCastleNodeKey(KeyPair.generate());
 
     final SubProtocol subprotocol1 = subProtocol("eth");
     final Capability cap1 = Capability.create(subprotocol1.getName(), 63);
     final SubProtocol subprotocol2 = subProtocol("oth");
     final Capability cap2 = Capability.create(subprotocol2.getName(), 63);
     try (final P2PNetwork listener =
-            builder().keyPair(listenKp).supportedCapabilities(cap1).build();
+            builder().nodeKey(listenerCryptoOps).supportedCapabilities(cap1).build();
         final P2PNetwork connector =
-            builder().keyPair(SECP256K1.KeyPair.generate()).supportedCapabilities(cap2).build()) {
+            builder().nodeKey(connectorCryptoOps).supportedCapabilities(cap2).build()) {
       listener.start();
       connector.start();
       final EnodeURL listenerEnode = listener.getLocalEnode().get();
@@ -330,7 +332,7 @@ public class P2PNetworkTest {
     return DefaultP2PNetwork.builder()
         .vertx(vertx)
         .config(config)
-        .keyPair(KeyPair.generate())
+        .nodeKey(new BouncyCastleNodeKey(KeyPair.generate()))
         .metricsSystem(new NoOpMetricsSystem())
         .supportedCapabilities(Arrays.asList(Capability.create("eth", 63)));
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
@@ -971,7 +972,7 @@ public class RlpxAgentTest {
   private RlpxAgent agent() {
     config.setLimitRemoteWireConnectionsEnabled(true);
     return RlpxAgent.builder()
-        .keyPair(KEY_PAIR)
+        .nodeKey(new BouncyCastleNodeKey(KEY_PAIR))
         .config(config)
         .peerPermissions(peerPermissions)
         .peerPrivileges(peerPrivileges)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.PrivateKey;
 import org.hyperledger.besu.ethereum.p2p.rlpx.handshake.Handshaker.HandshakeStatus;
@@ -80,6 +81,7 @@ public class ECIESHandshakeTest {
   }
 
   private static class Expectations {
+
     private static final byte[] aesSecret =
         h32("0xc0458fa97a5230830e05f4f20b7c755c1d4e54b1ce5cf43260bb191eef4e418d").toArray();
     private static final byte[] macSecret =
@@ -98,7 +100,8 @@ public class ECIESHandshakeTest {
     final ECIESHandshaker initiator = new ECIESHandshaker();
 
     // Prepare the handshaker to take the initiator role.
-    initiator.prepareInitiator(Input.initiatorKeyPair, Input.responderKeyPair.getPublicKey());
+    initiator.prepareInitiator(
+        new BouncyCastleNodeKey(Input.initiatorKeyPair), Input.responderKeyPair.getPublicKey());
 
     // Set the test vectors.
     initiator.setEphKeyPair(Input.initiatorEphKeyPair);
@@ -112,7 +115,7 @@ public class ECIESHandshakeTest {
     final ECIESHandshaker responder = new ECIESHandshaker();
 
     // Prepare the handshaker with the responder's keypair.
-    responder.prepareResponder(Input.responderKeyPair);
+    responder.prepareResponder(new BouncyCastleNodeKey(Input.responderKeyPair));
 
     // Set the test data.
     responder.setEphKeyPair(Input.responderEphKeyPair);
@@ -125,7 +128,7 @@ public class ECIESHandshakeTest {
             .orElseThrow(() -> new AssertionFailedError("Expected responder message"));
     assertThat(responder.getPartyEphPubKey()).isEqualTo(initiator.getEphKeyPair().getPublicKey());
     assertThat(responder.getInitiatorNonce()).isEqualTo(initiator.getInitiatorNonce());
-    assertThat(responder.partyPubKey()).isEqualTo(initiator.getIdentityKeyPair().getPublicKey());
+    assertThat(responder.partyPubKey()).isEqualTo(initiator.getOurCryptoOps().getPublicKey());
 
     // Provide that message to the initiator, check that it has nothing to send.
     final Optional<ByteBuf> noMessage = initiator.handleMessage(responderRp);
@@ -146,7 +149,7 @@ public class ECIESHandshakeTest {
     final ECIESHandshaker responder = new ECIESHandshaker();
 
     // Prepare the handshaker with the responder's keypair.
-    responder.prepareResponder(Input.responderKeyPair);
+    responder.prepareResponder(new BouncyCastleNodeKey(Input.responderKeyPair));
 
     // Set the test data.
     responder.setEphKeyPair(Input.responderEphKeyPair);
@@ -163,7 +166,8 @@ public class ECIESHandshakeTest {
   public void ingressEgressMacsAsExpected() {
     // Initiator end of the handshake.
     final ECIESHandshaker initiator = new ECIESHandshaker();
-    initiator.prepareInitiator(Input.initiatorKeyPair, Input.responderKeyPair.getPublicKey());
+    initiator.prepareInitiator(
+        new BouncyCastleNodeKey(Input.initiatorKeyPair), Input.responderKeyPair.getPublicKey());
     initiator.firstMessage();
     initiator.setInitiatorMsgEnc(Bytes.wrap(Messages.initiatorMsgEnc));
     initiator.setEphKeyPair(Input.initiatorEphKeyPair);
@@ -171,7 +175,7 @@ public class ECIESHandshakeTest {
 
     // Responder end of the handshake.
     final ECIESHandshaker responder = new ECIESHandshaker();
-    responder.prepareResponder(Input.responderKeyPair);
+    responder.prepareResponder(new BouncyCastleNodeKey(Input.responderKeyPair));
     responder.setEphKeyPair(Input.responderEphKeyPair);
     responder.setResponderNonce(Input.responderNonce);
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessageTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.SECP256K1;
 
 import java.util.concurrent.ThreadLocalRandom;
@@ -33,7 +34,8 @@ public final class EncryptedMessageTest {
     ThreadLocalRandom.current().nextBytes(message);
     final Bytes initial = Bytes.wrap(message);
     final Bytes encrypted = EncryptedMessage.encryptMsgEip8(initial, keyPair.getPublicKey());
-    final Bytes decrypted = EncryptedMessage.decryptMsgEIP8(encrypted, keyPair.getPrivateKey());
+    final Bytes decrypted =
+        EncryptedMessage.decryptMsgEIP8(encrypted, new BouncyCastleNodeKey(keyPair));
     Assertions.assertThat(decrypted.slice(0, 288)).isEqualTo(initial);
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4Test.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4Test.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies;
 
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
 import org.hyperledger.besu.crypto.KeyPairUtil;
 import org.hyperledger.besu.crypto.SECP256K1;
 
@@ -57,7 +58,8 @@ public final class InitiatorHandshakeMessageV4Test {
   @Test
   public void encodeDecodeRoundtrip() {
     final InitiatorHandshakeMessageV4 initial =
-        InitiatorHandshakeMessageV4.decode(EXAMPLE_MESSAGE, EXAMPLE_KEYPAIR);
+        InitiatorHandshakeMessageV4.decode(
+            EXAMPLE_MESSAGE, new BouncyCastleNodeKey(EXAMPLE_KEYPAIR));
     final Bytes encoded = initial.encode();
     Assertions.assertThat(encoded).isEqualTo(EXAMPLE_MESSAGE.slice(0, encoded.size()));
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This extends upon PR #618 and #650, and repalces all references to the node's KeyPair with the
NodeKey abstraction - effectively hiding the private key from the application at large.

This is the final change required to support cryptographic engines other than BouncyCastle.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
