### PR TITLE
Fix `TargetingGasLimitCalculator`

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
@@ -17,18 +17,30 @@ package org.hyperledger.besu.controller;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import org.hyperledger.besu.ethereum.blockcreation.GasLimitCalculator;
+import org.hyperledger.besu.ethereum.mainnet.AbstractGasLimitSpecification;
 
 import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class TargetingGasLimitCalculator implements GasLimitCalculator {
+public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
+    implements GasLimitCalculator {
   private static final Logger LOG = LogManager.getLogger();
-  public static final long ADJUSTMENT_FACTOR = 1024L;
+  private final long adjustFactor;
   private Long targetGasLimit;
 
-  public TargetingGasLimitCalculator(final Long targetGasLimit) {
+  public TargetingGasLimitCalculator(final long targetGasLimit) {
+    this(targetGasLimit, 1024L, 5000L, 0x7fffffffffffffffL);
+  }
+
+  public TargetingGasLimitCalculator(
+      final long targetGasLimit,
+      final long adjustFactor,
+      final long minGasLimit,
+      final long maxGasLimit) {
+    super(minGasLimit, maxGasLimit);
+    this.adjustFactor = adjustFactor;
     changeTargetGasLimit(targetGasLimit);
   }
 
@@ -52,13 +64,24 @@ public class TargetingGasLimitCalculator implements GasLimitCalculator {
 
   @Override
   public void changeTargetGasLimit(final Long targetGasLimit) {
-    checkArgument(targetGasLimit >= 0, "Target gas limit must be non-negative");
+    checkArgument(
+        targetGasLimit >= minGasLimit,
+        "targetGasLimit of " + targetGasLimit + " is below the minGasLimit of " + minGasLimit);
+
+    checkArgument(
+        targetGasLimit <= maxGasLimit,
+        "targetGasLimit of " + targetGasLimit + " is above the maxGasLimit of " + maxGasLimit);
     this.targetGasLimit = targetGasLimit;
+  }
+
+  private long adjustAmount(final long currentGasLimit) {
+    final long maxAdjustAmount = Math.max(deltaBound(currentGasLimit) - 1, 0);
+    return Math.min(adjustFactor, maxAdjustAmount);
   }
 
   private long safeAdd(final long gasLimit) {
     try {
-      return Math.addExact(gasLimit, ADJUSTMENT_FACTOR);
+      return Math.addExact(gasLimit, adjustAmount(gasLimit));
     } catch (final ArithmeticException ex) {
       return Long.MAX_VALUE;
     }
@@ -66,7 +89,7 @@ public class TargetingGasLimitCalculator implements GasLimitCalculator {
 
   private long safeSub(final long gasLimit) {
     try {
-      return Math.max(Math.subtractExact(gasLimit, ADJUSTMENT_FACTOR), 0);
+      return Math.max(Math.subtractExact(gasLimit, adjustAmount(gasLimit)), 0);
     } catch (final ArithmeticException ex) {
       return 0;
     }

--- a/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
@@ -48,9 +48,9 @@ public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
   public long nextGasLimit(final long currentGasLimit) {
     final long nextGasLimit;
     if (targetGasLimit > currentGasLimit) {
-      nextGasLimit = Math.min(targetGasLimit, safeAdd(currentGasLimit));
+      nextGasLimit = Math.min(targetGasLimit, safeAddAtMost(currentGasLimit));
     } else if (targetGasLimit < currentGasLimit) {
-      nextGasLimit = Math.max(targetGasLimit, safeSub(currentGasLimit));
+      nextGasLimit = Math.max(targetGasLimit, safeSubAtMost(currentGasLimit));
     } else {
       nextGasLimit = currentGasLimit;
     }
@@ -79,7 +79,7 @@ public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
     return Math.min(maxConstantAdjustmentIncrement, maxProportionalAdjustmentLimit);
   }
 
-  private long safeAdd(final long gasLimit) {
+  private long safeAddAtMost(final long gasLimit) {
     try {
       return Math.addExact(gasLimit, adjustAmount(gasLimit));
     } catch (final ArithmeticException ex) {
@@ -87,7 +87,7 @@ public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
     }
   }
 
-  private long safeSub(final long gasLimit) {
+  private long safeSubAtMost(final long gasLimit) {
     try {
       return Math.max(Math.subtractExact(gasLimit, adjustAmount(gasLimit)), 0);
     } catch (final ArithmeticException ex) {

--- a/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TargetingGasLimitCalculator.java
@@ -27,20 +27,20 @@ import org.apache.logging.log4j.Logger;
 public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
     implements GasLimitCalculator {
   private static final Logger LOG = LogManager.getLogger();
-  private final long adjustFactor;
+  private final long maxConstantAdjustmentIncrement;
   private Long targetGasLimit;
 
   public TargetingGasLimitCalculator(final long targetGasLimit) {
-    this(targetGasLimit, 1024L, 5000L, 0x7fffffffffffffffL);
+    this(targetGasLimit, 1024L, 5000L, Long.MAX_VALUE);
   }
 
   public TargetingGasLimitCalculator(
       final long targetGasLimit,
-      final long adjustFactor,
+      final long maxConstantAdjustmentIncrement,
       final long minGasLimit,
       final long maxGasLimit) {
     super(minGasLimit, maxGasLimit);
-    this.adjustFactor = adjustFactor;
+    this.maxConstantAdjustmentIncrement = maxConstantAdjustmentIncrement;
     changeTargetGasLimit(targetGasLimit);
   }
 
@@ -75,8 +75,8 @@ public class TargetingGasLimitCalculator extends AbstractGasLimitSpecification
   }
 
   private long adjustAmount(final long currentGasLimit) {
-    final long maxAdjustAmount = Math.max(deltaBound(currentGasLimit) - 1, 0);
-    return Math.min(adjustFactor, maxAdjustAmount);
+    final long maxProportionalAdjustmentLimit = Math.max(deltaBound(currentGasLimit) - 1, 0);
+    return Math.min(maxConstantAdjustmentIncrement, maxProportionalAdjustmentLimit);
   }
 
   private long safeAdd(final long gasLimit) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
@@ -26,10 +26,9 @@ public abstract class AbstractGasLimitSpecification {
   protected AbstractGasLimitSpecification(final long minGasLimit, final long maxGasLimit) {
     checkArgument(
         minGasLimit >= GAS_LIMIT_BOUND_DIVISOR,
-        "minGasLimit of "
-            + minGasLimit
-            + " is below the bound divisor of "
-            + GAS_LIMIT_BOUND_DIVISOR);
+        String.format(
+            "minGasLimit of %d is below the bound divisor of %d",
+            minGasLimit, GAS_LIMIT_BOUND_DIVISOR));
     this.minGasLimit = minGasLimit;
     this.maxGasLimit = maxGasLimit;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/** Specification for the block gasLimit. */
+public abstract class AbstractGasLimitSpecification {
+
+  private static final int GAS_LIMIT_BOUND_DIVISOR = 1024;
+  protected final long minGasLimit;
+  protected final long maxGasLimit;
+
+  protected AbstractGasLimitSpecification(final long minGasLimit, final long maxGasLimit) {
+    checkArgument(
+        minGasLimit >= GAS_LIMIT_BOUND_DIVISOR,
+        "minGasLimit of "
+            + minGasLimit
+            + " is below the bound divisor of "
+            + GAS_LIMIT_BOUND_DIVISOR);
+    this.minGasLimit = minGasLimit;
+    this.maxGasLimit = maxGasLimit;
+  }
+
+  protected static long deltaBound(final long currentGasLimit) {
+    return Long.divideUnsigned(currentGasLimit, GAS_LIMIT_BOUND_DIVISOR);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This PR is aimed to fix the disobedience for `GasLimitRangeAndDeltaValidationRule` in `TargetingGasLimitCalculator`.
There is a bound of  block gas limit delta in Ethereum specification which is enforced by `GasLimitRangeAndDeltaValidationRule` in Besu to limit the delta to 1024th of parent block gas limit.
The scenario can be reproduced in the added test case (which gas limit is less or equal than `1024 * 1024`).
