### PR TITLE
rayonism: fix newblock transaction decoding RPC

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ConsensusNewBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ConsensusNewBlock.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.ConsensusNewBlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -25,13 +27,17 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.encoding.TransactionDecoder;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -74,13 +80,28 @@ public class ConsensusNewBlock extends SyncJsonRpcMethod {
     } catch (JsonProcessingException e) {
       e.printStackTrace();
     }
+
+    final List<Transaction> transactions;
+    try {
+      transactions =
+          blockParam.getTransactions().stream()
+              .map(Bytes::fromHexString)
+              .map(TransactionDecoder::decodeOpaqueBytes)
+              .collect(Collectors.toList());
+    } catch (final RLPException | IllegalArgumentException e) {
+      LOG.warn("failed to decode transactions from newBlock RPC");
+      e.printStackTrace();
+      return new JsonRpcErrorResponse(
+          requestContext.getRequest().getId(), JsonRpcError.INVALID_PARAMS);
+    }
+
     final BlockHeader newBlockHeader =
         new BlockHeader(
             blockParam.getParentHash(),
             OMMERS_HASH_CONSTANT,
             blockParam.getMiner(),
             blockParam.getStateRoot(),
-            BodyValidation.transactionsRoot(blockParam.getTransactions()),
+            BodyValidation.transactionsRoot(transactions),
             blockParam.getReceiptsRoot(),
             blockParam.getLogsBloom(),
             Difficulty.ONE,
@@ -104,8 +125,7 @@ public class ConsensusNewBlock extends SyncJsonRpcMethod {
             .getBlockImporter()
             .importBlock(
                 protocolContext,
-                new Block(
-                    newBlockHeader, new BlockBody(blockParam.getTransactions(), OMMERS_CONSTANT)),
+                new Block(newBlockHeader, new BlockBody(transactions, OMMERS_CONSTANT)),
                 HeaderValidationMode.FULL);
     LOG.trace("importSuccess " + importSuccess);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ConsensusNewBlockParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ConsensusNewBlockParameter.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.LogsBloomFilter;
-import org.hyperledger.besu.ethereum.core.Transaction;
 
 import java.util.List;
 
@@ -35,7 +34,7 @@ public class ConsensusNewBlockParameter {
   private final long timestamp;
   private final Hash receiptsRoot;
   private final LogsBloomFilter logsBloom;
-  private final List<Transaction> transactions;
+  private final List<String> transactions;
 
   @JsonCreator
   public ConsensusNewBlockParameter(
@@ -49,7 +48,7 @@ public class ConsensusNewBlockParameter {
       @JsonProperty("timestamp") final UnsignedLongParameter timestamp,
       @JsonProperty("receiptsRoot") final Hash receiptsRoot,
       @JsonProperty("logsBloom") final LogsBloomFilter logsBloom,
-      @JsonProperty("transactions") final List<Transaction> transactions) {
+      @JsonProperty("transactions") final List<String> transactions) {
     this.blockHash = blockHash;
     this.parentHash = parentHash;
     this.miner = miner;
@@ -103,7 +102,7 @@ public class ConsensusNewBlockParameter {
     return logsBloom;
   }
 
-  public List<Transaction> getTransactions() {
+  public List<String> getTransactions() {
     return transactions;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)

Previous `consensus_newBlock` (for the Merge prototype) was expecting full transactions, but the beacon node sends opaque transactions, and so blocks with a transaction would fail and cause the besu node to fail to sync the chain.

This mirrors the encoding code (stream tx list, map from hex and decoding instead of encoding and to hex, collect in list), and wraps it with some logging and error handling just in case. Tested this on a local merge testnet with all consensus and execution clients mining on top of the blocks, no errors.

<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
  - Small fix in experimental fork of besu, no new features, not updating changelog.