### PR TITLE
Use istanbul 100 subprotocol in QBFT

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -110,7 +110,10 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
         .withSubProtocol(
             Istanbul100SubProtocol.get(),
             new BftProtocolManager(
-                bftEventQueue, peers, Istanbul100SubProtocol.ISTANBUL_100, Istanbul100SubProtocol.get().getName()));
+                bftEventQueue,
+                peers,
+                Istanbul100SubProtocol.ISTANBUL_100,
+                Istanbul100SubProtocol.get().getName()));
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -49,7 +49,7 @@ import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.QbftGossip;
 import org.hyperledger.besu.consensus.qbft.jsonrpc.QbftJsonRpcMethods;
 import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
-import org.hyperledger.besu.consensus.qbft.protocol.QbftSubProtocol;
+import org.hyperledger.besu.consensus.qbft.protocol.Istanbul100SubProtocol;
 import org.hyperledger.besu.consensus.qbft.statemachine.QbftBlockHeightManagerFactory;
 import org.hyperledger.besu.consensus.qbft.statemachine.QbftController;
 import org.hyperledger.besu.consensus.qbft.statemachine.QbftRoundFactory;
@@ -108,9 +108,9 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
     return new SubProtocolConfiguration()
         .withSubProtocol(EthProtocol.get(), ethProtocolManager)
         .withSubProtocol(
-            QbftSubProtocol.get(),
+            Istanbul100SubProtocol.get(),
             new BftProtocolManager(
-                bftEventQueue, peers, QbftSubProtocol.QBFV1, QbftSubProtocol.get().getName()));
+                bftEventQueue, peers, Istanbul100SubProtocol.ISTANBUL_100, Istanbul100SubProtocol.get().getName()));
   }
 
   @Override
@@ -144,7 +144,7 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
 
     // NOTE: peers should not be used for accessing the network as it does not enforce the
     // "only send once" filter applied by the UniqueMessageMulticaster.
-    peers = new ValidatorPeers(voteTallyCache, QbftSubProtocol.NAME);
+    peers = new ValidatorPeers(voteTallyCache, Istanbul100SubProtocol.NAME);
 
     final UniqueMessageMulticaster uniqueMessageMulticaster =
         new UniqueMessageMulticaster(peers, bftConfig.getGossipedHistoryLimit());

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/protocol/Istanbul100SubProtocol.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/protocol/Istanbul100SubProtocol.java
@@ -18,14 +18,14 @@ import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 
-public class QbftSubProtocol implements SubProtocol {
+public class Istanbul100SubProtocol implements SubProtocol {
 
-  public static String NAME = "QBF";
-  public static final Capability QBFV1 = Capability.create(NAME, 1);
+  public static String NAME = "istanbul";
+  public static final Capability ISTANBUL_100 = Capability.create(NAME, 100);
 
-  private static final QbftSubProtocol INSTANCE = new QbftSubProtocol();
+  private static final Istanbul100SubProtocol INSTANCE = new Istanbul100SubProtocol();
 
-  public static QbftSubProtocol get() {
+  public static Istanbul100SubProtocol get() {
     return INSTANCE;
   }
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/protocol/Istanbul100SubProtocolTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/protocol/Istanbul100SubProtocolTest.java
@@ -18,18 +18,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-public class QbftSubProtocolTest {
+public class Istanbul100SubProtocolTest {
 
   @Test
   public void messageSpaceReportsCorrectly() {
-    final QbftSubProtocol subProt = new QbftSubProtocol();
+    final Istanbul100SubProtocol subProt = new Istanbul100SubProtocol();
 
     assertThat(subProt.messageSpace(1)).isEqualTo(0x16);
   }
 
   @Test
   public void allIbftMessageTypesAreRecognisedAsValidByTheSubProtocol() {
-    final QbftSubProtocol subProt = new QbftSubProtocol();
+    final Istanbul100SubProtocol subProt = new Istanbul100SubProtocol();
 
     assertThat(subProt.isValidMessageCode(1, 0x12)).isTrue();
     assertThat(subProt.isValidMessageCode(1, 0x13)).isTrue();
@@ -39,7 +39,7 @@ public class QbftSubProtocolTest {
 
   @Test
   public void invalidMessageTypesAreNotAcceptedByTheSubprotocol() {
-    final QbftSubProtocol subProt = new QbftSubProtocol();
+    final Istanbul100SubProtocol subProt = new Istanbul100SubProtocol();
 
     assertThat(subProt.isValidMessageCode(1, 0x16)).isFalse();
   }


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Use istanbul/100 subprotocol in qbft to match the sub-protocol used in Quorum for qbft.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).