### PR TITLE
Add cli option to specify the name of the loadbalancer used by the Kubernetes nat manager 

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -136,6 +136,7 @@ public class RunnerBuilder {
   private String p2pListenInterface = NetworkUtility.INADDR_ANY;
   private int p2pListenPort;
   private NatMethod natMethod = NatMethod.AUTO;
+  private String natManagerPodName;
   private int maxPeers;
   private boolean limitRemoteWireConnectionsEnabled = false;
   private float fractionRemoteConnectionsAllowed;
@@ -203,6 +204,11 @@ public class RunnerBuilder {
 
   public RunnerBuilder natMethod(final NatMethod natMethod) {
     this.natMethod = natMethod;
+    return this;
+  }
+
+  public RunnerBuilder natManagerPodName(final String natManagerPodName) {
+    this.natManagerPodName = natManagerPodName;
     return this;
   }
 
@@ -631,7 +637,7 @@ public class RunnerBuilder {
         return Optional.of(
             new DockerNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
       case KUBERNETES:
-        return Optional.of(new KubernetesNatManager());
+        return Optional.of(new KubernetesNatManager(natManagerPodName));
       case NONE:
       default:
         return Optional.empty();

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -31,6 +31,7 @@ import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_REMOTE
 import static org.hyperledger.besu.metrics.BesuMetricCategory.DEFAULT_METRIC_CATEGORIES;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PORT;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PUSH_PORT;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_POD_NAME_FILTER;
 
 import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.Runner;
@@ -418,6 +419,13 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
           "Specify the NAT circumvention method to be used, possible values are ${COMPLETION-CANDIDATES}."
               + " NONE disables NAT functionality. (default: ${DEFAULT-VALUE})")
   private final NatMethod natMethod = DEFAULT_NAT_METHOD;
+
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
+  @Option(
+      names = {"--Xnat-manager-pod-name"},
+      description =
+          "Specify the name of the pod that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
+  private String natManagerPodName = DEFAULT_BESU_POD_NAME_FILTER;
 
   @Option(
       names = {"--network-id"},
@@ -1275,6 +1283,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
     validateP2PInterface(p2pInterface);
     validateMiningParams();
+    validateNatParams();
 
     return this;
   }
@@ -1303,6 +1312,17 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       }
     } catch (final UnknownHostException | SocketException e) {
       throw new ParameterException(commandLine, failMessage, e);
+    }
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private void validateNatParams() {
+    if (!(natMethod.equals(NatMethod.AUTO) || natMethod.equals(NatMethod.KUBERNETES))
+        && !natManagerPodName.equals(DEFAULT_BESU_POD_NAME_FILTER)) {
+      throw new ParameterException(
+          this.commandLine,
+          "The `--Xnat-manager-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-manager-pod-name"
+              + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
     }
   }
 
@@ -1943,6 +1963,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .besuController(controller)
             .p2pEnabled(p2pEnabled)
             .natMethod(natMethod)
+            .natManagerPodName(natManagerPodName)
             .discovery(peerDiscoveryEnabled)
             .ethNetworkConfig(ethNetworkConfig)
             .p2pAdvertisedHost(p2pAdvertisedHost)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -422,7 +422,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
   @Option(
-      names = {"--Xnat-manager-pod-name"},
+      names = {"--Xnat-kube-pod-name"},
       description =
           "Specify the name of the pod that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
   private String natManagerPodName = DEFAULT_BESU_POD_NAME_FILTER;
@@ -1321,7 +1321,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         && !natManagerPodName.equals(DEFAULT_BESU_POD_NAME_FILTER)) {
       throw new ParameterException(
           this.commandLine,
-          "The `--Xnat-manager-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-manager-pod-name"
+          "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name"
               + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
     }
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1357,9 +1357,8 @@ public class BesuCommandTest extends CommandTestAbstract {
     Mockito.verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
-            .contains(
-                    "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
-
+        .contains(
+            "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
   }
 
   @Test
@@ -1368,9 +1367,8 @@ public class BesuCommandTest extends CommandTestAbstract {
     Mockito.verifyZeroInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
-            .contains(
-                    "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
-
+        .contains(
+            "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1341,6 +1341,39 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void natManagerPodNamePropertyIsCorrectlyUpdated() {
+    final String podName = "besu-updated";
+    parseCommand("--Xnat-kube-pod-name", podName);
+
+    verify(mockRunnerBuilder).natManagerPodName(eq(podName));
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void natManagerPodNameCannotBeUsedWithNatDockerMethod() {
+    parseCommand("--nat-method", "DOCKER", "--Xnat-kube-pod-name", "besu-updated");
+    Mockito.verifyZeroInteractions(mockRunnerBuilder);
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString())
+            .contains(
+                    "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+
+  }
+
+  @Test
+  public void natManagerPodNameCannotBeUsedWithNatNoneMethod() {
+    parseCommand("--nat-method", "NONE", "--Xnat-kube-pod-name", "besu-updated");
+    Mockito.verifyZeroInteractions(mockRunnerBuilder);
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString())
+            .contains(
+                    "The `--Xnat-kube-pod-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-pod-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+
+  }
+
+  @Test
   public void rpcHttpEnabledPropertyDefaultIsFalse() {
     parseCommand();
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -31,6 +31,7 @@ import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis.NET;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis.PERM;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis.WEB3;
 import static org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration.MAINNET_BOOTSTRAP_NODES;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_POD_NAME_FILTER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
@@ -1324,6 +1325,16 @@ public class BesuCommandTest extends CommandTestAbstract {
     parseCommand();
 
     verify(mockRunnerBuilder).natMethod(eq(NatMethod.AUTO));
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void natManagerPodNamePropertyDefaultIsBesu() {
+    parseCommand();
+
+    verify(mockRunnerBuilder).natManagerPodName(eq(DEFAULT_BESU_POD_NAME_FILTER));
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -213,6 +213,7 @@ public abstract class CommandTestAbstract {
         .thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethod(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.natManagerPodName(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.jsonRpcConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.graphQLConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.webSocketConfiguration(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -21,6 +21,7 @@ security-module="localfile"
 identity="PegaSysEng"
 p2p-enabled=true
 nat-method="NONE"
+Xnat-manager-pod-name="besu"
 discovery-enabled=false
 bootnodes=[
   "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567",

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -21,7 +21,7 @@ security-module="localfile"
 identity="PegaSysEng"
 p2p-enabled=true
 nat-method="NONE"
-Xnat-manager-pod-name="besu"
+Xnat-kube-pod-name="besu"
 discovery-enabled=false
 bootnodes=[
   "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:4567",

--- a/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManager.java
@@ -47,13 +47,15 @@ import org.apache.logging.log4j.Logger;
 public class KubernetesNatManager extends AbstractNatManager {
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final String DEFAULT_BESU_POD_NAME_FILTER = "besu";
+  public static final String DEFAULT_BESU_POD_NAME_FILTER = "besu";
 
   private String internalAdvertisedHost;
+  private final String besuPodNameFilter;
   private final List<NatPortMapping> forwardedPorts = new ArrayList<>();
 
-  public KubernetesNatManager() {
+  public KubernetesNatManager(final String besuPodNameFilter) {
     super(NatMethod.KUBERNETES);
+    this.besuPodNameFilter = besuPodNameFilter;
   }
 
   @Override
@@ -75,9 +77,7 @@ public class KubernetesNatManager extends AbstractNatManager {
       final V1Service service =
           api.listServiceForAllNamespaces(null, null, null, null, null, null, null, null, null)
               .getItems().stream()
-              .filter(
-                  v1Service ->
-                      v1Service.getMetadata().getName().contains(DEFAULT_BESU_POD_NAME_FILTER))
+              .filter(v1Service -> v1Service.getMetadata().getName().contains(besuPodNameFilter))
               .findFirst()
               .orElseThrow(() -> new NatInitializationException("Service not found"));
       updateUsingBesuService(service);

--- a/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesNatManagerTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.nat.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_POD_NAME_FILTER;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
@@ -80,8 +81,8 @@ public final class KubernetesNatManagerTest {
                             .name(NatServiceType.DISCOVERY.getValue())
                             .port(p2pPort)
                             .targetPort(new IntOrString(p2pPort)))));
-    when(v1Service.getMetadata()).thenReturn(new V1ObjectMeta().name("besu"));
-    natManager = new KubernetesNatManager();
+    when(v1Service.getMetadata()).thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_POD_NAME_FILTER));
+    natManager = new KubernetesNatManager(DEFAULT_BESU_POD_NAME_FILTER);
     try {
       natManager.start();
     } catch (Exception ignored) {


### PR DESCRIPTION

## PR description

Add cli option to specify the name of the loadbalancer used by the Kubernetes nat manager 
`--Xnat-manager-pod-name`

We can specify the name of the load balancer

```yaml
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app.kubernetes.io/name: besu
    app.kubernetes.io/release: "1.0.0"
  name: besu-custom-name
spec:
  ports:
  - name: "json-rpc"
    port: 8545
    targetPort: 8545
  - name: "rlpx"
    port: 30303
    targetPort: 30303
  selector:
    app.kubernetes.io/name: besu
    app.kubernetes.io/release: "1.0.0"
  type: LoadBalancer
```

And add the `BESU_XNAT_MANAGER_POD_NAME`on the deployment script of Besu to specify the name.

```yaml
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: besu-config
  labels:
    app.kubernetes.io/name: besu
    app.kubernetes.io/release: 1.0.0
data:
  BESU_LOGGING: "DEBUG"
  ....
  BESU_XNAT_MANAGER_POD_NAME: "besu-custom-name"
  KUBE_CONFIG_PATH: "/opt/besu/shared/kube-config"
---
```
### Tested 

- With Kubernetes (valid and invalid parameters)
- Without Kubernetes (valid and invalid parameters)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
