### PR TITLE
Fix IndexOutOfBoundsException in DebugOperationTracer

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -108,7 +108,9 @@ public class DebugOperationTracer implements OperationTracer {
   @Override
   public void tracePrecompileCall(
       final MessageFrame frame, final Gas gasRequirement, final Bytes output) {
-    traceFrames.get(traceFrames.size() - 1).setPrecompiledGasCost(Optional.of(gasRequirement));
+    if (!traceFrames.isEmpty()) {
+      traceFrames.get(traceFrames.size() - 1).setPrecompiledGasCost(Optional.of(gasRequirement));
+    }
   }
 
   @Override


### PR DESCRIPTION
## PR description
Calling trace_block for block [#4063089](https://ropsten.etherscan.io/block/4063089) in Ropsten causes the DebugOperationTracer to throw an IndexOutOfBoundsException.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #915 
Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>