### PR TITLE
Loggers should be private, static and final.  Enforced with errorprone

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -121,7 +121,7 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class RunnerBuilder {
 
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private Vertx vertx;
   private BesuController<?> besuController;

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -188,6 +188,8 @@ import picocli.CommandLine.ParameterException;
     footer = "Besu is licensed under the Apache License 2.0")
 public class BesuCommand implements DefaultCommandValues, Runnable {
 
+  @SuppressWarnings("PrivateStaticFinalLoggers")
+  // non-static for testing
   private final Logger logger;
 
   private CommandLine commandLine;

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandLineUtilsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandLineUtilsTest.java
@@ -37,12 +37,17 @@ import picocli.CommandLine.RunLast;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandLineUtilsTest {
-  @Mock Logger mockLogger;
+  @SuppressWarnings("PrivateStaticFinalLoggers") // @Mocks are inited by JUnit
+  @Mock
+  Logger mockLogger;
 
   @Command(description = "This command is for testing.", name = "testcommand")
   private abstract static class AbstractTestCommand implements Runnable {
 
+    // inner class is needed for testing, so field can't be static
+    @SuppressWarnings("PrivateStaticFinalLoggers")
     final Logger logger;
+
     final CommandLine commandLine;
 
     AbstractTestCommand(final Logger logger) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -101,7 +101,7 @@ import picocli.CommandLine.RunLast;
 @RunWith(MockitoJUnitRunner.class)
 public abstract class CommandTestAbstract {
 
-  private final Logger TEST_LOGGER = LogManager.getLogger();
+  private static final Logger TEST_LOGGER = LogManager.getLogger();
 
   protected final ByteArrayOutputStream commandOutput = new ByteArrayOutputStream();
   private final PrintStream outPrintStream = new PrintStream(commandOutput);
@@ -134,9 +134,11 @@ public abstract class CommandTestAbstract {
   @Mock protected PrivacyKeyValueStorageFactory rocksDBSPrivacyStorageFactory;
   @Mock protected PicoCLIOptions cliOptions;
   @Mock protected NodeKey nodeKey;
-
-  @Mock protected Logger mockLogger;
   @Mock protected BesuPluginContextImpl mockBesuPluginContext;
+
+  @SuppressWarnings("PrivateStaticFinalLoggers") // @Mocks are inited by JUnit
+  @Mock
+  protected Logger mockLogger;
 
   @Captor protected ArgumentCaptor<Collection<Bytes>> bytesCollectionCollector;
   @Captor protected ArgumentCaptor<Path> pathArgumentCaptor;

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -28,12 +28,8 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Streams;
 import com.google.common.io.Resources;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public class GenesisConfigFile {
-
-  static final Logger LOG = LogManager.getLogger();
 
   public static final GenesisConfigFile DEFAULT =
       new GenesisConfigFile(JsonUtil.createEmptyObjectNode());

--- a/errorprone-checks/build.gradle
+++ b/errorprone-checks/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
   testImplementation 'com.google.errorprone:error_prone_test_helpers'
   testImplementation 'junit:junit'
+  testImplementation 'org.apache.logging.log4j:log4j-api'
   testImplementation 'org.assertj:assertj-core'
 
   epJavac 'com.google.errorprone:error_prone_check_api'

--- a/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggers.java
+++ b/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggers.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.errorpronechecks;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
+import static com.google.errorprone.fixes.SuggestedFixes.addModifiers;
+import static com.google.errorprone.matchers.Description.NO_MATCH;
+import static com.google.errorprone.util.ASTHelpers.getType;
+import static com.google.errorprone.util.ASTHelpers.isSubtype;
+
+import java.util.List;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+
+import com.google.auto.service.AutoService;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.VariableTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.VariableTree;
+import com.sun.tools.javac.code.Symbol;
+
+@AutoService(BugChecker.class)
+@BugPattern(
+    name = "PrivateStaticFinalLoggers",
+    summary = "Logger classes should be private, static, and final.",
+    severity = WARNING,
+    linkType = BugPattern.LinkType.NONE)
+public class PrivateStaticFinalLoggers extends BugChecker implements VariableTreeMatcher {
+
+  @Override
+  public Description matchVariable(final VariableTree tree, final VisitorState state) {
+    final Symbol.VarSymbol sym = ASTHelpers.getSymbol(tree);
+    if (sym == null || sym.getKind() != ElementKind.FIELD) {
+      return NO_MATCH;
+    }
+    if (sym.getModifiers()
+        .containsAll(List.of(Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL))) {
+      return NO_MATCH;
+    }
+    if (!isSubtype(
+        getType(tree), state.getTypeFromString("org.apache.logging.log4j.Logger"), state)) {
+      return NO_MATCH;
+    }
+    return buildDescription(tree)
+        .addFix(addModifiers(tree, state, Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL))
+        .build();
+  }
+}

--- a/errorprone-checks/src/test/java/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersTest.java
+++ b/errorprone-checks/src/test/java/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersTest.java
@@ -18,22 +18,23 @@ import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-public class BannedMethodTest {
+public class PrivateStaticFinalLoggersTest {
 
   private CompilationTestHelper compilationHelper;
 
   @Before
   public void setup() {
-    compilationHelper = CompilationTestHelper.newInstance(BannedMethod.class, getClass());
+    compilationHelper =
+        CompilationTestHelper.newInstance(PrivateStaticFinalLoggers.class, getClass());
   }
 
   @Test
-  public void bannedMethodsPositiveCases() {
-    compilationHelper.addSourceFile("BannedMethodPositiveCases.java").doTest();
+  public void privateStaticFinalLoggersPositiveCases() {
+    compilationHelper.addSourceFile("PrivateStaticFinalLoggersPositiveCases.java").doTest();
   }
 
   @Test
-  public void bannedMethodsNegativeCases() {
-    compilationHelper.addSourceFile("BannedMethodNegativeCases.java").doTest();
+  public void privateStaticFinalLoggersNegativeCases() {
+    compilationHelper.addSourceFile("PrivateStaticFinalLoggersNegativeCases.java").doTest();
   }
 }

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersNegativeCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersNegativeCases.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.errorpronechecks;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PrivateStaticFinalLoggersNegativeCases {
+
+  private static final Logger LOG = LogManager.getLogger();
+}

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersPositiveCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/PrivateStaticFinalLoggersPositiveCases.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.errorpronechecks;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PrivateStaticFinalLoggersPositiveCases {
+
+  // BUG: Diagnostic contains:  Logger classes should be private, static, and final.
+  private final Logger LOG = LogManager.getLogger();
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/AutoTransactionLogBloomCachingService.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class AutoTransactionLogBloomCachingService {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   private final Blockchain blockchain;
   private final TransactionLogBloomCacher transactionLogBloomCacher;
   private OptionalLong blockAddedSubscriptionId = OptionalLong.empty();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AncestryValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AncestryValidationRule.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
  * header.
  */
 public class AncestryValidationRule implements DetachedBlockHeaderValidationRule {
-  private final Logger LOG = LogManager.getLogger(AncestryValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class CalculatedDifficultyValidationRule<C> implements AttachedBlockHeaderValidationRule<C> {
-  private final Logger LOG = LogManager.getLogger(CalculatedDifficultyValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
   private final DifficultyCalculator<C> difficultyCalculator;
 
   public CalculatedDifficultyValidationRule(final DifficultyCalculator<C> difficultyCalculator) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasLimitValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasLimitValidationRule.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class EIP1559BlockHeaderGasLimitValidationRule implements DetachedBlockHeaderValidationRule {
-  private final Logger LOG = LogManager.getLogger(EIP1559BlockHeaderGasLimitValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
   private final EIP1559 eip1559;
   private final FeeMarket feeMarket = FeeMarket.eip1559();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasPriceValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasPriceValidationRule.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class EIP1559BlockHeaderGasPriceValidationRule implements DetachedBlockHeaderValidationRule {
-  private final Logger LOG = LogManager.getLogger(EIP1559BlockHeaderGasPriceValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
   private final EIP1559 eip1559;
   private final FeeMarket feeMarket = FeeMarket.eip1559();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ExtraDataMaxLengthValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ExtraDataMaxLengthValidationRule.java
@@ -27,7 +27,7 @@ import org.apache.tuweni.bytes.Bytes;
  */
 public class ExtraDataMaxLengthValidationRule implements DetachedBlockHeaderValidationRule {
 
-  private final Logger LOG = LogManager.getLogger(ExtraDataMaxLengthValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
   private final long maxExtraDataBytes;
 
   public ExtraDataMaxLengthValidationRule(final long maxExtraDataBytes) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/GasUsageValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/GasUsageValidationRule.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class GasUsageValidationRule implements DetachedBlockHeaderValidationRule {
 
-  private final Logger LOG = LogManager.getLogger(GasUsageValidationRule.class);
+  private static final Logger LOG = LogManager.getLogger();
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampBoundedByFutureParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampBoundedByFutureParameter.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
  */
 public class TimestampBoundedByFutureParameter implements DetachedBlockHeaderValidationRule {
 
-  private final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   private final long acceptableClockDriftSeconds;
 
   public TimestampBoundedByFutureParameter(final long acceptableClockDriftSeconds) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
 /** Responsible for ensuring the timestamp of a block is newer than its parent. */
 public class TimestampMoreRecentThanParent implements DetachedBlockHeaderValidationRule {
 
-  private final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
   private final long minimumSecondsSinceParent;
 
   public TimestampMoreRecentThanParent(final long minimumSecondsSinceParent) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/BLAKE2BFPrecompileContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/BLAKE2BFPrecompileContract.java
@@ -32,7 +32,7 @@ import org.apache.tuweni.bytes.Bytes;
 // https://github.com/keep-network/go-ethereum/pull/4
 public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
 
-  public static Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   public BLAKE2BFPrecompileContract(final GasCalculator gasCalculator) {
     super("BLAKE2f", gasCalculator);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -55,7 +55,7 @@ import org.apache.tuweni.bytes.Bytes;
  * via UDP.
  */
 public abstract class PeerDiscoveryAgent {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   // The devp2p specification says only accept packets up to 1280, but some
   // clients ignore that, so we add in a little extra padding.

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -31,9 +31,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 
 public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
+  private static final Logger LOG = LogManager.getLogger();
+
   // The set of known agents operating on the network
   private final Map<Bytes, MockPeerDiscoveryAgent> agentNetwork;
   private final Deque<IncomingPacket> incomingPackets = new ArrayDeque<>();

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TomlConfigFileParser.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TomlConfigFileParser.java
@@ -29,7 +29,7 @@ import org.apache.tuweni.toml.TomlParseResult;
 
 public class TomlConfigFileParser {
 
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private static TomlParseResult checkConfigurationValidity(
       final TomlParseResult result, final String toml) throws Exception {

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.Logger;
 /** Utility class to help interacting with various {@link NatManager}. */
 public class NatService {
 
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private NatMethod currentNatMethod;
   private Optional<NatManager> currentNatManager;

--- a/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/core/AbstractNatManager.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public abstract class AbstractNatManager implements NatManager {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   protected final NatMethod natMethod;
 

--- a/nat/src/main/java/org/hyperledger/besu/nat/docker/DockerNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/docker/DockerNatManager.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.Logger;
  * Docker’s NAT implementation when Besu is being run from a Docker container
  */
 public class DockerNatManager extends AbstractNatManager {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private static final String PORT_MAPPING_TAG = "HOST_PORT_";
 

--- a/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
@@ -45,7 +45,7 @@ import org.apache.logging.log4j.Logger;
  * support for Kubernetes’s NAT implementation when Besu is being run from a Kubernetes cluster
  */
 public class KubernetesNatManager extends AbstractNatManager {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   private static final String DEFAULT_BESU_POD_NAME_FILTER = "besu";
 

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -26,12 +26,16 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 /**
  * This class describes the behaviour of the Manual NAT manager. Manual Nat manager add the ability
  * to explicitly configure the external IP and Ports to broadcast without regards to NAT or other
  * considerations.
  */
 public class ManualNatManager extends AbstractNatManager {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final String advertisedHost;
   private final int p2pPort;

--- a/nat/src/main/java/org/hyperledger/besu/nat/upnp/BesuUpnpServiceConfiguration.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/upnp/BesuUpnpServiceConfiguration.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jupnp.DefaultUpnpServiceConfiguration;
 import org.jupnp.UpnpServiceConfiguration;
 import org.jupnp.binding.xml.DeviceDescriptorBinder;
@@ -50,6 +52,7 @@ import org.jupnp.transport.spi.StreamClient;
 import org.jupnp.transport.spi.StreamServer;
 
 class BesuUpnpServiceConfiguration implements UpnpServiceConfiguration {
+  private static final Logger LOG = LogManager.getLogger();
 
   private final ThreadPoolExecutor executorService;
   private final DeviceDescriptorBinder deviceDescriptorBinderUDA10;
@@ -80,7 +83,7 @@ class BesuUpnpServiceConfiguration implements UpnpServiceConfiguration {
               public void rejectedExecution(
                   final Runnable runnable, final ThreadPoolExecutor threadPoolExecutor) {
                 // Log and discard
-                UpnpNatManager.LOG.warn("Thread pool rejected execution of " + runnable.getClass());
+                LOG.warn("Thread pool rejected execution of " + runnable.getClass());
                 super.rejectedExecution(runnable, threadPoolExecutor);
               }
             });

--- a/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/upnp/UpnpNatManager.java
@@ -57,7 +57,7 @@ import org.jupnp.support.model.PortMapping;
  * with the NAT environment through UPnP.
  */
 public class UpnpNatManager extends AbstractNatManager {
-  protected static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getLogger();
 
   static final String SERVICE_TYPE_WAN_IP_CONNECTION = "WANIPConnection";
 


### PR DESCRIPTION
Some of our loggers were not private, static, and final.  In a few
cases these were non-static fields in classes that were repeatedly
instantiated in core transaction logic.

This is enforced via a new ErrorProne check, so the PR includes fixes
for all of the places this was a problem, not just the performance
impacting code.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>