### PR TITLE
Better invalid reasons logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 * Added `debug_standardTraceBlockToFile` JSON-RPC API. This API accepts a block hash and will replay the block. It returns a list of files containing the result of the trace (one file per transaction). [\#1392](https://github.com/hyperledger/besu/pull/1392)
 * Added `debug_standardTraceBadBlockToFile` JSON-RPC API. This API is similar to `debug_standardTraceBlockToFile`, but can be used to obtain info about a block which has been rejected as invalid. [\#1403](https://github.com/hyperledger/besu/pull/1403)
 * Added support for EIP-2929 to YOLOv2. [#1387](https://github.com/hyperledger/besu/pull/1387)     
-* Added `--start-block` and `--end-block` to the `blocks import` subcommand [\#1399](https://github.com/hyperledger/besu/pull/1399)     
+* Added `--start-block` and `--end-block` to the `blocks import` subcommand [\#1399](https://github.com/hyperledger/besu/pull/1399)
 
 ### Bug Fixes
+
+* Log block import rejection reasons at "INFO" level.  Bug [#1412](https://github.com/hyperledger/besu/issues/1412)
 
 #### Previously identified known issues
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -132,10 +132,12 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final long remainingGasBudget = blockHeader.getGasLimit() - currentGasUsed;
       if (!gasBudgetCalculator.hasBudget(
           transaction, blockHeader.getNumber(), blockHeader.getGasLimit(), currentGasUsed)) {
-        LOG.warn(
-            "Transaction processing error: transaction gas limit {} exceeds available block budget remaining {}",
+        LOG.info(
+            "Block processing error: transaction gas limit {} exceeds available block budget remaining {}. Block {} Transaction {}",
             transaction.getGasLimit(),
-            remainingGasBudget);
+            remainingGasBudget,
+            blockHeader.getHash().toHexString(),
+            transaction.getHash().toHexString());
         return AbstractBlockProcessor.Result.failed();
       }
 
@@ -157,6 +159,11 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
               TransactionValidationParams.processingBlock(),
               privateMetadataUpdater);
       if (result.isInvalid()) {
+        LOG.info(
+            "Block processing error: transaction invalid '{}'. Block {} Transaction {}",
+            result.getValidationResult().getInvalidReason(),
+            blockHeader.getHash().toHexString(),
+            transaction.getHash().toHexString());
         return AbstractBlockProcessor.Result.failed();
       }
 
@@ -176,6 +183,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     }
 
     if (!rewardCoinbase(worldState, blockHeader, ommers, skipZeroBlockRewards)) {
+      // no need to log, rewardCoinbase logs the error.
       return AbstractBlockProcessor.Result.failed();
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessor.java
@@ -66,11 +66,11 @@ public class MainnetBlockProcessor extends AbstractBlockProcessor {
     miningBeneficiaryAccount.incrementBalance(coinbaseReward);
     for (final BlockHeader ommerHeader : ommers) {
       if (ommerHeader.getNumber() - header.getNumber() > MAX_GENERATION) {
-        LOG.warn(
-            "Block processing error: ommer block number {} more than {} generations current block number {}",
+        LOG.info(
+            "Block processing error: ommer block number {} more than {} generations. Block {}",
             ommerHeader.getNumber(),
             MAX_GENERATION,
-            header.getNumber());
+            header.getHash().toHexString());
         return false;
       }
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -199,6 +199,9 @@ public class StateTestSubCommand implements Runnable {
           "pass",
           worldState.rootHash().equals(spec.getExpectedRootHash())
               && actualLogsHash.equals(spec.getExpectedLogsHash()));
+      if (result.isInvalid()) {
+        summaryLine.put("validationError", result.getValidationResult().getErrorMessage());
+      }
 
       System.out.println(summaryLine);
     }


### PR DESCRIPTION
Add better invalid reason logging.

The EVMTool state-test will add a field in the json result object.

Block transaction processing will log at INFO why the block is invalid
and include the block hash and (if relevant) transaction hash.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).