### PR TITLE
Refactored OrionTestHarness to use in memory storage.

### DIFF
--- a/testutil/src/main/java/org/hyperledger/orion/testutil/OrionConfiguration.java
+++ b/testutil/src/main/java/org/hyperledger/orion/testutil/OrionConfiguration.java
@@ -25,19 +25,22 @@ public class OrionConfiguration {
   private final Path tempDir;
   private final List<String> otherNodes = new ArrayList<>();
   private final boolean clearKnownNodes;
+  private final String storage;
 
   public OrionConfiguration(
       final Path[] publicKeys,
       final Path[] privateKeys,
       final Path tempDir,
       final List<String> otherNodes,
-      final boolean clearKnownNodes) {
+      final boolean clearKnownNodes,
+      final String storage) {
 
     this.publicKeys = publicKeys;
     this.privateKeys = privateKeys;
     this.tempDir = tempDir;
     this.otherNodes.addAll(otherNodes);
     this.clearKnownNodes = clearKnownNodes;
+    this.storage = storage;
   }
 
   public Path[] getPublicKeys() {
@@ -62,5 +65,9 @@ public class OrionConfiguration {
 
   public boolean isClearKnownNodes() {
     return clearKnownNodes;
+  }
+
+  public String getStorage() {
+    return storage;
   }
 }

--- a/testutil/src/main/java/org/hyperledger/orion/testutil/OrionTestHarness.java
+++ b/testutil/src/main/java/org/hyperledger/orion/testutil/OrionTestHarness.java
@@ -134,7 +134,9 @@ public class OrionTestHarness {
             + "clientnetworkinterface = \""
             + HOST
             + "\"\n"
-            + "storage = \"leveldb:database/orion_node\"\n"
+            + "storage = \""
+            + orionConfiguration.getStorage()
+            + "\"\n"
             + "publickeys = ["
             + joinPathsAsTomlListEntry(orionConfiguration.getPublicKeys())
             + "]\n"

--- a/testutil/src/main/java/org/hyperledger/orion/testutil/OrionTestHarnessFactory.java
+++ b/testutil/src/main/java/org/hyperledger/orion/testutil/OrionTestHarnessFactory.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class OrionTestHarnessFactory {
+  private static final String storage = "memory";
 
   public static OrionTestHarness create(
       final Path tempDir, final OrionKeyConfiguration orionConfig) {
@@ -69,8 +70,7 @@ public class OrionTestHarnessFactory {
       final Path[] key1pubs,
       final Path[] key1keys,
       final List<String> othernodes) {
-
     return new OrionTestHarness(
-        new OrionConfiguration(key1pubs, key1keys, tempDir, othernodes, false));
+        new OrionConfiguration(key1pubs, key1keys, tempDir, othernodes, false, storage));
   }
 }


### PR DESCRIPTION
Signed-off-by: Mark Terry <mark.terry@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Changed the default OrionTestHarness datastore from `leveldb` to `memory` to improve test stability.

## Fixed Issue(s)
Fixes #1660.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).