### PR TITLE
Add some Quality of Life changes to reference tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -668,7 +668,9 @@ task checkSpdxHeader(type: CheckSpdxHeader) {
   excludeRegex = [
     "(.*/generalstate/GeneralStateRegressionReferenceTest.*)",
     "(.*/generalstate/GeneralStateReferenceTest.*)",
+    "(.*/generalstate/LegacyGeneralStateReferenceTest.*)",
     "(.*/blockchain/BlockchainReferenceTest.*)",
+    "(.*/blockchain/LegacyBlockchainReferenceTest.*)",
     "(.*/.gradle/.*)",
     "(.*/.idea/.*)",
     "(.*/out/.*)",

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -71,6 +71,7 @@ public class BlockchainReferenceTestTools {
 
     // Consumes a huge amount of memory
     params.ignore("static_Call1MB1024Calldepth_d1g0v0_\\w+");
+    params.ignore("ShanghaiLove_.*");
 
     // Absurd amount of gas, doesn't run in parallel
     params.ignore("randomStatetest94_\\w+");

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -97,6 +97,7 @@ public class GeneralStateReferenceTestTools {
 
     // Consumes a huge amount of memory
     params.ignore("static_Call1MB1024Calldepth-\\w");
+    params.ignore("ShanghaiLove_.*");
 
     // Don't do time consuming tests
     params.ignore("CALLBlake2f_MaxRounds.*");


### PR DESCRIPTION

* ShanghaiLove tests tend to OOM in parallel execution.  Exclude them.
* LegacyTests, as generated code, are not subject to SPDX header checks.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).