### PR TITLE
Update Clique classes with NodeKey structure

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -85,7 +85,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
             protocolContext,
             protocolSchedule,
             transactionPool.getPendingTransactions(),
-            nodeKeys,
+            new BouncyCastleNodeKey(nodeKeys),
             miningParameters,
             new CliqueBlockScheduler(
                 clock,
@@ -111,7 +111,7 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder<CliqueCon
   protected ProtocolSchedule<CliqueContext> createProtocolSchedule() {
     return CliqueProtocolSchedule.create(
         genesisConfig.getConfigOptions(genesisConfigOverrides),
-        nodeKeys,
+        new BouncyCastleNodeKey(nodeKeys),
         privacyParameters,
         isRevertReasonEnabled);
   }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.consensus.clique;
 import org.hyperledger.besu.config.CliqueConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.common.EpochManager;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.MainnetBlockValidator;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
@@ -38,13 +38,13 @@ public class CliqueProtocolSchedule {
 
   public static ProtocolSchedule<CliqueContext> create(
       final GenesisConfigOptions config,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final PrivacyParameters privacyParameters,
       final boolean isRevertReasonEnabled) {
 
     final CliqueConfigOptions cliqueConfig = config.getCliqueConfigOptions();
 
-    final Address localNodeAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
+    final Address localNodeAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
 
     final EpochManager epochManager = new EpochManager(cliqueConfig.getEpochLength());
     return new ProtocolScheduleBuilder<>(
@@ -60,9 +60,9 @@ public class CliqueProtocolSchedule {
 
   public static ProtocolSchedule<CliqueContext> create(
       final GenesisConfigOptions config,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final boolean isRevertReasonEnabled) {
-    return create(config, nodeKeys, PrivacyParameters.DEFAULT, isRevertReasonEnabled);
+    return create(config, nodeKey, PrivacyParameters.DEFAULT, isRevertReasonEnabled);
   }
 
   private static ProtocolSpecBuilder<CliqueContext> applyCliqueSpecificModifications(

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
@@ -21,8 +21,7 @@ import org.hyperledger.besu.consensus.clique.CliqueExtraData;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.ValidatorVote;
 import org.hyperledger.besu.consensus.common.VoteTally;
-import org.hyperledger.besu.crypto.SECP256K1;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -42,7 +41,7 @@ import java.util.function.Function;
 
 public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
 
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final EpochManager epochManager;
 
   public CliqueBlockCreator(
@@ -52,7 +51,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
       final ProtocolContext<CliqueContext> protocolContext,
       final ProtocolSchedule<CliqueContext> protocolSchedule,
       final Function<Long, Long> gasLimitCalculator,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final Wei minTransactionGasPrice,
       final BlockHeader parentHeader,
       final EpochManager epochManager) {
@@ -64,9 +63,9 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
         protocolSchedule,
         gasLimitCalculator,
         minTransactionGasPrice,
-        Util.publicKeyToAddress(nodeKeys.getPublicKey()),
+        Util.publicKeyToAddress(nodeKey.getPublicKey()),
         parentHeader);
-    this.nodeKeys = nodeKeys;
+    this.nodeKey = nodeKey;
     this.epochManager = epochManager;
   }
 
@@ -109,7 +108,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
           cliqueContext.getVoteTallyCache().getVoteTallyAfterBlock(parentHeader);
       return cliqueContext
           .getVoteProposer()
-          .getVote(Util.publicKeyToAddress(nodeKeys.getPublicKey()), voteTally);
+          .getVote(Util.publicKeyToAddress(nodeKey.getPublicKey()), voteTally);
     }
   }
 
@@ -127,7 +126,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator<CliqueContext> {
         CliqueBlockHashing.calculateDataHashForProposerSeal(headerToSign, extraData);
     return new CliqueExtraData(
         extraData.getVanityData(),
-        SECP256K1.sign(hashToSign, nodeKeys),
+        nodeKey.sign(hashToSign),
         extraData.getValidators(),
         headerToSign);
   }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutor.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutor.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.consensus.clique.CliqueExtraData;
 import org.hyperledger.besu.consensus.common.ConsensusHelpers;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteTally;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockScheduler;
 import org.hyperledger.besu.ethereum.blockcreation.AbstractMinerExecutor;
@@ -44,14 +44,14 @@ import org.apache.tuweni.bytes.Bytes;
 public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, CliqueBlockMiner> {
 
   private final Address localAddress;
-  private final KeyPair nodeKeys;
+  private final NodeKey nodeKey;
   private final EpochManager epochManager;
 
   public CliqueMinerExecutor(
       final ProtocolContext<CliqueContext> protocolContext,
       final ProtocolSchedule<CliqueContext> protocolSchedule,
       final PendingTransactions pendingTransactions,
-      final KeyPair nodeKeys,
+      final NodeKey nodeKey,
       final MiningParameters miningParams,
       final AbstractBlockScheduler blockScheduler,
       final EpochManager epochManager,
@@ -63,8 +63,8 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
         miningParams,
         blockScheduler,
         gasLimitCalculator);
-    this.nodeKeys = nodeKeys;
-    this.localAddress = Util.publicKeyToAddress(nodeKeys.getPublicKey());
+    this.nodeKey = nodeKey;
+    this.localAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
     this.epochManager = epochManager;
   }
 
@@ -82,7 +82,7 @@ public class CliqueMinerExecutor extends AbstractMinerExecutor<CliqueContext, Cl
                 protocolContext,
                 protocolSchedule,
                 gasLimitCalculator,
-                nodeKeys,
+                nodeKey,
                 minTransactionGasPrice,
                 header,
                 epochManager);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
@@ -18,7 +18,8 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -27,7 +28,7 @@ import org.junit.Test;
 
 public class CliqueProtocolScheduleTest {
 
-  private static final KeyPair NODE_KEYS = KeyPair.generate();
+  private static final NodeKey NODE_KEY = BouncyCastleNodeKey.generate();
 
   @Test
   public void protocolSpecsAreCreatedAtBlockDefinedInJson() {
@@ -43,7 +44,7 @@ public class CliqueProtocolScheduleTest {
 
     final GenesisConfigOptions config = GenesisConfigFile.fromConfig(jsonInput).getConfigOptions();
     final ProtocolSchedule<CliqueContext> protocolSchedule =
-        CliqueProtocolSchedule.create(config, NODE_KEYS, false);
+        CliqueProtocolSchedule.create(config, NODE_KEY, false);
 
     final ProtocolSpec<CliqueContext> homesteadSpec = protocolSchedule.getByBlockNumber(1);
     final ProtocolSpec<CliqueContext> tangerineWhistleSpec = protocolSchedule.getByBlockNumber(2);
@@ -58,8 +59,7 @@ public class CliqueProtocolScheduleTest {
   @Test
   public void parametersAlignWithMainnetWithAdjustments() {
     final ProtocolSpec<CliqueContext> homestead =
-        CliqueProtocolSchedule.create(
-                GenesisConfigFile.DEFAULT.getConfigOptions(), NODE_KEYS, false)
+        CliqueProtocolSchedule.create(GenesisConfigFile.DEFAULT.getConfigOptions(), NODE_KEY, false)
             .getByBlockNumber(0);
 
     assertThat(homestead.getName()).isEqualTo("Frontier");

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
@@ -61,8 +63,8 @@ import org.junit.Test;
 
 public class CliqueBlockCreatorTest {
 
-  private final KeyPair proposerKeyPair = KeyPair.generate();
-  private final Address proposerAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+  private final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
+  private final Address proposerAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
   private final KeyPair otherKeyPair = KeyPair.generate();
   private final List<Address> validatorList = Lists.newArrayList();
   private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
@@ -80,7 +82,7 @@ public class CliqueBlockCreatorTest {
   public void setup() {
     protocolSchedule =
         CliqueProtocolSchedule.create(
-            GenesisConfigFile.DEFAULT.getConfigOptions(), proposerKeyPair, false);
+            GenesisConfigFile.DEFAULT.getConfigOptions(), proposerNodeKey, false);
 
     final Address otherAddress = Util.publicKeyToAddress(otherKeyPair.getPublicKey());
     validatorList.add(otherAddress);
@@ -128,7 +130,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -160,7 +162,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -191,7 +193,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);
@@ -225,7 +227,7 @@ public class CliqueBlockCreatorTest {
             protocolContext,
             protocolSchedule,
             gasLimit -> gasLimit,
-            proposerKeyPair,
+            proposerNodeKey,
             Wei.ZERO,
             blockchain.getChainHeadHeader(),
             epochManager);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -30,7 +30,8 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.VoteProposer;
 import org.hyperledger.besu.consensus.common.VoteTally;
 import org.hyperledger.besu.consensus.common.VoteTallyCache;
-import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
+import org.hyperledger.besu.crypto.BouncyCastleNodeKey;
+import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
@@ -59,7 +60,7 @@ public class CliqueMinerExecutorTest {
   private static final int EPOCH_LENGTH = 10;
   private static final GenesisConfigOptions GENESIS_CONFIG_OPTIONS =
       GenesisConfigFile.fromConfig("{}").getConfigOptions();
-  private final KeyPair proposerKeyPair = KeyPair.generate();
+  private final NodeKey proposerNodeKey = BouncyCastleNodeKey.generate();
   private final Random random = new Random(21341234L);
   private Address localAddress;
   private final List<Address> validatorList = Lists.newArrayList();
@@ -70,7 +71,7 @@ public class CliqueMinerExecutorTest {
 
   @Before
   public void setup() {
-    localAddress = Util.publicKeyToAddress(proposerKeyPair.getPublicKey());
+    localAddress = Util.publicKeyToAddress(proposerNodeKey.getPublicKey());
     validatorList.add(localAddress);
     validatorList.add(AddressHelpers.calculateAddressWithRespectTo(localAddress, 1));
     validatorList.add(AddressHelpers.calculateAddressWithRespectTo(localAddress, 2));
@@ -93,14 +94,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),
@@ -131,14 +132,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, vanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),
@@ -169,14 +170,14 @@ public class CliqueMinerExecutorTest {
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
             cliqueProtocolContext,
-            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerKeyPair, false),
+            CliqueProtocolSchedule.create(GENESIS_CONFIG_OPTIONS, proposerNodeKey, false),
             new PendingTransactions(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
                 5,
                 TestClock.fixed(),
                 metricsSystem),
-            proposerKeyPair,
+            proposerNodeKey,
             new MiningParameters(AddressHelpers.ofValue(1), Wei.ZERO, initialVanityData, false),
             mock(CliqueBlockScheduler.class),
             new EpochManager(EPOCH_LENGTH),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Updates the Clique mining classes to use the NodeKeys framework (Created in PR #618) (rather than KeyPair directly) - allowing Clique to use pluggable crypto.

## Fixed Issue(s)
N/A
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
