### PR TITLE
Fix invalid enode url when discovery is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * Fix a bug on `eth_estimateGas` which returned `Internal error` instead of `Execution reverted` in case of reverted transaction. [\#1478](https://github.com/hyperledger/besu/pull/1478)
 * Fixed a bug where Local Account Permissioning was being incorrectly enforced on block import/validation. [\#1510](https://github.com/hyperledger/besu/pull/1510)
+* Fixed invalid enode URL when discovery is disabled  [\#1521](https://github.com/hyperledger/besu/pull/1521)
 
 ## Deprecated 
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -330,7 +330,11 @@ public class RunnerBuilder {
 
     Preconditions.checkNotNull(besuController);
 
-    final DiscoveryConfiguration discoveryConfiguration;
+    final DiscoveryConfiguration discoveryConfiguration =
+        DiscoveryConfiguration.create()
+            .setBindHost(p2pListenInterface)
+            .setBindPort(p2pListenPort)
+            .setAdvertisedHost(p2pAdvertisedHost);
     if (discovery) {
       final List<EnodeURL> bootstrap;
       if (ethNetworkConfig.getBootNodes() == null) {
@@ -338,14 +342,9 @@ public class RunnerBuilder {
       } else {
         bootstrap = ethNetworkConfig.getBootNodes();
       }
-      discoveryConfiguration =
-          DiscoveryConfiguration.create()
-              .setBindHost(p2pListenInterface)
-              .setBindPort(p2pListenPort)
-              .setAdvertisedHost(p2pAdvertisedHost)
-              .setBootnodes(bootstrap);
+      discoveryConfiguration.setBootnodes(bootstrap);
     } else {
-      discoveryConfiguration = DiscoveryConfiguration.create().setActive(false);
+      discoveryConfiguration.setActive(false);
     }
 
     final NodeKey nodeKey = besuController.getNodeKey();

--- a/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.cli.config.EthNetworkConfig;
+import org.hyperledger.besu.consensus.ibft.IbftEventQueue;
+import org.hyperledger.besu.consensus.ibft.network.PeerConnectionTracker;
+import org.hyperledger.besu.consensus.ibft.protocol.IbftProtocolManager;
+import org.hyperledger.besu.consensus.ibft.protocol.IbftSubProtocol;
+import org.hyperledger.besu.controller.BesuController;
+import org.hyperledger.besu.crypto.NodeKey;
+import org.hyperledger.besu.crypto.SECP256K1;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
+import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
+import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
+import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.p2p.config.SubProtocolConfiguration;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+
+import java.util.Collections;
+
+import io.vertx.core.Vertx;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class RunnerBuilderTest {
+
+  @Rule public TemporaryFolder dataDir = new TemporaryFolder();
+
+  @Mock BesuController besuController;
+  @Mock Vertx vertx;
+
+  @Before
+  public void setup() {
+    final SubProtocolConfiguration subProtocolConfiguration = mock(SubProtocolConfiguration.class);
+    final EthProtocolManager ethProtocolManager = mock(EthProtocolManager.class);
+    final EthContext ethContext = mock(EthContext.class);
+    final ProtocolContext protocolContext = mock(ProtocolContext.class);
+    final NodeKey nodeKey = mock(NodeKey.class);
+    final SECP256K1.PublicKey publicKey = mock(SECP256K1.PublicKey.class);
+
+    when(subProtocolConfiguration.getProtocolManagers())
+        .thenReturn(
+            Collections.singletonList(
+                new IbftProtocolManager(
+                    mock(IbftEventQueue.class), mock(PeerConnectionTracker.class))));
+    when(ethContext.getScheduler()).thenReturn(mock(EthScheduler.class));
+    when(ethProtocolManager.ethContext()).thenReturn(ethContext);
+    when(subProtocolConfiguration.getSubProtocols())
+        .thenReturn(Collections.singletonList(new IbftSubProtocol()));
+    when(protocolContext.getBlockchain()).thenReturn(mock(MutableBlockchain.class));
+    when(publicKey.getEncodedBytes()).thenReturn(Bytes.of(new byte[64]));
+    when(nodeKey.getPublicKey()).thenReturn(publicKey);
+
+    when(besuController.getProtocolManager()).thenReturn(ethProtocolManager);
+    when(besuController.getSubProtocolConfiguration()).thenReturn(subProtocolConfiguration);
+    when(besuController.getProtocolContext()).thenReturn(protocolContext);
+    when(besuController.getNodeKey()).thenReturn(nodeKey);
+    when(besuController.getMiningParameters()).thenReturn(mock(MiningParameters.class));
+    when(besuController.getPrivacyParameters()).thenReturn(mock(PrivacyParameters.class));
+    when(besuController.getTransactionPool()).thenReturn(mock(TransactionPool.class));
+    when(besuController.getSynchronizer()).thenReturn(mock(Synchronizer.class));
+    when(besuController.getMiningCoordinator()).thenReturn(mock(MiningCoordinator.class));
+  }
+
+  @Test
+  public void enodeUrlShouldHaveAdvertisedHostWhenDiscoveryDisabled() {
+    final String p2pAdvertisedHost = "172.0.0.1";
+    final int p2pListenPort = 30301;
+
+    final Runner runner =
+        new RunnerBuilder()
+            .discovery(true)
+            .p2pListenInterface("0.0.0.0")
+            .p2pListenPort(p2pListenPort)
+            .p2pAdvertisedHost(p2pAdvertisedHost)
+            .p2pEnabled(true)
+            .discovery(false)
+            .besuController(besuController)
+            .ethNetworkConfig(mock(EthNetworkConfig.class))
+            .metricsSystem(mock(ObservableMetricsSystem.class))
+            .jsonRpcConfiguration(mock(JsonRpcConfiguration.class))
+            .graphQLConfiguration(mock(GraphQLConfiguration.class))
+            .webSocketConfiguration(mock(WebSocketConfiguration.class))
+            .metricsConfiguration(mock(MetricsConfiguration.class))
+            .vertx(vertx)
+            .dataDir(dataDir.getRoot().toPath())
+            .build();
+    runner.start();
+
+    final EnodeURL expectedEodeURL =
+        EnodeURL.builder()
+            .ipAddress(p2pAdvertisedHost)
+            .discoveryPort(0)
+            .listeningPort(p2pListenPort)
+            .nodeId(new byte[64])
+            .build();
+    assertThat(runner.getLocalEnode().orElseThrow()).isEqualTo(expectedEodeURL);
+  }
+}


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

## PR description

Fix invalid enode url when discovery is disabled.

- With discovery-enabled=true:

> main | INFO  | DefaultP2PNetwork | Enode URL enode://7315cd61201b679015287ef51f358cb5cbb69b0877392d247d07ced11ef9214168ad026ca862c600bda01e8f97c3b7ecdaf75a7928066a786df2e4e95e7478e7@172.0.0.1:30304


- With discovery-enabled=false:

> main | INFO  | DefaultP2PNetwork | Enode URL enode://7315cd61201b679015287ef51f358cb5cbb69b0877392d247d07ced11ef9214168ad026ca862c600bda01e8f97c3b7ecdaf75a7928066a786df2e4e95e7478e7@172.0.0.1:30304?discport=0



## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).