### PR TITLE
Deal with quick service start failures

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -184,7 +184,7 @@ public class Runner implements AutoCloseable {
 
   private void waitForServiceToStart(
       final String serviceName, final CompletableFuture<?> startFuture) {
-    while (!startFuture.isDone()) {
+    do {
       try {
         startFuture.get(60, TimeUnit.SECONDS);
       } catch (final InterruptedException e) {
@@ -196,7 +196,7 @@ public class Runner implements AutoCloseable {
       } catch (final TimeoutException e) {
         LOG.warn("Service {} is taking an unusually long time to start", serviceName);
       }
-    }
+    } while (!startFuture.isDone());
   }
 
   private void writeBesuPortsToFile() {


### PR DESCRIPTION
It is possible for the service furture to fail exceptionally before we
first poll for waiting, so we should switch to a do/while loop so we
will get the exception re-thrown instead of ignoring it.

This may fix #662

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
