### PR TITLE
Remove unused ECIES Agreement from NodeKey

### DIFF
--- a/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/BouncyCastleNodeKey.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.crypto.SECP256K1.KeyPair;
 import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class BouncyCastleNodeKey implements NodeKey {
@@ -46,10 +45,5 @@ public class BouncyCastleNodeKey implements NodeKey {
   @Override
   public Bytes32 calculateECDHKeyAgreement(final PublicKey publicKey) {
     return SECP256K1.calculateECDHKeyAgreement(nodeKeys.getPrivateKey(), publicKey);
-  }
-
-  @Override
-  public Bytes calculateECIESKeyAgreement(final SECP256K1.PublicKey pubKey) {
-    return SECP256K1.calculateECIESKeyAgreement(nodeKeys.getPrivateKey(), pubKey);
   }
 }

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/NodeKey.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.crypto;
 import org.hyperledger.besu.crypto.SECP256K1.PublicKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public interface NodeKey {
@@ -27,6 +26,4 @@ public interface NodeKey {
   PublicKey getPublicKey();
 
   Bytes32 calculateECDHKeyAgreement(PublicKey publicKey);
-
-  Bytes calculateECIESKeyAgreement(SECP256K1.PublicKey pubKey);
 }

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
@@ -34,8 +34,6 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.asn1.x9.X9ECParameters;
 import org.bouncycastle.asn1.x9.X9IntegerConverter;
-import org.bouncycastle.crypto.BasicAgreement;
-import org.bouncycastle.crypto.CipherParameters;
 import org.bouncycastle.crypto.agreement.ECDHBasicAgreement;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.params.ECDomainParameters;
@@ -50,7 +48,6 @@ import org.bouncycastle.math.ec.ECAlgorithms;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
 import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
-import org.bouncycastle.util.BigIntegers;
 
 /*
  * Adapted from the BitcoinJ ECKey (Apache 2 License) implementation:
@@ -294,18 +291,6 @@ public class SECP256K1 {
     final BigInteger agreed = agreement.calculateAgreement(pubKeyP);
 
     return UInt256.valueOf(agreed).toBytes();
-  }
-
-  public static Bytes calculateECIESKeyAgreement(final PrivateKey privKey, final PublicKey pubKey) {
-    final ECDomainParameters dp = SECP256K1.CURVE;
-
-    final CipherParameters pubParam = new ECPublicKeyParameters(pubKey.asEcPoint(), dp);
-    final CipherParameters privParam = new ECPrivateKeyParameters(privKey.getD(), dp);
-
-    final BasicAgreement agree = new ECDHBasicAgreement();
-    agree.init(privParam);
-    final BigInteger z = agree.calculateAgreement(pubParam);
-    return Bytes.wrap(BigIntegers.asUnsignedByteArray(agree.getFieldSize(), z));
   }
 
   public static class PrivateKey implements java.security.PrivateKey {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESEncryptionEngine.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESEncryptionEngine.java
@@ -118,7 +118,7 @@ public class ECIESEncryptionEngine {
     final byte[] ivb = ECIESHandshaker.random(CIPHER_BLOCK_SIZE).toArray();
 
     return new ECIESEncryptionEngine(
-        SECP256K1.calculateECIESKeyAgreement(ephKeyPair.getPrivateKey(), pubKey),
+        SECP256K1.calculateECDHKeyAgreement(ephKeyPair.getPrivateKey(), pubKey),
         ephKeyPair.getPublicKey(),
         ivb);
   }


### PR DESCRIPTION
Signed-off-by: Trent Mohay <trent.mohay@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
It was identified that during the creation of injectable crypto, that the NodeKey effectively offered duplicated functionality between ECDH and ECIES key agreements. The ECIES was superfluous and has been removed.
## Fixed Issue(s)
N/A

<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
