### PR TITLE
eth_gasPrice based on median block cost (#1546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction. [\#1478](https://github.com/hyperledger/besu/pull/1478)
 * Fixed a bug where Local Account Permissioning was being incorrectly enforced on block import/validation. [\#1510](https://github.com/hyperledger/besu/pull/1510)
 * Removed duplicate files from zip and tar.gz distributions. [\#1566](https://github.com/hyperledger/besu/pull/1566)
-* Add a more rational value to eth_gasPrice, based on median of last 100 blocks.  [\#1563](https://github.com/hyperledger/besu/pull/1563)
+* Add a more rational value to eth_gasPrice, based on a configurable percentile of prior block's transactions (default: median of last 100 blocks).  [\#1563](https://github.com/hyperledger/besu/pull/1563)
 
 ## Deprecated 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction. [\#1478](https://github.com/hyperledger/besu/pull/1478)
 * Fixed a bug where Local Account Permissioning was being incorrectly enforced on block import/validation. [\#1510](https://github.com/hyperledger/besu/pull/1510)
+* Add a more rational value to eth_gasPrice, based on median of last 100 blocks.  [\#1563](https://github.com/hyperledger/besu/pull/1563)
 
 ## Deprecated 
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.ApiConfiguration;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetcherContextImpl;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetchers;
@@ -155,6 +156,7 @@ public class RunnerBuilder {
   private JsonRpcConfiguration jsonRpcConfiguration;
   private GraphQLConfiguration graphQLConfiguration;
   private WebSocketConfiguration webSocketConfiguration;
+  private ApiConfiguration apiConfiguration;
   private Path dataDir;
   private Optional<Path> pidPath = Optional.empty();
   private MetricsConfiguration metricsConfiguration;
@@ -272,6 +274,11 @@ public class RunnerBuilder {
 
   public RunnerBuilder webSocketConfiguration(final WebSocketConfiguration webSocketConfiguration) {
     this.webSocketConfiguration = webSocketConfiguration;
+    return this;
+  }
+
+  public RunnerBuilder apiConfiguration(final ApiConfiguration apiConfiguration) {
+    this.apiConfiguration = apiConfiguration;
     return this;
   }
 
@@ -435,7 +442,8 @@ public class RunnerBuilder {
             context.getBlockchain(),
             context.getWorldStateArchive(),
             Optional.of(dataDir.resolve(CACHE_PATH)),
-            Optional.of(besuController.getProtocolManager().ethContext().getScheduler()));
+            Optional.of(besuController.getProtocolManager().ethContext().getScheduler()),
+            apiConfiguration);
 
     final PrivacyParameters privacyParameters = besuController.getPrivacyParameters();
 
@@ -795,7 +803,8 @@ public class RunnerBuilder {
     Optional<PrivacyQueries> privacyQueries = Optional.empty();
     if (privacyParameters.isEnabled()) {
       final BlockchainQueries blockchainQueries =
-          new BlockchainQueries(blockchain, worldStateArchive);
+          new BlockchainQueries(
+              blockchain, worldStateArchive, Optional.empty(), Optional.empty(), apiConfiguration);
       privacyQueries =
           Optional.of(
               new PrivacyQueries(

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -223,6 +223,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.jsonRpcConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.graphQLConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.webSocketConfiguration(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.apiConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.dataDir(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.bannedNodeIds(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.metricsSystem(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -90,6 +90,11 @@ rpc-ws-authentication-enabled=false
 rpc-ws-authentication-credentials-file="none"
 rpc-ws-authentication-jwt-public-key-file="none"
 
+# API
+api-gas-price-blocks=100
+api-gas-price-percentile=50.0
+api-gas-price-max=500000000000
+
 # Prometheus Metrics Endpoint
 metrics-enabled=false
 metrics-protocol="prometheus"

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -39,7 +39,7 @@ public abstract class ApiConfiguration {
 
   @Value.Default
   public long getGasPriceMax() {
-    return 1_000_000_000_000_000_000L; // 1 Eth
+    return 500_000_000_000L; // 500 GWei
   }
 
   @Value.Derived

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.api;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(allParameters = true)
+public abstract class ApiConfiguration {
+
+  @Value.Default
+  public long getGasPriceBlocks() {
+    return 100;
+  }
+
+  @Value.Default
+  public double getGasPricePercentile() {
+    return 50.0d;
+  }
+
+  @Value.Default
+  public long getGasPriceMin() {
+    return 1_000_000_000L; // 1 GWei
+  }
+
+  @Value.Default
+  public long getGasPriceMax() {
+    return 1_000_000_000_000_000_000L; // 1 Eth
+  }
+
+  @Value.Derived
+  public double getGasPriceFraction() {
+    return getGasPricePercentile() / 100.0;
+  };
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
-import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -115,10 +114,13 @@ public class GraphQLDataFetchers {
 
   DataFetcher<Optional<Wei>> getGasPriceDataFetcher() {
     return dataFetchingEnvironment -> {
-      final MiningCoordinator miningCoordinator =
-          ((GraphQLDataFetcherContext) dataFetchingEnvironment.getContext()).getMiningCoordinator();
-
-      return Optional.of(miningCoordinator.getMinTransactionGasPrice());
+      final GraphQLDataFetcherContext context =
+          (GraphQLDataFetcherContext) dataFetchingEnvironment.getContext();
+      return (context)
+          .getBlockchainQueries()
+          .gasPrice()
+          .map(Wei::of)
+          .or(() -> Optional.of(context.getMiningCoordinator().getMinTransactionGasPrice()));
     };
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPrice.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPrice.java
@@ -19,14 +19,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
-import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.function.Supplier;
-import java.util.stream.LongStream;
 
 public class EthGasPrice implements JsonRpcMethod {
 
@@ -51,27 +47,12 @@ public class EthGasPrice implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
-    final BlockchainQueries blockchainQueries = blockchain.get();
-    final long blockHeight = blockchainQueries.headBlockNumber();
-    final long[] gasCollection =
-        LongStream.range(Math.max(0, blockHeight - 100), blockHeight)
-            .mapToObj(
-                l ->
-                    blockchainQueries
-                        .blockByNumber(l)
-                        .map(BlockWithMetadata::getTransactions)
-                        .orElse(Collections.emptyList()))
-            .flatMap(Collection::stream)
-            .mapToLong(t -> t.getTransaction().getGasPrice().toLong())
-            .sorted()
-            .toArray();
-    final String result;
-    if (gasCollection == null || gasCollection.length == 0) {
-      result = Quantity.create(miningCoordinator.getMinTransactionGasPrice());
-    } else {
-      result = Quantity.create(gasCollection[gasCollection.length / 2]);
-    }
-
-    return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
+    return new JsonRpcSuccessResponse(
+        requestContext.getRequest().getId(),
+        blockchain
+            .get()
+            .gasPrice()
+            .map(Quantity::create)
+            .orElseGet(() -> Quantity.create(miningCoordinator.getMinTransactionGasPrice())));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -153,7 +153,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new EthMining(miningCoordinator),
         new EthCoinbase(miningCoordinator),
         new EthProtocolVersion(supportedCapabilities),
-        new EthGasPrice(miningCoordinator),
+        new EthGasPrice(blockchainQueries, miningCoordinator),
         new EthGetWork(miningCoordinator),
         new EthSubmitWork(miningCoordinator),
         new EthHashrate(miningCoordinator),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -743,7 +743,8 @@ public class BlockchainQueries {
                         .getBlockByNumber(l)
                         .map(Block::getBody)
                         .map(BlockBody::getTransactions)
-                        .orElse(Collections.emptyList()))
+                        .orElseThrow(
+                            () -> new IllegalStateException("Could not retrieve block #" + l)))
             .flatMap(Collection::stream)
             .mapToLong(t -> t.getGasPrice().toLong())
             .sorted()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.graphql;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.ImmutableApiConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.EthHashMiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
@@ -153,7 +154,12 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
         InMemoryStorageProvider.createInMemoryBlockchain(GENESIS_BLOCK);
     context = new ProtocolContext(blockchain, stateArchive, null);
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(context.getBlockchain(), context.getWorldStateArchive());
+        new BlockchainQueries(
+            context.getBlockchain(),
+            context.getWorldStateArchive(),
+            Optional.empty(),
+            Optional.empty(),
+            ImmutableApiConfiguration.builder().gasPriceMin(0).build());
 
     final Set<Capability> supportedCapabilities = new HashSet<>();
     supportedCapabilities.add(EthProtocol.ETH62);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.api.ImmutableApiConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -59,7 +60,15 @@ public class EthGasPriceTest {
 
   @Before
   public void setUp() {
-    method = new EthGasPrice(new BlockchainQueries(blockchain, null, null), miningCoordinator);
+    method =
+        new EthGasPrice(
+            new BlockchainQueries(
+                blockchain,
+                null,
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableApiConfiguration.builder().gasPriceMin(100).build()),
+            miningCoordinator);
   }
 
   @Test

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/graphql/eth_gasPrice.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/graphql/eth_gasPrice.json
@@ -4,7 +4,7 @@
 
   "response": {
     "data" : {
-      "gasPrice" : "0x10"
+      "gasPrice" : "0x1"
     }
   },
   "statusCode": 200


### PR DESCRIPTION
Update eth_gasPrice to return the median gas price of transactions in
the last 100 blocks (or whole chain if the chain is short).  If there
are no TXes return the old value.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

