### PR TITLE
Add RoundChangePayload validation for QBFT

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/validation/ValidationHelpers.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/validation/ValidationHelpers.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.qbft.validation;
+package org.hyperledger.besu.consensus.common.bft.validation;
 
 import org.hyperledger.besu.consensus.common.bft.payload.Authored;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangePayloadValidator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangePayloadValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.validation;
+
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.ethereum.core.Address;
+
+import java.util.Collection;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Note: This does not validate that the received payload is for a future round, only that it was
+ * signed by a known validator, and is for the current chain height. Future-round check must be
+ * performed elsewhere (eg. the BlockHeightManager)
+ */
+public class RoundChangePayloadValidator {
+
+  private static final String ERROR_PREFIX = "Invalid RoundChange Payload";
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Collection<Address> validators;
+  private final long chainHeight;
+
+  public RoundChangePayloadValidator(final Collection<Address> validators, final long chainHeight) {
+    this.validators = validators;
+    this.chainHeight = chainHeight;
+  }
+
+  public boolean validate(final SignedData<RoundChangePayload> signedPayload) {
+
+    if (!validators.contains(signedPayload.getAuthor())) {
+      LOG.info("{}: did not originate from a recognised validator.", ERROR_PREFIX);
+      return false;
+    }
+
+    final RoundChangePayload payload = signedPayload.getPayload();
+
+    if (payload.getRoundIdentifier().getSequenceNumber() != chainHeight) {
+      LOG.info("{}: did not target expected height", ERROR_PREFIX);
+      return false;
+    }
+
+    final int targetRound = payload.getRoundIdentifier().getRoundNumber();
+    if (targetRound <= 0) {
+      LOG.info("{}: must contain a positive target round number", ERROR_PREFIX);
+      return false;
+    }
+
+    if (payload.getPreparedRoundMetadata().isPresent()) {
+      final PreparedRoundMetadata metadata = payload.getPreparedRoundMetadata().get();
+      if (metadata.getPreparedRound() >= targetRound) {
+        LOG.info("{}: prepared metadata is from a round ahead of target round", ERROR_PREFIX);
+        return false;
+      }
+
+      if (metadata.getPreparedRound() < 0) {
+        LOG.info("{}: prepared metadata is from a negative round number", ERROR_PREFIX);
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ValidationHelpers.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ValidationHelpers.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.validation;
+
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.Authored;
+import org.hyperledger.besu.consensus.common.bft.payload.Payload;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.ethereum.core.Address;
+
+import java.util.Collection;
+import java.util.List;
+
+public class ValidationHelpers {
+
+  public static <T extends Payload> boolean hasDuplicateAuthors(
+      final Collection<SignedData<T>> msgs) {
+    final long distinctAuthorCount = msgs.stream().map(Authored::getAuthor).distinct().count();
+    return distinctAuthorCount != msgs.size();
+  }
+
+  public static <T extends Payload> boolean hasSufficientEntries(
+      final Collection<SignedData<T>> msgs, final long requiredMsgCount) {
+    return msgs.size() >= requiredMsgCount;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ValidationHelpers.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ValidationHelpers.java
@@ -14,14 +14,11 @@
  */
 package org.hyperledger.besu.consensus.qbft.validation;
 
-import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.Authored;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
-import org.hyperledger.besu.ethereum.core.Address;
 
 import java.util.Collection;
-import java.util.List;
 
 public class ValidationHelpers {
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/PrepareValidatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/PrepareValidatorTest.java
@@ -28,9 +28,9 @@ public class PrepareValidatorTest {
   private static final int VALIDATOR_COUNT = 4;
 
   private final QbftNodeList validators = QbftNodeList.createNodes(VALIDATOR_COUNT);
-  final ConsensusRoundIdentifier round = new ConsensusRoundIdentifier(1, 0);
-  final Hash expectedHash = Hash.fromHexStringLenient("0x1");
-  final PrepareValidator validator =
+  private final ConsensusRoundIdentifier round = new ConsensusRoundIdentifier(1, 0);
+  private final Hash expectedHash = Hash.fromHexStringLenient("0x1");
+  private final PrepareValidator validator =
       new PrepareValidator(validators.getNodeAddresses(), round, expectedHash);
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangePayloadValidatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangePayloadValidatorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.qbft.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.consensus.common.bft.payload.PayloadHelpers.hashForSignature;
+
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
+import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
+import org.hyperledger.besu.crypto.NodeKey;
+import org.hyperledger.besu.crypto.NodeKeyUtils;
+import org.hyperledger.besu.crypto.SECP256K1.Signature;
+import org.hyperledger.besu.ethereum.core.Hash;
+
+import java.util.Optional;
+
+import org.junit.Test;
+
+public class RoundChangePayloadValidatorTest {
+
+  private static final int VALIDATOR_COUNT = 4;
+
+  private final QbftNodeList validators = QbftNodeList.createNodes(VALIDATOR_COUNT);
+  private final long chainHeight = 5L;
+  private final Hash preparedBlockHash = Hash.fromHexStringLenient("0x1");
+  final RoundChangePayloadValidator messageValidator =
+      new RoundChangePayloadValidator(validators.getNodeAddresses(), chainHeight);
+
+  @Test
+  public void roundChangeIsValidIfItMatchesExpectedValues() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 0)));
+
+    for (int i = 0; i < VALIDATOR_COUNT; i++) {
+      final SignedData<RoundChangePayload> signedPayload =
+          createSignedPayload(payload, validators.getNode(i).getNodeKey());
+      assertThat(messageValidator.validate(signedPayload)).isTrue();
+    }
+  }
+
+  @Test
+  public void roundChangePayloadWithMissingPreparedMetadataIsValid() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(new ConsensusRoundIdentifier(chainHeight, 1), Optional.empty());
+
+    for (int i = 0; i < VALIDATOR_COUNT; i++) {
+      final SignedData<RoundChangePayload> signedPayload =
+          createSignedPayload(payload, validators.getNode(i).getNodeKey());
+      assertThat(messageValidator.validate(signedPayload)).isTrue();
+    }
+  }
+
+  @Test
+  public void roundChangePayloadSignedByNonValidatorFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 0)));
+
+    final NodeKey nonValidatorKey = NodeKeyUtils.generate();
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, nonValidatorKey);
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeForFutureHeightFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight + 1, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 0)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeForPriorHeightFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight - 1, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 0)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeWithMatchingTargetAndPrepareFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 1)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeWithPreparedRoundInTheFutureFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, 1),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 2)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeWithZeroTargetRoundFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, 0),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 0)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  @Test
+  public void roundChangeWithNegativeTargetRoundFails() {
+    final RoundChangePayload payload =
+        new RoundChangePayload(
+            new ConsensusRoundIdentifier(chainHeight, -3),
+            Optional.of(new PreparedRoundMetadata(preparedBlockHash, 1)));
+
+    final SignedData<RoundChangePayload> signedPayload =
+        createSignedPayload(payload, validators.getNode(0).getNodeKey());
+    assertThat(messageValidator.validate(signedPayload)).isFalse();
+  }
+
+  private SignedData<RoundChangePayload> createSignedPayload(
+      final RoundChangePayload payload, final NodeKey nodeKey) {
+    final Signature signature = nodeKey.sign(hashForSignature(payload));
+    return SignedData.create(payload, signature);
+  }
+}


### PR DESCRIPTION
Signed-off-by: Trent Mohay <trent.mohay@consensys.net>

## PR description
Adds the SignedData<RoundChangePayload> validation code, along with unit tests.
Does not wire this validation code into the QBFT business logic at this stage.
## Fixed Issue(s)
N/A

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).