### PR TITLE
Fix NullPointerException in FlatTraceGenerator.

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
@@ -350,9 +350,7 @@ public class FlatTraceGenerator {
 
     final Action.Builder callingAction = tracesContexts.peekLast().getBuilder().getActionBuilder();
     final String actionAddress =
-        callingAction.getCallType().equals("call")
-            ? callingAction.getTo()
-            : callingAction.getFrom();
+        getActionAddress(callingAction, traceFrame.getRecipient().toHexString());
     final Action.Builder subTraceActionBuilder =
         Action.builder()
             .address(actionAddress)
@@ -368,6 +366,25 @@ public class FlatTraceGenerator {
       nextContext.getBuilder().incSubTraces();
     }
     return nextContext;
+  }
+
+  private static String getActionAddress(
+      final Action.Builder callingAction, final String recipient) {
+    if (callingAction.getCallType() != null) {
+      return callingAction.getCallType().equals("call")
+          ? callingAction.getTo()
+          : callingAction.getFrom();
+    }
+    return firstNonNull("", recipient, callingAction.getFrom(), callingAction.getTo());
+  }
+
+  private static String firstNonNull(final String defaultValue, final String... values) {
+    for (String value : values) {
+      if (value != null) {
+        return value;
+      }
+    }
+    return defaultValue;
   }
 
   private static FlatTrace.Context handleCreateOperation(

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/chain-data/blocks.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/chain-data/blocks.json
@@ -487,6 +487,18 @@
           "data": "0x0000000000000000000000000150000000000000"
         }
       ]
+    },
+    {
+      "number": "0x1C",
+      "transactions": [
+        {
+          "comment": "Self destruct called in constructor with balance being returned to sender (from field)",
+          "secretKey": "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
+          "gasLimit": "0xFFFFF2",
+          "gasPrice": "0xEF",
+          "data": "0x60806040523373ffffffffffffffffffffffffffffffffffffffff16fffe"
+        }
+      ]
     }
   ]
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-block/trace_block_0x1C.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-block/trace_block_0x1C.json
@@ -1,0 +1,70 @@
+{
+  "request": {
+    "jsonrpc": "2.0",
+    "method": "trace_block",
+    "params": [
+      "0x1C"
+    ],
+    "id": 415
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "result": [
+      {
+        "action": {
+          "creationMethod": "create",
+          "from": "0x627306090abab3a6e1400e9345bc60c78a8bef57",
+          "gas": "0xff2f0a",
+          "init": "0x60806040523373ffffffffffffffffffffffffffffffffffffffff16fffe",
+          "value": "0x0"
+        },
+        "blockHash": "0x778a7c519692256e0bacae682e396a882810575822e2850c90ccfb4002bec95e",
+        "blockNumber": 28,
+        "result": {
+          "address": "0xa4392264a2d8c998901d10c154c91725b1bf0158",
+          "code": "0x",
+          "gasUsed": "0x13a2"
+        },
+        "subtraces": 1,
+        "traceAddress": [],
+        "transactionHash": "0xbe1b55619f540ea8a7d7e9330ea642a195afe0d6d60ced6f463da67b46d3f503",
+        "transactionPosition": 0,
+        "type": "create"
+      },
+      {
+        "action": {
+          "address": "0xa4392264a2d8c998901d10c154c91725b1bf0158",
+          "balance": "0x0",
+          "refundAddress": "0x627306090abab3a6e1400e9345bc60c78a8bef57"
+        },
+        "blockHash": "0x778a7c519692256e0bacae682e396a882810575822e2850c90ccfb4002bec95e",
+        "blockNumber": 28,
+        "result": null,
+        "subtraces": 0,
+        "traceAddress": [
+          0
+        ],
+        "transactionHash": "0xbe1b55619f540ea8a7d7e9330ea642a195afe0d6d60ced6f463da67b46d3f503",
+        "transactionPosition": 0,
+        "type": "suicide"
+      },
+      {
+        "action": {
+          "author": "0x0000000000000000000000000000000000000000",
+          "rewardType": "block",
+          "value": "0x1bc16d674ec80000"
+        },
+        "blockHash": "0x778a7c519692256e0bacae682e396a882810575822e2850c90ccfb4002bec95e",
+        "blockNumber": 28,
+        "result": null,
+        "subtraces": 0,
+        "traceAddress": [],
+        "transactionHash": null,
+        "transactionPosition": null,
+        "type": "reward"
+      }
+    ],
+    "id": 415
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
## PR description
Calling `trace_block` or `trace_transaction` rpc method fails with a `NullPointerException` when a transaction consists of a contract creation in which the contract self destructs within its own constructor.  
This PR fixes this bug.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #911 

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>