### PR TITLE
Handle backward compatibility for EIP-2124 fork id management

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManager.java
@@ -88,7 +88,7 @@ public class ForkIdManager {
   }
 
   private static long highestKnownFork(final List<Long> forks) {
-    return forks.size() > 0 ? forks.get(forks.size() - 1) : 0L;
+    return !forks.isEmpty() ? forks.get(forks.size() - 1) : 0L;
   }
 
   public List<ForkId> getForkAndHashList() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManager.java
@@ -23,7 +23,9 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.CRC32;
 
@@ -32,36 +34,69 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public class ForkIdManager {
 
-  private final Blockchain blockchain;
   private final Hash genesisHash;
-  private final List<Long> forks;
-  private long forkNext;
-  private final long highestKnownFork;
-  private List<ForkId> forkAndHashList;
+
+  private final List<ForkId> legacyForkAndHashList;
+  private final List<ForkId> forkAndHashList;
+
   private final List<ForkIDChecker> forkIDCheckers;
 
   public ForkIdManager(final Blockchain blockchain, final List<Long> forks) {
     assert blockchain != null && forks != null;
-    this.blockchain = blockchain;
     this.genesisHash = blockchain.getGenesisBlock().getHash();
+    this.legacyForkAndHashList = new ArrayList<>();
+    this.forkAndHashList = new ArrayList<>();
     // if the fork list contains only zeros then we may be in a consortium/dev network
     if (onlyZerosForkBlocks(forks)) {
       this.forkIDCheckers = singletonList(forkId -> true);
     } else {
-      this.forkIDCheckers = singletonList(this::eip2124Checker);
+      final ForkIDChecker legacyForkIdChecker =
+          createForkIDChecker(
+              blockchain,
+              genesisHash,
+              forks,
+              fs ->
+                  fs.stream()
+                      .filter(fork -> fork > 0)
+                      .distinct()
+                      .collect(Collectors.toUnmodifiableList()),
+              legacyForkAndHashList);
+      final ForkIDChecker newForkIdChecker =
+          createForkIDChecker(
+              blockchain,
+              genesisHash,
+              forks,
+              fs -> fs.stream().distinct().collect(Collectors.toUnmodifiableList()),
+              forkAndHashList);
+      this.forkIDCheckers = Arrays.asList(newForkIdChecker, legacyForkIdChecker);
     }
-    // de-dupe and sanitize forks
-    this.forks = forks.stream().distinct().collect(Collectors.toUnmodifiableList());
-    highestKnownFork = forks.size() > 0 ? forks.get(forks.size() - 1) : 0L;
-    createForkIds();
   }
 
-  private boolean onlyZerosForkBlocks(final List<Long> forks) {
+  private static ForkIDChecker createForkIDChecker(
+      final Blockchain blockchain,
+      final Hash genesisHash,
+      final List<Long> forks,
+      final Function<List<Long>, List<Long>> sanitizer,
+      final List<ForkId> forkIds) {
+    final List<Long> sanitizedForks = sanitizer.apply(forks);
+    final long forkNext = createForkIds(genesisHash, sanitizedForks, forkIds);
+    return eip2124(blockchain, forkNext, forkIds, highestKnownFork(sanitizedForks));
+  }
+
+  private static boolean onlyZerosForkBlocks(final List<Long> forks) {
     return forks.stream().allMatch(value -> 0L == value);
+  }
+
+  private static long highestKnownFork(final List<Long> forks) {
+    return forks.size() > 0 ? forks.get(forks.size() - 1) : 0L;
   }
 
   public List<ForkId> getForkAndHashList() {
     return this.forkAndHashList;
+  }
+
+  public List<ForkId> getLegacyForkAndHashList() {
+    return legacyForkAndHashList;
   }
 
   ForkId getLatestForkId() {
@@ -89,41 +124,47 @@ public class ForkIdManager {
     return forkIDCheckers.stream().anyMatch(checker -> checker.check(forkId));
   }
 
-  private boolean eip2124Checker(final ForkId forkId) {
-    if (forkId == null) {
-      return true; // Another method must be used to validate (i.e. genesis hash)
-    }
-    // Run the fork checksum validation rule set:
-    //   1. If local and remote FORK_CSUM matches, connect.
-    //        The two nodes are in the same fork state currently. They might know
-    //        of differing future forks, but that's not relevant until the fork
-    //        triggers (might be postponed, nodes might be updated to match).
-    //   2. If the remote FORK_CSUM is a subset of the local past forks and the
-    //      remote FORK_NEXT matches with the locally following fork block number,
-    //      connect.
-    //        Remote node is currently syncing. It might eventually diverge from
-    //        us, but at this current point in time we don't have enough information.
-    //   3. If the remote FORK_CSUM is a superset of the local past forks and can
-    //      be completed with locally known future forks, connect.
-    //        Local node is currently syncing. It might eventually diverge from
-    //        the remote, but at this current point in time we don't have enough
-    //        information.
-    //   4. Reject in all other cases.
-    if (isHashKnown(forkId.getHash())) {
-      if (blockchain.getChainHeadBlockNumber() < forkNext) {
-        return true;
-      } else {
-        if (isForkKnown(forkId.getNext())) {
-          return isRemoteAwareOfPresent(forkId.getHash(), forkId.getNext());
-        } else {
-          return false;
-        }
+  private static ForkIDChecker eip2124(
+      final Blockchain blockchain,
+      final long forkNext,
+      final List<ForkId> forkAndHashList,
+      final long highestKnownFork) {
+    return forkId -> {
+      if (forkId == null) {
+        return true; // Another method must be used to validate (i.e. genesis hash)
       }
-    } else {
-      return false;
-    }
+      // Run the fork checksum validation rule set:
+      //   1. If local and remote FORK_CSUM matches, connect.
+      //        The two nodes are in the same fork state currently. They might know
+      //        of differing future forks, but that's not relevant until the fork
+      //        triggers (might be postponed, nodes might be updated to match).
+      //   2. If the remote FORK_CSUM is a subset of the local past forks and the
+      //      remote FORK_NEXT matches with the locally following fork block number,
+      //      connect.
+      //        Remote node is currently syncing. It might eventually diverge from
+      //        us, but at this current point in time we don't have enough information.
+      //   3. If the remote FORK_CSUM is a superset of the local past forks and can
+      //      be completed with locally known future forks, connect.
+      //        Local node is currently syncing. It might eventually diverge from
+      //        the remote, but at this current point in time we don't have enough
+      //        information.
+      //   4. Reject in all other cases.
+      if (isHashKnown(forkId.getHash(), forkAndHashList)) {
+        if (blockchain.getChainHeadBlockNumber() < forkNext) {
+          return true;
+        } else {
+          if (isForkKnown(forkId.getNext(), highestKnownFork, forkAndHashList)) {
+            return isRemoteAwareOfPresent(
+                forkId.getHash(), forkId.getNext(), highestKnownFork, forkAndHashList);
+          } else {
+            return false;
+          }
+        }
+      } else {
+        return false;
+      }
+    };
   }
-
   /**
    * Non EIP-2124 behaviour
    *
@@ -134,16 +175,21 @@ public class ForkIdManager {
     return !peerGenesisHash.equals(genesisHash);
   }
 
-  private boolean isHashKnown(final Bytes forkHash) {
+  private static boolean isHashKnown(final Bytes forkHash, final List<ForkId> forkAndHashList) {
     return forkAndHashList.stream().map(ForkId::getHash).anyMatch(hash -> hash.equals(forkHash));
   }
 
-  private boolean isForkKnown(final Long nextFork) {
+  private static boolean isForkKnown(
+      final Long nextFork, final long highestKnownFork, final List<ForkId> forkAndHashList) {
     return highestKnownFork < nextFork
         || forkAndHashList.stream().map(ForkId::getNext).anyMatch(fork -> fork.equals(nextFork));
   }
 
-  private boolean isRemoteAwareOfPresent(final Bytes forkHash, final Long nextFork) {
+  private static boolean isRemoteAwareOfPresent(
+      final Bytes forkHash,
+      final Long nextFork,
+      final long highestKnownFork,
+      final List<ForkId> forkAndHashList) {
     for (final ForkId j : forkAndHashList) {
       if (forkHash.equals(j.getHash())) {
         if (nextFork.equals(j.getNext())) {
@@ -158,7 +204,8 @@ public class ForkIdManager {
     return false;
   }
 
-  private void createForkIds() {
+  private static long createForkIds(
+      final Hash genesisHash, final List<Long> forks, final List<ForkId> forkIds) {
     final CRC32 crc = new CRC32();
     crc.update(genesisHash.toArray());
     final List<Bytes> forkHashes = new ArrayList<>(List.of(getCurrentCrcHash(crc)));
@@ -166,24 +213,24 @@ public class ForkIdManager {
       updateCrc(crc, fork);
       forkHashes.add(getCurrentCrcHash(crc));
     }
-    final List<ForkId> forkIds = new ArrayList<>();
     // This loop is for all the fork hashes that have an associated "next fork"
     for (int i = 0; i < forks.size(); i++) {
       forkIds.add(new ForkId(forkHashes.get(i), forks.get(i)));
     }
+    long forkNext = 0;
     if (!forks.isEmpty()) {
       forkNext = forkIds.get(forkIds.size() - 1).getNext();
       forkIds.add(new ForkId(forkHashes.get(forkHashes.size() - 1), 0));
     }
-    this.forkAndHashList = forkIds;
+    return forkNext;
   }
 
-  private void updateCrc(final CRC32 crc, final Long block) {
+  private static void updateCrc(final CRC32 crc, final Long block) {
     final byte[] byteRepresentationFork = longToBigEndian(block);
     crc.update(byteRepresentationFork, 0, byteRepresentationFork.length);
   }
 
-  private Bytes getCurrentCrcHash(final CRC32 crc) {
+  private static Bytes getCurrentCrcHash(final CRC32 crc) {
     return Bytes.ofUnsignedInt(crc.getValue());
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ForkIdManagerTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.eth.manager.ForkIdManager.ForkId;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
@@ -60,21 +61,18 @@ public class ForkIdManagerTest {
 
   @Test
   public void checkCorrectMainnetForkIdHashesGenerated() {
-    final ForkIdManager.ForkId[] checkIds = {
-      new ForkIdManager.ForkId(Bytes.fromHexString("0xfc64ec04"), 1150000L), // Unsynced
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0x97c2c34c"), 1920000L), // First Homestead block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x91d1f948"), 2463000L), // First DAO block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0x7a64da13"), 2675000L), // First Tangerine block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x3edd5b10"), 4370000L), // First Spurious block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0xa00bc324"), 7280000L), // First Byzantium block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x668db0af"), 0L) // Today Petersburg block
+    final ForkId[] checkIds = {
+      new ForkId(Bytes.fromHexString("0xfc64ec04"), 1150000L), // Unsynced
+      new ForkId(Bytes.fromHexString("0x97c2c34c"), 1920000L), // First Homestead block
+      new ForkId(Bytes.fromHexString("0x91d1f948"), 2463000L), // First DAO block
+      new ForkId(Bytes.fromHexString("0x7a64da13"), 2675000L), // First Tangerine block
+      new ForkId(Bytes.fromHexString("0x3edd5b10"), 4370000L), // First Spurious block
+      new ForkId(Bytes.fromHexString("0xa00bc324"), 7280000L), // First Byzantium block
+      new ForkId(Bytes.fromHexString("0x668db0af"), 0L) // Today Petersburg block
     };
     final List<Long> list = Arrays.asList(forksMainnet);
     final ForkIdManager forkIdManager = new ForkIdManager(mockBlockchain(mainnetGenHash, 0), list);
-    final List<ForkIdManager.ForkId> entries = forkIdManager.getForkAndHashList();
+    final List<ForkId> entries = forkIdManager.getForkAndHashList();
     assertThat(entries).containsExactly(checkIds);
     assertThat(forkIdManager.getLatestForkId()).isNotNull();
     assertThat(forkIdManager.getLatestForkId()).isEqualTo(checkIds[6]);
@@ -84,20 +82,18 @@ public class ForkIdManagerTest {
   public void checkCorrectRopstenForkIdHashesGenerated() {
     final Long[] forks = {10L, 1700000L, 4230000L, 4939394L};
     final String genHash = "0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d";
-    final ForkIdManager.ForkId[] checkIds = {
-      new ForkIdManager.ForkId(
+    final ForkId[] checkIds = {
+      new ForkId(
           Bytes.fromHexString("0x30c7ddbc"),
           10L), // Unsynced, last Frontier, Homestead and first Tangerine block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x63760190"), 1700000L), // First Spurious block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0x3ea159c7"), 4230000L), // First Byzantium block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0x97b544f3"), 4939394L), // First Constantinople block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0xd6e2149b"), 0L) // Today Petersburg block
+      new ForkId(Bytes.fromHexString("0x63760190"), 1700000L), // First Spurious block
+      new ForkId(Bytes.fromHexString("0x3ea159c7"), 4230000L), // First Byzantium block
+      new ForkId(Bytes.fromHexString("0x97b544f3"), 4939394L), // First Constantinople block
+      new ForkId(Bytes.fromHexString("0xd6e2149b"), 0L) // Today Petersburg block
     };
     final List<Long> list = Arrays.asList(forks);
     final ForkIdManager forkIdManager = new ForkIdManager(mockBlockchain(genHash, 0), list);
-    final List<ForkIdManager.ForkId> entries = forkIdManager.getForkAndHashList();
+    final List<ForkId> entries = forkIdManager.getForkAndHashList();
 
     assertThat(entries).containsExactly(checkIds);
     assertThat(forkIdManager.getLatestForkId()).isNotNull();
@@ -108,23 +104,20 @@ public class ForkIdManagerTest {
   public void checkCorrectRinkebyForkIdHashesGenerated() {
     final Long[] forks = {1L, 2L, 3L, 1035301L, 3660663L, 4321234L};
     final String genHash = "0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177";
-    final ForkIdManager.ForkId[] checkIds = {
-      new ForkIdManager.ForkId(
+    final ForkId[] checkIds = {
+      new ForkId(
           Bytes.fromHexString("0x3b8e0691"),
           1L), // Unsynced, last Frontier, Homestead and first Tangerine block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x60949295"), 2L), // Last Tangerine block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0x8bde40dd"), 3L), // First Spurious block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0xcb3a64bb"), 1035301L), // First Byzantium block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0x8d748b57"), 3660663L), // First Constantinople block
-      new ForkIdManager.ForkId(
-          Bytes.fromHexString("0xe49cab14"), 4321234L), // First Petersburg block
-      new ForkIdManager.ForkId(Bytes.fromHexString("0xafec6b27"), 0L) // Today Petersburg block
+      new ForkId(Bytes.fromHexString("0x60949295"), 2L), // Last Tangerine block
+      new ForkId(Bytes.fromHexString("0x8bde40dd"), 3L), // First Spurious block
+      new ForkId(Bytes.fromHexString("0xcb3a64bb"), 1035301L), // First Byzantium block
+      new ForkId(Bytes.fromHexString("0x8d748b57"), 3660663L), // First Constantinople block
+      new ForkId(Bytes.fromHexString("0xe49cab14"), 4321234L), // First Petersburg block
+      new ForkId(Bytes.fromHexString("0xafec6b27"), 0L) // Today Petersburg block
     };
     final List<Long> list = Arrays.asList(forks);
     final ForkIdManager forkIdManager = new ForkIdManager(mockBlockchain(genHash, 0), list);
-    final List<ForkIdManager.ForkId> entries = forkIdManager.getForkAndHashList();
+    final List<ForkId> entries = forkIdManager.getForkAndHashList();
 
     assertThat(entries).containsExactly(checkIds);
     assertThat(forkIdManager.getLatestForkId()).isNotNull();
@@ -135,13 +128,13 @@ public class ForkIdManagerTest {
   public void checkCorrectGoerliForkIdHashesGenerated() {
     final Long[] forks = {1561651L};
     final String genHash = "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a";
-    final ForkIdManager.ForkId[] checkIds = {
-      new ForkIdManager.ForkId(Bytes.fromHexString("0xa3f5ab08"), 1561651L), // Frontier->Petersburg
-      new ForkIdManager.ForkId(Bytes.fromHexString("0xc25efa5c"), 0L) // Istanbul
+    final ForkId[] checkIds = {
+      new ForkId(Bytes.fromHexString("0xa3f5ab08"), 1561651L), // Frontier->Petersburg
+      new ForkId(Bytes.fromHexString("0xc25efa5c"), 0L) // Istanbul
     };
     final List<Long> list = Arrays.asList(forks);
     final ForkIdManager forkIdManager = new ForkIdManager(mockBlockchain(genHash, 0), list);
-    final List<ForkIdManager.ForkId> entries = forkIdManager.getForkAndHashList();
+    final List<ForkId> entries = forkIdManager.getForkAndHashList();
 
     assertThat(entries).containsExactly(checkIds);
     assertThat(forkIdManager.getLatestForkId()).isNotNull();
@@ -156,7 +149,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0x668db0af"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x668db0af"), 0L));
     assertThat(result).isTrue();
     assertThat(forkIdManager.getLatestForkId()).isNotNull();
   }
@@ -170,8 +163,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(
-            new ForkIdManager.ForkId(Bytes.fromHexString("0x668db0af"), Long.MAX_VALUE));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x668db0af"), Long.MAX_VALUE));
     assertThat(result).isTrue();
   }
 
@@ -186,7 +178,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7279999L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
     assertThat(result).isTrue();
   }
 
@@ -200,8 +192,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(
-            new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), 7280000L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xa00bc324"), 7280000L));
     assertThat(result).isTrue();
   }
 
@@ -216,8 +207,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7279999), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(
-            new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), Long.MAX_VALUE));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xa00bc324"), Long.MAX_VALUE));
     assertThat(result).isTrue();
   }
 
@@ -230,8 +220,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(
-            new ForkIdManager.ForkId(Bytes.fromHexString("0x668db0af"), 7280000L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x668db0af"), 7280000L));
     assertThat(result).isTrue();
   }
 
@@ -245,8 +234,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(
-            new ForkIdManager.ForkId(Bytes.fromHexString("0x3edd5b10"), 4370000L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x3edd5b10"), 4370000L));
     assertThat(result).isTrue();
   }
 
@@ -258,7 +246,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 727999L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0x668db0af"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x668db0af"), 0L));
     assertThat(result).isTrue();
   }
 
@@ -271,7 +259,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 4369999L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
     assertThat(result).isTrue();
   }
 
@@ -284,7 +272,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xa00bc324"), 0L));
     assertThat(result).isFalse();
   }
 
@@ -297,7 +285,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0x5cddc0e1"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x5cddc0e1"), 0L));
     assertThat(result).isFalse();
   }
 
@@ -310,7 +298,7 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7279999L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0x5cddc0e1"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0x5cddc0e1"), 0L));
     assertThat(result).isFalse();
   }
 
@@ -322,54 +310,50 @@ public class ForkIdManagerTest {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(mainnetGenHash, 7987396L), forkList);
     final Boolean result =
-        forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.fromHexString("0xafec6b27"), 0L));
+        forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xafec6b27"), 0L));
     assertThat(result).isFalse();
   }
 
   @Test
   public void createAndDecodeRLP() {
-    final ForkIdManager.ForkId forkIdEntry =
-        new ForkIdManager.ForkId(Bytes.fromHexString("0xa00bc324"), 7280000L);
+    final ForkId forkIdEntry = new ForkId(Bytes.fromHexString("0xa00bc324"), 7280000L);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     forkIdEntry.writeTo(out);
     final Bytes bytesValue = out.encoded();
     final BytesValueRLPInput in = new BytesValueRLPInput(bytesValue, false);
-    final ForkIdManager.ForkId decodedEntry = ForkIdManager.readFrom(in);
+    final ForkId decodedEntry = ForkIdManager.readFrom(in);
     assertThat(forkIdEntry).isEqualTo(decodedEntry);
   }
 
   @Test
   public void check1ZeroZeroProperRLPEncoding() {
-    final ForkIdManager.ForkId forkIdEntry =
-        new ForkIdManager.ForkId(Bytes.fromHexString("0x00000000"), 0);
+    final ForkId forkIdEntry = new ForkId(Bytes.fromHexString("0x00000000"), 0);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     forkIdEntry.writeTo(out);
     final String str1 = "0xc6840000000080";
     final Bytes bytesValue = out.encoded();
     assertThat(str1).isEqualTo(bytesValue.toString());
     final BytesValueRLPInput in = new BytesValueRLPInput(bytesValue, false);
-    final ForkIdManager.ForkId decodedEntry = ForkIdManager.readFrom(in);
+    final ForkId decodedEntry = ForkIdManager.readFrom(in);
     assertThat(forkIdEntry).isEqualTo(decodedEntry);
   }
 
   @Test
   public void check2ArbitraryProperRLPEncoding() {
-    final ForkIdManager.ForkId forkIdEntry =
-        new ForkIdManager.ForkId(Bytes.fromHexString("0xdeadbeef"), 0xbaddcafeL);
+    final ForkId forkIdEntry = new ForkId(Bytes.fromHexString("0xdeadbeef"), 0xbaddcafeL);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     forkIdEntry.writeTo(out);
     final String str1 = "0xca84deadbeef84baddcafe";
     final Bytes bytesValue = out.encoded();
     assertThat(str1).isEqualTo(bytesValue.toString());
     final BytesValueRLPInput in = new BytesValueRLPInput(bytesValue, false);
-    final ForkIdManager.ForkId decodedEntry = ForkIdManager.readFrom(in);
+    final ForkId decodedEntry = ForkIdManager.readFrom(in);
     assertThat(forkIdEntry).isEqualTo(decodedEntry);
   }
 
   @Test
   public void check3MaximumsProperRLPEncoding() {
-    final ForkIdManager.ForkId forkIdEntry =
-        new ForkIdManager.ForkId(Bytes.fromHexString("0xffffffff"), 0xffffffffffffffffL);
+    final ForkId forkIdEntry = new ForkId(Bytes.fromHexString("0xffffffff"), 0xffffffffffffffffL);
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     forkIdEntry.writeTo(out);
     final String str1 =
@@ -377,7 +361,7 @@ public class ForkIdManagerTest {
     final Bytes bytesValue = out.encoded();
     assertThat(str1).isEqualTo(bytesValue.toString());
     final BytesValueRLPInput in = new BytesValueRLPInput(bytesValue, false);
-    final ForkIdManager.ForkId decodedEntry = ForkIdManager.readFrom(in);
+    final ForkId decodedEntry = ForkIdManager.readFrom(in);
     assertThat(forkIdEntry).isEqualTo(decodedEntry);
   }
 
@@ -387,19 +371,40 @@ public class ForkIdManagerTest {
 
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(consortiumNetworkGenHash, 0), list);
-    assertThat(forkIdManager.peerCheck(new ForkIdManager.ForkId(Bytes.random(32), 0))).isTrue();
+    assertThat(forkIdManager.peerCheck(new ForkId(Bytes.random(32), 0))).isTrue();
   }
 
   @Test
   public void checkAlwaysAcceptPeersIfNull() {
     final ForkIdManager forkIdManager =
         new ForkIdManager(mockBlockchain(consortiumNetworkGenHash, 0), emptyList());
-    assertThat(forkIdManager.peerCheck((ForkIdManager.ForkId) null)).isTrue();
+    assertThat(forkIdManager.peerCheck((ForkId) null)).isTrue();
   }
 
   @Test
   public void assertThatConstructorParametersMustNotBeNull() {
     assertThatThrownBy(() -> new ForkIdManager(mockBlockchain(consortiumNetworkGenHash, 0), null))
         .isExactlyInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void checkBackwardCompatibility() {
+    final List<Long> list = Arrays.asList(0L, 1L, 2L, 0L, 3L, 4L);
+    final ForkIdManager forkIdManager = new ForkIdManager(mockBlockchain(mainnetGenHash, 0), list);
+    assertThat(forkIdManager.getLegacyForkAndHashList())
+        .containsExactly(
+            new ForkId(Bytes.fromHexString("0xfc64ec04"), 1),
+            new ForkId(Bytes.fromHexString("0x4ccedd76"), 2),
+            new ForkId(Bytes.fromHexString("0x9de68e5b"), 3),
+            new ForkId(Bytes.fromHexString("0xc5c5ebd2"), 4),
+            new ForkId(Bytes.fromHexString("0x47007050"), 0));
+    assertThat(forkIdManager.getForkAndHashList())
+        .containsExactly(
+            new ForkId(Bytes.fromHexString("0xfc64ec04"), 0),
+            new ForkId(Bytes.fromHexString("0x3bc9ede0"), 1),
+            new ForkId(Bytes.fromHexString("0x1394cba2"), 2),
+            new ForkId(Bytes.fromHexString("0x0ce92cc2"), 3),
+            new ForkId(Bytes.fromHexString("0x380e3a3a"), 4),
+            new ForkId(Bytes.fromHexString("0xd10a3cee"), 0));
   }
 }


### PR DESCRIPTION
Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Fork Id computation has been updated to work with Geth nodes in consortium networks.
Besu should allow fork id generated with old versions of Besu.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #980 
Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>