### PR TITLE
Ignoring changelog modification on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,19 @@ notify:
     - url: $HUBOT_URL
 
 commands:
+
+  check-tests-needed:
+    description: "Checks if tests are needed"
+    steps:
+      - checkout
+      - run:
+          name: Checking for changes
+          command: |
+            changes=`git --no-pager diff --name-only master...HEAD`
+            if [ "$changes" = ".circleci/config.yml" ]; then
+              echo "Only found a CHANGELOG change. Stopping build"
+              circleci-agent step halt
+            fi
   prepare:
     description: "Prepare"
     steps:
@@ -87,6 +100,7 @@ jobs:
   assemble:
     executor: besu_executor_xl
     steps:
+      - check-tests-needed
       - prepare
       - run:
           name: DCO check
@@ -112,8 +126,11 @@ jobs:
           destination: distributions
           when: always
   testWindows:
-    executor: win/default
+    executor:
+      name: win/default
+      shell: bash.exe
     steps:
+      - check-tests-needed
       - attach_workspace:
           at: ~/project
       - run:
@@ -128,12 +145,13 @@ jobs:
           name: Test Besu Windows executable
           no_output_timeout: 10m
           command: |
-            build\distributions\besu\bin\besu.bat --help
-            build\distributions\besu\bin\besu.bat --version
+            ./build/distributions/besu/bin/besu.bat --help
+            ./build/distributions/besu/bin/besu.bat --version
 
   unitTests:
     executor: besu_executor_xl
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -147,6 +165,7 @@ jobs:
   integrationTests:
     executor: besu_executor_xl
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -167,6 +186,7 @@ jobs:
   referenceTests:
     executor: besu_executor_xl
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -182,6 +202,7 @@ jobs:
     parallelism: 8
     executor: besu_executor_xl
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -204,6 +225,7 @@ jobs:
     parallelism: 1
     executor: machine_executor
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -217,6 +239,7 @@ jobs:
     parallelism: 1
     executor: acceptance_tests_executor
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project
@@ -233,6 +256,7 @@ jobs:
   buildDocker:
     executor: besu_executor_med
     steps:
+      - check-tests-needed
       - prepare
       - attach_workspace:
           at: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ commands:
           name: Checking for changes
           command: |
             changes=`git --no-pager diff --name-only master...HEAD`
-            if [ "$changes" = ".circleci/config.yml" ]; then
+            echo $changes
+            if [ "$changes" = "CHANGELOG.md" ]; then
               echo "Only found a CHANGELOG change. Stopping build"
               circleci-agent step halt
             fi


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

During releases we can waste time waiting for the pipeline while we only change the CHANGELOG. This PR will not run the tests if we only modify the CHANGELOG

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).