### PR TITLE
Move 3 maintainers to Emeritus status.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,10 +10,8 @@
 | Adrian Sutton    | ajsutton         | ajsutton         |
 | Antoine Toulme   | atoulme          | atoulme          |
 | Byron Gravenorst | bgravenorst      | bgravenorst      |
-| Chris Hare       | CjHare           | cjhare           |
 | David Mechler    | davemec          | davemec          |
 | Edward Mack      | edwardmack       | mackcom          | 
-| Ivaylo Kirilov   | iikirilov        | iikirilov        |
 | Jason Frame      | jframe           | jframe           |
 | Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Lucas Saldanha   | lucassaldanha    | lucassaldanha    |
@@ -21,21 +19,23 @@
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Mark Terry       | mark-terry       | m.terry          |
 | Karim Taam       | matkt            | matkt            |
-| Meredith Baxter  | mbaxter          | mbaxter          |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
 | Stefan Pingel    | pinges           | pinges           |
 | Trent Mohay      | rain-on          | trent.mohay      |
 | Rai Sur          | RatanRSur        | ratanraisur      |
-| Rob Dawson       | rojotek          | RobDawson        |
 | Danno Ferrin     | shemnon          | shemnon          |
 | Tim Beiko        | timbeiko         | timbeiko         |
 | Usman Saleem     | usmansaleem      | usmansaleem      |
 
 ## Emeritus Maintainers
 
-| Name         | Github  | LFID    |
-|--------------|---------|---------|
-| Edward Evans | EdJoJob | EdJoJob |
+| Name             | Github           | LFID             |
+|------------------|------------------|------------------|
+| Chris Hare       | CjHare           | cjhare           |
+| Edward Evans     | EdJoJob          | EdJoJob          |
+| Ivaylo Kirilov   | iikirilov        | iikirilov        |
+| Meredith Baxter  | mbaxter          | mbaxter          |
+| Rob Dawson       | rojotek          | RobDawson        |
 
 ## Becoming a Maintainer
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
 | Mark Terry       | mark-terry       | m.terry          |
 | Karim Taam       | matkt            | matkt            |
+| Meredith Baxter  | mbaxter          | mbaxter          |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
 | Stefan Pingel    | pinges           | pinges           |
 | Trent Mohay      | rain-on          | trent.mohay      |
@@ -34,7 +35,6 @@
 | Chris Hare       | CjHare           | cjhare           |
 | Edward Evans     | EdJoJob          | EdJoJob          |
 | Ivaylo Kirilov   | iikirilov        | iikirilov        |
-| Meredith Baxter  | mbaxter          | mbaxter          |
 | Rob Dawson       | rojotek          | RobDawson        |
 
 ## Becoming a Maintainer


### PR DESCRIPTION
I propose moving the following maintainers to Emeritus status, pursuant to the inactivity clause.  Since this is the first such proposal I am extending the window so that _two_ reporting quarters of inactivity be required for movement to Emeritus. (28 Sep 2020 was the start of the Q4 report)

* @iikirilov's last commit was on 24 Mar 2020
* @CjHare's last commit was on 5 Mar 2020
* @rojotek's last commit was on 7 Oct 2019

We very much appreciate their contributions but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly project. If any of these maintainers express in this PR that the intend to make contributions in the next quarter then they will not be moved to emeritus status.

I propose this vote is open until either an absolute majority of active maintainers (11) votes for the same outcome, or until two weeks has passed (3 April 2021), after which a voting majority will determine the outcome (with a tie resulting in no change).

(edit: @mbaxter was on the original list but (a) has had comments in the past two quarters, which my tooling didn't pick up and (b) has expressed a desire to stay active and contribute. Each reason is independently sufficient.)