### PR TITLE
Update repolinter.yml

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -16,14 +16,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: hyperledger-tools.jfrog.io/repolinter:0.10.0
+    container: ghcr.io/todogroup/repolinter:v0.10.1
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Repo
-        run: bundle exec /app/bin/repolinter.js --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/master/repo_structure/repolint.json --format markdown > /repolinter-report.md
-      - name: Save repolinter-report file
-        uses: actions/upload-artifact@v2
-        with:
-          name: repolinter-report
-          path: /repolinter-report.md
+        run: bundle exec /app/bin/repolinter.js --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/master/repo_structure/repolint.json --format markdown


### PR DESCRIPTION
Use current container image

Remove step which saves results to a file

Signed-off-by: Ry Jones <ry@linux.com>

## PR description

A new container issue has been published by the ToDo group; we should use this image.

The saving of the log file for later inspection was controversial; remove that.

## Fixed Issue(s)

## Changelog
