### PR TITLE
Rename AbstractIbftMessageData to AbstractBftMessageData and move to common package

### DIFF
--- a/consensus/common/build.gradle
+++ b/consensus/common/build.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation project(':crypto')
   implementation project(':ethereum:api')
   implementation project(':ethereum:core')
+  implementation project(':ethereum:p2p')
   implementation project(':ethereum:rlp')
   implementation project(':util')
 

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagedata/AbstractBftMessageData.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagedata/AbstractBftMessageData.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.ibft.messagedata;
+package org.hyperledger.besu.consensus.common.bft.messagedata;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.AbstractMessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
@@ -21,12 +21,12 @@ import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public abstract class AbstractIbftMessageData extends AbstractMessageData {
-  protected AbstractIbftMessageData(final Bytes data) {
+public abstract class AbstractBftMessageData extends AbstractMessageData {
+  protected AbstractBftMessageData(final Bytes data) {
     super(data);
   }
 
-  protected static <T extends AbstractIbftMessageData> T fromMessageData(
+  protected static <T extends AbstractBftMessageData> T fromMessageData(
       final MessageData messageData,
       final int messageCode,
       final Class<T> clazz,

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/CommitMessageData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/CommitMessageData.java
@@ -14,12 +14,13 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class CommitMessageData extends AbstractIbftMessageData {
+public class CommitMessageData extends AbstractBftMessageData {
 
   private static final int MESSAGE_CODE = IbftV2.COMMIT;
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/PrepareMessageData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/PrepareMessageData.java
@@ -14,12 +14,13 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class PrepareMessageData extends AbstractIbftMessageData {
+public class PrepareMessageData extends AbstractBftMessageData {
 
   private static final int MESSAGE_CODE = IbftV2.PREPARE;
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/ProposalMessageData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/ProposalMessageData.java
@@ -14,12 +14,13 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class ProposalMessageData extends AbstractIbftMessageData {
+public class ProposalMessageData extends AbstractBftMessageData {
 
   private static final int MESSAGE_CODE = IbftV2.PROPOSAL;
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/RoundChangeMessageData.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagedata/RoundChangeMessageData.java
@@ -14,12 +14,13 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class RoundChangeMessageData extends AbstractIbftMessageData {
+public class RoundChangeMessageData extends AbstractBftMessageData {
 
   private static final int MESSAGE_CODE = IbftV2.ROUND_CHANGE;
 


### PR DESCRIPTION
A minor step in the move to genericising the IBFT2 code for use in the QBFT implementation.

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>
