### PR TITLE
[MINOR] Metrics: reinstated get/setWhitelist with Deprecated warning

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
@@ -121,7 +121,7 @@ public class MetricsConfiguration {
     return prometheusJob;
   }
 
-  /** use getHostsAllowlist instead */
+  // use getHostsAllowlist instead
   @Deprecated
   Collection<String> getHostsWhitelist() {
     return Collections.unmodifiableCollection(this.hostsAllowlist);
@@ -247,7 +247,7 @@ public class MetricsConfiguration {
       return this;
     }
 
-    /** use hostsAllowlist instead */
+    // use hostsAllowlist instead
     @Deprecated
     public Builder hostsWhitelist(final List<String> hostsAllowlist) {
       this.hostsAllowlist = hostsAllowlist;

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
@@ -121,6 +121,12 @@ public class MetricsConfiguration {
     return prometheusJob;
   }
 
+  /** use getHostsAllowlist instead */
+  @Deprecated
+  Collection<String> getHostsWhitelist() {
+    return Collections.unmodifiableCollection(this.hostsAllowlist);
+  }
+
   Collection<String> getHostsAllowlist() {
     return Collections.unmodifiableCollection(this.hostsAllowlist);
   }
@@ -238,6 +244,13 @@ public class MetricsConfiguration {
 
     public Builder prometheusJob(final String prometheusJob) {
       this.prometheusJob = prometheusJob;
+      return this;
+    }
+
+    /** use hostsAllowlist instead */
+    @Deprecated
+    public Builder hostsWhitelist(final List<String> hostsAllowlist) {
+      this.hostsAllowlist = hostsAllowlist;
       return this;
     }
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Deprecated in favour of get/setAllowlist rather than removing which may break things elsewhere
