### PR TITLE
IBFT Block Production Logging Improvements

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -162,6 +162,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
 
     final Subscribers<MinedBlockObserver> minedBlockObservers = Subscribers.create();
     minedBlockObservers.subscribe(ethProtocolManager);
+    minedBlockObservers.subscribe(blockLogger(transactionPool, localAddress));
 
     final FutureMessageBuffer futureMessageBuffer =
         new FutureMessageBuffer(
@@ -265,5 +266,22 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
     }
 
     return result;
+  }
+
+  private static MinedBlockObserver blockLogger(
+      final TransactionPool transactionPool, final Address localAddress) {
+    return block ->
+        LOG.info(
+            String.format(
+                "%s #%,d / %d tx / %d pending / %,d (%01.1f%%) gas / (%s)",
+                block.getHeader().getCoinbase().equals(localAddress)
+                    ? "Produced"
+                    : "Imported",
+                block.getHeader().getNumber(),
+                block.getBody().getTransactions().size(),
+                transactionPool.getPendingTransactions().size(),
+                block.getHeader().getGasUsed(),
+                (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
+                block.getHash().toHexString()));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -274,9 +274,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
         LOG.info(
             String.format(
                 "%s #%,d / %d tx / %d pending / %,d (%01.1f%%) gas / (%s)",
-                block.getHeader().getCoinbase().equals(localAddress)
-                    ? "Produced"
-                    : "Imported",
+                block.getHeader().getCoinbase().equals(localAddress) ? "Produced" : "Imported",
                 block.getHeader().getNumber(),
                 block.getBody().getTransactions().size(),
                 transactionPool.getPendingTransactions().size(),

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.util.Subscribers;
 
 import java.util.Optional;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -238,7 +239,8 @@ public class IbftRound {
 
     final long blockNumber = blockToImport.getHeader().getNumber();
     final IbftExtraData extraData = IbftExtraData.decode(blockToImport.getHeader());
-    LOG.info(
+    LOG.log(
+        getRoundIdentifier().getRoundNumber() > 0 ? Level.INFO : Level.DEBUG,
         "Importing block to chain. round={}, hash={}",
         getRoundIdentifier(),
         blockToImport.getHash());

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockMiner.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockMiner.java
@@ -134,7 +134,7 @@ public class BlockMiner<M extends AbstractBlockCreator> implements Runnable {
       final double taskTimeInSec = stopwatch.elapsed(TimeUnit.MILLISECONDS) / 1000.0;
       LOG.info(
           String.format(
-              "Produced and imported block #%,d / %d tx / %d om / %,d (%01.1f%%) gas / (%s) in %01.3fs",
+              "Produced #%,d / %d tx / %d om / %,d (%01.1f%%) gas / (%s) in %01.3fs",
               block.getHeader().getNumber(),
               block.getBody().getTransactions().size(),
               block.getBody().getOmmers().size(),


### PR DESCRIPTION
For every block produced and imported directly log the same information
we would get from other import paths.
* If this node produced the block, note that with "Produced" instead of
  "Imported"
* Log the size of the pending transaction pool
* Only log IBFT rounds at INFO if they go past round 0, DEBUG otherwise.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>


- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).