### PR TITLE
Exposing chainId related errors on JSON-RCP responses

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
@@ -36,6 +36,10 @@ public class JsonRpcErrorConverter {
         return JsonRpcError.TRANSACTION_UPFRONT_COST_EXCEEDS_BALANCE;
       case EXCEEDS_BLOCK_GAS_LIMIT:
         return JsonRpcError.EXCEEDS_BLOCK_GAS_LIMIT;
+      case WRONG_CHAIN_ID:
+        return JsonRpcError.WRONG_CHAIN_ID;
+      case REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED:
+        return JsonRpcError.REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED;
       case TX_SENDER_NOT_AUTHORIZED:
         return JsonRpcError.TX_SENDER_NOT_AUTHORIZED;
         // Private Transaction Invalid Reasons

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -55,6 +55,8 @@ public enum JsonRpcError {
   TX_SENDER_NOT_AUTHORIZED(-32007, "Sender account not authorized to send transactions"),
   CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE(-32008, "Initial sync is still in progress"),
   GAS_PRICE_TOO_LOW(-32009, "Gas price below configured minimum gas price"),
+  WRONG_CHAIN_ID(-32000, "Wrong chainId"),
+  REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED(-32000, "ChainId not supported"),
 
   // Miner failures
   COINBASE_NOT_SET(-32010, "Coinbase not set. Unable to start mining without a coinbase"),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.mainnet.TransactionValidator.TransactionInvalidReason;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JsonRpcErrorConverterTest {
+
+  @Parameters
+  public static Collection<Object[]> expectedErrorMapping() {
+    return Arrays.asList(
+        new Object[][] {
+          {TransactionInvalidReason.NONCE_TOO_LOW, JsonRpcError.NONCE_TOO_LOW},
+          {TransactionInvalidReason.PRIVATE_NONCE_TOO_LOW, JsonRpcError.NONCE_TOO_LOW},
+          {TransactionInvalidReason.INCORRECT_NONCE, JsonRpcError.INCORRECT_NONCE},
+          {TransactionInvalidReason.INCORRECT_PRIVATE_NONCE, JsonRpcError.INCORRECT_NONCE},
+          {TransactionInvalidReason.INVALID_SIGNATURE, JsonRpcError.INVALID_TRANSACTION_SIGNATURE},
+          {
+            TransactionInvalidReason.INTRINSIC_GAS_EXCEEDS_GAS_LIMIT,
+            JsonRpcError.INTRINSIC_GAS_EXCEEDS_LIMIT
+          },
+          {
+            TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE,
+            JsonRpcError.TRANSACTION_UPFRONT_COST_EXCEEDS_BALANCE
+          },
+          {TransactionInvalidReason.EXCEEDS_BLOCK_GAS_LIMIT, JsonRpcError.EXCEEDS_BLOCK_GAS_LIMIT},
+          {TransactionInvalidReason.WRONG_CHAIN_ID, JsonRpcError.WRONG_CHAIN_ID},
+          {
+            TransactionInvalidReason.REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED,
+            JsonRpcError.REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED
+          },
+          {
+            TransactionInvalidReason.TX_SENDER_NOT_AUTHORIZED, JsonRpcError.TX_SENDER_NOT_AUTHORIZED
+          },
+          {
+            TransactionInvalidReason.CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE,
+            JsonRpcError.CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE
+          },
+          {TransactionInvalidReason.GAS_PRICE_TOO_LOW, JsonRpcError.GAS_PRICE_TOO_LOW},
+          {
+            TransactionInvalidReason.OFFCHAIN_PRIVACY_GROUP_DOES_NOT_EXIST,
+            JsonRpcError.OFFCHAIN_PRIVACY_GROUP_DOES_NOT_EXIST
+          },
+          {
+            TransactionInvalidReason.TRANSACTION_ALREADY_KNOWN,
+            JsonRpcError.ETH_SEND_TX_ALREADY_KNOWN
+          },
+          {
+            TransactionInvalidReason.TRANSACTION_REPLACEMENT_UNDERPRICED,
+            JsonRpcError.ETH_SEND_TX_REPLACEMENT_UNDERPRICED
+          }
+        });
+  }
+
+  @Parameter(0)
+  public TransactionInvalidReason txInvalidReason;
+
+  @Parameter(1)
+  public JsonRpcError expectedJsonRpcError;
+
+  @Test
+  public void expectedTransactionValidationToJsonRpcErrorConversion() {
+    assertThat(JsonRpcErrorConverter.convertTransactionInvalidReason(txInvalidReason))
+        .isEqualTo(expectedJsonRpcError);
+  }
+}


### PR DESCRIPTION
## PR description

I noticed that when we send a tx with the wrong chainId, Besu returns a generic "Invalid Params" (not super helpful). This PR is mapping `WRONG_CHAIN_ID` and `REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED` tx validation errors to JsonRpcErrors so the user knows what is wrong with the tx.

Thanks to @pinges for finding out this was happening! I could've saved him a few hours... :)