### PR TITLE
[1340] Added check for duplicate configuration ports.

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2253,7 +2253,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .filter(Objects::nonNull)
         .forEach(
             port -> {
-              if (!allocatedPorts.add(port)) {
+              if (port != 0 && !allocatedPorts.add(port)) {
                 throw new ParameterException(
                     commandLine,
                     "Port number '"

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3672,4 +3672,11 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString())
         .contains("Invalid value for option", "--Xws-timeout-seconds", "abc", "is not a long");
   }
+
+  @Test
+  public void assertThatDuplicatePortSpecifiedFails() {
+    parseCommand("--p2p-port=9", "--rpc-http-port=10", "--rpc-ws-port=10");
+    assertThat(commandErrorOutput.toString())
+        .contains("Port number '10' has been specified multiple times.");
+  }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3685,4 +3685,23 @@ public class BesuCommandTest extends CommandTestAbstract {
     parseCommand("--p2p-port=0", "--rpc-http-port=0", "--rpc-ws-port=0");
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
+
+  @Test
+  public void assertThatNoPortsSpecifiedSucceeds() {
+    parseCommand();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void assertThatAllPortsSpecifiedSucceeds() {
+    parseCommand(
+        "--p2p-port=9",
+        "--graphql-http-port=10",
+        "--rpc-http-port=11",
+        "--rpc-ws-port=12",
+        "--metrics-port=13",
+        "--metrics-push-port=14",
+        "--miner-stratum-port=15");
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3679,4 +3679,10 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandErrorOutput.toString())
         .contains("Port number '10' has been specified multiple times.");
   }
+
+  @Test
+  public void assertThatDuplicatePortZeroSucceeds() {
+    parseCommand("--p2p-port=0", "--rpc-http-port=0", "--rpc-ws-port=0");
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
 }


### PR DESCRIPTION
Signed-off-by: Mark Terry <mark.terry@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Added a check to throw an exception if duplicate port numbers are specified in the configuration.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #1340 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).