### PR TITLE
Retesteth eth_getBlockByHash requires "author" field.

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
@@ -31,16 +31,20 @@ public class EthGetBlockByHash implements JsonRpcMethod {
 
   private final BlockResultFactory blockResult;
   private final Supplier<BlockchainQueries> blockchain;
+  private final boolean includeCoinbase;
 
   public EthGetBlockByHash(
       final BlockchainQueries blockchain, final BlockResultFactory blockResult) {
-    this(Suppliers.ofInstance(blockchain), blockResult);
+    this(Suppliers.ofInstance(blockchain), blockResult, false);
   }
 
   public EthGetBlockByHash(
-      final Supplier<BlockchainQueries> blockchain, final BlockResultFactory blockResult) {
+      final Supplier<BlockchainQueries> blockchain,
+      final BlockResultFactory blockResult,
+      final boolean includeCoinbase) {
     this.blockchain = blockchain;
     this.blockResult = blockResult;
+    this.includeCoinbase = includeCoinbase;
   }
 
   @Override
@@ -65,7 +69,11 @@ public class EthGetBlockByHash implements JsonRpcMethod {
   }
 
   private BlockResult transactionComplete(final Hash hash) {
-    return blockchain.get().blockByHash(hash).map(blockResult::transactionComplete).orElse(null);
+    return blockchain
+        .get()
+        .blockByHash(hash)
+        .map(tx -> blockResult.transactionComplete(tx, includeCoinbase))
+        .orElse(null);
   }
 
   private BlockResult transactionHash(final Hash hash) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
@@ -88,7 +88,12 @@ public class DebugStorageRangeAtResult implements JsonRpcResult {
     public StorageEntry(final AccountStorageEntry entry, final boolean shortValues) {
       if (shortValues) {
         this.value = entry.getValue().toShortHexString();
-        this.key = entry.getKey().map(UInt256::toShortHexString).orElse(null);
+        this.key =
+            entry
+                .getKey()
+                .map(UInt256::toShortHexString)
+                .map(s -> "0x".equals(s) ? "0x00" : s)
+                .orElse(null);
       } else {
         this.value = entry.getValue().toHexString();
         this.key = entry.getKey().map(UInt256::toHexString).orElse(null);

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
@@ -63,6 +63,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
 
 public class RetestethContext {
 
@@ -72,6 +73,7 @@ public class RetestethContext {
 
   private final ReentrantLock contextLock = new ReentrantLock();
   private Address coinbase;
+  private Bytes extraData;
   private MutableBlockchain blockchain;
   private ProtocolContext<Void> protocolContext;
   private BlockchainQueries blockchainQueries;
@@ -128,6 +130,7 @@ public class RetestethContext {
 
     final GenesisState genesisState = GenesisState.fromJson(genesisConfigString, protocolSchedule);
     coinbase = genesisState.getBlock().getHeader().getCoinbase();
+    extraData = genesisState.getBlock().getHeader().getExtraData();
 
     final WorldStateArchive worldStateArchive =
         new WorldStateArchive(
@@ -246,6 +249,10 @@ public class RetestethContext {
 
   public Address getCoinbase() {
     return coinbase;
+  }
+
+  public Bytes getExtraData() {
+    return extraData;
   }
 
   public MutableBlockchain getBlockchain() {

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -72,7 +72,7 @@ public class RetestethService {
             new EthGetBlockByNumber(retestethContext::getBlockchainQueries, blockResult, true),
             new DebugAccountRange(retestethContext::getBlockchainQueries),
             new EthGetBalance(retestethContext::getBlockchainQueries),
-            new EthGetBlockByHash(retestethContext::getBlockchainQueries, blockResult),
+            new EthGetBlockByHash(retestethContext::getBlockchainQueries, blockResult, true),
             new EthGetCode(retestethContext::getBlockchainQueries),
             new EthGetTransactionCount(
                 retestethContext::getBlockchainQueries,

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.ethereum.retesteth.RetestethClock;
 import org.hyperledger.besu.ethereum.retesteth.RetestethContext;
 
 import com.google.common.base.Functions;
-import org.apache.tuweni.bytes.Bytes;
 
 public class TestMineBlocks implements JsonRpcMethod {
   private final RetestethContext context;

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
@@ -65,7 +65,7 @@ public class TestMineBlocks implements JsonRpcMethod {
     final EthHashBlockCreator blockCreator =
         new EthHashBlockCreator(
             context.getCoinbase(),
-            header -> Bytes.of(),
+            header -> context.getExtraData(),
             context.getTransactionPool().getPendingTransactions(),
             protocolContext,
             protocolSchedule,


### PR DESCRIPTION
When in retesteth return the coinbase in the eth_getBlockByHash, as
required by the retesteth tool.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
