### PR TITLE
[1476] Fixed transaction validation bug when local permissioning is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Bug Fixes
 
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction [\#1478](https://github.com/hyperledger/besu/pull/1478)
-* Fixed a bug in local Account Permissioning where a node is unable to import a block containing a transaction from a node that s not in the local allowlist [\#1476]()
+* Fixed a bug in local Account Permissioning where a node is unable to import a block containing a transaction from a node that s not in the local allowlist [\#1510](https://github.com/hyperledger/besu/pull/1510)
 
 ## Deprecated and Scheduled for removal in _Next_ Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction [\#1478](https://github.com/hyperledger/besu/pull/1478)
+* Fixed a bug in local Account Permissioning where a node is unable to import a block containing a transaction from a node that s not in the local allowlist [\#1476]()
 
 ## Deprecated and Scheduled for removal in _Next_ Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 
 ### Bug Fixes
 
-* Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction [\#1478](https://github.com/hyperledger/besu/pull/1478)
-* Fixed a bug in local Account Permissioning where a node is unable to import a block containing a transaction from a node that s not in the local allowlist [\#1510](https://github.com/hyperledger/besu/pull/1510)
+* Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction. [\#1478](https://github.com/hyperledger/besu/pull/1478)
+* Fixed a bug where Local Account Permissioning was being incorrectly enforced on block import/validation. [\#1510](https://github.com/hyperledger/besu/pull/1510)
 
 ## Deprecated 
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.tests.acceptance.dsl;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.tests.acceptance.dsl.account.Accounts;
 import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Blockchain;
@@ -30,6 +31,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.condition.process.ExitedWithCod
 import org.hyperledger.besu.tests.acceptance.dsl.condition.txpool.TxPoolConditions;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.web3.Web3Conditions;
 import org.hyperledger.besu.tests.acceptance.dsl.contract.ContractVerifier;
+import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.BesuNodeFactory;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.permissioning.PermissionedNodeBuilder;
@@ -51,6 +53,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.ProcessBuilder.Redirect;
+import java.math.BigInteger;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -216,4 +219,12 @@ public class AcceptanceTestBase {
           }
         }
       };
+
+  protected void waitForBlockHeight(final Node node, final long blockchainHeight) {
+    WaitUtils.waitFor(
+        120,
+        () ->
+            assertThat(node.execute(ethTransactions.blockNumber()))
+                .isGreaterThanOrEqualTo(BigInteger.valueOf(blockchainHeight)));
+  }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
@@ -26,11 +26,14 @@ import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.MiningParametersTestBuilder;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
+import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.genesis.GenesisConfigurationFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -283,6 +286,32 @@ public class BesuNodeFactory {
                 validators ->
                     genesis.createIbft2GenesisConfigFilterBootnode(validators, genesisFile))
             .bootnodeEligible(true)
+            .build());
+  }
+
+  public BesuNode createIbft2NodeWithLocalAccountPermissioning(
+      final String name,
+      final String genesisFile,
+      final List<String> accountAllowList,
+      final File configFile)
+      throws IOException {
+    final LocalPermissioningConfiguration config = LocalPermissioningConfiguration.createDefault();
+    config.setAccountAllowlist(accountAllowList);
+    config.setAccountPermissioningConfigFilePath(configFile.getAbsolutePath());
+    final PermissioningConfiguration permissioningConfiguration =
+        new PermissioningConfiguration(Optional.of(config), Optional.empty());
+    return create(
+        new BesuNodeConfigurationBuilder()
+            .name(name)
+            .miningEnabled()
+            .jsonRpcConfiguration(node.createJsonRpcWithIbft2AdminEnabledConfig())
+            .webSocketConfiguration(node.createWebSocketEnabledConfig())
+            .permissioningConfiguration(permissioningConfiguration)
+            .devMode(false)
+            .genesisConfigProvider(
+                validators ->
+                    genesis.createIbft2GenesisConfigFilterBootnode(validators, genesisFile))
+            .bootnodeEligible(false)
             .build());
   }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/AccountLocalConfigPermissioningImportAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/AccountLocalConfigPermissioningImportAcceptanceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.permissioning;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.Cluster;
+import org.hyperledger.besu.tests.acceptance.dsl.node.cluster.ClusterConfigurationBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class AccountLocalConfigPermissioningImportAcceptanceTest extends AcceptanceTestBase {
+
+  @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+  private static final String GENESIS_FILE = "/ibft/ibft.json";
+
+  private Account senderA;
+  private Account senderB;
+  private Account beneficiary;
+  private BesuNode bootnode;
+  private BesuNode nodeA;
+  private BesuNode nodeB;
+  private BesuNode nodeC;
+  private Cluster permissionedCluster;
+  private File file;
+
+  @Before
+  public void setUp() throws IOException {
+    senderA = accounts.getPrimaryBenefactor();
+    senderB = accounts.getSecondaryBenefactor();
+    beneficiary = accounts.createAccount("beneficiary");
+    final List<String> allowList =
+        List.of(senderA.getAddress(), senderB.getAddress(), beneficiary.getAddress());
+    file = folder.newFile();
+    bootnode = besu.createIbft2NonValidatorBootnode("bootnode", GENESIS_FILE);
+    nodeA =
+        besu.createIbft2NodeWithLocalAccountPermissioning("nodeA", GENESIS_FILE, allowList, file);
+    nodeB =
+        besu.createIbft2NodeWithLocalAccountPermissioning("nodeB", GENESIS_FILE, allowList, file);
+    permissionedCluster =
+        new Cluster(new ClusterConfigurationBuilder().awaitPeerDiscovery(false).build(), net);
+  }
+
+  @Test
+  public void transactionFromDeniedAccountShouldNotBreakBlockImport() throws IOException {
+    permissionedCluster.start(bootnode, nodeA, nodeB);
+
+    waitForBlockHeight(bootnode, 5);
+
+    nodeA.verify(beneficiary.balanceEquals(0));
+    nodeA.execute(accountTransactions.createTransfer(senderA, beneficiary, 1));
+    nodeA.verify(beneficiary.balanceEquals(1));
+    nodeC =
+        besu.createIbft2NodeWithLocalAccountPermissioning(
+            "nodeC", GENESIS_FILE, List.of(senderB.getAddress(), beneficiary.getAddress()), file);
+    permissionedCluster.startNode(nodeC);
+
+    waitForBlockHeight(bootnode, 10);
+    waitForBlockHeight(nodeC, 10);
+  }
+
+  @After
+  public void tearDown() {
+    permissionedCluster.stop();
+  }
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningAcceptanceTestBase.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningAcceptanceTestBase.java
@@ -14,11 +14,8 @@
  */
 package org.hyperledger.besu.tests.acceptance.permissioning;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
-import org.hyperledger.besu.tests.acceptance.dsl.WaitUtils;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.perm.NodeSmartContractPermissioningConditions;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
@@ -30,7 +27,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.perm.NodeSmartContractPermissioningTransactions;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 class NodeSmartContractPermissioningAcceptanceTestBase extends AcceptanceTestBase {
 
@@ -131,13 +127,5 @@ class NodeSmartContractPermissioningAcceptanceTestBase extends AcceptanceTestBas
   protected Condition connectionIsForbidden(final Node source, final Node target) {
     return nodeSmartContractPermissioningConditions.connectionIsForbidden(
         CONTRACT_ADDRESS, source, target);
-  }
-
-  protected void waitForBlockHeight(final Node node, final long blockchainHeight) {
-    WaitUtils.waitFor(
-        120,
-        () ->
-            assertThat(node.execute(ethTransactions.blockNumber()))
-                .isGreaterThanOrEqualTo(BigInteger.valueOf(blockchainHeight)));
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTestBase.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTestBase.java
@@ -14,11 +14,8 @@
  */
 package org.hyperledger.besu.tests.acceptance.permissioning;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
-import org.hyperledger.besu.tests.acceptance.dsl.WaitUtils;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.Condition;
 import org.hyperledger.besu.tests.acceptance.dsl.condition.perm.NodeSmartContractPermissioningV2Conditions;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
@@ -30,7 +27,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.perm.NodeSmartContractPermissioningV2Transactions;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 class NodeSmartContractPermissioningV2AcceptanceTestBase extends AcceptanceTestBase {
 
@@ -124,13 +120,5 @@ class NodeSmartContractPermissioningV2AcceptanceTestBase extends AcceptanceTestB
 
   protected Condition connectionIsAllowed(final Node node) {
     return nodeSmartContractPermissioningConditionsV2.connectionIsAllowed(CONTRACT_ADDRESS, node);
-  }
-
-  protected void waitForBlockHeight(final Node node, final long blockchainHeight) {
-    WaitUtils.waitFor(
-        120,
-        () ->
-            assertThat(node.execute(ethTransactions.blockNumber()))
-                .isGreaterThanOrEqualTo(BigInteger.valueOf(blockchainHeight)));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/TransactionFilter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/TransactionFilter.java
@@ -16,5 +16,6 @@ package org.hyperledger.besu.ethereum.core;
 
 @FunctionalInterface
 public interface TransactionFilter {
-  boolean permitted(Transaction transaction, boolean checkOnchainPermissions);
+  boolean permitted(
+      Transaction transaction, boolean checkLocalPermissions, boolean checkOnchainPermissions);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
@@ -206,7 +206,12 @@ public class MainnetTransactionValidator implements TransactionValidator {
       final Transaction transaction, final TransactionValidationParams validationParams) {
     if (validationParams.checkLocalPermissions() || validationParams.checkOnchainPermissions()) {
       return transactionFilter
-          .map(c -> c.permitted(transaction, validationParams.checkOnchainPermissions()))
+          .map(
+              c ->
+                  c.permitted(
+                      transaction,
+                      validationParams.checkLocalPermissions(),
+                      validationParams.checkOnchainPermissions()))
           .orElse(true);
     } else {
       return true;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidatorTest.java
@@ -202,9 +202,15 @@ public class MainnetTransactionValidatorTest {
 
   @Test
   public void shouldPropagateCorrectStateChangeParamToTransactionFilter() {
-    final ArgumentCaptor<Boolean> stateChangeParamCaptor = ArgumentCaptor.forClass(Boolean.class);
+    final ArgumentCaptor<Boolean> stateChangeLocalParamCaptor =
+        ArgumentCaptor.forClass(Boolean.class);
+    final ArgumentCaptor<Boolean> stateChangeOnchainParamCaptor =
+        ArgumentCaptor.forClass(Boolean.class);
     final TransactionFilter transactionFilter = mock(TransactionFilter.class);
-    when(transactionFilter.permitted(any(Transaction.class), stateChangeParamCaptor.capture()))
+    when(transactionFilter.permitted(
+            any(Transaction.class),
+            stateChangeLocalParamCaptor.capture(),
+            stateChangeOnchainParamCaptor.capture()))
         .thenReturn(true);
 
     final MainnetTransactionValidator validator =
@@ -216,7 +222,8 @@ public class MainnetTransactionValidatorTest {
 
     validator.validateForSender(basicTransaction, accountWithNonce(0), validationParams);
 
-    assertThat(stateChangeParamCaptor.getValue()).isTrue();
+    assertThat(stateChangeLocalParamCaptor.getValue()).isTrue();
+    assertThat(stateChangeOnchainParamCaptor.getValue()).isTrue();
   }
 
   @Test
@@ -334,7 +341,8 @@ public class MainnetTransactionValidatorTest {
 
   private TransactionFilter transactionFilter(final boolean permitted) {
     final TransactionFilter transactionFilter = mock(TransactionFilter.class);
-    when(transactionFilter.permitted(any(Transaction.class), anyBoolean())).thenReturn(permitted);
+    when(transactionFilter.permitted(any(Transaction.class), anyBoolean(), anyBoolean()))
+        .thenReturn(permitted);
     return transactionFilter;
   }
 }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningController.java
@@ -45,26 +45,33 @@ public class AccountPermissioningController {
         transactionSmartContractPermissioningController;
   }
 
-  public boolean isPermitted(final Transaction transaction, final boolean includeOnChainCheck) {
+  public boolean isPermitted(
+      final Transaction transaction,
+      final boolean includeLocalCheck,
+      final boolean includeOnChainCheck) {
     final Hash transactionHash = transaction.getHash();
     final Address sender = transaction.getSender();
-
-    LOG.trace("Account permissioning: Checking transaction {}", transactionHash);
-
     boolean permitted;
-    if (includeOnChainCheck) {
-      permitted =
-          accountLocalConfigPermissioningController
-                  .map(c -> c.isPermitted(transaction))
-                  .orElse(true)
-              && transactionSmartContractPermissioningController
-                  .map(c -> c.isPermitted(transaction))
-                  .orElse(true);
+
+    if (includeLocalCheck) {
+      LOG.trace("Account permissioning: Checking transaction {}", transactionHash);
+
+      if (includeOnChainCheck) {
+        permitted =
+            accountLocalConfigPermissioningController
+                    .map(c -> c.isPermitted(transaction))
+                    .orElse(true)
+                && transactionSmartContractPermissioningController
+                    .map(c -> c.isPermitted(transaction))
+                    .orElse(true);
+      } else {
+        permitted =
+            accountLocalConfigPermissioningController
+                .map(c -> c.isPermitted(transaction))
+                .orElse(true);
+      }
     } else {
-      permitted =
-          accountLocalConfigPermissioningController
-              .map(c -> c.isPermitted(transaction))
-              .orElse(true);
+      permitted = true;
     }
 
     if (permitted) {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerTest.java
@@ -52,7 +52,7 @@ public class AccountPermissioningControllerTest {
   public void shouldOnlyCheckLocalConfigControllerWhenNotPersistingState() {
     when(localConfigController.isPermitted(any())).thenReturn(true);
 
-    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), false);
+    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), true, false);
 
     assertThat(isPermitted).isTrue();
 
@@ -65,7 +65,7 @@ public class AccountPermissioningControllerTest {
     when(localConfigController.isPermitted(any())).thenReturn(true);
     when(smartContractController.isPermitted(any())).thenReturn(true);
 
-    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), true);
+    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), true, true);
 
     assertThat(isPermitted).isTrue();
 
@@ -78,7 +78,7 @@ public class AccountPermissioningControllerTest {
     when(localConfigController.isPermitted(any())).thenReturn(true);
     when(smartContractController.isPermitted(any())).thenReturn(false);
 
-    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), true);
+    boolean isPermitted = permissioningController.isPermitted(mock(Transaction.class), true, true);
 
     assertThat(isPermitted).isFalse();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Updates transaction validation to address the case where a node, with local permissioning enabled, tries to import a block containing a transaction from an account that's not in its allowlist and throws an InvalidBlockException.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #1476 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).