### PR TITLE
Sync status permissioning check conditional on onchain permissioning enabled

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
@@ -60,26 +60,27 @@ public class NodePermissioningControllerFactory {
       }
     }
 
-    if (permissioningConfiguration.getSmartContractConfig().isPresent()) {
-      SmartContractPermissioningConfiguration smartContractPermissioningConfiguration =
-          permissioningConfiguration.getSmartContractConfig().get();
-      if (smartContractPermissioningConfiguration.isSmartContractNodeAllowlistEnabled()) {
-        NodeSmartContractPermissioningController smartContractProvider =
-            new NodeSmartContractPermissioningController(
-                smartContractPermissioningConfiguration.getNodeSmartContractAddress(),
-                transactionSimulator,
-                metricsSystem);
-        providers.add(smartContractProvider);
+    if (permissioningConfiguration.getSmartContractConfig().isPresent()
+        && permissioningConfiguration
+            .getSmartContractConfig()
+            .get()
+            .isSmartContractNodeAllowlistEnabled()) {
+      NodeSmartContractPermissioningController smartContractProvider =
+          new NodeSmartContractPermissioningController(
+              permissioningConfiguration
+                  .getSmartContractConfig()
+                  .get()
+                  .getNodeSmartContractAddress(),
+              transactionSimulator,
+              metricsSystem);
+      providers.add(smartContractProvider);
 
-        if (fixedNodes.isEmpty()) {
-          syncStatusProviderOptional = Optional.empty();
-        } else {
-          syncStatusProviderOptional =
-              Optional.of(
-                  new SyncStatusNodePermissioningProvider(synchronizer, fixedNodes, metricsSystem));
-        }
-      } else {
+      if (fixedNodes.isEmpty()) {
         syncStatusProviderOptional = Optional.empty();
+      } else {
+        syncStatusProviderOptional =
+            Optional.of(
+                new SyncStatusNodePermissioningProvider(synchronizer, fixedNodes, metricsSystem));
       }
     } else {
       syncStatusProviderOptional = Optional.empty();
@@ -88,13 +89,14 @@ public class NodePermissioningControllerFactory {
     NodePermissioningController nodePermissioningController =
         new NodePermissioningController(syncStatusProviderOptional, providers);
 
-    if (permissioningConfiguration.getSmartContractConfig().isPresent()
-        && permissioningConfiguration
-            .getSmartContractConfig()
-            .get()
-            .isSmartContractNodeAllowlistEnabled()) {
-      validatePermissioningContract(nodePermissioningController);
-    }
+    permissioningConfiguration
+        .getSmartContractConfig()
+        .ifPresent(
+            config -> {
+              if (config.isSmartContractNodeAllowlistEnabled()) {
+                validatePermissioningContract(nodePermissioningController);
+              }
+            });
 
     return nodePermissioningController;
   }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProvider.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProvider.java
@@ -37,7 +37,7 @@ public class InsufficientPeersPermissioningProvider implements ContextualNodePer
    * Creates the provider observing the provided p2p network
    *
    * @param p2pNetwork the p2p network to observe
-   * @param bootnodeEnodes the bootnodes that this node is configured to connection to
+   * @param bootnodeEnodes the bootnodes that this node is configured to connect to
    */
   public InsufficientPeersPermissioningProvider(
       final P2PNetwork p2pNetwork, final Collection<EnodeURL> bootnodeEnodes) {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -128,6 +128,40 @@ public class NodePermissioningControllerFactoryTest {
   }
 
   @Test
+  public void
+      testCreateWithLocalNodePermissioningEnabledAndSmartContractPresentButDisabledAndBootnode() {
+    smartContractPermissioningConfiguration = new SmartContractPermissioningConfiguration();
+    smartContractPermissioningConfiguration.setNodeSmartContractAddress(
+        Address.fromHexString("0x0000000000000000000000000000000000001234"));
+    smartContractPermissioningConfiguration.setSmartContractNodeAllowlistEnabled(false);
+    final Collection<EnodeURL> fixedNodes = Collections.singleton(selfEnode);
+    localPermissioningConfig = LocalPermissioningConfiguration.createDefault();
+    localPermissioningConfig.setNodeAllowlist(Collections.emptyList());
+    localPermissioningConfig.setNodePermissioningConfigFilePath("fake-file-path");
+    config =
+        new PermissioningConfiguration(
+            Optional.of(localPermissioningConfig),
+            Optional.of(smartContractPermissioningConfiguration));
+
+    NodePermissioningControllerFactory factory = new NodePermissioningControllerFactory();
+    NodePermissioningController controller =
+        factory.create(
+            config,
+            synchronizer,
+            fixedNodes,
+            selfEnode.getNodeId(),
+            transactionSimulator,
+            new NoOpMetricsSystem());
+
+    List<NodePermissioningProvider> providers = controller.getProviders();
+    assertThat(providers.size()).isEqualTo(1);
+
+    NodePermissioningProvider p1 = providers.get(0);
+    assertThat(p1).isInstanceOf(NodeLocalConfigPermissioningController.class);
+    assertThat(controller.getSyncStatusNodePermissioningProvider()).isNotPresent();
+  }
+
+  @Test
   public void testCreateWithLocalNodeAndSmartContractPermissioningEnabled() {
     localPermissioningConfig = LocalPermissioningConfiguration.createDefault();
     localPermissioningConfig.setNodeAllowlist(Collections.emptyList());


### PR DESCRIPTION
Do not create sync status permissioning check if onchain permissioning is not enabled.

There was a flaw in the logic in that if onchain permissioning was configured (but not enabled) AND fixed nodes configured ie bootnodes, then the sync status permissioning check was rejecting connections.
