### PR TITLE
Update Berlin Block numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - [Fast sync when running Besu on cloud providers](KNOWN_ISSUES.md#fast-sync-when-running-besu-on-cloud-providers)
 - [Privacy users with private transactions created using v1.3.4 or earlier](KNOWN_ISSUES.md#privacy-users-with-private-transactions-created-using-v134-or-earlier)
 
+## 21.1.0
+* Added activation blocks for Berlin Network Upgrade [\#1929](https://github.com/hyperledger/besu/pull/1929)
+
 ## 21.1.0-RC2
 ### Additions and Improvements
 * Support for the Berlin Network Upgrade, although the block number must be set manually with `--override-genesis-config=berlinBlock=<blocknumber>`. This is because the block numbers haven't been determined yet. The next release will include the number in the genesis file so it will support Berlin with no intervention. [\#1898](https://github.com/hyperledger/besu/pull/1898)

--- a/config/src/main/resources/goerli.json
+++ b/config/src/main/resources/goerli.json
@@ -3,6 +3,7 @@
     "chainId":5,
     "petersburgBlock":0,
     "istanbulBlock":1561651,
+    "berlinBlock":4460644,
     "clique":{
       "blockperiodseconds":15,
       "epochlength":30000

--- a/config/src/main/resources/mainnet.json
+++ b/config/src/main/resources/mainnet.json
@@ -9,6 +9,7 @@
     "petersburgBlock": 7280000,
     "istanbulBlock": 9069000,
     "muirGlacierBlock": 9200000,
+    "berlinBlock": 12244000,
     "ethash": {
     }
   },

--- a/config/src/main/resources/rinkeby.json
+++ b/config/src/main/resources/rinkeby.json
@@ -8,6 +8,7 @@
     "constantinopleBlock": 3660663,
     "petersburgBlock": 4321234,
     "istanbulBlock":  5435345,
+    "berlinBlock": 8290928,
     "clique": {
       "blockperiodseconds": 15,
       "epochlength": 30000

--- a/config/src/main/resources/ropsten.json
+++ b/config/src/main/resources/ropsten.json
@@ -8,6 +8,7 @@
     "petersburgBlock": 4939394,
     "istanbulBlock": 6485846,
     "muirGlacierBlock": 7117117,
+    "berlinBlock": 9812189,
     "ethash": {
     }
   },

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolScheduleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolScheduleTest.java
@@ -44,8 +44,8 @@ public class MainnetProtocolScheduleTest {
     Assertions.assertThat(sched.getByBlockNumber(7_280_000L).getName()).isEqualTo("Petersburg");
     Assertions.assertThat(sched.getByBlockNumber(9_069_000L).getName()).isEqualTo("Istanbul");
     Assertions.assertThat(sched.getByBlockNumber(9_200_000L).getName()).isEqualTo("MuirGlacier");
-    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName())
-        .isEqualTo("MuirGlacier");
+    Assertions.assertThat(sched.getByBlockNumber(12_244_000L).getName()).isEqualTo("Berlin");
+    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Berlin");
   }
 
   @Test
@@ -103,8 +103,8 @@ public class MainnetProtocolScheduleTest {
     Assertions.assertThat(sched.getByBlockNumber(4_939_394L).getName()).isEqualTo("Petersburg");
     Assertions.assertThat(sched.getByBlockNumber(6_485_846L).getName()).isEqualTo("Istanbul");
     Assertions.assertThat(sched.getByBlockNumber(7_117_117L).getName()).isEqualTo("MuirGlacier");
-    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName())
-        .isEqualTo("MuirGlacier");
+    Assertions.assertThat(sched.getByBlockNumber(9_812_189L).getName()).isEqualTo("Berlin");
+    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Berlin");
   }
 
   @Test
@@ -117,7 +117,8 @@ public class MainnetProtocolScheduleTest {
                 .getConfigOptions());
     Assertions.assertThat(sched.getByBlockNumber(0L).getName()).isEqualTo("Petersburg");
     Assertions.assertThat(sched.getByBlockNumber(1_561_651L).getName()).isEqualTo("Istanbul");
-    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Istanbul");
+    Assertions.assertThat(sched.getByBlockNumber(4_460_644L).getName()).isEqualTo("Berlin");
+    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Berlin");
   }
 
   @Test
@@ -136,6 +137,7 @@ public class MainnetProtocolScheduleTest {
     Assertions.assertThat(sched.getByBlockNumber(3_660_663L).getName()).isEqualTo("Constantinople");
     Assertions.assertThat(sched.getByBlockNumber(4_321_234L).getName()).isEqualTo("Petersburg");
     Assertions.assertThat(sched.getByBlockNumber(5_435_345L).getName()).isEqualTo("Istanbul");
-    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Istanbul");
+    Assertions.assertThat(sched.getByBlockNumber(8_290_928L).getName()).isEqualTo("Berlin");
+    Assertions.assertThat(sched.getByBlockNumber(Long.MAX_VALUE).getName()).isEqualTo("Berlin");
   }
 }


### PR DESCRIPTION
Update ropsten, goerli, rinkeby, and mainnet block numbers to activate
Berlin.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).