### PR TITLE
Option to run besu after blocks import

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -152,6 +152,9 @@ public class BlocksSubCommand implements Runnable {
         description = "Skip proof of work validation when importing.")
     private final Boolean skipPow = false;
 
+    @Option(names = "--run", description = "Start besu after importing.")
+    private final Boolean runBesu = false;
+
     @SuppressWarnings("unused")
     @Spec
     private CommandSpec spec;
@@ -196,6 +199,10 @@ public class BlocksSubCommand implements Runnable {
               LOG.error("Unable to import blocks from " + path, e);
             }
           }
+        }
+
+        if (runBesu) {
+          parentCommand.parentCommand.run();
         }
       } finally {
         metricsService.ifPresent(MetricsService::stop);

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
@@ -57,7 +57,7 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
           + System.lineSeparator();
 
   private static final String EXPECTED_BLOCK_IMPORT_USAGE =
-      "Usage: besu blocks import [-hV] [--skip-pow-validation-enabled]\n"
+      "Usage: besu blocks import [-hV] [--run] [--skip-pow-validation-enabled]\n"
           + "                          [--format=<format>] [--start-time=<startTime>] [--from\n"
           + "                          [=<FILE>...]]... [<FILE>...]\n"
           + "This command imports blocks from a file into the database.\n"
@@ -66,6 +66,7 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
           + "                             are: RLP, JSON (default: RLP).\n"
           + "      --from[=<FILE>...]   File containing blocks to import.\n"
           + "  -h, --help               Show this help message and exit.\n"
+          + "      --run                Start besu after importing.\n"
           + "      --skip-pow-validation-enabled\n"
           + "                           Skip proof of work validation when importing.\n"
           + "      --start-time=<startTime>\n"


### PR DESCRIPTION
Add an option to run besu after blocks import.  This is aimed to cut the
startup penalty in half for hive testing, combining the block import
with the node execution.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
