### PR TITLE
Repair intermittent EthGetWork test

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/eth/SanityCheckEthGetWorkValues.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/eth/SanityCheckEthGetWorkValues.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.condition.eth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.tests.acceptance.dsl.WaitUtils;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthGetWorkTransaction;
@@ -30,8 +31,13 @@ public class SanityCheckEthGetWorkValues implements Condition {
 
   @Override
   public void verify(final Node node) {
-    final String[] response = node.execute(transaction);
-    assertThat(response).hasSize(3);
-    assertThat(response).doesNotContainNull();
+    // EthGetWork _can_ return "no work" error, if the next block solution is yet to be calculated.
+    WaitUtils.waitFor(
+        5,
+        () -> {
+          final String[] response = node.execute(transaction);
+          assertThat(response).hasSize(3);
+          assertThat(response).doesNotContainNull();
+        });
   }
 }


### PR DESCRIPTION
The EthGetWork.shouldReturnSuccessResponseWhenMining was exhibiting intermittent failures, as a mining node would occasionally report "No mining work available yet" - rather than the inputs required to be solved for the current block.

From investigation, it was found that Besu's EthHash miner has a small time window after completing a block, in which the target for the next block has not yet been computed (eg while collating transactions) - during this interval, Besu will validly report "No mining work available yet".

To overcome this, the acceptance test has been updated to poll Besu for upto 5 seconds, waiting for a valid work target to be provided - rather than executing a single-attempt (which may fall within the window specified above).
