### PR TITLE
fix goquorum privacy

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WorldUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WorldUpdater.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
+import org.hyperledger.besu.ethereum.vm.MessageFrame;
+
 import java.util.Collection;
 import java.util.Optional;
 
@@ -89,6 +91,17 @@ public interface WorldUpdater extends MutableWorldView {
    * @return the account {@code address}, or {@code null} if the account does not exist.
    */
   EvmAccount getAccount(Address address);
+
+  /**
+   * Retrieves the senders account, returning a modifiable object (whose updates are accumulated by
+   * this updater).
+   *
+   * @param frame the current message frame.
+   * @return the account {@code address}, or {@code null} if the account does not exist.
+   */
+  default EvmAccount getSenderAccount(final MessageFrame frame) {
+    return getAccount(frame.getSenderAddress());
+  }
 
   /**
    * Deletes the provided account.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetContractCreationProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetContractCreationProcessor.java
@@ -110,8 +110,8 @@ public class MainnetContractCreationProcessor extends AbstractMessageProcessor {
       LOG.trace("Executing contract-creation");
     }
     try {
-      final MutableAccount sender =
-          frame.getWorldState().getOrCreateSenderAccount(frame.getSenderAddress()).getMutable();
+
+      final MutableAccount sender = frame.getWorldState().getSenderAccount(frame).getMutable();
       sender.decrementBalance(frame.getValue());
 
       final MutableAccount contract =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetMessageCallProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetMessageCallProcessor.java
@@ -85,8 +85,7 @@ public class MainnetMessageCallProcessor extends AbstractMessageProcessor {
    * of the world state of this executor.
    */
   private void transferValue(final MessageFrame frame) {
-    final MutableAccount senderAccount =
-        frame.getWorldState().getOrCreateSenderAccount(frame.getSenderAddress()).getMutable();
+    final MutableAccount senderAccount = frame.getWorldState().getSenderAccount(frame).getMutable();
     // The yellow paper explicitly states that if the recipient account doesn't exist at this
     // point, it is created.
     final MutableAccount recipientAccount =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/GoQuorumMutablePrivateWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/GoQuorumMutablePrivateWorldStateUpdater.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.EvmAccount;
 import org.hyperledger.besu.ethereum.core.UpdateTrackingAccount;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
+import org.hyperledger.besu.ethereum.vm.MessageFrame;
 
 // This class uses a public WorldUpdater and a private WorldUpdater to provide a
 // MutableWorldStateUpdater that can read and write from the private world state and can read from
@@ -32,6 +33,16 @@ public class GoQuorumMutablePrivateWorldStateUpdater
 
   @Override
   public EvmAccount getOrCreateSenderAccount(final Address address) {
-    return new UpdateTrackingAccount<EvmAccount>(publicWorldUpdater.getOrCreate(address));
+    return new UpdateTrackingAccount<>(publicWorldUpdater.getOrCreate(address));
+  }
+
+  @Override
+  public EvmAccount getSenderAccount(final MessageFrame frame) {
+    final Address senderAddress = frame.getSenderAddress();
+    if (senderAddress.equals(frame.getOriginatorAddress())) {
+      return new UpdateTrackingAccount<>(publicWorldUpdater.getOrCreate(senderAddress));
+    } else {
+      return getAccount(senderAddress);
+    }
   }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -206,7 +206,7 @@ public class StateTestSubCommand implements Runnable {
         if (coinbase != null && coinbase.isEmpty()) {
           worldStateUpdater.deleteAccount(coinbase.getAddress());
         }
-        final Account sender = worldStateUpdater.getOrCreateSenderAccount(transaction.getSender());
+        final Account sender = worldStateUpdater.getAccount(transaction.getSender());
         if (sender != null && sender.isEmpty()) {
           worldStateUpdater.deleteAccount(sender.getAddress());
         }


### PR DESCRIPTION
fixes #2198
The bug was that when we have a private transaction in goquorum mode and a contract calls another contract or a contract deploys another contract the sender account from the public world state was used, which caused the nonce to be incremented in the public state. 

Signed-off-by: Stefan Pingel <stefan.pingel@consensys.net>
