### PR TITLE
Initial support for multi-tenancy with flexible privacy groups

### DIFF
--- a/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
@@ -75,8 +75,8 @@ public class Enclave {
         (statusCode, body) -> handleJsonResponse(statusCode, body, SendResponse.class));
   }
 
-  public ReceiveResponse receive(final String enclaveKey) {
-    final ReceiveRequest request = new ReceiveRequest(enclaveKey);
+  public ReceiveResponse receive(final String payloadKey) {
+    final ReceiveRequest request = new ReceiveRequest(payloadKey);
     return post(
         ORION,
         request,
@@ -84,8 +84,8 @@ public class Enclave {
         (statusCode, body) -> handleJsonResponse(statusCode, body, ReceiveResponse.class));
   }
 
-  public ReceiveResponse receive(final String enclaveKey, final String to) {
-    final ReceiveRequest request = new ReceiveRequest(enclaveKey, to);
+  public ReceiveResponse receive(final String payloadKey, final String to) {
+    final ReceiveRequest request = new ReceiveRequest(payloadKey, to);
     return post(
         ORION,
         request,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -154,8 +154,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
   public void returnsStoredPrivateTransaction() {
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(
-            blockchain, privacyController, privateStateStorage, enclavePublicKeyProvider);
+        new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider);
 
     when(blockchain.transactionByHash(any(Hash.class)))
         .thenReturn(Optional.of(returnedTransaction));

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivGetPrivateTransactionIntegrationTest.java
@@ -16,8 +16,10 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.privacyMarkerTransaction;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.crypto.SECP256K1;
@@ -30,11 +32,11 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.Enclav
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv.PrivGetPrivateTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionLegacyResult;
-import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.TransactionLocation;
 import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.privacy.DefaultPrivacyController;
@@ -55,7 +57,7 @@ import java.util.Optional;
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -66,47 +68,14 @@ public class PrivGetPrivateTransactionIntegrationTest {
   @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
   private static final String ENCLAVE_PUBLIC_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
 
-  private static Enclave enclave;
-
-  private static OrionTestHarness testHarness;
-  private static PrivacyController privacyController;
-
-  private final TransactionWithMetadata returnedTransaction = mock(TransactionWithMetadata.class);
-
-  private final Transaction justTransaction = mock(Transaction.class);
-  private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
-
-  private static final Vertx vertx = Vertx.vertx();
-
   private final EnclavePublicKeyProvider enclavePublicKeyProvider = (user) -> ENCLAVE_PUBLIC_KEY;
-
-  @Before
-  public void setUp() throws Exception {
-    folder.create();
-
-    testHarness =
-        OrionTestHarnessFactory.create(
-            folder.newFolder().toPath(),
-            new OrionKeyConfiguration("orion_key_0.pub", "orion_key_0.key"));
-
-    testHarness.start();
-    final EnclaveFactory factory = new EnclaveFactory(vertx);
-    enclave = factory.createVertxEnclave(testHarness.clientUrl());
-
-    privacyController =
-        new DefaultPrivacyController(
-            null, privateStateStorage, enclave, null, null, null, null, null);
-  }
-
-  @AfterClass
-  public static void tearDownOnce() {
-    testHarness.close();
-    vertx.close();
-  }
+  private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
+  private final Blockchain blockchain = mock(Blockchain.class);
 
   private final Address sender =
       Address.fromHexString("0x0000000000000000000000000000000000000003");
-  private static final SECP256K1.KeyPair KEY_PAIR =
+
+  private final SECP256K1.KeyPair KEY_PAIR =
       SECP256K1.KeyPair.create(
           SECP256K1.PrivateKey.create(
               new BigInteger(
@@ -140,26 +109,52 @@ public class PrivGetPrivateTransactionIntegrationTest {
           .restriction(Restriction.RESTRICTED)
           .signAndBuild(KEY_PAIR);
 
-  private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
-
-  private final BlockchainQueries blockchain = mock(BlockchainQueries.class);
+  private Vertx vertx = Vertx.vertx();
+  private OrionTestHarness testHarness;
+  private Enclave enclave;
+  private PrivacyController privacyController;
 
   @Before
-  public void before() {
-    when(privacyParameters.isEnabled()).thenReturn(true);
-    when(privacyParameters.getEnclave()).thenReturn(enclave);
+  public void setUp() throws Exception {
+    folder.create();
+
+    vertx = Vertx.vertx();
+
+    testHarness =
+        OrionTestHarnessFactory.create(
+            folder.newFolder().toPath(),
+            new OrionKeyConfiguration("orion_key_0.pub", "orion_key_0.key"));
+
+    testHarness.start();
+
+    final EnclaveFactory factory = new EnclaveFactory(vertx);
+    enclave = factory.createVertxEnclave(testHarness.clientUrl());
+
+    privacyController =
+        new DefaultPrivacyController(
+            blockchain, privateStateStorage, enclave, null, null, null, null, null);
+  }
+
+  @After
+  public void tearDown() {
+    testHarness.close();
+    vertx.close();
   }
 
   @Test
   public void returnsStoredPrivateTransaction() {
-
     final PrivGetPrivateTransaction privGetPrivateTransaction =
         new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider);
 
-    when(blockchain.transactionByHash(any(Hash.class)))
-        .thenReturn(Optional.of(returnedTransaction));
-    when(returnedTransaction.getTransaction()).thenReturn(justTransaction);
-    when(returnedTransaction.getBlockHash()).thenReturn(Optional.of(Hash.ZERO));
+    final Hash blockHash = Hash.ZERO;
+    final Transaction pmt = spy(privacyMarkerTransaction());
+    when(blockchain.getTransactionByHash(eq(pmt.getHash()))).thenReturn(Optional.of(pmt));
+    when(blockchain.getTransactionLocation(eq(pmt.getHash())))
+        .thenReturn(Optional.of(new TransactionLocation(blockHash, 0)));
+
+    final BlockHeader blockHeader = mock(BlockHeader.class);
+    when(blockHeader.getHash()).thenReturn(blockHash);
+    when(blockchain.getBlockHeader(eq(blockHash))).thenReturn(Optional.of(blockHeader));
 
     final BytesValueRLPOutput bvrlp = new BytesValueRLPOutput();
     privateTransaction.writeTo(bvrlp);
@@ -169,9 +164,9 @@ public class PrivGetPrivateTransactionIntegrationTest {
     final SendResponse sendResponse = enclave.send(payload, ENCLAVE_PUBLIC_KEY, to);
 
     final Bytes hexKey = Bytes.fromBase64String(sendResponse.getKey());
-    when(justTransaction.getPayload()).thenReturn(hexKey);
+    when(pmt.getPayload()).thenReturn(hexKey);
 
-    final Object[] params = new Object[] {Hash.ZERO};
+    final Object[] params = new Object[] {pmt.getHash()};
 
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(new JsonRpcRequest("1", "priv_getPrivateTransaction", params));
@@ -181,7 +176,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
     final PrivateTransactionLegacyResult result =
         (PrivateTransactionLegacyResult) response.getResult();
 
-    assertThat(new PrivateTransactionLegacyResult(privateTransaction))
+    assertThat(new PrivateTransactionLegacyResult(this.privateTransaction))
         .isEqualToComparingFieldByField(result);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.apache.logging.log4j.LogManager.getLogger;
 
-import java.util.function.Function;
 import org.hyperledger.besu.enclave.EnclaveClientException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcEnclaveErrorConverter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -29,11 +28,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionGroupResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionLegacyResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.privacy.PrivateTransactionResult;
-import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
-import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 
 import java.util.Optional;
 
@@ -43,19 +40,13 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
 
   private static final Logger LOG = getLogger();
 
-  private final BlockchainQueries blockchain;
   private final PrivacyController privacyController;
-  private final PrivateStateStorage privateStateStorage;
   private final EnclavePublicKeyProvider enclavePublicKeyProvider;
 
   public PrivGetPrivateTransaction(
-      final BlockchainQueries blockchain,
       final PrivacyController privacyController,
-      final PrivateStateStorage privateStateStorage,
       final EnclavePublicKeyProvider enclavePublicKeyProvider) {
-    this.blockchain = blockchain;
     this.privacyController = privacyController;
-    this.privateStateStorage = privateStateStorage;
     this.enclavePublicKeyProvider = enclavePublicKeyProvider;
   }
 
@@ -73,10 +64,13 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
 
     final Optional<PrivateTransaction> maybePrivateTx;
     try {
-      maybePrivateTx = privacyController.findPrivateTransactionByPmtHash(hash, enclaveKey)
-          .map(PrivateTransaction.class::cast);
+      maybePrivateTx =
+          privacyController
+              .findPrivateTransactionByPmtHash(hash, enclaveKey)
+              .map(PrivateTransaction.class::cast);
     } catch (EnclaveClientException e) {
-      return new JsonRpcErrorResponse(requestContext.getRequest().getId(),
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(),
           JsonRpcEnclaveErrorConverter.convertEnclaveInvalidReason(e.getMessage()));
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -146,15 +146,17 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
   }
 
   private String calculateContractAddress(final ExecutedPrivateTransaction privateTransaction) {
-    if (privateTransaction.getPrivacyGroupId().isEmpty()) {
-      LOG.warn(">>> NO PRIVACY GROUP ID <<<");
+    if (privateTransaction.getTo().isEmpty()) {
+      final Address sender = privateTransaction.getSender();
+      final long nonce = privateTransaction.getNonce();
+      final Bytes privacyGroupId = privateTransaction.getPrivacyGroupId().orElse(Bytes
+          .fromBase64String(privateTransaction.getInternalPrivacyGroup()));
+      final Address contractAddress = Address.privateContractAddress(sender, nonce, privacyGroupId);
+
+      return contractAddress.toString();
+    } else {
+      return null;
     }
-    return privateTransaction.getTo().isEmpty()
-        ? Address.privateContractAddress(
-        privateTransaction.getSender(),
-        privateTransaction.getNonce(),
-        privateTransaction.getPrivacyGroupId().orElse(Bytes32.EMPTY)).toString()
-        : null;
   }
 
   private Optional<? extends PrivateTransactionReceipt> findPrivateReceiptByPrivateTxHash(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -68,17 +68,12 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
     if (getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
       return mapOf(
           new PrivGetTransactionReceipt(
-              getBlockchainQueries(),
-              getPrivacyParameters(),
+              getPrivacyParameters().getPrivateStateStorage(),
               privacyController,
               enclavePublicKeyProvider),
           new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
           new PrivGetTransactionCount(privacyController, enclavePublicKeyProvider),
-          new PrivGetPrivateTransaction(
-              getBlockchainQueries(),
-              privacyController,
-              getPrivacyParameters().getPrivateStateStorage(),
-              enclavePublicKeyProvider),
+          new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider),
           new PrivDistributeRawTransaction(
               privacyController,
               enclavePublicKeyProvider,
@@ -97,8 +92,7 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
     } else {
       return mapOf(
           new PrivGetTransactionReceipt(
-              getBlockchainQueries(),
-              getPrivacyParameters(),
+              getPrivacyParameters().getPrivateStateStorage(),
               privacyController,
               enclavePublicKeyProvider),
           new PrivCreatePrivacyGroup(privacyController, enclavePublicKeyProvider),
@@ -106,11 +100,7 @@ public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
           new PrivFindPrivacyGroup(privacyController, enclavePublicKeyProvider),
           new PrivGetPrivacyPrecompileAddress(getPrivacyParameters()),
           new PrivGetTransactionCount(privacyController, enclavePublicKeyProvider),
-          new PrivGetPrivateTransaction(
-              getBlockchainQueries(),
-              privacyController,
-              getPrivacyParameters().getPrivateStateStorage(),
-              enclavePublicKeyProvider),
+          new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider),
           new PrivDistributeRawTransaction(
               privacyController,
               enclavePublicKeyProvider,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
@@ -115,8 +115,7 @@ public class PrivGetPrivateTransactionTest {
 
   protected PrivateTransactionResult makeRequest(final JsonRpcRequestContext request) {
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(
-            blockchain, privacyController, privateStateStorage, enclavePublicKeyProvider);
+        new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider);
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetPrivateTransaction.response(request);
     return (PrivateTransactionResult) response.getResult();
@@ -188,8 +187,7 @@ public class PrivGetPrivateTransactionTest {
     final JsonRpcRequestContext request = createRequestContext();
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(
-            blockchain, privacyController, privateStateStorage, enclavePublicKeyProvider);
+        new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider);
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetPrivateTransaction.response(request);
 
@@ -204,8 +202,7 @@ public class PrivGetPrivateTransactionTest {
         .thenThrow(new EnclaveClientException(500, "enclave failure"));
 
     final PrivGetPrivateTransaction privGetPrivateTransaction =
-        new PrivGetPrivateTransaction(
-            blockchain, privacyController, privateStateStorage, enclavePublicKeyProvider);
+        new PrivGetPrivateTransaction(privacyController, enclavePublicKeyProvider);
     final JsonRpcResponse response = privGetPrivateTransaction.response(request);
     final JsonRpcResponse expectedResponse =
         new JsonRpcErrorResponse(request.getRequest().getId(), JsonRpcError.ENCLAVE_ERROR);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -42,7 +42,6 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
@@ -83,7 +82,6 @@ public class PrivGetTransactionReceiptTest {
 
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final Blockchain blockchain = mock(Blockchain.class);
-  private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
   private final PrivateStateStorage privateStateStorage = mock(PrivateStateStorage.class);
   private final PrivacyController privacyController = mock(PrivacyController.class);
 
@@ -100,8 +98,6 @@ public class PrivGetTransactionReceiptTest {
     when(blockchain.getBlockHeader(any(Hash.class))).thenReturn(Optional.of(mockBlockHeader));
     when(mockBlockHeader.getNumber()).thenReturn(0L);
 
-    when(privacyParameters.isEnabled()).thenReturn(true);
-    when(privacyParameters.getPrivateStateStorage()).thenReturn(privateStateStorage);
     final PrivateTransactionReceipt receipt =
         new PrivateTransactionReceipt(1, Collections.emptyList(), Bytes.EMPTY, Optional.empty());
     when(privateStateStorage.getTransactionReceipt(any(Bytes32.class), any(Bytes32.class)))
@@ -167,7 +163,7 @@ public class PrivGetTransactionReceiptTest {
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetTransactionReceipt.response(request);
     final PrivateTransactionReceiptResult result =
@@ -184,7 +180,7 @@ public class PrivGetTransactionReceiptTest {
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetTransactionReceipt.response(request);
     final PrivateTransactionReceiptResult result =
@@ -202,7 +198,7 @@ public class PrivGetTransactionReceiptTest {
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
     final Throwable t = catchThrowable(() -> privGetTransactionReceipt.response(request));
     assertThat(t).isInstanceOf(RuntimeException.class);
   }
@@ -224,7 +220,7 @@ public class PrivGetTransactionReceiptTest {
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetTransactionReceipt.response(request);
     final PrivateTransactionReceiptResult result =
@@ -243,7 +239,7 @@ public class PrivGetTransactionReceiptTest {
 
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
     final Throwable t = catchThrowable(() -> privGetTransactionReceipt.response(request));
 
     assertThat(t).isInstanceOf(EnclaveClientException.class);
@@ -284,7 +280,7 @@ public class PrivGetTransactionReceiptTest {
       final PrivateTransactionReceiptResult expectedResult, final int i) {
     final PrivGetTransactionReceipt privGetTransactionReceipt =
         new PrivGetTransactionReceipt(
-            blockchainQueries, privacyParameters, privacyController, enclavePublicKeyProvider);
+            privateStateStorage, privacyController, enclavePublicKeyProvider);
 
     final JsonRpcRequestContext request = createRequestContext();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessor.java
@@ -30,10 +30,8 @@ import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateBlockMetadata;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateTransactionMetadata;
-import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -113,7 +111,7 @@ public class PrivacyBlockProcessor implements BlockProcessor {
               try {
                 final ReceiveResponse receiveResponse = enclave.receive(addKey.toBase64String());
                 final List<PrivateTransactionWithMetadata> privateTransactionWithMetadataList =
-                    deserializeAddToGroupPayload(
+                    PrivateTransactionWithMetadata.readListFromPayload(
                         Bytes.wrap(Base64.getDecoder().decode(receiveResponse.getPayload())));
                 final Bytes32 privacyGroupId =
                     Bytes32.wrap(
@@ -214,18 +212,5 @@ public class PrivacyBlockProcessor implements BlockProcessor {
       }
     }
     return actualList;
-  }
-
-  private List<PrivateTransactionWithMetadata> deserializeAddToGroupPayload(
-      final Bytes encodedAddToGroupPayload) {
-    final ArrayList<PrivateTransactionWithMetadata> deserializedResponse = new ArrayList<>();
-    final BytesValueRLPInput bytesValueRLPInput =
-        new BytesValueRLPInput(encodedAddToGroupPayload, false);
-    final int noOfEntries = bytesValueRLPInput.enterList();
-    for (int i = 0; i < noOfEntries; i++) {
-      deserializedResponse.add(PrivateTransactionWithMetadata.readFrom(bytesValueRLPInput));
-    }
-    bytesValueRLPInput.leaveList();
-    return deserializedResponse;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -422,7 +422,7 @@ public class DefaultPrivacyController implements PrivacyController {
   @Override
   public List<PrivateTransactionWithMetadata> retrieveAddBlob(final String addDataKey) {
     final ReceiveResponse addReceiveResponse = enclave.receive(addDataKey);
-    return deserializeAddToGroupPayload(
+    return PrivateTransactionWithMetadata.readListFromPayload(
         Bytes.wrap(Base64.getDecoder().decode(addReceiveResponse.getPayload())));
   }
 
@@ -436,19 +436,6 @@ public class DefaultPrivacyController implements PrivacyController {
     rlpOutput.endList();
 
     return rlpOutput.encoded();
-  }
-
-  private List<PrivateTransactionWithMetadata> deserializeAddToGroupPayload(
-      final Bytes encodedAddToGroupPayload) {
-    final ArrayList<PrivateTransactionWithMetadata> deserializedResponse = new ArrayList<>();
-    final BytesValueRLPInput bytesValueRLPInput =
-        new BytesValueRLPInput(encodedAddToGroupPayload, false);
-    final int noOfEntries = bytesValueRLPInput.enterList();
-    for (int i = 0; i < noOfEntries; i++) {
-      deserializedResponse.add(PrivateTransactionWithMetadata.readFrom(bytesValueRLPInput));
-    }
-    bytesValueRLPInput.leaveList();
-    return deserializedResponse;
   }
 
   private SendResponse sendRequest(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -69,6 +69,7 @@ public class DefaultPrivacyController implements PrivacyController {
   private final PrivateTransactionSimulator privateTransactionSimulator;
   private final PrivateNonceProvider privateNonceProvider;
   private final PrivateWorldStateReader privateWorldStateReader;
+  private final PrivateTransactionLocator privateTransactionLocator;
 
   public DefaultPrivacyController(
       final Blockchain blockchain,
@@ -106,6 +107,14 @@ public class DefaultPrivacyController implements PrivacyController {
     this.privateTransactionSimulator = privateTransactionSimulator;
     this.privateNonceProvider = privateNonceProvider;
     this.privateWorldStateReader = privateWorldStateReader;
+    this.privateTransactionLocator = new PrivateTransactionLocator(blockchain, enclave,
+        privateStateStorage);
+  }
+
+  @Override
+  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
+      final String enclaveKey) {
+    return privateTransactionLocator.findByPmtHash(pmtHash, enclaveKey);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -107,13 +107,13 @@ public class DefaultPrivacyController implements PrivacyController {
     this.privateTransactionSimulator = privateTransactionSimulator;
     this.privateNonceProvider = privateNonceProvider;
     this.privateWorldStateReader = privateWorldStateReader;
-    this.privateTransactionLocator = new PrivateTransactionLocator(blockchain, enclave,
-        privateStateStorage);
+    this.privateTransactionLocator =
+        new PrivateTransactionLocator(blockchain, enclave, privateStateStorage);
   }
 
   @Override
-  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
-      final String enclaveKey) {
+  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(
+      final Hash pmtHash, final String enclaveKey) {
     return privateTransactionLocator.findByPmtHash(pmtHash, enclaveKey);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
@@ -14,14 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.privacy;
 
-import org.hyperledger.besu.ethereum.chain.TransactionLocation;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.core.Transaction;
-
-import java.util.Objects;
-
-import com.google.common.annotations.VisibleForTesting;
 
 /**
  * This class represents a private transaction that has been executed. Therefore, it contains the
@@ -35,22 +28,6 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
   private final int pmtIndex;
   private final String internalPrivacyGroup;
 
-  ExecutedPrivateTransaction(
-      final BlockHeader blockHeader,
-      final Transaction pmt,
-      final TransactionLocation pmtLocation,
-      final String internalPrivacyGroup,
-      final PrivateTransaction privateTransaction) {
-    this(
-        blockHeader.getHash(),
-        blockHeader.getNumber(),
-        pmt.getHash(),
-        pmtLocation.getTransactionIndex(),
-        internalPrivacyGroup,
-        privateTransaction);
-  }
-
-  @VisibleForTesting
   public ExecutedPrivateTransaction(
       final Hash blockHash,
       final long blockNumber,
@@ -91,32 +68,5 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
    */
   public String getInternalPrivacyGroup() {
     return internalPrivacyGroup;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    if (!super.equals(o)) {
-      return false;
-    }
-
-    final ExecutedPrivateTransaction that = (ExecutedPrivateTransaction) o;
-
-    return blockNumber == that.blockNumber
-        && pmtIndex == that.pmtIndex
-        && blockHash.equals(that.blockHash)
-        && pmtHash.equals(that.pmtHash)
-        && internalPrivacyGroup.equals((that.internalPrivacyGroup));
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex, internalPrivacyGroup);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.privacy;
+
+import java.util.Objects;
+import org.hyperledger.besu.ethereum.chain.TransactionLocation;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
+
+/**
+ * This class represents a private transaction that has been executed. Therefore, it contains the
+ * original private transaction data plus information about the associated PMT and its block.
+ */
+public class ExecutedPrivateTransaction extends PrivateTransaction {
+
+  private final Hash blockHash;
+  private final long blockNumber;
+  private final Hash pmtHash;
+  private final int pmtIndex;
+
+  ExecutedPrivateTransaction(final BlockHeader blockHeader, final Transaction pmt,
+      final TransactionLocation pmtLocation, final PrivateTransaction privateTransaction) {
+    this(blockHeader.getHash(), blockHeader.getNumber(), pmt.getHash(),
+        pmtLocation.getTransactionIndex(), privateTransaction);
+  }
+
+  ExecutedPrivateTransaction(final Hash blockHash, final long blockNumber,
+      final Hash pmtHash, final int pmtIndex, final PrivateTransaction privateTransaction) {
+    super(privateTransaction);
+    this.blockHash = blockHash;
+    this.blockNumber = blockNumber;
+    this.pmtHash = pmtHash;
+    this.pmtIndex = pmtIndex;
+  }
+
+  public Hash getBlockHash() {
+    return blockHash;
+  }
+
+  public long getBlockNumber() {
+    return blockNumber;
+  }
+
+  public Hash getPmtHash() {
+    return pmtHash;
+  }
+
+  public int getPmtIndex() {
+    return pmtIndex;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    final ExecutedPrivateTransaction that = (ExecutedPrivateTransaction) o;
+
+    return blockNumber == that.blockNumber &&
+        pmtIndex == that.pmtIndex &&
+        blockHash.equals(that.blockHash) &&
+        pmtHash.equals(that.pmtHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
@@ -30,20 +30,25 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
   private final long blockNumber;
   private final Hash pmtHash;
   private final int pmtIndex;
+  private final String internalPrivacyGroup;
 
   ExecutedPrivateTransaction(final BlockHeader blockHeader, final Transaction pmt,
-      final TransactionLocation pmtLocation, final PrivateTransaction privateTransaction) {
+      final TransactionLocation pmtLocation, final String internalPrivacyGroup,
+      final PrivateTransaction privateTransaction) {
     this(blockHeader.getHash(), blockHeader.getNumber(), pmt.getHash(),
-        pmtLocation.getTransactionIndex(), privateTransaction);
+        pmtLocation.getTransactionIndex(), internalPrivacyGroup, privateTransaction);
   }
 
   ExecutedPrivateTransaction(final Hash blockHash, final long blockNumber,
-      final Hash pmtHash, final int pmtIndex, final PrivateTransaction privateTransaction) {
+      final Hash pmtHash, final int pmtIndex, final String internalPrivacyGroupId,
+      final PrivateTransaction privateTransaction) {
     super(privateTransaction);
     this.blockHash = blockHash;
     this.blockNumber = blockNumber;
     this.pmtHash = pmtHash;
     this.pmtIndex = pmtIndex;
+    this.internalPrivacyGroup = internalPrivacyGroupId;
+
   }
 
   public Hash getBlockHash() {
@@ -60,6 +65,17 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
 
   public int getPmtIndex() {
     return pmtIndex;
+  }
+
+  /**
+   * Legacy transactions don't have the privacyGroupId as part of their RLP data. The internal
+   * privacy group id is returned from the Enclave. We are keeping it separate from the
+   * 'getPrivacyGroup()' to differentiate legacy transactions.
+   *
+   * @return the privacy group id
+   */
+  public String getInternalPrivacyGroup() {
+    return internalPrivacyGroup;
   }
 
   @Override
@@ -79,11 +95,13 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
     return blockNumber == that.blockNumber &&
         pmtIndex == that.pmtIndex &&
         blockHash.equals(that.blockHash) &&
-        pmtHash.equals(that.pmtHash);
+        pmtHash.equals(that.pmtHash) &&
+        internalPrivacyGroup.equals((that.internalPrivacyGroup));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex);
+    return Objects
+        .hash(super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex, internalPrivacyGroup);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 
 import java.util.Objects;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * This class represents a private transaction that has been executed. Therefore, it contains the
  * original private transaction data plus information about the associated PMT and its block.
@@ -48,7 +50,8 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
         privateTransaction);
   }
 
-  ExecutedPrivateTransaction(
+  @VisibleForTesting
+  public ExecutedPrivateTransaction(
       final Hash blockHash,
       final long blockNumber,
       final Hash pmtHash,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/ExecutedPrivateTransaction.java
@@ -14,11 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.privacy;
 
-import java.util.Objects;
 import org.hyperledger.besu.ethereum.chain.TransactionLocation;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
+
+import java.util.Objects;
 
 /**
  * This class represents a private transaction that has been executed. Therefore, it contains the
@@ -32,15 +33,27 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
   private final int pmtIndex;
   private final String internalPrivacyGroup;
 
-  ExecutedPrivateTransaction(final BlockHeader blockHeader, final Transaction pmt,
-      final TransactionLocation pmtLocation, final String internalPrivacyGroup,
+  ExecutedPrivateTransaction(
+      final BlockHeader blockHeader,
+      final Transaction pmt,
+      final TransactionLocation pmtLocation,
+      final String internalPrivacyGroup,
       final PrivateTransaction privateTransaction) {
-    this(blockHeader.getHash(), blockHeader.getNumber(), pmt.getHash(),
-        pmtLocation.getTransactionIndex(), internalPrivacyGroup, privateTransaction);
+    this(
+        blockHeader.getHash(),
+        blockHeader.getNumber(),
+        pmt.getHash(),
+        pmtLocation.getTransactionIndex(),
+        internalPrivacyGroup,
+        privateTransaction);
   }
 
-  ExecutedPrivateTransaction(final Hash blockHash, final long blockNumber,
-      final Hash pmtHash, final int pmtIndex, final String internalPrivacyGroupId,
+  ExecutedPrivateTransaction(
+      final Hash blockHash,
+      final long blockNumber,
+      final Hash pmtHash,
+      final int pmtIndex,
+      final String internalPrivacyGroupId,
       final PrivateTransaction privateTransaction) {
     super(privateTransaction);
     this.blockHash = blockHash;
@@ -48,7 +61,6 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
     this.pmtHash = pmtHash;
     this.pmtIndex = pmtIndex;
     this.internalPrivacyGroup = internalPrivacyGroupId;
-
   }
 
   public Hash getBlockHash() {
@@ -92,16 +104,16 @@ public class ExecutedPrivateTransaction extends PrivateTransaction {
 
     final ExecutedPrivateTransaction that = (ExecutedPrivateTransaction) o;
 
-    return blockNumber == that.blockNumber &&
-        pmtIndex == that.pmtIndex &&
-        blockHash.equals(that.blockHash) &&
-        pmtHash.equals(that.pmtHash) &&
-        internalPrivacyGroup.equals((that.internalPrivacyGroup));
+    return blockNumber == that.blockNumber
+        && pmtIndex == that.pmtIndex
+        && blockHash.equals(that.blockHash)
+        && pmtHash.equals(that.pmtHash)
+        && internalPrivacyGroup.equals((that.internalPrivacyGroup));
   }
 
   @Override
   public int hashCode() {
-    return Objects
-        .hash(super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex, internalPrivacyGroup);
+    return Objects.hash(
+        super.hashCode(), blockHash, blockNumber, pmtHash, pmtIndex, internalPrivacyGroup);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -49,8 +49,8 @@ public class MultiTenancyPrivacyController implements PrivacyController {
   }
 
   @Override
-  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
-      final String enclaveKey) {
+  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(
+      final Hash pmtHash, final String enclaveKey) {
     return privacyController.findPrivateTransactionByPmtHash(pmtHash, enclaveKey);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -49,6 +49,12 @@ public class MultiTenancyPrivacyController implements PrivacyController {
   }
 
   @Override
+  public Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
+      final String enclaveKey) {
+    return privacyController.findPrivateTransactionByPmtHash(pmtHash, enclaveKey);
+  }
+
+  @Override
   public String sendTransaction(
       final PrivateTransaction privateTransaction,
       final String enclavePublicKey,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -31,6 +31,9 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public interface PrivacyController {
 
+  Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
+      final String enclaveKey);
+
   String sendTransaction(
       PrivateTransaction privateTransaction,
       String enclavePublicKey,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -31,8 +31,8 @@ import org.apache.tuweni.bytes.Bytes32;
 
 public interface PrivacyController {
 
-  Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(final Hash pmtHash,
-      final String enclaveKey);
+  Optional<ExecutedPrivateTransaction> findPrivateTransactionByPmtHash(
+      final Hash pmtHash, final String enclaveKey);
 
   String sendTransaction(
       PrivateTransaction privateTransaction,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
@@ -213,6 +213,16 @@ public class PrivateTransaction {
     this.restriction = restriction;
   }
 
+  protected PrivateTransaction(final PrivateTransaction privateTransaction) {
+    this(privateTransaction.getNonce(), privateTransaction.getGasPrice(),
+        privateTransaction.getGasLimit(), privateTransaction.getTo(), privateTransaction.getValue(),
+        privateTransaction.getSignature(), privateTransaction.getPayload(),
+        privateTransaction.getSender(), privateTransaction.getChainId(),
+        privateTransaction.getPrivateFrom(),
+        privateTransaction.getPrivateFor(), privateTransaction.getPrivacyGroupId(),
+        privateTransaction.getRestriction());
+  }
+
   /**
    * Returns the transaction nonce.
    *

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransaction.java
@@ -214,12 +214,19 @@ public class PrivateTransaction {
   }
 
   protected PrivateTransaction(final PrivateTransaction privateTransaction) {
-    this(privateTransaction.getNonce(), privateTransaction.getGasPrice(),
-        privateTransaction.getGasLimit(), privateTransaction.getTo(), privateTransaction.getValue(),
-        privateTransaction.getSignature(), privateTransaction.getPayload(),
-        privateTransaction.getSender(), privateTransaction.getChainId(),
+    this(
+        privateTransaction.getNonce(),
+        privateTransaction.getGasPrice(),
+        privateTransaction.getGasLimit(),
+        privateTransaction.getTo(),
+        privateTransaction.getValue(),
+        privateTransaction.getSignature(),
+        privateTransaction.getPayload(),
+        privateTransaction.getSender(),
+        privateTransaction.getChainId(),
         privateTransaction.getPrivateFrom(),
-        privateTransaction.getPrivateFor(), privateTransaction.getPrivacyGroupId(),
+        privateTransaction.getPrivateFor(),
+        privateTransaction.getPrivacyGroupId(),
         privateTransaction.getRestriction());
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocator.java
@@ -70,6 +70,7 @@ public class PrivateTransactionLocator {
    * @param pmtHash the hash of the PMT associated with the private transaction
    * @param enclaveKey participant public key that must match the private key used to decrypt the
    *     payload
+   * @return An executed private transaction
    */
   public Optional<ExecutedPrivateTransaction> findByPmtHash(
       final Hash pmtHash, final String enclaveKey) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocator.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.privacy;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.enclave.Enclave;
+import org.hyperledger.besu.enclave.EnclaveClientException;
+import org.hyperledger.besu.enclave.types.ReceiveResponse;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.TransactionLocation;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
+import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
+
+public class PrivateTransactionLocator {
+
+  private static final Logger LOG = getLogger();
+
+  private final Blockchain blockchain;
+  private final Enclave enclave;
+  private final PrivateStateStorage privateStateStorage;
+
+  public PrivateTransactionLocator(final Blockchain blockchain, final Enclave enclave,
+      final PrivateStateStorage privateStateStorage) {
+    this.blockchain = blockchain;
+    this.enclave = enclave;
+    this.privateStateStorage = privateStateStorage;
+  }
+
+  /**
+   * Returns a private transaction with extra data (block and pmt information). The private
+   * transaction is retrieved from the Enclave, either as a single transaction or from an existing
+   * "blob".<br> In both cases, we are passing the enclaveKey (public key of the participant) down
+   * to the Enclave, with the expectation that the Enclave will only return the payload if the
+   * matching private key of the enclaveKey passed as a parameter is able to be used to decrypt the
+   * payload.
+   *
+   * This enclaveKey "validation" in the Enclave makes retrieving a payload multi-tenancy safe.
+   *
+   * @param pmtHash the hash of the PMT associated with the private transaction
+   * @param enclaveKey participant public key that must match the private key used to decrypt the
+   * payload
+   */
+  public Optional<ExecutedPrivateTransaction> findByPmtHash(final Hash pmtHash,
+      final String enclaveKey) {
+    final Optional<TransactionLocation> maybePmtLocation = blockchain
+        .getTransactionLocation(pmtHash);
+    if (maybePmtLocation.isEmpty()) {
+      return Optional.empty();
+    }
+
+    /*
+      If tx location isn't empty it is safe to assume that the block header and transaction exist.
+      Therefore, using orElseThrow here makes sense
+     */
+    final TransactionLocation pmtLocation = maybePmtLocation.get();
+    final BlockHeader blockHeader = blockchain.getBlockHeader(pmtLocation.getBlockHash())
+        .orElseThrow();
+    final Transaction pmt = blockchain.getTransactionByHash(pmtHash).orElseThrow();
+    final String payloadKey = readPayloadKeyFromPmt(pmt);
+
+    return tryFetchingPrivateTransactionFromEnclave(payloadKey, enclaveKey)
+        .or(() -> tryFetchingTransactionFromAddBlob(blockHeader.getHash(), pmtHash, enclaveKey))
+        .map(tx -> new ExecutedPrivateTransaction(blockHeader, pmt, pmtLocation, tx));
+  }
+
+  private String readPayloadKeyFromPmt(final Transaction privacyMarkerTx) {
+    return privacyMarkerTx.getPayload().slice(0, 32).toBase64String();
+  }
+
+  /**
+   * Retrieves a single private transaction from the Enclave
+   *
+   * @param payloadKey unique key identifying the payload
+   * @param enclaveKey participant public key that must match the private key used to decrypt the
+   * payload
+   * @return an optional containing the private transaction, if found. Or an empty optional if the
+   * private transaction couldnt' be found.
+   */
+  private Optional<PrivateTransaction> tryFetchingPrivateTransactionFromEnclave(
+      final String payloadKey,
+      final String enclaveKey) {
+    return retrievePayloadFromEnclave(payloadKey, enclaveKey)
+        .map(this::readPrivateTransactionFromPayload);
+  }
+
+  private Optional<ReceiveResponse> retrievePayloadFromEnclave(final String payloadKey,
+      final String enclaveKey) {
+    try {
+      return Optional.of(enclave.receive(payloadKey, enclaveKey));
+    } catch (final EnclaveClientException e) {
+      // Enclave throws an exception with a 404 status code if the payload isn't found
+      if (e.getStatusCode() == 404) {
+        return Optional.empty();
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  private PrivateTransaction readPrivateTransactionFromPayload(
+      final ReceiveResponse receiveResponse) {
+    final PrivateTransaction privateTransaction;
+    final BytesValueRLPInput input = new BytesValueRLPInput(
+        Bytes.fromBase64String(new String(receiveResponse.getPayload(), UTF_8)), false);
+
+    /*
+      When using on-chain privacy groups, the payload is a list with the first element being the
+      private transaction RLP and the second element being the version. This is why we have the
+      nextIsList() check.
+     */
+    try {
+      input.enterList();
+      if (input.nextIsList()) {
+        // private transaction and version (we only read the first element in the list)
+        privateTransaction = PrivateTransaction.readFrom(input);
+        input.leaveListLenient();
+      } else {
+        // private transaction only (read the whole RLP)
+        input.reset();
+        privateTransaction = PrivateTransaction.readFrom(input);
+      }
+    } catch (RLPException e) {
+      LOG.debug("Error de-serializing private transaction from enclave", e);
+      throw e;
+    }
+
+    return privateTransaction;
+  }
+
+  private Optional<PrivateTransaction> tryFetchingTransactionFromAddBlob(final Bytes32 blockHash,
+      final Hash expectedPmtHash, final String enclaveKey) {
+    LOG.trace("Fetching transaction information from add blob");
+
+    final Optional<PrivacyGroupHeadBlockMap> privacyGroupHeadBlockMapOptional =
+        privateStateStorage.getPrivacyGroupHeadBlockMap(blockHash);
+
+    if (privacyGroupHeadBlockMapOptional.isPresent()) {
+      final Set<Bytes32> mappedPrivacyGroupIds = privacyGroupHeadBlockMapOptional.get().keySet();
+
+      for (final Bytes32 privacyGroupId : mappedPrivacyGroupIds) {
+        final Optional<Bytes32> addDataKey = privateStateStorage.getAddDataKey(privacyGroupId);
+
+        if (addDataKey.isPresent()) {
+          final Optional<ReceiveResponse> receiveResponse = retrievePayloadFromEnclave(
+              addDataKey.get().toBase64String(), enclaveKey);
+          if (receiveResponse.isEmpty()) {
+            return Optional.empty();
+          }
+
+          final Bytes payload = Bytes
+              .wrap(Base64.getDecoder().decode(receiveResponse.get().getPayload()));
+          final List<PrivateTransactionWithMetadata> privateTransactionWithMetadataList =
+              deserializeAddToGroupPayload(payload);
+
+          for (final PrivateTransactionWithMetadata privateTx : privateTransactionWithMetadataList) {
+            final Hash actualPrivacyMarkerTransactionHash =
+                privateTx
+                    .getPrivateTransactionMetadata()
+                    .getPrivacyMarkerTransactionHash();
+
+            if (expectedPmtHash.equals(actualPrivacyMarkerTransactionHash)) {
+              return Optional.of(privateTx.getPrivateTransaction());
+            }
+          }
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private List<PrivateTransactionWithMetadata> deserializeAddToGroupPayload(
+      final Bytes encodedAddToGroupPayload) {
+    final ArrayList<PrivateTransactionWithMetadata> deserializedResponse = new ArrayList<>();
+    final BytesValueRLPInput bytesValueRLPInput =
+        new BytesValueRLPInput(encodedAddToGroupPayload, false);
+    final int noOfEntries = bytesValueRLPInput.enterList();
+    for (int i = 0; i < noOfEntries; i++) {
+      deserializedResponse.add(PrivateTransactionWithMetadata.readFrom(bytesValueRLPInput));
+    }
+    bytesValueRLPInput.leaveList();
+    return deserializedResponse;
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionWithMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionWithMetadata.java
@@ -15,11 +15,16 @@
 package org.hyperledger.besu.ethereum.privacy;
 
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateTransactionMetadata;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+
+import org.apache.tuweni.bytes.Bytes;
 
 public class PrivateTransactionWithMetadata {
   private final PrivateTransaction privateTransaction;
@@ -54,6 +59,17 @@ public class PrivateTransactionWithMetadata {
 
   public PrivateTransactionMetadata getPrivateTransactionMetadata() {
     return privateTransactionMetadata;
+  }
+
+  public static List<PrivateTransactionWithMetadata> readListFromPayload(final Bytes payload) {
+    final ArrayList<PrivateTransactionWithMetadata> deserializedResponse = new ArrayList<>();
+    final BytesValueRLPInput bytesValueRLPInput = new BytesValueRLPInput(payload, false);
+    final int noOfEntries = bytesValueRLPInput.enterList();
+    for (int i = 0; i < noOfEntries; i++) {
+      deserializedResponse.add(PrivateTransactionWithMetadata.readFrom(bytesValueRLPInput));
+    }
+    bytesValueRLPInput.leaveList();
+    return deserializedResponse;
   }
 
   @Override

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
@@ -116,7 +116,12 @@ public class PrivateTransactionLocatorTest {
     mockEnclaveForExistingPayload(privacyGroupId, pmt, privateTransaction, Optional.empty());
 
     return new ExecutedPrivateTransaction(
-        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+        blockHeader.getHash(),
+        blockHeader.getNumber(),
+        pmt.getHash(),
+        pmtLocation.getTransactionIndex(),
+        privacyGroupId,
+        privateTransaction);
   }
 
   @Test
@@ -145,7 +150,12 @@ public class PrivateTransactionLocatorTest {
     mockEnclaveForExistingPayload(privacyGroupId, pmt, privateTransaction, Optional.of(txVersion));
 
     return new ExecutedPrivateTransaction(
-        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+        blockHeader.getHash(),
+        blockHeader.getNumber(),
+        pmt.getHash(),
+        pmtLocation.getTransactionIndex(),
+        privacyGroupId,
+        privateTransaction);
   }
 
   @Test
@@ -220,7 +230,12 @@ public class PrivateTransactionLocatorTest {
     mockEnclaveForAddBlob(pmt, privateTransaction, addDataKey);
 
     return new ExecutedPrivateTransaction(
-        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+        blockHeader.getHash(),
+        blockHeader.getNumber(),
+        pmt.getHash(),
+        pmtLocation.getTransactionIndex(),
+        privacyGroupId,
+        privateTransaction);
   }
 
   private void mockEnclaveForExistingPayload(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.privacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.encodePrivateTransaction;
+import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.generateAddToGroupReceiveResponse;
+import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.privateTransactionBesu;
+import static org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture.privateTransactionLegacy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.enclave.Enclave;
+import org.hyperledger.besu.enclave.EnclaveClientException;
+import org.hyperledger.besu.enclave.types.ReceiveResponse;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.TransactionLocation;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.PrivateTransactionDataFixture;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
+import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrivateTransactionLocatorTest {
+
+  private final String participantKey = "R24z0/bq4uTz0x1JxjdyRwfydh8Gi0L4oYYR0XpKdmc=";
+
+  @Mock private Blockchain blockchain;
+  @Mock private Enclave enclave;
+  @Mock private PrivateStateStorage privateStateStorage;
+
+  private PrivateTransactionLocator locator;
+
+  @Before
+  public void before() {
+    locator = new PrivateTransactionLocator(blockchain, enclave, privateStateStorage);
+  }
+
+  @Test
+  public void whenPmtDoesNotExistReturnEmpty() {
+    final Hash pmtHash = Hash.hash(Bytes.random(32));
+    when(blockchain.getTransactionLocation(eq(pmtHash))).thenReturn(Optional.empty());
+
+    final Optional<ExecutedPrivateTransaction> tx = locator.findByPmtHash(pmtHash, participantKey);
+
+    assertThat(tx).isEmpty();
+  }
+
+  @Test
+  public void locateLegacyPrivateTransactionSentToOffchainPrivacyGroup() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransaction();
+    final PrivateTransaction privateTransaction = privateTransactionLegacy();
+
+    final ExecutedPrivateTransaction expectedPrivateTx =
+        createExecutedPrivateTransaction(pmt, privateTransaction);
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isPresent().hasValue(expectedPrivateTx);
+  }
+
+  @Test
+  public void locateBesuPrivateTransactionSentToOffchainPrivacyGroup() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransaction();
+    final PrivateTransaction privateTransaction = privateTransactionBesu();
+
+    final ExecutedPrivateTransaction expectedPrivateTx =
+        createExecutedPrivateTransaction(pmt, privateTransaction);
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isPresent().hasValue(expectedPrivateTx);
+  }
+
+  private ExecutedPrivateTransaction createExecutedPrivateTransaction(
+      final Transaction pmt, final PrivateTransaction privateTransaction) {
+    final BlockHeader blockHeader = createBlockHeader();
+    final TransactionLocation pmtLocation = createPmtLocation(pmt, blockHeader);
+
+    // legacy transactions don't have a privacy group id, but Orion will return the internal privacy
+    // group id.
+    final String privacyGroupId =
+        privateTransaction.getPrivacyGroupId().orElse(Bytes.random(32)).toBase64String();
+
+    mockEnclaveForExistingPayload(privacyGroupId, pmt, privateTransaction, Optional.empty());
+
+    return new ExecutedPrivateTransaction(
+        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+  }
+
+  @Test
+  public void locateBesuPrivateTransactionSentToOnchainPrivacyGroup() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransactionOnChain();
+    final PrivateTransaction privateTransaction = privateTransactionBesu();
+
+    final ExecutedPrivateTransaction expectedPrivateTx =
+        createExecutedPrivateTransactionWithVersion(pmt, privateTransaction);
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isPresent().hasValue(expectedPrivateTx);
+  }
+
+  private ExecutedPrivateTransaction createExecutedPrivateTransactionWithVersion(
+      final Transaction pmt, final PrivateTransaction privateTransaction) {
+    final BlockHeader blockHeader = createBlockHeader();
+    final TransactionLocation pmtLocation = createPmtLocation(pmt, blockHeader);
+
+    final String privacyGroupId =
+        privateTransaction.getPrivacyGroupId().orElseThrow().toBase64String();
+
+    final Bytes32 txVersion = Bytes32.wrap(Bytes.random(32));
+    mockEnclaveForExistingPayload(privacyGroupId, pmt, privateTransaction, Optional.of(txVersion));
+
+    return new ExecutedPrivateTransaction(
+        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+  }
+
+  @Test
+  public void locateBesuPrivateTransactionFromAddBlobSentToOnchainPrivacyGroup() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransactionOnChain();
+    final PrivateTransaction privateTransaction = privateTransactionBesu();
+
+    final ExecutedPrivateTransaction expectedPrivateTx =
+        createExecutedPrivateTransactionFromAddBlob(pmt, privateTransaction);
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isPresent().hasValue(expectedPrivateTx);
+  }
+
+  @Test
+  public void locatePrivateTransactionWithNoEntryOnPGHeadBlockMap() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransactionOnChain();
+    final PrivateTransaction privateTransaction = privateTransactionBesu();
+
+    createExecutedPrivateTransactionFromAddBlob(pmt, privateTransaction);
+    mockEnclaveForNonExistingPayload(pmt);
+    // override private state removing any pg head block mapping
+    when(privateStateStorage.getPrivacyGroupHeadBlockMap(any())).thenReturn(Optional.empty());
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isEmpty();
+  }
+
+  @Test
+  public void locateBesuPrivateTransactionNotFoundInAddBlob() {
+    final Transaction pmt = PrivateTransactionDataFixture.privacyMarkerTransactionOnChain();
+    final PrivateTransaction privateTransaction = privateTransactionBesu();
+
+    createExecutedPrivateTransactionFromAddBlob(pmt, privateTransaction);
+    mockEnlaveNoSingleTxOrAddBlob();
+
+    final Optional<ExecutedPrivateTransaction> executedPrivateTx =
+        locator.findByPmtHash(pmt.getHash(), participantKey);
+
+    assertThat(executedPrivateTx).isEmpty();
+  }
+
+  /*
+   Overrride enclave so it returns 404 when searching for a single tx (first call) and when
+   searching for the add blob (second call)
+  */
+  private void mockEnlaveNoSingleTxOrAddBlob() {
+    final EnclaveClientException payloadNotFoundException =
+        new EnclaveClientException(404, "Payload not found");
+    when(enclave.receive(anyString(), eq(participantKey)))
+        .thenThrow(payloadNotFoundException)
+        .thenThrow(payloadNotFoundException);
+  }
+
+  private ExecutedPrivateTransaction createExecutedPrivateTransactionFromAddBlob(
+      final Transaction pmt, final PrivateTransaction privateTransaction) {
+    final BlockHeader blockHeader = createBlockHeader();
+    final TransactionLocation pmtLocation = createPmtLocation(pmt, blockHeader);
+    final String privacyGroupId =
+        privateTransaction.getPrivacyGroupId().orElseThrow().toBase64String();
+
+    mockStorageWithPrivacyGroupBlockHeaderMap(privacyGroupId, blockHeader);
+
+    final Bytes32 addDataKey = Bytes32.random();
+    when(privateStateStorage.getAddDataKey(any(Bytes32.class))).thenReturn(Optional.of(addDataKey));
+
+    mockEnclaveForNonExistingPayload(pmt);
+    mockEnclaveForAddBlob(pmt, privateTransaction, addDataKey);
+
+    return new ExecutedPrivateTransaction(
+        blockHeader, pmt, pmtLocation, privacyGroupId, privateTransaction);
+  }
+
+  private void mockEnclaveForExistingPayload(
+      final String privacyGroupId,
+      final Transaction pmt,
+      final PrivateTransaction privateTransaction,
+      final Optional<Bytes32> version) {
+    final String privateTxEnclaveKey = pmt.getData().orElseThrow().toBase64String();
+    final byte[] encodePrivateTransaction =
+        encodePrivateTransaction(privateTransaction, version)
+            .toBase64String()
+            .getBytes(StandardCharsets.UTF_8);
+    when(enclave.receive(eq(privateTxEnclaveKey), eq(participantKey)))
+        .thenReturn(new ReceiveResponse(encodePrivateTransaction, privacyGroupId, participantKey));
+  }
+
+  private void mockStorageWithPrivacyGroupBlockHeaderMap(
+      final String privacyGroupId, final BlockHeader blockHeader) {
+    final PrivacyGroupHeadBlockMap privacyGroupHeadBlockMap =
+        new PrivacyGroupHeadBlockMap(
+            Collections.singletonMap(
+                Bytes32.wrap(Bytes.fromBase64String(privacyGroupId)), blockHeader.getHash()));
+    when(privateStateStorage.getPrivacyGroupHeadBlockMap(eq(blockHeader.getHash())))
+        .thenReturn(Optional.of(privacyGroupHeadBlockMap));
+  }
+
+  private void mockEnclaveForNonExistingPayload(final Transaction pmt) {
+    final String privateTxEnclaveKey = pmt.getData().orElseThrow().toBase64String();
+    final EnclaveClientException payloadNotFoundException =
+        new EnclaveClientException(404, "Payload not found");
+    when(enclave.receive(eq(privateTxEnclaveKey), eq(participantKey)))
+        .thenThrow(payloadNotFoundException);
+  }
+
+  private void mockEnclaveForAddBlob(
+      final Transaction pmt,
+      final PrivateTransaction privateTransaction,
+      final Bytes32 addDataKey) {
+    final ReceiveResponse addBlobResponse =
+        generateAddToGroupReceiveResponse(privateTransaction, pmt);
+
+    when(enclave.receive(eq(addDataKey.toBase64String()), eq(participantKey)))
+        .thenReturn(addBlobResponse);
+  }
+
+  private BlockHeader createBlockHeader() {
+    final Hash blockHash = Hash.hash(Bytes.random(32));
+    final BlockHeader blockHeader = mock(BlockHeader.class);
+
+    when(blockHeader.getHash()).thenReturn(blockHash);
+    when(blockHeader.getNumber()).thenReturn(1L);
+    when(blockchain.getBlockHeader(eq(blockHash))).thenReturn(Optional.of(blockHeader));
+
+    return blockHeader;
+  }
+
+  private TransactionLocation createPmtLocation(
+      final Transaction pmt, final BlockHeader blockHeader) {
+    final TransactionLocation pmtLocation = new TransactionLocation(blockHeader.getHash(), 0);
+    when(blockchain.getTransactionLocation(eq(pmt.getHash()))).thenReturn(Optional.of(pmtLocation));
+    when(blockchain.getTransactionByHash(eq(pmt.getHash()))).thenReturn(Optional.of(pmt));
+    return pmtLocation;
+  }
+}


### PR DESCRIPTION
## PR description
- Created method `findPrivateTransactionByPmtHash(..)` on `PrivacyController`. This method is used to return a private transaction that has been executed (contains an associated PMT and the hash of the block that the PMT was included in the chain.
- Updated `PrivGetPrivateTransaction` and `PrivGetPrivateTransactionReceipt` to use the new controller method, avoiding code duplication.
- Updated the code when retrieving the payload from the transactions blob in the Enclave to always use the associated participant public key. This makes the retrieval of this data compatible with multi-tenancy.

**IMPORTANT**: this work is ongoing and complete support for multi-tenancy and flexible privacy groups isn't complete.

(see #879 and #880)