### PR TITLE
Correct a comment in source

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
@@ -171,7 +171,7 @@ public class TransactionSmartContractPermissioningController
     // 0 is false
     if (result.equals(FALSE_RESPONSE)) {
       return false;
-      // 32 bytes of 1's is true
+      // true is 1, padded to 32 bytes
     } else if (result.equals(TRUE_RESPONSE)) {
       return true;
       // Anything else is wrong


### PR DESCRIPTION
## PR Description

This is purely editorial / documentation. (And my fourth attempt to correctly file a Pull Request on this :( )

The original comment is misleading (probably copy-pasted from `connectionAllowed` which does use a custom definition for true).

Signed-off-by: chaals nevile <charles.nevile@consensys.net>
