### PR TITLE
deprecate CLI option for privacy precompile address

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -122,8 +122,6 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
         params.add("--privacy-public-key-file");
         params.add(node.getPrivacyParameters().getEnclavePublicKeyFile().getAbsolutePath());
       }
-      params.add("--privacy-precompiled-address");
-      params.add(String.valueOf(node.getPrivacyParameters().getPrivacyAddress()));
       params.add("--privacy-marker-transaction-signing-key-file");
       params.add(node.homeDirectory().resolve("key").toString());
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -70,7 +70,6 @@ public class PrivacyNode implements AutoCloseable {
   private final OrionTestHarness orion;
   private final BesuNode besu;
   private final Vertx vertx;
-  private final Integer privacyAddress;
   private final boolean isOnchainPrivacyEnabled;
 
   public PrivacyNode(final PrivacyNodeConfiguration privacyConfiguration, final Vertx vertx)
@@ -81,7 +80,6 @@ public class PrivacyNode implements AutoCloseable {
 
     final BesuNodeConfiguration besuConfig = privacyConfiguration.getBesuConfig();
 
-    privacyAddress = privacyConfiguration.getPrivacyAddress();
     isOnchainPrivacyEnabled = privacyConfiguration.isOnchainPrivacyGroupEnabled();
 
     this.besu =
@@ -177,7 +175,6 @@ public class PrivacyNode implements AutoCloseable {
               .setStorageProvider(createKeyValueStorageProvider(dataDir, dbDir))
               .setPrivateKeyPath(KeyPairUtil.getDefaultKeyFile(besu.homeDirectory()).toPath())
               .setEnclaveFactory(new EnclaveFactory(vertx))
-              .setPrivacyAddress(privacyAddress)
               .setOnchainPrivacyGroupsEnabled(isOnchainPrivacyEnabled)
               .build();
     } catch (IOException e) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -887,7 +887,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--privacy-precompiled-address"},
       description =
-          "The address to which the privacy pre-compiled contract will be mapped (default: ${DEFAULT-VALUE})")
+          "The address to which the privacy pre-compiled contract will be mapped (default: ${DEFAULT-VALUE})",
+      hidden = true)
   private final Integer privacyPrecompiledAddress = Address.PRIVACY;
 
   @Option(
@@ -1829,7 +1830,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         asList(
             "--privacy-url",
             "--privacy-public-key-file",
-            "--privacy-precompiled-address",
             "--privacy-multi-tenancy-enabled",
             "--privacy-tls-enabled"));
 
@@ -1892,7 +1892,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
               "Not a free gas network. --privacy-marker-transaction-signing-key-file must be specified and must be a funded account. Private transactions cannot be signed by random (non-funded) accounts in paid gas networks");
         }
       }
-      privacyParametersBuilder.setPrivacyAddress(privacyPrecompiledAddress);
+
+      if (!Address.PRIVACY.equals(privacyPrecompiledAddress)) {
+        logger.warn(
+            "--privacy-precompiled-address option is deprecated. This address is derived, based on --privacy-onchain-groups-enabled.");
+      }
+
       privacyParametersBuilder.setPrivateKeyPath(privacyMarkerTransactionSigningKeyPath);
       privacyParametersBuilder.setStorageProvider(
           privacyKeyStorageProvider(keyValueStorageName + "-privacy"));

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -83,11 +83,6 @@ public class PrivacyTest {
   public void onchainEnabledPrivacy() throws IOException, URISyntaxException {
     final BesuController besuController = setUpControllerWithPrivacyEnabled(true);
 
-    final PrecompiledContract privacyPrecompiledContract =
-        getPrecompile(besuController, Address.DEFAULT_PRIVACY);
-
-    assertThat(privacyPrecompiledContract.getName()).isEqualTo("Privacy");
-
     final PrecompiledContract onchainPrecompiledContract =
         getPrecompile(besuController, Address.ONCHAIN_PRIVACY);
 
@@ -100,7 +95,6 @@ public class PrivacyTest {
     final Path dbDir = dataDir.resolve("database");
     final PrivacyParameters privacyParameters =
         new PrivacyParameters.Builder()
-            .setPrivacyAddress(Address.PRIVACY)
             .setEnabled(true)
             .setEnclaveUrl(new URI("http://127.0.0.1:8000"))
             .setStorageProvider(createKeyValueStorageProvider(dataDir, dbDir))

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2941,19 +2941,10 @@ public class BesuCommandTest extends CommandTestAbstract {
     final File file = new File("./specific/enclavePublicKey");
     file.deleteOnExit();
 
-    parseCommand(
-        "--privacy-url",
-        ENCLAVE_URI,
-        "--privacy-public-key-file",
-        file.toString(),
-        "--privacy-precompiled-address",
-        String.valueOf(Byte.MAX_VALUE - 1));
+    parseCommand("--privacy-url", ENCLAVE_URI, "--privacy-public-key-file", file.toString());
 
     verifyOptionsConstraintLoggerCall(
-        "--privacy-enabled",
-        "--privacy-url",
-        "--privacy-precompiled-address",
-        "--privacy-public-key-file");
+        "--privacy-enabled", "--privacy-url", "--privacy-public-key-file");
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddressTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddressTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.priv;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
@@ -47,6 +48,7 @@ public class PrivGetPrivacyPrecompileAddressTest {
     final JsonRpcSuccessResponse response =
         (JsonRpcSuccessResponse) privGetPrivacyPrecompileAddress.response(request);
 
+    verify(privacyParameters).getPrivacyAddress();
     assertThat(response.getResult()).isEqualTo(privacyAddress);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/PrivacyParameters.java
@@ -43,7 +43,6 @@ public class PrivacyParameters {
   public static final URI DEFAULT_ENCLAVE_URL = URI.create("http://localhost:8888");
   public static final PrivacyParameters DEFAULT = new PrivacyParameters();
 
-  private Integer privacyAddress = Address.PRIVACY;
   private boolean enabled;
   private URI enclaveUri;
   private String enclavePublicKey;
@@ -59,11 +58,7 @@ public class PrivacyParameters {
   private PrivateWorldStateReader privateWorldStateReader;
 
   public Integer getPrivacyAddress() {
-    return privacyAddress;
-  }
-
-  private void setPrivacyAddress(final Integer privacyAddress) {
-    this.privacyAddress = privacyAddress;
+    return onchainPrivacyGroupsEnabled ? Address.PRIVACY - 1 : Address.PRIVACY;
   }
 
   public Boolean isEnabled() {
@@ -191,7 +186,6 @@ public class PrivacyParameters {
 
     private boolean enabled;
     private URI enclaveUrl;
-    private Integer privacyAddress = Address.PRIVACY;
     private File enclavePublicKeyFile;
     private String enclavePublicKey;
     private Path privateKeyPath;
@@ -202,11 +196,6 @@ public class PrivacyParameters {
     private Path privacyKeyStorePasswordFile;
     private Path privacyTlsKnownEnclaveFile;
     private boolean onchainPrivacyGroupsEnabled;
-
-    public Builder setPrivacyAddress(final Integer privacyAddress) {
-      this.privacyAddress = privacyAddress;
-      return this;
-    }
 
     public Builder setEnclaveUrl(final URI enclaveUrl) {
       this.enclaveUrl = enclaveUrl;
@@ -300,7 +289,6 @@ public class PrivacyParameters {
       }
       config.setEnabled(enabled);
       config.setEnclaveUri(enclaveUrl);
-      config.setPrivacyAddress(privacyAddress);
       config.setMultiTenancyEnabled(multiTenancyEnabled);
       config.setOnchainPrivacyGroupsEnabled(onchainPrivacyGroupsEnabled);
       return config;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
@@ -165,20 +165,25 @@ public abstract class MainnetPrecompiledContractRegistries {
       final PrecompileContractRegistry registry,
       final PrecompiledContractConfiguration precompiledContractConfiguration,
       final int accountVersion) {
-    final Address address =
-        Address.privacyPrecompiled(
-            precompiledContractConfiguration.getPrivacyParameters().getPrivacyAddress());
-    registry.put(
-        address,
-        accountVersion,
-        new PrivacyPrecompiledContract(
-            precompiledContractConfiguration.getGasCalculator(),
-            precompiledContractConfiguration.getPrivacyParameters()));
-    registry.put(
-        Address.ONCHAIN_PRIVACY,
-        accountVersion,
-        new OnChainPrivacyPrecompiledContract(
-            precompiledContractConfiguration.getGasCalculator(),
-            precompiledContractConfiguration.getPrivacyParameters()));
+
+    if (!precompiledContractConfiguration.getPrivacyParameters().isEnabled()) {
+      return;
+    }
+
+    if (precompiledContractConfiguration.getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
+      registry.put(
+          Address.ONCHAIN_PRIVACY,
+          accountVersion,
+          new OnChainPrivacyPrecompiledContract(
+              precompiledContractConfiguration.getGasCalculator(),
+              precompiledContractConfiguration.getPrivacyParameters()));
+    } else {
+      registry.put(
+          Address.DEFAULT_PRIVACY,
+          accountVersion,
+          new PrivacyPrecompiledContract(
+              precompiledContractConfiguration.getGasCalculator(),
+              precompiledContractConfiguration.getPrivacyParameters()));
+    }
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
@@ -299,15 +299,20 @@ public class ProtocolSpecBuilder {
               contractCreationProcessor,
               messageCallProcessor,
               privateTransactionValidator);
-      final Address address = Address.privacyPrecompiled(privacyParameters.getPrivacyAddress());
-      final PrivacyPrecompiledContract privacyPrecompiledContract =
-          (PrivacyPrecompiledContract)
-              precompileContractRegistry.get(address, Account.DEFAULT_VERSION);
-      privacyPrecompiledContract.setPrivateTransactionProcessor(privateTransactionProcessor);
-      final OnChainPrivacyPrecompiledContract onChainPrivacyPrecompiledContract =
-          (OnChainPrivacyPrecompiledContract)
-              precompileContractRegistry.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION);
-      onChainPrivacyPrecompiledContract.setPrivateTransactionProcessor(privateTransactionProcessor);
+
+      if (privacyParameters.isOnchainPrivacyGroupsEnabled()) {
+        final OnChainPrivacyPrecompiledContract onChainPrivacyPrecompiledContract =
+            (OnChainPrivacyPrecompiledContract)
+                precompileContractRegistry.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION);
+        onChainPrivacyPrecompiledContract.setPrivateTransactionProcessor(
+            privateTransactionProcessor);
+      } else {
+        final PrivacyPrecompiledContract privacyPrecompiledContract =
+            (PrivacyPrecompiledContract)
+                precompileContractRegistry.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION);
+        privacyPrecompiledContract.setPrivateTransactionProcessor(privateTransactionProcessor);
+      }
+
       blockProcessor =
           new PrivacyBlockProcessor(
               blockProcessor,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
@@ -1,0 +1,70 @@
+/*
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.ethereum.mainnet;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.ethereum.mainnet.MainnetPrecompiledContractRegistries.appendPrivacy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.core.Account;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.OnChainPrivacyPrecompiledContract;
+import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.PrivacyPrecompiledContract;
+import org.hyperledger.besu.ethereum.vm.GasCalculator;
+
+import org.junit.Test;
+
+public class MainnetPrecompiledContractRegistriesTest {
+  private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
+  private final GasCalculator gasCalculator = mock(GasCalculator.class);
+  private final PrecompileContractRegistry reg = new PrecompileContractRegistry();
+
+  private final PrecompiledContractConfiguration config =
+      new PrecompiledContractConfiguration(gasCalculator, privacyParameters);
+
+  @Test
+  public void whenOnchainPrivacyGroupsNotEnabled_defaultPrivacyPrecompileIsInRegistry() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(false);
+    when(privacyParameters.isEnabled()).thenReturn(true);
+
+    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    verify(privacyParameters).isEnabled();
+    verify(privacyParameters).isOnchainPrivacyGroupsEnabled();
+
+    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION))
+        .isInstanceOf(PrivacyPrecompiledContract.class);
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+  }
+
+  @Test
+  public void whenOnchainPrivacyGroupsEnabled_onchainPrivacyPrecompileIsInRegistry() {
+    when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(true);
+    when(privacyParameters.isEnabled()).thenReturn(true);
+
+    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    verify(privacyParameters).isEnabled();
+    verify(privacyParameters).isOnchainPrivacyGroupsEnabled();
+
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION))
+        .isInstanceOf(OnChainPrivacyPrecompiledContract.class);
+    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+  }
+
+  @Test
+  public void whenPrivacyNotEnabled_noPrivacyPrecompileInRegistry() {
+    when(privacyParameters.isEnabled()).thenReturn(false);
+
+    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    verify(privacyParameters).isEnabled();
+    verifyNoMoreInteractions(privacyParameters);
+
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
@@ -1,5 +1,16 @@
 /*
- *  SPDX-License-Identifier: Apache-2.0
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package org.hyperledger.besu.ethereum.mainnet;


### PR DESCRIPTION
Deprecate the CLI option and log a warning if used. Derive the address instead based on whether onchain privacy groups option is enabled.

## PR description

## Fixed Issue(s)
See #469 
