### PR TITLE
Update GraalVM Docker Container

### DIFF
--- a/docker/graalvm/Dockerfile
+++ b/docker/graalvm/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ghcr.io/graalvm/graalvm-ce:latest
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.0.0
 
 RUN adduser --home /opt/besu besu && \
     chown besu:besu /opt/besu

--- a/docker/graalvm/Dockerfile
+++ b/docker/graalvm/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM oracle/graalvm-ce:20.1.0-java11
+FROM ghcr.io/graalvm/graalvm-ce:latest
 
 RUN adduser --home /opt/besu besu && \
     chown besu:besu /opt/besu


### PR DESCRIPTION
Oracle moved their graalvm container hating from docker to github.
Update the docker file to keep up with this change.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>



## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).