### PR TITLE
Fix sync timeout issue 

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingPeerTask.java
@@ -141,4 +141,12 @@ public abstract class AbstractRetryingPeerTask<T> extends AbstractEthTask<T> {
 
     return error instanceof TimeoutException || (!assignedPeer.isPresent() && isPeerError);
   }
+
+  public int getRetryCount() {
+    return retryCount;
+  }
+
+  public int getMaxRetries() {
+    return maxRetries;
+  }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager.ethtaskutils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -50,7 +51,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 /**
  * @param <T> The type of data being requested from the network
@@ -83,7 +83,7 @@ public abstract class AbstractMessageTaskTest<T, R> {
   public void setupTest() {
     peersDoTimeout = new AtomicBoolean(false);
     peerCountToTimeout = new AtomicInteger(0);
-    ethPeers = Mockito.spy(new EthPeers(EthProtocol.NAME, TestClock.fixed(), metricsSystem));
+    ethPeers = spy(new EthPeers(EthProtocol.NAME, TestClock.fixed(), metricsSystem));
     final EthMessages ethMessages = new EthMessages();
     final EthScheduler ethScheduler =
         new DeterministicEthScheduler(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * @param <T> The type of data being requested from the network
@@ -62,6 +63,7 @@ public abstract class AbstractMessageTaskTest<T, R> {
   protected static MetricsSystem metricsSystem = new NoOpMetricsSystem();
   protected EthProtocolManager ethProtocolManager;
   protected EthContext ethContext;
+  protected EthPeers ethPeers;
   protected TransactionPool transactionPool;
   protected AtomicBoolean peersDoTimeout;
   protected AtomicInteger peerCountToTimeout;
@@ -81,7 +83,7 @@ public abstract class AbstractMessageTaskTest<T, R> {
   public void setupTest() {
     peersDoTimeout = new AtomicBoolean(false);
     peerCountToTimeout = new AtomicInteger(0);
-    final EthPeers ethPeers = new EthPeers(EthProtocol.NAME, TestClock.fixed(), metricsSystem);
+    ethPeers = Mockito.spy(new EthPeers(EthProtocol.NAME, TestClock.fixed(), metricsSystem));
     final EthMessages ethMessages = new EthMessages();
     final EthScheduler ethScheduler =
         new DeterministicEthScheduler(


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

This PR fixes an error when downloading chain (Async operation failed)

When there are several blocks which are very large (> 12M) and which are requested in the same segment (by default 200) we can have timeouts and never manage to synchronize. This modification will make it possible to gradually reduce the size of the segment with each attempt. Then the segment resumes its default size for the next blocks

If the reduction is not enough at the last attempt we try with a single block

## Tested

| Test |   |  
|-------|---|
|      Mordor - Fullsync after already Fastsync completed     |  OK  |   
|      Mordor - Complete Fastsync        | OK  |   
|      CLIQUE - Local      |  OK |   
|      IBFT - Local     | OK  |  
|      IBFT - Lacchain     | OK  |  
|       Goerli  - Fullsync  |  OK  |   


- Result with LACCHAIN network 
LACCHAIN (Before) -> Always stuck after 20 minutes
LACCHAIN (After) -> Download restart after 2-5 minutes of sync
