### PR TITLE
[Issue 1306] Allow sub commands access to options and functionality that are currently private within BesuCommand

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/PublicKeySubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/PublicKeySubCommand.java
@@ -63,25 +63,18 @@ public class PublicKeySubCommand implements Runnable {
   private CommandSpec spec; // Picocli injects reference to command spec
 
   private final PrintStream out;
-  private final Runnable besuConfigurationService;
   private final Supplier<NodeKey> nodeKey;
 
   public PublicKeySubCommand(
       final PrintStream out,
-      final Runnable besuConfigurationService,
       final Supplier<NodeKey> nodeKey) {
     this.out = out;
-    this.besuConfigurationService = besuConfigurationService;
     this.nodeKey = nodeKey;
   }
 
   @Override
   public void run() {
     spec.commandLine().usage(out);
-  }
-
-  private void initBesuConfigurationService() {
-    besuConfigurationService.run();
   }
 
   private NodeKey getNodeKey() {
@@ -118,7 +111,6 @@ public class PublicKeySubCommand implements Runnable {
       checkNotNull(parentCommand);
       checkNotNull(parentCommand.parentCommand);
 
-      parentCommand.initBesuConfigurationService();
       final NodeKey nodeKey = parentCommand.getNodeKey();
       Optional.ofNullable(nodeKey).ifPresent(this::outputPublicKey);
     }
@@ -172,7 +164,6 @@ public class PublicKeySubCommand implements Runnable {
       checkNotNull(parentCommand);
       checkNotNull(parentCommand.parentCommand);
 
-      parentCommand.initBesuConfigurationService();
       final NodeKey nodeKey = parentCommand.getNodeKey();
       Optional.ofNullable(nodeKey).ifPresent(this::outputAddress);
     }

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/InterceptingResultHandler.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/InterceptingResultHandler.java
@@ -1,0 +1,44 @@
+package org.hyperledger.besu.cli.util;
+
+import org.hyperledger.besu.cli.BesuCommand;
+import picocli.CommandLine;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InterceptingResultHandler extends CommandLine.AbstractParseResultHandler<List<Object>> {
+
+    private final CommandLine.AbstractParseResultHandler<List<Object>> resultHandler;
+    private final CommandLine.IExceptionHandler2<List<Object>> exceptionHandler;
+    private final BeforeExecutionHook beforeExecutionHook;
+
+    @FunctionalInterface
+    public interface BeforeExecutionHook {
+        void beforeExecution(BesuCommand command);
+    }
+
+    public InterceptingResultHandler(
+            final CommandLine.AbstractParseResultHandler<List<Object>> resultHandler,
+            final CommandLine.IExceptionHandler2<List<Object>> exceptionHandler,
+            final BeforeExecutionHook beforeExecutionHook) {
+        this.resultHandler = resultHandler;
+        this.exceptionHandler = exceptionHandler;
+        this.beforeExecutionHook = beforeExecutionHook;
+        // use the same output as the regular options handler to ensure that outputs are all going
+        // in the same place. No need to do this for the exception handler as we reuse it directly.
+        this.useOut(resultHandler.out());
+    }
+
+    @Override
+    protected List<Object> handle(final CommandLine.ParseResult parseResult) throws CommandLine.ExecutionException {
+        final CommandLine commandLine = parseResult.asCommandLineList().get(0);
+        beforeExecutionHook.beforeExecution(commandLine.getCommand());
+        commandLine.parseWithHandlers(resultHandler, exceptionHandler, parseResult.originalArgs().toArray(new String[0]));
+        return new ArrayList<>();
+    }
+
+    @Override
+    protected CommandLine.AbstractParseResultHandler<List<Object>> self() {
+        return this;
+    }
+}

--- a/besu/src/main/java/org/hyperledger/besu/services/StorageServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/StorageServiceImpl.java
@@ -29,9 +29,20 @@ public class StorageServiceImpl implements StorageService {
   private final List<SegmentIdentifier> segments;
   private final Map<String, KeyValueStorageFactory> factories;
 
+  private String keyValueStorageName;
+
   public StorageServiceImpl() {
     this.segments = List.of(KeyValueSegmentIdentifier.values());
     this.factories = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public String getKeyValueStorageName() {
+    return keyValueStorageName;
+  }
+
+  public void setKeyValueStorageName(final String keyValueStorageName) {
+    this.keyValueStorageName = keyValueStorageName;
   }
 
   @Override

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/StorageService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/StorageService.java
@@ -26,6 +26,13 @@ import java.util.Optional;
 public interface StorageService {
 
   /**
+   * Name of the storage factory used for node data
+   *
+   * @return name of the storage factory used for node data
+   */
+  String getKeyValueStorageName();
+
+  /**
    * Registers a factory as available for creating key-value storage instances.
    *
    * @param factory creates instances providing key-value storage.


### PR DESCRIPTION
## PR description

- make the plugin context public in the `BesuCommand` allowing it to be accessed
  via the parent command user object from a sub command.

- initialise and add plugin common configuration service to the plugin context after
  the executing command has been parsed but before it is executed.

- add the keyValueStorageName parameter to the `StorageService` allowing
  plugins and sub commands to know what underlying node storage has been
  configured.

## Fixed Issue(s)
Fixes #1306 
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).