### PR TITLE
Cope with retesteth's aversion to odd quantities

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
@@ -23,6 +23,7 @@ import java.util.TreeMap;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.MoreObjects;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
@@ -87,11 +88,12 @@ public class DebugStorageRangeAtResult implements JsonRpcResult {
 
     public StorageEntry(final AccountStorageEntry entry, final boolean shortValues) {
       if (shortValues) {
-        this.value = entry.getValue().toShortHexString();
+        this.value = entry.getValue().toMinimalBytes().toHexString();
         this.key =
             entry
                 .getKey()
-                .map(UInt256::toShortHexString)
+                .map(UInt256::toMinimalBytes)
+                .map(Bytes::toHexString)
                 .map(s -> "0x".equals(s) ? "0x00" : s)
                 .orElse(null);
       } else {


### PR DESCRIPTION
Retesteth requires even length quantities (in contravariance to the Eth
JSON-RPC standards).  For storage range at provide even length
quantities.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

