### PR TITLE
[issue-1300] Update net_version JSON-RPC call to return network ID instead of chain ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 * The metrics HTTP server no longer rejects requests containing `Accept` header that doesn't precisely match the prometheus text format [\#1345](https://github.com/hyperledger/besu/pull/1345)
+* JSON-RPC method `net_version` should return network ID instead of chain ID [\#1355](https://github.com/hyperledger/besu/pull/1355)
 
 #### Previously identified known issues
  

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersion.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersion.java
@@ -29,10 +29,10 @@ import java.util.Optional;
  * <p>This method can be deprecated in the future, @see https://github.com/ethereum/EIPs/issues/611
  */
 public class NetVersion implements JsonRpcMethod {
-  private final String chainId;
+  private final String networkId;
 
-  public NetVersion(final Optional<BigInteger> chainId) {
-    this.chainId = String.valueOf(chainId.orElse(null));
+  public NetVersion(final Optional<BigInteger> netId) {
+    this.networkId = String.valueOf(netId.orElse(null));
   }
 
   @Override
@@ -42,6 +42,6 @@ public class NetVersion implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), chainId);
+    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), networkId);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -97,7 +97,7 @@ public class JsonRpcMethodsFactory {
                   supportedCapabilities),
               new NetJsonRpcMethods(
                   p2pNetwork,
-                  protocolSchedule,
+                  networkId,
                   jsonRpcConfiguration,
                   webSocketConfiguration,
                   metricsConfiguration),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
@@ -35,7 +35,6 @@ public class NetJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final P2PNetwork p2pNetwork;
   private final BigInteger networkId;
-  //  private final ProtocolSchedule protocolSchedule;
   private final JsonRpcConfiguration jsonRpcConfiguration;
   private final WebSocketConfiguration webSocketConfiguration;
   private final MetricsConfiguration metricsConfiguration;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
@@ -24,28 +24,30 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.NetPeerCount;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.NetServices;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.NetVersion;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
-import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 
+import java.math.BigInteger;
 import java.util.Map;
+import java.util.Optional;
 
 public class NetJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final P2PNetwork p2pNetwork;
-  private final ProtocolSchedule protocolSchedule;
+  private final BigInteger networkId;
+  //  private final ProtocolSchedule protocolSchedule;
   private final JsonRpcConfiguration jsonRpcConfiguration;
   private final WebSocketConfiguration webSocketConfiguration;
   private final MetricsConfiguration metricsConfiguration;
 
   public NetJsonRpcMethods(
       final P2PNetwork p2pNetwork,
-      final ProtocolSchedule protocolSchedule,
+      final BigInteger networkId,
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,
       final MetricsConfiguration metricsConfiguration) {
     this.p2pNetwork = p2pNetwork;
-    this.protocolSchedule = protocolSchedule;
+    this.networkId = networkId;
     this.jsonRpcConfiguration = jsonRpcConfiguration;
     this.webSocketConfiguration = webSocketConfiguration;
     this.metricsConfiguration = metricsConfiguration;
@@ -59,7 +61,7 @@ public class NetJsonRpcMethods extends ApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create() {
     return mapOf(
-        new NetVersion(protocolSchedule.getChainId()),
+        new NetVersion(Optional.of(networkId)),
         new NetListening(p2pNetwork),
         new NetPeerCount(p2pNetwork),
         new NetEnode(p2pNetwork),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
@@ -43,7 +43,7 @@ public class NetVersionTest {
   }
 
   @Test
-  public void shouldReturnChainId() {
+  public void shouldReturnNetworkId() {
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(null, NETWORK_ID.toString());
 
@@ -53,7 +53,7 @@ public class NetVersionTest {
   }
 
   @Test
-  public void shouldReturnNullWhenNoChainId() {
+  public void shouldReturnNullWhenNoNetworkId() {
     method = new NetVersion(Optional.empty());
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "null");
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
@@ -30,11 +30,11 @@ import org.junit.Test;
 public class NetVersionTest {
 
   private NetVersion method;
-  private final BigInteger CHAIN_ID = BigInteger.ONE;
+  private final BigInteger NETWORK_ID = BigInteger.ONE;
 
   @Before
   public void setUp() {
-    method = new NetVersion(Optional.of(CHAIN_ID));
+    method = new NetVersion(Optional.of(NETWORK_ID));
   }
 
   @Test
@@ -44,7 +44,8 @@ public class NetVersionTest {
 
   @Test
   public void shouldReturnChainId() {
-    final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, CHAIN_ID.toString());
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcSuccessResponse(null, NETWORK_ID.toString());
 
     final JsonRpcResponse response = method.response(request());
 

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_chainId.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_chainId.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "id": 8,
+    "jsonrpc": "2.0",
+    "method": "eth_chainId",
+    "params": []
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 8,
+    "result": "0x1"
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/net_version.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/net_version.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "id": 7,
+    "jsonrpc": "2.0",
+    "method": "net_version",
+    "params": []
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 7,
+    "result": "123"
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This PR implements fix to JSON-RPC method `net_version` to return network ID as specified in [https://eth.wiki/json-rpc/API#net_version](https://eth.wiki/json-rpc/API#net_version). 
 
Signed-off-by: Edward Mack <ed@edwardmack.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #1300 
## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).