### PR TITLE
Implement faucet for Aleut devnet

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -77,6 +77,7 @@ import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.GoQuorumOptions;
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
+import org.hyperledger.besu.config.experimental.ExperimentalFeatures;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.controller.TargetingGasLimitCalculator;
@@ -1203,6 +1204,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private void enableExperimentalEIPs() {
     // Usage of static command line flags is strictly reserved for experimental EIPs
     commandLine.addMixin("experimentalEIPs", ExperimentalEIPs.class);
+    commandLine.addMixin("experimentalFeatures", ExperimentalFeatures.class);
   }
 
   private void addSubCommands(

--- a/config/src/main/java/org/hyperledger/besu/config/experimental/ExperimentalFeatures.java
+++ b/config/src/main/java/org/hyperledger/besu/config/experimental/ExperimentalFeatures.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.config.experimental;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Flags defined in this class must be used with caution, and strictly reserved to experimental
+ * featurres.
+ */
+public class ExperimentalFeatures {
+  public static final int FAUCET_DEFAULT_VALUE = 5;
+
+  @Option(
+      hidden = true,
+      names = {"--Xfaucet-value"},
+      description = "Faucet value denominate in ETH (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  public static Integer faucetValue = FAUCET_DEFAULT_VALUE;
+
+  @Option(
+      hidden = true,
+      names = {"--Xfaucet-private-key"},
+      description = "Faucet private key (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  public static String faucetPrivateKey =
+      "0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63";
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -42,6 +42,7 @@ public enum RpcMethod {
   DEBUG_TRACE_TRANSACTION("debug_traceTransaction"),
   DEBUG_BATCH_RAW_TRANSACTION("debug_batchSendRawTransaction"),
   DEBUG_GET_BAD_BLOCKS("debug_getBadBlocks"),
+  DEBUG_FAUCET("debug_faucet"),
   GOQUORUM_STORE_RAW("goquorum_storeRaw"),
   PRIV_CALL("priv_call"),
   PRIV_GET_PRIVATE_TRANSACTION("priv_getPrivateTransaction"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugFaucet.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugFaucet.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SignatureAlgorithm;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcErrorConverter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
+import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
+
+import java.math.BigInteger;
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class DebugFaucet implements JsonRpcMethod {
+  private static final com.google.common.base.Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
+      Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
+
+  private final Supplier<BlockchainQueries> blockchainQueries;
+  private final Supplier<TransactionPool> transactionPool;
+  private final BigInteger chaindId;
+  private final KeyPair faucetKeyPair;
+  private final Address faucetAddress;
+  final Wei faucetAmount;
+
+  public DebugFaucet(
+      final BlockchainQueries blockchainQueries,
+      final TransactionPool transactionPool,
+      final BigInteger chaindId,
+      final String faucetPrivateKey,
+      final Wei faucetAmount) {
+    this.blockchainQueries = Suppliers.ofInstance(blockchainQueries);
+    this.transactionPool = Suppliers.ofInstance(transactionPool);
+    this.chaindId = chaindId;
+    this.faucetKeyPair = keyPair(faucetPrivateKey);
+    this.faucetAddress = Util.publicKeyToAddress(this.faucetKeyPair.getPublicKey());
+    this.faucetAmount = faucetAmount;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.DEBUG_FAUCET.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
+    if (requestContext.getRequest().getParamLength() != 1) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
+    }
+    final String recipientAddress = requestContext.getRequiredParameter(0, String.class);
+
+    final Transaction transaction;
+    try {
+      final long nonce = this.blockchainQueries.get().getTransactionCount(faucetAddress);
+      transaction =
+          Transaction.builder()
+              .chainId(chaindId)
+              .nonce(nonce)
+              .value(faucetAmount)
+              .gasLimit(30000)
+              .payload(Bytes.EMPTY.trimLeadingZeros())
+              .gasPrice(Wei.of(1000))
+              .to(Address.fromHexString(recipientAddress))
+              .guessType()
+              .signAndBuild(faucetKeyPair);
+    } catch (final RLPException | IllegalArgumentException e) {
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
+    }
+
+    final ValidationResult<TransactionInvalidReason> validationResult =
+        transactionPool.get().addLocalTransaction(transaction);
+    return validationResult.either(
+        () ->
+            new JsonRpcSuccessResponse(
+                requestContext.getRequest().getId(), transaction.getHash().toString()),
+        errorReason ->
+            new JsonRpcErrorResponse(
+                requestContext.getRequest().getId(),
+                JsonRpcErrorConverter.convertTransactionInvalidReason(errorReason)));
+  }
+
+  private static KeyPair keyPair(final String privateKey) {
+    final SignatureAlgorithm signatureAlgorithm = SIGNATURE_ALGORITHM.get();
+    return signatureAlgorithm.createKeyPair(
+        signatureAlgorithm.createPrivateKey(Bytes32.fromHexString(privateKey)));
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionEIP1559Test.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionEIP1559Test.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import java.math.BigInteger;
-import java.util.List;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -35,7 +34,8 @@ public class TransactionEIP1559Test {
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
 
-  private static final String PRIVATE_KEY = "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3";
+  private static final String PRIVATE_KEY =
+      "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3";
 
   @After
   public void reset() {
@@ -45,10 +45,10 @@ public class TransactionEIP1559Test {
   @Test
   public void buildEip1559Transaction() {
     /*final List<AccessListEntry> accessListEntries =
-        List.of(
-            new AccessListEntry(
-                Address.fromHexString("0x000000000000000000000000000000000000aaaa"),
-                List.of(Bytes32.ZERO)));*/
+    List.of(
+        new AccessListEntry(
+            Address.fromHexString("0x000000000000000000000000000000000000aaaa"),
+            List.of(Bytes32.ZERO)));*/
     final Transaction tx =
         Transaction.builder()
             .chainId(new BigInteger("7822", 10))
@@ -58,11 +58,10 @@ public class TransactionEIP1559Test {
             .gasPremium(Wei.of(1000000000))
             .payload(Bytes.EMPTY.trimLeadingZeros())
             .feeCap(Wei.of(new BigInteger("5000000000", 10)))
-            //.gasPrice(Wei.of(1000000000))
+            // .gasPrice(Wei.of(1000000000))
             .to(Address.fromHexString("0xC3298C6341f82468309302611e24D3003Bc79B46"))
             .guessType()
-            .signAndBuild(
-                keyPair(PRIVATE_KEY));
+            .signAndBuild(keyPair(PRIVATE_KEY));
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     tx.writeTo(out);
     System.out.println(out.encoded().toHexString());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionEIP1559Test.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/TransactionEIP1559Test.java
@@ -35,6 +35,8 @@ public class TransactionEIP1559Test {
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
 
+  private static final String PRIVATE_KEY = "0xc87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3";
+
   @After
   public void reset() {
     ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
@@ -42,37 +44,35 @@ public class TransactionEIP1559Test {
 
   @Test
   public void buildEip1559Transaction() {
-    final List<AccessListEntry> accessListEntries =
+    /*final List<AccessListEntry> accessListEntries =
         List.of(
             new AccessListEntry(
                 Address.fromHexString("0x000000000000000000000000000000000000aaaa"),
-                List.of(Bytes32.ZERO)));
+                List.of(Bytes32.ZERO)));*/
     final Transaction tx =
         Transaction.builder()
-            .chainId(new BigInteger("1559", 10))
-            .nonce(0)
-            .value(Wei.ZERO)
+            .chainId(new BigInteger("7822", 10))
+            .nonce(1)
+            .value(Wei.fromEth(2))
             .gasLimit(30000)
-            .gasPremium(Wei.of(2))
+            .gasPremium(Wei.of(1000000000))
             .payload(Bytes.EMPTY.trimLeadingZeros())
             .feeCap(Wei.of(new BigInteger("5000000000", 10)))
-            .gasPrice(null)
-            .to(Address.fromHexString("0x000000000000000000000000000000000000aaaa"))
-            .accessList(accessListEntries)
+            //.gasPrice(Wei.of(1000000000))
+            .to(Address.fromHexString("0xC3298C6341f82468309302611e24D3003Bc79B46"))
             .guessType()
             .signAndBuild(
-                keyPair("0x8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63"));
+                keyPair(PRIVATE_KEY));
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     tx.writeTo(out);
     System.out.println(out.encoded().toHexString());
-    System.out.println(tx.getUpfrontCost());
     // final String raw =
     // "b8a902f8a686796f6c6f7632800285012a05f20082753094000000000000000000000000000000000000aaaa8080f838f794000000000000000000000000000000000000aaaae1a0000000000000000000000000000000000000000000000000000000000000000001a00c1d69648e348fe26155b45de45004f0e4195f6352d8f0935bc93e98a3e2a862a060064e5b9765c0ac74223b0cf49635c59ae0faf82044fd17bcc68a549ade6f95";
     final String raw = out.encoded().toHexString();
     final Transaction decoded = Transaction.readFrom(RLP.input(Bytes.fromHexString(raw)));
     System.out.println(decoded);
-    System.out.println(decoded.getAccessList().orElseThrow().get(0).getAddress().toHexString());
-    System.out.println(decoded.getAccessList().orElseThrow().get(0).getStorageKeys());
+    /*System.out.println(decoded.getAccessList().orElseThrow().get(0).getAddress().toHexString());
+    System.out.println(decoded.getAccessList().orElseThrow().get(0).getStorageKeys());*/
   }
 
   private static KeyPair keyPair(final String privateKey) {


### PR DESCRIPTION
## PR description

Implements `debug_faucet` JSON RPC endpoint to enable users to request `ETH` on Aleut devnet. The endpoint takes one parameter which corresponds to the address of the recipient.

Adds 2 experimental flags:
-  `--Xfaucet-value`: Faucet value denominate in ETH (default: 5 ETH)
- `--Xfaucet-private-key`: Faucet account private key (default: first account in `dev.json` genesis)

## Usage

### Sample request
```
{
   "method":"debug_faucet",
   "id":1,
   "jsonrpc":"2.0",
   "params":[
      "0xC3298C6341f82468309302611e24D3003Bc79B46"
   ]
}
```

### Success response
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": "0xb7d3183aff348d2d5994a978417129a4987d9f425295cc8e85b6563d2895a7bb"
}
```

### Unauthorized response
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -40100,
        "message": "Unauthorized"
    }
}
```
## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

Signed-off-by: Abdelhamid Bakhta <abdelhamid.bakhta@consensys.net>

