### PR TITLE
Enforce devp2p packet expiration

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
@@ -39,8 +39,11 @@ public class FindNeighborsPacketData implements PacketData {
   }
 
   public static FindNeighborsPacketData create(final Bytes target) {
-    return new FindNeighborsPacketData(
-        target, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+    return create(target, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+  }
+
+  static FindNeighborsPacketData create(final Bytes target, final long expirationMs) {
+    return new FindNeighborsPacketData(target, expirationMs);
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -533,12 +533,18 @@ public class PeerDiscoveryController {
 
   private void respondToPing(
       final PingPacketData packetData, final Bytes pingHash, final DiscoveryPeer sender) {
+    if (packetData.getExpiration() < System.currentTimeMillis()) {
+      return;
+    }
     final PongPacketData data = PongPacketData.create(packetData.getFrom(), pingHash);
     sendPacket(sender, PacketType.PONG, data);
   }
 
   private void respondToFindNeighbors(
       final FindNeighborsPacketData packetData, final DiscoveryPeer sender) {
+    if (packetData.getExpiration() < System.currentTimeMillis()) {
+      return;
+    }
     // TODO: for now return 16 peers. Other implementations calculate how many
     // peers they can fit in a 1280-byte payload.
     final List<DiscoveryPeer> peers = peerTable.nearestPeers(packetData.getTarget(), 16);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -45,8 +45,12 @@ public class PingPacketData implements PacketData {
   }
 
   public static PingPacketData create(final Endpoint from, final Endpoint to) {
-    return new PingPacketData(
-        from, to, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+    return create(from, to, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+  }
+
+  static PingPacketData create(
+      final Endpoint from, final Endpoint to, final long expirationMs) {
+    return new PingPacketData(from, to, expirationMs);
   }
 
   public static PingPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -48,8 +48,7 @@ public class PingPacketData implements PacketData {
     return create(from, to, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
   }
 
-  static PingPacketData create(
-      final Endpoint from, final Endpoint to, final long expirationMs) {
+  static PingPacketData create(final Endpoint from, final Endpoint to, final long expirationMs) {
     return new PingPacketData(from, to, expirationMs);
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
@@ -29,8 +29,7 @@ import org.apache.tuweni.bytes.Bytes32;
 
 class MockPacketDataFactory {
 
-  static Packet mockNeighborsPacket(
-      final DiscoveryPeer from, final DiscoveryPeer... neighbors) {
+  static Packet mockNeighborsPacket(final DiscoveryPeer from, final DiscoveryPeer... neighbors) {
     final Packet packet = mock(Packet.class);
 
     final NeighborsPacketData packetData = NeighborsPacketData.create(Arrays.asList(neighbors));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
@@ -27,9 +27,9 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
-public class MockPacketDataFactory {
+class MockPacketDataFactory {
 
-  public static Packet mockNeighborsPacket(
+  static Packet mockNeighborsPacket(
       final DiscoveryPeer from, final DiscoveryPeer... neighbors) {
     final Packet packet = mock(Packet.class);
 
@@ -44,7 +44,7 @@ public class MockPacketDataFactory {
     return packet;
   }
 
-  public static Packet mockPongPacket(final DiscoveryPeer from, final Bytes pingHash) {
+  static Packet mockPongPacket(final DiscoveryPeer from, final Bytes pingHash) {
     final Packet packet = mock(Packet.class);
 
     final PongPacketData pongPacketData = PongPacketData.create(from.getEndpoint(), pingHash);
@@ -57,13 +57,18 @@ public class MockPacketDataFactory {
     return packet;
   }
 
-  public static Packet mockFindNeighborsPacket(final Peer from) {
+  static Packet mockFindNeighborsPacket(final Peer from) {
+    return mockFindNeighborsPacket(
+        from, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+  }
+
+  static Packet mockFindNeighborsPacket(final Peer from, final long exparationMs) {
     final Packet packet = mock(Packet.class);
     final Bytes target =
         Bytes.fromHexString(
             "0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40");
 
-    final FindNeighborsPacketData packetData = FindNeighborsPacketData.create(target);
+    final FindNeighborsPacketData packetData = FindNeighborsPacketData.create(target, exparationMs);
     when(packet.getPacketData(any())).thenReturn(Optional.of(packetData));
     final Bytes id = from.getId();
     when(packet.getNodeId()).thenReturn(id);


### PR DESCRIPTION
Don't respond to neighbors and ping packets that have an expiration
prior to the system's current time.

Addresses two tests in #975

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

