### PR TITLE
[EIP-2124] Backward compatible fork id management implementation

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManagerTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.eth.manager;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -394,5 +395,11 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(consortiumNetworkGenHash, 0), emptyList());
     assertThat(forkIdManager.peerCheck((ForkIdManager.ForkId) null)).isTrue();
+  }
+
+  @Test
+  public void assertThatConstructorParametersMustNotBeNull() {
+    assertThatThrownBy(() -> new ForkIdManager(mockBlockchain(consortiumNetworkGenHash, 0), null))
+        .isExactlyInstanceOf(AssertionError.class);
   }
 }


### PR DESCRIPTION
## PR description
While implementing EIP-1559, we realized our EIP-2124 implementation differs from geth in how we handle forks on block #0.

In short, if we set fork block numbers to 0 to activate fork rules directly for a private network Besu nodes don't include those forks to compute the fork ID, Geth includes them. That results in an error and Besu nodes cannot connect to Geth nodes.

If we change to comply with geth, all previous Besu versions using the non-geth way will not interoperate with future Besu versions.

This PR introduces a more permissive check for private networks and aims to be backward compatible with previous versions.

## Fixed Issue(s)

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>