### PR TITLE
remove duplicate logging of P2P port conflicts on startup

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -133,7 +133,9 @@ public class RlpxAgent {
         .whenComplete(
             (res, err) -> {
               if (err != null) {
-                LOG.error("Failed to start P2P RLPx agent.", err);
+                // the detail of this error is already logged by the completeExceptionally() call in
+                // NettyConnectionInitializer
+                LOG.error("Failed to start P2P RLPx agent. Check for port conflicts.");
               }
             });
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
@@ -112,7 +112,7 @@ public class NettyConnectionInitializer implements ConnectionInitializer {
           if (!future.isSuccess() || socketAddress == null) {
             final String message =
                 String.format(
-                    "Unable start listening on %s:%s. Check for port conflicts.",
+                    "Unable to start listening on %s:%s. Check for port conflicts.",
                     config.getBindHost(), config.getBindPort());
             listeningPortFuture.completeExceptionally(
                 new IllegalStateException(message, future.cause()));


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

When starting with p2p-port already in use, the error (including stack trace) comes out twice

See #1064 