### PR TITLE
remove haveged; rename gq ATs executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ executors:
     machine:
       image: ubuntu-2004:202010-01
 
-  acceptance_tests_executor:
+  goquorum_acceptance_tests_executor:
     machine:
       image: ubuntu-2004:202101-01
     resource_class: xlarge
@@ -42,8 +42,7 @@ commands:
           name: Install Packages - LibSodium
           command: |
             sudo apt-get update
-            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged
-            sudo service haveged restart
+            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:
@@ -197,7 +196,7 @@ jobs:
 
   acceptanceTestsQuorum:
     parallelism: 1
-    executor: acceptance_tests_executor
+    executor: goquorum_acceptance_tests_executor
     steps:
       - prepare
       - attach_workspace:

--- a/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
+++ b/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
@@ -1,6 +1,6 @@
 ##### NOT FOR PRODUCTION USE ######
 ### FOR ACCEPTANCE TESTING ONLY ###
 # Disable OS provided entropy
-securerandom.source=/dev/urandom
+securerandom.source=file:/dev/urandom
 ### FOR ACCEPTANCE TESTING ONLY ###
 ##### NOT FOR PRODUCTION USE ######

--- a/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
+++ b/acceptance-tests/tests/src/test/resources/acceptanceTesting.security
@@ -1,6 +1,6 @@
 ##### NOT FOR PRODUCTION USE ######
 ### FOR ACCEPTANCE TESTING ONLY ###
 # Disable OS provided entropy
-securerandom.source=file:/dev/urandom
+securerandom.source=file:/dev/./urandom
 ### FOR ACCEPTANCE TESTING ONLY ###
 ##### NOT FOR PRODUCTION USE ######


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Remove haveged install; rename GoQuorum ATs executor to avoid confusion

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).