### PR TITLE
Remove duplicate files in zip distribution (#1565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction. [\#1478](https://github.com/hyperledger/besu/pull/1478)
 * Fixed a bug where Local Account Permissioning was being incorrectly enforced on block import/validation. [\#1510](https://github.com/hyperledger/besu/pull/1510)
+* Removed duplicate files from zip and tar.gz distributions. [\#1566](https://github.com/hyperledger/besu/pull/1566)
 
 ## Deprecated 
 

--- a/build.gradle
+++ b/build.gradle
@@ -545,12 +545,6 @@ task evmToolStartScripts(type: CreateStartScripts) {
   }
 }
 
-// Include the additional start scripts in the distribution
-applicationDistribution.into("bin") {
-  from(tasks.withType(CreateStartScripts))
-  fileMode = 0755
-}
-
 installDist { dependsOn checkLicenses }
 
 distTar {


### PR DESCRIPTION
The addition of the EvmTool resulted in duplication of some files in the
zip and tar.gz distributions.  Remove the build configurations that
caused that duplication.

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).