### PR TITLE
Better Handling of Pending Peer Requests Assigned to Disconnected Peers

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -76,8 +76,19 @@ public class EthPeers {
     if (peer != null) {
       disconnectCallbacks.forEach(callback -> callback.onDisconnect(peer));
       peer.handleDisconnect();
+      abortPendingRequestsAssignedToDisconnectedPeers();
     }
     reattemptPendingPeerRequests();
+  }
+
+  private void abortPendingRequestsAssignedToDisconnectedPeers() {
+    synchronized (this) {
+      pendingRequests.stream()
+          .filter(
+              pendingPeerRequest ->
+                  pendingPeerRequest.getAssignedPeer().map(EthPeer::isDisconnected).orElse(false))
+          .forEach(PendingPeerRequest::abort);
+    }
   }
 
   public EthPeer peer(final PeerConnection peerConnection) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
@@ -119,4 +119,8 @@ public class PendingPeerRequest {
       return Optional.empty();
     }
   }
+
+  public Optional<EthPeer> getAssignedPeer() {
+    return peer;
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
@@ -61,7 +61,6 @@ public class RequestManager {
 
   public void close() {
     closeOutstandingStreams(responseStreams.values());
-    outstandingRequests.set(0);
   }
 
   private ResponseStream createStream() {


### PR DESCRIPTION
This PR solves the same problem as 3a39fbb70740f921436bb2f26548d977c48a0d23 but better. The attempt there has an issue where it still emulates sending the request and therefore only 5 requests max can be aborted. Thus the problem of the peer becoming stuck in a busy state remains. Here we do what we should've done all along, which is proactively abort these requests when a disconnect event occurs.
