### PR TITLE
[#519] - Enable http/2 support for Json RPC Http API over TLS

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -299,7 +299,8 @@ public class JsonRpcHttpService {
           .setPfxKeyCertOptions(
               new PfxOptions()
                   .setPath(tlsConfiguration.getKeyStorePath().toString())
-                  .setPassword(tlsConfiguration.getKeyStorePassword()));
+                  .setPassword(tlsConfiguration.getKeyStorePassword()))
+          .setUseAlpn(true);
 
       tlsConfiguration
           .getClientAuthConfiguration()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc;
 
+import static okhttp3.Protocol.HTTP_1_1;
+import static okhttp3.Protocol.HTTP_2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis.ETH;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis.NET;
@@ -64,7 +66,6 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
-import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -186,15 +187,24 @@ public class JsonRpcHttpServiceTlsTest {
   }
 
   @Test
+  public void netVersionSuccessfulOnTlsWithHttp1_1() throws Exception {
+    netVersionSuccessfulOnTls(true);
+  }
+
+  @Test
   public void netVersionSuccessfulOnTlsWithHttp2() throws Exception {
+    netVersionSuccessfulOnTls(false);
+  }
+
+  public void netVersionSuccessfulOnTls(final boolean useHttp1) throws Exception {
     final String id = "123";
     final String json =
         "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}";
 
-    final OkHttpClient httpClient = getTlsHttpClient();
+    final OkHttpClient httpClient = getTlsHttpClient(useHttp1);
     try (final Response response = httpClient.newCall(buildPostRequest(json)).execute()) {
       assertThat(response.code()).isEqualTo(200);
-      assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2);
+      assertThat(response.protocol()).isEqualTo(useHttp1 ? HTTP_1_1 : HTTP_2);
       // Check general format of result
       final ResponseBody body = response.body();
       assertThat(body).isNotNull();
@@ -209,8 +219,11 @@ public class JsonRpcHttpServiceTlsTest {
     }
   }
 
-  private OkHttpClient getTlsHttpClient() {
-    return TlsOkHttpClientBuilder.anOkHttpClient().withBesuCertificate(besuCertificate).build();
+  private OkHttpClient getTlsHttpClient(boolean useHttp1) {
+    return TlsOkHttpClientBuilder.anOkHttpClient()
+        .withBesuCertificate(besuCertificate)
+        .withHttp1(useHttp1)
+        .build();
   }
 
   private Request buildPostRequest(final String json) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -219,7 +219,7 @@ public class JsonRpcHttpServiceTlsTest {
     }
   }
 
-  private OkHttpClient getTlsHttpClient(boolean useHttp1) {
+  private OkHttpClient getTlsHttpClient(final boolean useHttp1) {
     return TlsOkHttpClientBuilder.anOkHttpClient()
         .withBesuCertificate(besuCertificate)
         .withHttp1(useHttp1)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -64,6 +64,7 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
@@ -185,15 +186,15 @@ public class JsonRpcHttpServiceTlsTest {
   }
 
   @Test
-  public void netVersionSuccessfulOnTls() throws Exception {
+  public void netVersionSuccessfulOnTlsWithHttp2() throws Exception {
     final String id = "123";
     final String json =
         "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}";
 
     final OkHttpClient httpClient = getTlsHttpClient();
     try (final Response response = httpClient.newCall(buildPostRequest(json)).execute()) {
-
       assertThat(response.code()).isEqualTo(200);
+      assertThat(response.protocol()).isEqualTo(Protocol.HTTP_2);
       // Check general format of result
       final ResponseBody body = response.body();
       assertThat(body).isNotNull();


### PR DESCRIPTION
## PR description
Enable http/2 support for Json RPC Http API over TLS

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes issue #519 
Signed-off-by: Usman Saleem <usman@usmans.info>
