### PR TITLE
Add revert reason to eth_estimateGas RPC call error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions and Improvements
 * Implemented [EIP-778](https://eips.ethereum.org/EIPS/eip-778): Ethereum Node Records (ENR) [\#1680](https://github.com/hyperledger/besu/pull/1680)
 * Implemented [EIP-868](https://eips.ethereum.org/EIPS/eip-868): Simple Subroutines for the EVM [\#1721](https://github.com/hyperledger/besu/pull/1721)
+* Added revert reason to eth_estimateGas RPC call. [\#1730](https://github.com/hyperledger/besu/pull/1730)
 
 ### Bug Fixes
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -151,6 +151,7 @@ public class EthEstimateGas implements JsonRpcMethod {
       final TransactionProcessingResult resultTrx = result.getResult();
       if (resultTrx != null && resultTrx.getRevertReason().isPresent()) {
         jsonRpcError = JsonRpcError.REVERT_ERROR;
+        jsonRpcError.setData(resultTrx.getRevertReason().get().toHexString());
       } else {
         jsonRpcError = JsonRpcError.INTERNAL_ERROR;
       }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -17,8 +17,10 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum JsonRpcError {
   // Standard errors
@@ -184,10 +186,16 @@ public enum JsonRpcError {
 
   private final int code;
   private final String message;
+  private String data;
 
-  JsonRpcError(final int code, final String message) {
+  JsonRpcError(final int code, final String message, final String data) {
     this.code = code;
     this.message = message;
+    this.data = data;
+  }
+
+  JsonRpcError(final int code, final String message) {
+    this(code, message, null);
   }
 
   @JsonGetter("code")
@@ -200,11 +208,22 @@ public enum JsonRpcError {
     return message;
   }
 
+  @JsonGetter("data")
+  public String getData() {
+    return data;
+  }
+
+  public void setData(final String data) {
+    this.data = data;
+  }
+
   @JsonCreator
   public static JsonRpcError fromJson(
-      @JsonProperty("code") final int code, @JsonProperty("message") final String message) {
+      @JsonProperty("code") final int code,
+      @JsonProperty("message") final String message,
+      @JsonProperty("data") final String data) {
     for (final JsonRpcError error : JsonRpcError.values()) {
-      if (error.code == code && error.message.equals(message)) {
+      if (error.code == code && error.message.equals(message) && error.data.equals(data)) {
         return error;
       }
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/EthByzantiumJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/EthByzantiumJsonRpcHttpBySpecTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc;
+
+import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+
+import java.net.URL;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class EthByzantiumJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
+
+  public EthByzantiumJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
+    super(specName, specURL);
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    startService();
+  }
+
+  @Override
+  protected BlockchainSetupUtil getBlockchainSetupUtil() {
+    return createBlockchainSetupUtil(
+        "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin");
+  }
+
+  @Parameters(name = "{index}: {0}")
+  public static Object[][] specs() {
+    return AbstractJsonRpcHttpBySpecTest.findSpecFiles("eth_latest");
+  }
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_invalid.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_estimateGas_invalid.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "id": 3,
+    "jsonrpc": "2.0",
+    "method": "eth_estimateGas",
+    "params": [
+      {
+        "from": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "data": "0x600160005560016000fe6011600155"
+      }
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "error": {
+      "code": -32603,
+      "message": "Internal error"
+    }
+  },
+  "statusCode": 200
+}

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth_latest/eth_estimateGas_revert.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth_latest/eth_estimateGas_revert.json
@@ -1,0 +1,23 @@
+{
+  "request": {
+    "id": 3,
+    "jsonrpc": "2.0",
+    "method": "eth_estimateGas",
+    "params": [
+      {
+        "from": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "data": "0x600160005560016000fd6011600155"
+      }
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "error": {
+      "code": -32000,
+      "message": "Execution reverted",
+      "data": "0x00"
+    }
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Here I added revert reason to the `data` field of eth_estimateGas rpc error.

The error looks as shown here:

```
{
    "code": -32000,
    "message": "Execution reverted",
    "data": "0x08c379a0..."
}
```

## Fixed Issue(s)
fixes #1207

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).