### PR TITLE
Bonsai trie : fix consensus issue on ropsten

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
@@ -244,7 +244,7 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
 
   @Override
   public UInt256 getOriginalStorageValue(final UInt256 key) {
-    return context.getStorageValue(address, key);
+    return context.getPriorStorageValue(address, key);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
@@ -244,7 +244,7 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
 
   @Override
   public UInt256 getOriginalStorageValue(final UInt256 key) {
-    return context.getPriorStorageValue(address, key);
+    return context.getStorageValue(address, key);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiValue.java
@@ -24,10 +24,12 @@ import java.util.function.BiConsumer;
 public class BonsaiValue<T> {
   private T prior;
   private T updated;
+  private boolean cleared;
 
   BonsaiValue(final T prior, final T updated) {
     this.prior = prior;
     this.updated = updated;
+    this.cleared = false;
   }
 
   public T getPrior() {
@@ -43,6 +45,7 @@ public class BonsaiValue<T> {
   }
 
   public void setUpdated(final T updated) {
+    this.cleared = updated == null;
     this.updated = updated;
   }
 
@@ -69,8 +72,19 @@ public class BonsaiValue<T> {
     return Objects.equals(updated, prior);
   }
 
+  public boolean isCleared() {
+    return cleared;
+  }
+
   @Override
   public String toString() {
-    return "BonsaiValue{" + "prior=" + prior + ", updated=" + updated + '}';
+    return "BonsaiValue{"
+        + "prior="
+        + prior
+        + ", updated="
+        + updated
+        + ", cleared="
+        + cleared
+        + '}';
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -327,6 +327,9 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
         return original;
       }
     }
+    if (storageToClear.contains(address)) {
+      return UInt256.ZERO;
+    }
     return getStorageValue(address, storageKey);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -311,13 +311,13 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
   @Override
   public UInt256 getPriorStorageValue(final Address address, final UInt256 storageKey) {
     // TODO maybe log the read into the trie layer?
-    if (storageToClear.contains(address)) {
-      return UInt256.ZERO;
-    }
     final Map<Hash, BonsaiValue<UInt256>> localAccountStorage = storageToUpdate.get(address);
     final Hash slotHash = Hash.hash(storageKey.toBytes());
     if (localAccountStorage != null && localAccountStorage.containsKey(slotHash)) {
       final BonsaiValue<UInt256> value = localAccountStorage.get(slotHash);
+      if (value.isCleared()) {
+        return UInt256.ZERO;
+      }
       final UInt256 updated = value.getUpdated();
       if (updated != null) {
         return updated;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -265,6 +265,10 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
         storageToUpdate.remove(updatedAddress);
       }
 
+      if (tracked.getStorageWasCleared()) {
+        tracked.setStorageWasCleared(false); // storage already cleared for this transaction
+      }
+
       // TODO maybe add address preimage?
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UpdateTrackingAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UpdateTrackingAccount.java
@@ -263,6 +263,10 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
     return storageWasCleared;
   }
 
+  public void setStorageWasCleared(final boolean storageWasCleared) {
+    this.storageWasCleared = storageWasCleared;
+  }
+
   @Override
   public String toString() {
     String storage = updatedStorage.isEmpty() ? "[not updated]" : updatedStorage.toString();


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Fix an invalid originalValue for a specific storage slot :

in the same block we are doing
1 ) create a contract
2) change the value of a slot
3) change a second time the value of the same slot. the original is empty while it should be the previous value of the step 2

Why because when we create a contract we clear the storage so the method return 0x 

https://github.com/hyperledger/besu/blob/e13dd77c8d3a4ad6b003d2c71526a39818195ea8/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java#L314

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).