### PR TITLE
exception if --privacy-marker-transaction-signing-key-file not specified in non-zero-gas network

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1870,8 +1870,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             commandLine, "Please specify Enclave public key file path to enable privacy");
       }
 
-      // TODO use compareTo instead - and reject if < 0
-      if (!Wei.ZERO.equals(minTransactionGasPrice)) {
+      if (Wei.ZERO.compareTo(minTransactionGasPrice) < 0) {
         // if gas is required, cannot use random keys to sign private tx
         // ie --privacy-marker-transaction-signing-key-file must be set
         if (privacyMarkerTransactionSigningKeyPath == null) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -902,7 +902,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--target-gas-limit"},
       description =
-          "Sets target gas limit per block. If set each blocks gas limit will approach this setting over time if the current gas limit is different.")
+          "Sets target gas limit per block. If set each block's gas limit will approach this setting over time if the current gas limit is different.")
   private final Long targetGasLimit = null;
 
   @Option(
@@ -1307,13 +1307,13 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     if (isMiningEnabled && coinbase == null) {
       throw new ParameterException(
           this.commandLine,
-          "Unable to mine without a valid coinbase. Either disable mining (remove --miner-enabled)"
+          "Unable to mine without a valid coinbase. Either disable mining (remove --miner-enabled) "
               + "or specify the beneficiary of mining (via --miner-coinbase <Address>)");
     }
     if (!isMiningEnabled && iStratumMiningEnabled) {
       throw new ParameterException(
           this.commandLine,
-          "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled)"
+          "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled) "
               + "or specify mining is enabled (--miner-enabled)");
     }
   }
@@ -1868,6 +1868,17 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       } else if (!isPrivacyMultiTenancyEnabled) {
         throw new ParameterException(
             commandLine, "Please specify Enclave public key file path to enable privacy");
+      }
+
+      // TODO use compareTo instead - and reject if < 0
+      if (!Wei.ZERO.equals(minTransactionGasPrice)) {
+        // if gas is required, cannot use random keys to sign private tx
+        // ie --privacy-marker-transaction-signing-key-file must be set
+        if (privacyMarkerTransactionSigningKeyPath == null) {
+          throw new ParameterException(
+              commandLine,
+              "Not a free gas network. --privacy-marker-transaction-signing-key-file must be specified and must be a funded account. Private transactions cannot be signed by random (non-funded) accounts in paid gas networks");
+        }
       }
       privacyParametersBuilder.setPrivacyAddress(privacyPrecompiledAddress);
       privacyParametersBuilder.setPrivateKeyPath(privacyMarkerTransactionSigningKeyPath);

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1494,9 +1494,14 @@ public class BesuCommandTest extends CommandTestAbstract {
     when(storageService.getByName("rocksdb-privacy"))
         .thenReturn(Optional.of(rocksDBSPrivacyStorageFactory));
     final URL configFile = this.getClass().getResource("/orion_publickey.pub");
+    final String coinbaseStr = String.format("%040x", 1);
 
     parseCommand(
         "--privacy-enabled",
+        "--miner-enabled",
+        "--miner-coinbase=" + coinbaseStr,
+        "--min-gas-price",
+        "0",
         "--privacy-url",
         ENCLAVE_URI,
         "--privacy-public-key-file",
@@ -2576,7 +2581,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
         .startsWith(
-            "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled)or specify mining is enabled (--miner-enabled)");
+            "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled) or specify mining is enabled (--miner-enabled)");
   }
 
   @Test
@@ -2866,7 +2871,9 @@ public class BesuCommandTest extends CommandTestAbstract {
         "--privacy-url",
         ENCLAVE_URI,
         "--privacy-public-key-file",
-        configFile.getPath());
+        configFile.getPath(),
+        "--min-gas-price",
+        "0");
 
     final ArgumentCaptor<PrivacyParameters> enclaveArg =
         ArgumentCaptor.forClass(PrivacyParameters.class);
@@ -2936,7 +2943,9 @@ public class BesuCommandTest extends CommandTestAbstract {
         "--rpc-http-authentication-enabled",
         "--privacy-multi-tenancy-enabled",
         "--rpc-http-authentication-jwt-public-key-file",
-        "/non/existent/file");
+        "/non/existent/file",
+        "--min-gas-price",
+        "0");
 
     final ArgumentCaptor<PrivacyParameters> privacyParametersArgumentCaptor =
         ArgumentCaptor.forClass(PrivacyParameters.class);
@@ -2977,7 +2986,12 @@ public class BesuCommandTest extends CommandTestAbstract {
 
   @Test
   public void onChainPrivacyGroupEnabledFlagDefaultValueIsFalse() {
-    parseCommand("--privacy-enabled", "--privacy-public-key-file", ENCLAVE_PUBLIC_KEY_PATH);
+    parseCommand(
+        "--privacy-enabled",
+        "--privacy-public-key-file",
+        ENCLAVE_PUBLIC_KEY_PATH,
+        "--min-gas-price",
+        "0");
 
     final ArgumentCaptor<PrivacyParameters> privacyParametersArgumentCaptor =
         ArgumentCaptor.forClass(PrivacyParameters.class);
@@ -2998,7 +3012,9 @@ public class BesuCommandTest extends CommandTestAbstract {
         "--privacy-enabled",
         "--privacy-public-key-file",
         ENCLAVE_PUBLIC_KEY_PATH,
-        "--privacy-onchain-groups-enabled");
+        "--privacy-onchain-groups-enabled",
+        "--min-gas-price",
+        "0");
 
     final ArgumentCaptor<PrivacyParameters> privacyParametersArgumentCaptor =
         ArgumentCaptor.forClass(PrivacyParameters.class);
@@ -3025,6 +3041,15 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     assertThat(commandErrorOutput.toString())
         .startsWith("Privacy multi-tenancy and onchain privacy groups cannot be used together");
+  }
+
+  @Test
+  public void privacyMarkerTransactionSigningKeyFileRequiredIfMinGasPriceNonZero() {
+    parseCommand("--privacy-enabled", "--privacy-public-key-file", ENCLAVE_PUBLIC_KEY_PATH);
+
+    assertThat(commandErrorOutput.toString())
+        .startsWith(
+            "Not a free gas network. --privacy-marker-transaction-signing-key-file must be specified");
   }
 
   private Path createFakeGenesisFile(final JsonObject jsonGenesis) throws IOException {

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Quantity.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Quantity.java
@@ -33,7 +33,7 @@ public interface Quantity {
   Number getValue();
 
   /**
-   * The value as a hexadecimal string.
+   * The value as a hexideciam string.
    *
    * @return This value represented as hexadecimal, starting with "0x".
    */

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Quantity.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/Quantity.java
@@ -33,7 +33,7 @@ public interface Quantity {
   Number getValue();
 
   /**
-   * The value as a hexideciam string.
+   * The value as a hexadecimal string.
    *
    * @return This value represented as hexadecimal, starting with "0x".
    */


### PR DESCRIPTION
With privacy enabled, it is only valid to omit --privacy-marker-transaction-signing-key-file
if --min-gas-price=0
So - if --privacy-enabled and --min-gas-price > 0 and --privacy-marker-transaction-signing-key-file not specified, throw exception and prevent startup.

See #505 
