### PR TITLE
Gradle 6.3 upgrade

### DIFF
--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -33,8 +33,11 @@ dependencies {
   testImplementation project(':testutil')
   testImplementation project(':util')
 
+  testImplementation 'com.github.tomakehurst:wiremock-jre8-standalone'
+  testImplementation 'commons-io:commons-io'
   testImplementation 'junit:junit'
   testImplementation 'net.consensys:orion'
+  testImplementation 'org.apache.commons:commons-compress'
   testImplementation 'org.apache.tuweni:tuweni-crypto'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
@@ -42,10 +45,6 @@ dependencies {
   testImplementation 'org.web3j:besu'
   testImplementation 'tech.pegasys.ethsigner.internal:core'
   testImplementation 'tech.pegasys.ethsigner.internal:file-based'
-  testImplementation 'org.apache.commons:commons-compress'
-  testImplementation 'commons-io:commons-io'
-
-  testCompile "com.github.tomakehurst:wiremock-jre8-standalone:2.25.1"
 }
 
 test.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -499,7 +499,7 @@ startScripts {
 
 
 dependencies {
-  compile project(':besu')
+  implementation project(':besu')
   errorprone 'com.google.errorprone:error_prone_core'
 }
 

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -19,12 +19,12 @@ apply plugin: 'application'
 apply plugin: 'idea'
 
 jar {
-  baseName 'besu-evmtool'
+  archiveBaseName = 'besu-evmtool'
   manifest {
     attributes(
-      'Specification-Title': baseName,
+      'Specification-Title': archiveBaseName,
       'Specification-Version': project.version,
-      'Implementation-Title': baseName,
+      'Implementation-Title': archiveBaseName,
       'Implementation-Version': calculateVersion()
       )
   }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -19,6 +19,7 @@ dependencyManagement {
     dependency 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.0'
 
     dependency 'com.github.tomakehurst:wiremock-jre8:2.25.1'
+    dependency 'com.github.tomakehurst:wiremock-jre8-standalone:2.25.1'
 
     dependency 'com.google.auto.service:auto-service:1.0-rc6'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
* Change Gradle version to 6.3
  * Enables Java 14
* Clean up Gradle compatibility warnings
* Fix stray dependency version

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

