### PR TITLE
capture core dumps from AT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,9 @@ commands:
       - store_artifacts:
           path: acceptance-tests/tests/build/acceptanceTestLogs
           destination: acceptance-tests-logs
+      - store_artifacts:
+          path: /home/circleci/project/acceptance-tests/tests/core.*
+          destination: acceptance-tests-logs
 
 jobs:
   assemble:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ commands:
           path: acceptance-tests/tests/build/acceptanceTestLogs
           destination: acceptance-tests-logs
       - store_artifacts:
-          path: /home/circleci/project/acceptance-tests/tests/core.*
+          path: /home/circleci/project/acceptance-tests/tests/hs_err_pid*
           destination: acceptance-tests-logs
 
 jobs:


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Added a step to CI config to capture AT core dump output

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).