### PR TITLE
[EIP-1559] Compute transaction gas budget allocation according to EIP-1559 rules.

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -98,7 +99,8 @@ public class EthGetTransactionReceiptTest {
           false,
           null,
           TransactionPriceCalculator.frontier(),
-          Optional.empty());
+          Optional.empty(),
+          TransactionGasBudgetCalculator.frontier());
   private final ProtocolSpec<Void> statusTransactionTypeSpec =
       new ProtocolSpec<>(
           "status",
@@ -121,7 +123,8 @@ public class EthGetTransactionReceiptTest {
           false,
           null,
           TransactionPriceCalculator.frontier(),
-          Optional.empty());
+          Optional.empty(),
+          TransactionGasBudgetCalculator.frontier());
 
   @SuppressWarnings("unchecked")
   private final ProtocolSchedule<Void> protocolSchedule = mock(ProtocolSchedule.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ClassicBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
@@ -88,7 +89,8 @@ public class RewardTraceGeneratorTest {
             transactionReceiptFactory,
             blockReward,
             BlockHeader::getCoinbase,
-            true);
+            true,
+            TransactionGasBudgetCalculator.frontier());
     when(protocolSpec.getBlockProcessor()).thenReturn(blockProcessor);
 
     final Stream<Trace> traceStream =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.core.fees;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+
+@FunctionalInterface
+public interface TransactionGasBudgetCalculator {
+
+  boolean hasBudget(
+      final Transaction transaction, final BlockHeader blockHeader, final long gasUsed);
+
+  static TransactionGasBudgetCalculator frontier() {
+    return gasBudgetCalculator((blockHeader, ignored) -> blockHeader.getGasLimit());
+  }
+
+  static TransactionGasBudgetCalculator eip1559(final EIP1559 eip1559) {
+    return gasBudgetCalculator(
+        (blockHeader, transaction) ->
+            transaction.isEIP1559Transaction()
+                ? eip1559.eip1559GasPool(blockHeader.getNumber())
+                : eip1559.legacyGasPool(blockHeader.getNumber()));
+  }
+
+  static TransactionGasBudgetCalculator gasBudgetCalculator(
+      final BlockGasLimitCalculator blockGasLimitCalculator) {
+    return (transaction, blockHeader, gasUsed) -> {
+      final long remainingGasBudget =
+          blockGasLimitCalculator.apply(blockHeader, transaction) - gasUsed;
+      return Long.compareUnsigned(transaction.getGasLimit(), remainingGasBudget) <= 0;
+    };
+  }
+
+  @FunctionalInterface
+  interface BlockGasLimitCalculator {
+    long apply(BlockHeader blockHeader, Transaction transaction);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicBlockProcessor.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -44,7 +45,8 @@ public class ClassicBlockProcessor extends AbstractBlockProcessor {
         transactionReceiptFactory,
         blockReward,
         miningBeneficiaryCalculator,
-        skipZeroBlockRewards);
+        skipZeroBlockRewards,
+        TransactionGasBudgetCalculator.frontier());
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -71,7 +71,8 @@ public class ClassicProtocolSpecs {
                 transactionReceiptFactory,
                 blockReward,
                 miningBeneficiaryCalculator,
-                skipZeroBlockRewards) ->
+                skipZeroBlockRewards,
+                gasBudgetCalculator) ->
                 new ClassicBlockProcessor(
                     transactionProcessor,
                     transactionReceiptFactory,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessor.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 
 import java.util.List;
 
@@ -35,13 +36,15 @@ public class MainnetBlockProcessor extends AbstractBlockProcessor {
       final MainnetBlockProcessor.TransactionReceiptFactory transactionReceiptFactory,
       final Wei blockReward,
       final MiningBeneficiaryCalculator miningBeneficiaryCalculator,
-      final boolean skipZeroBlockRewards) {
+      final boolean skipZeroBlockRewards,
+      final TransactionGasBudgetCalculator gasBudgetCalculator) {
     super(
         transactionProcessor,
         transactionReceiptFactory,
         blockReward,
         miningBeneficiaryCalculator,
-        skipZeroBlockRewards);
+        skipZeroBlockRewards,
+        gasBudgetCalculator);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.core.WorldState;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
 import org.hyperledger.besu.ethereum.core.fees.CoinbaseFeePriceCalculator;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.mainnet.contractvalidation.MaxCodeSizeRule;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionProcessor;
@@ -169,14 +170,16 @@ public abstract class MainnetProtocolSpecs {
                 transactionReceiptFactory,
                 blockReward,
                 miningBeneficiaryCalculator,
-                skipZeroBlockRewards) ->
+                skipZeroBlockRewards,
+                gasBudgetCalculator) ->
                 new DaoBlockProcessor(
                     new MainnetBlockProcessor(
                         transactionProcessor,
                         transactionReceiptFactory,
                         blockReward,
                         miningBeneficiaryCalculator,
-                        skipZeroBlockRewards)))
+                        skipZeroBlockRewards,
+                        gasBudgetCalculator)))
         .name("DaoRecoveryInit");
   }
 
@@ -391,6 +394,7 @@ public abstract class MainnetProtocolSpecs {
         .name("EIP-1559")
         .transactionPriceCalculator(transactionPriceCalculator)
         .eip1559(Optional.of(eip1559))
+        .gasBudgetCalculator(TransactionGasBudgetCalculator.eip1559(eip1559))
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator.createEip1559Validator(eip1559))
         .ommerHeaderValidatorBuilder(
             MainnetBlockHeaderValidator.createEip1559OmmerValidator(eip1559));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpec.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransactionProcessor;
 import org.hyperledger.besu.ethereum.vm.EVM;
@@ -71,6 +72,8 @@ public class ProtocolSpec<C> {
 
   private final Optional<EIP1559> eip1559;
 
+  private final TransactionGasBudgetCalculator gasBudgetCalculator;
+
   /**
    * Creates a new protocol specification instance.
    *
@@ -95,6 +98,7 @@ public class ProtocolSpec<C> {
    * @param gasCalculator the gas calculator to use.
    * @param transactionPriceCalculator the transaction price calculator to use.
    * @param eip1559 an {@link Optional} wrapping {@link EIP1559} manager class if appropriate.
+   * @param gasBudgetCalculator the gas budget calculator to use.
    */
   public ProtocolSpec(
       final String name,
@@ -117,7 +121,8 @@ public class ProtocolSpec<C> {
       final boolean skipZeroBlockRewards,
       final GasCalculator gasCalculator,
       final TransactionPriceCalculator transactionPriceCalculator,
-      final Optional<EIP1559> eip1559) {
+      final Optional<EIP1559> eip1559,
+      final TransactionGasBudgetCalculator gasBudgetCalculator) {
     this.name = name;
     this.evm = evm;
     this.transactionValidator = transactionValidator;
@@ -139,6 +144,7 @@ public class ProtocolSpec<C> {
     this.gasCalculator = gasCalculator;
     this.transactionPriceCalculator = transactionPriceCalculator;
     this.eip1559 = eip1559;
+    this.gasBudgetCalculator = gasBudgetCalculator;
   }
 
   /**
@@ -319,5 +325,14 @@ public class ProtocolSpec<C> {
 
   public boolean isEip1559() {
     return ExperimentalEIPs.eip1559Enabled && eip1559.isPresent();
+  }
+
+  /**
+   * Returns the gas budget calculator in this specification.
+   *
+   * @return the gas budget calculator
+   */
+  public TransactionGasBudgetCalculator getGasBudgetCalculator() {
+    return gasBudgetCalculator;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.OnChainPrivacyPrecompiledContract;
 import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.PrivacyPrecompiledContract;
@@ -66,6 +67,8 @@ public class ProtocolSpecBuilder<T> {
   private TransactionPriceCalculator transactionPriceCalculator =
       TransactionPriceCalculator.frontier();
   private Optional<EIP1559> eip1559 = Optional.empty();
+  private TransactionGasBudgetCalculator gasBudgetCalculator =
+      TransactionGasBudgetCalculator.frontier();
 
   public ProtocolSpecBuilder<T> gasCalculator(final Supplier<GasCalculator> gasCalculatorBuilder) {
     this.gasCalculatorBuilder = gasCalculatorBuilder;
@@ -257,6 +260,12 @@ public class ProtocolSpecBuilder<T> {
     return this;
   }
 
+  public ProtocolSpecBuilder<T> gasBudgetCalculator(
+      final TransactionGasBudgetCalculator gasBudgetCalculator) {
+    this.gasBudgetCalculator = gasBudgetCalculator;
+    return this;
+  }
+
   public ProtocolSpec<T> build(final ProtocolSchedule<T> protocolSchedule) {
     checkNotNull(gasCalculatorBuilder, "Missing gasCalculator");
     checkNotNull(evmBuilder, "Missing operation registry");
@@ -313,7 +322,8 @@ public class ProtocolSpecBuilder<T> {
             transactionReceiptFactory,
             blockReward,
             miningBeneficiaryCalculator,
-            skipZeroBlockRewards);
+            skipZeroBlockRewards,
+            gasBudgetCalculator);
     // Set private Tx Processor
     PrivateTransactionProcessor privateTransactionProcessor = null;
     if (privacyParameters.isEnabled()) {
@@ -369,7 +379,8 @@ public class ProtocolSpecBuilder<T> {
         skipZeroBlockRewards,
         gasCalculator,
         transactionPriceCalculator,
-        eip1559);
+        eip1559,
+        gasBudgetCalculator);
   }
 
   public interface TransactionProcessorBuilder {
@@ -399,7 +410,8 @@ public class ProtocolSpecBuilder<T> {
         MainnetBlockProcessor.TransactionReceiptFactory transactionReceiptFactory,
         Wei blockReward,
         MiningBeneficiaryCalculator miningBeneficiaryCalculator,
-        boolean skipZeroBlockRewards);
+        boolean skipZeroBlockRewards,
+        TransactionGasBudgetCalculator gasBudgetCalculator);
   }
 
   public interface BlockValidatorBuilder<T> {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.core.fees;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TransactionGasBudgetCalculatorTest {
+
+  private static final long EIP_1559_FORK_BLOCK = 1L;
+  private static final TransactionGasBudgetCalculator FRONTIER_CALCULATOR =
+      TransactionGasBudgetCalculator.frontier();
+  private static final TransactionGasBudgetCalculator EIP1559_CALCULATOR =
+      TransactionGasBudgetCalculator.eip1559(new EIP1559(EIP_1559_FORK_BLOCK));
+  private static final FeeMarket FEE_MARKET = FeeMarket.eip1559();
+
+  private final TransactionGasBudgetCalculator gasBudgetCalculator;
+  private final boolean isEIP1559;
+  private final long transactionGasLimit;
+  private final long blockNumber;
+  private final long blockHeaderGasLimit;
+  private final long gasUsed;
+  private final boolean expectedHasBudget;
+
+  public TransactionGasBudgetCalculatorTest(
+      final TransactionGasBudgetCalculator gasBudgetCalculator,
+      final boolean isEIP1559,
+      final long transactionGasLimit,
+      final long blockNumber,
+      final long blockHeaderGasLimit,
+      final long gasUsed,
+      final boolean expectedHasBudget) {
+    this.gasBudgetCalculator = gasBudgetCalculator;
+    this.isEIP1559 = isEIP1559;
+    this.transactionGasLimit = transactionGasLimit;
+    this.blockNumber = blockNumber;
+    this.blockHeaderGasLimit = blockHeaderGasLimit;
+    this.gasUsed = gasUsed;
+    this.expectedHasBudget = expectedHasBudget;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 0L, true},
+          {FRONTIER_CALCULATOR, false, 11L, 1L, 10L, 0L, false},
+          {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 6L, false},
+          {EIP1559_CALCULATOR, false, 5L, EIP_1559_FORK_BLOCK, 10L, 0L, true},
+          {
+            EIP1559_CALCULATOR,
+            false,
+            (FEE_MARKET.getMaxGas() / 2) + 1,
+            1L,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            false
+          },
+          {
+            EIP1559_CALCULATOR,
+            false,
+            (FEE_MARKET.getMaxGas() / 2) - 1,
+            EIP_1559_FORK_BLOCK,
+            10L,
+            2L,
+            false
+          },
+          {
+            EIP1559_CALCULATOR,
+            true,
+            (FEE_MARKET.getMaxGas() / 2) + 1,
+            EIP_1559_FORK_BLOCK,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            false
+          },
+          {
+            EIP1559_CALCULATOR,
+            true,
+            (FEE_MARKET.getMaxGas() / 2) - 1,
+            EIP_1559_FORK_BLOCK,
+            10L,
+            2L,
+            false
+          },
+          {
+            EIP1559_CALCULATOR,
+            true,
+            (FEE_MARKET.getMaxGas() / 2) + FEE_MARKET.getGasIncrementAmount(),
+            EIP_1559_FORK_BLOCK + 1,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            true
+          },
+          {
+            EIP1559_CALCULATOR,
+            true,
+            (FEE_MARKET.getMaxGas() / 2) + FEE_MARKET.getGasIncrementAmount() + 1,
+            EIP_1559_FORK_BLOCK + 1,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            false
+          },
+          {
+            EIP1559_CALCULATOR,
+            false,
+            (FEE_MARKET.getMaxGas() / 2) - FEE_MARKET.getGasIncrementAmount(),
+            EIP_1559_FORK_BLOCK + 1,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            true
+          },
+          {
+            EIP1559_CALCULATOR,
+            false,
+            (FEE_MARKET.getMaxGas() / 2) - FEE_MARKET.getGasIncrementAmount() + 1,
+            EIP_1559_FORK_BLOCK + 1,
+            FEE_MARKET.getMaxGas(),
+            0L,
+            false
+          }
+        });
+  }
+
+  @BeforeClass
+  public static void initialize() {
+    ExperimentalEIPs.eip1559Enabled = true;
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
+  }
+
+  @Test
+  public void assertThatCalculatorWorks() {
+    assertThat(
+            gasBudgetCalculator.hasBudget(
+                transaction(isEIP1559, transactionGasLimit),
+                blockHeader(blockNumber, blockHeaderGasLimit),
+                gasUsed))
+        .isEqualTo(expectedHasBudget);
+  }
+
+  private BlockHeader blockHeader(final long blockNumber, final long gasLimit) {
+    final BlockHeader blockHeader = mock(BlockHeader.class);
+    when(blockHeader.getNumber()).thenReturn(blockNumber);
+    when(blockHeader.getGasLimit()).thenReturn(gasLimit);
+    return blockHeader;
+  }
+
+  private Transaction transaction(final boolean isEIP1559, final long gasLimit) {
+    final Transaction transaction = mock(Transaction.class);
+    when(transaction.isEIP1559Transaction()).thenReturn(isEIP1559);
+    when(transaction.getGasLimit()).thenReturn(gasLimit);
+    return transaction;
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.vm.TestBlockchain;
 import org.hyperledger.besu.ethereum.vm.WorldStateMock;
 
@@ -45,7 +46,8 @@ public class MainnetBlockProcessorTest {
             transactionReceiptFactory,
             Wei.ZERO,
             BlockHeader::getCoinbase,
-            true);
+            true,
+            TransactionGasBudgetCalculator.frontier());
 
     final MutableWorldState worldState = WorldStateMock.create(emptyMap());
     final Hash initialHash = worldState.rootHash();
@@ -70,7 +72,8 @@ public class MainnetBlockProcessorTest {
             transactionReceiptFactory,
             Wei.ZERO,
             BlockHeader::getCoinbase,
-            false);
+            false,
+            TransactionGasBudgetCalculator.frontier());
 
     final MutableWorldState worldState = WorldStateMock.create(emptyMap());
     final Hash initialHash = worldState.rootHash();

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/NoRewardProtocolScheduleWrapper.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/NoRewardProtocolScheduleWrapper.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.MainnetBlockValidator;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.TransactionFilter;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.mainnet.BlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockImporter;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockProcessor;
@@ -46,7 +47,8 @@ public class NoRewardProtocolScheduleWrapper<C> implements ProtocolSchedule<C> {
             original.getTransactionReceiptFactory(),
             Wei.ZERO,
             original.getMiningBeneficiaryCalculator(),
-            original.isSkipZeroBlockRewards());
+            original.isSkipZeroBlockRewards(),
+            TransactionGasBudgetCalculator.frontier());
     final BlockValidator<C> noRewardBlockValidator =
         new MainnetBlockValidator<>(
             original.getBlockHeaderValidator(),
@@ -75,7 +77,8 @@ public class NoRewardProtocolScheduleWrapper<C> implements ProtocolSchedule<C> {
         original.isSkipZeroBlockRewards(),
         original.getGasCalculator(),
         original.getTransactionPriceCalculator(),
-        original.getEip1559());
+        original.getEip1559(),
+        original.getGasBudgetCalculator());
   }
 
   @Override


### PR DESCRIPTION
## PR description
- `MAX_GAS_EIP1559` acts as the hard in-protocol gas limit, instead of the gas limit calculated using the previously existing formulas
- The `GASLIMIT` field in the block header is the gas limit for the `EIP1559 gas pool`, and over the transition period this value increases until it reaches `MAX_GAS_EIP1559` at `FINAL_FORK_BLKNUM`
- The gas limit for the legacy gas pool is `MAX_GAS_EIP1559 - GASLIMIT`, as `GASLIMIT` increases towards `MAX_GAS_EIP1559` gas is moved from the legacy pool into the EIP1559 pool until all of the gas is in the EIP1559 pool
- At `block.number == INITIAL_FORK_BLKNUM, let GASLIMIT = (MAX_GAS_EIP1559 / 2)` so that the gas maximum is split evenly between the legacy and EIP1559 gas pools
- As `block.number` increases towards `FINAL_FORK_BLKNUM`, at every block we shift `EIP1559_GAS_INCREMENT_AMOUNT` from the legacy pool into the EIP1559 gas pool
- At `block.number >= FINAL_FORK_BLKNUM` the entire `MAX_GAS_EIP1559` is assigned to the EIP1559 gas pool and the legacy pool is empty

### Changes summary
- Added `TransactionGasBudgetCalculator` with `hasBudget` method.
- Updated `AbstractBlockProcessor` to compute the gas budget using `TransactionGasBudgetCalculator`.
- Added unit tests in `TransactionGasBudgetCalculatorTest`.
- Updated `ProtocolSpec` and `ProtocolSpecBuilder` to use the `TransactionGasBudgetCalculator`.
- Updated `MainnetProtocolSpecs` accordingly
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#736 
Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>