### PR TITLE
Enclave key rename

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/MultiTenancyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/MultiTenancyAcceptanceTest.java
@@ -63,10 +63,14 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
               new BigInteger(
                   "853d7f0010fd86d0d7811c1f9d968ea89a24484a8127b4a483ddf5d2cfec766d", 16)));
   private static final String PRIVACY_GROUP_ID = "B1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
-  private static final String ENCLAVE_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
-  private static final String KEY1 = "sgFkVOyFndZe/5SAZJO5UYbrl7pezHetveriBBWWnE8=";
-  private static final String KEY2 = "R1kW75NQC9XX3kwNpyPjCBFflM29+XvnKKS9VLrUkzo=";
-  private static final String KEY3 = "QzHuACXpfhoGAgrQriWJcDJ6MrUwcCvutKMoAn9KplQ=";
+  private static final String PARTICIPANT_ENCLAVE_KEY0 =
+      "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
+  private static final String PARTICIPANT_ENCLAVE_KEY1 =
+      "sgFkVOyFndZe/5SAZJO5UYbrl7pezHetveriBBWWnE8=";
+  private static final String PARTICIPANT_ENCLAVE_KEY2 =
+      "R1kW75NQC9XX3kwNpyPjCBFflM29+XvnKKS9VLrUkzo=";
+  private static final String PARTICIPANT_ENCLAVE_KEY3 =
+      "QzHuACXpfhoGAgrQriWJcDJ6MrUwcCvutKMoAn9KplQ=";
   private final Address senderAddress =
       Address.wrap(Bytes.fromHexString(accounts.getPrimaryBenefactor().getAddress()));
 
@@ -108,7 +112,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
 
     receiveEnclaveStub(validSignedPrivateTransaction);
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
 
     final Hash transactionHash =
         node.execute(
@@ -124,7 +128,10 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
 
     node.verify(
         priv.createPrivacyGroup(
-            List.of(KEY1, KEY2, KEY3), "GroupName", "Group description.", PRIVACY_GROUP_ID));
+            List.of(PARTICIPANT_ENCLAVE_KEY1, PARTICIPANT_ENCLAVE_KEY2, PARTICIPANT_ENCLAVE_KEY3),
+            "GroupName",
+            "Group description.",
+            PRIVACY_GROUP_ID));
   }
 
   @Test
@@ -140,13 +147,13 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
       throws JsonProcessingException {
     final List<PrivacyGroup> groupMembership =
         List.of(
-            testPrivacyGroup(singletonList(ENCLAVE_KEY), PrivacyGroup.Type.PANTHEON),
-            testPrivacyGroup(singletonList(ENCLAVE_KEY), PrivacyGroup.Type.PANTHEON),
-            testPrivacyGroup(singletonList(ENCLAVE_KEY), PrivacyGroup.Type.PANTHEON));
+            testPrivacyGroup(singletonList(PARTICIPANT_ENCLAVE_KEY0), PrivacyGroup.Type.PANTHEON),
+            testPrivacyGroup(singletonList(PARTICIPANT_ENCLAVE_KEY0), PrivacyGroup.Type.PANTHEON),
+            testPrivacyGroup(singletonList(PARTICIPANT_ENCLAVE_KEY0), PrivacyGroup.Type.PANTHEON));
 
     findPrivacyGroupEnclaveStub(groupMembership);
 
-    node.verify(priv.findPrivacyGroup(groupMembership.size(), ENCLAVE_KEY));
+    node.verify(priv.findPrivacyGroup(groupMembership.size(), PARTICIPANT_ENCLAVE_KEY0));
   }
 
   @Test
@@ -156,7 +163,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
         getValidSignedPrivateTransaction(senderAddress);
 
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
     receiveEnclaveStub(validSignedPrivateTransaction);
 
     node.verify(
@@ -173,7 +180,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
     final BytesValueRLPOutput rlpOutput = getRLPOutput(validSignedPrivateTransaction);
 
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
     receiveEnclaveStub(validSignedPrivateTransaction);
 
     node.verify(priv.getTransactionCount(accountAddress, PRIVACY_GROUP_ID, 0));
@@ -187,10 +194,11 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
   @Test
   public void privDistributeRawTransactionSuccessShouldReturnEnclaveKey()
       throws JsonProcessingException {
-    final String enclaveResponseKeyBytes = Bytes.wrap(Bytes.fromBase64String(KEY1)).toString();
+    final String enclaveResponseKeyBytes =
+        Bytes.wrap(Bytes.fromBase64String(PARTICIPANT_ENCLAVE_KEY1)).toString();
 
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
 
     node.verify(
         priv.distributeRawTransaction(
@@ -206,7 +214,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
     final BytesValueRLPOutput rlpOutput = getRLPOutput(validSignedPrivateTransaction);
 
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
     receiveEnclaveStub(validSignedPrivateTransaction);
 
     final Hash transactionReceipt =
@@ -227,7 +235,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
         List.of(testPrivacyGroup(emptyList(), PrivacyGroup.Type.LEGACY));
 
     retrievePrivacyGroupEnclaveStub();
-    sendEnclaveStub(KEY1);
+    sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);
     receiveEnclaveStub(validSignedPrivateTransaction);
     findPrivacyGroupEnclaveStub(groupMembership);
 
@@ -237,7 +245,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
 
     node.verify(priv.getSuccessfulTransactionReceipt(transactionHash));
 
-    final String privateFrom = ENCLAVE_KEY;
+    final String privateFrom = PARTICIPANT_ENCLAVE_KEY0;
     final String[] privateFor = {senderAddressBase64};
     node.verify(priv.getEeaTransactionCount(accountAddress, privateFrom, privateFor, 1));
   }
@@ -262,7 +270,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
   private void retrievePrivacyGroupEnclaveStub() throws JsonProcessingException {
     final String retrieveGroupResponse =
         mapper.writeValueAsString(
-            testPrivacyGroup(List.of(ENCLAVE_KEY), PrivacyGroup.Type.PANTHEON));
+            testPrivacyGroup(List.of(PARTICIPANT_ENCLAVE_KEY0), PrivacyGroup.Type.PANTHEON));
     stubFor(post("/retrievePrivacyGroup").willReturn(ok(retrieveGroupResponse)));
   }
 
@@ -309,7 +317,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
         .payload(Bytes.wrap(new byte[] {}))
         .sender(senderAddress)
         .chainId(BigInteger.valueOf(2018))
-        .privateFrom(Bytes.fromBase64String(ENCLAVE_KEY))
+        .privateFrom(Bytes.fromBase64String(PARTICIPANT_ENCLAVE_KEY0))
         .restriction(Restriction.RESTRICTED)
         .privacyGroupId(Bytes.fromBase64String(PRIVACY_GROUP_ID))
         .signAndBuild(TEST_KEY);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransaction.java
@@ -115,7 +115,7 @@ public class EeaSendRawTransaction implements JsonRpcMethod {
             id, convertTransactionInvalidReason(validationResult.getInvalidReason()));
       }
 
-      final String enclaveKey =
+      final String privateTransactionLookupId =
           privacyController.sendTransaction(
               privateTransaction, enclavePublicKey, maybePrivacyGroup);
 
@@ -125,7 +125,7 @@ public class EeaSendRawTransaction implements JsonRpcMethod {
                 () ->
                     new RuntimeException(
                         JsonRpcError.OFFCHAIN_PRIVACY_GROUP_DOES_NOT_EXIST.getMessage()));
-        final Optional<String> addPayloadEnclaveKey =
+        final Optional<String> addPayloadPrivateTransactionLookupId =
             privacyController.buildAndSendAddPayload(
                 privateTransaction,
                 Bytes32.wrap(privacyGroupId),
@@ -133,10 +133,11 @@ public class EeaSendRawTransaction implements JsonRpcMethod {
         return createPMTAndAddToTxPool(
             id,
             privateTransaction,
-            buildCompoundKey(enclaveKey, addPayloadEnclaveKey),
+            buildCompoundLookupId(privateTransactionLookupId, addPayloadPrivateTransactionLookupId),
             Address.ONCHAIN_PRIVACY);
       } else { // legacy or pantheon transaction
-        return createPMTAndAddToTxPool(id, privateTransaction, enclaveKey, Address.DEFAULT_PRIVACY);
+        return createPMTAndAddToTxPool(
+            id, privateTransaction, privateTransactionLookupId, Address.DEFAULT_PRIVACY);
       }
     } catch (final IllegalArgumentException | RLPException e) {
       return new JsonRpcErrorResponse(id, DECODE_ERROR);
@@ -170,13 +171,14 @@ public class EeaSendRawTransaction implements JsonRpcMethod {
     return new JsonRpcErrorResponse(id, convertTransactionInvalidReason(errorReason));
   }
 
-  private String buildCompoundKey(
-      final String enclaveKey, final Optional<String> addPayloadEnclaveKey) {
-    return addPayloadEnclaveKey.isPresent()
+  private String buildCompoundLookupId(
+      final String privateTransactionLookupId,
+      final Optional<String> maybePrivateTransactionLookupId) {
+    return maybePrivateTransactionLookupId.isPresent()
         ? Bytes.concatenate(
-                Bytes.fromBase64String(enclaveKey),
-                Bytes.fromBase64String(addPayloadEnclaveKey.get()))
+                Bytes.fromBase64String(privateTransactionLookupId),
+                Bytes.fromBase64String(maybePrivateTransactionLookupId.get()))
             .toBase64String()
-        : enclaveKey;
+        : privateTransactionLookupId;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -263,7 +263,7 @@ public class EeaSendRawTransactionTest {
         .thenReturn(optionalPrivacyGroup);
     when(privacyController.buildAndSendAddPayload(
             any(PrivateTransaction.class), any(Bytes32.class), any(String.class)))
-        .thenReturn(Optional.of(ENCLAVE_PUBLIC_KEY));
+        .thenReturn(Optional.of(""));
     when(privacyController.createPrivacyMarkerTransaction(
             any(String.class), any(PrivateTransaction.class), any(Address.class)))
         .thenReturn(PUBLIC_TRANSACTION);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -37,7 +37,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -108,7 +107,6 @@ public class EeaSendRawTransactionTest {
   @Mock private TransactionPool transactionPool;
   @Mock private EeaSendRawTransaction method;
   @Mock private PrivacyController privacyController;
-  @Mock private PrivacyParameters privacyParameters;
 
   @Before
   public void before() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -259,9 +259,6 @@ public class EeaSendRawTransactionTest {
                 "", PrivacyGroup.Type.ONCHAIN, "", "", Arrays.asList(ENCLAVE_PUBLIC_KEY)));
     when(privacyController.retrieveOnChainPrivacyGroupWithToBeAddedMembers(any(), any(), any()))
         .thenReturn(optionalPrivacyGroup);
-    when(privacyController.buildAndSendAddPayload(
-            any(PrivateTransaction.class), any(Bytes32.class), any(String.class)))
-        .thenReturn(Optional.of(""));
     when(privacyController.createPrivacyMarkerTransaction(
             any(String.class), any(PrivateTransaction.class), any(Address.class)))
         .thenReturn(PUBLIC_TRANSACTION);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -57,7 +57,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.impl.JWTUser;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyController.java
@@ -164,17 +164,17 @@ public class DefaultPrivacyController implements PrivacyController {
 
   @Override
   public Transaction createPrivacyMarkerTransaction(
-      final String transactionEnclaveKey, final PrivateTransaction privateTransaction) {
-    return privateMarkerTransactionFactory.create(transactionEnclaveKey, privateTransaction);
+      final String privateTransactionLookupId, final PrivateTransaction privateTransaction) {
+    return privateMarkerTransactionFactory.create(privateTransactionLookupId, privateTransaction);
   }
 
   @Override
   public Transaction createPrivacyMarkerTransaction(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final Address privacyPrecompileAddress) {
     return privateMarkerTransactionFactory.create(
-        transactionEnclaveKey, privateTransaction, privacyPrecompileAddress);
+        privateTransactionLookupId, privateTransaction, privacyPrecompileAddress);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/MultiTenancyPrivacyController.java
@@ -129,18 +129,18 @@ public class MultiTenancyPrivacyController implements PrivacyController {
 
   @Override
   public Transaction createPrivacyMarkerTransaction(
-      final String transactionEnclaveKey, final PrivateTransaction privateTransaction) {
+      final String privateTransactionLookupId, final PrivateTransaction privateTransaction) {
     return privacyController.createPrivacyMarkerTransaction(
-        transactionEnclaveKey, privateTransaction);
+        privateTransactionLookupId, privateTransaction);
   }
 
   @Override
   public Transaction createPrivacyMarkerTransaction(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final Address privacyPrecompileAddress) {
     return privacyController.createPrivacyMarkerTransaction(
-        transactionEnclaveKey, privateTransaction, privacyPrecompileAddress);
+        privateTransactionLookupId, privateTransaction, privacyPrecompileAddress);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivacyController.java
@@ -49,10 +49,10 @@ public interface PrivacyController {
   PrivacyGroup[] findPrivacyGroup(List<String> addresses, String enclavePublicKey);
 
   Transaction createPrivacyMarkerTransaction(
-      String transactionEnclaveKey, PrivateTransaction privateTransaction);
+      String privateTransactionLookupId, PrivateTransaction privateTransaction);
 
   Transaction createPrivacyMarkerTransaction(
-      String transactionEnclaveKey,
+      String privateTransactionLookupId,
       PrivateTransaction privateTransaction,
       Address privacyPrecompileAddress);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/FixedKeySigningPrivateMarkerTransactionFactory.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/FixedKeySigningPrivateMarkerTransactionFactory.java
@@ -40,11 +40,11 @@ public class FixedKeySigningPrivateMarkerTransactionFactory
 
   @Override
   public Transaction create(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final Address precompileAddress) {
     return create(
-        transactionEnclaveKey,
+        privateTransactionLookupId,
         privateTransaction,
         nonceProvider.getNonce(sender),
         signingKey,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/PrivateMarkerTransactionFactory.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/PrivateMarkerTransactionFactory.java
@@ -34,17 +34,17 @@ public abstract class PrivateMarkerTransactionFactory {
   }
 
   public Transaction create(
-      final String transactionEnclaveKey, final PrivateTransaction privateTransaction) {
-    return create(transactionEnclaveKey, privateTransaction, privacyPrecompileAddress);
+      final String privateTransactionLookupId, final PrivateTransaction privateTransaction) {
+    return create(privateTransactionLookupId, privateTransaction, privacyPrecompileAddress);
   }
 
   public abstract Transaction create(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final Address precompileAddress);
 
   protected Transaction create(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final long nonce,
       final KeyPair signingKey) {
@@ -54,12 +54,12 @@ public abstract class PrivateMarkerTransactionFactory {
         .gasLimit(privateTransaction.getGasLimit())
         .to(getPrivacyPrecompileAddress())
         .value(privateTransaction.getValue())
-        .payload(Bytes.fromBase64String(transactionEnclaveKey))
+        .payload(Bytes.fromBase64String(privateTransactionLookupId))
         .signAndBuild(signingKey);
   }
 
   protected Transaction create(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final long nonce,
       final KeyPair signingKey,
@@ -70,7 +70,7 @@ public abstract class PrivateMarkerTransactionFactory {
         .gasLimit(privateTransaction.getGasLimit())
         .to(precompileAddress)
         .value(privateTransaction.getValue())
-        .payload(Bytes.fromBase64String(transactionEnclaveKey))
+        .payload(Bytes.fromBase64String(privateTransactionLookupId))
         .signAndBuild(signingKey);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/RandomSigningPrivateMarkerTransactionFactory.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/markertransaction/RandomSigningPrivateMarkerTransactionFactory.java
@@ -27,10 +27,10 @@ public class RandomSigningPrivateMarkerTransactionFactory extends PrivateMarkerT
 
   @Override
   public Transaction create(
-      final String transactionEnclaveKey,
+      final String privateTransactionLookupId,
       final PrivateTransaction privateTransaction,
       final Address precompileAddress) {
     final KeyPair signingKey = KeyPair.generate();
-    return create(transactionEnclaveKey, privateTransaction, 0, signingKey, precompileAddress);
+    return create(privateTransactionLookupId, privateTransaction, 0, signingKey, precompileAddress);
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/OnChainPrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/OnChainPrivacyPrecompiledContractTest.java
@@ -71,7 +71,7 @@ public class OnChainPrivacyPrecompiledContractTest {
 
   @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
-  private final Bytes txEnclaveKey = Bytes.random(32);
+  private final Bytes privateTransactionLookupId = Bytes.random(32);
   private MessageFrame messageFrame;
   private Blockchain blockchain;
   private final String DEFAULT_OUTPUT = "0x01";
@@ -166,7 +166,7 @@ public class OnChainPrivacyPrecompiledContractTest {
         .when(contractSpy)
         .canExecute(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
 
-    final Bytes actual = contractSpy.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contractSpy.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -178,7 +178,7 @@ public class OnChainPrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenThrow(EnclaveClientException.class);
 
-    final Bytes expected = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -189,7 +189,7 @@ public class OnChainPrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenThrow(new RuntimeException());
 
-    contract.compute(txEnclaveKey, messageFrame);
+    contract.compute(privateTransactionLookupId, messageFrame);
   }
 
   @Test
@@ -202,9 +202,10 @@ public class OnChainPrivacyPrecompiledContractTest {
 
     final ReceiveResponse responseWithoutSenderKey =
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, null);
-    when(enclave.receive(eq(txEnclaveKey.toBase64String()))).thenReturn(responseWithoutSenderKey);
+    when(enclave.receive(eq(privateTransactionLookupId.toBase64String())))
+        .thenReturn(responseWithoutSenderKey);
 
-    assertThatThrownBy(() -> contract.compute(txEnclaveKey, messageFrame))
+    assertThatThrownBy(() -> contract.compute(privateTransactionLookupId, messageFrame))
         .isInstanceOf(EnclaveConfigurationException.class)
         .hasMessage("Incompatible Orion version. Orion version must be 1.6.0 or greater.");
   }
@@ -220,9 +221,10 @@ public class OnChainPrivacyPrecompiledContractTest {
     final String wrongSenderKey = Bytes.random(32).toBase64String();
     final ReceiveResponse responseWithWrongSenderKey =
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, wrongSenderKey);
-    when(enclave.receive(eq(txEnclaveKey.toBase64String()))).thenReturn(responseWithWrongSenderKey);
+    when(enclave.receive(eq(privateTransactionLookupId.toBase64String())))
+        .thenReturn(responseWithWrongSenderKey);
 
-    final Bytes expected = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -256,7 +258,7 @@ public class OnChainPrivacyPrecompiledContractTest {
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, privateFrom);
     when(enclave.receive(any(String.class))).thenReturn(response);
 
-    final Bytes actual = contractSpy.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contractSpy.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -294,7 +296,7 @@ public class OnChainPrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenReturn(response);
 
-    final Bytes actual = contractSpy.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contractSpy.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -73,7 +73,7 @@ public class PrivacyPrecompiledContractTest {
   @Rule public final TemporaryFolder temp = new TemporaryFolder();
 
   private final String actual = "Test String";
-  private final Bytes txEnclaveKey = Bytes.wrap(actual.getBytes(UTF_8));
+  private final Bytes privateTransactionLookupId = Bytes.wrap(actual.getBytes(UTF_8));
   private MessageFrame messageFrame;
   private Blockchain blockchain;
   private final String DEFAULT_OUTPUT = "0x01";
@@ -160,7 +160,7 @@ public class PrivacyPrecompiledContractTest {
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, privateFrom);
     when(enclave.receive(any(String.class))).thenReturn(response);
 
-    final Bytes actual = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contract.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -172,7 +172,7 @@ public class PrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenThrow(EnclaveClientException.class);
 
-    final Bytes expected = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -183,7 +183,7 @@ public class PrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenThrow(new RuntimeException());
 
-    contract.compute(txEnclaveKey, messageFrame);
+    contract.compute(privateTransactionLookupId, messageFrame);
   }
 
   @Test
@@ -195,9 +195,10 @@ public class PrivacyPrecompiledContractTest {
 
     final ReceiveResponse responseWithoutSenderKey =
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, null);
-    when(enclave.receive(eq(txEnclaveKey.toBase64String()))).thenReturn(responseWithoutSenderKey);
+    when(enclave.receive(eq(privateTransactionLookupId.toBase64String())))
+        .thenReturn(responseWithoutSenderKey);
 
-    assertThatThrownBy(() -> contract.compute(txEnclaveKey, messageFrame))
+    assertThatThrownBy(() -> contract.compute(privateTransactionLookupId, messageFrame))
         .isInstanceOf(EnclaveConfigurationException.class)
         .hasMessage("Incompatible Orion version. Orion version must be 1.6.0 or greater.");
   }
@@ -213,9 +214,9 @@ public class PrivacyPrecompiledContractTest {
     final String senderKey = privateTransaction.getPrivateFrom().toBase64String();
     final ReceiveResponse response =
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, senderKey);
-    when(enclave.receive(eq(txEnclaveKey.toBase64String()))).thenReturn(response);
+    when(enclave.receive(eq(privateTransactionLookupId.toBase64String()))).thenReturn(response);
 
-    final Bytes expected = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -229,9 +230,10 @@ public class PrivacyPrecompiledContractTest {
     final String wrongSenderKey = Bytes.random(32).toBase64String();
     final ReceiveResponse responseWithWrongSenderKey =
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, wrongSenderKey);
-    when(enclave.receive(eq(txEnclaveKey.toBase64String()))).thenReturn(responseWithWrongSenderKey);
+    when(enclave.receive(eq(privateTransactionLookupId.toBase64String())))
+        .thenReturn(responseWithWrongSenderKey);
 
-    final Bytes expected = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -260,7 +262,7 @@ public class PrivacyPrecompiledContractTest {
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, privateFrom);
     when(enclave.receive(any(String.class))).thenReturn(response);
 
-    final Bytes actual = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contract.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -298,7 +300,7 @@ public class PrivacyPrecompiledContractTest {
 
     when(enclave.receive(any(String.class))).thenReturn(response);
 
-    final Bytes actual = contract.compute(txEnclaveKey, messageFrame);
+    final Bytes actual = contract.compute(privateTransactionLookupId, messageFrame);
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyControllerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/DefaultPrivacyControllerTest.java
@@ -89,7 +89,7 @@ public class DefaultPrivacyControllerTest {
       "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002";
   private static final PrivacyGroup PANTHEON_PRIVACY_GROUP =
       new PrivacyGroup("", PrivacyGroup.Type.PANTHEON, "", "", emptyList());
-  private static final PrivacyGroup ON_CHAIN_PRIVACY_GROUP =
+  private static final PrivacyGroup ONCHAIN_PRIVACY_GROUP =
       new PrivacyGroup("", PrivacyGroup.Type.ONCHAIN, "", "", Arrays.asList(ENCLAVE_PUBLIC_KEY));
 
   private PrivacyController privacyController;
@@ -185,14 +185,14 @@ public class DefaultPrivacyControllerTest {
   public void sendsValidLegacyTransaction() {
     final PrivateTransaction transaction = buildLegacyPrivateTransaction(1);
 
-    final String enclaveKey =
+    final String privateTransactionLookupId =
         privacyController.sendTransaction(transaction, ENCLAVE_PUBLIC_KEY, Optional.empty());
 
     final ValidationResult<TransactionInvalidReason> validationResult =
         privacyController.validatePrivateTransaction(transaction, ENCLAVE_PUBLIC_KEY);
 
     final Transaction markerTransaction =
-        privacyController.createPrivacyMarkerTransaction(enclaveKey, transaction);
+        privacyController.createPrivacyMarkerTransaction(privateTransactionLookupId, transaction);
 
     assertThat(validationResult).isEqualTo(ValidationResult.valid());
     assertThat(markerTransaction.contractAddress()).isEqualTo(PUBLIC_TRANSACTION.contractAddress());
@@ -208,7 +208,7 @@ public class DefaultPrivacyControllerTest {
   public void sendValidBesuTransaction() {
     final PrivateTransaction transaction = buildBesuPrivateTransaction(1);
 
-    final String enclaveKey =
+    final String privateTransactionLookupId =
         privacyController.sendTransaction(
             transaction, ENCLAVE_PUBLIC_KEY, Optional.of(PANTHEON_PRIVACY_GROUP));
 
@@ -216,7 +216,7 @@ public class DefaultPrivacyControllerTest {
         privacyController.validatePrivateTransaction(transaction, ENCLAVE_PUBLIC_KEY);
 
     final Transaction markerTransaction =
-        privacyController.createPrivacyMarkerTransaction(enclaveKey, transaction);
+        privacyController.createPrivacyMarkerTransaction(privateTransactionLookupId, transaction);
 
     assertThat(validationResult).isEqualTo(ValidationResult.valid());
     assertThat(markerTransaction.contractAddress()).isEqualTo(PUBLIC_TRANSACTION.contractAddress());
@@ -449,13 +449,13 @@ public class DefaultPrivacyControllerTest {
   public void canCreatePrivacyMarkerTransactionForOnChainPrivacy() {
     final PrivateTransaction transaction = buildBesuPrivateTransaction(0);
 
-    final String enclaveKey =
+    final String privateTransactionLookupId =
         privacyController.sendTransaction(
-            transaction, ENCLAVE_PUBLIC_KEY, Optional.of(ON_CHAIN_PRIVACY_GROUP));
+            transaction, ENCLAVE_PUBLIC_KEY, Optional.of(ONCHAIN_PRIVACY_GROUP));
 
     final Transaction onChainPrivacyMarkerTransaction =
         privacyController.createPrivacyMarkerTransaction(
-            enclaveKey, transaction, Address.ONCHAIN_PRIVACY);
+            privateTransactionLookupId, transaction, Address.ONCHAIN_PRIVACY);
 
     assertThat(onChainPrivacyMarkerTransaction.contractAddress())
         .isEqualTo(PUBLIC_TRANSACTION.contractAddress());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionLocatorTest.java
@@ -243,12 +243,12 @@ public class PrivateTransactionLocatorTest {
       final Transaction pmt,
       final PrivateTransaction privateTransaction,
       final Optional<Bytes32> version) {
-    final String privateTxEnclaveKey = pmt.getData().orElseThrow().toBase64String();
+    final String privateTransactionLookupId = pmt.getData().orElseThrow().toBase64String();
     final byte[] encodePrivateTransaction =
         encodePrivateTransaction(privateTransaction, version)
             .toBase64String()
             .getBytes(StandardCharsets.UTF_8);
-    when(enclave.receive(eq(privateTxEnclaveKey), eq(participantKey)))
+    when(enclave.receive(eq(privateTransactionLookupId), eq(participantKey)))
         .thenReturn(new ReceiveResponse(encodePrivateTransaction, privacyGroupId, participantKey));
   }
 
@@ -263,10 +263,10 @@ public class PrivateTransactionLocatorTest {
   }
 
   private void mockEnclaveForNonExistingPayload(final Transaction pmt) {
-    final String privateTxEnclaveKey = pmt.getData().orElseThrow().toBase64String();
+    final String privateTransactionLookupId = pmt.getData().orElseThrow().toBase64String();
     final EnclaveClientException payloadNotFoundException =
         new EnclaveClientException(404, "Payload not found");
-    when(enclave.receive(eq(privateTxEnclaveKey), eq(participantKey)))
+    when(enclave.receive(eq(privateTransactionLookupId), eq(participantKey)))
         .thenThrow(payloadNotFoundException);
   }
 


### PR DESCRIPTION
Rename enclaveKey to avoid confusion - ensure `enclaveKey` is only used as the participant (node or tenant) enclaveKey. The "lookup" key is now renamed `privateTransactionLookupId`

See #517 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).