### PR TITLE
Make BFT validator peers sub-protocol configurable

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -140,7 +140,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
     final ProposerSelector proposerSelector =
         new ProposerSelector(blockchain, blockInterface, true, voteTallyCache);
 
-    peers = new ValidatorPeers(voteTallyCache);
+    peers = new ValidatorPeers(voteTallyCache, IbftSubProtocol.NAME);
 
     final UniqueMessageMulticaster uniqueMessageMulticaster =
         new UniqueMessageMulticaster(peers, bftConfig.getGossipedHistoryLimit());

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/network/ValidatorPeers.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/network/ValidatorPeers.java
@@ -39,15 +39,15 @@ public class ValidatorPeers implements ValidatorMulticaster, PeerConnectionTrack
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private static final String PROTOCOL_NAME = "IBF";
-
   // It's possible for multiple connections between peers to exist for brief periods, so map each
   // address to a set of connections
   private final Map<Address, Set<PeerConnection>> connectionsByAddress = new ConcurrentHashMap<>();
   private final VoteTallyCache voteTallyCache;
+  private final String protocolName;
 
-  public ValidatorPeers(final VoteTallyCache voteTallyCache) {
+  public ValidatorPeers(final VoteTallyCache voteTallyCache, final String protocolName) {
     this.voteTallyCache = voteTallyCache;
+    this.protocolName = protocolName;
   }
 
   @Override
@@ -94,7 +94,7 @@ public class ValidatorPeers implements ValidatorMulticaster, PeerConnectionTrack
         .forEach(
             connection -> {
               try {
-                connection.sendForProtocol(PROTOCOL_NAME, message);
+                connection.sendForProtocol(protocolName, message);
               } catch (final PeerNotConnected peerNotConnected) {
                 LOG.trace(
                     "Lost connection to a validator. remoteAddress={} peerInfo={}",

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/network/ValidatorPeersTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/network/ValidatorPeersTest.java
@@ -46,6 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ValidatorPeersTest {
 
+  public static final String PROTOCOL_NAME = "BFT";
   private final List<Address> validators = newArrayList();
   private final List<PublicKey> publicKeys = newArrayList();
 
@@ -81,7 +82,7 @@ public class ValidatorPeersTest {
     // Only add the first Peer's address to the validators.
     validators.add(Util.publicKeyToAddress(publicKeys.get(0)));
 
-    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache);
+    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache, PROTOCOL_NAME);
     for (final PeerConnection peer : peerConnections) {
       peers.add(peer);
     }
@@ -89,7 +90,7 @@ public class ValidatorPeersTest {
     final MessageData messageToSend = new RawMessage(1, Bytes.EMPTY);
     peers.send(messageToSend);
 
-    verify(peerConnections.get(0), times(1)).sendForProtocol("IBF", messageToSend);
+    verify(peerConnections.get(0), times(1)).sendForProtocol(PROTOCOL_NAME, messageToSend);
     verify(peerConnections.get(1), never()).sendForProtocol(any(), any());
     verify(peerConnections.get(2), never()).sendForProtocol(any(), any());
     verify(peerConnections.get(3), never()).sendForProtocol(any(), any());
@@ -101,7 +102,7 @@ public class ValidatorPeersTest {
     validators.add(peer0Address);
     final PeerConnection duplicatePeer = mockPeerConnection(peer0Address);
 
-    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache);
+    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache, PROTOCOL_NAME);
     for (final PeerConnection peer : peerConnections) {
       peers.add(peer);
     }
@@ -110,8 +111,8 @@ public class ValidatorPeersTest {
     final MessageData messageToSend = new RawMessage(1, Bytes.EMPTY);
     peers.send(messageToSend);
 
-    verify(peerConnections.get(0), times(1)).sendForProtocol("IBF", messageToSend);
-    verify(duplicatePeer, times(1)).sendForProtocol("IBF", messageToSend);
+    verify(peerConnections.get(0), times(1)).sendForProtocol(PROTOCOL_NAME, messageToSend);
+    verify(duplicatePeer, times(1)).sendForProtocol(PROTOCOL_NAME, messageToSend);
     verify(peerConnections.get(1), never()).sendForProtocol(any(), any());
     verify(peerConnections.get(2), never()).sendForProtocol(any(), any());
     verify(peerConnections.get(3), never()).sendForProtocol(any(), any());
@@ -123,7 +124,7 @@ public class ValidatorPeersTest {
     validators.add(peer0Address);
     final PeerConnection duplicatePeer = mockPeerConnection(peer0Address);
 
-    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache);
+    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache, PROTOCOL_NAME);
     for (final PeerConnection peer : peerConnections) {
       peers.add(peer);
     }
@@ -133,7 +134,7 @@ public class ValidatorPeersTest {
     final MessageData messageToSend = new RawMessage(1, Bytes.EMPTY);
     peers.send(messageToSend);
 
-    verify(peerConnections.get(0), times(1)).sendForProtocol("IBF", messageToSend);
+    verify(peerConnections.get(0), times(1)).sendForProtocol(PROTOCOL_NAME, messageToSend);
     verify(duplicatePeer, never()).sendForProtocol("IBF", messageToSend);
     verify(peerConnections.get(1), never()).sendForProtocol(any(), any());
     verify(peerConnections.get(2), never()).sendForProtocol(any(), any());
@@ -144,7 +145,7 @@ public class ValidatorPeersTest {
   public void doesntSendToValidatorsWhichAreNotDirectlyConnected() throws PeerNotConnected {
     validators.add(Util.publicKeyToAddress(publicKeys.get(0)));
 
-    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache);
+    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache, PROTOCOL_NAME);
 
     // only add peer connections 1, 2 & 3, none of which should be invoked.
     newArrayList(1, 2, 3).forEach(i -> peers.add(peerConnections.get(i)));
@@ -165,7 +166,7 @@ public class ValidatorPeersTest {
     validators.add(validatorAddress);
     validators.add(Util.publicKeyToAddress(publicKeys.get(1)));
 
-    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache);
+    final ValidatorPeers peers = new ValidatorPeers(voteTallyCache, PROTOCOL_NAME);
     for (final PeerConnection peer : peerConnections) {
       peers.add(peer);
     }


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Make the BFT validators peers tracking sub-protocol configurable so that it can be re-used by QBFT.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).