### PR TITLE
Move IbftMessage to common

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagewrappers/BftMessage.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagewrappers/BftMessage.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.ibft.messagewrappers;
+package org.hyperledger.besu.consensus.common.bft.messagewrappers;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.Authored;
@@ -26,11 +26,11 @@ import java.util.StringJoiner;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
+public class BftMessage<P extends Payload> implements Authored, RoundSpecific {
 
   private final SignedData<P> payload;
 
-  public IbftMessage(final SignedData<P> payload) {
+  public BftMessage(final SignedData<P> payload) {
     this.payload = payload;
   }
 
@@ -64,7 +64,7 @@ public class IbftMessage<P extends Payload> implements Authored, RoundSpecific {
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", IbftMessage.class.getSimpleName() + "[", "]")
+    return new StringJoiner(", ", BftMessage.class.getSimpleName() + "[", "]")
         .add("payload=" + payload)
         .toString();
   }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/RoundSpecificPeers.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/RoundSpecificPeers.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.messagedata.CommitMessageData;
@@ -26,7 +27,6 @@ import org.hyperledger.besu.consensus.ibft.messagedata.IbftV2;
 import org.hyperledger.besu.consensus.ibft.messagedata.PrepareMessageData;
 import org.hyperledger.besu.consensus.ibft.messagedata.ProposalMessageData;
 import org.hyperledger.besu.consensus.ibft.messagedata.RoundChangeMessageData;
-import org.hyperledger.besu.consensus.ibft.messagewrappers.IbftMessage;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
 import org.hyperledger.besu.consensus.ibft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangePayload;
@@ -151,35 +151,35 @@ public class RoundSpecificPeers {
   }
 
   @SafeVarargs
-  public final void verifyMessagesReceivedProposer(final IbftMessage<? extends Payload>... msgs) {
+  public final void verifyMessagesReceivedProposer(final BftMessage<? extends Payload>... msgs) {
     verifyMessagesReceived(ImmutableList.of(proposer), msgs);
   }
 
   @SafeVarargs
   public final void verifyMessagesReceivedNonPropsingExcluding(
-      final ValidatorPeer exclude, final IbftMessage<? extends Payload>... msgs) {
+      final ValidatorPeer exclude, final BftMessage<? extends Payload>... msgs) {
     final Collection<ValidatorPeer> candidates = Lists.newArrayList(nonProposingPeers);
     candidates.remove(exclude);
     verifyMessagesReceived(candidates, msgs);
   }
 
-  public final void verifyMessagesReceivedNonPropsing(final IbftMessage<?>... msgs) {
+  public final void verifyMessagesReceivedNonPropsing(final BftMessage<?>... msgs) {
     verifyMessagesReceived(nonProposingPeers, msgs);
   }
 
-  public final void verifyMessagesReceived(final IbftMessage<?>... msgs) {
+  public final void verifyMessagesReceived(final BftMessage<?>... msgs) {
     verifyMessagesReceived(peers, msgs);
   }
 
   private void verifyMessagesReceived(
-      final Collection<ValidatorPeer> candidates, final IbftMessage<?>... msgs) {
+      final Collection<ValidatorPeer> candidates, final BftMessage<?>... msgs) {
     candidates.forEach(n -> assertThat(n.getReceivedMessages().size()).isEqualTo(msgs.length));
 
-    List<IbftMessage<? extends Payload>> msgList = Arrays.asList(msgs);
+    List<BftMessage<? extends Payload>> msgList = Arrays.asList(msgs);
 
     for (int i = 0; i < msgList.size(); i++) {
       final int index = i;
-      final IbftMessage<? extends Payload> msg = msgList.get(index);
+      final BftMessage<? extends Payload> msg = msgList.get(index);
       candidates.forEach(
           n -> {
             final List<MessageData> rxMsgs = n.getReceivedMessages();
@@ -190,8 +190,8 @@ public class RoundSpecificPeers {
     candidates.forEach(ValidatorPeer::clearReceivedMessages);
   }
 
-  private void verifyMessage(final MessageData actual, final IbftMessage<?> expectedMessage) {
-    IbftMessage<?> actualSignedPayload = null;
+  private void verifyMessage(final MessageData actual, final BftMessage<?> expectedMessage) {
+    BftMessage<?> actualSignedPayload = null;
 
     switch (expectedMessage.getMessageType()) {
       case IbftV2.PROPOSAL:

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Commit.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.payload.CommitPayload;
 import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
@@ -23,7 +24,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class Commit extends IbftMessage<CommitPayload> {
+public class Commit extends BftMessage<CommitPayload> {
 
   public Commit(final SignedData<CommitPayload> payload) {
     super(payload);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Prepare.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.ibft.payload.PreparePayload;
@@ -22,7 +23,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class Prepare extends IbftMessage<PreparePayload> {
+public class Prepare extends BftMessage<PreparePayload> {
 
   public Prepare(final SignedData<PreparePayload> payload) {
     super(payload);

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/Proposal.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
@@ -29,7 +30,7 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class Proposal extends IbftMessage<ProposalPayload> {
+public class Proposal extends BftMessage<ProposalPayload> {
 
   private final Block proposedBlock;
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/messagewrappers/RoundChange.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.messagewrappers;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.ibft.payload.PayloadDeserializers;
@@ -29,7 +30,7 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
-public class RoundChange extends IbftMessage<RoundChangePayload> {
+public class RoundChange extends BftMessage<RoundChangePayload> {
 
   private final Optional<Block> proposedBlock;
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -19,11 +19,11 @@ import static org.hyperledger.besu.consensus.ibft.statemachine.IbftBlockHeightMa
 import static org.hyperledger.besu.consensus.ibft.statemachine.IbftBlockHeightManager.MessageAge.PRIOR_ROUND;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.ibft.BlockTimer;
 import org.hyperledger.besu.consensus.ibft.ibftevent.RoundExpiry;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
-import org.hyperledger.besu.consensus.ibft.messagewrappers.IbftMessage;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.RoundChange;
@@ -189,7 +189,7 @@ public class IbftBlockHeightManager implements BlockHeightManager {
     actionOrBufferMessage(commit, currentRound::handleCommitMessage, RoundState::addCommitMessage);
   }
 
-  private <P extends Payload, M extends IbftMessage<P>> void actionOrBufferMessage(
+  private <P extends Payload, M extends BftMessage<P>> void actionOrBufferMessage(
       final M ibftMessage,
       final Consumer<M> inRoundHandler,
       final BiConsumer<RoundState, M> buffer) {

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftController.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftController.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibft.statemachine;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.Authored;
 import org.hyperledger.besu.consensus.ibft.Gossiper;
 import org.hyperledger.besu.consensus.ibft.MessageTracker;
@@ -28,7 +29,6 @@ import org.hyperledger.besu.consensus.ibft.messagedata.IbftV2;
 import org.hyperledger.besu.consensus.ibft.messagedata.PrepareMessageData;
 import org.hyperledger.besu.consensus.ibft.messagedata.ProposalMessageData;
 import org.hyperledger.besu.consensus.ibft.messagedata.RoundChangeMessageData;
-import org.hyperledger.besu.consensus.ibft.messagewrappers.IbftMessage;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Message;
@@ -127,7 +127,7 @@ public class IbftController {
     }
   }
 
-  private <P extends IbftMessage<?>> void consumeMessage(
+  private <P extends BftMessage<?>> void consumeMessage(
       final Message message, final P ibftMessage, final Consumer<P> handleMessage) {
     LOG.trace("Received IBFT {} message", ibftMessage.getClass().getSimpleName());
 
@@ -213,7 +213,7 @@ public class IbftController {
     futureMessageBuffer.retrieveMessagesForHeight(newChainHeight).forEach(this::handleMessage);
   }
 
-  private boolean processMessage(final IbftMessage<?> msg, final Message rawMsg) {
+  private boolean processMessage(final BftMessage<?> msg, final Message rawMsg) {
     final ConsensusRoundIdentifier msgRoundIdentifier = msg.getRoundIdentifier();
     if (isMsgForCurrentHeight(msgRoundIdentifier)) {
       return isMsgFromKnownValidator(msg) && ibftFinalState.isLocalNodeValidator();

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftGossipTest.java
@@ -17,9 +17,9 @@ package org.hyperledger.besu.consensus.ibft;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.ibft.messagedata.ProposalMessageData;
 import org.hyperledger.besu.consensus.ibft.messagedata.RoundChangeMessageData;
-import org.hyperledger.besu.consensus.ibft.messagewrappers.IbftMessage;
 import org.hyperledger.besu.consensus.ibft.network.MockPeerFactory;
 import org.hyperledger.besu.consensus.ibft.network.ValidatorMulticaster;
 import org.hyperledger.besu.crypto.NodeKey;
@@ -52,7 +52,7 @@ public class IbftGossipTest {
     peerConnection = MockPeerFactory.create(senderAddress);
   }
 
-  private <P extends IbftMessage<?>> void assertRebroadcastToAllExceptSignerAndSender(
+  private <P extends BftMessage<?>> void assertRebroadcastToAllExceptSignerAndSender(
       final Function<NodeKey, P> createPayload, final Function<P, MessageData> createMessageData) {
     final NodeKey nodeKey = NodeKeyUtils.generate();
     final P payload = createPayload.apply(nodeKey);


### PR DESCRIPTION
Moving the IbftMessage (and rename to BftMessage) to the common package such that it can be reused as part of the QBFT implementation.

Signed-off-by: Trent Mohay <trent.mohay@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).