### PR TITLE
Reduce RunHelpTest Acceptance Test

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
@@ -38,22 +38,5 @@ public class RunHelpTest extends AcceptanceTestBase {
     final String consoleContents = cluster.getConsoleContents();
     assertThat(consoleContents)
         .startsWith("Usage:\n\nbesu [OPTIONS] [COMMAND]\n\nDescription:\n\n");
-
-    // Depending on how the process capture worked we will have one of two end strings
-    // This is a test harness issue, not a Besu issue.
-    try {
-      assertThat(consoleContents)
-          .endsWith(
-              "\n      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>\n"
-                  + "                             Comma separated origin domain URLs for CORS\n"
-                  + "                               validation (default: none)\n"
-                  + "Besu is licensed under the Apache License 2.0\n");
-    } catch (final AssertionError ae) {
-      assertThat(consoleContents)
-          .endsWith(
-              "\n      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>\n"
-                  + "                             Comma separated origin domain URLs for CORS\n"
-                  + "                               validation (default: none)\n");
-    }
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
@@ -38,6 +38,22 @@ public class RunHelpTest extends AcceptanceTestBase {
     final String consoleContents = cluster.getConsoleContents();
     assertThat(consoleContents)
         .startsWith("Usage:\n\nbesu [OPTIONS] [COMMAND]\n\nDescription:\n\n");
-    assertThat(consoleContents).endsWith("\nBesu is licensed under the Apache License 2.0\n");
+
+    // Depending on how the process capture worked we will have one of two end strings
+    // This is a test harness issue, not a Besu issue.
+    try {
+      assertThat(consoleContents)
+          .endsWith(
+              "\n      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>\n"
+                  + "                             Comma separated origin domain URLs for CORS\n"
+                  + "                               validation (default: none)\n"
+                  + "\nBesu is licensed under the Apache License 2.0\n");
+    } catch (final AssertionError ae) {
+      assertThat(consoleContents)
+          .endsWith(
+              "\n      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>\n"
+                  + "                             Comma separated origin domain URLs for CORS\n"
+                  + "                               validation (default: none)\n");
+    }
   }
 }

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/RunHelpTest.java
@@ -47,7 +47,7 @@ public class RunHelpTest extends AcceptanceTestBase {
               "\n      --rpc-http-cors-origins=<rpcHttpCorsAllowedOrigins>\n"
                   + "                             Comma separated origin domain URLs for CORS\n"
                   + "                               validation (default: none)\n"
-                  + "\nBesu is licensed under the Apache License 2.0\n");
+                  + "Besu is licensed under the Apache License 2.0\n");
     } catch (final AssertionError ae) {
       assertThat(consoleContents)
           .endsWith(


### PR DESCRIPTION
The Acceptance Test harness occasionally misses the last line of the
help text (not sure if it's a linux, java, or harness issue, or all
three).

Accept two possible variants for trailer text.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).