### PR TITLE
Don't throw NoSuchElementException when the last checkpoint range fails validation

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/CheckpointHeaderValidationStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/CheckpointHeaderValidationStep.java
@@ -47,14 +47,20 @@ public class CheckpointHeaderValidationStep<C>
     if (isValid(rangeStart, firstHeaderToImport)) {
       return checkpointRangeHeaders.getHeadersToImport().stream();
     } else {
-      final BlockHeader rangeEnd = checkpointRangeHeaders.getCheckpointRange().getEnd();
+      final String rangeEndDescription;
+      if (checkpointRangeHeaders.getCheckpointRange().hasEnd()) {
+        final BlockHeader rangeEnd = checkpointRangeHeaders.getCheckpointRange().getEnd();
+        rangeEndDescription =
+            String.format("#%d (%s)", rangeEnd.getNumber(), rangeEnd.getBlockHash());
+      } else {
+        rangeEndDescription = "chain head";
+      }
       final String errorMessage =
           String.format(
-              "Invalid checkpoint headers.  Headers downloaded between #%d (%s) and #%d (%s) do not connect at #%d (%s)",
+              "Invalid checkpoint headers.  Headers downloaded between #%d (%s) and %s do not connect at #%d (%s)",
               rangeStart.getNumber(),
               rangeStart.getHash(),
-              rangeEnd.getNumber(),
-              rangeEnd.getHash(),
+              rangeEndDescription,
               firstHeaderToImport.getNumber(),
               firstHeaderToImport.getHash());
       throw new InvalidBlockException(


### PR DESCRIPTION
## PR description
When the first header in the last checkpoint range of a sync fails validation, Besu attempts to create an `InvalidBlockException` which includes the range being downloaded.  Since this is the last checkpoint range there is no end so a `NoSuchElement` exception is thrown while trying to build that error.

## Fixed Issue(s)
#582 and #992 are encountering this error.  Both may have separate underlying issues that need further investigation to determine why the block is invalid.