### PR TITLE
Upgrade discovery to include fix for nonce generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Fixed issue in discv5 where nonce was incorrectly reused.
+
 ### Early Access Features
 
 #### Previously identified known issues

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -153,7 +153,7 @@ dependencyManagement {
 
     dependency 'org.yaml:snakeyaml:1.26'
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.3'
+    dependency 'tech.pegasys.discovery:discovery:0.4.5'
 
     dependency 'tech.pegasys.ethsigner.internal:ethsigner-core:21.3.0'
     dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.16') {


### PR DESCRIPTION
## PR description
Upgrade the discv5 library to pull in https://github.com/ConsenSys/discovery/pull/98

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).