### PR TITLE
Allow Random Peer Prioritization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Additions and Improvements
+* `--random-peer-priority-enabled` flag added. Allows for incoming connections to be prioritized randomly. This will prevent (typically small, stable) networks from forming impenetrable peer cliques. [#1440](https://github.com/hyperledger/besu/pull/1440)
+
 ## Deprecated and Scheduled for removal in _Next_ Release
 
 ### --privacy-precompiled-address

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -164,7 +164,7 @@ public class RunnerBuilder {
   private Optional<String> identityString = Optional.empty();
   private BesuPluginContextImpl besuPluginContext;
   private boolean autoLogBloomCaching = true;
-  private boolean randomlyPrioritizeConnections;
+  private boolean randomPeerPriority;
 
   public RunnerBuilder vertx(final Vertx vertx) {
     this.vertx = vertx;
@@ -245,8 +245,8 @@ public class RunnerBuilder {
     return this;
   }
 
-  public RunnerBuilder randomlyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
-    this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
+  public RunnerBuilder randomPeerPriority(final boolean randomPeerPriority) {
+    this.randomPeerPriority = randomPeerPriority;
     return this;
   }
 
@@ -410,7 +410,7 @@ public class RunnerBuilder {
                 .metricsSystem(metricsSystem)
                 .supportedCapabilities(caps)
                 .natService(natService)
-                .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
+                .randomPeerPriority(randomPeerPriority)
                 .build();
 
     final NetworkRunner networkRunner =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -164,6 +164,7 @@ public class RunnerBuilder {
   private Optional<String> identityString = Optional.empty();
   private BesuPluginContextImpl besuPluginContext;
   private boolean autoLogBloomCaching = true;
+  private boolean randomlyPrioritizeConnections;
 
   public RunnerBuilder vertx(final Vertx vertx) {
     this.vertx = vertx;
@@ -241,6 +242,11 @@ public class RunnerBuilder {
   public RunnerBuilder fractionRemoteConnectionsAllowed(
       final float fractionRemoteConnectionsAllowed) {
     this.fractionRemoteConnectionsAllowed = fractionRemoteConnectionsAllowed;
+    return this;
+  }
+
+  public RunnerBuilder randomlyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
+    this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
     return this;
   }
 
@@ -404,6 +410,7 @@ public class RunnerBuilder {
                 .metricsSystem(metricsSystem)
                 .supportedCapabilities(caps)
                 .natService(natService)
+                .randomLyPrioritizeConnections(randomlyPrioritizeConnections)
                 .build();
 
     final NetworkRunner networkRunner =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -410,7 +410,7 @@ public class RunnerBuilder {
                 .metricsSystem(metricsSystem)
                 .supportedCapabilities(caps)
                 .natService(natService)
-                .randomLyPrioritizeConnections(randomlyPrioritizeConnections)
+                .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
                 .build();
 
     final NetworkRunner networkRunner =

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -354,9 +354,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--random-peer-priority-enabled"},
       description =
-          "Allow for incoming connections to be prioritized randomly. This will prevent (typically small, stable) networks from forming impenetrable peer cliques. (default: ${DEFAULT-VALUE})",
-      arity = "1")
-  private final Boolean randomPeerPriorityEnabled = false;
+          "Allow for incoming connections to be prioritized randomly. This will prevent (typically small, stable) networks from forming impenetrable peer cliques. (default: ${DEFAULT-VALUE})")
+  private final Boolean randomPeerPriority = false;
 
   @Option(
       names = {"--banned-node-ids", "--banned-node-id"},
@@ -2006,7 +2005,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .limitRemoteWireConnectionsEnabled(isLimitRemoteWireConnectionsEnabled)
             .fractionRemoteConnectionsAllowed(
                 Fraction.fromPercentage(maxRemoteConnectionsPercentage).getValue())
-            .randomPeerPriority(randomPeerPriorityEnabled)
+            .randomPeerPriority(randomPeerPriority)
             .networkingConfiguration(unstableNetworkingOptions.toDomainObject())
             .graphQLConfiguration(graphQLConfiguration)
             .jsonRpcConfiguration(jsonRpcConfiguration)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -352,11 +352,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
           .getValue();
 
   @Option(
-      names = {"--peer-randomization-enabled"},
+      names = {"--random-peer-priority-enabled"},
       description =
           "Allow for incoming connections to be prioritized randomly. This will prevent (typically small, stable) networks from forming impenetrable peer cliques. (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final boolean randomlyPrioritizeConnections = false;
+  private final Boolean randomPeerPriorityEnabled = false;
 
   @Option(
       names = {"--banned-node-ids", "--banned-node-id"},
@@ -2006,7 +2006,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .limitRemoteWireConnectionsEnabled(isLimitRemoteWireConnectionsEnabled)
             .fractionRemoteConnectionsAllowed(
                 Fraction.fromPercentage(maxRemoteConnectionsPercentage).getValue())
-            .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
+            .randomPeerPriority(randomPeerPriorityEnabled)
             .networkingConfiguration(unstableNetworkingOptions.toDomainObject())
             .graphQLConfiguration(graphQLConfiguration)
             .jsonRpcConfiguration(jsonRpcConfiguration)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -352,6 +352,14 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
           .getValue();
 
   @Option(
+      names = {"--peer-randomization-enabled"},
+      description =
+          // TODO
+          "(default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final boolean randomlyPrioritizeConnections = false;
+
+  @Option(
       names = {"--banned-node-ids", "--banned-node-id"},
       paramLabel = MANDATORY_NODE_ID_FORMAT_HELP,
       description = "A list of node IDs to ban from the P2P network.",
@@ -1999,6 +2007,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .limitRemoteWireConnectionsEnabled(isLimitRemoteWireConnectionsEnabled)
             .fractionRemoteConnectionsAllowed(
                 Fraction.fromPercentage(maxRemoteConnectionsPercentage).getValue())
+            .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
             .networkingConfiguration(unstableNetworkingOptions.toDomainObject())
             .graphQLConfiguration(graphQLConfiguration)
             .jsonRpcConfiguration(jsonRpcConfiguration)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -354,8 +354,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @Option(
       names = {"--peer-randomization-enabled"},
       description =
-          // TODO
-          "(default: ${DEFAULT-VALUE})",
+          "Allow for incoming connections to be prioritized randomly. This will prevent (typically small, stable) networks from forming impenetrable peer cliques. (default: ${DEFAULT-VALUE})",
       arity = "1")
   private final boolean randomlyPrioritizeConnections = false;
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1225,6 +1225,14 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void enableRandomConnectionPrioritization() {
+
+    parseCommand("--randomly-prioritize-connections");
+    verify(mockRunnerBuilder).randomPeerPriority(eq(true));
+    assertThat(commandOutput.toString()).isEmpty();
+  }
+
+  @Test
   public void syncMode_fast() {
     parseCommand("--sync-mode", "FAST");
     verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1226,10 +1226,18 @@ public class BesuCommandTest extends CommandTestAbstract {
 
   @Test
   public void enableRandomConnectionPrioritization() {
-
-    parseCommand("--randomly-prioritize-connections");
+    parseCommand("--random-peer-priority-enabled");
     verify(mockRunnerBuilder).randomPeerPriority(eq(true));
     assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
+  public void randomConnectionPrioritizationDisabledByDefault() {
+    parseCommand();
+    verify(mockRunnerBuilder).randomPeerPriority(eq(false));
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString()).isEmpty();
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -213,6 +213,7 @@ public abstract class CommandTestAbstract {
         .thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.fractionRemoteConnectionsAllowed(anyFloat()))
         .thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.randomPeerPriority(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.p2pEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethod(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natManagerServiceName(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -39,6 +39,7 @@ p2p-port=1234
 max-peers=42
 remote-connections-limit-enabled=true
 remote-connections-max-percentage=60
+random-peer-priority-enabled=false
 host-whitelist=["all"]
 required-blocks=["8675309=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
 

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/SECP256K1.java
@@ -493,7 +493,7 @@ public class SECP256K1 {
 
   public static class PublicKey implements java.security.PublicKey {
 
-    private static final int BYTE_LENGTH = 64;
+    public static final int BYTE_LENGTH = 64;
 
     private final Bytes encoded;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -473,7 +473,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
       return this;
     }
 
-    public Builder randomLyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
+    public Builder randomlyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
       checkNotNull(rlpxAgent);
       this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
       return this;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -398,7 +398,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private PeerPermissions peerPermissions = PeerPermissions.noop();
 
     private NatService natService = new NatService(Optional.empty());
-    private boolean randomlyPrioritizeConnections;
+    private boolean randomPeerPriority;
 
     private MetricsSystem metricsSystem;
 
@@ -457,7 +457,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
           .peerPrivileges(peerPrivileges)
           .localNode(localNode)
           .metricsSystem(metricsSystem)
-          .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
+          .randomPeerPriority(randomPeerPriority)
           .build();
     }
 
@@ -473,9 +473,9 @@ public class DefaultP2PNetwork implements P2PNetwork {
       return this;
     }
 
-    public Builder randomlyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
+    public Builder randomPeerPriority(final boolean randomPeerPriority) {
       checkNotNull(rlpxAgent);
-      this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
+      this.randomPeerPriority = randomPeerPriority;
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -474,7 +474,6 @@ public class DefaultP2PNetwork implements P2PNetwork {
     }
 
     public Builder randomPeerPriority(final boolean randomPeerPriority) {
-      checkNotNull(rlpxAgent);
       this.randomPeerPriority = randomPeerPriority;
       return this;
     }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -398,6 +398,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     private PeerPermissions peerPermissions = PeerPermissions.noop();
 
     private NatService natService = new NatService(Optional.empty());
+    private boolean randomlyPrioritizeConnections;
 
     private MetricsSystem metricsSystem;
 
@@ -456,6 +457,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
           .peerPrivileges(peerPrivileges)
           .localNode(localNode)
           .metricsSystem(metricsSystem)
+          .randomlyPrioritizeConnections(randomlyPrioritizeConnections)
           .build();
     }
 
@@ -468,6 +470,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
     public Builder rlpxAgent(final RlpxAgent rlpxAgent) {
       checkNotNull(rlpxAgent);
       this.rlpxAgent = rlpxAgent;
+      return this;
+    }
+
+    public Builder randomLyPrioritizeConnections(final boolean randomlyPrioritizeConnections) {
+      checkNotNull(rlpxAgent);
+      this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -222,7 +222,9 @@ public class RlpxAgent {
       return peerConnection.get();
     }
     // Check max peers
-    if (!peerPrivileges.canExceedConnectionLimits(peer) && getConnectionCount() >= maxConnections) {
+    if (!peerPrivileges.canExceedConnectionLimits(peer)
+        && getConnectionCount() >= maxConnections
+        && !randomlyPrioritizeConnections) {
       final String errorMsg =
           "Max peer peer connections established ("
               + maxConnections

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -639,7 +639,7 @@ public class RlpxAgent {
       return this;
     }
 
-    public Builder randomPeerPriority(boolean randomPeerPriority) {
+    public Builder randomPeerPriority(final boolean randomPeerPriority) {
       this.randomPeerPriority = randomPeerPriority;
       return this;
     }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 
 import org.hyperledger.besu.crypto.NodeKey;
+import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
@@ -69,7 +70,7 @@ public class RlpxAgent {
   private final int maxConnections;
   private final boolean randomlyPrioritizeConnections;
   private final int maxRemotelyInitiatedConnections;
-  private final Bytes nodeIdMask = Bytes.random(64);
+  private final Bytes nodeIdMask = Bytes.random(SECP256K1.PublicKey.BYTE_LENGTH);
 
   @VisibleForTesting final Map<Bytes, RlpxConnection> connectionsById = new ConcurrentHashMap<>();
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -70,6 +70,8 @@ public class RlpxAgent {
   private final int maxConnections;
   private final boolean randomPeerPriority;
   private final int maxRemotelyInitiatedConnections;
+  // xor'ing with this mask will allow us to randomly let new peers connect
+  // without allowing the counterparty to play nodeId farming games
   private final Bytes nodeIdMask = Bytes.random(SECP256K1.PublicKey.BYTE_LENGTH);
 
   @VisibleForTesting final Map<Bytes, RlpxConnection> connectionsById = new ConcurrentHashMap<>();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -68,7 +68,7 @@ public class RlpxAgent {
   private final PeerRlpxPermissions peerPermissions;
   private final PeerPrivileges peerPrivileges;
   private final int maxConnections;
-  private final boolean randomlyPrioritizeConnections;
+  private final boolean randomPeerPriority;
   private final int maxRemotelyInitiatedConnections;
   private final Bytes nodeIdMask = Bytes.random(SECP256K1.PublicKey.BYTE_LENGTH);
 
@@ -87,7 +87,7 @@ public class RlpxAgent {
       final PeerPrivileges peerPrivileges,
       final int maxConnections,
       final int maxRemotelyInitiatedConnections,
-      final boolean randomlyPrioritizeConnections,
+      final boolean randomPeerPriority,
       final MetricsSystem metricsSystem) {
     this.localNode = localNode;
     this.connectionEvents = connectionEvents;
@@ -95,7 +95,7 @@ public class RlpxAgent {
     this.peerPermissions = peerPermissions;
     this.peerPrivileges = peerPrivileges;
     this.maxConnections = maxConnections;
-    this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
+    this.randomPeerPriority = randomPeerPriority;
     this.maxRemotelyInitiatedConnections =
         Math.min(maxConnections, maxRemotelyInitiatedConnections);
 
@@ -343,7 +343,7 @@ public class RlpxAgent {
       peerConnection.disconnect(DisconnectReason.UNKNOWN);
       return;
     }
-    if (!randomlyPrioritizeConnections) {
+    if (!randomPeerPriority) {
       // Disconnect if too many peers
       if (!peerPrivileges.canExceedConnectionLimits(peer)
           && getConnectionCount() >= maxConnections) {
@@ -472,9 +472,7 @@ public class RlpxAgent {
     return connectionsById.values().stream()
         .filter(RlpxConnection::isActive)
         .sorted(
-            randomlyPrioritizeConnections
-                ? this::compareRandomly
-                : this::compareConnectionInitiationTimes);
+            randomPeerPriority ? this::compareRandomly : this::compareConnectionInitiationTimes);
   }
 
   private int compareConnectionInitiationTimes(final RlpxConnection a, final RlpxConnection b) {
@@ -550,7 +548,7 @@ public class RlpxAgent {
     private PeerPermissions peerPermissions;
     private ConnectionInitializer connectionInitializer;
     private PeerConnectionEvents connectionEvents;
-    private boolean randomlyPrioritizeConnections;
+    private boolean randomPeerPriority;
     private MetricsSystem metricsSystem;
 
     private Builder() {}
@@ -577,7 +575,7 @@ public class RlpxAgent {
           peerPrivileges,
           config.getMaxPeers(),
           config.getMaxRemotelyInitiatedConnections(),
-          randomlyPrioritizeConnections,
+          randomPeerPriority,
           metricsSystem);
     }
 
@@ -638,8 +636,8 @@ public class RlpxAgent {
       return this;
     }
 
-    public Builder randomlyPrioritizeConnections(boolean randomlyPrioritizeConnections) {
-      this.randomlyPrioritizeConnections = randomlyPrioritizeConnections;
+    public Builder randomPeerPriority(boolean randomPeerPriority) {
+      this.randomPeerPriority = randomPeerPriority;
       return this;
     }
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -484,7 +484,9 @@ public class RlpxAgent {
     } else if (bIgnoresPeerLimits && !aIgnoresPeerLimits) {
       return 1;
     } else {
-      return randomPeerPriority ? compareRandomly(a, b) : compareConnectionInitiationTimes(a, b);
+      return randomPeerPriority
+          ? compareByMaskedNodeId(a, b)
+          : compareConnectionInitiationTimes(a, b);
     }
   }
 
@@ -492,7 +494,7 @@ public class RlpxAgent {
     return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
   }
 
-  private int compareRandomly(final RlpxConnection a, final RlpxConnection b) {
+  private int compareByMaskedNodeId(final RlpxConnection a, final RlpxConnection b) {
     return a.getPeer().getId().xor(nodeIdMask).compareTo(b.getPeer().getId().xor(nodeIdMask));
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -223,9 +223,7 @@ public class RlpxAgent {
       return peerConnection.get();
     }
     // Check max peers
-    if (!peerPrivileges.canExceedConnectionLimits(peer)
-        && getConnectionCount() >= maxConnections
-        && !randomlyPrioritizeConnections) {
+    if (!peerPrivileges.canExceedConnectionLimits(peer) && getConnectionCount() >= maxConnections) {
       final String errorMsg =
           "Max peer peer connections established ("
               + maxConnections
@@ -345,19 +343,22 @@ public class RlpxAgent {
       peerConnection.disconnect(DisconnectReason.UNKNOWN);
       return;
     }
-    // Disconnect if too many peers
-    if (!peerPrivileges.canExceedConnectionLimits(peer) && getConnectionCount() >= maxConnections) {
-      LOG.debug("Too many peers. Disconnect incoming connection: {}", peerConnection);
-      peerConnection.disconnect(DisconnectReason.TOO_MANY_PEERS);
-      return;
-    }
-    // Disconnect if too many remotely-initiated connections
-    if (!peerPrivileges.canExceedConnectionLimits(peer) && remoteConnectionLimitReached()) {
-      LOG.debug(
-          "Too many remotely-initiated connections. Disconnect incoming connection: {}",
-          peerConnection);
-      peerConnection.disconnect(DisconnectReason.TOO_MANY_PEERS);
-      return;
+    if (!randomlyPrioritizeConnections) {
+      // Disconnect if too many peers
+      if (!peerPrivileges.canExceedConnectionLimits(peer)
+          && getConnectionCount() >= maxConnections) {
+        LOG.debug("Too many peers. Disconnect incoming connection: {}", peerConnection);
+        peerConnection.disconnect(DisconnectReason.TOO_MANY_PEERS);
+        return;
+      }
+      // Disconnect if too many remotely-initiated connections
+      if (!peerPrivileges.canExceedConnectionLimits(peer) && remoteConnectionLimitReached()) {
+        LOG.debug(
+            "Too many remotely-initiated connections. Disconnect incoming connection: {}",
+            peerConnection);
+        peerConnection.disconnect(DisconnectReason.TOO_MANY_PEERS);
+        return;
+      }
     }
     // Disconnect if not permitted
     if (!peerPermissions.allowNewInboundConnectionFrom(peer)) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -471,11 +471,10 @@ public class RlpxAgent {
   private Stream<RlpxConnection> getActivePrioritizedConnections() {
     return connectionsById.values().stream()
         .filter(RlpxConnection::isActive)
-        .sorted(
-            randomPeerPriority ? this::compareRandomly : this::compareConnectionInitiationTimes);
+        .sorted(this::comparePeerPriorities);
   }
 
-  private int compareConnectionInitiationTimes(final RlpxConnection a, final RlpxConnection b) {
+  private int comparePeerPriorities(final RlpxConnection a, final RlpxConnection b) {
     final boolean aIgnoresPeerLimits = peerPrivileges.canExceedConnectionLimits(a.getPeer());
     final boolean bIgnoresPeerLimits = peerPrivileges.canExceedConnectionLimits(b.getPeer());
     if (aIgnoresPeerLimits && !bIgnoresPeerLimits) {
@@ -483,8 +482,12 @@ public class RlpxAgent {
     } else if (bIgnoresPeerLimits && !aIgnoresPeerLimits) {
       return 1;
     } else {
-      return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
+      return randomPeerPriority ? compareRandomly(a, b) : compareConnectionInitiationTimes(a, b);
     }
+  }
+
+  private int compareConnectionInitiationTimes(final RlpxConnection a, final RlpxConnection b) {
+    return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
   }
 
   private int compareRandomly(final RlpxConnection a, final RlpxConnection b) {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -326,7 +326,7 @@ public class RlpxAgentTest {
   @Test
   public void incomingConnection_succeedsEventuallyWithRandomPeerPrioritization() {
     // Saturate connections with one local and one remote
-    startAgentWithMaxPeers(2, builder -> builder.randomlyPrioritizeConnections(true));
+    startAgentWithMaxPeers(2, builder -> builder.randomPeerPriority(true));
     agent.connect(createPeer());
     connectionInitializer.simulateIncomingConnection(connection(createPeer()));
     // Sanity check

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -303,19 +303,19 @@ public class RlpxAgentTest {
     startAgentWithMaxPeers(1, builder -> builder.randomlyPrioritizeConnections(true));
     agent.connect(createPeer());
 
-    // With very high probability, one of these should connect
-    assertThat(
-            Stream.generate(PeerTestHelper::createPeer)
-                .limit(1_000)
-                .flatMap(
-                    peer -> {
-                      try {
-                        return Stream.of(agent.connect(peer).join());
-                      } catch (CompletionException completionException) {
-                        return Stream.empty();
-                      }
-                    }))
-        .isNotEmpty();
+    boolean failureObserved = false;
+    boolean successObserved = false;
+    // With very high probability we should see connection failures and successes.
+    for (int i = 0; i < 1000; ++i) {
+      try {
+        agent.connect(createPeer()).join();
+        successObserved = true;
+      } catch (CompletionException completionException) {
+        failureObserved = true;
+      }
+    }
+    assertThat(successObserved).isTrue();
+    assertThat(failureObserved).isTrue();
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -352,8 +352,8 @@ public class RlpxAgentTest {
       } else if (!connectionsBefore.equals(connectionsAfter)) {
         oldConnectionDisconnected = true;
       }
+      assertThat(agent.getConnectionCount()).isEqualTo(2);
     }
-    assertThat(agent.getConnectionCount()).isEqualTo(2);
     assertThat(newConnectionDisconnected).isTrue();
     assertThat(oldConnectionDisconnected).isTrue();
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -335,7 +335,7 @@ public class RlpxAgentTest {
     boolean newConnectionDisconnected = false;
     boolean oldConnectionDisconnected = false;
     // With very high probability we should see the connections churn
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 1000 && !(newConnectionDisconnected && oldConnectionDisconnected); ++i) {
       final List<PeerConnection> connectionsBefore =
           agent.streamConnections().collect(Collectors.toUnmodifiableList());
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -311,12 +311,11 @@ public class RlpxAgentTest {
                     peer -> {
                       try {
                         return Stream.of(agent.connect(peer).join());
-                      } catch (CompletionException __) {
+                      } catch (CompletionException completionException) {
                         return Stream.empty();
                       }
-                    })
-                .findFirst())
-        .isPresent();
+                    }))
+        .isNotEmpty();
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -301,6 +301,7 @@ public class RlpxAgentTest {
   public void connect_succeedsEventuallyWithRandomPeerPrioritization() {
     // Saturate connections but allow peers to new peers to randomly be prioritized
     startAgentWithMaxPeers(1, builder -> builder.randomlyPrioritizeConnections(true));
+    agent.connect(createPeer());
 
     // With very high probability, one of these should connect
     assertThat(


### PR DESCRIPTION
### PR description
Thanks to @shemnon for the suggestion of using a randomly generated mask so we get a "deterministic" randomness without allowing nodes to nodeId farm. Review suggestion: hide widespace.

### Fixed Issue(s)
fixes #983

### Testing
Manually tested that 2 peers connected with `max-peers` of 1 and unlimited inbound peers reject a 3rd peer unless the flag is enabled.

### Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
