### PR TITLE
Reduce Exception Hiding in Trie RLP Processing

### DIFF
--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/StoredNodeFactory.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/StoredNodeFactory.java
@@ -118,36 +118,40 @@ class StoredNodeFactory<V> implements NodeFactory<V> {
 
   private Node<V> decode(final RLPInput nodeRLPs, final Supplier<String> errMessage) {
     final int nodesCount = nodeRLPs.enterList();
-    try {
-      switch (nodesCount) {
-        case 1:
-          return decodeNull(nodeRLPs, errMessage);
+    switch (nodesCount) {
+      case 1:
+        final NullNode<V> nullNode = decodeNull(nodeRLPs, errMessage);
+        nodeRLPs.leaveList();
+        return nullNode;
 
-        case 2:
-          final Bytes encodedPath = nodeRLPs.readBytes();
-          final Bytes path;
-          try {
-            path = CompactEncoding.decode(encodedPath);
-          } catch (final IllegalArgumentException ex) {
-            throw new MerkleTrieException(errMessage.get() + ": invalid path " + encodedPath, ex);
-          }
+      case 2:
+        final Bytes encodedPath = nodeRLPs.readBytes();
+        final Bytes path;
+        try {
+          path = CompactEncoding.decode(encodedPath);
+        } catch (final IllegalArgumentException ex) {
+          throw new MerkleTrieException(errMessage.get() + ": invalid path " + encodedPath, ex);
+        }
 
-          final int size = path.size();
-          if (size > 0 && path.get(size - 1) == CompactEncoding.LEAF_TERMINATOR) {
-            return decodeLeaf(path, nodeRLPs, errMessage);
-          } else {
-            return decodeExtension(path, nodeRLPs, errMessage);
-          }
+        final int size = path.size();
+        if (size > 0 && path.get(size - 1) == CompactEncoding.LEAF_TERMINATOR) {
+          final LeafNode<V> leafNode = decodeLeaf(path, nodeRLPs, errMessage);
+          nodeRLPs.leaveList();
+          return leafNode;
+        } else {
+          final Node<V> extensionNode = decodeExtension(path, nodeRLPs, errMessage);
+          nodeRLPs.leaveList();
+          return extensionNode;
+        }
 
-        case (BranchNode.RADIX + 1):
-          return decodeBranch(nodeRLPs, errMessage);
+      case (BranchNode.RADIX + 1):
+        final BranchNode<V> branchNode = decodeBranch(nodeRLPs, errMessage);
+        nodeRLPs.leaveList();
+        return branchNode;
 
-        default:
-          throw new MerkleTrieException(
-              errMessage.get() + format(": invalid list size %s", nodesCount));
-      }
-    } finally {
-      nodeRLPs.leaveList();
+      default:
+        throw new MerkleTrieException(
+            errMessage.get() + format(": invalid list size %s", nodesCount));
     }
   }
 


### PR DESCRIPTION
The current formulation of the decode can hide exceptions if the finally
block does not complete.  Since exceptions are thrown mid-rlp processing
this typically results in the list not being fully consumed and the real
exception is hidden by a "not at end of list" exception.

This more verbose form prevents such exceptions from being overruled by
rlp processing errors.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).