### PR TITLE
Remove unnecessary JSON-RPC mapping in the case of manual nat manager

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -614,8 +614,7 @@ public class RunnerBuilder {
       case UPNP:
         return Optional.of(new UpnpNatManager());
       case MANUAL:
-        return Optional.of(
-            new ManualNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
+        return Optional.of(new ManualNatManager(p2pAdvertisedHost, p2pListenPort));
       case DOCKER:
         return Optional.of(
             new DockerNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -39,14 +39,12 @@ public class ManualNatManager extends AbstractNatManager {
 
   private final String advertisedHost;
   private final int p2pPort;
-  private final int rpcHttpPort;
   private final List<NatPortMapping> forwardedPorts;
 
-  public ManualNatManager(final String advertisedHost, final int p2pPort, final int rpcHttpPort) {
+  public ManualNatManager(final String advertisedHost, final int p2pPort) {
     super(NatMethod.MANUAL);
     this.advertisedHost = advertisedHost;
     this.p2pPort = p2pPort;
-    this.rpcHttpPort = rpcHttpPort;
     this.forwardedPorts = buildForwardedPorts();
   }
 
@@ -67,14 +65,7 @@ public class ManualNatManager extends AbstractNatManager {
               internalHost,
               advertisedHost,
               p2pPort,
-              p2pPort),
-          new NatPortMapping(
-              NatServiceType.JSON_RPC,
-              NetworkProtocol.TCP,
-              internalHost,
-              advertisedHost,
-              rpcHttpPort,
-              rpcHttpPort));
+              p2pPort));
     } catch (Exception e) {
       LOG.warn("Failed to create forwarded port list", e);
     }

--- a/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
@@ -36,13 +36,12 @@ public class ManualNatManagerTest {
 
   private final String advertisedHost = "99.45.69.12";
   private final int p2pPort = 1;
-  private final int rpcHttpPort = 2;
 
   private ManualNatManager natManager;
 
   @Before
   public void initialize() throws NatInitializationException {
-    natManager = new ManualNatManager(advertisedHost, p2pPort, rpcHttpPort);
+    natManager = new ManualNatManager(advertisedHost, p2pPort);
     natManager.start();
   }
 
@@ -74,25 +73,6 @@ public class ManualNatManagerTest {
             advertisedHost,
             p2pPort,
             p2pPort);
-
-    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
-  }
-
-  @Test
-  public void assertThatMappingForJsonRpcWorks() throws UnknownHostException {
-    final String internalHost = InetAddress.getLocalHost().getHostAddress();
-
-    final NatPortMapping mapping =
-        natManager.getPortMapping(NatServiceType.JSON_RPC, NetworkProtocol.TCP);
-
-    final NatPortMapping expectedMapping =
-        new NatPortMapping(
-            NatServiceType.JSON_RPC,
-            NetworkProtocol.TCP,
-            internalHost,
-            advertisedHost,
-            rpcHttpPort,
-            rpcHttpPort);
 
     assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
   }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

Remove unnecessary JSON-RPC mapping in the case of manual nat manager

JSON-RPC mapping is useless in the case of the manual nat manager. Indeed it is not retrieved by the getPortMapping method
