### PR TITLE
Remove docker-ro creds from circle ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ executors:
   besu_executor_med: # 2cpu, 4G ram
     docker:
       - image: circleci/openjdk:11.0.8-jdk-buster
-        auth:
-          username: $DOCKER_USER_RO
-          password: $DOCKER_PASSWORD_RO
     resource_class: medium
     working_directory: ~/project
     environment:
@@ -18,9 +15,6 @@ executors:
   besu_executor_xl: # 8cpu, 16G ram
     docker:
       - image: circleci/openjdk:11.0.8-jdk-buster
-        auth:
-          username: $DOCKER_USER_RO
-          password: $DOCKER_PASSWORD_RO
     resource_class: xlarge
     working_directory: ~/project
     environment:
@@ -294,41 +288,27 @@ workflows:
       - unitTests:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - testWindows:
           requires:
             - assemble
       - referenceTests:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - integrationTests:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - acceptanceTests:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - acceptanceTestsQuorum:
           requires:
             - buildDocker
-          context:
-            - besu-dockerhub-ro
       - containerTests:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - buildDocker:
           requires:
             - assemble
-          context:
-            - besu-dockerhub-ro
       - publish:
           filters:
             branches:
@@ -342,8 +322,6 @@ workflows:
             - acceptanceTests
             - referenceTests
             - buildDocker
-          context:
-            - besu-dockerhub-ro
       - publishDocker:
           filters:
             branches:


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Change to docker creds handling so that CI can run on external contributors' PRs

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
n/a

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).