### PR TITLE
Upgrade discovery to a version available from the new repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,7 @@ allprojects {
     mavenCentral()
     maven { url "https://hyperledger.jfrog.io/hyperledger/besu-maven" }
     maven { url "https://hyperledger-org.bintray.com/besu-repo" }
+    maven { url "https://artifacts.consensys.net/public/maven/maven/" }
     maven { url "https://consensys.bintray.com/pegasys-repo" }
     maven { url "https://consensys.bintray.com/consensys" }
     maven { url "https://splunk.jfrog.io/splunk/ext-releases-local" }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
 
     dependency 'org.yaml:snakeyaml:1.26'
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.2'
+    dependency 'tech.pegasys.discovery:discovery:0.4.3'
 
     dependency 'tech.pegasys.ethsigner.internal:core:0.4.0'
     dependency 'tech.pegasys.ethsigner.internal:file-based:0.4.0'


### PR DESCRIPTION
## PR description
Upgrade discovery dependency to 0.4.3 which is published to the new repo (bintray repo is being shut down).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).