### PR TITLE
Revert "Remove manual nat manager (#921)"

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -97,6 +97,7 @@ import org.hyperledger.besu.nat.docker.DockerDetector;
 import org.hyperledger.besu.nat.docker.DockerNatManager;
 import org.hyperledger.besu.nat.kubernetes.KubernetesDetector;
 import org.hyperledger.besu.nat.kubernetes.KubernetesNatManager;
+import org.hyperledger.besu.nat.manual.ManualNatManager;
 import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
@@ -626,6 +627,9 @@ public class RunnerBuilder {
     switch (detectedNatMethod) {
       case UPNP:
         return Optional.of(new UpnpNatManager());
+      case MANUAL:
+        return Optional.of(
+            new ManualNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
       case DOCKER:
         return Optional.of(
             new DockerNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1305,7 +1305,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .contains(
-            "Invalid value for option '--nat-method': expected one of [UPNP, DOCKER, KUBERNETES, AUTO, NONE] (case-insensitive) but was 'invalid'");
+            "Invalid value for option '--nat-method': expected one of [UPNP, MANUAL, DOCKER, KUBERNETES, AUTO, NONE] (case-insensitive) but was 'invalid'");
   }
 
   @Test

--- a/nat/src/main/java/org/hyperledger/besu/nat/NatMethod.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatMethod.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.nat;
 
 public enum NatMethod {
   UPNP,
+  MANUAL,
   DOCKER,
   KUBERNETES,
   AUTO,

--- a/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/manual/ManualNatManager.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.nat.manual;
+
+import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.nat.core.AbstractNatManager;
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * This class describes the behaviour of the Manual NAT manager. Manual Nat manager add the ability
+ * to explicitly configure the external IP and Ports to broadcast without regards to NAT or other
+ * considerations.
+ */
+public class ManualNatManager extends AbstractNatManager {
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final String advertisedHost;
+  private final int p2pPort;
+  private final int rpcHttpPort;
+  private final List<NatPortMapping> forwardedPorts;
+
+  public ManualNatManager(final String advertisedHost, final int p2pPort, final int rpcHttpPort) {
+    super(NatMethod.MANUAL);
+    this.advertisedHost = advertisedHost;
+    this.p2pPort = p2pPort;
+    this.rpcHttpPort = rpcHttpPort;
+    this.forwardedPorts = buildForwardedPorts();
+  }
+
+  private List<NatPortMapping> buildForwardedPorts() {
+    try {
+      final String internalHost = queryLocalIPAddress().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      return Arrays.asList(
+          new NatPortMapping(
+              NatServiceType.DISCOVERY,
+              NetworkProtocol.UDP,
+              internalHost,
+              advertisedHost,
+              p2pPort,
+              p2pPort),
+          new NatPortMapping(
+              NatServiceType.RLPX,
+              NetworkProtocol.TCP,
+              internalHost,
+              advertisedHost,
+              p2pPort,
+              p2pPort),
+          new NatPortMapping(
+              NatServiceType.JSON_RPC,
+              NetworkProtocol.TCP,
+              internalHost,
+              advertisedHost,
+              rpcHttpPort,
+              rpcHttpPort));
+    } catch (Exception e) {
+      LOG.warn("Failed to create forwarded port list", e);
+    }
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void doStart() {
+    LOG.info("Starting Manual NatManager");
+  }
+
+  @Override
+  protected void doStop() {
+    LOG.info("Stopping Manual NatManager");
+  }
+
+  @Override
+  protected CompletableFuture<String> retrieveExternalIPAddress() {
+    return CompletableFuture.completedFuture(advertisedHost);
+  }
+
+  @Override
+  public CompletableFuture<List<NatPortMapping>> getPortMappings() {
+    return CompletableFuture.completedFuture(forwardedPorts);
+  }
+}

--- a/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/manual/ManualNatManagerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.nat.manual;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.nat.core.domain.NatPortMapping;
+import org.hyperledger.besu.nat.core.domain.NatServiceType;
+import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+import org.hyperledger.besu.nat.core.exception.NatInitializationException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ManualNatManagerTest {
+
+  private final String advertisedHost = "99.45.69.12";
+  private final int p2pPort = 1;
+  private final int rpcHttpPort = 2;
+
+  private ManualNatManager natManager;
+
+  @Before
+  public void initialize() throws NatInitializationException {
+    natManager = new ManualNatManager(advertisedHost, p2pPort, rpcHttpPort);
+    natManager.start();
+  }
+
+  @Test
+  public void assertThatExternalIPIsEqualToRemoteHost()
+      throws ExecutionException, InterruptedException {
+    assertThat(natManager.queryExternalIPAddress().get()).isEqualTo(advertisedHost);
+  }
+
+  @Test
+  public void assertThatLocalIPIsEqualToLocalHost()
+      throws ExecutionException, InterruptedException, UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+    assertThat(natManager.queryLocalIPAddress().get()).isEqualTo(internalHost);
+  }
+
+  @Test
+  public void assertThatMappingForDiscoveryWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.DISCOVERY, NetworkProtocol.UDP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.DISCOVERY,
+            NetworkProtocol.UDP,
+            internalHost,
+            advertisedHost,
+            p2pPort,
+            p2pPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+
+  @Test
+  public void assertThatMappingForJsonRpcWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.JSON_RPC, NetworkProtocol.TCP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.JSON_RPC,
+            NetworkProtocol.TCP,
+            internalHost,
+            advertisedHost,
+            rpcHttpPort,
+            rpcHttpPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+
+  @Test
+  public void assertThatMappingForRlpxWorks() throws UnknownHostException {
+    final String internalHost = InetAddress.getLocalHost().getHostAddress();
+
+    final NatPortMapping mapping =
+        natManager.getPortMapping(NatServiceType.RLPX, NetworkProtocol.TCP);
+
+    final NatPortMapping expectedMapping =
+        new NatPortMapping(
+            NatServiceType.RLPX,
+            NetworkProtocol.TCP,
+            internalHost,
+            advertisedHost,
+            p2pPort,
+            p2pPort);
+
+    assertThat(mapping).isEqualToComparingFieldByField(expectedMapping);
+  }
+}


### PR DESCRIPTION
This reverts commit 013280b843c86ba04715e4315713fdcc10443625.

Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

We must wait for a quarterly version before changing the CLI options

