### PR TITLE
Improve the stability of the Clique stall mining AT

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
@@ -72,6 +72,8 @@ public class CliqueMiningAcceptanceTest extends AcceptanceTestBase {
     cluster.stopNode(minerNode2);
     cluster.stopNode(minerNode3);
     minerNode1.verify(net.awaitPeerCount(0));
+    minerNode1.verify(clique.blockIsCreatedByProposer(minerNode1));
+
     minerNode1.verify(clique.noNewBlockCreated(minerNode1));
   }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
@@ -89,6 +89,7 @@ public class CliqueMiningAcceptanceTest extends AcceptanceTestBase {
     cluster.stopNode(minerNode3);
     cluster.verifyOnActiveNodes(net.awaitPeerCount(1));
 
+
     cluster.verifyOnActiveNodes(blockchain.reachesHeight(minerNode1, 2));
     cluster.verifyOnActiveNodes(clique.blockIsCreatedByProposer(minerNode1));
     cluster.verifyOnActiveNodes(clique.blockIsCreatedByProposer(minerNode2));

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
@@ -89,7 +89,6 @@ public class CliqueMiningAcceptanceTest extends AcceptanceTestBase {
     cluster.stopNode(minerNode3);
     cluster.verifyOnActiveNodes(net.awaitPeerCount(1));
 
-
     cluster.verifyOnActiveNodes(blockchain.reachesHeight(minerNode1, 2));
     cluster.verifyOnActiveNodes(clique.blockIsCreatedByProposer(minerNode1));
     cluster.verifyOnActiveNodes(clique.blockIsCreatedByProposer(minerNode2));


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Improve the stability of the Clique stall mining AT by waiting for the still running miner node head block to be the proposed by this miner. If the head block is proposed by another miner just before they were shutdown then it would be valid for this node to create another block.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixed #1876 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).