### PR TITLE
update spdx exclusions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,7 @@ allprojects {
     jcenter()
     mavenCentral()
     mavenLocal()
-    maven {url "https://hyperledger-org.bintray.com/besu-repo"}
+    maven { url "https://hyperledger-org.bintray.com/besu-repo" }
     maven { url "https://consensys.bintray.com/pegasys-repo" }
     maven { url "https://repo.spring.io/libs-release" }
   }
@@ -637,7 +637,7 @@ task checkSpdxHeader(type: CheckSpdxHeader) {
     "(.*/.idea/.*)",
     "(.*/out/.*)",
     "(.*/build/.*)",
-    "(.*/src/main/generated/.*)",
+    "(.*/src/[^/]+/generated/.*)",
   ].join("|")
 
 }


### PR DESCRIPTION
SPDX checks shouldn't be done against jmh generated files.  Make it
generic so that the gradle/intellij favoured location of generated files
will never be a problem. These are also covered by `.gitignore` already.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

