### PR TITLE
QBFT to send prepare when we receive a proposal

### DIFF
--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/RoundChangeTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/RoundChangeTest.java
@@ -326,9 +326,7 @@ public class RoundChangeTest {
                 .createProposal(roundId, blockToPropose, Optional.empty()),
             emptyList());
 
-    peers
-        .getNonProposing(2)
-        .injectRoundChange(targetRound, Optional.of(illegalPreparedRoundArtifacts));
+    peers.getProposer().injectRoundChange(targetRound, Optional.of(illegalPreparedRoundArtifacts));
 
     // Ensure no Proposal message is sent.
     peers.verifyNoMessagesReceived();

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureHeightTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureHeightTest.java
@@ -140,6 +140,7 @@ public class FutureHeightTest {
     final Block currentHeightBlock = context.createBlockForProposalFromChainHead(0, 30);
 
     peers.getProposer().injectProposal(roundId, currentHeightBlock);
+    peers.getProposer().injectPrepare(roundId, currentHeightBlock.getHash());
     peers.getNonProposing(0).injectPrepare(roundId, currentHeightBlock.getHash());
 
     peers.clearReceivedMessages();

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
@@ -68,11 +68,11 @@ public class FutureRoundTest {
     final ConsensusRoundIdentifier subsequentRoundId = new ConsensusRoundIdentifier(1, 6);
     final RoundSpecificPeers subsequentRoles = context.roundSpecificPeers(subsequentRoundId);
 
-    // required remotely received Prepares = quorum-2
+    // required remotely received Prepares = quorum-1
     // required remote received commits = quorum-1
 
     // Inject 1 too few Commit messages (but sufficient Prepare)
-    for (int i = 0; i < quorum - 3; i++) {
+    for (int i = 0; i < quorum - 2; i++) {
       futurePeers.getNonProposing(i).injectPrepare(futureRoundId, futureBlock.getHash());
     }
 
@@ -103,7 +103,7 @@ public class FutureRoundTest {
     peers.verifyMessagesReceived(expectedPrepare);
 
     // following 1 more prepare, a commit msg will be sent
-    futurePeers.getNonProposing(quorum - 3).injectPrepare(futureRoundId, futureBlock.getHash());
+    futurePeers.getNonProposing(quorum - 2).injectPrepare(futureRoundId, futureBlock.getHash());
 
     final Commit expectedCommit =
         localNodeMessageFactory.createCommit(

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
@@ -68,10 +68,6 @@ public class FutureRoundTest {
     final ConsensusRoundIdentifier subsequentRoundId = new ConsensusRoundIdentifier(1, 6);
     final RoundSpecificPeers subsequentRoles = context.roundSpecificPeers(subsequentRoundId);
 
-    // required remotely received Prepares = quorum-1
-    // required remote received commits = quorum-1
-
-    // Inject 1 too few Commit messages (but sufficient Prepare)
     for (int i = 0; i < quorum - 2; i++) {
       futurePeers.getNonProposing(i).injectPrepare(futureRoundId, futureBlock.getHash());
     }

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeNotProposerTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeNotProposerTest.java
@@ -96,30 +96,6 @@ public class LocalNodeNotProposerTest {
   }
 
   @Test
-  public void prepareFromProposerIsIgnored() {
-    peers.getProposer().injectProposal(roundId, blockToPropose);
-    peers.verifyMessagesReceived(expectedTxPrepare);
-
-    // No commit message transmitted after receiving prepare from proposer
-    peers.getProposer().injectPrepare(roundId, blockToPropose.getHash());
-    peers.verifyNoMessagesReceived();
-    assertThat(context.getCurrentChainHeight()).isEqualTo(0);
-
-    peers.getNonProposing(1).injectPrepare(roundId, blockToPropose.getHash());
-    peers.verifyMessagesReceived(expectedTxCommit);
-
-    // Inject a commit, ensure blockChain is not updated, and no message are sent (not quorum yet)
-    peers.getNonProposing(0).injectCommit(roundId, blockToPropose.getHash());
-    peers.verifyNoMessagesReceived();
-    assertThat(context.getCurrentChainHeight()).isEqualTo(0);
-
-    // A second commit message means quorum is reached, and blockchain should be updated.
-    peers.getNonProposing(1).injectCommit(roundId, blockToPropose.getHash());
-    peers.verifyNoMessagesReceived();
-    assertThat(context.getCurrentChainHeight()).isEqualTo(1);
-  }
-
-  @Test
   public void commitMessagesReceivedBeforePrepareCorrectlyImports() {
     // All peers send a commit, then all non-proposing peers send a prepare, when then Proposal
     // arrives last, the chain is updated, and a prepare and commit message are transmitted.

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ReceivedFutureProposalTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ReceivedFutureProposalTest.java
@@ -166,6 +166,7 @@ public class ReceivedFutureProposalTest {
 
     nextProposer.injectProposalForFutureRound(
         nextRoundId, roundChanges, preparedRoundArtifacts.getPrepares(), reproposedBlock);
+    nextProposer.injectPrepare(nextRoundId, reproposedBlock.getHash());
     peers.verifyNoMessagesReceived();
 
     nextRoles.getNonProposing(1).injectPrepare(nextRoundId, reproposedBlock.getHash());

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/RoundChangeTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/RoundChangeTest.java
@@ -114,6 +114,7 @@ public class RoundChangeTest {
         localNodeMessageFactory.createPrepare(roundId, blockToPropose.getHash());
 
     peers.getProposer().injectProposal(roundId, blockToPropose);
+    final Prepare p0 = peers.getProposer().injectPrepare(roundId, blockToPropose.getHash());
     peers.clearReceivedMessages();
 
     final Prepare p1 = peers.getNonProposing(0).injectPrepare(roundId, blockToPropose.getHash());
@@ -128,7 +129,7 @@ public class RoundChangeTest {
             Optional.of(
                 new PreparedCertificate(
                     blockToPropose,
-                    List.of(localPrepareMessage, p1, p2).stream()
+                    List.of(localPrepareMessage, p0, p1, p2).stream()
                         .map(Prepare::getSignedPayload)
                         .collect(Collectors.toList()),
                     roundId.getRoundNumber())));
@@ -160,7 +161,10 @@ public class RoundChangeTest {
                 rc4.getSignedPayload()),
             emptyList());
 
-    peers.verifyMessagesReceived(expectedProposal);
+    final Prepare expectedPrepare =
+        localNodeMessageFactory.createPrepare(targetRound, locallyProposedBlock.getHash());
+
+    peers.verifyMessagesReceived(expectedProposal, expectedPrepare);
   }
 
   @Test
@@ -212,7 +216,10 @@ public class RoundChangeTest {
                 rc4.getSignedPayload()),
             bestPrepCert.getPrepares());
 
-    peers.verifyMessagesReceived(expectedProposal);
+    final Prepare expectedPrepare =
+        localNodeMessageFactory.createPrepare(targetRound, expectedBlockToPropose.getHash());
+
+    peers.verifyMessagesReceived(expectedProposal, expectedPrepare);
   }
 
   @Test
@@ -232,7 +239,10 @@ public class RoundChangeTest {
         localNodeMessageFactory.createProposal(
             futureRound, locallyProposedBlock, roundChangeMessages, emptyList());
 
-    peers.verifyMessagesReceived(expectedProposal);
+    final Prepare expectedPrepare =
+        localNodeMessageFactory.createPrepare(futureRound, locallyProposedBlock.getHash());
+
+    peers.verifyMessagesReceived(expectedProposal, expectedPrepare);
   }
 
   @Test
@@ -285,7 +295,10 @@ public class RoundChangeTest {
             Lists.newArrayList(roundChangeMessages),
             prepCert.getPrepares());
 
-    peers.verifyMessagesReceived(expectedProposal);
+    final Prepare expectedPrepare =
+        localNodeMessageFactory.createPrepare(targetRound, expectedBlockToPropose.getHash());
+
+    peers.verifyMessagesReceived(expectedProposal, expectedPrepare);
   }
 
   @Test

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -129,7 +129,7 @@ public class QbftRoundIntegrationTest {
             roundIdentifier, proposedBlock, emptyList(), emptyList()));
 
     assertThat(roundState.getProposedBlock()).isNotEmpty();
-    assertThat(roundState.isPrepared()).isTrue();
+    assertThat(roundState.isPrepared()).isFalse();
     assertThat(roundState.isCommitted()).isFalse();
 
     verifyNoInteractions(multicaster);
@@ -163,7 +163,7 @@ public class QbftRoundIntegrationTest {
     round.handlePrepareMessage(peerMessageFactory.createPrepare(roundIdentifier, Hash.EMPTY));
 
     assertThat(roundState.getProposedBlock()).isNotEmpty();
-    assertThat(roundState.isPrepared()).isTrue();
+    assertThat(roundState.isPrepared()).isFalse();
     assertThat(roundState.isCommitted()).isFalse();
     verifyNoInteractions(multicaster);
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRound.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRound.java
@@ -142,6 +142,7 @@ public class QbftRound {
         roundChanges,
         prepares);
     updateStateWithProposedBlock(proposal);
+    sendPrepare(block);
   }
 
   public void handleProposalMessage(final Proposal msg) {
@@ -149,16 +150,20 @@ public class QbftRound {
     final Block block = msg.getSignedPayload().getPayload().getProposedBlock();
 
     if (updateStateWithProposedBlock(msg)) {
-      LOG.debug("Sending prepare message. round={}", roundState.getRoundIdentifier());
-      try {
-        final Prepare localPrepareMessage =
-            messageFactory.createPrepare(getRoundIdentifier(), block.getHash());
-        peerIsPrepared(localPrepareMessage);
-        transmitter.multicastPrepare(
-            localPrepareMessage.getRoundIdentifier(), localPrepareMessage.getDigest());
-      } catch (final SecurityModuleException e) {
-        LOG.warn("Failed to create a signed Prepare; {}", e.getMessage());
-      }
+      sendPrepare(block);
+    }
+  }
+
+  private void sendPrepare(final Block block) {
+    LOG.debug("Sending prepare message. round={}", roundState.getRoundIdentifier());
+    try {
+      final Prepare localPrepareMessage =
+          messageFactory.createPrepare(getRoundIdentifier(), block.getHash());
+      peerIsPrepared(localPrepareMessage);
+      transmitter.multicastPrepare(
+          localPrepareMessage.getRoundIdentifier(), localPrepareMessage.getDigest());
+    } catch (final SecurityModuleException e) {
+      LOG.warn("Failed to create a signed Prepare; {}", e.getMessage());
     }
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/RoundState.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/RoundState.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.consensus.qbft.statemachine;
 
-import org.hyperledger.besu.consensus.common.bft.BftHelpers;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Prepare;
@@ -96,17 +95,14 @@ public class RoundState {
   }
 
   private void updateState() {
-    // NOTE: The quorum for Prepare messages is 1 less than the quorum size as the proposer
-    // does not supply a prepare message
-    final long prepareQuorum = BftHelpers.prepareMessageCountForQuorum(quorum);
-    prepared = (prepareMessages.size() >= prepareQuorum) && proposalMessage.isPresent();
+    prepared = (prepareMessages.size() >= quorum) && proposalMessage.isPresent();
     committed = (commitMessages.size() >= quorum) && proposalMessage.isPresent();
     LOG.trace(
         "Round state updated prepared={} committed={} preparedQuorum={}/{} committedQuorum={}/{}",
         prepared,
         committed,
         prepareMessages.size(),
-        prepareQuorum,
+        quorum,
         commitMessages.size(),
         quorum);
   }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -348,6 +348,9 @@ public class QbftBlockHeightManagerTest {
 
     manager.handleBlockTimerExpiry(roundIdentifier); // Trigger a Proposal creation.
 
+    final Prepare localPrepare =
+        messageFactory.createPrepare(roundIdentifier, createdBlock.getHash());
+
     final Prepare firstPrepare =
         validatorMessageFactory
             .get(0)
@@ -356,8 +359,13 @@ public class QbftBlockHeightManagerTest {
         validatorMessageFactory
             .get(1)
             .createPrepare(roundIdentifier, Hash.fromHexStringLenient("0"));
+    final Prepare thirdPrepare =
+        validatorMessageFactory
+            .get(2)
+            .createPrepare(roundIdentifier, Hash.fromHexStringLenient("0"));
     manager.handlePreparePayload(firstPrepare);
     manager.handlePreparePayload(secondPrepare);
+    manager.handlePreparePayload(thirdPrepare);
 
     manager.roundExpired(new RoundExpiry(roundIdentifier));
 
@@ -372,7 +380,11 @@ public class QbftBlockHeightManagerTest {
     Assertions.assertThat(receivedRoundChange.getPreparedRoundMetadata()).isNotEmpty();
 
     assertThat(receivedRoundChange.getPrepares())
-        .containsOnly(firstPrepare.getSignedPayload(), secondPrepare.getSignedPayload());
+        .containsOnly(
+            localPrepare.getSignedPayload(),
+            firstPrepare.getSignedPayload(),
+            secondPrepare.getSignedPayload(),
+            thirdPrepare.getSignedPayload());
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -210,10 +211,9 @@ public class QbftBlockHeightManagerTest {
             messageFactory);
 
     manager.handleBlockTimerExpiry(roundIdentifier);
-    verify(messageTransmitter, times(1))
+    verify(messageTransmitter, atMostOnce())
         .multicastProposal(eq(roundIdentifier), any(), any(), any());
-    verify(messageTransmitter, never()).multicastPrepare(any(), any());
-    verify(messageTransmitter, never()).multicastPrepare(any(), any());
+    verify(messageTransmitter, atMostOnce()).multicastPrepare(eq(roundIdentifier), any());
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -178,7 +178,7 @@ public class QbftRoundTest {
     verify(transmitter, times(1))
         .multicastProposal(
             roundIdentifier, proposedBlock, Collections.emptyList(), Collections.emptyList());
-    verify(transmitter, never()).multicastPrepare(any(), any());
+    verify(transmitter, times(1)).multicastPrepare(roundIdentifier, proposedBlock.getHash());
     verify(transmitter, never()).multicastCommit(any(), any(), any());
   }
 
@@ -200,7 +200,7 @@ public class QbftRoundTest {
     verify(transmitter, times(1))
         .multicastProposal(
             roundIdentifier, proposedBlock, Collections.emptyList(), Collections.emptyList());
-    verify(transmitter, never()).multicastPrepare(any(), any());
+    verify(transmitter, times(1)).multicastPrepare(roundIdentifier, proposedBlock.getHash());
     verify(transmitter, times(1)).multicastCommit(any(), any(), any());
     verify(blockImporter, times(1)).importBlock(any(), any(), any());
   }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -160,7 +160,7 @@ public class QbftRoundTest {
   }
 
   @Test
-  public void sendsAProposalWhenRequested() {
+  public void sendsAProposalAndPrepareWhenSendProposalRequested() {
     final RoundState roundState = new RoundState(roundIdentifier, 3, messageValidator);
     final QbftRound round =
         new QbftRound(
@@ -259,6 +259,7 @@ public class QbftRoundTest {
     round.startRoundWith(new RoundChangeArtifacts(emptyList(), Optional.empty()), 15);
     verify(transmitter, times(1))
         .multicastProposal(eq(roundIdentifier), any(), eq(emptyList()), eq(emptyList()));
+    verify(transmitter, times(1)).multicastPrepare(eq(roundIdentifier), any());
   }
 
   @Test
@@ -295,6 +296,8 @@ public class QbftRoundTest {
             blockCaptor.capture(),
             eq(singletonList(roundChange.getSignedPayload())),
             eq(singletonList(preparedPayload)));
+    verify(transmitter, times(1))
+        .multicastPrepare(eq(roundIdentifier), eq(blockCaptor.getValue().getHash()));
 
     final BftExtraData proposedExtraData = BftExtraData.decode(blockCaptor.getValue().getHeader());
     assertThat(proposedExtraData.getRound()).isEqualTo(roundIdentifier.getRoundNumber());
@@ -334,6 +337,8 @@ public class QbftRoundTest {
             blockCaptor.capture(),
             eq(List.of(roundChange.getSignedPayload())),
             eq(Collections.emptyList()));
+    verify(transmitter, times(1))
+        .multicastPrepare(eq(roundIdentifier), eq(blockCaptor.getValue().getHash()));
 
     // Inject a single Prepare message, and confirm the roundState has gone to Prepared (which
     // indicates the block has entered the roundState (note: all msgs are deemed valid due to mocks)


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com><!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Change QBFT to also send a prepare when receive a proposal. This also requires changing the quorum needed to be same as the standard quorum used for other QBFT messages.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).