### PR TITLE
Add QBFT Propose and RoundChange messages

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/headervalidationrules/BftValidatorsValidationRule.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/headervalidationrules/BftValidatorsValidationRule.java
@@ -54,8 +54,8 @@ public class BftValidatorsValidationRule implements AttachedBlockHeaderValidatio
           new TreeSet<>(bftExtraData.getValidators());
 
       if (!Iterables.elementsEqual(bftExtraData.getValidators(), sortedReportedValidators)) {
-        LOGGER.trace(
-            "Validators are not sorted in ascending order. Expected {} but got {}.",
+        LOGGER.info(
+            "Invalid block header: Validators are not sorted in ascending order. Expected {} but got {}.",
             sortedReportedValidators,
             bftExtraData.getValidators());
         return false;
@@ -63,8 +63,8 @@ public class BftValidatorsValidationRule implements AttachedBlockHeaderValidatio
 
       final Collection<Address> storedValidators = validatorProvider.getValidators();
       if (!Iterables.elementsEqual(bftExtraData.getValidators(), storedValidators)) {
-        LOGGER.trace(
-            "Incorrect validators. Expected {} but got {}.",
+        LOGGER.info(
+            "Invalid block header: Incorrect validators. Expected {} but got {}.",
             storedValidators,
             bftExtraData.getValidators());
         return false;

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/ProposalMessageData.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/ProposalMessageData.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagedata;
+
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
+import org.hyperledger.besu.consensus.qbft.messagewrappers.Proposal;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class ProposalMessageData extends AbstractBftMessageData {
+
+  private static final int MESSAGE_CODE = QbftV1.PROPOSAL;
+
+  private ProposalMessageData(final Bytes data) {
+    super(data);
+  }
+
+  public static ProposalMessageData fromMessageData(final MessageData messageData) {
+    return fromMessageData(
+        messageData, MESSAGE_CODE, ProposalMessageData.class, ProposalMessageData::new);
+  }
+
+  public Proposal decode() {
+    return Proposal.decode(data);
+  }
+
+  public static ProposalMessageData create(final Proposal proposal) {
+    return new ProposalMessageData(proposal.encode());
+  }
+
+  @Override
+  public int getCode() {
+    return MESSAGE_CODE;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/RoundChangeMessageData.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/RoundChangeMessageData.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagedata;
+
+import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
+import org.hyperledger.besu.consensus.qbft.messagewrappers.RoundChange;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class RoundChangeMessageData extends AbstractBftMessageData {
+
+  private static final int MESSAGE_CODE = QbftV1.ROUND_CHANGE;
+
+  private RoundChangeMessageData(final Bytes data) {
+    super(data);
+  }
+
+  public static RoundChangeMessageData fromMessageData(final MessageData messageData) {
+    return fromMessageData(
+        messageData, MESSAGE_CODE, RoundChangeMessageData.class, RoundChangeMessageData::new);
+  }
+
+  public RoundChange decode() {
+    return RoundChange.decode(data);
+  }
+
+  public static RoundChangeMessageData create(final RoundChange signedPayload) {
+
+    return new RoundChangeMessageData(signedPayload.encode());
+  }
+
+  @Override
+  public int getCode() {
+    return MESSAGE_CODE;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
@@ -57,7 +57,7 @@ public class Proposal extends BftMessage<ProposalPayload> {
     return getPayload().getProposedBlock();
   }
 
-  public Optional<RoundChangeMetadata> getRoundChangeCertificate() {
+  public Optional<RoundChangeMetadata> getRoundChangeMetadata() {
     if (!roundChanges.isEmpty() && !prepares.isEmpty()) {
       return Optional.of(new RoundChangeMetadata(roundChanges, prepares));
     } else {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.payload.PayloadDeserializers;
 import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.qbft.payload.ProposalPayload;
-import org.hyperledger.besu.consensus.qbft.payload.RoundChangeCertificate;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangeMetadata;
 import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
@@ -57,9 +57,9 @@ public class Proposal extends BftMessage<ProposalPayload> {
     return getPayload().getProposedBlock();
   }
 
-  public Optional<RoundChangeCertificate> getRoundChangeCertificate() {
+  public Optional<RoundChangeMetadata> getRoundChangeCertificate() {
     if (!roundChanges.isEmpty() && !prepares.isEmpty()) {
-      return Optional.of(new RoundChangeCertificate(roundChanges, prepares));
+      return Optional.of(new RoundChangeMetadata(roundChanges, prepares));
     } else {
       return Optional.empty();
     }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagewrappers;
+
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.payload.PayloadDeserializers;
+import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
+import org.hyperledger.besu.consensus.qbft.payload.ProposalPayload;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangeCertificate;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class Proposal extends BftMessage<ProposalPayload> {
+
+  private final List<SignedData<RoundChangePayload>> roundChanges;
+  private final List<SignedData<PreparePayload>> prepares;
+
+  public Proposal(
+      final SignedData<ProposalPayload> payload,
+      final List<SignedData<RoundChangePayload>> roundChanges,
+      final List<SignedData<PreparePayload>> prepares) {
+    super(payload);
+    this.roundChanges = roundChanges;
+    this.prepares = prepares;
+  }
+
+  public List<SignedData<RoundChangePayload>> getRoundChanges() {
+    return roundChanges;
+  }
+
+  public List<SignedData<PreparePayload>> getPrepares() {
+    return prepares;
+  }
+
+  public Block getBlock() {
+    return getPayload().getProposedBlock();
+  }
+
+  public Optional<RoundChangeCertificate> getRoundChangeCertificate() {
+    if (!roundChanges.isEmpty() && !prepares.isEmpty()) {
+      return Optional.of(new RoundChangeCertificate(roundChanges, prepares));
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  @Override
+  public Bytes encode() {
+    final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
+    rlpOut.startList();
+    getSignedPayload().writeTo(rlpOut);
+    rlpOut.writeList(roundChanges, SignedData::writeTo);
+    rlpOut.writeList(prepares, SignedData::writeTo);
+    rlpOut.endList();
+    return rlpOut.encoded();
+  }
+
+  public static Proposal decode(final Bytes data) {
+    final RLPInput rlpIn = RLP.input(data);
+    rlpIn.enterList();
+    final SignedData<ProposalPayload> payload =
+        PayloadDeserializers.readSignedProposalPayloadFrom(rlpIn);
+    final List<SignedData<RoundChangePayload>> roundChanges =
+        rlpIn.readList(PayloadDeserializers::readSignedRoundChangePayloadFrom);
+    final List<SignedData<PreparePayload>> prepares =
+        rlpIn.readList(PayloadDeserializers::readSignedPreparePayloadFrom);
+
+    rlpIn.leaveList();
+    return new Proposal(payload, roundChanges, prepares);
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChange.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChange.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagewrappers;
+
+import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.payload.PayloadDeserializers;
+import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
+import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class RoundChange extends BftMessage<RoundChangePayload> {
+
+  private final Optional<Block> proposedBlock;
+  private final List<SignedData<PreparePayload>> prepares;
+
+  public RoundChange(
+      final SignedData<RoundChangePayload> payload,
+      final Optional<Block> proposedBlock,
+      final List<SignedData<PreparePayload>> prepares) {
+    super(payload);
+    this.proposedBlock = proposedBlock;
+    this.prepares = prepares;
+  }
+
+  public Optional<Block> getProposedBlock() {
+    return proposedBlock;
+  }
+
+  public List<SignedData<PreparePayload>> getPrepares() {
+    return prepares;
+  }
+
+  public Optional<PreparedRoundMetadata> getPreparedRoundMetadata() {
+    return getPayload().getPreparedRoundMetadata();
+  }
+
+  @Override
+  public Bytes encode() {
+    final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
+    rlpOut.startList();
+    getSignedPayload().writeTo(rlpOut);
+    proposedBlock.ifPresentOrElse(pb -> pb.writeTo(rlpOut), rlpOut::writeNull);
+    rlpOut.writeList(prepares, SignedData::writeTo);
+    rlpOut.endList();
+    return rlpOut.encoded();
+  }
+
+  public static RoundChange decode(final Bytes data) {
+
+    final RLPInput rlpIn = RLP.input(data);
+    rlpIn.enterList();
+    final SignedData<RoundChangePayload> payload =
+        PayloadDeserializers.readSignedRoundChangePayloadFrom(rlpIn);
+
+    final Optional<Block> block;
+    if (rlpIn.nextIsNull()) {
+      rlpIn.skipNext();
+      block = Optional.empty();
+    } else {
+      block = Optional.of(Block.readFrom(rlpIn, BftBlockHeaderFunctions.forCommittedSeal()));
+    }
+
+    final List<SignedData<PreparePayload>> prepares =
+        rlpIn.readList(PayloadDeserializers::readSignedPreparePayloadFrom);
+    rlpIn.leaveList();
+
+    return new RoundChange(payload, block, prepares);
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Util;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
@@ -95,7 +96,7 @@ public class MessageFactory {
               roundIdentifier,
               Optional.of(
                   new PreparedRoundMetadata(
-                      preparedRoundData.get().preparedBlock.getHash(), round)));
+                      preparedRoundData.get().preparedBlock.getHash(), BigInteger.valueOf(round))));
       return new RoundChange(
           createSignedMessage(payload),
           Optional.of(preparedRoundData.get().preparedBlock),

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -53,9 +53,7 @@ public class MessageFactory {
         roundChangeMetadata
             .map(rc -> new ArrayList<>(rc.getRoundChangePayloads()))
             .orElse(new ArrayList<>()),
-        roundChangeMetadata
-            .map(rc -> new ArrayList<>(rc.getPrepares()))
-            .orElse(new ArrayList<>()));
+        roundChangeMetadata.map(rc -> new ArrayList<>(rc.getPrepares())).orElse(new ArrayList<>()));
   }
 
   public Prepare createPrepare(final ConsensusRoundIdentifier roundIdentifier, final Hash digest) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -44,16 +44,16 @@ public class MessageFactory {
   public Proposal createProposal(
       final ConsensusRoundIdentifier roundIdentifier,
       final Block block,
-      final Optional<RoundChangeMetadata> roundChangeCertificate) {
+      final Optional<RoundChangeMetadata> roundChangeMetadata) {
 
     final ProposalPayload payload = new ProposalPayload(roundIdentifier, block);
 
     return new Proposal(
         createSignedMessage(payload),
-        roundChangeCertificate
+        roundChangeMetadata
             .map(rc -> new ArrayList<>(rc.getRoundChangePayloads()))
             .orElse(new ArrayList<>()),
-        roundChangeCertificate
+        roundChangeMetadata
             .map(rc -> new ArrayList<>(rc.getPrepares()))
             .orElse(new ArrayList<>()));
   }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Util;
 
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
@@ -96,7 +95,7 @@ public class MessageFactory {
               roundIdentifier,
               Optional.of(
                   new PreparedRoundMetadata(
-                      preparedRoundData.get().preparedBlock.getHash(), BigInteger.valueOf(round))));
+                      preparedRoundData.get().preparedBlock.getHash(), round)));
       return new RoundChange(
           createSignedMessage(payload),
           Optional.of(preparedRoundData.get().preparedBlock),

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -19,10 +19,17 @@ import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Prepare;
+import org.hyperledger.besu.consensus.qbft.messagewrappers.Proposal;
+import org.hyperledger.besu.consensus.qbft.messagewrappers.RoundChange;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECP256K1.Signature;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -34,8 +41,27 @@ public class MessageFactory {
     this.nodeKey = nodeKey;
   }
 
+  public Proposal createProposal(
+      final ConsensusRoundIdentifier roundIdentifier,
+      final Block block,
+      final Optional<RoundChangeCertificate> roundChangeCertificate) {
+
+    final ProposalPayload payload = new ProposalPayload(roundIdentifier, block);
+
+    return new Proposal(
+        createSignedMessage(payload),
+        roundChangeCertificate
+            .map(rc -> new ArrayList<>(rc.getRoundChangePayloads()))
+            .orElse(new ArrayList<>()),
+        roundChangeCertificate
+            .map(rc -> new ArrayList<>(rc.getPrepares()))
+            .orElse(new ArrayList<>()));
+  }
+
   public Prepare createPrepare(final ConsensusRoundIdentifier roundIdentifier, final Hash digest) {
+
     final PreparePayload payload = new PreparePayload(roundIdentifier, digest);
+
     return new Prepare(createSignedMessage(payload));
   }
 
@@ -43,8 +69,43 @@ public class MessageFactory {
       final ConsensusRoundIdentifier roundIdentifier,
       final Hash digest,
       final Signature commitSeal) {
+
     final CommitPayload payload = new CommitPayload(roundIdentifier, digest, commitSeal);
+
     return new Commit(createSignedMessage(payload));
+  }
+
+  public RoundChange createRoundChange(
+      final ConsensusRoundIdentifier roundIdentifier,
+      final Optional<PreparedCertificate> preparedRoundData) {
+
+    final RoundChangePayload payload;
+    if (preparedRoundData.isPresent()) {
+      final int round =
+          preparedRoundData
+              .get()
+              .getPrepares()
+              .get(0)
+              .getPayload()
+              .getRoundIdentifier()
+              .getRoundNumber();
+
+      payload =
+          new RoundChangePayload(
+              roundIdentifier,
+              Optional.of(
+                  new PreparedRoundMetadata(
+                      preparedRoundData.get().preparedBlock.getHash(), round)));
+      return new RoundChange(
+          createSignedMessage(payload),
+          Optional.of(preparedRoundData.get().preparedBlock),
+          Collections.emptyList());
+
+    } else {
+      payload = new RoundChangePayload(roundIdentifier, Optional.empty());
+      return new RoundChange(
+          createSignedMessage(payload), Optional.empty(), Collections.emptyList());
+    }
   }
 
   private <M extends Payload> SignedData<M> createSignedMessage(final M payload) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/MessageFactory.java
@@ -45,7 +45,7 @@ public class MessageFactory {
   public Proposal createProposal(
       final ConsensusRoundIdentifier roundIdentifier,
       final Block block,
-      final Optional<RoundChangeCertificate> roundChangeCertificate) {
+      final Optional<RoundChangeMetadata> roundChangeCertificate) {
 
     final ProposalPayload payload = new ProposalPayload(roundIdentifier, block);
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PayloadDeserializers.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PayloadDeserializers.java
@@ -23,25 +23,52 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 public class PayloadDeserializers {
 
+  public static SignedData<ProposalPayload> readSignedProposalPayloadFrom(final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final ProposalPayload unsignedMessageData = ProposalPayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
   public static SignedData<PreparePayload> readSignedPreparePayloadFrom(final RLPInput rlpInput) {
+
     rlpInput.enterList();
     final PreparePayload unsignedMessageData = PreparePayload.readFrom(rlpInput);
     final Signature signature = readSignature(rlpInput);
     rlpInput.leaveList();
+
     return from(unsignedMessageData, signature);
   }
 
   public static SignedData<CommitPayload> readSignedCommitPayloadFrom(final RLPInput rlpInput) {
+
     rlpInput.enterList();
     final CommitPayload unsignedMessageData = CommitPayload.readFrom(rlpInput);
     final Signature signature = readSignature(rlpInput);
     rlpInput.leaveList();
+
+    return from(unsignedMessageData, signature);
+  }
+
+  public static SignedData<RoundChangePayload> readSignedRoundChangePayloadFrom(
+      final RLPInput rlpInput) {
+
+    rlpInput.enterList();
+    final RoundChangePayload unsignedMessageData = RoundChangePayload.readFrom(rlpInput);
+    final Signature signature = readSignature(rlpInput);
+    rlpInput.leaveList();
+
     return from(unsignedMessageData, signature);
   }
 
   protected static <M extends Payload> SignedData<M> from(
       final M unsignedMessageData, final Signature signature) {
+
     final Address sender = recoverSender(unsignedMessageData, signature);
+
     return new SignedData<>(unsignedMessageData, sender, signature);
   }
 
@@ -51,6 +78,7 @@ public class PayloadDeserializers {
 
   protected static Address recoverSender(
       final Payload unsignedMessageData, final Signature signature) {
+
     return Util.signatureToAddress(signature, MessageFactory.hashForSignature(unsignedMessageData));
   }
 }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedCertificate.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedCertificate.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.payload;
+
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.ethereum.core.Block;
+
+import java.util.List;
+
+public class PreparedCertificate {
+  final Block preparedBlock;
+  final List<SignedData<PreparePayload>> prepares;
+
+  public PreparedCertificate(
+      final Block preparedBlock, final List<SignedData<PreparePayload>> prepares) {
+    this.preparedBlock = preparedBlock;
+    this.prepares = prepares;
+  }
+
+  public Block getPreparedBlock() {
+    return preparedBlock;
+  }
+
+  public List<SignedData<PreparePayload>> getPrepares() {
+    return prepares;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
@@ -18,16 +18,15 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.math.BigInteger;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
 public class PreparedRoundMetadata {
   private final Hash preparedBlockHash;
-  private final BigInteger preparedRound;
+  private final int preparedRound;
 
-  public PreparedRoundMetadata(final Hash preparedBlockHash, final BigInteger preparedRound) {
+  public PreparedRoundMetadata(final Hash preparedBlockHash, final int preparedRound) {
     this.preparedBlockHash = preparedBlockHash;
     this.preparedRound = preparedRound;
   }
@@ -36,7 +35,7 @@ public class PreparedRoundMetadata {
     return preparedBlockHash;
   }
 
-  public BigInteger getPreparedRound() {
+  public int getPreparedRound() {
     return preparedRound;
   }
 
@@ -48,7 +47,7 @@ public class PreparedRoundMetadata {
    */
   public static PreparedRoundMetadata readFrom(final RLPInput in) {
     final Hash preparedBlockHash = Hash.wrap(in.readBytes32());
-    final BigInteger preparedRound = in.readBigIntegerScalar();
+    final int preparedRound = in.readIntScalar();
     return new PreparedRoundMetadata(preparedBlockHash, preparedRound);
   }
 
@@ -59,7 +58,7 @@ public class PreparedRoundMetadata {
    */
   public void writeTo(final RLPOutput out) {
     out.writeBytes(preparedBlockHash);
-    out.writeBigIntegerScalar(preparedRound);
+    out.writeIntScalar(preparedRound);
   }
 
   @Override
@@ -71,7 +70,7 @@ public class PreparedRoundMetadata {
       return false;
     }
     PreparedRoundMetadata that = (PreparedRoundMetadata) o;
-    return preparedRound.equals(that.preparedRound)
+    return preparedRound == that.preparedRound
         && Objects.equals(preparedBlockHash, that.preparedBlockHash);
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.payload;
+
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+public class PreparedRoundMetadata {
+  private final Hash preparedBlockHash;
+  private final int preparedRound;
+
+  public PreparedRoundMetadata(final Hash preparedBlockHash, final int preparedRound) {
+    this.preparedBlockHash = preparedBlockHash;
+    this.preparedRound = preparedRound;
+  }
+
+  public Hash getPreparedBlockHash() {
+    return preparedBlockHash;
+  }
+
+  public int getPreparedRound() {
+    return preparedRound;
+  }
+
+  /**
+   * Constructor that derives the sequence and round information from an RLP encoded message
+   *
+   * @param in The RLP body of the message to check
+   * @return A derived sequence and round number
+   */
+  public static PreparedRoundMetadata readFrom(final RLPInput in) {
+    in.enterList();
+    final Hash preparedBlockHash = Hash.wrap(in.readBytes32());
+    final int preparedRound = in.readIntScalar();
+    in.leaveList();
+    return new PreparedRoundMetadata(preparedBlockHash, preparedRound);
+  }
+
+  /**
+   * Adds this rounds information to a given RLP buffer
+   *
+   * @param out The RLP buffer to add to
+   */
+  public void writeTo(final RLPOutput out) {
+    out.startList();
+    out.writeBytes(preparedBlockHash);
+    out.writeIntScalar(preparedRound);
+    out.endList();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PreparedRoundMetadata that = (PreparedRoundMetadata) o;
+    return preparedRound == that.preparedRound
+        && Objects.equals(preparedBlockHash, that.preparedBlockHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(preparedBlockHash, preparedRound);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("preparedBlockHash", preparedBlockHash)
+        .add("preparedRound", preparedRound)
+        .toString();
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
@@ -18,15 +18,16 @@ import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
 public class PreparedRoundMetadata {
   private final Hash preparedBlockHash;
-  private final int preparedRound;
+  private final BigInteger preparedRound;
 
-  public PreparedRoundMetadata(final Hash preparedBlockHash, final int preparedRound) {
+  public PreparedRoundMetadata(final Hash preparedBlockHash, final BigInteger preparedRound) {
     this.preparedBlockHash = preparedBlockHash;
     this.preparedRound = preparedRound;
   }
@@ -35,7 +36,7 @@ public class PreparedRoundMetadata {
     return preparedBlockHash;
   }
 
-  public int getPreparedRound() {
+  public BigInteger getPreparedRound() {
     return preparedRound;
   }
 
@@ -43,13 +44,11 @@ public class PreparedRoundMetadata {
    * Constructor that derives the sequence and round information from an RLP encoded message
    *
    * @param in The RLP body of the message to check
-   * @return A derived sequence and round number
+   * @return A PreparedRoundMetadata as extracted from the supplied RLP input
    */
   public static PreparedRoundMetadata readFrom(final RLPInput in) {
-    in.enterList();
     final Hash preparedBlockHash = Hash.wrap(in.readBytes32());
-    final int preparedRound = in.readIntScalar();
-    in.leaveList();
+    final BigInteger preparedRound = in.readBigIntegerScalar();
     return new PreparedRoundMetadata(preparedBlockHash, preparedRound);
   }
 
@@ -59,10 +58,8 @@ public class PreparedRoundMetadata {
    * @param out The RLP buffer to add to
    */
   public void writeTo(final RLPOutput out) {
-    out.startList();
     out.writeBytes(preparedBlockHash);
-    out.writeIntScalar(preparedRound);
-    out.endList();
+    out.writeBigIntegerScalar(preparedRound);
   }
 
   @Override

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
@@ -71,7 +71,7 @@ public class PreparedRoundMetadata {
       return false;
     }
     PreparedRoundMetadata that = (PreparedRoundMetadata) o;
-    return preparedRound == that.preparedRound
+    return preparedRound.equals(that.preparedRound)
         && Objects.equals(preparedBlockHash, that.preparedBlockHash);
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/ProposalPayload.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/ProposalPayload.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.payload;
+
+import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.Payload;
+import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+public class ProposalPayload implements Payload {
+
+  private static final int TYPE = QbftV1.PROPOSAL;
+  private final ConsensusRoundIdentifier roundIdentifier;
+  private final Block proposedBlock;
+
+  public ProposalPayload(
+      final ConsensusRoundIdentifier roundIdentifier, final Block proposedBlock) {
+    this.roundIdentifier = roundIdentifier;
+    this.proposedBlock = proposedBlock;
+  }
+
+  public static ProposalPayload readFrom(final RLPInput rlpInput) {
+    rlpInput.enterList();
+    final ConsensusRoundIdentifier roundIdentifier = ConsensusRoundIdentifier.readFrom(rlpInput);
+    final Block proposedBlock =
+        Block.readFrom(rlpInput, BftBlockHeaderFunctions.forCommittedSeal());
+    rlpInput.leaveList();
+
+    return new ProposalPayload(roundIdentifier, proposedBlock);
+  }
+
+  @Override
+  public void writeTo(final RLPOutput rlpOutput) {
+    rlpOutput.startList();
+    roundIdentifier.writeTo(rlpOutput);
+    proposedBlock.writeTo(rlpOutput);
+    rlpOutput.endList();
+  }
+
+  public Block getProposedBlock() {
+    return proposedBlock;
+  }
+
+  @Override
+  public int getMessageType() {
+    return TYPE;
+  }
+
+  @Override
+  public ConsensusRoundIdentifier getRoundIdentifier() {
+    return roundIdentifier;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProposalPayload that = (ProposalPayload) o;
+    return Objects.equals(roundIdentifier, that.roundIdentifier)
+        && Objects.equals(proposedBlock, that.proposedBlock);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(roundIdentifier, proposedBlock);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("roundIdentifier", roundIdentifier)
+        .add("proposedBlock", proposedBlock)
+        .toString();
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangeCertificate.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangeCertificate.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.payload;
+
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+
+import java.util.Collection;
+import java.util.StringJoiner;
+
+public class RoundChangeCertificate {
+
+  private final Collection<SignedData<RoundChangePayload>> roundChangePayloads;
+  private final Collection<SignedData<PreparePayload>> prepares;
+
+  public RoundChangeCertificate(
+      final Collection<SignedData<RoundChangePayload>> roundChangePayloads,
+      final Collection<SignedData<PreparePayload>> prepares) {
+    this.roundChangePayloads = roundChangePayloads;
+    this.prepares = prepares;
+  }
+
+  public Collection<SignedData<PreparePayload>> getPrepares() {
+    return prepares;
+  }
+
+  public Collection<SignedData<RoundChangePayload>> getRoundChangePayloads() {
+    return roundChangePayloads;
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", RoundChangeCertificate.class.getSimpleName() + "[", "]")
+        .add("roundChangePayloads=" + roundChangePayloads)
+        .toString();
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangeMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangeMetadata.java
@@ -19,12 +19,12 @@ import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import java.util.Collection;
 import java.util.StringJoiner;
 
-public class RoundChangeCertificate {
+public class RoundChangeMetadata {
 
   private final Collection<SignedData<RoundChangePayload>> roundChangePayloads;
   private final Collection<SignedData<PreparePayload>> prepares;
 
-  public RoundChangeCertificate(
+  public RoundChangeMetadata(
       final Collection<SignedData<RoundChangePayload>> roundChangePayloads,
       final Collection<SignedData<PreparePayload>> prepares) {
     this.roundChangePayloads = roundChangePayloads;
@@ -41,7 +41,7 @@ public class RoundChangeCertificate {
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", RoundChangeCertificate.class.getSimpleName() + "[", "]")
+    return new StringJoiner(", ", RoundChangeMetadata.class.getSimpleName() + "[", "]")
         .add("roundChangePayloads=" + roundChangePayloads)
         .toString();
   }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangePayload.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/RoundChangePayload.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.payload;
+
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.Payload;
+import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.google.common.base.MoreObjects;
+
+public class RoundChangePayload implements Payload {
+  private static final int TYPE = QbftV1.ROUND_CHANGE;
+  private final ConsensusRoundIdentifier roundChangeIdentifier;
+  private final Optional<PreparedRoundMetadata> preparedRoundMetadata;
+
+  public RoundChangePayload(
+      final ConsensusRoundIdentifier roundChangeIdentifier,
+      final Optional<PreparedRoundMetadata> preparedRoundMetadata) {
+    this.roundChangeIdentifier = roundChangeIdentifier;
+    this.preparedRoundMetadata = preparedRoundMetadata;
+  }
+
+  @Override
+  public ConsensusRoundIdentifier getRoundIdentifier() {
+    return roundChangeIdentifier;
+  }
+
+  public Optional<PreparedRoundMetadata> getPreparedRoundMetadata() {
+    return preparedRoundMetadata;
+  }
+
+  @Override
+  public void writeTo(final RLPOutput rlpOutput) {
+    // RLP encode of the message data content (round identifier and prepared certificate)
+    rlpOutput.startList();
+    roundChangeIdentifier.writeTo(rlpOutput);
+    preparedRoundMetadata.ifPresentOrElse(prm -> prm.writeTo(rlpOutput), rlpOutput::writeNull);
+    rlpOutput.endList();
+  }
+
+  public static RoundChangePayload readFrom(final RLPInput rlpInput) {
+    rlpInput.enterList();
+    final ConsensusRoundIdentifier roundIdentifier = ConsensusRoundIdentifier.readFrom(rlpInput);
+    final Optional<PreparedRoundMetadata> preparedRoundMetadata;
+    if (rlpInput.nextIsNull()) {
+      preparedRoundMetadata = Optional.empty();
+      rlpInput.skipNext();
+    } else {
+      preparedRoundMetadata = Optional.of(PreparedRoundMetadata.readFrom(rlpInput));
+    }
+    rlpInput.leaveList();
+
+    return new RoundChangePayload(roundIdentifier, preparedRoundMetadata);
+  }
+
+  @Override
+  public int getMessageType() {
+    return TYPE;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RoundChangePayload that = (RoundChangePayload) o;
+    return Objects.equals(roundChangeIdentifier, that.roundChangeIdentifier)
+        && Objects.equals(preparedRoundMetadata, that.preparedRoundMetadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(roundChangeIdentifier, preparedRoundMetadata);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("roundChangeIdentifier", roundChangeIdentifier)
+        .add("preparedRoundMetadata", preparedRoundMetadata)
+        .toString();
+  }
+}

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagewrappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.consensus.common.bft.BftExtraData;
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
+import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
+import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
+import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
+import org.hyperledger.besu.consensus.qbft.payload.ProposalPayload;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.crypto.NodeKey;
+import org.hyperledger.besu.crypto.NodeKeyUtils;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.Util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Test;
+
+public class ProposalTest {
+
+  private static final BftExtraData extraData =
+      new BftExtraData(
+          Bytes32.ZERO, Collections.emptyList(), Optional.empty(), 1, Collections.emptyList());
+
+  private static final Block BLOCK =
+      new Block(
+          new BlockHeaderTestFixture().extraData(extraData.encode()).buildHeader(),
+          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+
+  @Test
+  public void canRoundTripProposalMessage() {
+    final NodeKey nodeKey = NodeKeyUtils.generate();
+    final Address addr = Util.publicKeyToAddress(nodeKey.getPublicKey());
+
+    final ProposalPayload payload = new ProposalPayload(new ConsensusRoundIdentifier(1, 1), BLOCK);
+
+    final SignedData<ProposalPayload> signedPayload =
+        new SignedData<>(payload, addr, nodeKey.sign(MessageFactory.hashForSignature(payload)));
+
+    final PreparePayload preparePayload =
+        new PreparePayload(new ConsensusRoundIdentifier(1, 0), BLOCK.getHash());
+    final SignedData<PreparePayload> prepare =
+        new SignedData<>(
+            preparePayload, addr, nodeKey.sign(MessageFactory.hashForSignature(preparePayload)));
+
+    final RoundChangePayload roundChangePayload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(1, 0),
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
+
+    final SignedData<RoundChangePayload> roundChange =
+        new SignedData<>(
+            roundChangePayload,
+            addr,
+            nodeKey.sign(MessageFactory.hashForSignature(roundChangePayload)));
+
+    final Proposal proposal = new Proposal(signedPayload, List.of(roundChange), List.of(prepare));
+
+    final Proposal decodedProposal = Proposal.decode(proposal.encode());
+
+    assertThat(decodedProposal.getAuthor()).isEqualTo(addr);
+    assertThat(decodedProposal.getMessageType()).isEqualTo(QbftV1.PROPOSAL);
+    assertThat(decodedProposal.getPrepares()).hasSize(1);
+    assertThat(decodedProposal.getPrepares().get(0)).isEqualToComparingFieldByField(prepare);
+    assertThat(decodedProposal.getRoundChanges()).hasSize(1);
+    assertThat(decodedProposal.getRoundChanges().get(0))
+        .isEqualToComparingFieldByField(roundChange);
+    assertThat(decodedProposal.getSignedPayload().getPayload().getProposedBlock()).isEqualTo(BLOCK);
+    assertThat(decodedProposal.getSignedPayload().getPayload().getRoundIdentifier())
+        .isEqualTo(payload.getRoundIdentifier());
+  }
+}

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigInteger;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -70,7 +71,7 @@ public class ProposalTest {
     final RoundChangePayload roundChangePayload =
         new RoundChangePayload(
             new ConsensusRoundIdentifier(1, 0),
-            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), BigInteger.ZERO)));
 
     final SignedData<RoundChangePayload> roundChange =
         new SignedData<>(

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.math.BigInteger;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -34,6 +33,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +70,7 @@ public class ProposalTest {
     final RoundChangePayload roundChangePayload =
         new RoundChangePayload(
             new ConsensusRoundIdentifier(1, 0),
-            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), BigInteger.ZERO)));
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
 
     final SignedData<RoundChangePayload> roundChange =
         new SignedData<>(

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -98,12 +98,6 @@ public class RoundChangeTest {
     final SignedData<RoundChangePayload> signedRoundChangePayload =
         new SignedData<>(payload, addr, nodeKey.sign(MessageFactory.hashForSignature(payload)));
 
-    final PreparePayload preparePayload =
-        new PreparePayload(new ConsensusRoundIdentifier(1, 0), BLOCK.getHash());
-    final SignedData<PreparePayload> signedPreparePayload =
-        new SignedData<>(
-            preparePayload, addr, nodeKey.sign(MessageFactory.hashForSignature(preparePayload)));
-
     final RoundChange roundChange =
         new RoundChange(signedRoundChangePayload, Optional.empty(), Collections.emptyList());
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.math.BigInteger;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -33,6 +32,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
+import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.math.BigInteger;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -58,7 +59,7 @@ public class RoundChangeTest {
     final RoundChangePayload payload =
         new RoundChangePayload(
             new ConsensusRoundIdentifier(1, 1),
-            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), BigInteger.ZERO)));
 
     final SignedData<RoundChangePayload> signedRoundChangePayload =
         new SignedData<>(payload, addr, nodeKey.sign(MessageFactory.hashForSignature(payload)));

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.messagewrappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.consensus.common.bft.BftExtraData;
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
+import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
+import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
+import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.crypto.NodeKey;
+import org.hyperledger.besu.crypto.NodeKeyUtils;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.Util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Test;
+
+public class RoundChangeTest {
+
+  private static final BftExtraData extraData =
+      new BftExtraData(
+          Bytes32.ZERO, Collections.emptyList(), Optional.empty(), 1, Collections.emptyList());
+
+  private static final Block BLOCK =
+      new Block(
+          new BlockHeaderTestFixture().extraData(extraData.encode()).buildHeader(),
+          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+
+  @Test
+  public void canRoundTripARoundChangeMessage() {
+    final NodeKey nodeKey = NodeKeyUtils.generate();
+    final Address addr = Util.publicKeyToAddress(nodeKey.getPublicKey());
+
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(1, 1),
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
+
+    final SignedData<RoundChangePayload> signedRoundChangePayload =
+        new SignedData<>(payload, addr, nodeKey.sign(MessageFactory.hashForSignature(payload)));
+
+    final PreparePayload preparePayload =
+        new PreparePayload(new ConsensusRoundIdentifier(1, 0), BLOCK.getHash());
+    final SignedData<PreparePayload> signedPreparePayload =
+        new SignedData<>(
+            preparePayload, addr, nodeKey.sign(MessageFactory.hashForSignature(preparePayload)));
+
+    final RoundChange roundChange =
+        new RoundChange(
+            signedRoundChangePayload, Optional.of(BLOCK), List.of(signedPreparePayload));
+
+    final RoundChange decodedRoundChange = RoundChange.decode(roundChange.encode());
+
+    assertThat(decodedRoundChange.getMessageType()).isEqualTo(QbftV1.ROUND_CHANGE);
+    assertThat(decodedRoundChange.getAuthor()).isEqualTo(addr);
+    assertThat(decodedRoundChange.getSignedPayload())
+        .isEqualToComparingFieldByField(signedRoundChangePayload);
+    assertThat(decodedRoundChange.getProposedBlock()).isNotEmpty();
+    assertThat(decodedRoundChange.getProposedBlock().get()).isEqualToComparingFieldByField(BLOCK);
+    assertThat(decodedRoundChange.getPrepares()).hasSize(1);
+    assertThat(decodedRoundChange.getPrepares().get(0))
+        .isEqualToComparingFieldByField(signedPreparePayload);
+  }
+}

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -32,7 +32,6 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -59,7 +58,7 @@ public class RoundChangeTest {
     final RoundChangePayload payload =
         new RoundChangePayload(
             new ConsensusRoundIdentifier(1, 1),
-            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), BigInteger.ZERO)));
+            Optional.of(new PreparedRoundMetadata(BLOCK.getHash(), 0)));
 
     final SignedData<RoundChangePayload> signedRoundChangePayload =
         new SignedData<>(payload, addr, nodeKey.sign(MessageFactory.hashForSignature(payload)));


### PR DESCRIPTION
This adds the proposal and roundchange messages required for QBFT.

This does _not_ wire in the ability to transmit/receive these messages, it just defines the message structure.

- [ X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).