### PR TITLE
Remove restriction about base fee on eth_sendRawTransaction

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -273,8 +273,9 @@ public class PendingTransactions {
     final TransactionInfo existingTransaction =
         getTrackedTransactionBySenderAndNonce(transactionInfo);
     if (existingTransaction != null) {
-      if (!transactionReplacementHandler.shouldReplace(
-          existingTransaction, transactionInfo, chainHeadHeaderSupplier.get())) {
+      if (existingTransaction.transaction.isFrontierTransaction()
+          && !transactionReplacementHandler.shouldReplace(
+              existingTransaction, transactionInfo, chainHeadHeaderSupplier.get())) {
         return REJECTED_UNDERPRICED_REPLACEMENT;
       }
       removeTransaction(existingTransaction.getTransaction());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -160,14 +160,16 @@ public class TransactionPool implements BlockAddedObserver {
 
   public ValidationResult<TransactionInvalidReason> addLocalTransaction(
       final Transaction transaction) {
-    final Wei transactionGasPrice = minTransactionGasPrice(transaction);
-    if (transactionGasPrice.compareTo(minTransactionGasPrice) < 0) {
-      return ValidationResult.invalid(TransactionInvalidReason.GAS_PRICE_TOO_LOW);
-    }
-
-    if (!configuration.getTxFeeCap().isZero()
-        && transactionGasPrice.compareTo(configuration.getTxFeeCap()) > 0) {
-      return ValidationResult.invalid(TransactionInvalidReason.TX_FEECAP_EXCEEDED);
+    if (transaction.isFrontierTransaction()
+        && (!ExperimentalEIPs.eip1559Enabled || this.eip1559.isEmpty())) {
+      final Wei transactionGasPrice = minTransactionGasPrice(transaction);
+      if (transactionGasPrice.compareTo(minTransactionGasPrice) < 0) {
+        return ValidationResult.invalid(TransactionInvalidReason.GAS_PRICE_TOO_LOW);
+      }
+      if (!configuration.getTxFeeCap().isZero()
+          && transactionGasPrice.compareTo(configuration.getTxFeeCap()) > 0) {
+        return ValidationResult.invalid(TransactionInvalidReason.TX_FEECAP_EXCEEDED);
+      }
     }
 
     final ValidationResult<TransactionInvalidReason> validationResult =


### PR DESCRIPTION
## PR description
The current implementation rejects transaction if the gas price is below the chain head base fee. We should remove this restriction on the RPC endpoint. If we implement a restriction it should be on the P2P layer rather than the RPC interface.
## Fixed Issue(s)
#1472 

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>
