### PR TITLE
haveged + urandom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged
+            sudo service haveged restart
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    parallelism: 6
+    parallelism: 8
     executor: besu_executor_xl
     steps:
       - prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ commands:
           name: Install Packages - LibSodium
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https
+            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:

--- a/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
+++ b/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
@@ -1,6 +1,6 @@
 ##### NOT FOR PRODUCTION USE ######
 ### FOR ACCEPTANCE TESTING ONLY ###
 # Disable OS provided entropy
-securerandom.source=
+securerandom.source=/dev/urandom
 ### FOR ACCEPTANCE TESTING ONLY ###
 ##### NOT FOR PRODUCTION USE ######


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Install haveged on AT executor to increase entropy available for non-java processes.

Also setting secure source to /dev/urandom/ explicitly (but not sure that is relevant)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).