### PR TITLE
Allow to disable ErrorProne

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,10 @@ allprojects {
     ]
 
     options.errorprone {
+      if ('true'.equalsIgnoreCase(System.getProperty('avt.disableErrorProne'))) {
+        enabled = false
+      }
+
       excludedPaths = '.*/(generated/*.*|.*ReferenceTest_.*)'
 
       // Our equals need to be symmetric, this checker doesn't respect that.


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Simplifies javac calls to allow the build to be run by other analyzers.

Example:
```
./gradlew installDist -Davt.disableErrorProne=true
```

Signed-off-by: Horacio Mijail Anton Quiles <hmijail@gmail.com>

## Fixed Issue(s)


## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).