### PR TITLE
fix: allow domain names with - in ethstats

### DIFF
--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/NetstatsUrl.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/util/NetstatsUrl.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface NetstatsUrl {
 
-  Pattern NETSTATS_URL_REGEX = Pattern.compile("([-\\w]+):([\\w]+)?@([.\\w]+):([\\d]+)");
+  Pattern NETSTATS_URL_REGEX = Pattern.compile("([-\\w]+):([\\w]+)?@([-.\\w]+):([\\d]+)");
 
   String getNodeName();
 

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/NetstatsUrlTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/NetstatsUrlTest.java
@@ -39,6 +39,17 @@ public class NetstatsUrlTest {
   }
 
   @Test
+  public void buildWithValidHost() {
+    final String[] validHosts =
+        new String[] {"url-test.test.com", "url.test.com", "test.com", "10.10.10.15"};
+    for (String host : validHosts) {
+      final NetstatsUrl netstatsUrl =
+          NetstatsUrl.fromParams("Dev-Node-1:secret@" + host + ":3001", CONTACT);
+      assertThat(netstatsUrl.getHost()).isEqualTo(host);
+    }
+  }
+
+  @Test
   public void shouldDetectEmptyParams() {
     assertThatThrownBy(() -> NetstatsUrl.fromParams("", CONTACT))
         .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Our ethstats is hosted on the following domain (example): consortium-netstats.settlemint.com
The NETSTATS_URL_REGEX allows domain names (hence \w and not \d) but only allows dots, letters and numbers.
So netstats.settlemint.com would work, and consortium.netstats.settlemint.com and 10.10.10.15, but not consortium-netstats.settlemint.com
Modified the NETSTATS_URL_REGEX to allow dashes

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).