### PR TITLE
Make public key decode errors debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes
 
+- Reduced logging level of public key decoding failure of malformed packets. [\#2143](https://github.com/hyperledger/besu/pull/2143)
+
 ### Early Access Features
 
 #### Previously identified known issues

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/Packet.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/Packet.java
@@ -119,11 +119,13 @@ public class Packet {
     final PacketData packetData;
     try {
       packetData = deserializer.deserialize(RLP.input(message, PACKET_DATA_INDEX));
+      return new Packet(packetType, packetData, Bytes.wrapBuffer(message));
     } catch (final RLPException e) {
       throw new PeerDiscoveryPacketDecodingException("Malformed packet of type: " + packetType, e);
+    } catch (final IllegalArgumentException e) {
+      throw new PeerDiscoveryPacketDecodingException(
+          "Failed decoding packet of type: " + packetType, e);
     }
-
-    return new Packet(packetType, packetData, Bytes.wrapBuffer(message));
   }
 
   public Buffer encode() {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.p2p.discovery.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
+import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryPacketDecodingException;
 
 import java.util.Optional;
 
@@ -30,6 +31,8 @@ public class PacketTest {
 
   private static final String VALID_PONG_PACKET =
       "53cec0d27af44bdc0471d34c4eb631f74b502df7b5513a80a054f0d619f0417d6ba4fd4d6fb83994b95c6d0ae8b175b068a6bffc397e2b408e797069b9370ce47b153dd884b60108e686546a775ed5f85e71059a9c5791e266bd949d0dcfba380102f83bcb84b4b57a1a82040182765fa046896547d3b4259aa1a67bd26e7ec58ab4be650c5552ef0360caf9dae489d53b845b872dc8880000000000000003";
+  private static final String INVALID_SIGNATURE_PACKET =
+      "43f91d11b3338b4dbdf16db4f9fa25d7b4e2db81e6fd63f8f6884dfaea851e106f8f692c77169b387bde7c38832cf2d37a9b97b1553d07587ebe251ee21ee36e0ed54fd9218e3feea3bd13ca6982b25c204d5186e7ec5373ea664c91d42467b30102f3cb842f3ee37b82040e82765fa04139782abaccbc8fd290a7fde1ff138943fa9659f7bd67f97c97b09893d1ee8a84607806e108";
 
   @Test
   public void shouldDecodeValidPongPacket() {
@@ -60,6 +63,11 @@ public class PacketTest {
   public void shouldRoundTripPacket() {
     final Packet packet = decode(VALID_PONG_PACKET);
     assertThat(Hex.toHexString(packet.encode().getBytes())).isEqualTo(VALID_PONG_PACKET);
+  }
+
+  @Test(expected = PeerDiscoveryPacketDecodingException.class)
+  public void invalidSignatureShouldThrowPeerDiscoveryPacketDecodingException() {
+    decode(INVALID_SIGNATURE_PACKET);
   }
 
   private Packet decode(final String hexData) {


### PR DESCRIPTION
## PR description
Catches packets where deciding public key failed, reducing the log level from ERROR to DEBUG.

## Fixed Issue(s)
fixes #2142

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).