### PR TITLE
Add gate for multi-tenancy + onchain privacy groups

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1774,6 +1774,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       privacyParametersBuilder.setMultiTenancyEnabled(isPrivacyMultiTenancyEnabled);
       privacyParametersBuilder.setOnchainPrivacyGroupsEnabled(isOnchainPrivacyGroupEnabled);
 
+      if (isPrivacyMultiTenancyEnabled && isOnchainPrivacyGroupEnabled) {
+        throw new ParameterException(
+            commandLine,
+            "Privacy multi-tenancy and onchain privacy groups cannot be used together");
+      }
+
       final boolean hasPrivacyPublicKey = privacyPublicKeyFile != null;
       if (hasPrivacyPublicKey && !isPrivacyMultiTenancyEnabled) {
         try {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2923,6 +2923,20 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(privacyParameters.isOnchainPrivacyGroupsEnabled()).isEqualTo(true);
   }
 
+  @Test
+  public void onchainPrivacyAndMultiTenancyCannotBeUsedTogether() {
+    parseCommand(
+        "--privacy-enabled",
+        "--privacy-onchain-groups-enabled",
+        "--privacy-multi-tenancy-enabled",
+        "--rpc-http-authentication-jwt-public-key-file",
+        "/non/existent/file",
+        "--rpc-http-authentication-enabled");
+
+    assertThat(commandErrorOutput.toString())
+        .startsWith("Privacy multi-tenancy and onchain privacy groups cannot be used together");
+  }
+
   private Path createFakeGenesisFile(final JsonObject jsonGenesis) throws IOException {
     final Path genesisFile = Files.createTempFile("genesisFile", "");
     Files.write(genesisFile, encodeJsonGenesis(jsonGenesis).getBytes(UTF_8));


### PR DESCRIPTION
## PR description
Prevent user from starting up Besu using multi-tenancy AND onchain privacy groups. The support for using both features at the same time is under development and targeting 1.5 release.