### PR TITLE
[ci] bash comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,8 +221,8 @@ jobs:
           name: Publish Docker
           command: |
             docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
-            // temporarily commented out because AWS credentials are broken
-            // docker login "${ACR_REPO}" --username "${ACR_USER_RW}" --password "${ACR_PASSWORD_RW}"
+            # temporarily commented out because AWS credentials are broken
+            # docker login "${ACR_REPO}" --username "${ACR_USER_RW}" --password "${ACR_PASSWORD_RW}"
             ./gradlew --no-daemon "-Pbranch=${CIRCLE_BRANCH}" dockerUpload
 
 workflows:


### PR DESCRIPTION
switch to bash comments for commented out commands.
(It's inside a scalar, so it should still go to bash)

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).