### PR TITLE
Performance: Cache address hash

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AbstractWorldUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AbstractWorldUpdater.java
@@ -171,6 +171,7 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
    */
   public static class UpdateTrackingAccount<A extends Account> implements MutableAccount {
     private final Address address;
+    private final Hash addressHash;
 
     @Nullable private final A account; // null if this is a new account.
 
@@ -190,6 +191,7 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
     UpdateTrackingAccount(final Address address) {
       checkNotNull(address);
       this.address = address;
+      this.addressHash = Hash.hash(this.address);
       this.account = null;
 
       this.nonce = 0;
@@ -204,6 +206,10 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
       checkNotNull(account);
 
       this.address = account.getAddress();
+      this.addressHash =
+          (account instanceof UpdateTrackingAccount)
+              ? ((UpdateTrackingAccount<?>) account).addressHash
+              : Hash.hash(this.address);
       this.account = account;
 
       this.nonce = account.getNonce();
@@ -250,7 +256,7 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
 
     @Override
     public Hash getAddressHash() {
-      return Hash.hash(getAddress());
+      return addressHash;
     }
 
     @Override


### PR DESCRIPTION
When updating an account we often calculate the address hash multiple
times.  We also will always calculate it at least once when tracking an
account update.  Hence, just calculate it in the constructor and re-use
it.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
