### PR TITLE
Qbft invalid timestamp

### DIFF
--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.time.Clock;
@@ -113,7 +112,7 @@ public class IbftBlockHeightManager implements BaseIbftBlockHeightManager {
   @Override
   public void handleBlockTimerExpiry(final ConsensusRoundIdentifier roundIdentifier) {
     if (roundIdentifier.equals(currentRound.getRoundIdentifier())) {
-      final long headerTimeStampSeconds = Util.fastDivCeiling(clock.millis(), 1000L);
+      final long headerTimeStampSeconds = Math.round(clock.millis() / 1000D);
       currentRound.createAndSendProposalMessage(headerTimeStampSeconds);
     } else {
       LOG.trace(

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManager.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.time.Clock;
@@ -112,7 +113,8 @@ public class IbftBlockHeightManager implements BaseIbftBlockHeightManager {
   @Override
   public void handleBlockTimerExpiry(final ConsensusRoundIdentifier roundIdentifier) {
     if (roundIdentifier.equals(currentRound.getRoundIdentifier())) {
-      currentRound.createAndSendProposalMessage(clock.millis() / 1000);
+      final long headerTimeStampSeconds = Util.fastDivCeiling(clock.millis(), 1000L);
+      currentRound.createAndSendProposalMessage(headerTimeStampSeconds);
     } else {
       LOG.trace(
           "Block timer expired for a round ({}) other than current ({})",

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.qbft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.qbft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.time.Clock;
@@ -121,7 +122,8 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
 
     if (isProposer) {
       if (roundIdentifier.equals(qbftRound.getRoundIdentifier())) {
-        qbftRound.createAndSendProposalMessage(clock.millis() / 1000L);
+        final long headerTimeStampSeconds = Util.fastDivCeiling(clock.millis(), 1000L);
+        qbftRound.createAndSendProposalMessage(headerTimeStampSeconds);
       } else {
         LOG.trace(
             "Block timer expired for a round ({}) other than current ({})",

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.qbft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.qbft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.time.Clock;
@@ -122,7 +121,7 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
 
     if (isProposer) {
       if (roundIdentifier.equals(qbftRound.getRoundIdentifier())) {
-        final long headerTimeStampSeconds = Util.fastDivCeiling(clock.millis(), 1000L);
+        final long headerTimeStampSeconds = Math.round(clock.millis() / 1000D);
         qbftRound.createAndSendProposalMessage(headerTimeStampSeconds);
       } else {
         LOG.trace(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Util.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Util.java
@@ -56,8 +56,4 @@ public class Util {
   public static int fastDivCeiling(final int numerator, final int denominator) {
     return ((numerator - 1) / denominator) + 1;
   }
-
-  public static long fastDivCeiling(final long numerator, final long denominator) {
-    return ((numerator - 1) / denominator) + 1;
-  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Util.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Util.java
@@ -56,4 +56,8 @@ public class Util {
   public static int fastDivCeiling(final int numerator, final int denominator) {
     return ((numerator - 1) / denominator) + 1;
   }
+
+  public static long fastDivCeiling(final long numerator, final long denominator) {
+    return ((numerator - 1) / denominator) + 1;
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Fix error where we get an invalid header timestamp occasionally. This seems to be due slight deviation from the block period. It's not likely we can ever get the timing exact as we need determine the delay before scheduling the block expiry event so there can be a very discrepancy.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).