### PR TITLE
Adding goquorum-compatibility-enabled config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Additions and Improvements
 * Added support for batched requests in WebSockets. [#1583](https://github.com/hyperledger/besu/pull/1583)
-* Added protocols section to `admin_peers` to provide info about peer health. [\#1582](https://github.com/hyperledger/besu/pull/1582)
+* Added a protocols section to `admin_peers` to provide info about peer health. [\#1582](https://github.com/hyperledger/besu/pull/1582)
+* Added CLI option `--goquorum-compatibility-enabled` to enable GoQuorum compatibility mode. [#1598](https://github.com/hyperledger/besu/pull/1598)
 
 ### Bug Fixes
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -3836,9 +3836,17 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void quorumInteropDisabledDoesNotEnforceZeroGasPrice() throws IOException {
+    final Path genesisFile = createFakeGenesisFile(GENESIS_QUORUM_INTEROP_ENABLED);
+    parseCommand(
+        "--goquorum-compatibility-enabled=false", "--genesis-file", genesisFile.toString());
+    assertThat(commandErrorOutput.toString()).isEmpty();
+  }
+
+  @Test
   public void quorumInteropEnabledFailsWithoutGasPriceSet() throws IOException {
     final Path genesisFile = createFakeGenesisFile(GENESIS_QUORUM_INTEROP_ENABLED);
-    parseCommand("--genesis-file", genesisFile.toString());
+    parseCommand("--goquorum-compatibility-enabled", "--genesis-file", genesisFile.toString());
     assertThat(commandErrorOutput.toString())
         .contains(
             "--min-gas-price must be set to zero if GoQuorum compatibility is enabled in the genesis config.");
@@ -3847,7 +3855,12 @@ public class BesuCommandTest extends CommandTestAbstract {
   @Test
   public void quorumInteropEnabledFailsWithoutGasPriceSetToZero() throws IOException {
     final Path genesisFile = createFakeGenesisFile(GENESIS_QUORUM_INTEROP_ENABLED);
-    parseCommand("--genesis-file", genesisFile.toString(), "--min-gas-price", "1");
+    parseCommand(
+        "--goquorum-compatibility-enabled",
+        "--genesis-file",
+        genesisFile.toString(),
+        "--min-gas-price",
+        "1");
     assertThat(commandErrorOutput.toString())
         .contains(
             "--min-gas-price must be set to zero if GoQuorum compatibility is enabled in the genesis config.");
@@ -3856,7 +3869,12 @@ public class BesuCommandTest extends CommandTestAbstract {
   @Test
   public void quorumInteropEnabledSucceedsWithGasPriceSetToZero() throws IOException {
     final Path genesisFile = createFakeGenesisFile(GENESIS_QUORUM_INTEROP_ENABLED);
-    parseCommand("--genesis-file", genesisFile.toString(), "--min-gas-price", "0");
+    parseCommand(
+        "--goquorum-compatibility-enabled",
+        "--genesis-file",
+        genesisFile.toString(),
+        "--min-gas-price",
+        "0");
     assertThat(commandErrorOutput.toString()).isEmpty();
   }
 }


### PR DESCRIPTION
## PR description
- Add CLI option `--goquorum-compatibility-enabled` to enable GoQuorum compatibility mode.

## Changelog
- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).