### PR TITLE
Upgrade picocli

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -133,7 +133,7 @@ public class BlocksSubCommand implements Runnable {
         paramLabel = DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP,
         description = "File containing blocks to import.",
         arity = "0..*")
-    private final List<Path> blockImportFileOption = blockImportFiles;
+    private final List<Path> blockImportFileOption = new ArrayList<>();
 
     @Option(
         names = "--format",
@@ -164,11 +164,12 @@ public class BlocksSubCommand implements Runnable {
     @Override
     public void run() {
       parentCommand.parentCommand.configureLogging(false);
+      blockImportFiles.addAll(blockImportFileOption);
 
       checkCommand(parentCommand);
       checkNotNull(parentCommand.rlpBlockImporter);
       checkNotNull(parentCommand.jsonBlockImporterFactory);
-      if (blockImportFileOption.isEmpty()) {
+      if (blockImportFiles.isEmpty()) {
         throw new ParameterException(spec.commandLine(), "No files specified to import.");
       }
       LOG.info("Import {} block data from {} files", format, blockImportFiles.size());

--- a/besu/src/test/java/org/hyperledger/besu/cli/PasswordSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/PasswordSubCommandTest.java
@@ -44,7 +44,7 @@ public class PasswordSubCommandTest extends CommandTestAbstract {
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString())
-        .contains("Missing required option '--password=<password>'");
+        .contains("Missing required option: '--password=<password>'");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
@@ -233,7 +233,7 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
         "--data-path=" + folder.getRoot().getAbsolutePath(),
         BLOCK_SUBCOMMAND_NAME,
         BLOCK_EXPORT_SUBCOMMAND_NAME);
-    final String expectedErrorOutputStart = "Missing required option '--to=<FILE>'";
+    final String expectedErrorOutputStart = "Missing required option: '--to=<FILE>'";
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).startsWith(expectedErrorOutputStart);
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,7 +43,7 @@ dependencyManagement {
 
     dependency 'commons-io:commons-io:2.7'
 
-    dependency 'info.picocli:picocli:4.1.4'
+    dependency 'info.picocli:picocli:4.5.0'
 
     dependency 'io.kubernetes:client-java:5.0.0'
 


### PR DESCRIPTION
## PR description

Upgrade PicoCLI to 4.5.0. The main motivation was to enable inherited
options: options that can show up on either side of a subcommand and be
managed by one field.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>
## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).