### PR TITLE
[Issue 1278] Rework static peer discovery handling

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
@@ -16,9 +16,12 @@ package org.hyperledger.besu.ethereum.p2p.discovery;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -43,6 +46,17 @@ public class DiscoveryPeer extends DefaultPeer {
 
   public static DiscoveryPeer fromEnode(final EnodeURL enode) {
     return new DiscoveryPeer(enode, Endpoint.fromEnode(enode));
+  }
+
+  public static Optional<DiscoveryPeer> from(final Peer peer) {
+    if (peer instanceof DiscoveryPeer) {
+      return Optional.of((DiscoveryPeer) peer);
+    }
+
+    return Optional.of(peer)
+        .map(Peer::getEnodeURL)
+        .filter(EnodeURL::isRunningDiscovery)
+        .map(DiscoveryPeer::fromEnode);
   }
 
   public static DiscoveryPeer fromIdAndEndpoint(final Bytes id, final Endpoint endpoint) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerRequirement;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.nat.NatService;
@@ -307,7 +308,10 @@ public abstract class PeerDiscoveryAgent {
     return isActive;
   }
 
-  public void bond(final DiscoveryPeer peer) {
-    controller.ifPresent(c -> c.handleBondingRequest(peer));
+  public void bond(final Peer peer) {
+    controller.ifPresent(
+        c -> {
+          DiscoveryPeer.from(peer).ifPresent(c::handleBondingRequest);
+        });
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerRequirement;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
-import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.nat.NatService;
@@ -82,15 +81,13 @@ public abstract class PeerDiscoveryAgent {
   /* Is discovery enabled? */
   private boolean isActive = false;
   protected final Subscribers<PeerBondedObserver> peerBondedObservers = Subscribers.create();
-  private final MaintainedPeers maintainedPeers;
 
   protected PeerDiscoveryAgent(
       final NodeKey nodeKey,
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final NatService natService,
-      final MetricsSystem metricsSystem,
-      final MaintainedPeers maintainedPeers) {
+      final MetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
     checkArgument(nodeKey != null, "nodeKey cannot be null");
     checkArgument(config != null, "provided configuration cannot be null");
@@ -104,7 +101,7 @@ public abstract class PeerDiscoveryAgent {
 
     this.config = config;
     this.nodeKey = nodeKey;
-    this.maintainedPeers = maintainedPeers;
+
     id = nodeKey.getPublicKey().getEncodedBytes();
   }
 
@@ -176,7 +173,6 @@ public abstract class PeerDiscoveryAgent {
         .peerPermissions(peerPermissions)
         .peerBondedObservers(peerBondedObservers)
         .metricsSystem(metricsSystem)
-        .maintainedPeers(maintainedPeers)
         .build();
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryControl
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController.AsyncExecutor;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.VertxTimerUtil;
-import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.nat.NatService;
@@ -63,9 +62,8 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final NatService natService,
-      final MetricsSystem metricsSystem,
-      final MaintainedPeers maintainedPeers) {
-    super(nodeKey, config, peerPermissions, natService, metricsSystem, maintainedPeers);
+      final MetricsSystem metricsSystem) {
+    super(nodeKey, config, peerPermissions, natService, metricsSystem);
     checkArgument(vertx != null, "vertx instance cannot be null");
     this.vertx = vertx;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -203,7 +203,7 @@ public class PeerDiscoveryController {
 
   private void onPeerAdded(final Peer peer, final boolean wasAdded) {
     if (wasAdded) {
-      addToPeerTable(DiscoveryPeer.fromEnode(peer.getEnodeURL()));
+      DiscoveryPeer.from(peer).ifPresent(this::addToPeerTable);
     }
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryController.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerBondedObserver;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryEvent;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
-import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
@@ -159,8 +158,7 @@ public class PeerDiscoveryController {
       final PeerRequirement peerRequirement,
       final PeerPermissions peerPermissions,
       final Subscribers<PeerBondedObserver> peerBondedObservers,
-      final MetricsSystem metricsSystem,
-      final MaintainedPeers maintainedPeers) {
+      final MetricsSystem metricsSystem) {
     this.timerUtil = timerUtil;
     this.nodeKey = nodeKey;
     this.localPeer = localPeer;
@@ -175,10 +173,6 @@ public class PeerDiscoveryController {
     this.discoveryProtocolLogger = new DiscoveryProtocolLogger(metricsSystem);
 
     this.peerPermissions = new PeerDiscoveryPermissions(localPeer, peerPermissions);
-
-    // Listening to the added and removed peer event to update the maintainted peers
-    maintainedPeers.subscribeAdd(this::onPeerAdded);
-    maintainedPeers.subscribeRemove(this::onPeerRemoved);
 
     metricsSystem.createIntegerGauge(
         BesuMetricCategory.NETWORK,
@@ -199,18 +193,6 @@ public class PeerDiscoveryController {
             "discovery_interaction_retry_count",
             "Total number of interaction retries performed",
             "type");
-  }
-
-  private void onPeerAdded(final Peer peer, final boolean wasAdded) {
-    if (wasAdded) {
-      DiscoveryPeer.from(peer).ifPresent(this::addToPeerTable);
-    }
-  }
-
-  private void onPeerRemoved(final Peer peer, final boolean wasRemoved) {
-    if (wasRemoved) {
-      peerTable.tryEvict(peer);
-    }
   }
 
   public static Builder builder() {
@@ -712,7 +694,6 @@ public class PeerDiscoveryController {
     private final List<DiscoveryPeer> bootstrapNodes = new ArrayList<>();
     private PeerTable peerTable;
     private Subscribers<PeerBondedObserver> peerBondedObservers = Subscribers.create();
-    private MaintainedPeers maintainedPeers = new MaintainedPeers();
 
     // Required dependencies
     private NodeKey nodeKey;
@@ -743,8 +724,7 @@ public class PeerDiscoveryController {
           peerRequirement,
           peerPermissions,
           peerBondedObservers,
-          metricsSystem,
-          maintainedPeers);
+          metricsSystem);
     }
 
     private void validate() {
@@ -834,12 +814,6 @@ public class PeerDiscoveryController {
     public Builder metricsSystem(final MetricsSystem metricsSystem) {
       checkNotNull(metricsSystem);
       this.metricsSystem = metricsSystem;
-      return this;
-    }
-
-    public Builder maintainedPeers(final MaintainedPeers maintainedPeers) {
-      checkNotNull(maintainedPeers);
-      this.maintainedPeers = maintainedPeers;
       return this;
     }
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -265,6 +265,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
   @Override
   public boolean addMaintainConnectionPeer(final Peer peer) {
     final boolean wasAdded = maintainedPeers.add(peer);
+    peerDiscoveryAgent.bond(peer);
     rlpxAgent.connect(peer);
     return wasAdded;
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -443,13 +443,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private PeerDiscoveryAgent createDiscoveryAgent() {
 
       return new VertxPeerDiscoveryAgent(
-          vertx,
-          nodeKey,
-          config.getDiscovery(),
-          peerPermissions,
-          natService,
-          metricsSystem,
-          maintainedPeers);
+          vertx, nodeKey, config.getDiscovery(), peerPermissions, natService, metricsSystem);
     }
 
     private RlpxAgent createRlpxAgent(

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PongPacketData;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
-import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.nat.NatService;
@@ -265,10 +264,8 @@ public class PeerDiscoveryTestHelper {
       config.setAdvertisedHost(advertisedHost);
       config.setBindPort(port);
       config.setActive(active);
-      MaintainedPeers maintainedPeers = new MaintainedPeers();
 
-      return new MockPeerDiscoveryAgent(
-          nodeKey, config, peerPermissions, agents, natService, maintainedPeers);
+      return new MockPeerDiscoveryAgent(nodeKey, config, peerPermissions, agents, natService);
     }
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/MockPeerDiscoveryAgent.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryController.AsyncExecutor;
-import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.nat.NatService;
@@ -49,9 +48,8 @@ public class MockPeerDiscoveryAgent extends PeerDiscoveryAgent {
       final DiscoveryConfiguration config,
       final PeerPermissions peerPermissions,
       final Map<Bytes, MockPeerDiscoveryAgent> agentNetwork,
-      final NatService natService,
-      final MaintainedPeers maintainedPeers) {
-    super(nodeKey, config, peerPermissions, natService, new NoOpMetricsSystem(), maintainedPeers);
+      final NatService natService) {
+    super(nodeKey, config, peerPermissions, natService, new NoOpMetricsSystem());
     this.agentNetwork = agentNetwork;
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -111,7 +111,8 @@ public final class DefaultP2PNetworkTest {
     assertThat(network.addMaintainConnectionPeer(peer)).isTrue();
 
     assertThat(maintainedPeers.contains(peer)).isTrue();
-    verify(rlpxAgent, times(1)).connect(peer);
+    verify(rlpxAgent).connect(peer);
+    verify(discoveryAgent).bond(peer);
   }
 
   @Test
@@ -123,6 +124,7 @@ public final class DefaultP2PNetworkTest {
     assertThat(network.addMaintainConnectionPeer(peer)).isTrue();
     assertThat(network.addMaintainConnectionPeer(peer)).isFalse();
     verify(rlpxAgent, times(2)).connect(peer);
+    verify(discoveryAgent, times(2)).bond(peer);
     assertThat(maintainedPeers.contains(peer)).isTrue();
   }
 
@@ -136,9 +138,10 @@ public final class DefaultP2PNetworkTest {
     assertThat(network.removeMaintainedConnectionPeer(peer)).isTrue();
 
     assertThat(maintainedPeers.contains(peer)).isFalse();
-    verify(rlpxAgent, times(1)).connect(peer);
-    verify(rlpxAgent, times(1)).disconnect(peer.getId(), DisconnectReason.REQUESTED);
-    verify(discoveryAgent, times(1)).dropPeer(peer);
+    verify(rlpxAgent).connect(peer);
+    verify(discoveryAgent).bond(peer);
+    verify(rlpxAgent).disconnect(peer.getId(), DisconnectReason.REQUESTED);
+    verify(discoveryAgent).dropPeer(peer);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Rework discovery-level handling of static peers to fix a few issues:
* Make sure that permissions are respected when pushing static peers into the discovery layer
* Initiate ping-pong bonding cycle rather than directly adding peers to our peer table to ensure that peer is live and running discovery
* Check that enode url indicates discovery protocol is running before attempting to bond with peer
* Remove duplicate `dropPeer` logic

## Fixed Issue(s)
Fixes #1278 
