### PR TITLE
Fix retesteth testing of blockchain transition tests

### DIFF
--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.ScheduleBasedBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.WorldStatePreimageKeyValueStorage;
@@ -78,6 +79,7 @@ public class RetestethContext {
   private ProtocolContext protocolContext;
   private BlockchainQueries blockchainQueries;
   private ProtocolSchedule protocolSchedule;
+  private BlockHeaderFunctions blockHeaderFunctions;
   private HeaderValidationMode headerValidationMode;
   private BlockReplay blockReplay;
   private RetestethClock retestethClock;
@@ -127,6 +129,7 @@ public class RetestethContext {
     if ("NoReward".equalsIgnoreCase(sealEngine)) {
       protocolSchedule = new NoRewardProtocolScheduleWrapper(protocolSchedule);
     }
+    blockHeaderFunctions = ScheduleBasedBlockHeaderFunctions.create(protocolSchedule);
 
     final GenesisState genesisState = GenesisState.fromJson(genesisConfigString, protocolSchedule);
     coinbase = genesisState.getBlock().getHeader().getCoinbase();
@@ -209,6 +212,10 @@ public class RetestethContext {
 
   public ProtocolSchedule getProtocolSchedule() {
     return protocolSchedule;
+  }
+
+  public BlockHeaderFunctions getBlockHeaderFunctions() {
+    return blockHeaderFunctions;
   }
 
   public ProtocolContext getProtocolContext() {

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParams.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParams.java
@@ -113,6 +113,7 @@ public class TestSetChainParams implements JsonRpcMethod {
     config.put("ethash", ethash);
 
     maybeMoveToNumber(params, "homesteadForkBlock", config, "homesteadBlock");
+    maybeMoveToNumber(params, "daoHardforkBlock", config, "daoForkBlock");
     maybeMoveToNumber(params, "EIP150ForkBlock", config, "eip150Block");
     maybeMoveToNumber(params, "EIP158ForkBlock", config, "eip158Block");
     maybeMoveToNumber(params, "byzantiumForkBlock", config, "byzantiumBlock");


### PR DESCRIPTION
Besu's Retesteth implementation failed transition tests.  Two reasons:
* It wasn't adding the DaoForkBlock to genesis files correctly
* It wasn't using the  protocol schedules og the block being imported,
  but instead to the current chain head.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
