### PR TITLE
update javadoc headers for jdk13

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -66,7 +66,7 @@ import org.apache.tuweni.bytes.Bytes;
  * <p>When necessary, it updates the underlying {@link PeerTable}, particularly with additions which
  * may succeed or not depending on the contents of the target bucket for the peer.
  *
- * <h3>Peer state machine</h3>
+ * <h2>Peer state machine</h2>
  *
  * <pre>{@code
  *                                                                +--------------------+

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTable.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTable.java
@@ -94,7 +94,7 @@ public class PeerTable {
    * Attempts to add the provided peer to the peer table, and returns an {@link AddResult}
    * signalling one of three outcomes.
    *
-   * <h3>Possible outcomes:</h3>
+   * <h4>Possible outcomes:</h4>
    *
    * <ul>
    *   <li>the operation succeeded and the peer was added to the corresponding k-bucket.

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV1.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV1.java
@@ -30,7 +30,7 @@ import org.apache.tuweni.bytes.MutableBytes;
  * <p>This message must be sent by the party that initiates the RLPX connection, as the first
  * message in the handshake protocol.
  *
- * <h3>Message structure</h3>
+ * <h2>Message structure</h2>
  *
  * The following describes the message structure:
  *

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ResponderHandshakeMessageV1.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ResponderHandshakeMessageV1.java
@@ -28,7 +28,7 @@ import org.apache.tuweni.bytes.MutableBytes;
  * <p>This message must be sent by the party who responded to the RLPX connection, in response to
  * the initiator message.
  *
- * <h3>Message structure</h3>
+ * <h2>Message structure</h2>
  *
  * The following describes the message structure:
  *


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
When I updated my system jdk to jdk13, `./gradlew javadoc` started failing because this header sequencing is now enforced.
