### PR TITLE
Remove Misleading Fast-Sync Logging

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloader.java
@@ -91,8 +91,7 @@ public class FastSyncDownloader {
     if (ExceptionUtils.rootCause(error) instanceof FastSyncException) {
       return CompletableFuture.failedFuture(error);
     } else if (ExceptionUtils.rootCause(error) instanceof StalledDownloadException) {
-      LOG.warn(
-          "Fast sync was unable to download the world state. Retrying with a new pivot block.");
+      LOG.info("Re-pivoting to newer block.");
       return start(FastSyncState.EMPTY_SYNC_STATE);
     } else {
       LOG.error(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/CompleteTaskStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/CompleteTaskStep.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.services.tasks.Task;
 
-import java.text.DecimalFormat;
 import java.util.function.LongSupplier;
 
 import org.apache.logging.log4j.LogManager;
@@ -35,7 +34,6 @@ public class CompleteTaskStep {
   private final RunnableCounter completedRequestsCounter;
   private final Counter retriedRequestsCounter;
   private final LongSupplier worldStatePendingRequestsCurrentSupplier;
-  private final DecimalFormat doubleFormatter = new DecimalFormat("#.##");
 
   public CompleteTaskStep(
       final WorldStateStorage worldStateStorage,
@@ -78,16 +76,9 @@ public class CompleteTaskStep {
 
   private void displayWorldStateSyncProgress() {
     LOG.info(
-        "Downloaded {} world state nodes. At least {} nodes remaining. Estimated World State completion: {} %.",
+        "Downloaded {} world state nodes. At least {} nodes remaining.",
         getCompletedRequests(),
-        worldStatePendingRequestsCurrentSupplier.getAsLong(),
-        doubleFormatter.format(computeWorldStateSyncProgress() * 100.0));
-  }
-
-  public double computeWorldStateSyncProgress() {
-    final double pendingRequests = getPendingRequests();
-    final double completedRequests = getCompletedRequests();
-    return completedRequests / (completedRequests + pendingRequests);
+        worldStatePendingRequestsCurrentSupplier.getAsLong());
   }
 
   long getCompletedRequests() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/CompleteTaskStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/CompleteTaskStepTest.java
@@ -78,13 +78,6 @@ public class CompleteTaskStepTest {
     verify(downloadState).checkCompletion(worldStateStorage, blockHeader);
   }
 
-  @Test
-  public void shouldComputeWorldStateProgress() {
-    completeTaskStep.markAsCompleteOrFailed(blockHeader, downloadState, validTask());
-    // One task has been completed and there are 2 pending requests, progress should be 1/4 (25%)
-    assertThat(completeTaskStep.computeWorldStateSyncProgress()).isEqualTo(1.0 / 4.0);
-  }
-
   private StubTask validTask() {
     final Hash hash =
         Hash.fromHexString("0x601a7b0d0267209790cf4c4d9e0cab11b26c537e2ade006412f48b070010e847");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Users have been confused by this logging all the time. Probably best we remove those aspects that confuse them.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2156 
## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).