### PR TITLE
Add remote enode to admin_peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions and Improvements
 * Added `besu_transaction_pool_transactions` to the reported metrics, counting the mempool size [\#1869](https://github.com/hyperledger/besu/pull/1869)
 * Distributions and maven artifacts have been moved off of bintray [\#1886](https://github.com/hyperledger/besu/pull/1886)
+* admin_peers json RPC response now includes the remote nodes enode URL
 
 ### Bug Fixes
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
-import java.util.List;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
@@ -28,7 +27,6 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException
 import java.util.stream.Collectors;
 
 public class AdminPeers implements JsonRpcMethod {
-
   private final EthPeers ethPeers;
 
   public AdminPeers(final EthPeers ethPeers) {
@@ -44,12 +42,9 @@ public class AdminPeers implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
 
     try {
-      final List<PeerResult> peers =
-          ethPeers.streamAllPeers().map(PeerResult::fromEthPeer).collect(Collectors.toList());
-
       return new JsonRpcSuccessResponse(
           requestContext.getRequest().getId(),
-          peers.size() == 1 ? peers.get(0) : peers);
+          ethPeers.streamAllPeers().map(PeerResult::fromEthPeer).collect(Collectors.toList()));
     } catch (P2PDisabledException e) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), JsonRpcError.P2P_DISABLED);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
+import java.util.List;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
@@ -27,6 +28,7 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException
 import java.util.stream.Collectors;
 
 public class AdminPeers implements JsonRpcMethod {
+
   private final EthPeers ethPeers;
 
   public AdminPeers(final EthPeers ethPeers) {
@@ -42,9 +44,12 @@ public class AdminPeers implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
 
     try {
+      final List<PeerResult> peers =
+          ethPeers.streamAllPeers().map(PeerResult::fromEthPeer).collect(Collectors.toList());
+
       return new JsonRpcSuccessResponse(
           requestContext.getRequest().getId(),
-          ethPeers.streamAllPeers().map(PeerResult::fromEthPeer).collect(Collectors.toList()));
+          peers.size() == 1 ? peers.get(0) : peers);
     } catch (P2PDisabledException e) {
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), JsonRpcError.P2P_DISABLED);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.immutables.value.Value;
 
-@JsonPropertyOrder({"version", "name", "caps", "network", "port", "id", "protocols"})
+@JsonPropertyOrder({"version", "name", "caps", "network", "port", "id", "protocols", "enode"})
 @Value.Immutable
 @Value.Style(allParameters = true)
 public interface PeerResult {
@@ -49,6 +49,7 @@ public interface PeerResult {
         .port(Quantity.create(peerInfo.getPort()))
         .id(peerInfo.getNodeId().toString())
         .protocols(Map.of(peer.getProtocolName(), ProtocolsResult.fromEthPeer(peer)))
+        .enode(connection.getRemoteEnode().toString())
         .build();
   }
 
@@ -72,4 +73,7 @@ public interface PeerResult {
 
   @JsonGetter(value = "protocols")
   Map<String, ProtocolsResult> getProtocols();
+
+  @JsonGetter(value = "enode")
+  String getEnode();
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -49,11 +49,11 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTest {
     caps.add(Capability.create("eth", 62));
     final List<EthPeer> peerList = new ArrayList<>();
     final PeerInfo info1 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 30302, Bytes.fromHexString("0001"));
+        new PeerInfo(4, CLIENT_VERSION, caps, 30302, Bytes.fromHexString(String.format("%0128x", 1)));
     final PeerInfo info2 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 60302, Bytes.fromHexString("0002"));
+        new PeerInfo(4, CLIENT_VERSION, caps, 60302, Bytes.fromHexString(String.format("%0128x", 2)));
     final PeerInfo info3 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 60303, Bytes.fromHexString("0003"));
+        new PeerInfo(4, CLIENT_VERSION, caps, 60303, Bytes.fromHexString(String.format("%0128x", 3)));
     final InetSocketAddress addr30301 = new InetSocketAddress("localhost", 30301);
     final InetSocketAddress addr30302 = new InetSocketAddress("localhost", 30302);
     final InetSocketAddress addr60301 = new InetSocketAddress("localhost", 60301);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -49,11 +49,14 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTest {
     caps.add(Capability.create("eth", 62));
     final List<EthPeer> peerList = new ArrayList<>();
     final PeerInfo info1 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 30302, Bytes.fromHexString(String.format("%0128x", 1)));
+        new PeerInfo(
+            4, CLIENT_VERSION, caps, 30302, Bytes.fromHexString(String.format("%0128x", 1)));
     final PeerInfo info2 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 60302, Bytes.fromHexString(String.format("%0128x", 2)));
+        new PeerInfo(
+            4, CLIENT_VERSION, caps, 60302, Bytes.fromHexString(String.format("%0128x", 2)));
     final PeerInfo info3 =
-        new PeerInfo(4, CLIENT_VERSION, caps, 60303, Bytes.fromHexString(String.format("%0128x", 3)));
+        new PeerInfo(
+            4, CLIENT_VERSION, caps, 60303, Bytes.fromHexString(String.format("%0128x", 3)));
     final InetSocketAddress addr30301 = new InetSocketAddress("localhost", 30301);
     final InetSocketAddress addr30302 = new InetSocketAddress("localhost", 30302);
     final InetSocketAddress addr60301 = new InetSocketAddress("localhost", 60301);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
@@ -40,7 +40,7 @@ public class MockPeerConnection {
         .thenReturn(
             EnodeURL.builder()
                 .nodeId(peerInfo.getNodeId())
-                .ipAddress(remoteAddress.getHostString())
+                .ipAddress(remoteAddress.getAddress().getHostAddress())
                 .disableDiscovery()
                 .listeningPort(peerInfo.getPort())
                 .build());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import java.net.InetSocketAddress;
 
 public class MockPeerConnection {
-
   PeerInfo peerInfo;
   InetSocketAddress localAddress;
   InetSocketAddress remoteAddress;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
@@ -17,12 +17,14 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 
 import java.net.InetSocketAddress;
 
 public class MockPeerConnection {
+
   PeerInfo peerInfo;
   InetSocketAddress localAddress;
   InetSocketAddress remoteAddress;
@@ -35,6 +37,14 @@ public class MockPeerConnection {
     when(peerConnection.getPeerInfo()).thenReturn(peerInfo);
     when(peerConnection.getLocalAddress()).thenReturn(localAddress);
     when(peerConnection.getRemoteAddress()).thenReturn(remoteAddress);
+    when(peerConnection.getRemoteEnode())
+        .thenReturn(
+            EnodeURL.builder()
+                .nodeId(peerInfo.getNodeId())
+                .ipAddress(remoteAddress.getHostString())
+                .disableDiscovery()
+                .listeningPort(peerInfo.getPort())
+                .build());
 
     return peerConnection;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -17,8 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.MockPeerConnection;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -29,7 +27,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.PeerResult;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
-import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
@@ -58,7 +55,7 @@ public class AdminPeersTest {
 
   private final String VALID_NODE_ID =
       "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0";
-  
+
   @Mock private EthPeers ethPeers;
 
   @Before

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -54,6 +54,9 @@ public class AdminPeersTest {
 
   private AdminPeers adminPeers;
 
+  private final String VALID_NODE_ID =
+      "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0";
+
   @Mock private P2PNetwork p2pNetwork;
   @Mock private EthPeers ethPeers;
 
@@ -107,7 +110,8 @@ public class AdminPeersTest {
   }
 
   private Collection<EthPeer> peerList() {
-    final PeerInfo peerInfo = new PeerInfo(5, "0x0", Collections.emptyList(), 30303, Bytes.EMPTY);
+    final PeerInfo peerInfo =
+        new PeerInfo(5, "0x0", Collections.emptyList(), 30303, Bytes.fromHexString(VALID_NODE_ID));
     final PeerConnection p =
         MockPeerConnection.create(
             peerInfo,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.MockPeerConnection;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -56,8 +58,7 @@ public class AdminPeersTest {
 
   private final String VALID_NODE_ID =
       "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0";
-
-  @Mock private P2PNetwork p2pNetwork;
+  
   @Mock private EthPeers ethPeers;
 
   @Before
@@ -115,8 +116,8 @@ public class AdminPeersTest {
     final PeerConnection p =
         MockPeerConnection.create(
             peerInfo,
-            InetSocketAddress.createUnresolved("1.2.3.4", 9876),
-            InetSocketAddress.createUnresolved("4.3.2.1", 6789));
+            new InetSocketAddress("1.2.3.4", 9876),
+            new InetSocketAddress("4.3.2.1", 6789));
     final EthPeer ethPeer = new EthPeer(p, "eth", c -> {}, List.of(), TestClock.fixed());
     return Lists.newArrayList(ethPeer);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Besu and GoQuorum provide different information in the response from the admin_peers Json RPC.
This change adds just the "enode" field to the Besu response, to make the results more similar (but still different).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog
admin_peers now includes the remote node's enode URL as a string
- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).