### PR TITLE
force downloadLicenses when clean (#2104)

### DIFF
--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -153,7 +153,7 @@ downloadLicenses {
 }
 
 task lazyDownloadLicenses() {
-  if (!file("$rootProject.buildDir/reports/license/license-dependency.xml").exists()) {
+  if (gradle.startParameter.taskNames.contains('clean') || !file("$rootProject.buildDir/reports/license/license-dependency.xml").exists()) {
     dependsOn ':downloadLicenses'
   }
 }


### PR DESCRIPTION
when clean task is mentioned the lazyDownloadLicenses gets called before the clean runs, but during clean the license-dependency.xml also gets removed hence the checkLicenses.doLast fails. added the check to force downloadLicenses when clean task is going to run

Signed-off-by: Saravana Perumal Shanmugam <perusworld@linux.com>

fixes #2104 

