### PR TITLE
Add Reference Test checker

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -28,7 +28,7 @@ dependencies { testOutput sourceSets.test.output }
 task ('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentially changed"
   doLast {
-    def expectedHash = 'b8abaebf5949877ead03e8f74ac03c0ede41d5f7'// Bogus value to force CI failure
+    def expectedHash = 'b8abaebf5949877ead03e8f74ac03c0ede41d5f7'
     def result = new ByteArrayOutputStream()
     try {
       exec {

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -28,7 +28,7 @@ dependencies { testOutput sourceSets.test.output }
 task ('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentially changed"
   doLast {
-    def expectedHash = '0123456789abcdeffedcba987654321001234567'// Bogus value to force CI failure
+    def expectedHash = 'b8abaebf5949877ead03e8f74ac03c0ede41d5f7'// Bogus value to force CI failure
     def result = new ByteArrayOutputStream()
     try {
       exec {

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -24,3 +24,38 @@ sourceSets {
 configurations { testOutput }
 
 dependencies { testOutput sourceSets.test.output }
+
+tasks.register('checkReferenceTestSubmodule') {
+  description = "Checks that the reference tests submodule is not accidentially changed"
+  doLast {
+    def expectedHash = '0123456789abcdeffedcba987654321001234567'// Bogus value to force CI failure
+    def result = new ByteArrayOutputStream()
+    try {
+      exec {
+        commandLine 'git', 'submodule'
+        standardOutput = result
+        errorOutput = result
+      }
+    } catch (Exception ignore) {
+      // Ignore it.  We want to fail in a friendly fashion if they don't have git installed.
+      // The CI servers have git and that is the only critical place for this failure
+      expectedHash = ''
+    }
+    if (!result.toString().contains(expectedHash)) {
+      throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
+
+If this is a deliberate change where you are updating the reference tests version,
+then update "expectedHash" in `ethereum/referencetests/build.gradle` as the commit hash for this task.
+Expected   : ${expectedHash}
+git output : ${result}
+
+If this is accidental you can correct the reference test versions with the following commands:
+    pushd ethereum/referencetests/src/test/resources
+    git checkout ${expectedHash}
+    cd ..
+    git add resources
+    popd""")
+    }
+  }
+}
+check.dependsOn('checkReferenceTestSubmodule')

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -75,13 +75,13 @@ dependencyManagement {
     dependency 'org.apache.logging.log4j:log4j-core:2.13.3'
     dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.13.3'
 
-    dependency 'org.apache.tuweni:tuweni-bytes:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-config:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-crypto:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-io:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-toml:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-units:1.0.0'
-    dependency 'org.apache.tuweni:tuweni-net:1.0.0'
+    dependency 'org.apache.tuweni:tuweni-bytes:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-config:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-crypto:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-io:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-toml:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-units:1.1.0'
+    dependency 'org.apache.tuweni:tuweni-net:1.1.0'
 
     dependency 'org.assertj:assertj-core:3.16.1'
 


### PR DESCRIPTION
Add a check test to fail the build if the reference test submodule is
accidentally updated.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>