### PR TITLE
Fix experimental options not correctly displayed

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.node;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.hyperledger.besu.cli.options.NetworkingOptions;
+import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DnsOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DnsOptions.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import org.hyperledger.besu.cli.options.CLIOptions;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
+import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import picocli.CommandLine;
+
+public class DnsOptions implements CLIOptions<EnodeDnsConfiguration> {
+
+  private final String DNS_ENABLED = "--Xdns-enabled";
+  private final String DNS_UPDATE_ENABLED = "--Xdns-update-enabled";
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xdns-enabled"},
+      description = "Enabled DNS support",
+      arity = "1")
+  private Boolean dnsEnabled = Boolean.FALSE;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xdns-update-enabled"},
+      description = "Allow to detect an IP update automatically",
+      arity = "1")
+  private Boolean dnsUpdateEnabled = Boolean.FALSE;
+
+  public static DnsOptions create() {
+    return new DnsOptions();
+  }
+
+  public static DnsOptions fromConfig(final EnodeDnsConfiguration enodeDnsConfiguration) {
+    final DnsOptions cliOptions = new DnsOptions();
+    cliOptions.dnsEnabled = enodeDnsConfiguration.dnsEnabled();
+    cliOptions.dnsUpdateEnabled = enodeDnsConfiguration.updateEnabled();
+    return cliOptions;
+  }
+
+  public Boolean getDnsEnabled() {
+    return dnsEnabled;
+  }
+
+  public Boolean getDnsUpdateEnabled() {
+    return dnsUpdateEnabled;
+  }
+
+  @Override
+  public EnodeDnsConfiguration toDomainObject() {
+    return ImmutableEnodeDnsConfiguration.builder()
+        .updateEnabled(dnsUpdateEnabled)
+        .dnsEnabled(dnsEnabled)
+        .build();
+  }
+
+  @Override
+  public List<String> getCLIOptions() {
+    return Arrays.asList(
+        DNS_ENABLED, dnsEnabled.toString(), DNS_UPDATE_ENABLED, dnsUpdateEnabled.toString());
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthProtocolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthProtocolOptions.java
@@ -12,8 +12,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
+import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.util.number.PositiveNumber;
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthstatsOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthstatsOptions.java
@@ -12,8 +12,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.ethstats.util.NetstatsUrl;
 
 import java.util.Arrays;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
@@ -12,8 +12,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 
 import java.util.Arrays;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MiningOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MiningOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_REMOTE_SEALERS_LIMIT;
+import static org.hyperledger.besu.ethereum.core.MiningParameters.DEFAULT_REMOTE_SEALERS_TTL;
+
+import picocli.CommandLine;
+
+public class MiningOptions {
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xminer-remote-sealers-limit"},
+      description =
+          "Limits the number of remote sealers that can submit their hashrates (default: ${DEFAULT-VALUE})")
+  private final Integer remoteSealersLimit = DEFAULT_REMOTE_SEALERS_LIMIT;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xminer-remote-sealers-hashrate-ttl"},
+      description =
+          "Specifies the lifetime of each entry in the cache. An entry will be automatically deleted if no update has been received before the deadline (default: ${DEFAULT-VALUE} minutes)")
+  private final Long remoteSealersTimeToLive = DEFAULT_REMOTE_SEALERS_TTL;
+
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xminer-stratum-extranonce"},
+      description = "Extranonce for Stratum network miners (default: ${DEFAULT-VALUE})")
+  private String stratumExtranonce = "080c";
+
+  public static MiningOptions create() {
+    return new MiningOptions();
+  }
+
+  public Integer getRemoteSealersLimit() {
+    return remoteSealersLimit;
+  }
+
+  public Long getRemoteSealersTimeToLive() {
+    return remoteSealersTimeToLive;
+  }
+
+  public String getStratumExtranonce() {
+    return stratumExtranonce;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+
+import picocli.CommandLine;
+
+public class NatOptions {
+
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xnat-kube-service-name"},
+      description =
+          "Specify the name of the service that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
+  private String natManagerServiceName = DEFAULT_BESU_SERVICE_NAME_FILTER;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xnat-method-fallback-enabled"},
+      description =
+          "Enable fallback to NONE for the nat manager in case of failure. If False BESU will exit on failure. (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final Boolean natMethodFallbackEnabled = true;
+
+  public static NatOptions create() {
+    return new NatOptions();
+  }
+
+  public String getNatManagerServiceName() {
+    return natManagerServiceName;
+  }
+
+  public Boolean getNatMethodFallbackEnabled() {
+    return natMethodFallbackEnabled;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NativeLibraryOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NativeLibraryOptions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import picocli.CommandLine;
+
+public class NativeLibraryOptions {
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xsecp256k1-native-enabled"},
+      description = "Path to PID file (optional)",
+      arity = "1")
+  private final Boolean nativeSecp256k1 = Boolean.TRUE;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xaltbn128-native-enabled"},
+      description = "Path to PID file (optional)",
+      arity = "1")
+  private final Boolean nativeAltbn128 = Boolean.TRUE;
+
+  public static NativeLibraryOptions create() {
+    return new NativeLibraryOptions();
+  }
+
+  public Boolean getNativeSecp256k1() {
+    return nativeSecp256k1;
+  }
+
+  public Boolean getNativeAltbn128() {
+    return nativeAltbn128;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
@@ -12,8 +12,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
+import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 
 import java.util.Arrays;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/RPCOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/RPCOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import org.hyperledger.besu.ethereum.api.handlers.TimeoutOptions;
+
+import picocli.CommandLine;
+
+public class RPCOptions {
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xhttp-timeout-seconds"},
+      description = "HTTP timeout in seconds (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final Long httpTimeoutSec = TimeoutOptions.defaultOptions().getTimeoutSeconds();
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xws-timeout-seconds"},
+      description = "Web socket timeout in seconds (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final Long wsTimeoutSec = TimeoutOptions.defaultOptions().getTimeoutSeconds();
+
+  public static RPCOptions create() {
+    return new RPCOptions();
+  }
+
+  public Long getHttpTimeoutSec() {
+    return httpTimeoutSec;
+  }
+
+  public Long getWsTimeoutSec() {
+    return wsTimeoutSec;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/SynchronizerOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/SynchronizerOptions.java
@@ -12,8 +12,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
+import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 
 import java.util.Arrays;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/TransactionPoolOptions.java
@@ -12,8 +12,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.cli.options;
+package org.hyperledger.besu.cli.options.unstable;
 
+import org.hyperledger.besu.cli.options.CLIOptions;
+import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 
 import java.util.Arrays;

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -31,11 +31,11 @@ import org.hyperledger.besu.chainexport.RlpBlockExporter;
 import org.hyperledger.besu.chainimport.JsonBlockImporter;
 import org.hyperledger.besu.chainimport.RlpBlockImporter;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
-import org.hyperledger.besu.cli.options.EthProtocolOptions;
-import org.hyperledger.besu.cli.options.MetricsCLIOptions;
-import org.hyperledger.besu.cli.options.NetworkingOptions;
-import org.hyperledger.besu.cli.options.SynchronizerOptions;
-import org.hyperledger.besu.cli.options.TransactionPoolOptions;
+import org.hyperledger.besu.cli.options.unstable.EthProtocolOptions;
+import org.hyperledger.besu.cli.options.unstable.MetricsCLIOptions;
+import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
+import org.hyperledger.besu.cli.options.unstable.SynchronizerOptions;
+import org.hyperledger.besu.cli.options.unstable.TransactionPoolOptions;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.controller.NoopPluginServiceFactory;
@@ -382,23 +382,23 @@ public abstract class CommandTestAbstract {
     }
 
     public NetworkingOptions getNetworkingOptions() {
-      return networkingOptions;
+      return unstableNetworkingOptions;
     }
 
     public SynchronizerOptions getSynchronizerOptions() {
-      return synchronizerOptions;
+      return unstableSynchronizerOptions;
     }
 
     public EthProtocolOptions getEthProtocolOptions() {
-      return ethProtocolOptions;
+      return unstableEthProtocolOptions;
     }
 
     public TransactionPoolOptions getTransactionPoolOptions() {
-      return transactionPoolOptions;
+      return unstableTransactionPoolOptions;
     }
 
     public MetricsCLIOptions getMetricsCLIOptions() {
-      return metricsCLIOptions;
+      return unstableMetricsCLIOptions;
     }
 
     public void close() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/EthProtocolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/EthProtocolOptionsTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.cli.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import org.hyperledger.besu.cli.options.unstable.EthProtocolOptions;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.util.number.PositiveNumber;
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsCLIOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsCLIOptionsTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.cli.options;
 
+import org.hyperledger.besu.cli.options.unstable.MetricsCLIOptions;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 
 public class MetricsCLIOptionsTest

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 
 import org.junit.Test;

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/SynchronizerOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/SynchronizerOptionsTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.cli.options;
 
+import org.hyperledger.besu.cli.options.unstable.SynchronizerOptions;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 
 import java.util.Arrays;

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.cli.options;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.cli.options.unstable.TransactionPoolOptions;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 
 import org.junit.Test;

--- a/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayed.java
+++ b/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayed.java
@@ -51,7 +51,6 @@ public class ExperimentalCliOptionMustBeCorrectlyDisplayed extends BugChecker
         final JCTree.JCCompilationUnit compilation =
             (JCTree.JCCompilationUnit) state.getPath().getCompilationUnit();
         if (compilation.getSourceFile().getName().endsWith("BesuCommand.java")) {
-          System.out.println("alllo");
           return describeMatch(tree);
         }
         final Optional<? extends AnnotationValue> isHidden =

--- a/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayed.java
+++ b/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayed.java
@@ -30,14 +30,16 @@ import com.google.errorprone.bugpatterns.BugChecker.AnnotationTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
+import com.sun.tools.javac.tree.JCTree;
 
 @AutoService(BugChecker.class)
 @BugPattern(
-    name = "ExperimentalCliOptionMustBeHidden",
-    summary = "Experimental options must be hidden.",
+    name = "ExperimentalCliOptionMustBeCorrectlyDisplayed",
+    summary = "Experimental options must be hidden and not present in the BesuCommand class.",
     severity = WARNING,
     linkType = BugPattern.LinkType.NONE)
-public class ExperimentalCliOptionMustBeHidden extends BugChecker implements AnnotationTreeMatcher {
+public class ExperimentalCliOptionMustBeCorrectlyDisplayed extends BugChecker
+    implements AnnotationTreeMatcher {
 
   @Override
   public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
@@ -46,6 +48,12 @@ public class ExperimentalCliOptionMustBeHidden extends BugChecker implements Ann
       final Optional<? extends AnnotationValue> names =
           getAnnotationValue(annotationMirror, "names");
       if (names.isPresent() && names.get().getValue().toString().contains("--X")) {
+        final JCTree.JCCompilationUnit compilation =
+            (JCTree.JCCompilationUnit) state.getPath().getCompilationUnit();
+        if (compilation.getSourceFile().getName().endsWith("BesuCommand.java")) {
+          System.out.println("alllo");
+          return describeMatch(tree);
+        }
         final Optional<? extends AnnotationValue> isHidden =
             getAnnotationValue(annotationMirror, "hidden");
         if (isHidden.isEmpty() || !((boolean) isHidden.get().getValue())) {

--- a/errorprone-checks/src/test/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedTest.java
+++ b/errorprone-checks/src/test/java/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedTest.java
@@ -18,35 +18,28 @@ import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ExperimentalCliOptionMustBeHiddenTest {
+public class ExperimentalCliOptionMustBeCorrectlyDisplayedTest {
 
   private CompilationTestHelper compilationHelper;
 
   @Before
   public void setup() {
     compilationHelper =
-        CompilationTestHelper.newInstance(ExperimentalCliOptionMustBeHidden.class, getClass());
+        CompilationTestHelper.newInstance(
+            ExperimentalCliOptionMustBeCorrectlyDisplayed.class, getClass());
   }
 
   @Test
   public void experimentalCliOptionMustBeHiddenPositiveCases() {
-    compilationHelper.addSourceFile("ExperimentalCliOptionNotHiddenPositiveCases.java").doTest();
+    compilationHelper
+        .addSourceFile("ExperimentalCliOptionMustBeCorrectlyDisplayedPositiveCases.java")
+        .doTest();
   }
 
   @Test
   public void experimentalCliOptionMustBeHiddenNegativeCases() {
-    compilationHelper.addSourceFile("ExperimentalCliOptionNotHiddenNegativeCases.java").doTest();
-  }
-
-  @Test
-  public void methodInputParametersMustBeFinalNegativeCases() {
-    compilationHelper.addSourceFile("MethodInputParametersMustBeFinalNegativeCases.java").doTest();
-  }
-
-  @Test
-  public void methodInputParametersMustBeFinalInterfaceNegativeCases() {
     compilationHelper
-        .addSourceFile("MethodInputParametersMustBeFinalInterfaceNegativeCases.java")
+        .addSourceFile("ExperimentalCliOptionMustBeCorrectlyDisplayedNegativeCases.java")
         .doTest();
   }
 }

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedNegativeCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedNegativeCases.java
@@ -19,16 +19,37 @@ import picocli.CommandLine;
 
 import java.util.Objects;
 
-public class ExperimentalCliOptionNotHiddenPositiveCases {
+public class ExperimentalCliOptionMustBeCorrectlyDisplayedNegativeCases {
 
-  // BUG: Diagnostic contains:  Experimental options must be hidden.
   @CommandLine.Option(
-          hidden = false,
+          hidden = true,
           names = {"--Xexperimental"})
   private String experimental = "";
 
-  // BUG: Diagnostic contains:  Experimental options must be hidden.
   @CommandLine.Option(
-          names = {"--Xexperimental2"})
-  private String experimental2 = "";
+          hidden = false,
+          names = {"--notExperimental"})
+  private String notExperimental = "";
+
+  @CommandLine.Option(
+          names = {"--notExperimental2"})
+  private String notExperimental2 = "";
+
+  private class AnotherClass {
+    @CommandLine.Option(
+            names = {"--notExperimentalInAnotherClass"})
+    private String notExperimentalInAnotherClass = "";
+
+    @CommandLine.Option(
+            hidden = true,
+            names = {"--XexperimentalInAnotherClass"})
+    private String experimentalInAnotherClass = "";
+  }
+
+  private class BesuCommand {
+
+    @CommandLine.Option(
+            names = {"--notExperimentalInBesuCommandClass"})
+    private String notExperimentalInBesuCommandClass = "";
+  }
 }

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedPositiveCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/ExperimentalCliOptionMustBeCorrectlyDisplayedPositiveCases.java
@@ -19,19 +19,25 @@ import picocli.CommandLine;
 
 import java.util.Objects;
 
-public class ExperimentalCliOptionNotHiddenNegativeCases {
+public class ExperimentalCliOptionMustBeCorrectlyDisplayedPositiveCases {
 
+  // BUG: Diagnostic contains:  Experimental options must be hidden and not present in the BesuCommand class.
   @CommandLine.Option(
-          hidden = true,
+          hidden = false,
           names = {"--Xexperimental"})
   private String experimental = "";
 
+  // BUG: Diagnostic contains:  Experimental options must be hidden and not present in the BesuCommand class.
   @CommandLine.Option(
-          hidden = false,
-          names = {"--notExperimental"})
-  private String notExperimental = "";
+          names = {"--Xexperimental2"})
+  private String experimental2 = "";
 
-  @CommandLine.Option(
-          names = {"--notExperimental2"})
-  private String notExperimental2 = "";
+  private class BesuCommand {
+
+    // BUG: Diagnostic contains:  Experimental options must be hidden and not present in the BesuCommand class.
+    @CommandLine.Option(
+            names = {"--XexperimentalInBesuCommandClass"})
+    private String experimentalInBesuCommandClass = "";
+  }
+
 }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

All --X options listed in the BesuCommand class are not displayed.

- Add new errorprone check to avoid future --X options in  theBesuCommand class
- Small refactor of the Experimental Options classes

List of missing options : 

```
--Xsecp256k1-native-enabled
--Xaltbn128-native-enabled
--Xhttp-timeout-seconds
--Xws-timeout-seconds
--Xdns-enabled
--Xdns-update-enabled
--Xminer-stratum-extranonce
...
```

## Result

````

Unstable options for Native Library
      --Xaltbn128-native-enabled=<nativeAltbn128>
         Path to PID file (optional)
      --Xsecp256k1-native-enabled=<nativeSecp256k1>
         Path to PID file (optional)

Unstable options for RPC
      --Xhttp-timeout-seconds=<httpTimeoutSec>
         HTTP timeout in seconds (default: 300)
      --Xws-timeout-seconds=<wsTimeoutSec>
         Web socket timeout in seconds (default: 300)

Unstable options for DNS Configuration
      --Xdns-enabled=<dnsEnabled>
         Enabled DNS support
      --Xdns-update-enabled=<dnsUpdateEnabled>
         Allow to detect an IP update automatically

Unstable options for NAT Configuration
      --Xnat-kube-service-name=<natManagerServiceName>
         Specify the name of the service that will be used by the nat manager
           in Kubernetes. (default: besu)
      --Xnat-method-fallback-enabled=<natMethodFallbackEnabled>
         Enable fallback to NONE for the nat manager in case of failure. If
           False BESU will exit on failure. (default: true)

Unstable options for Mining
      --Xminer-remote-sealers-hashrate-ttl=<remoteSealersTimeToLive>
         Specifies the lifetime of each entry in the cache. An entry will be
           automatically deleted if no update has been received before the
           deadline (default: 10 minutes)
      --Xminer-remote-sealers-limit=<remoteSealersLimit>
         Limits the number of remote sealers that can submit their hashrates
           (default: 1000)
      --Xminer-stratum-extranonce=<stratumExtranonce>
         Extranonce for Stratum network miners (default: 080c)

`````

## Test performed

> ./besu --help
```
Usage:

besu [OPTIONS] [COMMAND]

Description:

This command runs the Besu Ethereum client full node.

Options:
      --auto-log-bloom-caching-enabled=<autoLogBloomCachingEnabled>
                             Enable automatic log bloom caching (default: true)
      --banned-node-id, --banned-node-ids=<NODEID>[,<NODEID>...]...
                             A list of node IDs to ban from the P2P network.
      --bootnodes[=<enode://id@host:port>[,<enode://id@host:port>...]...]
                             Comma separated enode URLs for P2P discovery
                               bootstrap. Default is a predefined list.
      --color-enabled        Force color output to be enabled/disabled
                               (default: colorized only if printing to console
      --config-file=<FILE>   TOML config file (default: none)
      --data-path=<PATH>     The path to Besu data directory (default:
                               /Users/karimtaam/git-consensys/chupacabra/besu/bu
                               ild/install/besu)
      --discovery-enabled=<peerDiscoveryEnabled>
                             Enable P2P peer discovery (default: true)
      --fast-sync-min-peers=<INTEGER>
                             Minimum number of peers required before starting
                               fast sync. (default: 5)
      --genesis-file=<FILE>  Genesis file. Setting this option makes --network
                               option ignored and requires --network-id to be
                               set.
      --graphql-http-cors-origins=<graphQLHttpCorsAllowedOrigins>
                             Comma separated origin domain URLs for CORS
                               validation (default: none)
      --graphql-http-enabled Set to start the GraphQL HTTP service (default:
                               false)
      --graphql-http-host=<HOST>
                             Host for GraphQL HTTP to listen on (default:
                               127.0.0.1)
      --graphql-http-port=<PORT>
                             Port for GraphQL HTTP to listen on (default: 8547)
  -h, --help                 Show this help message and exit.
      --host-allowlist, --host-whitelist=<hostname>[,<hostname>...]... or * or 
        all
                             Comma separated list of hostnames to allow for RPC
                               access, or * to accept any host (default:
                               localhost,127.0.0.1)
      --identity=<String>    Identification for this node in the Client ID
      --key-value-storage=<keyValueStorageName>
                             Identity for the key-value storage to be used.
  -l, --logging=<LOG VERBOSITY LEVEL>
                             Logging verbosity levels: OFF, FATAL, ERROR, WARN,
                               INFO, DEBUG, TRACE, ALL
      --max-peers=<INTEGER>  Maximum P2P peer connections that can be
                               established (default: 25)
      --metrics-category, --metrics-categories=<category name>[,<category 
        name>...]...
                             Comma separated list of categories to track
                               metrics for (default: [BLOCKCHAIN, ETHEREUM,
                               EXECUTORS, NETWORK, PEERS, PERMISSIONING,
                               PRUNER, RPC, SYNCHRONIZER, TRANSACTION_POOL,
                               JVM, PROCESS])
      --metrics-enabled      Set to start the metrics exporter (default: false)
      --metrics-host=<HOST>  Host for the metrics exporter to listen on
                               (default: 127.0.0.1)
      --metrics-port=<PORT>  Port for the metrics exporter to listen on
                               (default: 9545)
      --metrics-push-enabled Enable the metrics push gateway integration
                               (default: false)
      --metrics-push-host=<HOST>
                             Host of the Prometheus Push Gateway for push mode
                               (default: 127.0.0.1)
      --metrics-push-interval=<INTEGER>
                             Interval in seconds to push metrics when in push
                               mode (default: 15)
      --metrics-push-port=<PORT>
                             Port of the Prometheus Push Gateway for push mode
                               (default: 9001)
      --metrics-push-prometheus-job=<metricsPrometheusJob>
                             Job name to use when in push mode (default:
                               besu-client)
      --min-block-occupancy-ratio=<minBlockOccupancyRatio>
                             Minimum occupancy ratio for a mined block
                               (default: 0.8)
      --min-gas-price=<minTransactionGasPrice>
                             Minimum price (in Wei) offered by a transaction
                               for it to be included in a mined block (default:
                               1000)
      --miner-coinbase=<coinbase>
                             Account to which mining rewards are paid. You must
                               specify a valid coinbase if mining is enabled
                               using --miner-enabled option
      --miner-enabled        Set if node will perform mining (default: false)
      --miner-extra-data=<extraData>
                             A hex string representing the (32) bytes to be
                               included in the extra data field of a mined
                               block (default: 0x)
      --miner-stratum-enabled
                             Set if node will perform Stratum mining (default:
                               false)
      --miner-stratum-host=<stratumNetworkInterface>
                             Host for Stratum network mining service (default:
                               0.0.0.0)
      --miner-stratum-port=<stratumPort>
                             Stratum port binding (default: 8008)
      --nat-method=<natMethod>
                             Specify the NAT circumvention method to be used,
                               possible values are UPNP, DOCKER, KUBERNETES,
                               AUTO, NONE. NONE disables NAT functionality.
                               (default: AUTO)
      --network=<NETWORK>    Synchronize against the indicated network,
                               possible values are MAINNET, RINKEBY, ROPSTEN,
                               GOERLI, DEV, CLASSIC, KOTTI, MORDOR, YOLO_V1.
                               (default: MAINNET)
      --network-id=<BIG INTEGER>
                             P2P network identifier. (default: the selected
                               network chain ID or custom genesis chain ID)
      --node-private-key-file=<PATH>
                             The node's private key file (default: a file named
                               "key" in the Besu data folder)
      --p2p-enabled=<p2pEnabled>
                             Enable P2P functionality (default: true)
      --p2p-host=<HOST>      Ip address this node advertises to its peers
                               (default: 127.0.0.1)
      --p2p-interface=<HOST> The network interface address on which this node
                               listens for P2P communication (default: 0.0.0.0)
      --p2p-port=<PORT>      Port on which to listen for P2P communication
                               (default: 30303)
      --permissions-accounts-config-file=<accountPermissionsConfigFile>
                             Account permissioning config TOML file (default: a
                               file named "permissions_config.toml" in the Besu
                               data folder)
      --permissions-accounts-config-file-enabled
                             Enable account level permissions (default: false)
      --permissions-accounts-contract-address=<permissionsAccountsContractAddres
        s>
                             Address of the account permissioning smart contract
      --permissions-accounts-contract-enabled
                             Enable account level permissions via smart
                               contract (default: false)
      --permissions-nodes-config-file=<nodePermissionsConfigFile>
                             Node permissioning config TOML file (default: a
                               file named "permissions_config.toml" in the Besu
                               data folder)
      --permissions-nodes-config-file-enabled
                             Enable node level permissions (default: false)
      --permissions-nodes-contract-address=<permissionsNodesContractAddress>
                             Address of the node permissioning smart contract
      --permissions-nodes-contract-enabled
                             Enable node level permissions via smart contract
                               (default: false)
      --pid-path=<PATH>      Path to PID file (optional)
      --privacy-enable-database-migration
                             Enable private database metadata migration
                               (default: false)
      --privacy-enabled      Enable private transactions (default: false)
      --privacy-marker-transaction-signing-key-file=<privacyMarkerTransactionSig
        ningKeyPath>
                             The name of a file containing the private key used
                               to sign privacy marker transactions. If unset,
                               each will be signed with a random key.
      --privacy-multi-tenancy-enabled
                             Enable multi-tenant private transactions (default:
                               false)
      --privacy-onchain-groups-enabled
                             Enable onchain privacy groups (default: false)
      --privacy-public-key-file=<privacyPublicKeyFile>
                             The enclave's public key file
      --privacy-tls-enabled  Enable TLS for connecting to privacy enclave
                               (default: false)
      --privacy-tls-keystore-file=<FILE>
                             Path to a PKCS#12 formatted keystore; used to
                               enable TLS on inbound connections.
      --privacy-tls-keystore-password-file=<FILE>
                             Path to a file containing the password used to
                               decrypt the keystore.
      --privacy-tls-known-enclave-file=<FILE>
                             Path to a file containing the fingerprints of the
                               authorized privacy enclave.
      --privacy-url=<privacyUrl>
                             The URL on which the enclave is running
      --pruning-block-confirmations=<INTEGER>
                             Minimum number of confirmations on a block before
                               marking begins (default: 10)
      --pruning-blocks-retained=<INTEGER>
                             Minimum number of recent blocks for which to keep
                               entire world state (default: 1024)
      --pruning-enabled      Enable disk-space saving optimization that removes
                               old state that is unlikely to be required
                               (default: false)
      --remote-connections-limit-enabled
                             Whether to limit the number of P2P connections
                               initiated remotely. (default: true)
      --remote-connections-max-percentage=<DOUBLE>
                             The maximum percentage of P2P connections that can
                               be initiated remotely. Must be between 0 and 100
                               inclusive. (default: 60)
      --reorg-logging-threshold=<reorgLoggingThreshold>
                             How deep a chain reorganization must be in order
                               for it to be logged (default: 6)
      --required-block, --required-blocks[=BLOCK=HASH[,BLOCK=HASH...]...]
                             Block number and hash peers are required to have.
      --revert-reason-enabled
                             Enable passing the revert reason back through
                               TransactionReceipts (default: false)
      --rpc-http-api, --rpc-http-apis=<api name>[,<api name>...]...
                             Comma separated list of APIs to enable on JSON-RPC
                               HTTP service (default: [ETH, NET, WEB3])
      --rpc-http-authentication-credentials-file=<FILE>
                             Storage file for JSON-RPC HTTP authentication
                               credentials (default: null)
      --rpc-http-authentication-enabled
                             Require authentication for the JSON-RPC HTTP
                               service (default: false)
      --rpc-http-authentication-jwt-public-key-file=<FILE>
                             JWT public key file for JSON-RPC HTTP
                               authentication
      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>
                             Comma separated origin domain URLs for CORS
                               validation (default: none)
      --rpc-http-enabled     Set to start the JSON-RPC HTTP service (default:
                               false)
      --rpc-http-host=<HOST> Host for JSON-RPC HTTP to listen on (default:
                               127.0.0.1)
      --rpc-http-port=<PORT> Port for JSON-RPC HTTP to listen on (default: 8545)
      --rpc-http-tls-ca-clients-enabled
                             Enable to accept clients certificate signed by a
                               valid CA for client authentication (default:
                               false)
      --rpc-http-tls-client-auth-enabled
                             Enable TLS client authentication for the JSON-RPC
                               HTTP service (default: false)
      --rpc-http-tls-enabled Enable TLS for the JSON-RPC HTTP service (default:
                               false)
      --rpc-http-tls-keystore-file=<FILE>
                             Keystore (PKCS#12) containing key/certificate for
                               the JSON-RPC HTTP service. Required if TLS is
                               enabled.
      --rpc-http-tls-keystore-password-file=<FILE>
                             File containing password to unlock keystore for
                               the JSON-RPC HTTP service. Required if TLS is
                               enabled.
      --rpc-http-tls-known-clients-file=<FILE>
                             Path to file containing clients certificate common
                               name and fingerprint for client authentication
      --rpc-tx-feecap=<txFeeCap>
                             Maximum transaction fees (in Wei) accepted for
                               transaction submitted through RPC (default:
                               1000000000000000000)
      --rpc-ws-api, --rpc-ws-apis=<api name>[,<api name>...]...
                             Comma separated list of APIs to enable on JSON-RPC
                               WebSocket service (default: [ETH, NET, WEB3])
      --rpc-ws-authentication-credentials-file=<FILE>
                             Storage file for JSON-RPC WebSocket authentication
                               credentials (default: null)
      --rpc-ws-authentication-enabled
                             Require authentication for the JSON-RPC WebSocket
                               service (default: false)
      --rpc-ws-authentication-jwt-public-key-file=<FILE>
                             JWT public key file for JSON-RPC WebSocket
                               authentication
      --rpc-ws-enabled       Set to start the JSON-RPC WebSocket service
                               (default: false)
      --rpc-ws-host=<HOST>   Host for JSON-RPC WebSocket service to listen on
                               (default: 127.0.0.1)
      --rpc-ws-port=<PORT>   Port for JSON-RPC WebSocket service to listen on
                               (default: 8546)
      --security-module=<NAME>
                             Identity for the Security Module to be used.
      --sync-mode=<MODE>     Synchronization mode, possible values are FULL,
                               FAST (default: FAST if a --network is supplied
                               and privacy isn't enabled. FULL otherwise.)
      --target-gas-limit=<targetGasLimit>
                             Sets target gas limit per block. If set each
                               block's gas limit will approach this setting
                               over time if the current gas limit is different.
      --tx-pool-hashes-max-size=<INTEGER>
                             Maximum number of pending transaction hashes that
                               will be kept in the transaction pool (default:
                               4096)
      --tx-pool-max-size=<INTEGER>
                             Maximum number of pending transactions that will
                               be kept in the transaction pool (default: 4096)
      --tx-pool-price-bump=<INTEGER>
                             Price bump percentage to replace an already
                               existing transaction  (default: 10)
      --tx-pool-retention-hours=<INTEGER>
                             Maximum retention period of pending transactions
                               in hours (default: 13)
  -V, --version              Print version information and exit.
Commands:
  blocks      This command provides blocks related actions.
  public-key  This command provides node public key related actions.
  password    This command provides password related actions.
  retesteth   Run a Retesteth compatible server for reference tests.
  rlp         This command provides RLP data related actions.
  operator    Operator related actions such as generating configuration and
                caches.

Besu is licensed under the Apache License 2.0
```

> ./besu --Xhelp
```
Unstable options for experimentalEIPs
      --Xberlin-enabled=<berlinEnabled>
         Enable non-finalized Berlin features (default: false)
      --Xeip1559-basefee-max-change-denominator=<basefeeMaxChangeDenominator>

      --Xeip1559-enabled=<eip1559Enabled>
         Enable experimental EIP-1559 fee market change (default: false)
      --Xeip1559-initial-base-fee=<initialBasefee>

      --Xeip1559-migration-duration-in-blocks=<migrationDurationInBlocks>


Unstable options for Ethereum Wire Protocol
      --Xeth-65-enabled   Enable the Eth/65 subprotocol. (default: false)
      --Xewp-max-get-bodies=<INTEGER>
                          Maximum request limit for Ethereum Wire Protocol
                            GET_BLOCK_BODIES. (default: +128)
      --Xewp-max-get-headers=<INTEGER>
                          Maximum request limit for Ethereum Wire Protocol
                            GET_BLOCK_HEADERS. (default: +192)
      --Xewp-max-get-node-data=<INTEGER>
                          Maximum request limit for Ethereum Wire Protocol
                            GET_NODE_DATA. (default: +384)
      --Xewp-max-get-pooled-transactions=<INTEGER>
                          Maximum request limit for Ethereum Wire Protocol
                            GET_POOLED_TRANSACTIONS. (default: +256)
      --Xewp-max-get-receipts=<INTEGER>
                          Maximum request limit for Ethereum Wire Protocol
                            GET_RECEIPTS. (default: +256)

Unstable options for Metrics
      --Xmetrics-timers-enabled
         Whether to enable timer metrics (default: true).

Unstable options for P2P Network
      --Xp2p-check-maintained-connections-frequency=<INTEGER>
         The frequency (in seconds) at which to check maintained connections
           (default: 60)
      --Xp2p-initiate-connections-frequency=<INTEGER>
         The frequency (in seconds) at which to initiate new outgoing
           connections (default: 30)

Unstable options for RPC
      --Xhttp-timeout-seconds=<httpTimeoutSec>
         HTTP timeout in seconds (default: 300)
      --Xws-timeout-seconds=<wsTimeoutSec>
         Web socket timeout in seconds (default: 300)

Unstable options for DNS Configuration
      --Xdns-enabled=<dnsEnabled>
         Enabled DNS support
      --Xdns-update-enabled=<dnsUpdateEnabled>
         Allow to detect an IP update automatically

Unstable options for NAT Configuration
      --Xnat-kube-service-name=<natManagerServiceName>
         Specify the name of the service that will be used by the nat manager
           in Kubernetes. (default: besu)
      --Xnat-method-fallback-enabled=<natMethodFallbackEnabled>
         Enable fallback to NONE for the nat manager in case of failure. If
           False BESU will exit on failure. (default: true)

Unstable options for Synchronizer
      --Xsynchronizer-block-propagation-range=<LONG>..<LONG>
         Range around chain head where inbound blocks are propagated (default:
           -10..30)
      --Xsynchronizer-computation-parallelism=<INTEGER>
         Number of threads to make available for bulk hash computations during
           downloads (default: # of processors)
      --Xsynchronizer-downloader-chain-segment-size=<INTEGER>
         Distance between checkpoint headers (default: 200)
      --Xsynchronizer-downloader-change-target-threshold-by-height=<LONG>
         Minimum height difference before switching fast sync download peers
           (default: 200)
      --Xsynchronizer-downloader-change-target-threshold-by-td=<UINT256>
         Minimum total difficulty difference before switching fast sync
           download peers (default: 1000000000000000000)
      --Xsynchronizer-downloader-checkpoint-timeouts-permitted=<INTEGER>
         Number of tries to attempt to download checkpoints before stopping
           (default: 5)
      --Xsynchronizer-downloader-header-request-size=<INTEGER>
         Number of headers to request per packet (default: 200)
      --Xsynchronizer-downloader-parallelism=<INTEGER>
         Number of threads to provide to chain downloader (default: 4)
      --Xsynchronizer-fast-sync-full-validation-rate=<FLOAT>
         Fraction of headers fast sync will fully validate (default: 0.1)
      --Xsynchronizer-fast-sync-pivot-distance=<INTEGER>
         Distance from initial chain head to fast sync target (default: 50)
      --Xsynchronizer-transactions-parallelism=<INTEGER>
         Number of threads to commit to transaction processing (default: 2)
      --Xsynchronizer-world-state-hash-count-per-request=<INTEGER>
         Fast sync world state hashes queried per request (default: 384)
      --Xsynchronizer-world-state-max-requests-without-progress=<INTEGER>
         Number of world state requests accepted without progress before
           considering the download stalled (default: 1000)
      --Xsynchronizer-world-state-min-millis-before-stalling=<LONG>
         Minimum time in ms without progress before considering a world state
           download as stalled (default: 300000)
      --Xsynchronizer-world-state-request-parallelism=<INTEGER>
         Number of concurrent requests to use when downloading fast sync world
           state (default: 10)
      --Xsynchronizer-world-state-task-cache-size=<INTEGER>
         The max number of pending node data requests cached in-memory during
           fast sync world state download. (default: 1000000)

Unstable options for TransactionPool
      --Xincoming-tx-messages-keep-alive-seconds=<INTEGER>
         Keep alive of incoming transaction messages in seconds (default: 60)

Unstable options for Ethstats
      --Xethstats=<nodename:secret@host:port>
         Reporting URL of a ethstats server
      --Xethstats-contact=<ethstatsContact>
         Contact address to send to ethstats server

Unstable options for Mining
      --Xminer-remote-sealers-hashrate-ttl=<remoteSealersTimeToLive>
         Specifies the lifetime of each entry in the cache. An entry will be
           automatically deleted if no update has been received before the
           deadline (default: 10 minutes)
      --Xminer-remote-sealers-limit=<remoteSealersLimit>
         Limits the number of remote sealers that can submit their hashrates
           (default: 1000)
      --Xminer-stratum-extranonce=<stratumExtranonce>
         Extranonce for Stratum network miners (default: 080c)

Unstable options for Native Library
      --Xaltbn128-native-enabled=<nativeAltbn128>
         Path to PID file (optional)
      --Xsecp256k1-native-enabled=<nativeSecp256k1>
         Path to PID file (optional)

Unstable options for Plugin rocksdb
      --Xplugin-rocksdb-background-thread-count=<INTEGER>
         Number of RocksDB background threads (default: 4)
      --Xplugin-rocksdb-cache-capacity=<LONG>
         Cache capacity of RocksDB (default: 8388608)
      --Xplugin-rocksdb-max-background-compactions=<INTEGER>
         Maximum number of RocksDB background compactions (default: 4)
      --Xplugin-rocksdb-max-open-files=<INTEGER>
         Max number of files RocksDB will open (default: 1024)
```

- Trying to add an experimental feature on the BesuCommand class (check failed)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).