### PR TITLE
Permissioning Whitelist JSON-RPC methods now extend Allowlist methods

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
@@ -15,70 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
-import org.hyperledger.besu.ethereum.permissioning.AllowlistOperationResult;
 
-import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public class PermAddAccountsToWhitelist implements JsonRpcMethod {
-
-  private final Optional<AccountLocalConfigPermissioningController> whitelistController;
+public class PermAddAccountsToWhitelist extends PermAddAccountsToAllowlist {
 
   public PermAddAccountsToWhitelist(
-      final Optional<AccountLocalConfigPermissioningController> whitelistController) {
-    this.whitelistController = whitelistController;
+      final Optional<AccountLocalConfigPermissioningController> allowlistController) {
+    super(allowlistController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_ADD_ACCOUNTS_TO_WHITELIST.getMethodName();
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final List<String> accountsList = requestContext.getRequiredParameter(0, List.class);
-
-    if (whitelistController.isPresent()) {
-      final AllowlistOperationResult addResult =
-          whitelistController.get().addAccounts(accountsList);
-
-      switch (addResult) {
-        case ERROR_EMPTY_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_EMPTY_ENTRY);
-        case ERROR_INVALID_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_INVALID_ENTRY);
-        case ERROR_EXISTING_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_EXISTING_ENTRY);
-        case ERROR_DUPLICATED_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_DUPLICATED_ENTRY);
-        case ERROR_ALLOWLIST_PERSIST_FAIL:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_PERSIST_FAILURE);
-        case ERROR_ALLOWLIST_FILE_SYNC:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_FILE_SYNC);
-        case SUCCESS:
-          return new JsonRpcSuccessResponse(requestContext.getRequest().getId());
-        default:
-          throw new IllegalStateException(
-              "Unmapped result from AccountLocalConfigPermissioningController");
-      }
-    } else {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_NOT_ENABLED);
-    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
@@ -15,83 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.StringListParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 
-import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public class PermAddNodesToWhitelist implements JsonRpcMethod {
-
-  private final Optional<NodeLocalConfigPermissioningController>
-      nodeWhitelistPermissioningController;
+public class PermAddNodesToWhitelist extends PermAddNodesToAllowlist {
 
   public PermAddNodesToWhitelist(
-      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController) {
-    this.nodeWhitelistPermissioningController = nodeWhitelistPermissioningController;
+      final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
+    super(nodeAllowlistPermissioningController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_ADD_NODES_TO_WHITELIST.getMethodName();
-  }
-
-  @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final StringListParameter enodeListParam =
-        requestContext.getRequiredParameter(0, StringListParameter.class);
-
-    try {
-      if (nodeWhitelistPermissioningController.isPresent()) {
-        try {
-          final List<String> enodeURLs = enodeListParam.getStringList();
-          final NodeLocalConfigPermissioningController.NodesWhitelistResult nodesWhitelistResult =
-              nodeWhitelistPermissioningController.get().addNodes(enodeURLs);
-
-          switch (nodesWhitelistResult.result()) {
-            case SUCCESS:
-              return new JsonRpcSuccessResponse(requestContext.getRequest().getId());
-            case ERROR_EMPTY_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_EMPTY_ENTRY);
-            case ERROR_EXISTING_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_EXISTING_ENTRY);
-            case ERROR_DUPLICATED_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(),
-                  JsonRpcError.NODE_ALLOWLIST_DUPLICATED_ENTRY);
-            case ERROR_ALLOWLIST_PERSIST_FAIL:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_PERSIST_FAILURE);
-            case ERROR_ALLOWLIST_FILE_SYNC:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_FILE_SYNC);
-            default:
-              throw new Exception();
-          }
-        } catch (IllegalArgumentException e) {
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_INVALID_ENTRY);
-        } catch (Exception e) {
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.INTERNAL_ERROR);
-        }
-      } else {
-        return new JsonRpcErrorResponse(
-            requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_NOT_ENABLED);
-      }
-    } catch (P2PDisabledException e) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.P2P_DISABLED);
-    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelist.java
@@ -15,39 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
 
 import java.util.Optional;
 
 @Deprecated
-public class PermGetAccountsWhitelist implements JsonRpcMethod {
-
-  private final Optional<AccountLocalConfigPermissioningController> whitelistController;
+public class PermGetAccountsWhitelist extends PermGetAccountsAllowlist {
 
   public PermGetAccountsWhitelist(
-      final Optional<AccountLocalConfigPermissioningController> whitelistController) {
-    this.whitelistController = whitelistController;
+      final Optional<AccountLocalConfigPermissioningController> allowlistController) {
+    super(allowlistController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_GET_ACCOUNTS_WHITELIST.getMethodName();
-  }
-
-  @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    if (whitelistController.isPresent()) {
-      return new JsonRpcSuccessResponse(
-          requestContext.getRequest().getId(), whitelistController.get().getAccountAllowlist());
-    } else {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_NOT_ENABLED);
-    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelist.java
@@ -15,49 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 
-import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public class PermGetNodesWhitelist implements JsonRpcMethod {
-
-  private final Optional<NodeLocalConfigPermissioningController>
-      nodeWhitelistPermissioningController;
+public class PermGetNodesWhitelist extends PermGetNodesAllowlist {
 
   public PermGetNodesWhitelist(
-      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController) {
-    this.nodeWhitelistPermissioningController = nodeWhitelistPermissioningController;
+      final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
+    super(nodeAllowlistPermissioningController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_GET_NODES_WHITELIST.getMethodName();
-  }
-
-  @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    try {
-      if (nodeWhitelistPermissioningController.isPresent()) {
-        final List<String> enodeList =
-            nodeWhitelistPermissioningController.get().getNodesWhitelist();
-
-        return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), enodeList);
-      } else {
-        return new JsonRpcErrorResponse(
-            requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_NOT_ENABLED);
-      }
-    } catch (P2PDisabledException e) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.P2P_DISABLED);
-    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
@@ -15,69 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
-import org.hyperledger.besu.ethereum.permissioning.AllowlistOperationResult;
 
-import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public class PermRemoveAccountsFromWhitelist implements JsonRpcMethod {
-
-  private final Optional<AccountLocalConfigPermissioningController> allowlistController;
+public class PermRemoveAccountsFromWhitelist extends PermRemoveAccountsFromAllowlist {
 
   public PermRemoveAccountsFromWhitelist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
-    this.allowlistController = allowlistController;
+    super(allowlistController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_REMOVE_ACCOUNTS_FROM_WHITELIST.getMethodName();
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final List<String> accountsList = requestContext.getRequiredParameter(0, List.class);
-    if (allowlistController.isPresent()) {
-      final AllowlistOperationResult removeResult =
-          allowlistController.get().removeAccounts(accountsList);
-
-      switch (removeResult) {
-        case ERROR_EMPTY_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_EMPTY_ENTRY);
-        case ERROR_INVALID_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_INVALID_ENTRY);
-        case ERROR_ABSENT_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_ABSENT_ENTRY);
-        case ERROR_DUPLICATED_ENTRY:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_DUPLICATED_ENTRY);
-        case ERROR_ALLOWLIST_PERSIST_FAIL:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_PERSIST_FAILURE);
-        case ERROR_ALLOWLIST_FILE_SYNC:
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_FILE_SYNC);
-        case SUCCESS:
-          return new JsonRpcSuccessResponse(requestContext.getRequest().getId());
-        default:
-          throw new IllegalStateException(
-              "Unmapped result from AccountLocalConfigPermissioningController");
-      }
-    } else {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.ACCOUNT_ALLOWLIST_NOT_ENABLED);
-    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
@@ -15,86 +15,20 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.StringListParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 
-import java.util.List;
 import java.util.Optional;
 
 @Deprecated
-public class PermRemoveNodesFromWhitelist implements JsonRpcMethod {
-
-  private final Optional<NodeLocalConfigPermissioningController>
-      nodeWhitelistPermissioningController;
+public class PermRemoveNodesFromWhitelist extends PermRemoveNodesFromAllowlist {
 
   public PermRemoveNodesFromWhitelist(
-      final Optional<NodeLocalConfigPermissioningController> nodeWhitelistPermissioningController) {
-    this.nodeWhitelistPermissioningController = nodeWhitelistPermissioningController;
+      final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
+    super(nodeAllowlistPermissioningController);
   }
 
   @Override
   public String getName() {
     return RpcMethod.PERM_REMOVE_NODES_FROM_WHITELIST.getMethodName();
-  }
-
-  @Override
-  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final StringListParameter enodeListParam =
-        requestContext.getRequiredParameter(0, StringListParameter.class);
-    try {
-      if (nodeWhitelistPermissioningController.isPresent()) {
-        try {
-          final List<String> enodeURLs = enodeListParam.getStringList();
-          final NodeLocalConfigPermissioningController.NodesWhitelistResult nodesWhitelistResult =
-              nodeWhitelistPermissioningController.get().removeNodes(enodeURLs);
-
-          switch (nodesWhitelistResult.result()) {
-            case SUCCESS:
-              return new JsonRpcSuccessResponse(requestContext.getRequest().getId());
-            case ERROR_EMPTY_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_EMPTY_ENTRY);
-            case ERROR_ABSENT_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_MISSING_ENTRY);
-            case ERROR_DUPLICATED_ENTRY:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(),
-                  JsonRpcError.NODE_ALLOWLIST_DUPLICATED_ENTRY);
-            case ERROR_ALLOWLIST_PERSIST_FAIL:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_PERSIST_FAILURE);
-            case ERROR_ALLOWLIST_FILE_SYNC:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(), JsonRpcError.ALLOWLIST_FILE_SYNC);
-            case ERROR_FIXED_NODE_CANNOT_BE_REMOVED:
-              return new JsonRpcErrorResponse(
-                  requestContext.getRequest().getId(),
-                  JsonRpcError.NODE_ALLOWLIST_FIXED_NODE_CANNOT_BE_REMOVED);
-            default:
-              throw new Exception();
-          }
-        } catch (IllegalArgumentException e) {
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_INVALID_ENTRY);
-        } catch (Exception e) {
-          return new JsonRpcErrorResponse(
-              requestContext.getRequest().getId(), JsonRpcError.INTERNAL_ERROR);
-        }
-      } else {
-        return new JsonRpcErrorResponse(
-            requestContext.getRequest().getId(), JsonRpcError.NODE_ALLOWLIST_NOT_ENABLED);
-      }
-    } catch (P2PDisabledException e) {
-      return new JsonRpcErrorResponse(
-          requestContext.getRequest().getId(), JsonRpcError.P2P_DISABLED);
-    }
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethodsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_ADD_ACCOUNTS_TO_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_ADD_ACCOUNTS_TO_WHITELIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_ADD_NODES_TO_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_ADD_NODES_TO_WHITELIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_GET_ACCOUNTS_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_GET_ACCOUNTS_WHITELIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_GET_NODES_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_GET_NODES_WHITELIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_REMOVE_ACCOUNTS_FROM_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_REMOVE_ACCOUNTS_FROM_WHITELIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_REMOVE_NODES_FROM_ALLOWLIST;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.PERM_REMOVE_NODES_FROM_WHITELIST;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermAddAccountsToAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermAddAccountsToWhitelist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermAddNodesToAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermGetAccountsAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermGetAccountsWhitelist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermGetNodesAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermGetNodesWhitelist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveAccountsFromAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveAccountsFromWhitelist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveNodesFromAllowlist;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.permissioning.PermRemoveNodesFromWhitelist;
+import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
+import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PermJsonRpcMethodsTest {
+
+  @Mock private AccountLocalConfigPermissioningController accountLocalConfigPermissioningController;
+  @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
+
+  private PermJsonRpcMethods permJsonRpcMethods;
+
+  @Before
+  public void setup() {
+    permJsonRpcMethods =
+        new PermJsonRpcMethods(
+            Optional.of(accountLocalConfigPermissioningController),
+            Optional.of(nodeLocalConfigPermissioningController));
+  }
+
+  @Test
+  public void allowlistMethodsPresent() {
+    final Map<String, JsonRpcMethod> rpcMethods = permJsonRpcMethods.create();
+
+    // Account methods x 3
+    assertThat(rpcMethods.get(PERM_GET_ACCOUNTS_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermGetAccountsAllowlist.class);
+    assertThat(rpcMethods.get(PERM_ADD_ACCOUNTS_TO_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermAddAccountsToAllowlist.class);
+    assertThat(rpcMethods.get(PERM_REMOVE_ACCOUNTS_FROM_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermRemoveAccountsFromAllowlist.class);
+
+    // Node methods x 3
+    assertThat(rpcMethods.get(PERM_GET_NODES_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermGetNodesAllowlist.class);
+    assertThat(rpcMethods.get(PERM_ADD_NODES_TO_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermAddNodesToAllowlist.class);
+    assertThat(rpcMethods.get(PERM_REMOVE_NODES_FROM_ALLOWLIST.getMethodName()))
+        .isInstanceOf(PermRemoveNodesFromAllowlist.class);
+  }
+
+  @Deprecated
+  @Test
+  public void whitelistMethodsPresent() {
+    final Map<String, JsonRpcMethod> rpcMethods = permJsonRpcMethods.create();
+    assertThat(rpcMethods.size()).isEqualTo(13);
+
+    // Account methods x 3
+    assertThat(rpcMethods.get(PERM_GET_ACCOUNTS_WHITELIST.getMethodName()))
+        .isInstanceOf(PermGetAccountsWhitelist.class);
+    assertThat(rpcMethods.get(PERM_ADD_ACCOUNTS_TO_WHITELIST.getMethodName()))
+        .isInstanceOf(PermAddAccountsToWhitelist.class);
+    assertThat(rpcMethods.get(PERM_REMOVE_ACCOUNTS_FROM_WHITELIST.getMethodName()))
+        .isInstanceOf(PermRemoveAccountsFromWhitelist.class);
+
+    // Node methods x 3
+    assertThat(rpcMethods.get(PERM_GET_NODES_WHITELIST.getMethodName()))
+        .isInstanceOf(PermGetNodesWhitelist.class);
+    assertThat(rpcMethods.get(PERM_ADD_NODES_TO_WHITELIST.getMethodName()))
+        .isInstanceOf(PermAddNodesToAllowlist.class);
+    assertThat(rpcMethods.get(PERM_REMOVE_NODES_FROM_WHITELIST.getMethodName()))
+        .isInstanceOf(PermRemoveNodesFromWhitelist.class);
+  }
+}


### PR DESCRIPTION
Refactoring to remove duplicated code. Whitelist methods now extend the Allowlist methods and just override getName()

Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>


See #1108 
