### PR TITLE
GoQuorum store raw private transaction base64 encoding of payload

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/GoQuorumStoreRawPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/GoQuorumStoreRawPrivateTransaction.java
@@ -53,8 +53,10 @@ public class GoQuorumStoreRawPrivateTransaction implements JsonRpcMethod {
     final String payload = requestContext.getRequiredParameter(0, String.class);
 
     try {
-      LOG.debug("sending payload " + payload);
-      final StoreRawResponse storeRawResponse = enclave.storeRaw(payload);
+      LOG.debug("sending payload to GoQuorum enclave" + payload);
+      final StoreRawResponse storeRawResponse =
+          enclave.storeRaw(
+              Base64.getEncoder().encodeToString(Bytes.fromHexString(payload).toArray()));
       final String enclaveLookupId = storeRawResponse.getKey();
       LOG.debug("retrieved lookupId from GoQuorum enclave " + enclaveLookupId);
       return new JsonRpcSuccessResponse(id, hexEncodeEnclaveKey(enclaveLookupId));


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Base64 encode the payload sent to Tessera /storeraw

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).