### PR TITLE
Ignore accept header in requests to metrics service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+* The metrics HTTP server no longer rejects requests containing `Accept` header that doesn't precisely match the prometheus text format [\#1345](https://github.com/hyperledger/besu/pull/1345)
+
 #### Previously identified known issues
  
 - [Logs queries missing results against chain head](KNOWN_ISSUES.md#Logs-queries-missing-results-against-chain-head)

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -91,10 +91,7 @@ class MetricsHttpService implements MetricsService {
     router.route("/").method(HttpMethod.GET).handler(this::handleEmptyRequest);
 
     // Endpoint for Prometheus metrics monitoring.
-    router
-        .route("/metrics")
-        .method(HttpMethod.GET)
-        .handler(this::metricsRequest);
+    router.route("/metrics").method(HttpMethod.GET).handler(this::metricsRequest);
 
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
     httpServer

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -94,7 +94,6 @@ class MetricsHttpService implements MetricsService {
     router
         .route("/metrics")
         .method(HttpMethod.GET)
-        .produces(TextFormat.CONTENT_TYPE_004)
         .handler(this::metricsRequest);
 
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpServiceTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpServiceTest.java
@@ -174,6 +174,22 @@ public class MetricsHttpServiceTest {
     }
   }
 
+  @Test
+  // There is only one available representation so content negotiation should not be used
+  public void acceptHeaderIgnored() throws Exception {
+    final Request metricsRequest =
+        new Request.Builder().addHeader("Accept", "text/xml").url(baseUrl + "/metrics").build();
+    try (final Response resp = client.newCall(metricsRequest).execute()) {
+      assertThat(resp.code()).isEqualTo(200);
+      // Check general format of result, it maps to java.util.Properties
+      final Properties props = new Properties();
+      props.load(resp.body().byteStream());
+
+      // We should have JVM metrics already loaded, verify a simple key.
+      assertThat(props).containsKey("jvm_threads_deadlocked");
+    }
+  }
+
   private Request buildGetRequest(final String path) {
     return new Request.Builder().get().url(baseUrl + path).build();
   }

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpServiceTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpServiceTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.util.NetworkUtility.urlForSocketAddress;
 import java.net.InetSocketAddress;
 import java.util.Properties;
 
+import io.prometheus.client.exporter.common.TextFormat;
 import io.vertx.core.Vertx;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -187,6 +188,7 @@ public class MetricsHttpServiceTest {
 
       // We should have JVM metrics already loaded, verify a simple key.
       assertThat(props).containsKey("jvm_threads_deadlocked");
+      assertThat(resp.header("Content-Type")).contains(TextFormat.CONTENT_TYPE_004);
     }
   }
 


### PR DESCRIPTION
## PR description
The metrics HTTP service only has one supported representation for content but is applying overly strict content type negotiation and refusing to return any content if the Accept header is present and set to anything other than `text/plain; version=0.0.4; charset=utf-8`.  This makes it incompatible with tools like DataDog which specify `Accept: text/plain`.

## Fixed Issue(s)
https://github.com/PegaSysEng/teku/issues/2678

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).