### PR TITLE
Reduce hash calculations in Bonsai Tries

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -217,7 +217,9 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
       } else {
         updatedAccount.setBalance(tracked.getBalance());
         updatedAccount.setNonce(tracked.getNonce());
-        updatedAccount.setCode(tracked.getCode());
+        if (tracked.codeWasUpdated()) {
+          updatedAccount.setCode(tracked.getCode());
+        }
         if (tracked.getStorageWasCleared()) {
           updatedAccount.clearStorage();
         }


### PR DESCRIPTION
Setting contract code on a bonsai account results in a re-hashing. To
reduce this only set the code if the code was changed.  In some cases
this was responsible for 40% of load.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>



## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).