### PR TITLE
buildDocker depends on assemble only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
             - besu-dockerhub-ro
       - buildDocker:
           requires:
-            - unitTests
+            - assemble
           context:
             - besu-dockerhub-ro            
       - publish:
@@ -314,7 +314,6 @@ workflows:
             - containerTests
             - acceptanceTests
             - referenceTests
-            - buildDocker
             - buildDocker
           context:
             - besu-dockerhub-ro


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Run buildDocker in parallel with tests. publishDocker still happens after buildDocker AND all tests (but doesn't run on PRs)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).