### PR TITLE
Remove download links and specify 21.1.2 where 21.1.1 was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,14 @@
 
 ### Berlin Network Upgrade
 
+### Important note: the 21.1.1 release contains an outdated version of the Berlin network upgrade. If you are using Besu on public Ethereum networks, you must upgrade to 21.1.2.
+
 This release contains the activation blocks for Berlin across all supported testnets and the Ethereum mainnet. They are: 
   * Ropsten 9_812_189 (10 Mar 2021)
   * Goerli 4_460_644 (17 Mar 2021)
   * Rinkeby 8_290_928 (24 Mar 2021)
   * Ethereum 12_244_000 (14 Apr 2021)
 
-
-**Important note: the 21.1.1 release contains an outdated version of the Berlin network upgrade. If you are using Besu on public Ethereum networks, you must upgrade to 21.1.2.
-**
 
 ### Additions and Improvements
 - Added option to set a limit for JSON-RPC connections 
@@ -35,13 +34,13 @@ https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/21.1.2/besu-21.1.2.z
 
 ### Berlin Network Upgrade
 
+### Important note: this release contains an outdated version of the Berlin network upgrade. If you are using Besu on public Ethereum networks, you must upgrade to 21.1.2.
+
 This release contains the activation blocks for Berlin across all supported testnets and the Ethereum mainnet. They are: 
   * Ropsten 9_812_189 (10 Mar 2021)
   * Goerli 4_460_644 (17 Mar 2021)
   * Rinkeby 8_290_928 (24 Mar 2021)
   * Ethereum 12_244_000 (14 Apr 2021)
-
-**Important note: the 21.1.0 release contains an outdated version of the Berlin network upgrade. If you are using Besu on public Ethereum networks, you must upgrade to 21.1.1.**
 
 ### Additions and Improvements
 * Removed EIP-2315 from the Berlin network upgrade [\#1983](https://github.com/hyperledger/besu/pull/1983)
@@ -61,13 +60,12 @@ This release contains the activation blocks for Berlin across all supported test
 - [Privacy users with private transactions created using v1.3.4 or earlier](KNOWN_ISSUES.md#privacy-users-with-private-transactions-created-using-v134-or-earlier)
 
 ### Download link
-https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/21.1.1/besu-21.1.1.zip
 sha256: `c22a80a54e9fed864734b9fbd69a0a46840fd27ca5211648a3eaf8a955417218 `
 
 
 ## 21.1.0
 
-**Important note: this release contains an outdated version of the Berlin network upgrade, which was changed on March 5, 2021 ([link](https://github.com/ethereum/pm/issues/263#issuecomment-791473406)). If you are using Besu on public Ethereum networks, you must upgrade to 21.1.1.**
+### Important note: this release contains an outdated version of the Berlin network upgrade, which was changed on March 5, 2021 ([link](https://github.com/ethereum/pm/issues/263#issuecomment-791473406)). If you are using Besu on public Ethereum networks, you must upgrade to 21.1.2.
 
 ## 21.1.0 Features
 
@@ -104,7 +102,6 @@ Features added between 20.10.0 to 21.1.0 include:
 - [Privacy users with private transactions created using v1.3.4 or earlier](KNOWN_ISSUES.md#privacy-users-with-private-transactions-created-using-v134-or-earlier)
 
 ### Download link
-https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/21.1.0/besu-21.1.0.zip
 sha256: `e4c8fe4007e3e5f7f2528cbf1eeb5457caf06536c974a6ff4305035ff5724476`
 
 ## 21.1.0-RC2


### PR DESCRIPTION
Remove download links for Besu versions with Berlin consensus bug, and have both 21.1.0 and 21.1.1 point to 21.1.2. 