### PR TITLE
DevP2P expiration conformance

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
@@ -19,8 +19,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.time.Instant;
-
 import org.apache.tuweni.bytes.Bytes;
 
 public class FindNeighborsPacketData implements PacketData {
@@ -41,8 +39,7 @@ public class FindNeighborsPacketData implements PacketData {
   }
 
   public static FindNeighborsPacketData create(final Bytes target) {
-    return create(
-        target, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
+    return create(target, PacketData.defaultExpiration());
   }
 
   static FindNeighborsPacketData create(final Bytes target, final long expirationSec) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketData.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.time.Instant;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class FindNeighborsPacketData implements PacketData {
@@ -39,11 +41,12 @@ public class FindNeighborsPacketData implements PacketData {
   }
 
   public static FindNeighborsPacketData create(final Bytes target) {
-    return create(target, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+    return create(
+        target, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
   }
 
-  static FindNeighborsPacketData create(final Bytes target, final long expirationMs) {
-    return new FindNeighborsPacketData(target, expirationMs);
+  static FindNeighborsPacketData create(final Bytes target, final long expirationSec) {
+    return new FindNeighborsPacketData(target, expirationSec);
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketData.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.time.Instant;
 import java.util.List;
 
 public class NeighborsPacketData implements PacketData {
@@ -40,8 +39,7 @@ public class NeighborsPacketData implements PacketData {
 
   @SuppressWarnings("unchecked")
   public static NeighborsPacketData create(final List<DiscoveryPeer> peers) {
-    return new NeighborsPacketData(
-        peers, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
+    return new NeighborsPacketData(peers, PacketData.defaultExpiration());
   }
 
   public static NeighborsPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketData.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.time.Instant;
 import java.util.List;
 
 public class NeighborsPacketData implements PacketData {
@@ -40,7 +41,7 @@ public class NeighborsPacketData implements PacketData {
   @SuppressWarnings("unchecked")
   public static NeighborsPacketData create(final List<DiscoveryPeer> peers) {
     return new NeighborsPacketData(
-        peers, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+        peers, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
   }
 
   public static NeighborsPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketData.java
@@ -22,7 +22,7 @@ public interface PacketData {
    * Expiration is not standardised. We use Geth's expiration period (60 seconds); whereas Parity's
    * is 20 seconds.
    */
-  long DEFAULT_EXPIRATION_PERIOD_MS = 60000;
+  long DEFAULT_EXPIRATION_PERIOD_SEC = 60;
 
   /**
    * Serializes the implementing packet data onto the provided RLP output buffer.

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketData.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.ethereum.p2p.discovery.internal;
 
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.time.Instant;
+
 public interface PacketData {
 
   /**
@@ -30,4 +32,8 @@ public interface PacketData {
    * @param out The RLP output buffer.
    */
   void writeTo(RLPOutput out);
+
+  static long defaultExpiration() {
+    return Instant.now().getEpochSecond() + DEFAULT_EXPIRATION_PERIOD_SEC;
+  }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -533,7 +534,7 @@ public class PeerDiscoveryController {
 
   private void respondToPing(
       final PingPacketData packetData, final Bytes pingHash, final DiscoveryPeer sender) {
-    if (packetData.getExpiration() < System.currentTimeMillis()) {
+    if (packetData.getExpiration() < Instant.now().getEpochSecond()) {
       return;
     }
     final PongPacketData data = PongPacketData.create(packetData.getFrom(), pingHash);
@@ -542,7 +543,7 @@ public class PeerDiscoveryController {
 
   private void respondToFindNeighbors(
       final FindNeighborsPacketData packetData, final DiscoveryPeer sender) {
-    if (packetData.getExpiration() < System.currentTimeMillis()) {
+    if (packetData.getExpiration() < Instant.now().getEpochSecond()) {
       return;
     }
     // TODO: for now return 16 peers. Other implementations calculate how many

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -20,6 +20,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.time.Instant;
+
 public class PingPacketData implements PacketData {
 
   /* Fixed value that represents we're using v5 of the P2P discovery protocol. */
@@ -45,11 +47,12 @@ public class PingPacketData implements PacketData {
   }
 
   public static PingPacketData create(final Endpoint from, final Endpoint to) {
-    return create(from, to, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+    return create(
+        from, to, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
   }
 
-  static PingPacketData create(final Endpoint from, final Endpoint to, final long expirationMs) {
-    return new PingPacketData(from, to, expirationMs);
+  static PingPacketData create(final Endpoint from, final Endpoint to, final long expirationSec) {
+    return new PingPacketData(from, to, expirationSec);
   }
 
   public static PingPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketData.java
@@ -20,8 +20,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.time.Instant;
-
 public class PingPacketData implements PacketData {
 
   /* Fixed value that represents we're using v5 of the P2P discovery protocol. */
@@ -47,8 +45,7 @@ public class PingPacketData implements PacketData {
   }
 
   public static PingPacketData create(final Endpoint from, final Endpoint to) {
-    return create(
-        from, to, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
+    return create(from, to, PacketData.defaultExpiration());
   }
 
   static PingPacketData create(final Endpoint from, final Endpoint to, final long expirationSec) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketData.java
@@ -18,8 +18,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.time.Instant;
-
 import org.apache.tuweni.bytes.Bytes;
 
 public class PongPacketData implements PacketData {
@@ -40,8 +38,7 @@ public class PongPacketData implements PacketData {
   }
 
   public static PongPacketData create(final Endpoint to, final Bytes pingHash) {
-    return new PongPacketData(
-        to, pingHash, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
+    return new PongPacketData(to, pingHash, PacketData.defaultExpiration());
   }
 
   public static PongPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketData.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.time.Instant;
+
 import org.apache.tuweni.bytes.Bytes;
 
 public class PongPacketData implements PacketData {
@@ -39,7 +41,7 @@ public class PongPacketData implements PacketData {
 
   public static PongPacketData create(final Endpoint to, final Bytes pingHash) {
     return new PongPacketData(
-        to, pingHash, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+        to, pingHash, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
   }
 
   public static PongPacketData readFrom(final RLPInput in) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Random;
 
@@ -70,11 +71,11 @@ public class PeerDiscoveryPacketSedesTest {
     final FindNeighborsPacketData deserialized =
         FindNeighborsPacketData.readFrom(RLP.input(serialized));
     assertThat(deserialized.getTarget()).isEqualTo(target);
-    // Fuzziness: allow a skew of 1.5 seconds between the time the message was generated until the
+    // Fuzziness: allow a skew of 2 seconds between the time the message was generated until the
     // assertion.
     assertThat(deserialized.getExpiration())
         .isCloseTo(
-            System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS, offset(1500L));
+            Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC, offset(2L));
   }
 
   @Test
@@ -87,11 +88,11 @@ public class PeerDiscoveryPacketSedesTest {
 
     final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(serialized));
     assertThat(deserialized.getNodes()).isEqualTo(peers);
-    // Fuzziness: allow a skew of 1.5 seconds between the time the message was generated until the
+    // Fuzziness: allow a skew of 2 seconds between the time the message was generated until the
     // assertion.
     assertThat(deserialized.getExpiration())
         .isCloseTo(
-            System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS, offset(1500L));
+            Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC, offset(2L));
   }
 
   @Test(expected = RLPException.class)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 
-import java.time.Instant;
 import java.util.List;
 import java.util.Random;
 
@@ -73,9 +72,7 @@ public class PeerDiscoveryPacketSedesTest {
     assertThat(deserialized.getTarget()).isEqualTo(target);
     // Fuzziness: allow a skew of 2 seconds between the time the message was generated until the
     // assertion.
-    assertThat(deserialized.getExpiration())
-        .isCloseTo(
-            Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC, offset(2L));
+    assertThat(deserialized.getExpiration()).isCloseTo(PacketData.defaultExpiration(), offset(2L));
   }
 
   @Test
@@ -90,9 +87,7 @@ public class PeerDiscoveryPacketSedesTest {
     assertThat(deserialized.getNodes()).isEqualTo(peers);
     // Fuzziness: allow a skew of 2 seconds between the time the message was generated until the
     // assertion.
-    assertThat(deserialized.getExpiration())
-        .isCloseTo(
-            Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC, offset(2L));
+    assertThat(deserialized.getExpiration()).isCloseTo(PacketData.defaultExpiration(), offset(2L));
   }
 
   @Test(expected = RLPException.class)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
@@ -20,13 +20,15 @@ import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
+import java.time.Instant;
+
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Test;
 
 public class FindNeighborsPacketDataTest {
   @Test
   public void serializeDeserialize() {
-    final long time = System.currentTimeMillis();
+    final long timeSec = Instant.now().getEpochSecond();
     final Bytes target = Peer.randomId();
 
     final FindNeighborsPacketData packet = FindNeighborsPacketData.create(target);
@@ -35,7 +37,7 @@ public class FindNeighborsPacketDataTest {
         FindNeighborsPacketData.readFrom(RLP.input(serialized));
 
     assertThat(deserialized.getTarget()).isEqualTo(target);
-    assertThat(deserialized.getExpiration()).isGreaterThan(time);
+    assertThat(deserialized.getExpiration()).isGreaterThan(timeSec);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -58,7 +59,7 @@ class MockPacketDataFactory {
 
   static Packet mockFindNeighborsPacket(final Peer from) {
     return mockFindNeighborsPacket(
-        from, System.currentTimeMillis() + PacketData.DEFAULT_EXPIRATION_PERIOD_MS);
+        from, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
   }
 
   static Packet mockFindNeighborsPacket(final Peer from, final long exparationMs) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPacketDataFactory.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -58,8 +57,7 @@ class MockPacketDataFactory {
   }
 
   static Packet mockFindNeighborsPacket(final Peer from) {
-    return mockFindNeighborsPacket(
-        from, Instant.now().getEpochSecond() + PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
+    return mockFindNeighborsPacket(from, PacketData.defaultExpiration());
   }
 
   static Packet mockFindNeighborsPacket(final Peer from, final long exparationMs) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class NeighborsPacketDataTest {
 
   @Test
   public void serializeDeserialize() {
-    final long time = System.currentTimeMillis();
+    final long timeSec = Instant.now().getEpochSecond();
     final List<DiscoveryPeer> peers =
         Arrays.asList(DiscoveryPeer.fromEnode(enode()), DiscoveryPeer.fromEnode(enode()));
 
@@ -40,25 +41,25 @@ public class NeighborsPacketDataTest {
     final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(serialized));
 
     assertThat(deserialized.getNodes()).isEqualTo(peers);
-    assertThat(deserialized.getExpiration()).isGreaterThan(time);
+    assertThat(deserialized.getExpiration()).isGreaterThan(timeSec);
   }
 
   @Test
   public void readFrom() {
-    final long time = System.currentTimeMillis();
+    final long timeSec = Instant.now().getEpochSecond();
     final List<DiscoveryPeer> peers =
         Arrays.asList(DiscoveryPeer.fromEnode(enode()), DiscoveryPeer.fromEnode(enode()));
 
     BytesValueRLPOutput out = new BytesValueRLPOutput();
     out.startList();
     out.writeList(peers, DiscoveryPeer::writeTo);
-    out.writeLongScalar(time);
+    out.writeLongScalar(timeSec);
     out.endList();
     Bytes encoded = out.encoded();
 
     final NeighborsPacketData deserialized = NeighborsPacketData.readFrom(RLP.input(encoded));
     assertThat(deserialized.getNodes()).isEqualTo(peers);
-    assertThat(deserialized.getExpiration()).isEqualTo(time);
+    assertThat(deserialized.getExpiration()).isEqualTo(timeSec);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsBlacklist;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -302,7 +303,9 @@ public class PeerDiscoveryControllerTest {
     final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     final PingPacketData pingPacketData =
         PingPacketData.create(
-            localEndpoint, discoPeer.getEndpoint(), System.currentTimeMillis() - 20_000);
+            localEndpoint,
+            discoPeer.getEndpoint(),
+            Instant.now().getEpochSecond() - PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
     final Packet discoPeerPing = Packet.create(PacketType.PING, pingPacketData, nodeKeys.get(0));
     mockPacketCreation(PacketType.PING, discoPeer, discoPeerPing);
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -894,7 +894,7 @@ public class PeerDiscoveryControllerTest {
 
     final Packet findNeighborsPacket =
         MockPacketDataFactory.mockFindNeighborsPacket(
-            discoPeer, System.currentTimeMillis() - 20_000);
+            discoPeer, Instant.now().getEpochSecond() - PacketData.DEFAULT_EXPIRATION_PERIOD_SEC);
     controller.onMessage(findNeighborsPacket, discoPeer);
 
     verify(outboundMessageHandler, times(0))

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketDataTest.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
+import java.time.Instant;
 import java.util.OptionalInt;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -29,7 +30,7 @@ public class PingPacketDataTest {
 
   @Test
   public void serializeDeserialize() {
-    final long currentTime = System.currentTimeMillis();
+    final long currentTimeSec = Instant.now().getEpochSecond();
 
     final Endpoint from = new Endpoint("127.0.0.1", 30303, OptionalInt.of(30303));
     final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
@@ -39,7 +40,7 @@ public class PingPacketDataTest {
 
     assertThat(deserialized.getFrom()).isEqualTo(from);
     assertThat(deserialized.getTo()).isEqualTo(to);
-    assertThat(deserialized.getExpiration()).isGreaterThan(currentTime);
+    assertThat(deserialized.getExpiration()).isGreaterThan(currentTimeSec);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketDataTest.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
+import java.time.Instant;
 import java.util.OptionalInt;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -30,7 +31,7 @@ public class PongPacketDataTest {
 
   @Test
   public void serializeDeserialize() {
-    final long currentTime = System.currentTimeMillis();
+    final long currentTimeSec = Instant.now().getEpochSecond();
     final Endpoint to = new Endpoint("127.0.0.2", 30303, OptionalInt.empty());
     final Bytes32 hash = Bytes32.fromHexStringLenient("0x1234");
 
@@ -40,7 +41,7 @@ public class PongPacketDataTest {
 
     assertThat(deserialized.getTo()).isEqualTo(to);
     assertThat(deserialized.getPingHash()).isEqualTo(hash);
-    assertThat(deserialized.getExpiration()).isGreaterThan(currentTime);
+    assertThat(deserialized.getExpiration()).isGreaterThan(currentTimeSec);
   }
 
   @Test


### PR DESCRIPTION
DevP2P packets expiration fields should be in seconds past the epoch,
not milliseconds past the epoch.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
