### PR TITLE
qbft roundchange metadata message encoding to match quorum

### DIFF
--- a/consensus/qbft/build.gradle
+++ b/consensus/qbft/build.gradle
@@ -117,7 +117,7 @@ task ('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = 'df4ad968987672e30c598e3e2196cec470a72cbf'
+    def expectedHash = '3862d7282e017f8d2c5af88e4c1eeeafcbb97697'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "consensus/qbft/src/reference-test/resources").toAbsolutePath()
     try {
       exec {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/PreparedRoundMetadata.java
@@ -46,8 +46,8 @@ public class PreparedRoundMetadata {
    * @return A PreparedRoundMetadata as extracted from the supplied RLP input
    */
   public static PreparedRoundMetadata readFrom(final RLPInput in) {
-    final Hash preparedBlockHash = Hash.wrap(in.readBytes32());
     final int preparedRound = in.readIntScalar();
+    final Hash preparedBlockHash = Hash.wrap(in.readBytes32());
     return new PreparedRoundMetadata(preparedBlockHash, preparedRound);
   }
 
@@ -57,8 +57,8 @@ public class PreparedRoundMetadata {
    * @param out The RLP buffer to add to
    */
   public void writeTo(final RLPOutput out) {
-    out.writeBytes(preparedBlockHash);
     out.writeIntScalar(preparedRound);
+    out.writeBytes(preparedBlockHash);
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Jason Frame <jasonwframe@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Update encoding of round change encoding to match that of quorum.

Order of fields in the metadata are different to what Besu was using.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2145 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).