### PR TITLE
Remove ellipsis from block hash logs

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
@@ -49,11 +49,6 @@ public class FullImportBlockStep implements Consumer<Block> {
   public void accept(final Block block) {
     final long blockNumber = block.getHeader().getNumber();
     final String blockHash = block.getHash().toHexString();
-    final String shortHash =
-        String.format(
-            "%s..%s",
-            blockHash.substring(0, 6),
-            blockHash.substring(blockHash.length() - 4, blockHash.length()));
     final BlockImporter importer =
         protocolSchedule.getByBlockNumber(blockNumber).getBlockImporter();
     if (!importer.importBlock(protocolContext, block, HeaderValidationMode.SKIP_DETACHED)) {
@@ -74,7 +69,7 @@ public class FullImportBlockStep implements Consumer<Block> {
       LOG.info(
           "Import reached block {} ({}), {} Mg/s, Peers: {}",
           blockNumber,
-          shortHash,
+          blockHash,
           mgps,
           peerCount);
       lastReportMillis = nowMilli;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Remove ellipsis from block hash logs. Thus, full block hashes will be shown in logs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #1594

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).