### PR TITLE
Add logging to highlight No Sync Target problem

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -318,6 +318,7 @@ public class EthPeer {
       if (callback == null) {
         return;
       }
+      LOG.debug("Triggering peer connection callback for {}", connection.getPeerInfo().getNodeId());
       callback.accept(this);
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -264,6 +264,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
 
   @Override
   public void handleNewConnection(final PeerConnection connection) {
+    LOG.debug("Handling new connection from {}", connection.getPeerInfo().getNodeId());
     ethPeers.registerConnection(connection, peerValidators);
     final EthPeer peer = ethPeers.peer(connection);
     if (peer.statusHasBeenSentToPeer()) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/WaitForPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/WaitForPeerTask.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager.task;
 
+import java.util.Random;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -40,14 +41,16 @@ public class WaitForPeerTask extends AbstractEthTask<Void> {
 
   @Override
   protected void executeTask() {
+    final Random rand = new Random();
+    final int thisFuture = rand.nextInt();
     final EthPeers ethPeers = ethContext.getEthPeers();
     LOG.debug(
-        "Waiting for new peer connection. {} peers currently connected.", ethPeers.peerCount());
+        "{} - Waiting for new peer connection. {} peers currently connected.", thisFuture, ethPeers.peerCount());
     // Listen for peer connections and complete task when we hit our target
     peerListenerId =
         ethPeers.subscribeConnect(
             (peer) -> {
-              LOG.debug("Finished waiting for peer connection.");
+              LOG.debug("{} Finished waiting for peer connection ({})", thisFuture, peer.nodeId());
               // We hit our target
               result.get().complete(null);
             });

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/WaitForPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/WaitForPeerTask.java
@@ -14,10 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager.task;
 
-import java.util.Random;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.util.Random;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,7 +46,9 @@ public class WaitForPeerTask extends AbstractEthTask<Void> {
     final int thisFuture = rand.nextInt();
     final EthPeers ethPeers = ethContext.getEthPeers();
     LOG.debug(
-        "{} - Waiting for new peer connection. {} peers currently connected.", thisFuture, ethPeers.peerCount());
+        "{} - Waiting for new peer connection. {} peers currently connected.",
+        thisFuture,
+        ethPeers.peerCount());
     // Listen for peer connections and complete task when we hit our target
     peerListenerId =
         ethPeers.subscribeConnect(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetManager.java
@@ -102,7 +102,7 @@ public abstract class SyncTargetManager {
                                 .orElseGet(this::waitForPeerAndThenSetSyncTarget));
               } else {
                 return waitForPeerAndThenSetSyncTarget();
-            }
+              }
             });
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetManager.java
@@ -102,7 +102,7 @@ public abstract class SyncTargetManager {
                                 .orElseGet(this::waitForPeerAndThenSetSyncTarget));
               } else {
                 return waitForPeerAndThenSetSyncTarget();
-              }
+            }
             });
   }
 

--- a/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
+++ b/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
@@ -14,6 +14,9 @@
  */
 package org.hyperledger.besu.util;
 
+import com.google.common.collect.Lists;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
@@ -104,8 +107,10 @@ public class Subscribers<T> {
   public void forEach(final Consumer<T> action) {
     final Random rand = new Random();
     final int thisIteration = rand.nextInt();
-    subscribers
-        .values()
+    final List<T> callbacks = Lists.newArrayList();
+    subscribers.values().forEach(callbacks::add);
+
+    callbacks
         .forEach(
             subscriber -> {
               LOG.debug("Executing subscriber in executor {}", thisIteration);

--- a/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
+++ b/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.util;
 
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -101,10 +102,13 @@ public class Subscribers<T> {
    * @param action the action to perform for each subscriber
    */
   public void forEach(final Consumer<T> action) {
+    final Random rand = new Random();
+    final int thisIteration = rand.nextInt();
     subscribers
         .values()
         .forEach(
             subscriber -> {
+              LOG.debug("Executing subscriber in executor {}", thisIteration);
               try {
                 action.accept(subscriber);
               } catch (Throwable throwable) {

--- a/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
+++ b/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.util;
 
-import com.google.common.collect.Lists;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -23,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -110,20 +109,19 @@ public class Subscribers<T> {
     final List<T> callbacks = Lists.newArrayList();
     subscribers.values().forEach(callbacks::add);
 
-    callbacks
-        .forEach(
-            subscriber -> {
-              LOG.debug("Executing subscriber in executor {}", thisIteration);
-              try {
-                action.accept(subscriber);
-              } catch (Throwable throwable) {
-                if (suppressCallbackExceptions) {
-                  LOG.error("Error in callback: ", throwable);
-                } else {
-                  throw throwable;
-                }
-              }
-            });
+    callbacks.forEach(
+        subscriber -> {
+          LOG.debug("Executing subscriber in executor {}", thisIteration);
+          try {
+            action.accept(subscriber);
+          } catch (Throwable throwable) {
+            if (suppressCallbackExceptions) {
+              LOG.error("Error in callback: ", throwable);
+            } else {
+              throw throwable;
+            }
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
Going through a test log file, and I saw I was getting a LOT of:
`INFO  | FullSyncTargetManager | No sync target, waiting for peers:`
Log lines for a single node - specifically at startup when no blocks are yet mined.

From additional logging added - it looks like we’ve got a loop via “WaitForPeerTask --> EthPeers --> Subscribers” - where:
* SyncTargetManager creates a WaitForPeerTask
* WaitForPeerTask registers a handler against new connections
* A new connection is found, Subscribers fires all registered listeners
* In the Subscribers thread, the WaitForPeersTask is ended, but no sync-target can be found, so:
* A NEW WaitForPeersTask is created, which registers against New Connections … which is IMMEDIATELY fired by “Subscribers” (as we’re still in the original event-handler! repeat from step 1.

This is hypothesis underpinned with log data … so I could be misinterpreting …

I also made it so that Subscribers copy handlers prior to execution, such that a handler cannot re-add itself to the list (probably not a great fix, but proof of concept) (