### PR TITLE
handle case where onchain groups do not exist

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
@@ -52,6 +53,18 @@ public class MultiTenancyPrivacyController implements PrivacyController {
             ? Optional.of(
                 new OnchainPrivacyGroupContract(privacyController.getTransactionSimulator()))
             : Optional.empty();
+    privateTransactionValidator = new PrivateTransactionValidator(chainId);
+  }
+
+  @VisibleForTesting
+  MultiTenancyPrivacyController(
+      final PrivacyController privacyController,
+      final Optional<BigInteger> chainId,
+      final Enclave enclave,
+      final Optional<OnchainPrivacyGroupContract> onchainPrivacyGroupContract) {
+    this.privacyController = privacyController;
+    this.enclave = enclave;
+    this.onchainPrivacyGroupContract = onchainPrivacyGroupContract;
     privateTransactionValidator = new PrivateTransactionValidator(chainId);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -273,8 +273,6 @@ public class MultiTenancyPrivacyController implements PrivacyController {
   public void verifyPrivacyGroupContainsEnclavePublicKey(
       final String privacyGroupId, final String enclavePublicKey, final Optional<Long> blockNumber)
       throws MultiTenancyValidationException {
-    // TODO: There's potentially a bug here where an onchain privacyGroup
-    // that isn't found will default to the offchain privacy group.
     Optional<PrivacyGroup> maybePrivacyGroup;
     PrivacyGroup offchainPrivacyGroup;
     if (onchainPrivacyGroupContract.isPresent()) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyControllerOnchainTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyControllerOnchainTest.java
@@ -52,20 +52,27 @@ public class MultiTenancyPrivacyControllerOnchainTest {
   private final Enclave enclave = mock(Enclave.class);
   private final PrivateTransactionSimulator privateTransactionSimulator =
       mock(PrivateTransactionSimulator.class);
+  private final OnchainPrivacyGroupContract onchainPrivacyGroupContract =
+      mock(OnchainPrivacyGroupContract.class);
 
   private MultiTenancyPrivacyController multiTenancyPrivacyController;
 
   @Before
   public void setup() {
-    when(privacyController.getTransactionSimulator()).thenReturn(privateTransactionSimulator);
+    when(onchainPrivacyGroupContract.getPrivacyGroupByIdAndBlockNumber(
+            PRIVACY_GROUP_ID, Optional.of(1L)))
+        .thenReturn(Optional.of(ONCHAIN_PRIVACY_GROUP));
+
     multiTenancyPrivacyController =
         new MultiTenancyPrivacyController(
-            privacyController, Optional.of(BigInteger.valueOf(2018)), enclave, true);
+            privacyController,
+            Optional.of(BigInteger.valueOf(2018)),
+            enclave,
+            Optional.of(onchainPrivacyGroupContract));
   }
 
   @Test
   public void simulatePrivateTransactionSucceedsForPresentEnclaveKey() {
-    when(enclave.retrievePrivacyGroup(PRIVACY_GROUP_ID)).thenReturn(ONCHAIN_PRIVACY_GROUP);
     when(privacyController.simulatePrivateTransaction(any(), any(), any(), any(long.class)))
         .thenReturn(
             Optional.of(
@@ -84,8 +91,6 @@ public class MultiTenancyPrivacyControllerOnchainTest {
 
   @Test(expected = MultiTenancyValidationException.class)
   public void simulatePrivateTransactionFailsForAbsentEnclaveKey() {
-    when(enclave.retrievePrivacyGroup(PRIVACY_GROUP_ID)).thenReturn(ONCHAIN_PRIVACY_GROUP);
-
     multiTenancyPrivacyController.simulatePrivateTransaction(
         PRIVACY_GROUP_ID,
         ENCLAVE_PUBLIC_KEY2,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyControllerOnchainTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyControllerOnchainTest.java
@@ -50,8 +50,6 @@ public class MultiTenancyPrivacyControllerOnchainTest {
 
   private final PrivacyController privacyController = mock(PrivacyController.class);
   private final Enclave enclave = mock(Enclave.class);
-  private final PrivateTransactionSimulator privateTransactionSimulator =
-      mock(PrivateTransactionSimulator.class);
   private final OnchainPrivacyGroupContract onchainPrivacyGroupContract =
       mock(OnchainPrivacyGroupContract.class);
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Onchain groups do not get created before they are queried. This means we cannot assume the privacyGroup will exist. Also added unit tests for this case.

Manual testing:
Postman query priv_getTransactionCount() for a group that does not exist returns zero (previously "Unable to determine nonce for account in group.")
WIP web3js-eea onChainPrivacy/multiTenancyExample can now create privacy group  (previously "Unable to determine nonce for account in group.")

See #1389 for further testing that was carried out

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).