### PR TITLE
Speed up build time

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -71,6 +71,10 @@ public class BlockchainReferenceTestTools {
 
     // Absurd amount of gas, doesn't run in parallel
     params.blacklist("randomStatetest94_\\w+");
+
+    // Don't do time consuming tests
+    params.blacklist("CALLBlake2f_MaxRounds.*");
+    params.blacklist(".*\\w50000[-_].*");
   }
 
   public static Collection<Object[]> generateTestParametersForConfig(final String[] filePath) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -82,13 +82,20 @@ public class GeneralStateReferenceTestTools {
     if (EIPS_TO_RUN.isEmpty()) {
       params.blacklistAll();
     }
+
     // Known incorrect test.
     params.blacklist(
         "RevertPrecompiledTouch(_storage)?-(EIP158|Byzantium|Constantinople|ConstantinopleFix)");
+
     // Gas integer value is too large to construct a valid transaction.
     params.blacklist("OverflowGasRequire");
+
     // Consumes a huge amount of memory
     params.blacklist("static_Call1MB1024Calldepth-\\w");
+
+    // Don't do time consuming tests
+    params.blacklist("CALLBlake2f_MaxRounds.*");
+    params.blacklist(".*\\w50000[-_].*");
   }
 
   public static Collection<Object[]> generateTestParametersForConfig(final String[] filePath) {


### PR DESCRIPTION
Speed up build time by removing some of the most time consuming reference 
tests.

* CALLBlake2f_MaxRounds - runs Blake2f 4 billion rounds, something no
  one ever does and there is never enough gas to do. We have a unit test
  for this already.
* The "do this 50k times" tests.  Each has a smaller "5k times" or less
  variant. This drifts into performance testing instead of conformance
  testing

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
