### PR TITLE
Add `--start-block` and `--end-block` to `blocks import` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## 1.5.5
 
 ### Additions and Improvements
-* The new version of the [web3js-eea library (v0.10)](https://github.com/PegaSysEng/web3js-eea) supports the onchain privacy group management changes made in Besu v1.5.3.     
+* The new version of the [web3js-eea library (v0.10)](https://github.com/PegaSysEng/web3js-eea) supports the onchain privacy group management changes made in Besu v1.5.3.
 
 ### Bug Fixes
 * Added `debug_getBadBlocks` JSON-RPC API to analyze and detect consensus flaws. Even if a block is rejected it will be returned by this method [\#1378](https://github.com/hyperledger/besu/pull/1378)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.6.0-RC1
 
 ### Additions and Improvements
-* Added `--start-block` and `--end-block` to the `blocks import` subcommand [\#???](https://github.com/hyperledger/besu/pull/???)     
+* Added `--start-block` and `--end-block` to the `blocks import` subcommand [\#1399](https://github.com/hyperledger/besu/pull/1399)     
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.6.0-RC1
+
+### Additions and Improvements
+* Added `--start-block` and `--end-block` to the `blocks import` subcommand [\#???](https://github.com/hyperledger/besu/pull/???)     
+
+### Bug Fixes
+
+#### Previously identified known issues
+
+- [Eth/65 loses peers](KNOWN_ISSUES.md#eth65-loses-peers)
+- [Fast sync when running Besu on cloud providers](KNOWN_ISSUES.md#fast-sync-when-running-besu-on-cloud-providers)
+- [Privacy users with private transactions created using v1.3.4 or earlier](KNOWN_ISSUES.md#privacy-users-with-private-transactions-created-using-v134-or-earlier)
+- [Changes not saved to database correctly causing inconsistent private states](KNOWN_ISSUES.md#Changes-not-saved-to-database-correctly-causing-inconsistent-private-states)
+
 ## 1.5.5
 
 ### Additions and Improvements

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -157,6 +157,22 @@ public class BlocksSubCommand implements Runnable {
     @Option(names = "--run", description = "Start besu after importing.")
     private final Boolean runBesu = false;
 
+    @Option(
+        names = "--start-block",
+        paramLabel = DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP,
+        description =
+            "The starting index of the block, or block list to import.  If not specified all blocks before the end block will be imported",
+        arity = "1..1")
+    private final Long startBlock = 0L;
+
+    @Option(
+        names = "--end-block",
+        paramLabel = DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP,
+        description =
+            "The ending index of the block list to import (exclusive).  If not specified all blocks after the start block will be imported.",
+        arity = "1..1")
+    private final Long endBlock = Long.MAX_VALUE;
+
     @SuppressWarnings("unused")
     @Spec
     private CommandSpec spec;
@@ -263,7 +279,7 @@ public class BlocksSubCommand implements Runnable {
     private void importRlpBlocks(final BesuController controller, final Path path)
         throws IOException {
       try (final RlpBlockImporter rlpBlockImporter = parentCommand.rlpBlockImporter.get()) {
-        rlpBlockImporter.importBlockchain(path, controller, skipPow);
+        rlpBlockImporter.importBlockchain(path, controller, skipPow, startBlock, endBlock);
       }
     }
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,10 +59,14 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
 
   private static final String EXPECTED_BLOCK_IMPORT_USAGE =
       "Usage: besu blocks import [-hV] [--run] [--skip-pow-validation-enabled]\n"
-          + "                          [--format=<format>] [--start-time=<startTime>] [--from\n"
-          + "                          [=<FILE>...]]... [<FILE>...]\n"
+          + "                          [--end-block=<LONG>] [--format=<format>]\n"
+          + "                          [--start-block=<LONG>] [--start-time=<startTime>]\n"
+          + "                          [--from[=<FILE>...]]... [<FILE>...]\n"
           + "This command imports blocks from a file into the database.\n"
           + "      [<FILE>...]          Files containing blocks to import.\n"
+          + "      --end-block=<LONG>     The ending index of the block list to import\n"
+          + "                               (exclusive).  If not specified all blocks after\n"
+          + "                               the start block will be imported.\n"
           + "      --format=<format>    The type of data to be imported, possible values\n"
           + "                             are: RLP, JSON (default: RLP).\n"
           + "      --from[=<FILE>...]   File containing blocks to import.\n"
@@ -69,10 +74,13 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
           + "      --run                Start besu after importing.\n"
           + "      --skip-pow-validation-enabled\n"
           + "                           Skip proof of work validation when importing.\n"
+          + "      --start-block=<LONG>   The starting index of the block, or block list to\n"
+          + "                               import.  If not specified all blocks before the\n"
+          + "                               end block will be imported\n"
           + "      --start-time=<startTime>\n"
-          + "                           The timestamp in seconds of the first block for JSON\n"
-          + "                             imports. Subsequent blocks will be 1 second later.\n"
-          + "                             (default: current time)\n"
+          + "                             The timestamp in seconds of the first block for\n"
+          + "                               JSON imports. Subsequent blocks will be 1 second\n"
+          + "                               later. (default: current time)\n"
           + "  -V, --version            Print version information and exit.\n";
 
   private static final String EXPECTED_BLOCK_EXPORT_USAGE =
@@ -150,7 +158,8 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
     parseCommand(
         BLOCK_SUBCOMMAND_NAME, BLOCK_IMPORT_SUBCOMMAND_NAME, "--from", fileToImport.getPath());
 
-    verify(rlpBlockImporter).importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean());
+    verify(rlpBlockImporter)
+        .importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean(), anyLong(), anyLong());
 
     assertThat(pathArgumentCaptor.getValue()).isEqualByComparingTo(fileToImport.toPath());
 
@@ -169,7 +178,8 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
         "--from",
         fileToImport.getPath());
 
-    verify(rlpBlockImporter).importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean());
+    verify(rlpBlockImporter)
+        .importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean(), anyLong(), anyLong());
 
     assertThat(pathArgumentCaptor.getValue()).isEqualByComparingTo(fileToImport.toPath());
 
@@ -192,7 +202,7 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
         file3ToImport.getPath());
 
     verify(rlpBlockImporter, times(3))
-        .importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean());
+        .importBlockchain(pathArgumentCaptor.capture(), any(), anyBoolean(), anyLong(), anyLong());
 
     assertThat(pathArgumentCaptor.getAllValues())
         .containsExactlyInAnyOrder(

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
@@ -63,17 +63,17 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
           + "                          [--start-block=<LONG>] [--start-time=<startTime>]\n"
           + "                          [--from[=<FILE>...]]... [<FILE>...]\n"
           + "This command imports blocks from a file into the database.\n"
-          + "      [<FILE>...]          Files containing blocks to import.\n"
+          + "      [<FILE>...]            Files containing blocks to import.\n"
           + "      --end-block=<LONG>     The ending index of the block list to import\n"
           + "                               (exclusive).  If not specified all blocks after\n"
           + "                               the start block will be imported.\n"
-          + "      --format=<format>    The type of data to be imported, possible values\n"
-          + "                             are: RLP, JSON (default: RLP).\n"
-          + "      --from[=<FILE>...]   File containing blocks to import.\n"
-          + "  -h, --help               Show this help message and exit.\n"
-          + "      --run                Start besu after importing.\n"
+          + "      --format=<format>      The type of data to be imported, possible values\n"
+          + "                               are: RLP, JSON (default: RLP).\n"
+          + "      --from[=<FILE>...]     File containing blocks to import.\n"
+          + "  -h, --help                 Show this help message and exit.\n"
+          + "      --run                  Start besu after importing.\n"
           + "      --skip-pow-validation-enabled\n"
-          + "                           Skip proof of work validation when importing.\n"
+          + "                             Skip proof of work validation when importing.\n"
           + "      --start-block=<LONG>   The starting index of the block, or block list to\n"
           + "                               import.  If not specified all blocks before the\n"
           + "                               end block will be imported\n"
@@ -81,7 +81,7 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
           + "                             The timestamp in seconds of the first block for\n"
           + "                               JSON imports. Subsequent blocks will be 1 second\n"
           + "                               later. (default: current time)\n"
-          + "  -V, --version            Print version information and exit.\n";
+          + "  -V, --version              Print version information and exit.\n";
 
   private static final String EXPECTED_BLOCK_EXPORT_USAGE =
       "Usage: besu blocks export [-hV] [--end-block=<LONG>] [--start-block=<LONG>]"


### PR DESCRIPTION
Add starting and ending blocks options to import.  The command will only
import blocks within the [start, end) range specified in the CLI when
iterating through the blocks files.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).