### PR TITLE
[EIP-1559] Set the gas block limit as a factor of the target gas usage instead of hard coded value.

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarket.java
@@ -29,7 +29,9 @@ public interface FeeMarket {
 
   long getPerTxGaslimit();
 
+  double getSlackCoefficient();
+
   static FeeMarket eip1559() {
-    return new FeeMarketConfig(8L, 10000000L, 20000000L, 800000L, 10L, 1000000000L, 8000000L);
+    return new FeeMarketConfig(8L, 10000000L, 2.0, 800000L, 10L, 1000000000L, 8000000L);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarketConfig.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarketConfig.java
@@ -77,6 +77,6 @@ public class FeeMarketConfig implements FeeMarket {
 
   @Override
   public double getSlackCoefficient() {
-    return 0;
+    return slackCoefficient;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarketConfig.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/FeeMarketConfig.java
@@ -17,23 +17,23 @@ package org.hyperledger.besu.ethereum.core.fees;
 public class FeeMarketConfig implements FeeMarket {
   private final long basefeeMaxChangeDenominator;
   private final long targetGasUsed;
-  private final long maxGas;
   private final long decayRange;
   private final long gasIncrementAmount;
   private final long initialBasefee;
   private final long perTxGaslimit;
+  private final double slackCoefficient;
 
   public FeeMarketConfig(
       final long basefeeMaxChangeDenominator,
       final long targetGasUsed,
-      final long maxGas,
+      final double slackCoefficient,
       final long decayRange,
       final long gasIncrementAmount,
       final long initialBasefee,
       final long perTxGaslimit) {
     this.basefeeMaxChangeDenominator = basefeeMaxChangeDenominator;
     this.targetGasUsed = targetGasUsed;
-    this.maxGas = maxGas;
+    this.slackCoefficient = slackCoefficient;
     this.decayRange = decayRange;
     this.gasIncrementAmount = gasIncrementAmount;
     this.initialBasefee = initialBasefee;
@@ -52,7 +52,7 @@ public class FeeMarketConfig implements FeeMarket {
 
   @Override
   public long getMaxGas() {
-    return maxGas;
+    return (long) (slackCoefficient * targetGasUsed);
   }
 
   @Override
@@ -73,5 +73,10 @@ public class FeeMarketConfig implements FeeMarket {
   @Override
   public long getPerTxGaslimit() {
     return perTxGaslimit;
+  }
+
+  @Override
+  public double getSlackCoefficient() {
+    return 0;
   }
 }


### PR DESCRIPTION
## PR description
Set the gas block limit as a factor of the target gas usage instead of hard coded value.
## Fixed Issue(s)
#817 

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>
