### PR TITLE
Thread Safe Evicting Queue Access

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -38,7 +38,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -375,8 +374,10 @@ public class PendingTransactions {
     }
   }
 
-  Collection<Hash> getNewPooledHashes() {
-    return newPooledHashes;
+  List<Hash> getNewPooledHashes() {
+    synchronized (newPooledHashes) {
+      return List.copyOf(newPooledHashes);
+    }
   }
 
   /**

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -48,7 +48,6 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -122,7 +121,8 @@ public class TransactionPool implements BlockAddedObserver {
   }
 
   void handleConnect(final EthPeer peer) {
-    getLocalTransactions()
+    pendingTransactions
+        .getLocalTransactions()
         .forEach(transaction -> peerTransactionTracker.addToPeerSendQueue(peer, transaction));
 
     maybePeerPendingTransactionTracker
@@ -131,16 +131,9 @@ public class TransactionPool implements BlockAddedObserver {
                 peerPendingTransactionTracker.isPeerSupported(peer, EthProtocol.ETH65))
         .ifPresent(
             peerPendingTransactionTracker ->
-                getNewPooledHashes()
+                pendingTransactions
+                    .getNewPooledHashes()
                     .forEach(hash -> peerPendingTransactionTracker.addToPeerSendQueue(peer, hash)));
-  }
-
-  private List<Transaction> getLocalTransactions() {
-    return pendingTransactions.getLocalTransactions();
-  }
-
-  public List<Hash> getNewPooledHashes() {
-    return pendingTransactions.getNewPooledHashes();
   }
 
   public boolean addTransactionHash(final Hash transactionHash) {


### PR DESCRIPTION
I previously had it ignore the evicted hashes when it there was a concurrent modification exception but this is more elegant. It shouldn't matter if the hash that we send has been evicted by the time the peer recieves it. The protocol is not designed such that nodes have to have the hashes they advertise.

### Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
