### PR TITLE
fix selection of receive RPC

### DIFF
--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
@@ -52,7 +52,7 @@ public class GoQuorumEnclaveTest {
 
   @Test
   public void upCheck() {
-    when(vertxTransmitter.get(any(), any(), ArgumentMatchers.contains("/upcheck"), any()))
+    when(vertxTransmitter.get(any(), any(), ArgumentMatchers.contains("/upcheck"), any(), false))
         .thenReturn("I'm up!");
 
     assertThat(enclave.upCheck()).isTrue();
@@ -60,7 +60,8 @@ public class GoQuorumEnclaveTest {
 
   @Test
   public void receiveThrowsWhenPayloadDoesNotExist() {
-    when(vertxTransmitter.get(any(), any(), ArgumentMatchers.contains("/transaction"), any()))
+    when(vertxTransmitter.get(
+            any(), any(), ArgumentMatchers.contains("/transaction"), any(), false))
         .thenThrow(
             new EnclaveClientException(404, "Message with hash " + MOCK_KEY + " was not found"));
 
@@ -72,7 +73,8 @@ public class GoQuorumEnclaveTest {
   @Test
   public void sendAndReceive() {
     when(vertxTransmitter.post(any(), any(), any(), any())).thenReturn(new SendResponse(KEY));
-    when(vertxTransmitter.get(any(), any(), ArgumentMatchers.contains("/transaction"), any()))
+    when(vertxTransmitter.get(
+            any(), any(), ArgumentMatchers.contains("/transaction"), any(), false))
         .thenReturn(new GoQuorumReceiveResponse(PAYLOAD, 0, null, null));
 
     final List<String> publicKeys = Arrays.asList("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.enclave;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +53,8 @@ public class GoQuorumEnclaveTest {
 
   @Test
   public void upCheck() {
-    when(vertxTransmitter.get(any(), any(), ArgumentMatchers.contains("/upcheck"), any(), false))
+    when(vertxTransmitter.get(
+            any(), any(), ArgumentMatchers.contains("/upcheck"), any(), anyBoolean()))
         .thenReturn("I'm up!");
 
     assertThat(enclave.upCheck()).isTrue();
@@ -61,7 +63,7 @@ public class GoQuorumEnclaveTest {
   @Test
   public void receiveThrowsWhenPayloadDoesNotExist() {
     when(vertxTransmitter.get(
-            any(), any(), ArgumentMatchers.contains("/transaction"), any(), false))
+            any(), any(), ArgumentMatchers.contains("/transaction"), any(), anyBoolean()))
         .thenThrow(
             new EnclaveClientException(404, "Message with hash " + MOCK_KEY + " was not found"));
 
@@ -74,7 +76,7 @@ public class GoQuorumEnclaveTest {
   public void sendAndReceive() {
     when(vertxTransmitter.post(any(), any(), any(), any())).thenReturn(new SendResponse(KEY));
     when(vertxTransmitter.get(
-            any(), any(), ArgumentMatchers.contains("/transaction"), any(), false))
+            any(), any(), ArgumentMatchers.contains("/transaction"), any(), anyBoolean()))
         .thenReturn(new GoQuorumReceiveResponse(PAYLOAD, 0, null, null));
 
     final List<String> publicKeys = Arrays.asList("/+UuD63zItL1EbjxkKUljMgG8Z1w0AJ8pNOR4iq2yQc=");

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/Enclave.java
@@ -49,7 +49,7 @@ public class Enclave {
   public boolean upCheck() {
     try {
       final String upcheckResponse =
-          requestTransmitter.get(null, null, "/upcheck", this::handleRawResponse);
+          requestTransmitter.get(null, null, "/upcheck", this::handleRawResponse, false);
       return upcheckResponse.equals("I'm up!");
     } catch (final Exception e) {
       return false;

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/GoQuorumEnclave.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/GoQuorumEnclave.java
@@ -44,7 +44,7 @@ public class GoQuorumEnclave {
   public boolean upCheck() {
     try {
       final String upcheckResponse =
-          requestTransmitter.get(null, null, "/upcheck", this::handleRawResponse);
+          requestTransmitter.get(null, null, "/upcheck", this::handleRawResponse, false);
       return upcheckResponse.equals("I'm up!");
     } catch (final Exception e) {
       return false;
@@ -99,7 +99,6 @@ public class GoQuorumEnclave {
     } catch (final JsonProcessingException e) {
       throw new EnclaveClientException(400, "Unable to serialize request.");
     }
-
     return requestTransmitter.post(mediaType, bodyText, endpoint, responseBodyHandler);
   }
 
@@ -107,7 +106,7 @@ public class GoQuorumEnclave {
       final String mediaType,
       final String endpoint,
       final ResponseBodyHandler<T> responseBodyHandler) {
-    final T t = requestTransmitter.get(mediaType, null, endpoint, responseBodyHandler);
+    final T t = requestTransmitter.get(mediaType, null, endpoint, responseBodyHandler, true);
     return t;
   }
 

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/RequestTransmitter.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/RequestTransmitter.java
@@ -31,5 +31,6 @@ public interface RequestTransmitter {
       String mediaType,
       String content,
       String endpoint,
-      ResponseBodyHandler<T> responseBodyHandler);
+      ResponseBodyHandler<T> responseBodyHandler,
+      final boolean withAcceptJsonHeader);
 }

--- a/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
+++ b/enclave/src/main/java/org/hyperledger/besu/enclave/VertxRequestTransmitter.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -26,6 +27,7 @@ import io.vertx.core.http.HttpMethod;
 
 public class VertxRequestTransmitter implements RequestTransmitter {
 
+  private static final String APPLICATION_JSON = "application/json";
   private final HttpClient client;
   private static final long REQUEST_TIMEOUT_MS = 5000L;
 
@@ -71,7 +73,11 @@ public class VertxRequestTransmitter implements RequestTransmitter {
               .handler(response -> handleResponse(response, responseHandler, result))
               .setTimeout(REQUEST_TIMEOUT_MS)
               .exceptionHandler(result::completeExceptionally)
-              .setChunked(false);
+              .setChunked(false)
+              .putHeader(
+                  HttpHeaderNames.ACCEPT,
+                  APPLICATION_JSON); // necessary for using /transaction/{hash} with Tessera, as
+      // this is not unique without this
       contentType.ifPresent(ct -> request.putHeader(HttpHeaders.CONTENT_TYPE, ct));
       if (content.isPresent()) {
         request.end(content.get());


### PR DESCRIPTION
There are two RPC in Tessera for GET "/transaction/{hash}". This makes sure we are using the right one.

Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>
 