### PR TITLE
entropy - reduce parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    parallelism: 8
+    parallelism: 4
     executor: besu_executor_xl
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    parallelism: 4
+    parallelism: 6
     executor: besu_executor_xl
     steps:
       - prepare


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Reduce parallelism to improve thread blockage situation.
Changing from 8 to 4 increased test time from 13 to 23 min
Changing to 6 made it ~15 min which is acceptable.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).