### PR TITLE
Allow nodes to start in parallel during AT

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.tests.acceptance.dsl.node;
 import static org.hyperledger.besu.cli.config.NetworkName.DEV;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 
-import java.util.concurrent.ConcurrentHashMap;
 import org.hyperledger.besu.Runner;
 import org.hyperledger.besu.RunnerBuilder;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
@@ -57,6 +56,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.node;
 import static org.hyperledger.besu.cli.config.NetworkName.DEV;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 
+import java.util.concurrent.ConcurrentHashMap;
 import org.hyperledger.besu.Runner;
 import org.hyperledger.besu.RunnerBuilder;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
@@ -70,7 +71,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
   private static final Logger LOG = LogManager.getLogger();
   private final Map<String, Runner> besuRunners = new HashMap<>();
 
-  private final Map<Node, BesuPluginContextImpl> besuPluginContextMap = new HashMap<>();
+  private final Map<Node, BesuPluginContextImpl> besuPluginContextMap = new ConcurrentHashMap<>();
 
   private BesuPluginContextImpl buildPluginContext(
       final BesuNode node,

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/cluster/Cluster.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/cluster/Cluster.java
@@ -85,7 +85,8 @@ public class Cluster implements AutoCloseable {
 
     final Optional<? extends RunnableNode> bootnode = selectAndStartBootnode(nodes);
 
-    nodes.parallelStream()
+    nodes
+        .parallelStream()
         .filter(node -> bootnode.map(boot -> boot != node).orElse(true))
         .forEach(this::startNode);
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/cluster/Cluster.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/cluster/Cluster.java
@@ -85,7 +85,7 @@ public class Cluster implements AutoCloseable {
 
     final Optional<? extends RunnableNode> bootnode = selectAndStartBootnode(nodes);
 
-    nodes.stream()
+    nodes.parallelStream()
         .filter(node -> bootnode.map(boot -> boot != node).orElse(true))
         .forEach(this::startNode);
 


### PR DESCRIPTION
In AT, when starting a cluster of nodes, they are to be started in parallel rather than sequentially.

This appears to not affect test stability, while offering a time saving.

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>
