### PR TITLE
Address EIP-2930 transactions not in EIP-2718 typed transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+- Fixed an issue with access list transactions which were RLP encoded (non EIP-2718)
 - Fixed issue in discv5 where nonce was incorrectly reused.
 
 ### Early Access Features

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtils.java
@@ -14,9 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.api.util;
 
+import static org.hyperledger.besu.plugin.data.TransactionType.FRONTIER;
+
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcRequestException;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.encoding.TransactionDecoder;
+import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 
 import org.apache.logging.log4j.LogManager;
@@ -29,7 +32,12 @@ public class DomainObjectDecodeUtils {
   public static Transaction decodeRawTransaction(final String rawTransaction)
       throws InvalidJsonRpcRequestException {
     try {
-      return TransactionDecoder.decodeOpaqueBytes(Bytes.fromHexString(rawTransaction));
+      Bytes txnBytes = Bytes.fromHexString(rawTransaction);
+      if (!txnBytes.isEmpty() && FRONTIER.compareTo(txnBytes.get(0)) < 0) {
+        return TransactionDecoder.decodeOpaqueBytes(txnBytes);
+      } else {
+        return Transaction.readFrom(RLP.input(txnBytes));
+      }
     } catch (final IllegalArgumentException | RLPException e) {
       LOG.debug(e);
       throw new InvalidJsonRpcRequestException("Invalid raw transaction hex", e);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
@@ -1,0 +1,54 @@
+package org.hyperledger.besu.ethereum.api.util;
+
+import org.hyperledger.besu.crypto.SECPSignature;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.ethereum.core.*;
+import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class DomainObjectDecodeUtilsTest {
+
+  static final BlockDataGenerator gen = new BlockDataGenerator();
+  private static final SECPSignature signature =
+      SignatureAlgorithmFactory.getInstance()
+          .createSignature(BigInteger.ONE, BigInteger.TEN, (byte) 1);
+  private static final Address sender =
+      Address.fromHexString("0x0000000000000000000000000000000000000003");
+
+  private static final Transaction accessListTxn =
+      Transaction.builder()
+          .accessList(List.of(new AccessListEntry(gen.address(), List.of(gen.bytes32()))))
+          .nonce(1)
+          .gasPrice(Wei.of(12))
+          .gasLimit(43)
+          .payload(Bytes.EMPTY)
+          .value(Wei.ZERO)
+          .signature(signature)
+          .sender(sender)
+          .guessType()
+          .build();
+
+  @Test
+  public void testAccessListRLPSerDes() {
+    final BytesValueRLPOutput encoded = new BytesValueRLPOutput();
+    TransactionEncoder.encodeForWire(accessListTxn, encoded);
+    Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.toString());
+    Assertions.assertThat(decoded.getAccessList().isPresent());
+    Assertions.assertThat(decoded.getAccessList().map(l -> l.size() == 1));
+  }
+
+  @Test
+  public void testAccessList2718OpaqueSerDes() {
+    final Bytes encoded = TransactionEncoder.encodeOpaqueBytes(accessListTxn);
+    Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.toString());
+    Assertions.assertThat(decoded.getAccessList().isPresent());
+    Assertions.assertThat(decoded.getAccessList().map(l -> l.size() == 1));
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
@@ -1,7 +1,5 @@
 package org.hyperledger.besu.ethereum.api.util;
 
-import org.apache.tuweni.bytes.Bytes;
-import org.assertj.core.api.Assertions;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.ethereum.core.AccessListEntry;
@@ -11,10 +9,13 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
-import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 
 public class DomainObjectDecodeUtilsTest {
 
@@ -43,7 +44,8 @@ public class DomainObjectDecodeUtilsTest {
   public void testAccessListRLPSerDes() {
     final BytesValueRLPOutput encoded = new BytesValueRLPOutput();
     TransactionEncoder.encodeForWire(accessListTxn, encoded);
-    Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.encoded().toHexString());
+    Transaction decoded =
+        DomainObjectDecodeUtils.decodeRawTransaction(encoded.encoded().toHexString());
     Assertions.assertThat(decoded.getAccessList().isPresent()).isTrue();
     Assertions.assertThat(decoded.getAccessList().map(List::size).get()).isEqualTo(1);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
@@ -1,17 +1,20 @@
 package org.hyperledger.besu.ethereum.api.util;
 
+import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.api.Assertions;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
-import org.hyperledger.besu.ethereum.core.*;
+import org.hyperledger.besu.ethereum.core.AccessListEntry;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.List;
-
-import org.apache.tuweni.bytes.Bytes;
-import org.assertj.core.api.Assertions;
-import org.junit.Test;
 
 public class DomainObjectDecodeUtilsTest {
 
@@ -24,6 +27,7 @@ public class DomainObjectDecodeUtilsTest {
 
   private static final Transaction accessListTxn =
       Transaction.builder()
+          .chainId(BigInteger.valueOf(2018))
           .accessList(List.of(new AccessListEntry(gen.address(), List.of(gen.bytes32()))))
           .nonce(1)
           .gasPrice(Wei.of(12))
@@ -39,16 +43,16 @@ public class DomainObjectDecodeUtilsTest {
   public void testAccessListRLPSerDes() {
     final BytesValueRLPOutput encoded = new BytesValueRLPOutput();
     TransactionEncoder.encodeForWire(accessListTxn, encoded);
-    Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.toString());
-    Assertions.assertThat(decoded.getAccessList().isPresent());
-    Assertions.assertThat(decoded.getAccessList().map(l -> l.size() == 1));
+    Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.encoded().toHexString());
+    Assertions.assertThat(decoded.getAccessList().isPresent()).isTrue();
+    Assertions.assertThat(decoded.getAccessList().map(List::size).get()).isEqualTo(1);
   }
 
   @Test
   public void testAccessList2718OpaqueSerDes() {
     final Bytes encoded = TransactionEncoder.encodeOpaqueBytes(accessListTxn);
     Transaction decoded = DomainObjectDecodeUtils.decodeRawTransaction(encoded.toString());
-    Assertions.assertThat(decoded.getAccessList().isPresent());
-    Assertions.assertThat(decoded.getAccessList().map(l -> l.size() == 1));
+    Assertions.assertThat(decoded.getAccessList().isPresent()).isTrue();
+    Assertions.assertThat(decoded.getAccessList().map(List::size).get()).isEqualTo(1);
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '5lK7AFvgqEiSvrDn6sRB4DpwCJc0YJ/RfOcB0Y3i8yI='
+  knownHash = 'Hn13dH/yIThZ47izfRh4lFJ26+Lwi+lwIoImzSY8oAg='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionType.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionType.java
@@ -31,6 +31,10 @@ public enum TransactionType {
     return (byte) this.typeValue;
   }
 
+  public int compareTo(final Byte b) {
+    return Byte.valueOf(getSerializedType()).compareTo(b);
+  }
+
   public static TransactionType of(final int serializedTypeValue) {
     return Arrays.stream(TransactionType.values())
         .filter(transactionType -> transactionType.typeValue == serializedTypeValue)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
json-rpc fix for access list transactions which are RLP encoded rather than EIP-2718 typed transactions

this was discovered when manually running the ethereum reference tests for EIP-2930.  It isn't clear whether these transactions should be considered valid or not given that EIP-2930 specifies a typed transaction envelope, but this 
PR correctly handles them.




## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).