### PR TITLE
Fix get logs patch 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Bug Fixes
 * Added `debug_getBadBlocks` JSON-RPC API to analyze and detect consensus flaws. Even if a block is rejected it will be returned by this method [\#1378](https://github.com/hyperledger/besu/pull/1378)
-* Fix logs queries missing results against chain head [\#1351](https://github.com/hyperledger/besu/pull/1351)
+* Fix logs queries missing results against chain head [\#1351](https://github.com/hyperledger/besu/pull/1351) and [\#1381](https://github.com/hyperledger/besu/pull/1381) 
 
 #### Previously identified known issues
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.query.cache;
 import static org.hyperledger.besu.ethereum.api.query.cache.LogBloomCacheMetadata.DEFAULT_VERSION;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,10 +66,14 @@ public class AutoTransactionLogBloomCachingService {
               blockchain.observeBlockAdded(
                   event -> {
                     if (event.isNewCanonicalHead()) {
+                      final BlockHeader eventBlockHeader = event.getBlock().getHeader();
+                      final Optional<BlockHeader> commonAncestorBlockHeader =
+                          blockchain.getBlockHeader(event.getCommonAncestorHash());
                       transactionLogBloomCacher.cacheLogsBloomForBlockHeader(
-                          event.getBlock().getHeader(), Optional.empty());
+                          eventBlockHeader, commonAncestorBlockHeader, Optional.empty());
                     }
                   }));
+
       transactionLogBloomCacher
           .getScheduler()
           .scheduleFutureTask(transactionLogBloomCacher::cacheAll, Duration.ofMinutes(1));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
@@ -52,7 +52,7 @@ public class AutoTransactionLogBloomCachingService {
       }
       final LogBloomCacheMetadata logBloomCacheMetadata =
           LogBloomCacheMetadata.lookUpFrom(cacheDir);
-      if (logBloomCacheMetadata.getVersion() == 0) {
+      if (logBloomCacheMetadata.getVersion() < DEFAULT_VERSION) {
         try (Stream<Path> walk = Files.walk(cacheDir)) {
           walk.filter(Files::isRegularFile).map(Path::toFile).forEach(File::delete);
         } catch (Exception e) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/LogBloomCacheMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/LogBloomCacheMetadata.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.Logger;
 public class LogBloomCacheMetadata {
   private static final Logger LOG = LogManager.getLogger();
 
-  public static final int DEFAULT_VERSION = 1;
+  public static final int DEFAULT_VERSION = 2;
 
   private static final String METADATA_FILENAME = "CACHE_METADATA.json";
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
@@ -159,15 +159,13 @@ public class TransactionLogBloomCacher {
           final Optional<Long> ancestorBlockNumber =
               commonAncestorBlockHeader.map(ProcessableBlockHeader::getNumber);
           if (ancestorBlockNumber.isPresent()) {
+            // walk through the blocks from the common ancestor to the received block in order to
+            // reload the cache in case of reorg
             for (long number = ancestorBlockNumber.get() + 1;
                 number < blockHeader.getNumber();
                 number++) {
               Optional<BlockHeader> ancestorBlockHeader = blockchain.getBlockHeader(number);
               if (ancestorBlockHeader.isPresent()) {
-                LOG.info(
-                    "Restore old block {} {}",
-                    ancestorBlockHeader.get().getNumber(),
-                    ancestorBlockHeader.get().getHash());
                 cacheSingleBlock(ancestorBlockHeader.get(), cacheFile);
               }
             }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

LogBloom could be invalid in the cache after a reorg. With this PR, there is an update of the cache every time a reorg takes place

## Test performed

- Sync on goerli (reorg etc.)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).