### PR TITLE
Estimate gas: ignore nonce

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
 import static java.lang.Boolean.FALSE;
 
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.Wei;
@@ -27,10 +26,12 @@ import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.tuweni.bytes.Bytes;
 
+@JsonIgnoreProperties("nonce")
 public class JsonCallParameter extends CallParameter {
 
   private final boolean strict;
@@ -39,7 +40,6 @@ public class JsonCallParameter extends CallParameter {
   public JsonCallParameter(
       @JsonProperty("from") final Address from,
       @JsonProperty("to") final Address to,
-      //      @JsonProperty("nonce") final int nonce,
       @JsonDeserialize(using = GasDeserializer.class) @JsonProperty("gas") final Gas gasLimit,
       @JsonProperty("gasPrice") final Wei gasPrice,
       @JsonProperty("gasPremium") final Wei gasPremium,
@@ -58,34 +58,6 @@ public class JsonCallParameter extends CallParameter {
         value,
         payload);
     this.strict = Optional.ofNullable(strict).orElse(FALSE);
-  }
-
-  @JsonCreator
-  public JsonCallParameter(
-      @JsonProperty("from") final Address from,
-      @JsonProperty("to") final Address to,
-      @JsonProperty("nonce") final int nonce,
-      @JsonDeserialize(using = GasDeserializer.class) @JsonProperty("gas") final Gas gasLimit,
-      @JsonProperty("gasPrice") final Wei gasPrice,
-      @JsonProperty("gasPremium") final Wei gasPremium,
-      @JsonProperty("feeCap") final Wei feeCap,
-      @JsonProperty("value") final Wei value,
-      @JsonDeserialize(using = HexStringDeserializer.class) @JsonProperty("data")
-          final Bytes payload,
-      @JsonProperty("strict") final Boolean strict) {
-    super(
-        from,
-        to,
-        gasLimit != null ? gasLimit.toLong() : -1,
-        gasPrice,
-        Optional.ofNullable(gasPremium),
-        Optional.ofNullable(feeCap),
-        value,
-        payload);
-    this.strict = Optional.ofNullable(strict).orElse(FALSE);
-    if (strict) {
-      throw new InvalidJsonRpcParameters("nonce cannot be specified when strict is enforced");
-    }
   }
 
   public boolean isStrict() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
 import static java.lang.Boolean.FALSE;
 
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.Wei;
@@ -38,6 +39,7 @@ public class JsonCallParameter extends CallParameter {
   public JsonCallParameter(
       @JsonProperty("from") final Address from,
       @JsonProperty("to") final Address to,
+      //      @JsonProperty("nonce") final int nonce,
       @JsonDeserialize(using = GasDeserializer.class) @JsonProperty("gas") final Gas gasLimit,
       @JsonProperty("gasPrice") final Wei gasPrice,
       @JsonProperty("gasPremium") final Wei gasPremium,
@@ -56,6 +58,34 @@ public class JsonCallParameter extends CallParameter {
         value,
         payload);
     this.strict = Optional.ofNullable(strict).orElse(FALSE);
+  }
+
+  @JsonCreator
+  public JsonCallParameter(
+      @JsonProperty("from") final Address from,
+      @JsonProperty("to") final Address to,
+      @JsonProperty("nonce") final int nonce,
+      @JsonDeserialize(using = GasDeserializer.class) @JsonProperty("gas") final Gas gasLimit,
+      @JsonProperty("gasPrice") final Wei gasPrice,
+      @JsonProperty("gasPremium") final Wei gasPremium,
+      @JsonProperty("feeCap") final Wei feeCap,
+      @JsonProperty("value") final Wei value,
+      @JsonDeserialize(using = HexStringDeserializer.class) @JsonProperty("data")
+          final Bytes payload,
+      @JsonProperty("strict") final Boolean strict) {
+    super(
+        from,
+        to,
+        gasLimit != null ? gasLimit.toLong() : -1,
+        gasPrice,
+        Optional.ofNullable(gasPremium),
+        Optional.ofNullable(feeCap),
+        value,
+        payload);
+    this.strict = Optional.ofNullable(strict).orElse(FALSE);
+    if (strict) {
+      throw new InvalidJsonRpcParameters("nonce cannot be specified when strict is enforced");
+    }
   }
 
   public boolean isStrict() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -105,31 +105,6 @@ public class EthEstimateGasTest {
   }
 
   @Test
-  public void shouldIgnoreNonceWhenNonStrict() {
-    final JsonRpcRequestContext request = ethEstimateGasRequestWithNonce(88, false);
-    when(transactionSimulator.process(
-            eq(modifiedLegacyTransactionCallParameter(Wei.ZERO)),
-            any(TransactionValidationParams.class),
-            any(OperationTracer.class),
-            eq(1L)))
-        .thenReturn(Optional.empty());
-
-    final JsonRpcResponse expectedResponse =
-        new JsonRpcErrorResponse(null, JsonRpcError.INTERNAL_ERROR);
-
-    Assertions.assertThat(method.response(request))
-        .isEqualToComparingFieldByField(expectedResponse);
-  }
-
-  @Test
-  public void shouldThrowInvalidParamWithNonceWhenStrict() {
-
-    Assertions.assertThatThrownBy(() -> ethEstimateGasRequestWithNonce(88, true))
-        .isInstanceOf(InvalidJsonRpcParameters.class)
-        .hasMessageContaining("nonce cannot be specified when strict is enforced");
-  }
-
-  @Test
   public void shouldReturnErrorWhenTransientEip1559TransactionProcessorReturnsEmpty() {
     final JsonRpcRequestContext request = ethEstimateGasRequest(eip1559TransactionCallParameter());
     when(transactionSimulator.process(
@@ -363,31 +338,11 @@ public class EthEstimateGasTest {
     return legacyTransactionCallParameter(gasPrice, false);
   }
 
-  private JsonCallParameter defaultLegacyTransactionCallParameterWithNonce(
-      final Wei gasPrice, final boolean isStrict, final int nonce) {
-    return legacyTransactionCallParameterWithNonce(gasPrice, isStrict, nonce);
-  }
-
   private JsonCallParameter legacyTransactionCallParameter(
       final Wei gasPrice, final boolean isStrict) {
     return new JsonCallParameter(
         Address.fromHexString("0x0"),
         Address.fromHexString("0x0"),
-        Gas.ZERO,
-        gasPrice,
-        null,
-        null,
-        Wei.ZERO,
-        Bytes.EMPTY,
-        isStrict);
-  }
-
-  private JsonCallParameter legacyTransactionCallParameterWithNonce(
-      final Wei gasPrice, final boolean isStrict, final int nonce) {
-    return new JsonCallParameter(
-        Address.fromHexString("0x0"),
-        Address.fromHexString("0x0"),
-        nonce,
         Gas.ZERO,
         gasPrice,
         null,
@@ -439,14 +394,6 @@ public class EthEstimateGasTest {
   }
 
   private JsonRpcRequestContext ethEstimateGasRequest(final CallParameter callParameter) {
-    return new JsonRpcRequestContext(
-        new JsonRpcRequest("2.0", "eth_estimateGas", new Object[] {callParameter}));
-  }
-
-  private JsonRpcRequestContext ethEstimateGasRequestWithNonce(
-      final int nonce, final boolean isStrict) {
-    final CallParameter callParameter =
-        defaultLegacyTransactionCallParameterWithNonce(Wei.ZERO, isStrict, nonce);
     return new JsonRpcRequestContext(
         new JsonRpcRequest("2.0", "eth_estimateGas", new Object[] {callParameter}));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -105,6 +105,31 @@ public class EthEstimateGasTest {
   }
 
   @Test
+  public void shouldIgnoreNonceWhenNonStrict() {
+    final JsonRpcRequestContext request = ethEstimateGasRequestWithNonce(88, false);
+    when(transactionSimulator.process(
+            eq(modifiedLegacyTransactionCallParameter(Wei.ZERO)),
+            any(TransactionValidationParams.class),
+            any(OperationTracer.class),
+            eq(1L)))
+        .thenReturn(Optional.empty());
+
+    final JsonRpcResponse expectedResponse =
+        new JsonRpcErrorResponse(null, JsonRpcError.INTERNAL_ERROR);
+
+    Assertions.assertThat(method.response(request))
+        .isEqualToComparingFieldByField(expectedResponse);
+  }
+
+  @Test
+  public void shouldThrowInvalidParamWithNonceWhenStrict() {
+
+    Assertions.assertThatThrownBy(() -> ethEstimateGasRequestWithNonce(88, true))
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasMessageContaining("nonce cannot be specified when strict is enforced");
+  }
+
+  @Test
   public void shouldReturnErrorWhenTransientEip1559TransactionProcessorReturnsEmpty() {
     final JsonRpcRequestContext request = ethEstimateGasRequest(eip1559TransactionCallParameter());
     when(transactionSimulator.process(
@@ -338,11 +363,31 @@ public class EthEstimateGasTest {
     return legacyTransactionCallParameter(gasPrice, false);
   }
 
+  private JsonCallParameter defaultLegacyTransactionCallParameterWithNonce(
+      final Wei gasPrice, final boolean isStrict, final int nonce) {
+    return legacyTransactionCallParameterWithNonce(gasPrice, isStrict, nonce);
+  }
+
   private JsonCallParameter legacyTransactionCallParameter(
       final Wei gasPrice, final boolean isStrict) {
     return new JsonCallParameter(
         Address.fromHexString("0x0"),
         Address.fromHexString("0x0"),
+        Gas.ZERO,
+        gasPrice,
+        null,
+        null,
+        Wei.ZERO,
+        Bytes.EMPTY,
+        isStrict);
+  }
+
+  private JsonCallParameter legacyTransactionCallParameterWithNonce(
+      final Wei gasPrice, final boolean isStrict, final int nonce) {
+    return new JsonCallParameter(
+        Address.fromHexString("0x0"),
+        Address.fromHexString("0x0"),
+        nonce,
         Gas.ZERO,
         gasPrice,
         null,
@@ -394,6 +439,14 @@ public class EthEstimateGasTest {
   }
 
   private JsonRpcRequestContext ethEstimateGasRequest(final CallParameter callParameter) {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest("2.0", "eth_estimateGas", new Object[] {callParameter}));
+  }
+
+  private JsonRpcRequestContext ethEstimateGasRequestWithNonce(
+      final int nonce, final boolean isStrict) {
+    final CallParameter callParameter =
+        defaultLegacyTransactionCallParameterWithNonce(Wei.ZERO, isStrict, nonce);
     return new JsonRpcRequestContext(
         new JsonRpcRequest("2.0", "eth_estimateGas", new Object[] {callParameter}));
   }


### PR DESCRIPTION
Ignore nonce when supplied to eth_estimateGas or eth_call. This is to better support web3j calls as per #2125 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).