### PR TITLE
check that doesn't break during release

### DIFF
--- a/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
+++ b/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
@@ -121,7 +121,7 @@ public class ContainerTestBase {
             goQuorumContainer.getContainerIpAddress(),
             goQuorumContainer.getMappedPort(goQuorumRpcPort));
 
-    waitFor(10, () -> assertClientVersion(besuWeb3j, "dev"));
+    waitFor(10, () -> assertClientVersion(besuWeb3j, "besu"));
     waitFor(10, () -> assertClientVersion(goQuorumWeb3j, goQuorumVersion));
 
     // Tell GoQuorum to peer to Besu


### PR DESCRIPTION
`dev` isn't present in the version string during a release. `besu` is, however.