### PR TITLE
Accept Nested TOML Array for Default Value Decoding

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
@@ -57,11 +57,16 @@ public class TomlConfigFileDefaultProvider implements IDefaultValueProvider {
   }
 
   private String getConfigurationValue(final OptionSpec optionSpec) {
+    // NOTE: This temporary fix is necessary to make certain options be treated as a multi-value.
+    // This can be done automatically by picocli if the object implements Collection.
+    final boolean isArray =
+        getKeyName(optionSpec).map(keyName -> result.isArray(keyName)).orElse(false);
     final String defaultValue;
+
     // Convert config values to the right string representation for default string value
     if (optionSpec.type().equals(Boolean.class)) {
       defaultValue = getBooleanEntryAsString(optionSpec);
-    } else if (optionSpec.isMultiValue()) {
+    } else if (optionSpec.isMultiValue() || isArray) {
       defaultValue = getListEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Integer.class)) {
       defaultValue = getIntegerEntryAsString(optionSpec);

--- a/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
@@ -101,6 +101,7 @@ public class TomlConfigFileDefaultProviderTest {
     validOptionsMap.put("--an-int-value-option", null);
     validOptionsMap.put("--a-wei-value-option", null);
     validOptionsMap.put("--a-string-value-option", null);
+    validOptionsMap.put("--a-nested-multi-value-option", null);
 
     when(mockCommandSpec.optionsMap()).thenReturn(validOptionsMap);
 
@@ -119,6 +120,9 @@ public class TomlConfigFileDefaultProviderTest {
       fileWriter.write("a-wei-value-option=1");
       fileWriter.newLine();
       fileWriter.write("a-string-value-option='my value'");
+      fileWriter.newLine();
+      fileWriter.write(
+          "a-nested-multi-value-option=[ [\"value1\", \"value2\"], [\"value3\", \"value4\"] ]");
       fileWriter.flush();
 
       final TomlConfigFileDefaultProvider providerUnderTest =
@@ -153,6 +157,11 @@ public class TomlConfigFileDefaultProviderTest {
               providerUnderTest.defaultValue(
                   OptionSpec.builder("a-string-value-option").type(String.class).build()))
           .isEqualTo("my value");
+
+      assertThat(
+              providerUnderTest.defaultValue(
+                  OptionSpec.builder("a-nested-multi-value-option").type(Collection.class).build()))
+          .isEqualTo("[value1,value2],[value3,value4]");
     }
   }
 


### PR DESCRIPTION
## PR Description
This PR resolves an issue in decoding nested TOML arrays, where the default value decoder would always assume a multi-value/array was only one level deep. In so doing, toString would be called, even when the array element was an array itself, resulting in a parsing error.

This PR tests each array element during decoding to see if it is an array itself, and if it is, the decoding function is called recursively until a base primitive is found. In addition, this PR allows the `TomlConfigFileDefaultProvider` to determine if a `picocli` option should be treated as a multi-value, even if the base type failed to implement Collection.

## Fixed Issue(s)
Fixes issue in PegaSys Plus/plugins.

Signed-off-by: Steven J Schroeder <steven.schroeder@consensys.net>
