### PR TITLE
Refactor methods out of ProtocolSpec

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MutableProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MutableProtocolSchedule.java
@@ -77,15 +77,20 @@ public class MutableProtocolSchedule<C> implements ProtocolSchedule<C> {
 
   @Override
   public void setTransactionFilter(final TransactionFilter transactionFilter) {
-    protocolSpecs.forEach(spec -> spec.getSpec().setTransactionFilter(transactionFilter));
+    protocolSpecs.forEach(
+        spec -> spec.getSpec().getTransactionValidator().setTransactionFilter(transactionFilter));
   }
 
   @Override
   public void setPublicWorldStateArchiveForPrivacyBlockProcessor(
       final WorldStateArchive publicWorldStateArchive) {
     protocolSpecs.forEach(
-        spec ->
-            spec.getSpec()
-                .setPublicWorldStateArchiveForPrivacyBlockProcessor(publicWorldStateArchive));
+        spec -> {
+          final BlockProcessor blockProcessor =
+              ((ScheduledProtocolSpec<?>) spec).getSpec().getBlockProcessor();
+          if (PrivacyBlockProcessor.class.isAssignableFrom(blockProcessor.getClass()))
+            ((PrivacyBlockProcessor) blockProcessor)
+                .setPublicWorldStateArchive(publicWorldStateArchive);
+        });
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
@@ -285,14 +285,4 @@ public class ProtocolSpec<C> {
   public GasCalculator getGasCalculator() {
     return gasCalculator;
   }
-
-  public void setTransactionFilter(final TransactionFilter transactionFilter) {
-    transactionValidator.setTransactionFilter(transactionFilter);
-  }
-
-  public void setPublicWorldStateArchiveForPrivacyBlockProcessor(
-      final WorldStateArchive publicWorldStateArchive) {
-    if (PrivacyBlockProcessor.class.isAssignableFrom(blockProcessor.getClass()))
-      ((PrivacyBlockProcessor) blockProcessor).setPublicWorldStateArchive(publicWorldStateArchive);
-  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
@@ -17,12 +17,10 @@ package org.hyperledger.besu.ethereum.mainnet;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
-import org.hyperledger.besu.ethereum.core.TransactionFilter;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionProcessor;
 import org.hyperledger.besu.ethereum.vm.EVM;
 import org.hyperledger.besu.ethereum.vm.GasCalculator;
-import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
 /** A protocol specification. */
 public class ProtocolSpec<C> {


### PR DESCRIPTION
Pull two methods out of ProtocolSpec into the only class that uses them.
This is in preparation for future refactoring of the ProtocolSpec.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

