### PR TITLE
Editorial: Correct code comment for permissions contract

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
@@ -171,7 +171,7 @@ public class TransactionSmartContractPermissioningController
     // 0 is false
     if (result.equals(FALSE_RESPONSE)) {
       return false;
-      // 32 bytes of 1's is true
+      // a 32-byte version of 1 is true
     } else if (result.equals(TRUE_RESPONSE)) {
       return true;
       // Anything else is wrong


### PR DESCRIPTION
TRUE_RESPONSE is defined as 1 padded out with zeros to take up 32 bytes.

(This is probably a copy-paste error from the Node controller, which uses 256 bits of 1...)

Signed-off-by: chaals <chaals@users.noreply.github.com>