### PR TITLE
Fix submodule path in gradle for commit hash check

### DIFF
--- a/consensus/qbft/build.gradle
+++ b/consensus/qbft/build.gradle
@@ -113,13 +113,14 @@ dependencies {
 }
 
 task ('validateReferenceTestSubmodule') {
-  description = "Checks that the reference tests submodule is not accidentially changed"
+  description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
-    def expectedHash = '2fe00d76d97e35aa2df6449b5f567c41cf6f58fc'
     def result = new ByteArrayOutputStream()
+    def expectedHash = '2fe00d76d97e35aa2df6449b5f567c41cf6f58fc'
+    def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "consensus/qbft/src/reference-test/resources").toAbsolutePath()
     try {
       exec {
-        commandLine 'git', 'submodule'
+        commandLine 'git', 'submodule', 'status', submodulePath
         standardOutput = result
         errorOutput = result
       }
@@ -128,9 +129,10 @@ task ('validateReferenceTestSubmodule') {
       // The CI servers have git and that is the only critical place for this failure
       expectedHash = ''
     }
+
     if (!result.toString().contains(expectedHash)) {
       throw new GradleException("""For the QBFT Reference Tests the git commit did not match what was expected.
-
+  
 If this is a deliberate change where you are updating the reference tests 
 then update "expectedHash" in `consensus/qbft/build.gradle` as the 
 commit hash for this task.
@@ -139,7 +141,7 @@ Full git output : ${result}
 
 If this is accidental you can correct the reference test versions with the 
 following commands:
-    pushd consensus/qbft/src/reference-test/resources
+    pushd ${submodulePath}
     git checkout ${expectedHash}
     cd ..
     git add resources

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -41,8 +41,8 @@ task ('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def submoduleHash = '1508126ea04cd61495b60db2f036ac823de274b1'
-    def submodulePath = 'ethereum/referencetests/src/test/resources'
+    def expectedHash = '1508126ea04cd61495b60db2f036ac823de274b1'
+    def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/test/resources").toAbsolutePath()
     try {
       exec {
         commandLine 'git', 'submodule', 'status', submodulePath
@@ -52,22 +52,22 @@ task ('validateReferenceTestSubmodule') {
     } catch (Exception ignore) {
       // Ignore it.  We want to fail in a friendly fashion if they don't have git installed.
       // The CI servers have git and that is the only critical place for this failure
-      submoduleHash = ''
+      expectedHash = ''
     }
 
-    if (!result.toString().contains(submoduleHash)) {
+    if (!result.toString().contains(expectedHash)) {
       throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
   
 If this is a deliberate change where you are updating the reference tests 
 then update "expectedHash" in `ethereum/referencetests/build.gradle` as the 
 commit hash for this task.
-Expected hash   :  ${submoduleHash}
+Expected hash   :  ${expectedHash}
 Full git output : ${result}
 
 If this is accidental you can correct the reference test versions with the 
 following commands:
     pushd ${submodulePath}
-    git checkout ${submoduleHash}
+    git checkout ${expectedHash}
     cd ..
     git add resources
     popd""")

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -55,7 +55,7 @@ task ('validateReferenceTestSubmodule') {
     def submoduleHashes = [
       [
         '2fe00d76d97e35aa2df6449b5f567c41cf6f58fc',
-        'ethereum/referencetests/src/test/resources'
+        'consensus/qbft/src/reference-test/resources'
       ],
       [
         '1508126ea04cd61495b60db2f036ac823de274b1',

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -41,44 +41,36 @@ task ('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
+    def submoduleHash = '1508126ea04cd61495b60db2f036ac823de274b1'
+    def submodulePath = 'ethereum/referencetests/src/test/resources'
     try {
       exec {
-        commandLine 'git', 'submodule'
+        commandLine 'git', 'submodule', 'status', submodulePath
         standardOutput = result
         errorOutput = result
       }
     } catch (Exception ignore) {
       // Ignore it.  We want to fail in a friendly fashion if they don't have git installed.
       // The CI servers have git and that is the only critical place for this failure
-      expectedHash = ''
+      submoduleHash = ''
     }
-    def submoduleHashes = [
-      [
-        '2fe00d76d97e35aa2df6449b5f567c41cf6f58fc',
-        'consensus/qbft/src/reference-test/resources'
-      ],
-      [
-        '1508126ea04cd61495b60db2f036ac823de274b1',
-        'ethereum/referencetests/src/test/resources']
-    ]
-    for (def expectedHash : submoduleHashes) {
-      if (!result.toString().contains(expectedHash[0])) {
-        throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
+
+    if (!result.toString().contains(submoduleHash)) {
+      throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
   
 If this is a deliberate change where you are updating the reference tests 
 then update "expectedHash" in `ethereum/referencetests/build.gradle` as the 
 commit hash for this task.
-Expected hash   :  ${expectedHash[0]}
+Expected hash   :  ${submoduleHash}
 Full git output : ${result}
 
 If this is accidental you can correct the reference test versions with the 
 following commands:
-    pushd ${expectedHash[1]}
-    git checkout ${expectedHash[0]}
+    pushd ${submodulePath}
+    git checkout ${submoduleHash}
     cd ..
     git add resources
     popd""")
-      }
     }
   }
 }


### PR DESCRIPTION
## PR description
Fix submodule path in gradle for hash check

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

Signed-off-by: Usman Saleem <usman@usmans.info>