### PR TITLE
[EIP-1559] Handle absolute difference between transaction price and burned fees when processing EIP-1559 transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,59 +172,15 @@ Workaround -> When using onchain permissioning, ensure bootnodes are also valida
 ### Additions and Improvements 
 
 - Added priv_getCode [\#250](https://github.com/hyperledger/besu/pull/408). Gets the bytecode associated with a private address.
-- Added `trace_transaction` JSON RPC API [\#441](https://github.com/hyperledger/besu/pull/441)
-- Removed -X unstable prefix for pruning options (`--pruning-blocks-retained`, `--pruning-block-confirmations`) [\#440](https://github.com/hyperledger/besu/pull/440)
-- Implemented [ECIP-1088](https://ecips.ethereumclassic.org/ECIPs/ecip-1088): Phoenix EVM and Protocol upgrades. [\#434](https://github.com/hyperledger/besu/pull/434)
-
+- Added database migration acceptance tests [\#430](https://github.com/hyperledger/besu/pull/430) .
+- Removed -X unstable prefix for pruning options (`--pruning-blocks-retained`, `--pruning-block-confirmations`) [\#440](https://github.com/hyperledger/besu/pull/440).
 ### Bug Fixes
 
 - [BESU-25](https://jira.hyperledger.org/browse/BESU-25) Use v5 Devp2p when pinging [\#392](https://github.com/hyperledger/besu/pull/392)
 - Fixed a bug to manage concurrent access to cache files [\#438](https://github.com/hyperledger/besu/pull/438)
 - Fixed configuration file bug: `pruning-blocks-retained` now accepts an integer in the config [\#440](https://github.com/hyperledger/besu/pull/440)
 - Specifying RPC credentials file should not force RPC Authentication to be enabled [\#454](https://github.com/hyperledger/besu/pull/454) 
-- Enhanced estimateGas messages [\#436](https://github.com/hyperledger/besu/pull/436). When a estimateGas request fails a validation check, an improved error message is returned in the response.
-
-### Early Access Features
-
-Early access features are available features that are not recommended for production networks and may
-have unstable interfaces.
-
-* [Onchain privacy groups](https://besu.hyperledger.org/en/latest/Concepts/Privacy/Onchain-PrivacyGroups/) with add and remove members. 
-  Not being able to to re-add a member to an onchain privacy group is a [known issue](https://github.com/hyperledger/besu/issues/455) 
-  with the add and remove functionality. 
-
-### Known Issues 
-
-#### Fast sync defaulting to full sync
-
--  When fast sync cannot find enough valid peers rapidly enough, Besu defaults to full sync.
-
-Workarounds:
-1. To re-attempt fast syncing rather than continue full syncing, stop Besu, delete your database,
-and start again.
-2. When fast syncing, explicitly disable pruning using `--pruning-enabled=false` to reduce the likelihood
-of encountering the pruning bug.
-
-A fix to remove the default to full sync is [in progress](https://github.com/hyperledger/besu/pull/427)
-and is planned for inclusion in v1.4.1.
-
-#### Error full syncing with pruning
-
-- Error syncing with mainnet on Besu 1.3.7 node - MerkleTrieException [\#BESU-160](https://jira.hyperledger.org/browse/BESU-160)
-The associated error is `Unable to load trie node value for hash` and is caused by the combination of
-full sync and pruning.
-
-Workarounds:
-1. Explicitly disable pruning using `--pruning-enabled=false` when using fast sync.
-2. If the `MerkleTrieException` occurs, delete the database and resync.
-
-Investigation of this issue is in progress and a fix is targeted for v1.4.1.
-
-#### Bootnodes must be validators when using onchain permissioning
-
-- Onchain permissioning nodes can't peer when using a non-validator bootnode [\#BESU-181](https://jira.hyperledger.org/browse/BESU-181)
-
-Workaround -> When using onchain permissioning, ensure bootnodes are also validators. 
+- Fixed configuration file bug: `pruning-blocks-retained` now accepts an integer in the config [\#440](https://github.com/hyperledger/besu/pull/440).
 
 ## 1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,15 +172,59 @@ Workaround -> When using onchain permissioning, ensure bootnodes are also valida
 ### Additions and Improvements 
 
 - Added priv_getCode [\#250](https://github.com/hyperledger/besu/pull/408). Gets the bytecode associated with a private address.
-- Added database migration acceptance tests [\#430](https://github.com/hyperledger/besu/pull/430) .
-- Removed -X unstable prefix for pruning options (`--pruning-blocks-retained`, `--pruning-block-confirmations`) [\#440](https://github.com/hyperledger/besu/pull/440).
+- Added `trace_transaction` JSON RPC API [\#441](https://github.com/hyperledger/besu/pull/441)
+- Removed -X unstable prefix for pruning options (`--pruning-blocks-retained`, `--pruning-block-confirmations`) [\#440](https://github.com/hyperledger/besu/pull/440)
+- Implemented [ECIP-1088](https://ecips.ethereumclassic.org/ECIPs/ecip-1088): Phoenix EVM and Protocol upgrades. [\#434](https://github.com/hyperledger/besu/pull/434)
+
 ### Bug Fixes
 
 - [BESU-25](https://jira.hyperledger.org/browse/BESU-25) Use v5 Devp2p when pinging [\#392](https://github.com/hyperledger/besu/pull/392)
 - Fixed a bug to manage concurrent access to cache files [\#438](https://github.com/hyperledger/besu/pull/438)
 - Fixed configuration file bug: `pruning-blocks-retained` now accepts an integer in the config [\#440](https://github.com/hyperledger/besu/pull/440)
 - Specifying RPC credentials file should not force RPC Authentication to be enabled [\#454](https://github.com/hyperledger/besu/pull/454) 
-- Fixed configuration file bug: `pruning-blocks-retained` now accepts an integer in the config [\#440](https://github.com/hyperledger/besu/pull/440).
+- Enhanced estimateGas messages [\#436](https://github.com/hyperledger/besu/pull/436). When a estimateGas request fails a validation check, an improved error message is returned in the response.
+
+### Early Access Features
+
+Early access features are available features that are not recommended for production networks and may
+have unstable interfaces.
+
+* [Onchain privacy groups](https://besu.hyperledger.org/en/latest/Concepts/Privacy/Onchain-PrivacyGroups/) with add and remove members. 
+  Not being able to to re-add a member to an onchain privacy group is a [known issue](https://github.com/hyperledger/besu/issues/455) 
+  with the add and remove functionality. 
+
+### Known Issues 
+
+#### Fast sync defaulting to full sync
+
+-  When fast sync cannot find enough valid peers rapidly enough, Besu defaults to full sync.
+
+Workarounds:
+1. To re-attempt fast syncing rather than continue full syncing, stop Besu, delete your database,
+and start again.
+2. When fast syncing, explicitly disable pruning using `--pruning-enabled=false` to reduce the likelihood
+of encountering the pruning bug.
+
+A fix to remove the default to full sync is [in progress](https://github.com/hyperledger/besu/pull/427)
+and is planned for inclusion in v1.4.1.
+
+#### Error full syncing with pruning
+
+- Error syncing with mainnet on Besu 1.3.7 node - MerkleTrieException [\#BESU-160](https://jira.hyperledger.org/browse/BESU-160)
+The associated error is `Unable to load trie node value for hash` and is caused by the combination of
+full sync and pruning.
+
+Workarounds:
+1. Explicitly disable pruning using `--pruning-enabled=false` when using fast sync.
+2. If the `MerkleTrieException` occurs, delete the database and resync.
+
+Investigation of this issue is in progress and a fix is targeted for v1.4.1.
+
+#### Bootnodes must be validators when using onchain permissioning
+
+- Onchain permissioning nodes can't peer when using a non-validator bootnode [\#BESU-181](https://jira.hyperledger.org/browse/BESU-181)
+
+Workaround -> When using onchain permissioning, ensure bootnodes are also validators. 
 
 ## 1.4.0
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/CoinbaseFeePriceCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/CoinbaseFeePriceCalculator.java
@@ -18,20 +18,18 @@ import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.Wei;
 
-import java.util.Optional;
-
 @FunctionalInterface
 public interface CoinbaseFeePriceCalculator {
-  Wei price(Gas coinbaseFee, Wei transactionGasPrice, Optional<Long> baseFee);
+  Wei price(Gas coinbaseFee, Wei price, Wei burned);
 
   static CoinbaseFeePriceCalculator frontier() {
-    return (coinbaseFee, transactionGasPrice, baseFee) -> coinbaseFee.priceFor(transactionGasPrice);
+    return (coinbaseFee, price, burned) -> coinbaseFee.priceFor(price);
   }
 
   static CoinbaseFeePriceCalculator eip1559() {
-    return (coinbaseFee, transactionGasPrice, baseFee) -> {
+    return (coinbaseFee, price, burned) -> {
       ExperimentalEIPs.eip1559MustBeEnabled();
-      return coinbaseFee.priceFor(transactionGasPrice.subtract(Wei.of(baseFee.orElseThrow())));
+      return coinbaseFee.priceFor(price.subtract(burned));
     };
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -327,12 +327,15 @@ public class MainnetTransactionProcessor implements TransactionProcessor {
 
     final MutableAccount coinbase = worldState.getOrCreate(miningBeneficiary).getMutable();
     final Gas coinbaseFee = Gas.of(transaction.getGasLimit()).minus(refunded);
-    final Wei coinbaseWeiDelta =
-        coinbaseFeePriceCalculator.price(
-            coinbaseFee, transactionGasPrice, blockHeader.getBaseFee());
-    if (coinbaseWeiDelta.compareTo(Wei.ZERO) > 0) {
+    final Wei baseFee =
+        blockHeader.getBaseFee().isPresent() ? Wei.of(blockHeader.getBaseFee().get()) : Wei.ZERO;
+    final boolean credit = transactionGasPrice.compareTo(baseFee) >= 0;
+    final Wei price = credit ? transactionGasPrice : baseFee;
+    final Wei burned = credit ? baseFee : transactionGasPrice;
+    final Wei coinbaseWeiDelta = coinbaseFeePriceCalculator.price(coinbaseFee, price, burned);
+    if (credit) {
       coinbase.incrementBalance(coinbaseWeiDelta);
-    } else if (coinbaseWeiDelta.compareTo(Wei.ZERO) < 0) {
+    } else {
       if (coinbaseWeiDelta.compareTo(coinbase.getBalance()) > 0) {
         return Result.failed(
             refunded.toLong(),

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/CoinbaseFeePriceCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/CoinbaseFeePriceCalculatorTest.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.core.Wei;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Optional;
 
 import org.junit.After;
 import org.junit.Before;
@@ -40,20 +39,20 @@ public class CoinbaseFeePriceCalculatorTest {
 
   private final CoinbaseFeePriceCalculator coinbaseFeePriceCalculator;
   private final Gas coinbaseFee;
-  private final Wei transactionGasPrice;
-  private final Optional<Long> baseFee;
+  private final Wei price;
+  private final Wei burned;
   private final Wei expectedPrice;
 
   public CoinbaseFeePriceCalculatorTest(
       final CoinbaseFeePriceCalculator coinbaseFeePriceCalculator,
       final Gas coinbaseFee,
-      final Wei transactionGasPrice,
-      final Optional<Long> baseFee,
+      final Wei price,
+      final Wei burned,
       final Wei expectedPrice) {
     this.coinbaseFeePriceCalculator = coinbaseFeePriceCalculator;
     this.coinbaseFee = coinbaseFee;
-    this.transactionGasPrice = transactionGasPrice;
-    this.baseFee = baseFee;
+    this.price = price;
+    this.burned = burned;
     this.expectedPrice = expectedPrice;
   }
 
@@ -62,17 +61,15 @@ public class CoinbaseFeePriceCalculatorTest {
     return Arrays.asList(
         new Object[][] {
           // legacy transaction must return gas price * gas
-          {FRONTIER_CALCULATOR, Gas.of(100), Wei.of(10L), Optional.empty(), Wei.of(1000L)},
+          {FRONTIER_CALCULATOR, Gas.of(100), Wei.of(10L), Wei.ZERO, Wei.of(1000L)},
           // EIP-1559 must return gas * (gas price - base fee)
-          {EIP_1559_CALCULATOR, Gas.of(100), Wei.of(10L), Optional.of(4L), Wei.of(600L)},
-          // Negative transaction gas price case
-          // {EIP_1559_CALCULATOR, Gas.of(100), Wei.of(95L), Optional.of(100L), Wei.of(-500L)}
+          {EIP_1559_CALCULATOR, Gas.of(100), Wei.of(10L), Wei.of(4L), Wei.of(600L)}
         });
   }
 
   @Test
   public void assertThatCalculatorWorks() {
-    assertThat(coinbaseFeePriceCalculator.price(coinbaseFee, transactionGasPrice, baseFee))
+    assertThat(coinbaseFeePriceCalculator.price(coinbaseFee, price, burned))
         .isEqualByComparingTo(expectedPrice);
   }
 


### PR DESCRIPTION
## PR description
Handle absolute difference between transaction price and burned fees when processing EIP-1559 transactions.
2 scenarios:
- transaction price is greater than base fee then do an increment of coinbase balance
- transaction price is less than base fee then do an decrement of coinbase balance

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>