### PR TITLE
recognize from and to block parameters in eth subscribe

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
@@ -38,7 +40,11 @@ public class EthNewFilter implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
     final FilterParameter filter = requestContext.getRequiredParameter(0, FilterParameter.class);
 
-    // todo: add test for invalid filter
+    if (!filter.isValid()) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
+    }
+
     final String logFilterId =
         filterManager.installLogFilter(
             filter.getFromBlock(), filter.getToBlock(), filter.getLogsQuery());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -16,14 +16,10 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 
 public class EthNewFilter implements JsonRpcMethod {
 
@@ -40,18 +36,12 @@ public class EthNewFilter implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final FilterParameter filter;
-    final LogsQuery query;
-    try {
-      filter = requestContext.getRequiredParameter(0, FilterParameter.class);
-      query = new LogsQuery(filter.getAddresses(), filter.getTopics());
-    } catch (InvalidJsonRpcParameters __) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
-    }
+    final FilterParameter filter = requestContext.getRequiredParameter(0, FilterParameter.class);
 
+    // todo: add test for invalid filter
     final String logFilterId =
-        filterManager.installLogFilter(filter.getFromBlock(), filter.getToBlock(), query);
+        filterManager.installLogFilter(
+            filter.getFromBlock(), filter.getToBlock(), filter.getLogsQuery());
 
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), logFilterId);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -16,8 +16,11 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -37,9 +40,15 @@ public class EthNewFilter implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final FilterParameter filter = requestContext.getRequiredParameter(0, FilterParameter.class);
-    final LogsQuery query =
-        new LogsQuery.Builder().addresses(filter.getAddresses()).topics(filter.getTopics()).build();
+    final FilterParameter filter;
+    final LogsQuery query;
+    try {
+      filter = requestContext.getRequiredParameter(0, FilterParameter.class);
+      query = new LogsQuery(filter.getAddresses(), filter.getTopics());
+    } catch (InvalidJsonRpcParameters __) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
+    }
 
     final String logFilterId =
         filterManager.installLogFilter(filter.getFromBlock(), filter.getToBlock(), query);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameter.java
@@ -28,6 +28,9 @@ public class BlockParameter {
 
   private final BlockParameterType type;
   private final OptionalLong number;
+  public static final BlockParameter EARLIEST = new BlockParameter("earliest");
+  public static final BlockParameter LATEST = new BlockParameter("latest");
+  public static final BlockParameter PENDING = new BlockParameter("pending");
 
   @JsonCreator
   public BlockParameter(final String value) {
@@ -48,6 +51,11 @@ public class BlockParameter {
     }
   }
 
+  public BlockParameter(final long value) {
+    type = BlockParameterType.NUMERIC;
+    number = OptionalLong.of(value);
+  }
+
   public OptionalLong getNumber() {
     return number;
   }
@@ -66,6 +74,24 @@ public class BlockParameter {
 
   public boolean isNumeric() {
     return this.type == BlockParameterType.NUMERIC;
+  }
+
+  @Override
+  public String toString() {
+    return "BlockParameter{" + "type=" + type + ", number=" + number + '}';
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BlockParameter that = (BlockParameter) o;
+    return type == that.type && number.equals(that.number);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, number);
   }
 
   private enum BlockParameterType {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
 import static java.util.Collections.emptyList;
 
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -40,6 +39,7 @@ public class FilterParameter {
   private final List<List<LogTopic>> topics;
   private final Optional<Hash> maybeBlockHash;
   private final LogsQuery logsQuery;
+  private final boolean isValid;
 
   @JsonCreator
   public FilterParameter(
@@ -50,9 +50,7 @@ public class FilterParameter {
       @JsonDeserialize(using = TopicsDeserializer.class) @JsonProperty("topics")
           final List<List<LogTopic>> topics,
       @JsonProperty("blockhash") final Hash blockHash) {
-    if (blockHash != null && (fromBlock != null || toBlock != null))
-      throw new InvalidJsonRpcParameters(
-          "If blockHash is present in the filter criteria, then neither fromBlock nor toBlock are allowed.");
+    this.isValid = blockHash == null || (fromBlock == null && toBlock == null);
     this.fromBlock = fromBlock == null ? new BlockParameter("latest") : fromBlock;
     this.toBlock = toBlock == null ? new BlockParameter("latest") : toBlock;
     this.addresses = address != null ? address : emptyList();
@@ -77,7 +75,7 @@ public class FilterParameter {
     return topics;
   }
 
-  public Optional<Hash> getMaybeBlockHash() {
+  public Optional<Hash> getBlockHash() {
     return maybeBlockHash;
   }
 
@@ -112,5 +110,9 @@ public class FilterParameter {
         .add("topics", topics)
         .add("blockHash", maybeBlockHash)
         .toString();
+  }
+
+  public boolean isValid() {
+    return isValid;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
@@ -51,8 +51,8 @@ public class FilterParameter {
           final List<List<LogTopic>> topics,
       @JsonProperty("blockhash") final Hash blockHash) {
     this.isValid = blockHash == null || (fromBlock == null && toBlock == null);
-    this.fromBlock = fromBlock == null ? new BlockParameter("latest") : fromBlock;
-    this.toBlock = toBlock == null ? new BlockParameter("latest") : toBlock;
+    this.fromBlock = fromBlock != null ? fromBlock : BlockParameter.LATEST;
+    this.toBlock = toBlock != null ? toBlock : BlockParameter.LATEST;
     this.addresses = address != null ? address : emptyList();
     this.topics = topics != null ? topics : emptyList();
     this.logsQuery = new LogsQuery(addresses, topics);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.EnclavePublicKeyProvider;
@@ -26,9 +25,11 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogsResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.api.query.PrivacyQueries;
+import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
+
+import java.util.List;
 
 public class PrivGetLogs implements JsonRpcMethod {
 
@@ -55,37 +56,33 @@ public class PrivGetLogs implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final String privacyGroupId;
-    final FilterParameter filter;
-    try {
-      privacyGroupId = requestContext.getRequiredParameter(0, String.class);
-      filter = requestContext.getRequiredParameter(1, FilterParameter.class);
-    } catch (InvalidJsonRpcParameters __) {
+    final String privacyGroupId = requestContext.getRequiredParameter(0, String.class);
+    final FilterParameter filter = requestContext.getRequiredParameter(1, FilterParameter.class);
+
+    checkIfPrivacyGroupMatchesAuthenticatedEnclaveKey(requestContext, privacyGroupId);
+
+    if (!filter.isValid()) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
     }
 
-    checkIfPrivacyGroupMatchesAuthenticatedEnclaveKey(requestContext, privacyGroupId);
-
-    final LogsQuery query =
-        new LogsQuery.Builder().addresses(filter.getAddresses()).topics(filter.getTopics()).build();
-
-    if (filter.getMaybeBlockHash().isPresent()) {
-      return new JsonRpcSuccessResponse(
-          requestContext.getRequest().getId(),
-          new LogsResult(
-              privacyQueries.matchingLogs(
-                  privacyGroupId, filter.getMaybeBlockHash().get(), query)));
-    }
-
-    final long fromBlockNumber = filter.getFromBlock().getNumber().orElse(0);
-    final long toBlockNumber =
-        filter.getToBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
+    final List<LogWithMetadata> matchingLogs =
+        filter
+            .getBlockHash()
+            .map(
+                blockHash ->
+                    privacyQueries.matchingLogs(privacyGroupId, blockHash, filter.getLogsQuery()))
+            .orElseGet(
+                () -> {
+                  final long fromBlockNumber = filter.getFromBlock().getNumber().orElse(0);
+                  final long toBlockNumber =
+                      filter.getToBlock().getNumber().orElse(blockchainQueries.headBlockNumber());
+                  return privacyQueries.matchingLogs(
+                      privacyGroupId, fromBlockNumber, toBlockNumber, filter.getLogsQuery());
+                });
 
     return new JsonRpcSuccessResponse(
-        requestContext.getRequest().getId(),
-        new LogsResult(
-            privacyQueries.matchingLogs(privacyGroupId, fromBlockNumber, toBlockNumber, query)));
+        requestContext.getRequest().getId(), new LogsResult(matchingLogs));
   }
 
   private void checkIfPrivacyGroupMatchesAuthenticatedEnclaveKey(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
@@ -49,14 +50,16 @@ public class PrivNewFilter implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
-    final String privacyGroupId = request.getRequiredParameter(0, String.class);
-    final FilterParameter filter = request.getRequiredParameter(1, FilterParameter.class);
-
-    checkIfPrivacyGroupMatchesAuthenticatedEnclaveKey(request, privacyGroupId);
-
-    if (!filter.isValid()) {
+    final String privacyGroupId;
+    final FilterParameter filter;
+    try {
+      privacyGroupId = request.getRequiredParameter(0, String.class);
+      filter = request.getRequiredParameter(1, FilterParameter.class);
+    } catch (InvalidJsonRpcParameters __) {
       return new JsonRpcErrorResponse(request.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
     }
+
+    checkIfPrivacyGroupMatchesAuthenticatedEnclaveKey(request, privacyGroupId);
 
     final LogsQuery query =
         new LogsQuery.Builder().addresses(filter.getAddresses()).topics(filter.getTopics()).build();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilder.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilder.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing.SyncingSubscription;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 public class SubscriptionBuilder {
@@ -36,11 +35,7 @@ public class SubscriptionBuilder {
         }
       case LOGS:
         {
-          return new LogsSubscription(
-              subscriptionId,
-              connectionId,
-              Optional.ofNullable(request.getLogsQuery())
-                  .orElseThrow(IllegalArgumentException::new));
+          return new LogsSubscription(subscriptionId, connectionId, request.getFilterParameter());
         }
       case SYNCING:
         {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscription.java
@@ -14,21 +14,21 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.logs;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 
 public class LogsSubscription extends Subscription {
 
-  private final LogsQuery logsQuery;
+  private final FilterParameter filterParameter;
 
   public LogsSubscription(
-      final Long subscriptionId, final String connectionId, final LogsQuery logsQuery) {
+      final Long subscriptionId, final String connectionId, final FilterParameter filterParameter) {
     super(subscriptionId, connectionId, SubscriptionType.LOGS, Boolean.FALSE);
-    this.logsQuery = logsQuery;
+    this.filterParameter = filterParameter;
   }
 
-  public LogsQuery getLogsQuery() {
-    return logsQuery;
+  public FilterParameter getFilterParameter() {
+    return filterParameter;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionService.java
@@ -14,9 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.logs;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 
 import java.util.function.Consumer;
@@ -32,7 +34,18 @@ public class LogsSubscriptionService implements Consumer<LogWithMetadata> {
   @Override
   public void accept(final LogWithMetadata logWithMetadata) {
     subscriptionManager.subscriptionsOfType(SubscriptionType.LOGS, LogsSubscription.class).stream()
-        .filter(logsSubscription -> logsSubscription.getLogsQuery().matches(logWithMetadata))
+        .filter(
+            logsSubscription -> {
+              final FilterParameter filterParameter = logsSubscription.getFilterParameter();
+              final long blockNumber = logWithMetadata.getBlockNumber();
+              return filterParameter
+                          .getFromBlock()
+                          .getNumber()
+                          .orElse(BlockHeader.GENESIS_BLOCK_NUMBER)
+                      <= blockNumber
+                  && filterParameter.getToBlock().getNumber().orElse(Long.MAX_VALUE) >= blockNumber
+                  && filterParameter.getLogsQuery().matches(logWithMetadata);
+            })
         .forEach(
             logsSubscription ->
                 subscriptionManager.sendMessage(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscribeRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscribeRequest.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request;
 
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 
 import java.util.Objects;
 
@@ -22,17 +22,17 @@ public class SubscribeRequest {
 
   private final SubscriptionType subscriptionType;
   private final Boolean includeTransaction;
-  private final LogsQuery logsQuery;
+  private final FilterParameter filterParameter;
   private final String connectionId;
 
   public SubscribeRequest(
       final SubscriptionType subscriptionType,
-      final LogsQuery logsQuery,
+      final FilterParameter filterParameter,
       final Boolean includeTransaction,
       final String connectionId) {
     this.subscriptionType = subscriptionType;
     this.includeTransaction = includeTransaction;
-    this.logsQuery = logsQuery;
+    this.filterParameter = filterParameter;
     this.connectionId = connectionId;
   }
 
@@ -40,8 +40,8 @@ public class SubscribeRequest {
     return subscriptionType;
   }
 
-  public LogsQuery getLogsQuery() {
-    return logsQuery;
+  public FilterParameter getFilterParameter() {
+    return filterParameter;
   }
 
   public Boolean getIncludeTransaction() {
@@ -55,8 +55,8 @@ public class SubscribeRequest {
   @Override
   public String toString() {
     return String.format(
-        "SubscribeRequest{subscriptionType=%s, includeTransaction=%s, logsQuery=%s, connectionId=%s}",
-        subscriptionType, includeTransaction, logsQuery, connectionId);
+        "SubscribeRequest{subscriptionType=%s, includeTransaction=%s, filterParameter=%s, connectionId=%s}",
+        subscriptionType, includeTransaction, filterParameter, connectionId);
   }
 
   @Override
@@ -70,12 +70,12 @@ public class SubscribeRequest {
     final SubscribeRequest that = (SubscribeRequest) o;
     return subscriptionType == that.subscriptionType
         && Objects.equals(includeTransaction, that.includeTransaction)
-        && Objects.equals(logsQuery, that.logsQuery)
+        && Objects.equals(filterParameter, that.filterParameter)
         && Objects.equals(connectionId, that.connectionId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(subscriptionType, includeTransaction, logsQuery, connectionId);
+    return Objects.hash(subscriptionType, includeTransaction, filterParameter, connectionId);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcRequest;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 
 import java.util.Optional;
 
@@ -70,8 +70,9 @@ public class SubscriptionRequestMapper {
   }
 
   private SubscribeRequest parseLogsRequest(final WebSocketRpcRequest request) {
-    final LogsQuery logsQuery = request.getRequiredParameter(1, LogsQuery.class);
-    return new SubscribeRequest(SubscriptionType.LOGS, logsQuery, null, request.getConnectionId());
+    final FilterParameter filterParameter = request.getRequiredParameter(1, FilterParameter.class);
+    return new SubscribeRequest(
+        SubscriptionType.LOGS, filterParameter, null, request.getConnectionId());
   }
 
   public UnsubscribeRequest mapUnsubscribeRequest(final JsonRpcRequestContext jsonRpcRequestContext)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
@@ -28,10 +28,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogTopic;
 
 import java.util.Collections;
@@ -157,6 +160,26 @@ public class EthNewFilterTest {
     verify(filterManager)
         .installLogFilter(
             refEq(BlockParameter.LATEST), refEq(BlockParameter.LATEST), eq(expectedLogsQuery));
+  }
+
+  @Test
+  public void filterWithInvalidParameters() {
+    final FilterParameter invalidFilter =
+        new FilterParameter(
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Hash.ZERO);
+
+    final JsonRpcRequestContext request = ethNewFilter(invalidFilter);
+
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(null, JsonRpcError.INVALID_PARAMS);
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).usingRecursiveComparison().isEqualTo(expectedResponse);
   }
 
   private List<List<LogTopic>> topics() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
@@ -68,7 +68,7 @@ public class EthNewFilterTest {
 
     method.response(request);
 
-    verify(filterManager).installLogFilter(refEq(blockParamLatest()), any(), any());
+    verify(filterManager).installLogFilter(refEq(BlockParameter.LATEST), any(), any());
   }
 
   @Test
@@ -78,13 +78,13 @@ public class EthNewFilterTest {
 
     method.response(request);
 
-    verify(filterManager).installLogFilter(any(), refEq(blockParamLatest()), any());
+    verify(filterManager).installLogFilter(any(), refEq(BlockParameter.LATEST), any());
   }
 
   @Test
   public void newFilterWithoutAddressAndTopicsParamsInstallsEmptyLogFilter() {
     final FilterParameter filterParameter =
-        new FilterParameter("latest", "latest", null, null, null);
+        new FilterParameter(BlockParameter.LATEST, BlockParameter.LATEST, null, null, null);
     final JsonRpcRequestContext request = ethNewFilter(filterParameter);
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), "0x1");
@@ -97,7 +97,7 @@ public class EthNewFilterTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
     verify(filterManager)
         .installLogFilter(
-            refEq(blockParamLatest()), refEq(blockParamLatest()), eq(expectedLogsQuery));
+            refEq(BlockParameter.LATEST), refEq(BlockParameter.LATEST), eq(expectedLogsQuery));
   }
 
   @Test
@@ -116,7 +116,7 @@ public class EthNewFilterTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
     verify(filterManager)
         .installLogFilter(
-            refEq(blockParamLatest()), refEq(blockParamLatest()), eq(expectedLogsQuery));
+            refEq(BlockParameter.LATEST), refEq(BlockParameter.LATEST), eq(expectedLogsQuery));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class EthNewFilterTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
     verify(filterManager)
         .installLogFilter(
-            refEq(blockParamLatest()), refEq(blockParamLatest()), eq(expectedLogsQuery));
+            refEq(BlockParameter.LATEST), refEq(BlockParameter.LATEST), eq(expectedLogsQuery));
   }
 
   @Test
@@ -156,7 +156,7 @@ public class EthNewFilterTest {
     assertThat(actualResponse).isEqualToComparingFieldByField(expectedResponse);
     verify(filterManager)
         .installLogFilter(
-            refEq(blockParamLatest()), refEq(blockParamLatest()), eq(expectedLogsQuery));
+            refEq(BlockParameter.LATEST), refEq(BlockParameter.LATEST), eq(expectedLogsQuery));
   }
 
   private List<List<LogTopic>> topics() {
@@ -169,8 +169,8 @@ public class EthNewFilterTest {
   private FilterParameter filterParamWithAddressAndTopics(
       final Address address, final List<List<LogTopic>> topics) {
     return new FilterParameter(
-        "latest",
-        "latest",
+        BlockParameter.LATEST,
+        BlockParameter.LATEST,
         Optional.ofNullable(address).map(Collections::singletonList).orElse(emptyList()),
         topics,
         null);
@@ -179,9 +179,5 @@ public class EthNewFilterTest {
   private JsonRpcRequestContext ethNewFilter(final FilterParameter filterParameter) {
     return new JsonRpcRequestContext(
         new JsonRpcRequest("2.0", ETH_METHOD, new Object[] {filterParameter}));
-  }
-
-  private BlockParameter blockParamLatest() {
-    return new BlockParameter("latest");
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -18,12 +18,10 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogTopic;
 
 import java.io.IOException;
@@ -34,7 +32,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 
@@ -173,17 +170,6 @@ public class FilterParameterTest {
 
     assertThat(readJsonAsFilterParameter(jsonWithTopicsFirst))
         .isEqualToComparingFieldByFieldRecursively(readJsonAsFilterParameter(jsonWithTopicsLast));
-  }
-
-  @Test
-  public void jsonSpecifyingBlockHashAndRangeShouldThrowIllegalArgumentException() {
-    final String invalidJson =
-        "{\"address\":\"0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0\",\"fromBlock\":\"earliest\",\"toBlock\":\"latest\",\"topics\":[\"0x492e34c7da2a87c57444aa0f6143558999bceec63065f04557cfb20932e0d591\"], \"blockhash\": \""
-            + Hash.ZERO.toHexString()
-            + "\"}";
-
-    assertThatThrownBy(() -> readJsonAsFilterParameter(invalidJson))
-        .isInstanceOf(ValueInstantiationException.class);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -18,10 +18,12 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogTopic;
 
 import java.io.IOException;
@@ -32,6 +34,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 
@@ -170,6 +173,17 @@ public class FilterParameterTest {
 
     assertThat(readJsonAsFilterParameter(jsonWithTopicsFirst))
         .isEqualToComparingFieldByFieldRecursively(readJsonAsFilterParameter(jsonWithTopicsLast));
+  }
+
+  @Test
+  public void jsonSpecifyingBlockHashAndRangeShouldThrowIllegalArgumentException() {
+    final String invalidJson =
+        "{\"address\":\"0x8CdaF0CD259887258Bc13a92C0a6dA92698644C0\",\"fromBlock\":\"earliest\",\"toBlock\":\"latest\",\"topics\":[\"0x492e34c7da2a87c57444aa0f6143558999bceec63065f04557cfb20932e0d591\"], \"blockhash\": \""
+            + Hash.ZERO.toHexString()
+            + "\"}";
+
+    assertThatThrownBy(() -> readJsonAsFilterParameter(invalidJson))
+        .isInstanceOf(ValueInstantiationException.class);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -141,7 +141,7 @@ public class FilterParameterTest {
   }
 
   @Test
-  public void jsonWithFromAndToParametersDeserializersCorrectly() throws Exception {
+  public void jsonWithFromAndToParametersDeserializesCorrectly() throws Exception {
     final String jsonWithSingleAddress =
         "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getLogs\",\"params\":[{"
             + "\"address\":\"0x0\", \"fromBlock\": \"0x0\", \"toBlock\": \"pending\","

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
@@ -29,9 +29,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.EnclavePublicKeyProvider;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogsResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -100,26 +97,6 @@ public class PrivGetLogsTest {
     assertThatThrownBy(() -> method.response(request))
         .isInstanceOf(InvalidJsonRpcParameters.class)
         .hasMessageContaining("Missing required json rpc parameter at index 1");
-  }
-
-  @Test
-  public void filterWithInvalidParameters() {
-    final FilterParameter invalidFilter =
-        new FilterParameter(
-            BlockParameter.EARLIEST,
-            BlockParameter.LATEST,
-            Collections.emptyList(),
-            Collections.emptyList(),
-            Hash.ZERO);
-
-    final JsonRpcRequestContext request = privGetLogRequest(PRIVACY_GROUP_ID, invalidFilter);
-
-    final JsonRpcResponse expectedResponse =
-        new JsonRpcErrorResponse(null, JsonRpcError.INVALID_PARAMS);
-
-    final JsonRpcResponse response = method.response(request);
-
-    assertThat(response).usingRecursiveComparison().isEqualTo(expectedResponse);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
@@ -29,6 +29,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.EnclavePublicKeyProvider;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogsResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -97,6 +100,26 @@ public class PrivGetLogsTest {
     assertThatThrownBy(() -> method.response(request))
         .isInstanceOf(InvalidJsonRpcParameters.class)
         .hasMessageContaining("Missing required json rpc parameter at index 1");
+  }
+
+  @Test
+  public void filterWithInvalidParameters() {
+    final FilterParameter invalidFilter =
+        new FilterParameter(
+            BlockParameter.EARLIEST,
+            BlockParameter.EARLIEST,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Hash.ZERO);
+
+    final JsonRpcRequestContext request = privGetLogRequest(PRIVACY_GROUP_ID, invalidFilter);
+
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(null, JsonRpcError.INVALID_PARAMS);
+
+    final JsonRpcResponse response = method.response(request);
+
+    assertThat(response).usingRecursiveComparison().isEqualTo(expectedResponse);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.EnclavePublicKeyProvider;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
@@ -105,11 +106,11 @@ public class PrivGetLogsTest {
   public void filterWithInvalidParameters() {
     final FilterParameter invalidFilter =
         new FilterParameter(
-            "earliest",
-            "earliest",
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
             Collections.emptyList(),
             Collections.emptyList(),
-            Hash.ZERO.toHexString());
+            Hash.ZERO);
 
     final JsonRpcRequestContext request = privGetLogRequest(PRIVACY_GROUP_ID, invalidFilter);
 
@@ -128,7 +129,7 @@ public class PrivGetLogsTest {
     final List<List<LogTopic>> logTopics = List.of(List.of(LogTopic.of(Bytes32.random())));
 
     final FilterParameter blockHashFilter =
-        new FilterParameter(null, null, addresses, logTopics, blockHash.toHexString());
+        new FilterParameter(null, null, addresses, logTopics, blockHash);
 
     final LogsQuery expectedQuery =
         new LogsQuery.Builder().addresses(addresses).topics(logTopics).build();
@@ -144,7 +145,7 @@ public class PrivGetLogsTest {
     final Hash blockHash = Hash.hash(Bytes32.random());
     final FilterParameter blockHashFilter =
         new FilterParameter(
-            null, null, Collections.emptyList(), Collections.emptyList(), blockHash.toHexString());
+            null, null, Collections.emptyList(), Collections.emptyList(), blockHash);
 
     final List<LogWithMetadata> logWithMetadataList = logWithMetadataList(3);
     final LogsResult expectedLogsResult = new LogsResult(logWithMetadataList);
@@ -164,7 +165,11 @@ public class PrivGetLogsTest {
     long chainHeadBlockNumber = 3L;
     final FilterParameter blockHashFilter =
         new FilterParameter(
-            "earliest", "latest", Collections.emptyList(), Collections.emptyList(), null);
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            null);
     final List<LogWithMetadata> logWithMetadataList = logWithMetadataList(3);
     final LogsResult expectedLogsResult = new LogsResult(logWithMetadataList);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
@@ -96,11 +96,11 @@ public class PrivNewFilterTest {
   public void filterWithInvalidParameters() {
     final FilterParameter invalidFilter =
         new FilterParameter(
-            "earliest",
-            "earliest",
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
             Collections.emptyList(),
             Collections.emptyList(),
-            Hash.ZERO.toHexString());
+            Hash.ZERO);
 
     final JsonRpcRequestContext request = privNewFilterRequest(PRIVACY_GROUP_ID, invalidFilter);
 
@@ -114,13 +114,12 @@ public class PrivNewFilterTest {
 
   @Test
   public void filterWithExpectedQueryIsCreated() {
-    final BlockParameter fromBlock = new BlockParameter("earliest");
-    final BlockParameter toBlock = new BlockParameter("latest");
     final List<Address> addresses = List.of(Address.ZERO);
     final List<List<LogTopic>> logTopics = List.of(List.of(LogTopic.of(Bytes32.random())));
 
     final FilterParameter filter =
-        new FilterParameter("earliest", "latest", addresses, logTopics, null);
+        new FilterParameter(
+            BlockParameter.EARLIEST, BlockParameter.LATEST, addresses, logTopics, null);
 
     final LogsQuery expectedQuery =
         new LogsQuery.Builder().addresses(addresses).topics(logTopics).build();
@@ -130,7 +129,10 @@ public class PrivNewFilterTest {
 
     verify(filterManager)
         .installPrivateLogFilter(
-            eq(PRIVACY_GROUP_ID), refEq(fromBlock), refEq(toBlock), eq((expectedQuery)));
+            eq(PRIVACY_GROUP_ID),
+            refEq(BlockParameter.EARLIEST),
+            refEq(BlockParameter.LATEST),
+            eq((expectedQuery)));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
@@ -17,12 +17,13 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.blockheaders.NewBlockHeadersSubscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.logs.LogsSubscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscribeRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing.SyncingSubscription;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 
 import java.util.function.Function;
 
@@ -41,11 +42,11 @@ public class SubscriptionBuilderTest {
 
   @Test
   public void shouldBuildLogsSubscriptionWhenSubscribeRequestTypeIsLogs() {
-    final LogsQuery logsQuery = logsQuery();
+    final FilterParameter filterParameter = filterParameter();
     final SubscribeRequest subscribeRequest =
-        new SubscribeRequest(SubscriptionType.LOGS, logsQuery, null, CONNECTION_ID);
+        new SubscribeRequest(SubscriptionType.LOGS, filterParameter, null, CONNECTION_ID);
     final LogsSubscription expectedSubscription =
-        new LogsSubscription(1L, CONNECTION_ID, logsQuery);
+        new LogsSubscription(1L, CONNECTION_ID, filterParameter);
 
     final Subscription builtSubscription =
         subscriptionBuilder.build(1L, CONNECTION_ID, subscribeRequest);
@@ -96,7 +97,7 @@ public class SubscriptionBuilderTest {
   public void shouldReturnLogsSubscriptionWhenMappingLogsSubscription() {
     final Function<Subscription, LogsSubscription> function =
         subscriptionBuilder.mapToSubscriptionClass(LogsSubscription.class);
-    final Subscription subscription = new LogsSubscription(1L, CONNECTION_ID, logsQuery());
+    final Subscription subscription = new LogsSubscription(1L, CONNECTION_ID, filterParameter());
 
     assertThat(function.apply(subscription)).isInstanceOf(LogsSubscription.class);
   }
@@ -147,7 +148,7 @@ public class SubscriptionBuilderTest {
             "NewBlockHeadersSubscription instance can't be mapped to type LogsSubscription");
   }
 
-  private LogsQuery logsQuery() {
-    return new LogsQuery(null, null);
+  private FilterParameter filterParameter() {
+    return new FilterParameter(BlockParameter.EARLIEST, BlockParameter.LATEST, null, null, null);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
@@ -21,10 +21,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.LogResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -354,7 +355,10 @@ public class LogsSubscriptionServiceTest {
       final List<Address> addresses, final List<List<LogTopic>> logTopics) {
 
     return new LogsSubscription(
-        nextSubscriptionId.incrementAndGet(), "conn", new LogsQuery(addresses, logTopics));
+        nextSubscriptionId.incrementAndGet(),
+        "conn",
+        new FilterParameter(
+            BlockParameter.LATEST, BlockParameter.LATEST, addresses, logTopics, null));
   }
 
   private void registerSubscriptions(final LogsSubscription... subscriptions) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
@@ -26,8 +26,9 @@ import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcRequest;
-import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.LogTopic;
 
@@ -171,9 +172,12 @@ public class SubscriptionRequestMapperTest {
     final SubscribeRequest expectedSubscribeRequest =
         new SubscribeRequest(
             SubscriptionType.LOGS,
-            new LogsQuery(
+            new FilterParameter(
+                BlockParameter.LATEST,
+                BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
-                emptyList()),
+                emptyList(),
+                null),
             null,
             null);
 
@@ -193,7 +197,9 @@ public class SubscriptionRequestMapperTest {
     final SubscribeRequest expectedSubscribeRequest =
         new SubscribeRequest(
             SubscriptionType.LOGS,
-            new LogsQuery(
+            new FilterParameter(
+                BlockParameter.LATEST,
+                BlockParameter.LATEST,
                 Stream.of(
                         "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd",
                         "0xf17f52151EbEF6C7334FAD080c5704D77216b732")
@@ -202,7 +208,8 @@ public class SubscriptionRequestMapperTest {
                 singletonList(
                     singletonList(
                         LogTopic.fromHexString(
-                            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902")))),
+                            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"))),
+                null),
             null,
             null);
 
@@ -222,7 +229,9 @@ public class SubscriptionRequestMapperTest {
     final SubscribeRequest expectedSubscribeRequest =
         new SubscribeRequest(
             SubscriptionType.LOGS,
-            new LogsQuery(
+            new FilterParameter(
+                BlockParameter.LATEST,
+                BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
                 List.of(
                     singletonList(
@@ -230,7 +239,8 @@ public class SubscriptionRequestMapperTest {
                             "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902")),
                     singletonList(
                         LogTopic.fromHexString(
-                            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab901")))),
+                            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab901"))),
+                null),
             null,
             null);
 
@@ -250,9 +260,12 @@ public class SubscriptionRequestMapperTest {
     final SubscribeRequest expectedSubscribeRequest =
         new SubscribeRequest(
             SubscriptionType.LOGS,
-            new LogsQuery(
+            new FilterParameter(
+                BlockParameter.LATEST,
+                BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
-                emptyList()),
+                emptyList(),
+                null),
             null,
             null);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Geth sneakily accepts from and to blocks in its websocket log subscriptions parameters. This extends the websocket subscription to be able to take block parameters. That makes us compatible with their implementation and also our http and ws filter parameters align.

## Fixed Issue(s)
fixes #654
