### PR TITLE
Use the txworker pool to issue pending transaction messages, therefore liberating the sync worker pool

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
@@ -127,6 +127,13 @@ public class EthScheduler {
     return syncFuture;
   }
 
+  public <T> CompletableFuture<T> scheduleTxWorkerTask(final EthTask<T> task) {
+    final CompletableFuture<T> txFuture = task.runAsync(txWorkerExecutor);
+    pendingFutures.add(txFuture);
+    txFuture.whenComplete((r, t) -> pendingFutures.remove(txFuture));
+    return txFuture;
+  }
+
   public void scheduleTxWorkerTask(final Runnable command) {
     txWorkerExecutor.execute(command);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsMessageProcessor.java
@@ -100,7 +100,7 @@ class PendingTransactionsMessageProcessor {
         task.assignPeer(peer);
         ethContext
             .getScheduler()
-            .scheduleSyncWorkerTask(task)
+            .scheduleTxWorkerTask(task)
             .thenAccept(
                 result -> {
                   List<Transaction> txs = result.getResult();


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>

## PR description

eth/65 messages use the sync worker thread. It is possible that under strain, such as during fast sync, the thread pool gets backed up enough that eventually this creates memory exhaustion.

This PR changes the thread to use to the transaction worker thread.
