### PR TITLE
Add check for spoofed IP in ping message

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -300,6 +300,7 @@ public class PeerDiscoveryController {
                 pingPacketData ->
                     !sender.getEndpoint().getHost().equals(pingPacketData.getFrom().getHost()))
             .orElse(false)) {
+      LOG.debug("Rejecting ping attempt from IP {}", sender.getEndpoint().getHost());
       return;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -295,11 +295,11 @@ public class PeerDiscoveryController {
     //  Message from spoofed IP should be ignored
     if (packet.getType().equals(PacketType.PING)
         && packet
-        .getPacketData(PingPacketData.class)
-        .map(
-            pingPacketData ->
-                !sender.getEndpoint().getHost().equals(pingPacketData.getFrom().getHost()))
-        .orElse(false)) {
+            .getPacketData(PingPacketData.class)
+            .map(
+                pingPacketData ->
+                    !sender.getEndpoint().getHost().equals(pingPacketData.getFrom().getHost()))
+            .orElse(false)) {
       return;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -292,6 +292,17 @@ public class PeerDiscoveryController {
       return;
     }
 
+    //  Message from spoofed IP should be ignored
+    if (packet.getType().equals(PacketType.PING)
+        && packet
+        .getPacketData(PingPacketData.class)
+        .map(
+            pingPacketData ->
+                !sender.getEndpoint().getHost().equals(pingPacketData.getFrom().getHost()))
+        .orElse(false)) {
+      return;
+    }
+
     // Load the peer from the table, or use the instance that comes in.
     final Optional<DiscoveryPeer> maybeKnownPeer =
         peerTable.get(sender).filter(known -> known.discoveryEndpointMatches(sender));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -586,6 +586,36 @@ public class PeerDiscoveryControllerTest {
   }
 
   @Test
+  public void shouldIgnorePeerWhenReceivedInvalidReplyToken() {
+    // test spoofs a ping from a different ip address('victim ip')
+    startPeerDiscoveryController();
+
+    final DiscoveryPeer peer =
+        spy(
+            DiscoveryPeer.fromEnode(
+                EnodeURL.builder()
+                    .nodeId(Peer.randomId())
+                    .ipAddress("10.20.30.40")
+                    .discoveryAndListeningPorts(30303)
+                    .build()));
+
+    final DiscoveryPeer victimPeer =
+        spy(
+            DiscoveryPeer.fromEnode(
+                EnodeURL.builder()
+                    .nodeId(Peer.randomId())
+                    .ipAddress("10.20.30.41")
+                    .discoveryAndListeningPorts(30303)
+                    .build()));
+
+    final Packet pingPacket = mockPingPacket(peer, this.localPeer);
+    controller.onMessage(pingPacket, victimPeer);
+
+    assertThat(controller.streamDiscoveredPeers()).doesNotContain(victimPeer);
+    assertThat(controller.streamDiscoveredPeers()).doesNotContain(peer);
+  }
+
+  @Test
   public void shouldNotAddNewPeerWhenReceivedPongFromBlacklistedPeer() {
     final List<DiscoveryPeer> peers = createPeersInLastBucket(localPeer, 3);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 org.gradle.jvmargs=-Xmx1g
-version=1.4.5-RC1
+version=1.4.6-SNAPSHOT


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Add check for spoofed IP in ping message and return without bonding to node.

Signed-off-by: David Mechler <david.mechler@consensys.net>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#792 