### PR TITLE
Fix flaky test

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOnchainGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOnchainGroupAcceptanceTest.java
@@ -42,7 +42,7 @@ public class PrivDebugGetStateRootOnchainGroupAcceptanceTest
         privacyBesu.createOnChainPrivacyGroupEnabledMinerNode(
             "alice-node", PrivacyAccountResolver.ALICE, Address.PRIVACY, false);
     bobNode =
-        privacyBesu.createOnChainPrivacyGroupEnabledMinerNode(
+        privacyBesu.createOnChainPrivacyGroupEnabledNode(
             "bob-node", PrivacyAccountResolver.BOB, Address.PRIVACY, false);
     privacyCluster.start(aliceNode, bobNode);
   }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Simplify this test setup by making only one node a miner. This also improves performance of the test.
Before: was failing 20% of the time when running locally (100 runs)
After: passing 100% of the time (100 runs)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).