### PR TITLE
add support for 1559 in retesteth besu command

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.config;
 
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
+
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +71,15 @@ public interface GenesisConfigOptions {
 
   // TODO EIP-1559 change for the actual fork name when known
   OptionalLong getEIP1559BlockNumber();
+
+  default Long getGenesisBaseFee() {
+    return getEIP1559BlockNumber().stream()
+        .boxed()
+        .filter(g -> g.equals(0L))
+        .map(g -> ExperimentalEIPs.initialBasefee)
+        .findAny()
+        .orElse(null);
+  }
 
   List<Long> getForks();
 

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -72,9 +72,10 @@ public interface GenesisConfigOptions {
   // TODO EIP-1559 change for the actual fork name when known
   OptionalLong getEIP1559BlockNumber();
 
-  default OptionalLong getGenesisBaseFee() {
+  default Optional<Long> getGenesisBaseFee() {
     return getEIP1559BlockNumber().stream()
-        .filter(g -> g == 0L)
+        .boxed()
+        .filter(g -> g.equals(0L))
         .map(g -> ExperimentalEIPs.initialBasefee)
         .findAny();
   }

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -72,13 +72,11 @@ public interface GenesisConfigOptions {
   // TODO EIP-1559 change for the actual fork name when known
   OptionalLong getEIP1559BlockNumber();
 
-  default Long getGenesisBaseFee() {
+  default OptionalLong getGenesisBaseFee() {
     return getEIP1559BlockNumber().stream()
-        .boxed()
-        .filter(g -> g.equals(0L))
+        .filter(g -> g == 0L)
         .map(g -> ExperimentalEIPs.initialBasefee)
-        .findAny()
-        .orElse(null);
+        .findAny();
   }
 
   List<Long> getForks();

--- a/config/src/main/java/org/hyperledger/besu/config/experimental/ExperimentalEIPs.java
+++ b/config/src/main/java/org/hyperledger/besu/config/experimental/ExperimentalEIPs.java
@@ -23,6 +23,7 @@ import picocli.CommandLine.Option;
 public class ExperimentalEIPs {
   // To make it easier for tests to reset the value to default
   public static final boolean EIP1559_ENABLED_DEFAULT_VALUE = false;
+  public static final long EIP1559_BASEFEE_DEFAULT_VALUE = 1000000000L;
 
   @Option(
       hidden = true,
@@ -47,7 +48,7 @@ public class ExperimentalEIPs {
       hidden = true,
       names = {"--Xeip1559-initial-base-fee"},
       arity = "1")
-  public static Long initialBasefee = 1000000000L;
+  public static Long initialBasefee = EIP1559_BASEFEE_DEFAULT_VALUE;
 
   @Option(
       hidden = true,

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigOptionsTest.java
@@ -193,7 +193,7 @@ public class GenesisConfigOptionsTest {
       ExperimentalEIPs.eip1559Enabled = true;
       final GenesisConfigOptions config = fromConfigOptions(singletonMap("aleutblock", 1000));
       assertThat(config.getEIP1559BlockNumber()).hasValue(1000);
-      assertThat(config.getGenesisBaseFee()).isNull();
+      assertThat(config.getGenesisBaseFee()).isEmpty();
     } finally {
       ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
     }
@@ -207,7 +207,7 @@ public class GenesisConfigOptionsTest {
       final GenesisConfigOptions config = fromConfigOptions(singletonMap("aleutblock", 0));
       assertThat(config.getEIP1559BlockNumber()).hasValue(0);
       assertThat(config.getGenesisBaseFee())
-          .isEqualTo(ExperimentalEIPs.EIP1559_BASEFEE_DEFAULT_VALUE);
+          .hasValue(ExperimentalEIPs.EIP1559_BASEFEE_DEFAULT_VALUE);
     } finally {
       ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
     }

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigOptionsTest.java
@@ -193,6 +193,21 @@ public class GenesisConfigOptionsTest {
       ExperimentalEIPs.eip1559Enabled = true;
       final GenesisConfigOptions config = fromConfigOptions(singletonMap("aleutblock", 1000));
       assertThat(config.getEIP1559BlockNumber()).hasValue(1000);
+      assertThat(config.getGenesisBaseFee()).isNull();
+    } finally {
+      ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
+    }
+  }
+
+  @Test
+  // TODO EIP-1559 change for the actual fork name when known
+  public void shouldGetEIP1559BaseFeeAtGenesis() {
+    try {
+      ExperimentalEIPs.eip1559Enabled = true;
+      final GenesisConfigOptions config = fromConfigOptions(singletonMap("aleutblock", 0));
+      assertThat(config.getEIP1559BlockNumber()).hasValue(0);
+      assertThat(config.getGenesisBaseFee())
+          .isEqualTo(ExperimentalEIPs.EIP1559_BASEFEE_DEFAULT_VALUE);
     } finally {
       ExperimentalEIPs.eip1559Enabled = ExperimentalEIPs.EIP1559_ENABLED_DEFAULT_VALUE;
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -156,7 +156,7 @@ public final class GenesisState {
         .mixHash(parseMixHash(genesis))
         .nonce(parseNonce(genesis))
         .blockHeaderFunctions(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule))
-        .baseFee(genesis.getConfigOptions().getGenesisBaseFee())
+        .baseFee(genesis.getConfigOptions().getGenesisBaseFee().orElse(null))
         .buildBlockHeader();
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -156,6 +156,7 @@ public final class GenesisState {
         .mixHash(parseMixHash(genesis))
         .nonce(parseNonce(genesis))
         .blockHeaderFunctions(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule))
+        .baseFee(genesis.getConfigOptions().getGenesisBaseFee())
         .buildBlockHeader();
   }
 

--- a/ethereum/retesteth/src/test/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParamsTest.java
+++ b/ethereum/retesteth/src/test/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParamsTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.retesteth.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
@@ -84,5 +85,32 @@ public class TestSetChainParamsTest {
         .isEqualTo("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     assertThat(blockHeader.getOmmersHash().toString())
         .isEqualTo("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+  }
+
+  @Test
+  public void testValidate1559GenesisImport() throws IOException {
+    ExperimentalEIPs.eip1559Enabled = true;
+    final String chainParamsJsonString =
+        Resources.toString(
+            TestSetChainParamsTest.class.getResource("1559ChainParams.json"), Charsets.UTF_8);
+    final JsonObject chainParamsJson = new JsonObject(chainParamsJsonString);
+
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest(
+                "2.0", TestSetChainParams.METHOD_NAME, new Object[] {chainParamsJson.getMap()}));
+
+    assertThat(test_setChainParams.response(request))
+        .isEqualTo(new JsonRpcSuccessResponse(null, true));
+
+    final BlockHeader blockHeader = context.getBlockHeader(0);
+    assertThat(blockHeader.getDifficulty()).isEqualTo(UInt256.fromHexString("0x20000"));
+    assertThat(blockHeader.getGasLimit()).isEqualTo(1234L);
+    assertThat(blockHeader.getBaseFee()).hasValue(12345L);
+    assertThat(blockHeader.getExtraData().toHexString()).isEqualTo("0x00");
+    assertThat(blockHeader.getTimestamp()).isEqualTo(0l);
+    assertThat(blockHeader.getNonce()).isEqualTo(0L);
+    assertThat(blockHeader.getMixHash().toHexString())
+        .isEqualTo("0x0000000000000000000000000000000000000000000000000000000000000000");
   }
 }

--- a/ethereum/retesteth/src/test/resources/org/hyperledger/besu/ethereum/retesteth/methods/1559ChainParams.json
+++ b/ethereum/retesteth/src/test/resources/org/hyperledger/besu/ethereum/retesteth/methods/1559ChainParams.json
@@ -1,0 +1,21 @@
+{
+  "genesis" : {
+    "author" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+    "difficulty" : "0x020000",
+    "gasTarget" : "0x04d2",
+    "baseFeePerGas" : "0x3039",
+    "extraData" : "0x00",
+    "timestamp" : "0x00",
+    "nonce" : "0x0000000000000000",
+    "mixHash" : "0x0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "params": {
+    "EIP150ForkBlock": "0x00",
+    "EIP158ForkBlock": "0x00",
+    "byzantiumForkBlock": "0x00",
+    "homesteadForkBlock": "0x00",
+    "londonForkBlock": "0x00"
+  },
+  "sealEngine": "NoProof",
+  "accounts": {}
+}


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
* add support for 1559 in test_setChainParams 
* add a "1559 at genesis" provision

This pr kicks the can down the road for 2 things: 
* hardfork naming
* 1559 baseFee as a part of genesis json configuration

the first is NBD, but we might want to incorporate baseFee in genesis config at some point.  Probably once we move 1559 out of 'experimental' status.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2180

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).