### PR TITLE
#1066 Switched to use unprefixed hex strings for memory and stack values

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -47,14 +47,14 @@ public class StructLog {
     memory =
         traceFrame
             .getMemory()
-            .map(a -> Arrays.stream(a).map(Bytes::toShortHexString).toArray(String[]::new))
+            .map(a -> Arrays.stream(a).map(Bytes::toUnprefixedHexString).toArray(String[]::new))
             .orElse(null);
     op = traceFrame.getOpcode();
     pc = traceFrame.getPc();
     stack =
         traceFrame
             .getStack()
-            .map(a -> Arrays.stream(a).map(Bytes::toShortHexString).toArray(String[]::new))
+            .map(a -> Arrays.stream(a).map(Bytes::toUnprefixedHexString).toArray(String[]::new))
             .orElse(null);
     storage = traceFrame.getStorage().map(StructLog::formatStorage).orElse(null);
     reason = traceFrame.getRevertReason().map(Bytes::toShortHexString).orElse(null);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class DebugTraceTransactionTest {
@@ -76,6 +77,15 @@ public class DebugTraceTransactionTest {
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", "debug_traceTransaction", params));
     final Result result = mock(Result.class);
 
+    final Bytes32[] stackBytes =
+        new Bytes32[] {
+          Bytes32.fromHexString(
+              "0x0000000000000000000000000000000000000000000000000000000000000001")
+        };
+    final Bytes[] memoryBytes =
+        new Bytes[] {
+          Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000002")
+        };
     final TraceFrame traceFrame =
         new TraceFrame(
             12,
@@ -89,8 +99,8 @@ public class DebugTraceTransactionTest {
             Wei.ZERO,
             Bytes.EMPTY,
             Bytes.EMPTY,
-            Optional.empty(),
-            Optional.empty(),
+            Optional.of(stackBytes),
+            Optional.of(memoryBytes),
             Optional.empty(),
             null,
             Optional.of(Bytes.fromHexString("0x1122334455667788")),
@@ -122,6 +132,13 @@ public class DebugTraceTransactionTest {
     assertThat(transactionResult.getReturnValue()).isEqualTo("1234");
     final List<StructLog> expectedStructLogs = Collections.singletonList(new StructLog(traceFrame));
     assertThat(transactionResult.getStructLogs()).isEqualTo(expectedStructLogs);
+    assertThat(transactionResult.getStructLogs().size()).isEqualTo(1);
+    assertThat(transactionResult.getStructLogs().get(0).stack().length).isEqualTo(1);
+    assertThat(transactionResult.getStructLogs().get(0).stack()[0])
+        .isEqualTo(stackBytes[0].toUnprefixedHexString());
+    assertThat(transactionResult.getStructLogs().get(0).memory().length).isEqualTo(1);
+    assertThat(transactionResult.getStructLogs().get(0).memory()[0])
+        .isEqualTo(memoryBytes[0].toUnprefixedHexString());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: David Mechler <david.mechler@consensys.net>

## PR description
Changed the `StructLog` code to use an unprefixed hex string for memory and stack values.

## Testing
- Ran test suite locally
- Started Goerli sync
- Started Ropsten sync
- Started mainnet sync

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#1066 