### PR TITLE
Fix GraphQL IBFT Coinbase Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Bug Fixes
 
+- GraphQL queries of `miner` in IBFT networks will no longer return an error.  PR [\#1282](https://github.com/hyperledger/besu/pull/1282) issue [\#1272](https://github.com/hyperledger/besu/issues/1272).
+
 #### Previously identified known issues
  
 - [Scope of logs query causing Besu to hang](KNOWN_ISSUES.md#scope-of-logs-query-causing-besu-to-hang)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
@@ -83,7 +83,7 @@ public class BlockAdapterBase extends AdapterBase {
     return Optional.of(header.getReceiptsRoot());
   }
 
-  public Optional<AccountAdapter> getMiner(final DataFetchingEnvironment environment) {
+  public Optional<AdapterBase> getMiner(final DataFetchingEnvironment environment) {
 
     final BlockchainQueries query = getBlockchainQueries(environment);
     long blockNumber = header.getNumber();
@@ -91,8 +91,10 @@ public class BlockAdapterBase extends AdapterBase {
     if (bn != null) {
       blockNumber = bn;
     }
-    return Optional.of(
-        new AccountAdapter(query.getWorldState(blockNumber).get().get(header.getCoinbase())));
+
+    return Optional.ofNullable(query.getWorldState(blockNumber).get().get(header.getCoinbase()))
+        .map(account -> (AdapterBase) new AccountAdapter(account))
+        .or(() -> Optional.of(new EmptyAccountAdapter(header.getCoinbase())));
   }
 
   public Optional<Bytes> getExtraData() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/EmptyAccountAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/EmptyAccountAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
+
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Wei;
+
+import java.util.Optional;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+@SuppressWarnings("unused") // reflected by GraphQL
+public class EmptyAccountAdapter extends AdapterBase {
+  private final Address address;
+
+  public EmptyAccountAdapter(final Address address) {
+    this.address = address;
+  }
+
+  public Optional<Address> getAddress() {
+    return Optional.of(address);
+  }
+
+  public Optional<Wei> getBalance() {
+    return Optional.of(Wei.ZERO);
+  }
+
+  public Optional<Long> getTransactionCount() {
+    return Optional.of(0L);
+  }
+
+  public Optional<Bytes> getCode() {
+    return Optional.of(Bytes.EMPTY);
+  }
+
+  public Optional<Bytes32> getStorage(final DataFetchingEnvironment environment) {
+    return Optional.of(Bytes32.ZERO);
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.ethereum.api.graphql;
 
 import org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter.NormalBlockAdapter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 
 import java.util.Optional;
@@ -24,15 +26,12 @@ import java.util.Set;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
 public abstract class AbstractDataFetcherTest {
 
   DataFetcher<Optional<NormalBlockAdapter>> fetcher;
-  private GraphQLDataFetchers fetchers;
 
   @Mock protected Set<Capability> supportedCapabilities;
 
@@ -42,11 +41,13 @@ public abstract class AbstractDataFetcherTest {
 
   @Mock protected BlockchainQueries query;
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Mock protected BlockHeader header;
+
+  @Mock protected MutableWorldState mutableWorldState;
 
   @Before
   public void before() {
-    fetchers = new GraphQLDataFetchers(supportedCapabilities);
+    final GraphQLDataFetchers fetchers = new GraphQLDataFetchers(supportedCapabilities);
     fetcher = fetchers.getBlockDataFetcher();
     Mockito.when(environment.getContext()).thenReturn(context);
     Mockito.when(context.getBlockchainQueries()).thenReturn(query);


### PR DESCRIPTION
When IBFT produces blocks the coinbase may correspond to an empty
account (as mining rewards are not paid out).  In this case allow
GraphQL to return an all zero account for the empty account only in
context of a miner.  Other tests exist that verify a plain accounts
query of a non-existent account throws an exception.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>