### PR TITLE
Fix support of peers that do not support eth/65

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.eth.messages.GetReceiptsMessage;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection.PeerNotConnected;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 
@@ -376,6 +377,10 @@ public class EthPeer {
 
   public boolean hasAvailableRequestCapacity() {
     return outstandingRequests() < MAX_OUTSTANDING_REQUESTS;
+  }
+
+  public Set<Capability> getAgreedCapabilities() {
+    return connection.getAgreedCapabilities();
   }
 
   public Bytes nodeId() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import static java.util.Collections.emptySet;
 
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 
 import java.util.Collection;
@@ -65,6 +66,10 @@ public class PeerPendingTransactionTracker implements EthPeer.DisconnectCallback
     } else {
       return emptySet();
     }
+  }
+
+  public boolean isPeerSupported(final EthPeer peer) {
+    return peer.getAgreedCapabilities().contains(EthProtocol.ETH65);
   }
 
   private Set<Hash> getOrCreateSeenTransactionsForPeer(final EthPeer peer) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
@@ -68,8 +68,8 @@ public class PeerPendingTransactionTracker implements EthPeer.DisconnectCallback
     }
   }
 
-  public boolean isPeerSupported(final EthPeer peer) {
-    return peer.getAgreedCapabilities().contains(EthProtocol.ETH65);
+  public boolean isPeerSupported(final EthPeer peer, final Capability capability) {
+    return peer.getAgreedCapabilities().contains(capability);
   }
 
   private Set<Hash> getOrCreateSeenTransactionsForPeer(final EthPeer peer) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerPendingTransactionTracker.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import static java.util.Collections.emptySet;
 
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionSender.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionSender.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.transactions;
 
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.TransactionBatchAddedListener;
 
@@ -38,7 +39,7 @@ class PendingTransactionSender implements TransactionBatchAddedListener {
     ethContext
         .getEthPeers()
         .streamAvailablePeers()
-        .filter(transactionTracker::isPeerSupported)
+        .filter(peer -> transactionTracker.isPeerSupported(peer, EthProtocol.ETH65))
         .forEach(
             peer ->
                 transactions.forEach(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionSender.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionSender.java
@@ -38,6 +38,7 @@ class PendingTransactionSender implements TransactionBatchAddedListener {
     ethContext
         .getEthPeers()
         .streamAvailablePeers()
+        .filter(transactionTracker::isPeerSupported)
         .forEach(
             peer ->
                 transactions.forEach(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessor.java
@@ -89,7 +89,7 @@ class PendingTransactionsMessageProcessor {
       transactionTracker.markTransactionsHashesAsSeen(peer, pendingHashes);
       List<Hash> toRequest = new ArrayList<>();
       for (Hash hash : pendingHashes) {
-        if (transactionPool.addTransactionHashes(hash)) {
+        if (transactionPool.addTransactionHash(hash)) {
           toRequest.add(hash);
         }
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -106,14 +106,16 @@ public class TransactionPool implements BlockAddedObserver {
     ethContext.getEthPeers().subscribeConnect(this::handleConnect);
   }
 
-  private void handleConnect(final EthPeer peer) {
+  void handleConnect(final EthPeer peer) {
     final List<Transaction> localTransactions = getLocalTransactions();
     for (final Transaction transaction : localTransactions) {
       peerTransactionTracker.addToPeerSendQueue(peer, transaction);
     }
-    final Collection<Hash> hashes = getNewPooledHashes();
-    for (final Hash hash : hashes) {
-      peerPendingTransactionTracker.addToPeerSendQueue(peer, hash);
+    if (peerPendingTransactionTracker.isPeerSupported(peer)) {
+      final Collection<Hash> hashes = getNewPooledHashes();
+      for (final Hash hash : hashes) {
+        peerPendingTransactionTracker.addToPeerSendQueue(peer, hash);
+      }
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -127,7 +127,7 @@ public class TransactionPool implements BlockAddedObserver {
     return pendingTransactions.getNewPooledHashes();
   }
 
-  public boolean addTransactionHashes(final Hash transactionHash) {
+  public boolean addTransactionHash(final Hash transactionHash) {
     return pendingTransactions.addTransactionHash(transactionHash);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -111,7 +112,7 @@ public class TransactionPool implements BlockAddedObserver {
     for (final Transaction transaction : localTransactions) {
       peerTransactionTracker.addToPeerSendQueue(peer, transaction);
     }
-    if (peerPendingTransactionTracker.isPeerSupported(peer)) {
+    if (peerPendingTransactionTracker.isPeerSupported(peer, EthProtocol.ETH65)) {
       final Collection<Hash> hashes = getNewPooledHashes();
       for (final Hash hash : hashes) {
         peerPendingTransactionTracker.addToPeerSendQueue(peer, hash);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessorTest.java
@@ -68,9 +68,9 @@ public class PendingTransactionsMessageProcessorTest {
         NewPooledTransactionHashesMessage.create(asList(hash1, hash2, hash3)),
         now(),
         ofMinutes(1));
-    verify(transactionPool).addTransactionHashes(hash1);
-    verify(transactionPool).addTransactionHashes(hash2);
-    verify(transactionPool).addTransactionHashes(hash3);
+    verify(transactionPool).addTransactionHash(hash1);
+    verify(transactionPool).addTransactionHash(hash2);
+    verify(transactionPool).addTransactionHash(hash3);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsSenderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsSenderTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -57,8 +58,8 @@ public class PendingTransactionsSenderTest {
     EthPeers ethPeers = mock(EthPeers.class);
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
     when(ethPeers.streamAvailablePeers()).thenReturn(Arrays.asList(peer1, peer2).stream());
-    when(peerPendingTransactionTracker.isPeerSupported(peer1)).thenReturn(true);
-    when(peerPendingTransactionTracker.isPeerSupported(peer2)).thenReturn(false);
+    when(peerPendingTransactionTracker.isPeerSupported(peer1, EthProtocol.ETH65)).thenReturn(true);
+    when(peerPendingTransactionTracker.isPeerSupported(peer2, EthProtocol.ETH65)).thenReturn(false);
     sender.onTransactionsAdded(Collections.singleton(tx));
     verify(peerPendingTransactionTracker, times(1)).addToPeerSendQueue(peer1, hash);
     verify(peerPendingTransactionTracker, never()).addToPeerSendQueue(peer2, hash);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsSenderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsSenderTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.transactions;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Test;
+
+public class PendingTransactionsSenderTest {
+
+  @Test
+  public void testSendEth65PeersOnly() {
+    PeerPendingTransactionTracker peerPendingTransactionTracker =
+        mock(PeerPendingTransactionTracker.class);
+
+    PendingTransactionsMessageSender pendingTransactionsMessageSender =
+        mock(PendingTransactionsMessageSender.class);
+    EthContext ethContext = mock(EthContext.class);
+    EthScheduler ethScheduler = mock(EthScheduler.class);
+    when(ethContext.getScheduler()).thenReturn(ethScheduler);
+    PendingTransactionSender sender =
+        new PendingTransactionSender(
+            peerPendingTransactionTracker, pendingTransactionsMessageSender, ethContext);
+
+    EthPeer peer1 = mock(EthPeer.class);
+    EthPeer peer2 = mock(EthPeer.class);
+    Transaction tx = mock(Transaction.class);
+    Hash hash = Hash.wrap(Bytes32.random());
+    when(tx.getHash()).thenReturn(hash);
+    EthPeers ethPeers = mock(EthPeers.class);
+    when(ethContext.getEthPeers()).thenReturn(ethPeers);
+    when(ethPeers.streamAvailablePeers()).thenReturn(Arrays.asList(peer1, peer2).stream());
+    when(peerPendingTransactionTracker.isPeerSupported(peer1)).thenReturn(true);
+    when(peerPendingTransactionTracker.isPeerSupported(peer2)).thenReturn(false);
+    sender.onTransactionsAdded(Collections.singleton(tx));
+    verify(peerPendingTransactionTracker, times(1)).addToPeerSendQueue(peer1, hash);
+    verify(peerPendingTransactionTracker, never()).addToPeerSendQueue(peer2, hash);
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -50,6 +50,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -496,8 +497,9 @@ public class TransactionPoolTest {
   public void shouldNotNotifyPeerForPendingTransactionsIfItDoesntSupportEth65() {
     EthPeer peer = mock(EthPeer.class);
     EthPeer validPeer = mock(EthPeer.class);
-    when(peerPendingTransactionTracker.isPeerSupported(peer)).thenReturn(false);
-    when(peerPendingTransactionTracker.isPeerSupported(validPeer)).thenReturn(true);
+    when(peerPendingTransactionTracker.isPeerSupported(peer, EthProtocol.ETH65)).thenReturn(false);
+    when(peerPendingTransactionTracker.isPeerSupported(validPeer, EthProtocol.ETH65))
+        .thenReturn(true);
     when(transactionValidator.validate(any())).thenReturn(valid());
     transactionPool.addTransactionHash(transaction1.getHash());
     transactionPool.handleConnect(peer);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -50,6 +51,7 @@ import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
@@ -111,6 +113,7 @@ public class TransactionPoolTest {
   private long genesisBlockGasLimit;
   private SyncState syncState;
   private EthContext ethContext;
+  private EthPeers ethPeers;
   private PeerTransactionTracker peerTransactionTracker;
   private PeerPendingTransactionTracker peerPendingTransactionTracker;
 
@@ -123,7 +126,7 @@ public class TransactionPoolTest {
     syncState = mock(SyncState.class);
     when(syncState.isInSync(anyLong())).thenReturn(true);
     ethContext = mock(EthContext.class);
-    EthPeers ethPeers = mock(EthPeers.class);
+    ethPeers = mock(EthPeers.class);
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
     peerTransactionTracker = mock(PeerTransactionTracker.class);
     peerPendingTransactionTracker = mock(PeerPendingTransactionTracker.class);
@@ -487,6 +490,21 @@ public class TransactionPoolTest {
   public void shouldNotNotifyBatchListenerIfNoTransactionsAreAdded() {
     transactionPool.addRemoteTransactions(emptyList());
     verifyZeroInteractions(batchAddedListener);
+  }
+
+  @Test
+  public void shouldNotNotifyPeerForPendingTransactionsIfItDoesntSupportEth65() {
+    EthPeer peer = mock(EthPeer.class);
+    EthPeer validPeer = mock(EthPeer.class);
+    when(peerPendingTransactionTracker.isPeerSupported(peer)).thenReturn(false);
+    when(peerPendingTransactionTracker.isPeerSupported(validPeer)).thenReturn(true);
+    when(transactionValidator.validate(any())).thenReturn(valid());
+    transactionPool.addLocalTransaction(transaction1);
+    transactionPool.handleConnect(peer);
+    verify(peerPendingTransactionTracker, never()).addToPeerSendQueue(peer, transaction1.getHash());
+    transactionPool.handleConnect(validPeer);
+    verify(peerPendingTransactionTracker, times(1))
+        .addToPeerSendQueue(validPeer, transaction1.getHash());
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -499,7 +499,7 @@ public class TransactionPoolTest {
     when(peerPendingTransactionTracker.isPeerSupported(peer)).thenReturn(false);
     when(peerPendingTransactionTracker.isPeerSupported(validPeer)).thenReturn(true);
     when(transactionValidator.validate(any())).thenReturn(valid());
-    transactionPool.addLocalTransaction(transaction1);
+    transactionPool.addTransactionHash(transaction1.getHash());
     transactionPool.handleConnect(peer);
     verify(peerPendingTransactionTracker, never()).addToPeerSendQueue(peer, transaction1.getHash());
     transactionPool.handleConnect(validPeer);


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Make sure to not enroll peers that do not support eth/65 for sending pending transactions, as the client will otherwise throw an error when negotiating sending the message to the peer.

## Fixed Issue(s)
Fixes #723
