### PR TITLE
Remove ternary operator for better readability

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/TransactionRLPEncoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/TransactionRLPEncoder.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.core.encoding;
 
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
-import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
@@ -23,6 +22,7 @@ import org.hyperledger.besu.plugin.data.Quantity;
 import org.hyperledger.besu.plugin.data.TransactionType;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.tuweni.bytes.Bytes;
 
 public class TransactionRLPEncoder {
 
@@ -42,7 +42,7 @@ public class TransactionRLPEncoder {
       out.writeLongScalar(transaction.getNonce());
       out.writeUInt256Scalar(transaction.getGasPrice());
       out.writeLongScalar(transaction.getGasLimit());
-      out.writeBytes(transaction.getTo().orElse(Address.ZERO));
+      out.writeBytes(transaction.getTo().map(Bytes::copy).orElse(Bytes.EMPTY));
       out.writeUInt256Scalar(transaction.getValue());
       out.writeBytes(transaction.getPayload());
       writeSignature(transaction, out);
@@ -61,7 +61,7 @@ public class TransactionRLPEncoder {
       out.writeLongScalar(transaction.getNonce());
       out.writeNull();
       out.writeLongScalar(transaction.getGasLimit());
-      out.writeBytes(transaction.getTo().orElse(Address.ZERO));
+      out.writeBytes(transaction.getTo().map(Bytes::copy).orElse(Bytes.EMPTY));
       out.writeUInt256Scalar(transaction.getValue());
       out.writeBytes(transaction.getPayload());
       out.writeUInt256Scalar(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/TransactionRLPEncoder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/encoding/TransactionRLPEncoder.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.core.encoding;
 
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
+import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
@@ -22,7 +23,6 @@ import org.hyperledger.besu.plugin.data.Quantity;
 import org.hyperledger.besu.plugin.data.TransactionType;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.tuweni.bytes.Bytes;
 
 public class TransactionRLPEncoder {
 
@@ -42,7 +42,7 @@ public class TransactionRLPEncoder {
       out.writeLongScalar(transaction.getNonce());
       out.writeUInt256Scalar(transaction.getGasPrice());
       out.writeLongScalar(transaction.getGasLimit());
-      out.writeBytes(transaction.getTo().isPresent() ? transaction.getTo().get() : Bytes.EMPTY);
+      out.writeBytes(transaction.getTo().orElse(Address.ZERO));
       out.writeUInt256Scalar(transaction.getValue());
       out.writeBytes(transaction.getPayload());
       writeSignature(transaction, out);
@@ -61,7 +61,7 @@ public class TransactionRLPEncoder {
       out.writeLongScalar(transaction.getNonce());
       out.writeNull();
       out.writeLongScalar(transaction.getGasLimit());
-      out.writeBytes(transaction.getTo().isPresent() ? transaction.getTo().get() : Bytes.EMPTY);
+      out.writeBytes(transaction.getTo().orElse(Address.ZERO));
       out.writeUInt256Scalar(transaction.getValue());
       out.writeBytes(transaction.getPayload());
       out.writeUInt256Scalar(


### PR DESCRIPTION
Remove ternary operator for better readability during encoding of transactions .

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>