### PR TITLE
Implement price bump mechanism for transaction pool replacement.

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -21,6 +21,7 @@ public class TransactionPoolConfiguration {
   public static final int MAX_PENDING_TRANSACTIONS = 4096;
   public static final int MAX_PENDING_TRANSACTIONS_HASHES = 4096;
   public static final int DEFAULT_TX_RETENTION_HOURS = 13;
+  public static final int DEFAULT_PRICE_BUMP = 10;
 
   private final int txPoolMaxSize;
   private final int pooledTransactionHashesSize;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolReplacementHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolReplacementHandler.java
@@ -19,6 +19,7 @@ import static java.util.Arrays.asList;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions.TransactionInfo;
+import org.hyperledger.besu.util.number.Percentage;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +31,11 @@ public class TransactionPoolReplacementHandler {
   private final Optional<EIP1559> eip1559;
 
   public TransactionPoolReplacementHandler(final Optional<EIP1559> eip1559) {
-    this(asList(new TransactionReplacementByPriceRule()), eip1559);
+    this(
+        asList(
+            new TransactionReplacementByPriceRule(
+                Percentage.fromInt(TransactionPoolConfiguration.DEFAULT_PRICE_BUMP))),
+        eip1559);
   }
 
   @VisibleForTesting

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionsTest.java
@@ -384,7 +384,8 @@ public class PendingTransactionsTest {
     final List<Transaction> replacedTransactions = new ArrayList<>();
     int remoteDuplicateCount = 0;
     for (int i = 0; i < replacedTxCount; i++) {
-      final Transaction duplicateTx = transactionWithNonceSenderAndGasPrice(1, KEYS1, i + 1);
+      final Transaction duplicateTx =
+          transactionWithNonceSenderAndGasPrice(1, KEYS1, (i * 110 / 100) + 1);
       replacedTransactions.add(duplicateTx);
       if (i % 2 == 0) {
         transactions.addRemoteTransaction(duplicateTx);


### PR DESCRIPTION
## PR description
We should implement a new transaction replacement mechanism, similar to other client implementations.
Currently a new transaction (same user and same nonce) replaces an old one if the new gas price is higher than the old one. Other client implementations require the delta to be higher than a minimum percentage.
For instance this option is called `pricebump` in Geth implementation, configurable using `--txpool.pricebump` . This command line option is described as Price bump percentage to replace an already existing transaction and is defaulted to `10%`.
The current PR introduces the price bump without making this option configurable. A follow up PR will then come after to expose this parameter to the `CLI` interface.

## Fixed Issue(s)

- #559 
- #906 

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>