### PR TITLE
Make 2930 accesslist transactions use frontier txn price calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 
+- Added ACCESS_LIST transactions to the list of transactions using legacy gas pricing for 1559
 - Reduced logging level of public key decoding failure of malformed packets. [\#2143](https://github.com/hyperledger/besu/pull/2143)
 
 ### Early Access Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug Fixes
 
-- Added ACCESS_LIST transactions to the list of transactions using legacy gas pricing for 1559
+- Added ACCESS_LIST transactions to the list of transactions using legacy gas pricing for 1559 [\#2239](https://github.com/hyperledger/besu/pull/2239)
 - Reduced logging level of public key decoding failure of malformed packets. [\#2143](https://github.com/hyperledger/besu/pull/2143)
 
 ### Early Access Features

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -152,7 +152,7 @@ public class Transaction implements org.hyperledger.besu.plugin.data.Transaction
 
     if (maybeAccessList.isPresent()) {
       checkState(
-          transactionType.supportAccessList(),
+          transactionType.supportsAccessList(),
           "Must not specify access list for transaction not supporting it");
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculator.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.core.fees;
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Wei;
-import org.hyperledger.besu.plugin.data.TransactionType;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -34,7 +33,7 @@ public interface TransactionPriceCalculator {
     return (transaction, maybeBaseFee) -> {
       ExperimentalEIPs.eip1559MustBeEnabled();
       final Wei baseFee = Wei.of(maybeBaseFee.orElseThrow());
-      if (transaction.getType().equals(TransactionType.FRONTIER)) {
+      if (!transaction.getType().supports1559FeeMarket()) {
         return transaction.getGasPrice();
       }
       final Wei gasPremium =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculatorTest.java
@@ -75,15 +75,49 @@ public class TransactionPriceCalculatorTest {
           // legacy transaction must return gas price
           {FRONTIER_CALCULATOR, FRONTIER, Wei.of(578L), null, null, Optional.empty(), Wei.of(578L)},
           // ACCESSLIST transaction must return gas price
-          {FRONTIER_CALCULATOR, ACCESS_LIST, Wei.of(578L), null, null, Optional.empty(), Wei.of(578L)},
+          {
+            FRONTIER_CALCULATOR,
+            ACCESS_LIST,
+            Wei.of(578L),
+            null,
+            null,
+            Optional.empty(),
+            Wei.of(578L)
+          },
           // legacy transaction must return gas price
-          {EIP_1559_CALCULATOR, FRONTIER, Wei.of(578L), null, null, Optional.of(150L), Wei.of(578L)},
+          {
+            EIP_1559_CALCULATOR, FRONTIER, Wei.of(578L), null, null, Optional.of(150L), Wei.of(578L)
+          },
           // ACCESSLIST transaction must return gas price
-          {EIP_1559_CALCULATOR, ACCESS_LIST, Wei.of(578L), null, null, Optional.of(150L), Wei.of(578L)},
+          {
+            EIP_1559_CALCULATOR,
+            ACCESS_LIST,
+            Wei.of(578L),
+            null,
+            null,
+            Optional.of(150L),
+            Wei.of(578L)
+          },
           // EIP-1559 must return gas premium + base fee
-          {EIP_1559_CALCULATOR, EIP1559, null, Wei.of(100L), Wei.of(300L), Optional.of(150L), Wei.of(250L)},
+          {
+            EIP_1559_CALCULATOR,
+            EIP1559,
+            null,
+            Wei.of(100L),
+            Wei.of(300L),
+            Optional.of(150L),
+            Wei.of(250L)
+          },
           // EIP-1559 must return fee cap
-          {EIP_1559_CALCULATOR, EIP1559, null, Wei.of(100L), Wei.of(300L), Optional.of(250L), Wei.of(300L)}
+          {
+            EIP_1559_CALCULATOR,
+            EIP1559,
+            null,
+            Wei.of(100L),
+            Wei.of(300L),
+            Optional.of(250L),
+            Wei.of(300L)
+          }
         });
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionPriceCalculatorTest.java
@@ -15,6 +15,9 @@
 package org.hyperledger.besu.ethereum.core.fees;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.plugin.data.TransactionType.ACCESS_LIST;
+import static org.hyperledger.besu.plugin.data.TransactionType.EIP1559;
+import static org.hyperledger.besu.plugin.data.TransactionType.FRONTIER;
 
 import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -23,6 +26,7 @@ import org.hyperledger.besu.plugin.data.TransactionType;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.After;
@@ -40,6 +44,7 @@ public class TransactionPriceCalculatorTest {
       TransactionPriceCalculator.eip1559();
 
   private final TransactionPriceCalculator transactionPriceCalculator;
+  private final TransactionType transactionType;
   private final Wei gasPrice;
   private final Wei gasPremium;
   private final Wei feeCap;
@@ -48,12 +53,14 @@ public class TransactionPriceCalculatorTest {
 
   public TransactionPriceCalculatorTest(
       final TransactionPriceCalculator transactionPriceCalculator,
+      final TransactionType transactionType,
       final Wei gasPrice,
       final Wei gasPremium,
       final Wei feeCap,
       final Optional<Long> baseFee,
       final Wei expectedPrice) {
     this.transactionPriceCalculator = transactionPriceCalculator;
+    this.transactionType = transactionType;
     this.gasPrice = gasPrice;
     this.gasPremium = gasPremium;
     this.feeCap = feeCap;
@@ -66,11 +73,17 @@ public class TransactionPriceCalculatorTest {
     return Arrays.asList(
         new Object[][] {
           // legacy transaction must return gas price
-          {FRONTIER_CALCULATOR, Wei.of(578L), null, null, Optional.empty(), Wei.of(578L)},
+          {FRONTIER_CALCULATOR, FRONTIER, Wei.of(578L), null, null, Optional.empty(), Wei.of(578L)},
+          // ACCESSLIST transaction must return gas price
+          {FRONTIER_CALCULATOR, ACCESS_LIST, Wei.of(578L), null, null, Optional.empty(), Wei.of(578L)},
+          // legacy transaction must return gas price
+          {EIP_1559_CALCULATOR, FRONTIER, Wei.of(578L), null, null, Optional.of(150L), Wei.of(578L)},
+          // ACCESSLIST transaction must return gas price
+          {EIP_1559_CALCULATOR, ACCESS_LIST, Wei.of(578L), null, null, Optional.of(150L), Wei.of(578L)},
           // EIP-1559 must return gas premium + base fee
-          {EIP_1559_CALCULATOR, null, Wei.of(100L), Wei.of(300L), Optional.of(150L), Wei.of(250L)},
+          {EIP_1559_CALCULATOR, EIP1559, null, Wei.of(100L), Wei.of(300L), Optional.of(150L), Wei.of(250L)},
           // EIP-1559 must return fee cap
-          {EIP_1559_CALCULATOR, null, Wei.of(100L), Wei.of(300L), Optional.of(250L), Wei.of(300L)}
+          {EIP_1559_CALCULATOR, EIP1559, null, Wei.of(100L), Wei.of(300L), Optional.of(250L), Wei.of(300L)}
         });
   }
 
@@ -79,7 +92,8 @@ public class TransactionPriceCalculatorTest {
     assertThat(
             transactionPriceCalculator.price(
                 Transaction.builder()
-                    .type(TransactionType.EIP1559)
+                    .type(transactionType)
+                    .accessList(transactionType == ACCESS_LIST ? Collections.emptyList() : null)
                     .gasPrice(gasPrice)
                     .gasPremium(gasPremium)
                     .feeCap(feeCap)

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'CSYnesxrM26KNr8yz9WZEWLvxkHMBofp0QA4kkSZ3Zw='
+  knownHash = 'Kpl9Vh8naMrXaUp+N9nDWRycQOywft4mZrjUaH1vsQY='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionType.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionType.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.plugin.data;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Set;
 
 public enum TransactionType {
@@ -24,6 +25,9 @@ public enum TransactionType {
 
   private static final Set<TransactionType> ACCESS_LIST_SUPPORTED_TRANSACTION_TYPES =
       Set.of(ACCESS_LIST, EIP1559);
+
+  private static final EnumSet<TransactionType> LEGACY_FEE_MARKET_TRANSACTION_TYPES =
+      EnumSet.of(TransactionType.FRONTIER, TransactionType.ACCESS_LIST);
 
   private final int typeValue;
 
@@ -49,7 +53,11 @@ public enum TransactionType {
                     String.format("Unsupported transaction type %x", serializedTypeValue)));
   }
 
-  public boolean supportAccessList() {
+  public boolean supportsAccessList() {
     return ACCESS_LIST_SUPPORTED_TRANSACTION_TYPES.contains(this);
+  }
+
+  public boolean supports1559FeeMarket() {
+    return !LEGACY_FEE_MARKET_TRANSACTION_TYPES.contains(this);
   }
 }


### PR DESCRIPTION

Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
* Makes 1559 transaction price calculator use frontier for ACCESSLIST txns (as well as frontier txns)


## Fixed Issue(s)
fixes #2220

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).