### PR TITLE
Split signedData into separate types

### DIFF
--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.ibft.payload.CommitPayload;
-import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -38,6 +38,6 @@ public class Commit extends IbftMessage<CommitPayload> {
   }
 
   public static Commit decode(final Bytes data) {
-    return new Commit(PayloadDeserialisers.readSignedCommitPayloadFrom(RLP.input(data)));
+    return new Commit(PayloadDeserializers.readSignedCommitPayloadFrom(RLP.input(data)));
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.ibft.payload.CommitPayload;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -37,6 +38,6 @@ public class Commit extends IbftMessage<CommitPayload> {
   }
 
   public static Commit decode(final Bytes data) {
-    return new Commit(SignedData.readSignedCommitPayloadFrom(RLP.input(data)));
+    return new Commit(PayloadDeserialisers.readSignedCommitPayloadFrom(RLP.input(data)));
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
 import org.hyperledger.besu.consensus.ibft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -32,6 +33,6 @@ public class Prepare extends IbftMessage<PreparePayload> {
   }
 
   public static Prepare decode(final Bytes data) {
-    return new Prepare(SignedData.readSignedPreparePayloadFrom(RLP.input(data)));
+    return new Prepare(PayloadDeserialisers.readSignedPreparePayloadFrom(RLP.input(data)));
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
-import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.ibft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -33,6 +33,6 @@ public class Prepare extends IbftMessage<PreparePayload> {
   }
 
   public static Prepare decode(final Bytes data) {
-    return new Prepare(PayloadDeserialisers.readSignedPreparePayloadFrom(RLP.input(data)));
+    return new Prepare(PayloadDeserializers.readSignedPreparePayloadFrom(RLP.input(data)));
   }
 }

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
-import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.ibft.payload.ProposalPayload;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
@@ -75,7 +75,7 @@ public class Proposal extends IbftMessage<ProposalPayload> {
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
     final SignedData<ProposalPayload> payload =
-        PayloadDeserialisers.readSignedProposalPayloadFrom(rlpIn);
+        PayloadDeserializers.readSignedProposalPayloadFrom(rlpIn);
     final Block proposedBlock = Block.readFrom(rlpIn, IbftBlockHeaderFunctions.forCommittedSeal());
 
     final Optional<RoundChangeCertificate> roundChangeCertificate =

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
 import org.hyperledger.besu.consensus.ibft.payload.ProposalPayload;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
@@ -73,7 +74,8 @@ public class Proposal extends IbftMessage<ProposalPayload> {
   public static Proposal decode(final Bytes data) {
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
-    final SignedData<ProposalPayload> payload = SignedData.readSignedProposalPayloadFrom(rlpIn);
+    final SignedData<ProposalPayload> payload =
+        PayloadDeserialisers.readSignedProposalPayloadFrom(rlpIn);
     final Block proposedBlock = Block.readFrom(rlpIn, IbftBlockHeaderFunctions.forCommittedSeal());
 
     final Optional<RoundChangeCertificate> roundChangeCertificate =

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
-import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangePayload;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
@@ -71,7 +71,7 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
     final SignedData<RoundChangePayload> payload =
-        PayloadDeserialisers.readSignedRoundChangePayloadFrom(rlpIn);
+        PayloadDeserializers.readSignedRoundChangePayloadFrom(rlpIn);
     Optional<Block> block = Optional.empty();
     if (!rlpIn.nextIsNull()) {
       block = Optional.of(Block.readFrom(rlpIn, IbftBlockHeaderFunctions.forCommittedSeal()));

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserialisers;
 import org.hyperledger.besu.consensus.ibft.payload.PreparedCertificate;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangePayload;
 import org.hyperledger.besu.consensus.ibft.payload.SignedData;
@@ -70,7 +71,7 @@ public class RoundChange extends IbftMessage<RoundChangePayload> {
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
     final SignedData<RoundChangePayload> payload =
-        SignedData.readSignedRoundChangePayloadFrom(rlpIn);
+        PayloadDeserialisers.readSignedRoundChangePayloadFrom(rlpIn);
     Optional<Block> block = Optional.empty();
     if (!rlpIn.nextIsNull()) {
       block = Optional.of(Block.readFrom(rlpIn, IbftBlockHeaderFunctions.forCommittedSeal()));

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PayloadDeserialisers.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PayloadDeserialisers.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.ibft.payload;
+
+import org.hyperledger.besu.crypto.SECP256K1.Signature;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+
+public class PayloadDeserialisers {
+
+  public static SignedData<ProposalPayload> readSignedProposalPayloadFrom(final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final ProposalPayload unsignedMessageData = ProposalPayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
+  public static SignedData<PreparePayload> readSignedPreparePayloadFrom(final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final PreparePayload unsignedMessageData = PreparePayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
+  public static SignedData<CommitPayload> readSignedCommitPayloadFrom(final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final CommitPayload unsignedMessageData = CommitPayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
+  public static SignedData<RoundChangePayload> readSignedRoundChangePayloadFrom(
+      final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final RoundChangePayload unsignedMessageData = RoundChangePayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
+  protected static <M extends Payload> SignedData<M> from(
+      final M unsignedMessageData, final Signature signature) {
+
+    final Address sender = recoverSender(unsignedMessageData, signature);
+
+    return new SignedData<>(unsignedMessageData, sender, signature);
+  }
+
+  protected static Signature readSignature(final RLPInput signedMessage) {
+    return signedMessage.readBytes(Signature::decode);
+  }
+
+  protected static Address recoverSender(
+      final Payload unsignedMessageData, final Signature signature) {
+
+    return Util.signatureToAddress(signature, MessageFactory.hashForSignature(unsignedMessageData));
+  }
+}

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PayloadDeserializers.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PayloadDeserializers.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
-public class PayloadDeserialisers {
+public class PayloadDeserializers {
 
   public static SignedData<ProposalPayload> readSignedProposalPayloadFrom(final RLPInput rlpInput) {
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificate.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificate.java
@@ -38,8 +38,8 @@ public class PreparedCertificate {
     final List<SignedData<PreparePayload>> prepareMessages;
 
     rlpInput.enterList();
-    proposalMessage = PayloadDeserialisers.readSignedProposalPayloadFrom(rlpInput);
-    prepareMessages = rlpInput.readList(PayloadDeserialisers::readSignedPreparePayloadFrom);
+    proposalMessage = PayloadDeserializers.readSignedProposalPayloadFrom(rlpInput);
+    prepareMessages = rlpInput.readList(PayloadDeserializers::readSignedPreparePayloadFrom);
     rlpInput.leaveList();
 
     return new PreparedCertificate(proposalMessage, prepareMessages);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificate.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificate.java
@@ -38,8 +38,8 @@ public class PreparedCertificate {
     final List<SignedData<PreparePayload>> prepareMessages;
 
     rlpInput.enterList();
-    proposalMessage = SignedData.readSignedProposalPayloadFrom(rlpInput);
-    prepareMessages = rlpInput.readList(SignedData::readSignedPreparePayloadFrom);
+    proposalMessage = PayloadDeserialisers.readSignedProposalPayloadFrom(rlpInput);
+    prepareMessages = rlpInput.readList(PayloadDeserialisers::readSignedPreparePayloadFrom);
     rlpInput.leaveList();
 
     return new PreparedCertificate(proposalMessage, prepareMessages);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificate.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificate.java
@@ -38,7 +38,7 @@ public class RoundChangeCertificate {
     final List<SignedData<RoundChangePayload>> roundChangePayloads;
 
     rlpInput.enterList();
-    roundChangePayloads = rlpInput.readList(SignedData::readSignedRoundChangePayloadFrom);
+    roundChangePayloads = rlpInput.readList(PayloadDeserialisers::readSignedRoundChangePayloadFrom);
     rlpInput.leaveList();
 
     return new RoundChangeCertificate(roundChangePayloads);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificate.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificate.java
@@ -38,7 +38,7 @@ public class RoundChangeCertificate {
     final List<SignedData<RoundChangePayload>> roundChangePayloads;
 
     rlpInput.enterList();
-    roundChangePayloads = rlpInput.readList(PayloadDeserialisers::readSignedRoundChangePayloadFrom);
+    roundChangePayloads = rlpInput.readList(PayloadDeserializers::readSignedRoundChangePayloadFrom);
     rlpInput.leaveList();
 
     return new RoundChangeCertificate(roundChangePayloads);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/SignedData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/payload/SignedData.java
@@ -16,9 +16,7 @@ package org.hyperledger.besu.consensus.ibft.payload;
 
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
-import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
 import java.util.Objects;
@@ -59,65 +57,6 @@ public class SignedData<M extends Payload> implements Authored {
     final BytesValueRLPOutput rlpEncode = new BytesValueRLPOutput();
     writeTo(rlpEncode);
     return rlpEncode.encoded();
-  }
-
-  public static SignedData<ProposalPayload> readSignedProposalPayloadFrom(final RLPInput rlpInput) {
-
-    rlpInput.enterList();
-    final ProposalPayload unsignedMessageData = ProposalPayload.readFrom(rlpInput);
-    final Signature signature = readSignature(rlpInput);
-    rlpInput.leaveList();
-
-    return from(unsignedMessageData, signature);
-  }
-
-  public static SignedData<PreparePayload> readSignedPreparePayloadFrom(final RLPInput rlpInput) {
-
-    rlpInput.enterList();
-    final PreparePayload unsignedMessageData = PreparePayload.readFrom(rlpInput);
-    final Signature signature = readSignature(rlpInput);
-    rlpInput.leaveList();
-
-    return from(unsignedMessageData, signature);
-  }
-
-  public static SignedData<CommitPayload> readSignedCommitPayloadFrom(final RLPInput rlpInput) {
-
-    rlpInput.enterList();
-    final CommitPayload unsignedMessageData = CommitPayload.readFrom(rlpInput);
-    final Signature signature = readSignature(rlpInput);
-    rlpInput.leaveList();
-
-    return from(unsignedMessageData, signature);
-  }
-
-  public static SignedData<RoundChangePayload> readSignedRoundChangePayloadFrom(
-      final RLPInput rlpInput) {
-
-    rlpInput.enterList();
-    final RoundChangePayload unsignedMessageData = RoundChangePayload.readFrom(rlpInput);
-    final Signature signature = readSignature(rlpInput);
-    rlpInput.leaveList();
-
-    return from(unsignedMessageData, signature);
-  }
-
-  protected static <M extends Payload> SignedData<M> from(
-      final M unsignedMessageData, final Signature signature) {
-
-    final Address sender = recoverSender(unsignedMessageData, signature);
-
-    return new SignedData<>(unsignedMessageData, sender, signature);
-  }
-
-  protected static Signature readSignature(final RLPInput signedMessage) {
-    return signedMessage.readBytes(Signature::decode);
-  }
-
-  protected static Address recoverSender(
-      final Payload unsignedMessageData, final Signature signature) {
-
-    return Util.signatureToAddress(signature, MessageFactory.hashForSignature(unsignedMessageData));
   }
 
   @Override

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
@@ -63,7 +63,8 @@ public class PreparedCertificateTest {
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    final SignedData<PreparePayload> signedPrepare = SignedData.from(preparePayload, signature);
+    final SignedData<PreparePayload> signedPrepare =
+        PayloadDeserialisers.from(preparePayload, signature);
 
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposalPayload, Lists.newArrayList(signedPrepare));
@@ -83,6 +84,6 @@ public class PreparedCertificateTest {
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    return SignedData.from(proposalPayload, signature);
+    return PayloadDeserialisers.from(proposalPayload, signature);
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/PreparedCertificateTest.java
@@ -64,7 +64,7 @@ public class PreparedCertificateTest {
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     final SignedData<PreparePayload> signedPrepare =
-        PayloadDeserialisers.from(preparePayload, signature);
+        PayloadDeserializers.from(preparePayload, signature);
 
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposalPayload, Lists.newArrayList(signedPrepare));
@@ -84,6 +84,6 @@ public class PreparedCertificateTest {
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    return PayloadDeserialisers.from(proposalPayload, signature);
+    return PayloadDeserializers.from(proposalPayload, signature);
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificateTest.java
@@ -59,11 +59,13 @@ public class RoundChangeCertificateTest {
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    SignedData<ProposalPayload> signedProposal = SignedData.from(proposalPayload, signature);
+    SignedData<ProposalPayload> signedProposal =
+        PayloadDeserialisers.from(proposalPayload, signature);
 
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
-    final SignedData<PreparePayload> signedPrepare = SignedData.from(preparePayload, signature);
+    final SignedData<PreparePayload> signedPrepare =
+        PayloadDeserialisers.from(preparePayload, signature);
 
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposal, Lists.newArrayList(signedPrepare));

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificateTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangeCertificateTest.java
@@ -60,12 +60,12 @@ public class RoundChangeCertificateTest {
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
     SignedData<ProposalPayload> signedProposal =
-        PayloadDeserialisers.from(proposalPayload, signature);
+        PayloadDeserializers.from(proposalPayload, signature);
 
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
     final SignedData<PreparePayload> signedPrepare =
-        PayloadDeserialisers.from(preparePayload, signature);
+        PayloadDeserializers.from(preparePayload, signature);
 
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposal, Lists.newArrayList(signedPrepare));

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
@@ -83,7 +83,7 @@ public class RoundChangePayloadTest {
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
     final SignedData<PreparePayload> signedPrepare =
-        PayloadDeserialisers.from(preparePayload, SIGNATURE);
+        PayloadDeserializers.from(preparePayload, SIGNATURE);
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposal, Lists.newArrayList(signedPrepare));
 
@@ -105,6 +105,6 @@ public class RoundChangePayloadTest {
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    return PayloadDeserialisers.from(proposalPayload, signature);
+    return PayloadDeserializers.from(proposalPayload, signature);
   }
 }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/payload/RoundChangePayloadTest.java
@@ -82,7 +82,8 @@ public class RoundChangePayloadTest {
 
     final PreparePayload preparePayload =
         new PreparePayload(ROUND_IDENTIFIER, Hash.fromHexStringLenient("0x8523ba6e7c5f59ae87"));
-    final SignedData<PreparePayload> signedPrepare = SignedData.from(preparePayload, SIGNATURE);
+    final SignedData<PreparePayload> signedPrepare =
+        PayloadDeserialisers.from(preparePayload, SIGNATURE);
     final PreparedCertificate preparedCert =
         new PreparedCertificate(signedProposal, Lists.newArrayList(signedPrepare));
 
@@ -104,6 +105,6 @@ public class RoundChangePayloadTest {
         TestHelpers.createProposalBlock(singletonList(AddressHelpers.ofValue(1)), ROUND_IDENTIFIER);
     final ProposalPayload proposalPayload = new ProposalPayload(ROUND_IDENTIFIER, block.getHash());
     final Signature signature = Signature.create(BigInteger.ONE, BigInteger.TEN, (byte) 0);
-    return SignedData.from(proposalPayload, signature);
+    return PayloadDeserialisers.from(proposalPayload, signature);
   }
 }


### PR DESCRIPTION
SignedData is to be used as part of QBFT, and as such the IBFT specific aspects of this class are to be moved into a separate class (allowed SignedData to be moved into the common package)

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>