### PR TITLE
Adding support for isQuorum and qip714block options in genesis

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -129,6 +129,8 @@ public interface GenesisConfigOptions {
    * @see <a
    *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1054">https://ecips.ethereumclassic.org/ECIPs/ecip-1054</a>
    * @return block number for Atlantis fork on Classic network
+   * @see <a
+   *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1054">https://ecips.ethereumclassic.org/ECIPs/ecip-1054</a>
    */
   OptionalLong getAtlantisBlockNumber();
 
@@ -140,6 +142,8 @@ public interface GenesisConfigOptions {
    * @see <a
    *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1056">https://ecips.ethereumclassic.org/ECIPs/ecip-1056</a>
    * @return block number for Agharta fork on Classic network
+   * @see <a
+   *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1056">https://ecips.ethereumclassic.org/ECIPs/ecip-1056</a>
    */
   OptionalLong getAghartaBlockNumber();
 
@@ -148,9 +152,9 @@ public interface GenesisConfigOptions {
    * Istanbul network protocol upgrades on the Ethereum Classic network in a hard-fork code-named
    * Phoenix to enable maximum compatibility across these networks.
    *
+   * @return block number of Phoenix fork on Classic networks
    * @see <a
    *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1088">https://ecips.ethereumclassic.org/ECIPs/ecip-1088</a>
-   * @return block number of Phoenix fork on Classic networks
    */
   OptionalLong getPhoenixBlockNumber();
 
@@ -158,9 +162,9 @@ public interface GenesisConfigOptions {
    * Block number to activate ECIP-1099 (Thanos) on Classic networks. Doubles the length of the
    * Ethash epoch, with the impact being a reduced DAG size.
    *
+   * @return block number of ECIP-1099 fork on Classic networks
    * @see <a
    *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1099">https://ecips.ethereumclassic.org/ECIPs/ecip-1099</a>
-   * @return block number of ECIP-1099 fork on Classic networks
    */
   OptionalLong getThanosBlockNumber();
 
@@ -176,13 +180,28 @@ public interface GenesisConfigOptions {
    * other networks, for example Mordor testnet uses 2,000,000). The values defaults to 5,000,000 if
    * not set.
    *
+   * @return number of rounds pre Era
    * @see <a
    *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1017">https://ecips.ethereumclassic.org/ECIPs/ecip-1017</a>
-   * @return number of rounds pre Era
    */
   OptionalLong getEcip1017EraRounds();
 
   Map<String, Object> asMap();
 
   TransitionsConfigOptions getTransitions();
+
+  /**
+   * Set Besu in Quorum-compatibility mode
+   *
+   * @return true, if Besu is running on Quorum-compatibility mode, false, otherwise.
+   */
+  boolean isQuorum();
+
+  /**
+   * Block number to activate Quorum Permissioning. This options is used on Quorum-compatibility
+   * mode.
+   *
+   * @return block number to activate Quorum Permissioning
+   */
+  OptionalLong getQip714BlockNumber();
 }

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -301,6 +301,16 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
+  public boolean isQuorum() {
+    return getOptionalBoolean("isQuorum").orElse(false);
+  }
+
+  @Override
+  public OptionalLong getQip714BlockNumber() {
+    return getOptionalLong("qip714block");
+  }
+
+  @Override
   public Map<String, Object> asMap() {
     final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
     getChainId().ifPresent(chainId -> builder.put("chainId", chainId));
@@ -348,6 +358,12 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     if (isIbft2()) {
       builder.put("ibft2", getIbft2ConfigOptions().asMap());
     }
+
+    if (isQuorum()) {
+      builder.put("isQuorum", true);
+      getQip714BlockNumber().ifPresent(blockNumber -> builder.put("qip714block", blockNumber));
+    }
+
     return builder.build();
   }
 
@@ -390,6 +406,17 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
           : Optional.of(new BigInteger(value));
     } else {
       return JsonUtil.getValueAsString(configRoot, key).map(s -> new BigInteger(s, 10));
+    }
+  }
+
+  private Optional<Boolean> getOptionalBoolean(final String key) {
+    if (configOverrides.containsKey(key)) {
+      final String value = configOverrides.get(key);
+      return value == null || value.isEmpty()
+          ? Optional.empty()
+          : Optional.of(Boolean.valueOf(configOverrides.get(key)));
+    } else {
+      return JsonUtil.getBoolean(configRoot, key);
     }
   }
 }

--- a/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
@@ -266,6 +266,16 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
     return TransitionsConfigOptions.DEFAULT;
   }
 
+  @Override
+  public boolean isQuorum() {
+    return false;
+  }
+
+  @Override
+  public OptionalLong getQip714BlockNumber() {
+    return OptionalLong.empty();
+  }
+
   public StubGenesisConfigOptions homesteadBlock(final long blockNumber) {
     homesteadBlockNumber = OptionalLong.of(blockNumber);
     return this;

--- a/config/src/test/resources/valid_config_with_quorum_config.json
+++ b/config/src/test/resources/valid_config_with_quorum_config.json
@@ -1,0 +1,35 @@
+{
+  "chainId": 4,
+  "eip150Block": 2,
+  "homesteadBlock": 1,
+  "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "eip155Block": 3,
+  "eip158Block": 3,
+  "byzantiumBlock": 1035301,
+  "isQuorum": true,
+  "qip714block": 99999,
+  "ibft2": {
+    "blockperiodseconds": 2,
+    "epochlength": 30000,
+    "requesttimeoutseconds": 10,
+    "blockreward": "0x15",
+    "miningbeneficiary": "0x1234567890123456789012345678901234567890"
+  },
+  "transitions": {
+    "ibft2": [
+      {
+        "block": 20,
+        "validators": [
+          "0x1234567890123456789012345678901234567890",
+          "0x9876543210987654321098765432109876543210"
+        ]
+      },
+      {
+        "block": 25,
+        "validators": [
+          "0x1234567890123456789012345678901234567890"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## PR description

- Added support for Quorum config options in genesis in preparation for Quorum-compatibility mode.

## Changelog

(I'll update the changelog once we finish the Quorum-compatibility mode)
- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).