### PR TITLE
update getForks to ignore ClassicForkBlock param, update gotham number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The [1.5 release](docs/1_5_Upgrade.md) is scheduled for early July.
 
 - Added timeout to queries. [\#986](https://github.com/hyperledger/besu/pull/986)
 - Fixed issue where networks using onchain permissioning could stall when the bootnodes were not validators. [\#969](https://github.com/hyperledger/besu/pull/969)
+- Update getForks method to ignore ClassicForkBlock chain parameter to fix issue with ETC syncing. [\#1014](https://github.com/hyperledger/besu/pull/1014)
 
 ### Known Issues 
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/eth/SanityCheckEthGetWorkValues.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/eth/SanityCheckEthGetWorkValues.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.condition.eth;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.tests.acceptance.dsl.WaitUtils;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthGetWorkTransaction;
@@ -30,8 +31,13 @@ public class SanityCheckEthGetWorkValues implements Condition {
 
   @Override
   public void verify(final Node node) {
-    final String[] response = node.execute(transaction);
-    assertThat(response).hasSize(3);
-    assertThat(response).doesNotContainNull();
+    // EthGetWork _can_ return "no work" error, if the next block solution is yet to be calculated.
+    WaitUtils.waitFor(
+        5,
+        () -> {
+          final String[] response = node.execute(transaction);
+          assertThat(response).hasSize(3);
+          assertThat(response).doesNotContainNull();
+        });
   }
 }

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -138,6 +138,7 @@ public class GenesisConfigFile {
                     .filter(name -> !name.equals("chainid"))
                     .filter(name -> node.get(name).canConvertToLong())
                     .filter(name -> name.contains("block"))
+                    .filter(name -> !name.equals("classicforkblock"))
                     .map(name -> node.get(name).asLong()))
         .sorted()
         .collect(toUnmodifiableList());

--- a/config/src/main/resources/classic.json
+++ b/config/src/main/resources/classic.json
@@ -5,7 +5,7 @@
     "classicForkBlock": 1920000,
     "ecip1015Block": 2500000,
     "diehardBlock": 3000000,
-    "gothamBlock": 5000001,
+    "gothamBlock": 5000000,
     "ecip1041Block": 5900000,
     "atlantisBlock": 8772000,
     "aghartaBlock": 9573000,

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
@@ -338,6 +338,26 @@ public class GenesisConfigFileTest {
     assertThat(config.getConfigOptions().getChainId()).hasValue(BigInteger.valueOf(4));
   }
 
+  @Test
+  public void shouldLoadForksIgnoreClassicForkBlock() throws IOException {
+    final ObjectNode configNode =
+        new ObjectMapper()
+            .createObjectNode()
+            .set(
+                "config",
+                JsonUtil.objectNodeFromString(
+                    Resources.toString(
+                        Resources.getResource(
+                            // If you inspect this config, you should see that classicForkBlock is
+                            // declared (which we want to ignore)
+                            "valid_config_with_etc_forks.json"),
+                        StandardCharsets.UTF_8)));
+    final GenesisConfigFile config = fromConfig(configNode);
+
+    assertThat(config.getForks()).containsExactly(1L, 2L, 3L, 3L, 1035301L);
+    assertThat(config.getConfigOptions().getChainId()).hasValue(BigInteger.valueOf(61));
+  }
+
   private GenesisConfigFile configWithProperty(final String key, final String value) {
     return fromConfig("{\"" + key + "\":\"" + value + "\"}");
   }

--- a/config/src/test/resources/valid_config_with_etc_forks.json
+++ b/config/src/test/resources/valid_config_with_etc_forks.json
@@ -1,0 +1,32 @@
+{
+  "chainId": 61,
+  "eip150Block": 2,
+  "homesteadBlock": 1,
+  "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "eip155Block": 3,
+  "eip158Block": 3,
+  "classicForkBlock": 1920000,
+  "byzantiumBlock": 1035301,
+  "ibft2": {
+    "blockperiodseconds": 2,
+    "epochlength": 30000,
+    "requesttimeoutseconds": 10
+  },
+  "transitions": {
+    "ibft2": [
+      {
+        "block": 20,
+        "validators": [
+          "0x1234567890123456789012345678901234567890",
+          "0x9876543210987654321098765432109876543210"
+        ]
+      },
+      {
+        "block": 25,
+        "validators": [
+          "0x1234567890123456789012345678901234567890"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This PR implements functionality to ignore ClassicForkBlock chain config parameter in getForks method. Since getForks method is intended to list blocks when chains have forked, and the ClassicForkBlock parameter is to define when a fork on classic network did NOT happen, it should not be included in this list.

update ETC gotham fork number to conform with spec.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
