### PR TITLE
Add gas measurement to full import log line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Added support for the updated smart contract-based [node permissioning EEA interface](https://entethalliance.github.io/client-spec/spec.html#dfn-connectionallowed). [\#1435](https://github.com/hyperledger/besu/pull/1435) and [\#1496](https://github.com/hyperledger/besu/pull/1496)
 * Added EvmTool binary to the distribution.  EvmTool is a CLI that can execute EVM bytecode and execute ethereum state tests. [\#1465](https://github.com/hyperledger/besu/pull/1465)
 * Updated the libraries for secp256k1 and AltBN series precompiles. These updates provide significant performance improvements to those areas. [\#1499](https://github.com/hyperledger/besu/pull/1499)
+* Provide MegaGas/second measurements in the log when doing a full block import, such as the catch up phase of a fast sync. [\#1512](https://github.com/hyperledger/besu/pull/1512)
 
 ### Bug Fixes
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
@@ -29,8 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class FullImportBlockStep implements Consumer<Block> {
-  private static final Logger LOG = LogManager.getFormatterLogger();
-
+  private static final Logger LOG = LogManager.getLogger();
   private final ProtocolSchedule protocolSchedule;
   private final ProtocolContext protocolContext;
   private final EthContext ethContext;
@@ -67,19 +66,17 @@ public class FullImportBlockStep implements Consumer<Block> {
     }
     if (blockNumber % 200 == 0) {
       final long nowMilli = Instant.now().toEpochMilli();
-      if (lastReportMillis == 0 || gasAccumulator == 0) {
-        // this is a formatted logger statement
-        //noinspection PlaceholderCountMatchesArgumentCount
-        LOG.info("Import reached block %d (%s), Peers: %d", blockNumber, shortHash, peerCount);
-      } else {
-        final long deltaMilli = nowMilli - lastReportMillis;
-        final double mgps = gasAccumulator / 1000.0 / deltaMilli;
-        // this is a formatted logger statement
-        //noinspection PlaceholderCountMatchesArgumentCount
-        LOG.info(
-            "Import reached block %d (%s), %.3f Mg/s, Peers: %d",
-            blockNumber, shortHash, mgps, peerCount);
-      }
+      final long deltaMilli = nowMilli - lastReportMillis;
+      final String mgps =
+          (lastReportMillis == 0 || gasAccumulator == 0)
+              ? "-"
+              : String.format("%.3f", gasAccumulator / 1000.0 / deltaMilli);
+      LOG.info(
+          "Import reached block {} ({}), {} Mg/s, Peers: {}",
+          blockNumber,
+          shortHash,
+          mgps,
+          peerCount);
       lastReportMillis = nowMilli;
       gasAccumulator = 0;
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
@@ -76,7 +76,9 @@ public class FullImportBlockStep implements Consumer<Block> {
         final double mgps = gasAccumulator / 1000.0 / deltaMilli;
         // this is a formatted logger statement
         //noinspection PlaceholderCountMatchesArgumentCount
-        LOG.info("Import reached block %d (%s), %.3f Mg/s, Peers: %d", blockNumber, shortHash, mgps, peerCount);
+        LOG.info(
+            "Import reached block %d (%s), %.3f Mg/s, Peers: %d",
+            blockNumber, shortHash, mgps, peerCount);
       }
       lastReportMillis = nowMilli;
       gasAccumulator = 0;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
@@ -22,16 +22,20 @@ import org.hyperledger.besu.ethereum.eth.sync.tasks.exceptions.InvalidBlockExcep
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
+import java.time.Instant;
 import java.util.function.Consumer;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class FullImportBlockStep implements Consumer<Block> {
-  private static final Logger LOG = LogManager.getLogger();
+  private static final Logger LOG = LogManager.getFormatterLogger();
+
   private final ProtocolSchedule protocolSchedule;
   private final ProtocolContext protocolContext;
   private final EthContext ethContext;
+  private long gasAccumulator = 0;
+  private long lastReportMillis = 0;
 
   public FullImportBlockStep(
       final ProtocolSchedule protocolSchedule,
@@ -56,12 +60,26 @@ public class FullImportBlockStep implements Consumer<Block> {
     if (!importer.importBlock(protocolContext, block, HeaderValidationMode.SKIP_DETACHED)) {
       throw new InvalidBlockException("Failed to import block", blockNumber, block.getHash());
     }
+    gasAccumulator += block.getHeader().getGasUsed();
     int peerCount = -1; // ethContext is not available in tests
     if (ethContext != null && ethContext.getEthPeers().peerCount() >= 0) {
       peerCount = ethContext.getEthPeers().peerCount();
     }
     if (blockNumber % 200 == 0) {
-      LOG.info("Import reached block {} ({}), Peers: {}", blockNumber, shortHash, peerCount);
+      final long nowMilli = Instant.now().toEpochMilli();
+      if (lastReportMillis == 0 || gasAccumulator == 0) {
+        // this is a formatted logger statement
+        //noinspection PlaceholderCountMatchesArgumentCount
+        LOG.info("Import reached block %d (%s), Peers: %d", blockNumber, shortHash, peerCount);
+      } else {
+        final long deltaMilli = nowMilli - lastReportMillis;
+        final double mgps = gasAccumulator / 1000.0 / deltaMilli;
+        // this is a formatted logger statement
+        //noinspection PlaceholderCountMatchesArgumentCount
+        LOG.info("Import reached block %d (%s), %.3f Mg/s, Peers: %d", blockNumber, shortHash, mgps, peerCount);
+      }
+      lastReportMillis = nowMilli;
+      gasAccumulator = 0;
     }
   }
 }


### PR DESCRIPTION
To provide more context to admins and to add more meaning the full sync
log lines report the amount of gas processed in MegaGas/Second.  Some
blocks are fuller than others and this provides a gauge as to wether the
import is slowing down or if the blocks are filling up.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).