### PR TITLE
refactor: expose EnodeUrl to plugins

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -30,11 +30,12 @@ import org.hyperledger.besu.ethereum.blockcreation.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
 import org.hyperledger.besu.metrics.MetricsSystemFactory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -130,7 +131,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
         MetricsSystemFactory.create(node.getMetricsConfiguration());
     final List<EnodeURL> bootnodes =
         node.getConfiguration().getBootnodes().stream()
-            .map(EnodeURL::fromURI)
+            .map(EnodeURLImpl::fromURI)
             .collect(Collectors.toList());
     final EthNetworkConfig.Builder networkConfigBuilder =
         new EthNetworkConfig.Builder(EthNetworkConfig.getNetworkConfig(DEV))
@@ -194,7 +195,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
             .graphQLConfiguration(GraphQLConfiguration.createDefault())
             .staticNodes(
                 node.getStaticNodes().stream()
-                    .map(EnodeURL::fromString)
+                    .map(EnodeURLImpl::fromString)
                     .collect(Collectors.toList()))
             .besuPluginContext(new BesuPluginContextImpl())
             .autoLogBloomCaching(false)

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/permissioning/PermissionedNodeBuilder.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/permissioning/PermissionedNodeBuilder.java
@@ -21,12 +21,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.AllowlistPersistor;
 import org.hyperledger.besu.ethereum.permissioning.AllowlistPersistor.ALLOWLIST_TYPE;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.SmartContractPermissioningConfiguration;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
@@ -227,7 +228,9 @@ public class PermissionedNodeBuilder {
       }
 
       final List<EnodeURL> nodeAllowList =
-          localConfigPermittedNodes.stream().map(EnodeURL::fromURI).collect(Collectors.toList());
+          localConfigPermittedNodes.stream()
+              .map(EnodeURLImpl::fromURI)
+              .collect(Collectors.toList());
 
       initPermissioningConfigurationFile(
           ALLOWLIST_TYPE.NODES,

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningAllowNodeTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningAllowNodeTransaction.java
@@ -19,7 +19,7 @@ import static org.web3j.utils.Numeric.toHexString;
 
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.NodeSmartContractPermissioningController;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
@@ -68,7 +68,7 @@ public class NodeSmartContractPermissioningAllowNodeTransaction implements Trans
     final String enodeURL = ((RunnableNode) node).enodeUrl().toASCIIString();
     final Bytes payload =
         NodeSmartContractPermissioningController.createPayload(
-            ADD_ENODE_SIGNATURE, EnodeURL.fromString(enodeURL));
+            ADD_ENODE_SIGNATURE, EnodeURLImpl.fromString(enodeURL));
 
     RawTransaction transaction =
         RawTransaction.createTransaction(

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningAllowNodeV2Transaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningAllowNodeV2Transaction.java
@@ -18,7 +18,8 @@ import static org.web3j.utils.Numeric.toHexString;
 
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
@@ -62,7 +63,7 @@ public class NodeSmartContractPermissioningAllowNodeV2Transaction implements Tra
   }
 
   private String signedTransactionData() {
-    final EnodeURL enodeURL = EnodeURL.fromURI(((RunnableNode) node).enodeUrl());
+    final EnodeURL enodeURL = EnodeURLImpl.fromURI(((RunnableNode) node).enodeUrl());
     final Bytes payload = createPayload(enodeURL);
 
     RawTransaction transaction =

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningConnectionIsAllowedTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningConnectionIsAllowedTransaction.java
@@ -19,7 +19,7 @@ import static org.hyperledger.besu.ethereum.permissioning.NodeSmartContractPermi
 
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.NodeSmartContractPermissioningController;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
@@ -69,8 +69,8 @@ public class NodeSmartContractPermissioningConnectionIsAllowedTransaction
     final Bytes payload =
         NodeSmartContractPermissioningController.createPayload(
             IS_CONNECTION_ALLOWED_SIGNATURE,
-            EnodeURL.fromString(sourceEnodeURL),
-            EnodeURL.fromString(targetEnodeURL));
+            EnodeURLImpl.fromString(sourceEnodeURL),
+            EnodeURLImpl.fromString(targetEnodeURL));
 
     return org.web3j.protocol.core.methods.request.Transaction.createFunctionCallTransaction(
         null, null, null, null, contractAddress.toString(), payload.toString());

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningConnectionIsAllowedV2Transaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningConnectionIsAllowedV2Transaction.java
@@ -15,8 +15,9 @@
 package org.hyperledger.besu.tests.acceptance.dsl.transaction.perm;
 
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.NodeSmartContractV2PermissioningController;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
@@ -56,7 +57,7 @@ public class NodeSmartContractPermissioningConnectionIsAllowedV2Transaction
   }
 
   private org.web3j.protocol.core.methods.request.Transaction payload() {
-    final EnodeURL enodeURL = EnodeURL.fromURI(((RunnableNode) node).enodeUrl());
+    final EnodeURL enodeURL = EnodeURLImpl.fromURI(((RunnableNode) node).enodeUrl());
     final Bytes payload = createPayload(enodeURL);
 
     return org.web3j.protocol.core.methods.request.Transaction.createFunctionCallTransaction(

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningForbidNodeTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningForbidNodeTransaction.java
@@ -19,7 +19,7 @@ import static org.web3j.utils.Numeric.toHexString;
 
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.NodeSmartContractPermissioningController;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
@@ -68,7 +68,7 @@ public class NodeSmartContractPermissioningForbidNodeTransaction implements Tran
     final String enodeURL = ((RunnableNode) node).enodeUrl().toASCIIString();
     final Bytes payload =
         NodeSmartContractPermissioningController.createPayload(
-            REMOVE_ENODE_SIGNATURE, EnodeURL.fromString(enodeURL));
+            REMOVE_ENODE_SIGNATURE, EnodeURLImpl.fromString(enodeURL));
 
     RawTransaction transaction =
         RawTransaction.createTransaction(

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningForbidNodeV2Transaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningForbidNodeV2Transaction.java
@@ -18,7 +18,8 @@ import static org.web3j.utils.Numeric.toHexString;
 
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
@@ -62,7 +63,7 @@ public class NodeSmartContractPermissioningForbidNodeV2Transaction implements Tr
   }
 
   private String signedTransactionData() {
-    final EnodeURL enodeURL = EnodeURL.fromURI(((RunnableNode) node).enodeUrl());
+    final EnodeURL enodeURL = EnodeURLImpl.fromURI(((RunnableNode) node).enodeUrl());
     final Bytes payload = createPayload(enodeURL);
 
     RawTransaction transaction =

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningIsAllowedTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/perm/NodeSmartContractPermissioningIsAllowedTransaction.java
@@ -18,7 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.NodeSmartContractPermissioningController;
 import org.hyperledger.besu.tests.acceptance.dsl.node.Node;
 import org.hyperledger.besu.tests.acceptance.dsl.node.RunnableNode;
@@ -84,7 +84,7 @@ public class NodeSmartContractPermissioningIsAllowedTransaction implements Trans
     final String sourceEnodeURL = ((RunnableNode) node).enodeUrl().toASCIIString();
     final Bytes payload =
         NodeSmartContractPermissioningController.createPayload(
-            IS_NODE_ALLOWED_SIGNATURE, EnodeURL.fromString(sourceEnodeURL));
+            IS_NODE_ALLOWED_SIGNATURE, EnodeURLImpl.fromString(sourceEnodeURL));
 
     return org.web3j.protocol.core.methods.request.Transaction.createFunctionCallTransaction(
         null, null, null, null, contractAddress.toString(), payload.toString());

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -22,11 +22,11 @@ import org.hyperledger.besu.ethereum.api.query.cache.AutoTransactionLogBloomCach
 import org.hyperledger.besu.ethereum.api.query.cache.TransactionLogBloomCacher;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.p2p.network.NetworkRunner;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.stratum.StratumServer;
 import org.hyperledger.besu.ethstats.EthStatsService;
 import org.hyperledger.besu.metrics.MetricsService;
 import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -74,7 +74,6 @@ import org.hyperledger.besu.ethereum.p2p.network.NoopP2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsDenylist;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
@@ -107,6 +106,7 @@ import org.hyperledger.besu.nat.kubernetes.KubernetesDetector;
 import org.hyperledger.besu.nat.kubernetes.KubernetesNatManager;
 import org.hyperledger.besu.nat.upnp.UpnpNatManager;
 import org.hyperledger.besu.plugin.BesuPlugin;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
 import org.hyperledger.besu.util.NetworkUtility;
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -112,7 +112,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfigurati
 import org.hyperledger.besu.ethereum.mainnet.precompiles.AbstractAltBnPrecompiledContract;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.StaticNodesParser;
 import org.hyperledger.besu.ethereum.permissioning.GoQuorumPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
@@ -138,6 +138,7 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.vertx.VertxMetricsAdapterFactory;
 import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -397,7 +398,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       bannedNodeIds =
           values.stream()
               .filter(value -> !value.isEmpty())
-              .map(EnodeURL::parseNodeId)
+              .map(EnodeURLImpl::parseNodeId)
               .collect(Collectors.toList());
     } catch (final IllegalArgumentException e) {
       throw new ParameterException(
@@ -451,7 +452,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       paramLabel = MANDATORY_PORT_FORMAT_HELP,
       description = "Port on which to listen for P2P communication (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Integer p2pPort = EnodeURL.DEFAULT_LISTENING_PORT;
+  private final Integer p2pPort = EnodeURLImpl.DEFAULT_LISTENING_PORT;
 
   @Option(
       names = {"--nat-method"},
@@ -2427,7 +2428,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         final List<EnodeURL> listBootNodes =
             bootNodes.stream()
                 .filter(value -> !value.isEmpty())
-                .map(url -> EnodeURL.fromString(url, getEnodeDnsConfiguration()))
+                .map(url -> EnodeURLImpl.fromString(url, getEnodeDnsConfiguration()))
                 .collect(Collectors.toList());
         DiscoveryConfiguration.assertValidBootnodes(listBootNodes);
         builder.setBootNodes(listBootNodes);

--- a/besu/src/main/java/org/hyperledger/besu/cli/config/EthNetworkConfig.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/config/EthNetworkConfig.java
@@ -28,7 +28,7 @@ import static org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration.RI
 import static org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration.ROPSTEN_BOOTSTRAP_NODES;
 import static org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration.ROPSTEN_DISCOVERY_URL;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.IOException;
 import java.math.BigInteger;

--- a/besu/src/main/java/org/hyperledger/besu/cli/custom/EnodeToURIPropertyConverter.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/custom/EnodeToURIPropertyConverter.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.cli.custom;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 
 import java.net.URI;
 import java.util.function.Function;
@@ -27,7 +27,7 @@ public class EnodeToURIPropertyConverter implements ITypeConverter<URI> {
   private final Function<String, URI> converter;
 
   EnodeToURIPropertyConverter() {
-    this.converter = (s) -> EnodeURL.fromString(s).toURI();
+    this.converter = (s) -> EnodeURLImpl.fromString(s).toURI();
   }
 
   @VisibleForTesting

--- a/besu/src/main/java/org/hyperledger/besu/util/PermissioningConfigurationValidator.java
+++ b/besu/src/main/java/org/hyperledger/besu/util/PermissioningConfigurationValidator.java
@@ -16,8 +16,8 @@ package org.hyperledger.besu.util;
 
 import static java.util.stream.Collectors.toList;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.net.URI;
 import java.util.Collection;

--- a/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
@@ -49,12 +49,13 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.config.SubProtocolConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -143,7 +144,7 @@ public final class RunnerBuilderTest {
     runner.start();
 
     final EnodeURL expectedEodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .ipAddress(p2pAdvertisedHost)
             .discoveryPort(0)
             .listeningPort(p2pListenPort)

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -45,13 +45,14 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfigurati
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValueStorageFactory;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
@@ -116,10 +117,10 @@ public final class RunnerTest {
   @Test
   public void getFixedNodes() {
     final EnodeURL staticNode =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://8f4b88336cc40ef2516d8b27df812e007fb2384a61e93635f1899051311344f3dcdbb49a4fe49a79f66d2f589a9f282e8cc4f1d7381e8ef7e4fcc6b0db578c77@127.0.0.1:30301");
     final EnodeURL bootnode =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://8f4b88336cc40ef2516d8b27df812e007fb2384a61e93635f1899051311344f3dcdbb49a4fe49a79f66d2f589a9f282e8cc4f1d7381e8ef7e4fcc6b0db578c77@127.0.0.1:30302");
     final List<EnodeURL> bootnodes = new ArrayList<>();
     bootnodes.add(bootnode);

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -67,7 +67,7 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.SmartContractPermissioningConfiguration;
@@ -76,6 +76,7 @@ import org.hyperledger.besu.ethereum.worldstate.PrunerConfiguration;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.StringUtils;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
@@ -354,9 +355,9 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     final List<EnodeURL> nodes =
         asList(
-            EnodeURL.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"),
-            EnodeURL.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"),
-            EnodeURL.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"));
+            EnodeURLImpl.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"),
+            EnodeURLImpl.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"),
+            EnodeURLImpl.fromString("enode://" + VALID_NODE_ID + "@192.168.0.1:4567"));
     assertThat(ethNetworkConfigArgumentCaptor.getValue().getBootNodes()).isEqualTo(nodes);
 
     final EthNetworkConfig networkConfig =
@@ -675,9 +676,9 @@ public class BesuCommandTest extends CommandTestAbstract {
   public void nodePermissioningTomlPathMustUseOption() throws IOException {
     final List<EnodeURL> allowedNodes =
         Lists.newArrayList(
-            EnodeURL.fromString(
+            EnodeURLImpl.fromString(
                 "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.9:4567"),
-            EnodeURL.fromString(
+            EnodeURLImpl.fromString(
                 "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.169.0.9:4568"));
 
     final URL configFile = this.getClass().getResource(PERMISSIONING_CONFIG_TOML);
@@ -1252,7 +1253,9 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     assertThat(ethNetworkConfigArgumentCaptor.getValue().getBootNodes())
         .isEqualTo(
-            Stream.of(validENodeStrings).map(EnodeURL::fromString).collect(Collectors.toList()));
+            Stream.of(validENodeStrings)
+                .map(EnodeURLImpl::fromString)
+                .collect(Collectors.toList()));
 
     assertThat(commandOutput.toString()).isEmpty();
     assertThat(commandErrorOutput.toString()).isEmpty();
@@ -3265,7 +3268,9 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     assertThat(networkArg.getValue().getBootNodes())
         .isEqualTo(
-            Stream.of(validENodeStrings).map(EnodeURL::fromString).collect(Collectors.toList()));
+            Stream.of(validENodeStrings)
+                .map(EnodeURLImpl::fromString)
+                .collect(Collectors.toList()));
     assertThat(networkArg.getValue().getNetworkId()).isEqualTo(1234567);
 
     assertThat(commandOutput.toString()).isEmpty();
@@ -3611,7 +3616,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     permissioningConfig.deleteOnExit();
 
     final EnodeURL staticNodeURI =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(
                 "50203c6bfca6874370e71aecc8958529fd723feb05013dc1abca8fc1fff845c5259faba05852e9dfe5ce172a7d6e7c2a3a5eaa8b541c8af15ea5518bbff5f2fa")
             .ipAddress("127.0.0.1")
@@ -3619,7 +3624,7 @@ public class BesuCommandTest extends CommandTestAbstract {
             .build();
 
     final EnodeURL allowedNode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(
                 "50203c6bfca6874370e71aecc8958529fd723feb05013dc1abca8fc1fff845c5259faba05852e9dfe5ce172a7d6e7c2a3a5eaa8b541c8af15ea5518bbff5f2fa")
             .useDefaultPorts()

--- a/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
@@ -21,10 +21,11 @@ import static org.assertj.core.api.Assertions.fail;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfigurationBuilder;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.net.URL;
 import java.nio.file.Files;
@@ -119,7 +120,7 @@ public class LocalPermissioningConfigurationValidatorTest {
 
     // This node is defined in the PERMISSIONING_CONFIG file without the discovery port
     final EnodeURL enodeURL =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.9:4567?discport=30303");
 
     // In an URI comparison the URLs should not match
@@ -156,7 +157,7 @@ public class LocalPermissioningConfigurationValidatorTest {
 
     // This node is defined in the PERMISSIONING_CONFIG_DNS file without the discovery port
     final EnodeURL enodeURL =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@localhost:4567?discport=30303",
             enodeDnsConfiguration);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
@@ -19,8 +19,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,7 +42,7 @@ public class AdminAddPeer extends AdminModifyPeer {
   @Override
   protected JsonRpcResponse performOperation(final Object id, final String enode) {
     LOG.debug("Adding ({}) to peers", enode);
-    final EnodeURL enodeURL = EnodeURL.fromString(enode);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enode);
     final Peer peer = DefaultPeer.fromEnodeURL(enodeURL);
     final boolean addedToNetwork = peerNetwork.addMaintainConnectionPeer(peer);
     return new JsonRpcSuccessResponse(id, addedToNetwork);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -24,11 +24,11 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.math.BigInteger;
 import java.net.URI;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
@@ -19,7 +19,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,7 +41,7 @@ public class AdminRemovePeer extends AdminModifyPeer {
   @Override
   protected JsonRpcResponse performOperation(final Object id, final String enode) {
     LOG.debug("Remove ({}) from peer cache", enode);
-    final EnodeURL enodeURL = EnodeURL.fromString(enode);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enode);
     final boolean result =
         peerNetwork.removeMaintainedConnectionPeer(DefaultPeer.fromEnodeURL(enodeURL));
     return new JsonRpcSuccessResponse(id, result);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnode.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Optional;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetServices.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetServices.java
@@ -21,8 +21,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import com.google.common.collect.ImmutableMap;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MockPeerConnection.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 
@@ -38,7 +38,7 @@ public class MockPeerConnection {
     when(peerConnection.getRemoteAddress()).thenReturn(remoteAddress);
     when(peerConnection.getRemoteEnode())
         .thenReturn(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(peerInfo.getNodeId())
                 .ipAddress(remoteAddress.getAddress().getHostAddress())
                 .disableDiscovery()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -34,11 +34,12 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.math.BigInteger;
 import java.util.Collections;
@@ -72,7 +73,7 @@ public class AdminNodeInfoTest {
       new StubGenesisConfigOptions().chainId(BigInteger.valueOf(2019));
   private final DefaultPeer defaultPeer =
       DefaultPeer.fromEnodeURL(
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(nodeId)
               .ipAddress("1.2.3.4")
               .discoveryPort(7890)
@@ -188,7 +189,7 @@ public class AdminNodeInfoTest {
   @Test
   public void handlesLocalEnodeWithListeningAndDiscoveryDisabled() {
     final EnodeURL localEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(nodeId)
             .ipAddress("1.2.3.4")
             .discoveryAndListeningPorts(0)
@@ -233,7 +234,7 @@ public class AdminNodeInfoTest {
   @Test
   public void handlesLocalEnodeWithListeningDisabled() {
     final EnodeURL localEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(nodeId)
             .ipAddress("1.2.3.4")
             .discoveryAndListeningPorts(0)
@@ -279,7 +280,7 @@ public class AdminNodeInfoTest {
   @Test
   public void handlesLocalEnodeWithDiscoveryDisabled() {
     final EnodeURL localEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(nodeId)
             .ipAddress("1.2.3.4")
             .discoveryAndListeningPorts(0)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnodeTest.java
@@ -26,7 +26,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Optional;
 
@@ -49,7 +50,7 @@ public class NetEnodeTest {
 
   private final DefaultPeer defaultPeer =
       DefaultPeer.fromEnodeURL(
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(nodeId)
               .ipAddress("1.2.3.4")
               .discoveryPort(7890)

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/MockPeerConnection.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/MockPeerConnection.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
@@ -47,7 +47,7 @@ public class MockPeerConnection implements PeerConnection {
     this.nodeId = Peer.randomId();
     this.peer =
         DefaultPeer.fromEnodeURL(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(nodeId)
                 .discoveryAndListeningPorts(30303)

--- a/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
+++ b/ethereum/ethstats/src/main/java/org/hyperledger/besu/ethstats/EthStatsService.java
@@ -41,7 +41,6 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethstats.authentication.ImmutableAuthenticationData;
 import org.hyperledger.besu.ethstats.authentication.ImmutableNodeInfo;
 import org.hyperledger.besu.ethstats.authentication.NodeInfo;
@@ -56,6 +55,7 @@ import org.hyperledger.besu.ethstats.report.PendingTransactionsReport;
 import org.hyperledger.besu.ethstats.request.EthStatsRequest;
 import org.hyperledger.besu.ethstats.util.NetstatsUrl;
 import org.hyperledger.besu.ethstats.util.PrimusHeartBeatsHelper;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.platform.PlatformDetector;
 
 import java.math.BigInteger;

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -30,11 +30,12 @@ import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethstats.request.EthStatsRequest;
 import org.hyperledger.besu.ethstats.util.ImmutableNetstatsUrl;
 import org.hyperledger.besu.ethstats.util.NetstatsUrl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.math.BigInteger;
 import java.time.Duration;
@@ -83,7 +84,7 @@ public class EthStatsServiceTest {
           .build();
 
   final EnodeURL node =
-      EnodeURL.builder()
+      EnodeURLImpl.builder()
           .nodeId(
               "50203c6bfca6874370e71aecc8958529fd723feb05013dc1abca8fc1fff845c5259faba05852e9dfe5ce172a7d6e7c2a3a5eaa8b541c8af15ea5518bbff5f2fa")
           .useDefaultPorts()

--- a/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.p2p.testing;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.DisconnectCallback;
@@ -28,6 +27,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Message;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.net.InetSocketAddress;

--- a/ethereum/mock-p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetworkTest.java
+++ b/ethereum/mock-p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetworkTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.testing;
 
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
@@ -44,7 +44,7 @@ public final class MockNetworkTest {
     final MockNetwork network = new MockNetwork(Arrays.asList(cap));
     final Peer one =
         DefaultPeer.fromEnodeURL(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(randomId())
                 .ipAddress("192.168.1.2")
                 .discoveryPort(1234)
@@ -52,7 +52,7 @@ public final class MockNetworkTest {
                 .build());
     final Peer two =
         DefaultPeer.fromEnodeURL(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(randomId())
                 .ipAddress("192.168.1.3")
                 .discoveryPort(1234)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfiguration.java
@@ -16,7 +16,8 @@ package org.hyperledger.besu.ethereum.p2p.config;
 
 import static java.util.stream.Collectors.toList;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.NetworkUtility;
 
 import java.util.ArrayList;
@@ -59,7 +60,7 @@ public class DiscoveryConfiguration {
                   // Ethereum Foundation Aleth Bootnodes
                   "enode://979b7fa28feeb35a4741660a16076f1943202cb72b6af70d327f053e248bab9ba81760f39d0701ef1d8f89cc1fbd2cacba0710a12cd5314d5e0c9021aa3637f9@5.1.83.226:30303" // DE
                   )
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
   public static final List<EnodeURL> RINKEBY_BOOTSTRAP_NODES =
       Collections.unmodifiableList(
@@ -67,7 +68,7 @@ public class DiscoveryConfiguration {
                   "enode://a24ac7c5484ef4ed0c5eb2d36620ba4e4aa13b8c84684e1b4aab0cebea2ae45cb4d375b77eab56516d34bfbd3c1a833fc51296ff084b770b94fb9028c4d25ccf@52.169.42.101:30303",
                   "enode://343149e4feefa15d882d9fe4ac7d88f885bd05ebb735e547f12e12080a9fa07c8014ca6fd7f373123488102fe5e34111f8509cf0b7de3f5b44339c9f25e87cb8@52.3.158.184:30303",
                   "enode://b6b28890b006743680c52e64e0d16db57f28124885595fa03a562be1d2bf0f3a1da297d56b13da25fb992888fd556d4c1a27b1f39d531bde7de1921c90061cc6@159.89.28.211:30303")
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
   public static final List<EnodeURL> ROPSTEN_BOOTSTRAP_NODES =
       Collections.unmodifiableList(
@@ -76,7 +77,7 @@ public class DiscoveryConfiguration {
                   "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.81.208.223:30303",
                   "enode://30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606@52.176.7.10:30303",
                   "enode://865a63255b3bb68023b6bffd5095118fcc13e79dcf014fe4e47e065c350c7cc72af2e53eff895f11ba1bbb6a2b33271c1116ee870f266618eadfc2e78aa7349c@52.176.100.77:30303")
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   public static final List<EnodeURL> GOERLI_BOOTSTRAP_NODES =
@@ -95,7 +96,7 @@ public class DiscoveryConfiguration {
                   "enode://807b37ee4816ecf407e9112224494b74dd5933625f655962d892f2f0f02d7fbbb3e2a94cf87a96609526f30c998fd71e93e2f53015c558ffc8b03eceaf30ee33@51.15.119.157:30303", // @q9f Uklun
                   "enode://a59e33ccd2b3e52d578f1fbd70c6f9babda2650f0760d6ff3b37742fdcdfdb3defba5d56d315b40c46b70198c7621e63ffa3f987389c7118634b0fefbbdfa7fd@51.15.119.157:40303" // @q9f Uklun
                   )
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   public static final List<EnodeURL> CLASSIC_BOOTSTRAP_NODES =
@@ -139,7 +140,7 @@ public class DiscoveryConfiguration {
                   "enode://0daae2a30f2c73b0b257746587136efb8e3479496f7ea1e943eeb9a663b72dd04582f699f7010ee02c57fc45d1f09568c20a9050ff937f9139e2973ddd98b87b@159.89.169.103:30303",
                   "enode://50808461dd73b3d70537e4c1e5fafd1132b3a90f998399af9205f8889987d62096d4e853813562dd43e7270a71c9d9d4e4dd73a534fdb22fbac98c389c1a7362@178.128.55.119:30303",
                   "enode://5cd218959f8263bc3721d7789070806b0adff1a0ed3f95ec886fb469f9362c7507e3b32b256550b9a7964a23a938e8d42d45a0c34b332bfebc54b29081e83b93@35.187.57.94:30303")
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   public static final List<EnodeURL> KOTTI_BOOTSTRAP_NODES =
@@ -159,7 +160,7 @@ public class DiscoveryConfiguration {
                   "enode://efd7391a3bed73ad74ae5760319bb48f9c9f1983ff22964422688cdb426c5d681004ece26c47121396653cf9bafe7104aa4ecff70e24cc5b11fd76be8e5afce0@51.158.191.43:45678", // @q9f Mizar
                   "enode://93b12383c74c39b67afa99a7ff44ce250fe94295fa1fc087465cc4fe2d0b33b91a8d8cabe03b250104a9096aa0e06bcde5f95665a5bd9f890edd2ab33e16ae47@51.15.41.19:30303" // @q9f Zibal
                   )
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   public static final List<EnodeURL> MORDOR_BOOTSTRAP_NODES =
@@ -194,14 +195,14 @@ public class DiscoveryConfiguration {
                   "enode://8fa15f5012ac3c47619147220b7772fcc5db0cb7fd132b5d196e7ccacb166ac1fcf83be1dace6cd288e288a85e032423b6e7e9e57f479fe7373edea045caa56b@176.9.51.216:31355", // @q9f Ceibo
                   "enode://34c14141b79652afc334dcd2ba4d8047946246b2310dc8e45737ebe3e6f15f9279ca4702b90bc5be12929f6194e2c3ce19a837b7fec7ebffcee9e9fe4693b504@176.9.51.216:31365" // @q9f Ceibo
                   )
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   public static final List<EnodeURL> ASTOR_BOOTSTRAP_NODES =
       Collections.unmodifiableList(
           Stream.of(
                   "enode://b638fc3dca6181ae97fac2ea0157e8330f5ac8a20c0d4c63aa6f98dcbac4e35b4e023f656757b58c1da7a7b2be9ffad9342e0f769b8cf0f5e35ff73116ff7dfd@3.16.171.213:30303")
-              .map(EnodeURL::fromString)
+              .map(EnodeURLImpl::fromString)
               .collect(toList()));
 
   private boolean active = true;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
@@ -15,11 +15,11 @@
 package org.hyperledger.besu.ethereum.p2p.discovery;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Optional;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/Endpoint.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/Endpoint.java
@@ -18,9 +18,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.util.NetworkUtility.checkPort;
 import static org.hyperledger.besu.util.Preconditions.checkGuard;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.IllegalPortException;
 
 import java.net.InetAddress;
@@ -63,7 +64,7 @@ public class Endpoint {
   }
 
   public EnodeURL toEnode(final Bytes nodeId) {
-    return EnodeURL.builder()
+    return EnodeURLImpl.builder()
         .nodeId(nodeId)
         .ipAddress(host)
         .listeningPort(tcpPort.orElse(udpPort))

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -30,13 +30,14 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDiscoveryControl
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerRequirement;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.TimerUtil;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
@@ -161,7 +162,7 @@ public abstract class PeerDiscoveryAgent {
                 final int discoveryPort = localAddress.getPort();
                 final DiscoveryPeer ourNode =
                     DiscoveryPeer.fromEnode(
-                        EnodeURL.builder()
+                        EnodeURLImpl.builder()
                             .nodeId(id)
                             .ipAddress(advertisedAddress)
                             .listeningPort(tcpPort)
@@ -289,7 +290,7 @@ public abstract class PeerDiscoveryAgent {
     final String host = sourceEndpoint.getHost();
     final DiscoveryPeer peer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(packet.getNodeId())
                 .ipAddress(host)
                 .listeningPort(tcpPort)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryEvent.PeerBonded
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
 import org.hyperledger.besu.ethereum.p2p.discovery.VertxPeerDiscoveryAgent;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeerPrivileges;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.peers.MutableLocalNode;
@@ -47,6 +47,7 @@ import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.nat.core.domain.NatServiceType;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
 import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.time.Duration;
@@ -211,7 +212,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
                 List<DiscoveryPeer> peers = new ArrayList<>();
                 for (EthereumNodeRecord enr : records) {
                   EnodeURL enodeURL =
-                      EnodeURL.builder()
+                      EnodeURLImpl.builder()
                           .ipAddress(enr.ip())
                           .nodeId(enr.publicKey().bytes())
                           .discoveryPort(Optional.ofNullable(enr.udp()))
@@ -418,7 +419,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
     final String advertisedAddress = natService.queryExternalIPAddress(address);
 
     final EnodeURL localEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(nodeId)
             .ipAddress(advertisedAddress)
             .listeningPort(listeningPort)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/NoopP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/NoopP2PNetwork.java
@@ -16,13 +16,13 @@ package org.hyperledger.besu.ethereum.p2p.network;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.DisconnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.MessageCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetwork.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.p2p.network;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.DisconnectCallback;
@@ -23,6 +22,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.MessageCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Message;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.Closeable;
 import java.util.Collection;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNode.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.peers;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.List;
 import java.util.Optional;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeer.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.p2p.peers;
 
+import org.hyperledger.besu.plugin.data.EnodeURL;
+
 import java.net.URI;
 import java.util.Objects;
 
@@ -39,7 +41,7 @@ public class DefaultPeer extends DefaultPeerId implements Peer {
    * @see <a href="https://github.com/ethereum/wiki/wiki/enode-url-format">enode URL format</a>
    */
   public static DefaultPeer fromURI(final String uri) {
-    return new DefaultPeer(EnodeURL.fromString(uri));
+    return new DefaultPeer(EnodeURLImpl.fromString(uri));
   }
 
   /**
@@ -50,7 +52,7 @@ public class DefaultPeer extends DefaultPeerId implements Peer {
    * @see <a href="https://github.com/ethereum/wiki/wiki/enode-url-format">enode URL format</a>
    */
   public static DefaultPeer fromURI(final URI uri) {
-    return new DefaultPeer(EnodeURL.fromURI(uri));
+    return new DefaultPeer(EnodeURLImpl.fromURI(uri));
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.p2p.peers;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.NetworkUtility;
 
 import java.net.InetAddress;
@@ -32,7 +33,7 @@ import com.google.common.net.InetAddresses;
 import com.google.common.primitives.Ints;
 import org.apache.tuweni.bytes.Bytes;
 
-public class EnodeURL {
+public class EnodeURLImpl implements EnodeURL {
 
   public static final int DEFAULT_LISTENING_PORT = 30303;
   public static final int NODE_ID_SIZE = 64;
@@ -46,7 +47,7 @@ public class EnodeURL {
   private final Optional<Integer> listeningPort;
   private final Optional<Integer> discoveryPort;
 
-  private EnodeURL(
+  private EnodeURLImpl(
       final Bytes nodeId,
       final InetAddress address,
       final Optional<String> maybeHostname,
@@ -143,16 +144,17 @@ public class EnodeURL {
   }
 
   public static Bytes parseNodeId(final String nodeId) {
-    int expectedSize = EnodeURL.NODE_ID_SIZE * 2;
+    int expectedSize = EnodeURLImpl.NODE_ID_SIZE * 2;
     if (nodeId.toLowerCase().startsWith("0x")) {
       expectedSize += 2;
     }
     checkArgument(
         nodeId.length() == expectedSize,
-        "Expected " + EnodeURL.NODE_ID_SIZE + " bytes in " + nodeId);
+        "Expected " + EnodeURLImpl.NODE_ID_SIZE + " bytes in " + nodeId);
     return Bytes.fromHexString(nodeId, NODE_ID_SIZE);
   }
 
+  @Override
   public URI toURI() {
 
     final String uri =
@@ -169,6 +171,7 @@ public class EnodeURL {
     }
   }
 
+  @Override
   public URI toURIWithoutDiscoveryPort() {
     final String uri =
         String.format(
@@ -202,10 +205,12 @@ public class EnodeURL {
     return fromString(url, enodeDnsConfiguration).toURI();
   }
 
+  @Override
   public Bytes getNodeId() {
     return nodeId;
   }
 
+  @Override
   public String getIpAsString() {
     return getIp().getHostAddress();
   }
@@ -221,6 +226,7 @@ public class EnodeURL {
    *
    * @return ip
    */
+  @Override
   public InetAddress getIp() {
     this.ip =
         maybeHostname
@@ -236,26 +242,32 @@ public class EnodeURL {
     return ip;
   }
 
+  @Override
   public boolean isListening() {
     return listeningPort.isPresent();
   }
 
+  @Override
   public boolean isRunningDiscovery() {
     return discoveryPort.isPresent();
   }
 
+  @Override
   public Optional<Integer> getListeningPort() {
     return listeningPort;
   }
 
+  @Override
   public int getListeningPortOrZero() {
     return listeningPort.orElse(0);
   }
 
+  @Override
   public Optional<Integer> getDiscoveryPort() {
     return discoveryPort;
   }
 
+  @Override
   public int getDiscoveryPortOrZero() {
     return discoveryPort.orElse(0);
   }
@@ -297,7 +309,7 @@ public class EnodeURL {
 
     public EnodeURL build() {
       validate();
-      return new EnodeURL(nodeId, ip, maybeHostname, listeningPort, discoveryPort);
+      return new EnodeURLImpl(nodeId, ip, maybeHostname, listeningPort, discoveryPort);
     }
 
     private void validate() {
@@ -379,7 +391,7 @@ public class EnodeURL {
     }
 
     public Builder useDefaultPorts() {
-      discoveryAndListeningPorts(EnodeURL.DEFAULT_LISTENING_PORT);
+      discoveryAndListeningPorts(EnodeURLImpl.DEFAULT_LISTENING_PORT);
       return this;
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/LocalNode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/LocalNode.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.peers;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.List;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/MutableLocalNode.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/MutableLocalNode.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.p2p.peers;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.List;
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/Peer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/Peer.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.p2p.peers;
 
 import org.hyperledger.besu.crypto.SecureRandomProvider;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -33,7 +34,7 @@ public interface Peer extends PeerId {
    * @return The generated peer ID.
    */
   static Bytes randomId() {
-    final byte[] id = new byte[EnodeURL.NODE_ID_SIZE];
+    final byte[] id = new byte[EnodeURLImpl.NODE_ID_SIZE];
     SecureRandomProvider.publicSecureRandom().nextBytes(id);
     return Bytes.wrap(id);
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/StaticNodesParser.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/StaticNodesParser.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptySet;
 
+import org.hyperledger.besu.plugin.data.EnodeURL;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -72,7 +74,7 @@ public class StaticNodesParser {
   private static EnodeURL decodeString(
       final String input, final EnodeDnsConfiguration enodeDnsConfiguration) {
     try {
-      final EnodeURL enode = EnodeURL.fromString(input, enodeDnsConfiguration);
+      final EnodeURL enode = EnodeURLImpl.fromString(input, enodeDnsConfiguration);
       checkArgument(
           enode.isListening(), "Static node must be configured with a valid listening port.");
       return enode;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECPPublicKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerPrivileges;
@@ -36,6 +35,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty.NettyConnectionI
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.util.Subscribers;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/PeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/PeerConnection.java
@@ -14,12 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.p2p.rlpx.connections;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.IncompatiblePeerExce
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.PeerDisconnectedException;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.UnexpectedPeerConnectionException;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
@@ -194,7 +194,7 @@ final class DeFramer extends ByteToMessageDecoder {
     final InetSocketAddress remoteAddress = ((InetSocketAddress) ctx.channel().remoteAddress());
     int port = peerInfo.getPort();
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(peerInfo.getNodeId())
             .ipAddress(remoteAddress.getAddress())
             .listeningPort(port)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyConnectionInitializer.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
@@ -25,6 +24,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.connections.ConnectionInitializer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnectionEventDispatcher;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.Subscribers;
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfigurationTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfigurationTest.java
@@ -16,8 +16,9 @@ package org.hyperledger.besu.ethereum.p2p.config;
 
 import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Collections;
 
@@ -28,7 +29,7 @@ public class DiscoveryConfigurationTest {
   @Test
   public void setBootnodes_withDiscoveryDisabled() {
     final EnodeURL invalidBootnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(Peer.randomId())
             .ipAddress("127.0.0.1")
             .listeningPort(30303)
@@ -46,7 +47,7 @@ public class DiscoveryConfigurationTest {
   @Test
   public void setBootnodes_withListeningDisabled() {
     final EnodeURL invalidBootnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(Peer.randomId())
             .ipAddress("127.0.0.1")
             .discoveryAndListeningPorts(0)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -36,11 +36,12 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.NeighborsPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsDenylist;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +65,7 @@ public class PeerDiscoveryAgentTest {
   @Test
   public void createAgentWithInvalidBootnodes() {
     final EnodeURL invalidBootnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(Peer.randomId())
             .ipAddress("127.0.0.1")
             .listeningPort(30303)
@@ -372,7 +373,10 @@ public class PeerDiscoveryAgentTest {
     assertThat(otherNode.getAdvertisedPeer().isPresent()).isTrue();
     final DiscoveryPeer remotePeer = otherNode.getAdvertisedPeer().get();
     final EnodeURL enodeWithDiscoveryDisabled =
-        EnodeURL.builder().configureFromEnode(remotePeer.getEnodeURL()).disableDiscovery().build();
+        EnodeURLImpl.builder()
+            .configureFromEnode(remotePeer.getEnodeURL())
+            .disableDiscovery()
+            .build();
     final Peer peerWithDisabledDiscovery = DefaultPeer.fromEnodeURL(enodeWithDiscoveryDisabled);
 
     final PeerPermissions peerPermissions = mock(PeerPermissions.class);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTestHelper.java
@@ -26,10 +26,11 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PongPacketData;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.nat.NatService;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class PeerDiscoveryTestHelper {
     final int port = nextAvailablePort.incrementAndGet();
     DiscoveryPeer discoveryPeer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(peerId)
                 .ipAddress(LOOPBACK_IP_ADDR)
                 .discoveryAndListeningPorts(port)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -36,7 +36,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.Endpoint;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerBondedObserver;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
@@ -1080,7 +1080,7 @@ public class PeerDiscoveryControllerTest {
 
     final DiscoveryPeer localNode =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(Peer.randomId())
                 .discoveryAndListeningPorts(30303)
@@ -1120,7 +1120,7 @@ public class PeerDiscoveryControllerTest {
 
     final DiscoveryPeer localNode =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(Peer.randomId())
                 .discoveryAndListeningPorts(30303)
@@ -1166,7 +1166,7 @@ public class PeerDiscoveryControllerTest {
 
     final DiscoveryPeer localNode =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(Peer.randomId())
                 .discoveryAndListeningPorts(30303)
@@ -1214,7 +1214,7 @@ public class PeerDiscoveryControllerTest {
 
     final DiscoveryPeer localNode =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(Peer.randomId())
                 .discoveryAndListeningPorts(30303)
@@ -1254,7 +1254,7 @@ public class PeerDiscoveryControllerTest {
 
     final DiscoveryPeer localNode =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .ipAddress("127.0.0.1")
                 .nodeId(Peer.randomId())
                 .discoveryAndListeningPorts(30303)
@@ -1377,7 +1377,7 @@ public class PeerDiscoveryControllerTest {
       final DiscoveryPeer peer =
           spy(
               DiscoveryPeer.fromEnode(
-                  EnodeURL.builder()
+                  EnodeURLImpl.builder()
                       .nodeId(id)
                       .ipAddress("127.0.0.1")
                       .discoveryAndListeningPorts(100 + counter.incrementAndGet())

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
@@ -24,7 +24,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerTable.AddResult.AddOutcome;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerTable.EvictResult;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerTable.EvictResult.EvictOutcome;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 
 import java.util.List;
@@ -58,7 +58,7 @@ public class PeerTableTest {
   public void addSelf() {
     final DiscoveryPeer localPeer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(Peer.randomId())
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(12345)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshStateTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshStateTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.RecursivePeerRefreshState.BondingAgent;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.RecursivePeerRefreshState.FindNeighbourDispatcher;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 
 import java.util.Collections;
 import java.util.List;
@@ -514,7 +514,7 @@ public class RecursivePeerRefreshStateTest {
   private static DiscoveryPeer createPeer(
       final Bytes id, final String ip, final int discoveryPort, final int listeningPort) {
     return DiscoveryPeer.fromEnode(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(id)
             .ipAddress(ip)
             .discoveryPort(discoveryPort)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/NetworkingServiceLifecycleTest.java
@@ -24,9 +24,9 @@ import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.p2p.config.DiscoveryConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryServiceException;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.IncompatiblePeerException;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsDenylist;
@@ -38,6 +38,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.SubProtocol;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.net.InetAddress;
 import java.util.Arrays;
@@ -294,7 +295,7 @@ public class P2PNetworkTest {
 
   private Peer createPeer(final Bytes nodeId, final int listenPort) {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .ipAddress(InetAddress.getLoopbackAddress().getHostAddress())
             .nodeId(nodeId)
             .discoveryAndListeningPorts(listenPort)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerReputationManagerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerReputationManagerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsDenylist;
@@ -113,7 +113,7 @@ public class PeerReputationManagerTest {
 
   private Peer generatePeer() {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(Peer.randomId())
             .ipAddress("10.9.8.7")
             .discoveryPort(65535)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNodeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNodeTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +36,7 @@ public class DefaultLocalNodeTest {
   private final Bytes nodeId = Bytes.of(new byte[64]);
   private final int port = 30303;
   private final EnodeURL enode =
-      EnodeURL.builder()
+      EnodeURLImpl.builder()
           .ipAddress("127.0.0.1")
           .discoveryAndListeningPorts(port)
           .nodeId(nodeId)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.IllegalPortException;
 
 import java.net.URI;
@@ -29,7 +30,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 
-public class EnodeURLTest {
+public class EnodeURLImplTest {
 
   private final String VALID_NODE_ID =
       "6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0";
@@ -43,7 +44,7 @@ public class EnodeURLTest {
   @Test
   public void build_withMatchingDiscoveryAndListeningPorts() {
     final EnodeURL enode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -56,7 +57,7 @@ public class EnodeURLTest {
   @Test
   public void build_withNonMatchingDiscoveryAndListeningPorts() {
     final EnodeURL enode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -69,7 +70,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withDiscoveryPortShouldBuildExpectedEnodeURLObject() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -78,7 +79,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + P2P_PORT + "?" + DISCOVERY_QUERY;
 
-    final EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);
     assertThat(enodeURL.toString()).isEqualTo(enodeURLString);
@@ -87,14 +88,14 @@ public class EnodeURLTest {
   @Test
   public void fromString_withoutDiscoveryPortShouldBuildExpectedEnodeURLObject() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryAndListeningPorts(P2P_PORT)
             .build();
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + P2P_PORT;
 
-    final EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);
     assertThat(enodeURL.toString()).isEqualTo(enodeURLString);
@@ -103,7 +104,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withIPV6ShouldBuildExpectedEnodeURLObject() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV6_FULL_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -119,7 +120,7 @@ public class EnodeURLTest {
             + "?"
             + DISCOVERY_QUERY;
 
-    final EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);
   }
@@ -127,7 +128,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withIPV6InCompactFormShouldBuildExpectedEnodeURLObject() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV6_COMPACT_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -143,7 +144,7 @@ public class EnodeURLTest {
             + "?"
             + DISCOVERY_QUERY;
 
-    final EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    final EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);
     assertThat(enodeURL.toString()).isEqualTo(enodeURLString);
@@ -155,7 +156,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_COMPACT_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
     assertThat(enodeURL.getNodeId().toUnprefixedHexString()).isEqualTo(VALID_NODE_ID);
     assertThat("[" + enodeURL.getIpAsString() + "]").isEqualTo(IPV6_FULL_ADDRESS);
     assertThat(enodeURL.getListeningPort()).isEqualTo(Optional.of(P2P_PORT));
@@ -170,7 +171,7 @@ public class EnodeURLTest {
   public void fromString_with0ValuedListeningPort() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + 0;
 
-    EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
     assertThat(enodeURL.getNodeId().toUnprefixedHexString()).isEqualTo(VALID_NODE_ID);
     assertThat(enodeURL.getIpAsString()).isEqualTo(IPV4_ADDRESS);
     assertThat(enodeURL.getListeningPortOrZero()).isEqualTo(0);
@@ -187,7 +188,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + 0 + "?" + query;
 
-    EnodeURL enodeURL = EnodeURL.fromString(enodeURLString);
+    EnodeURL enodeURL = EnodeURLImpl.fromString(enodeURLString);
     assertThat(enodeURL.getNodeId().toUnprefixedHexString()).isEqualTo(VALID_NODE_ID);
     assertThat(enodeURL.getIpAsString()).isEqualTo(IPV4_ADDRESS);
     assertThat(enodeURL.getListeningPortOrZero()).isEqualTo(0);
@@ -199,7 +200,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withoutNodeIdShouldFail() {
     final String enodeURLString = "enode://@" + IPV4_ADDRESS + ":" + P2P_PORT;
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -209,7 +210,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withInvalidSizeNodeIdShouldFail() {
     final String enodeURLString = "enode://wrong_size_string@" + IPV4_ADDRESS + ":" + P2P_PORT;
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -223,7 +224,7 @@ public class EnodeURLTest {
             + IPV4_ADDRESS
             + ":"
             + P2P_PORT;
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -233,7 +234,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withoutIpShouldFail() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@:" + P2P_PORT;
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -243,7 +244,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withInvalidIpFormatShouldFail() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@192.0.1:" + P2P_PORT;
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -253,7 +254,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withoutListeningPortShouldFail() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":";
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown).hasCauseInstanceOf(IllegalPortException.class);
   }
@@ -262,7 +263,7 @@ public class EnodeURLTest {
   public void fromString_withoutListeningPortAndWithDiscoveryPortShouldFail() {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":?discport=30301";
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown).hasCauseInstanceOf(IllegalPortException.class);
   }
@@ -270,7 +271,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withAboveRangeListeningPortShouldFail() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":98765";
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown).hasCauseInstanceOf(IllegalPortException.class);
   }
@@ -279,7 +280,7 @@ public class EnodeURLTest {
   public void fromString_withAboveRangeDiscoveryPortShouldFail() {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + P2P_PORT + "?discport=98765";
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(enodeURLString));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(enodeURLString));
 
     assertThat(thrown).hasCauseInstanceOf(IllegalPortException.class);
   }
@@ -290,7 +291,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_FULL_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    assertThatThrownBy(() -> EnodeURL.fromString(enodeURLString))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(enodeURLString))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid discovery port: '" + query + "'");
   }
@@ -301,7 +302,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_FULL_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    assertThatThrownBy(() -> EnodeURL.fromString(enodeURLString))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(enodeURLString))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid discovery port: '" + query + "'");
   }
@@ -312,7 +313,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_FULL_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    assertThatThrownBy(() -> EnodeURL.fromString(enodeURLString))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(enodeURLString))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid discovery port: '" + query + "'");
   }
@@ -323,7 +324,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_FULL_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    assertThatThrownBy(() -> EnodeURL.fromString(enodeURLString))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(enodeURLString))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid discovery port: '" + query + "'");
   }
@@ -334,14 +335,14 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV6_FULL_ADDRESS + ":" + P2P_PORT + "?" + query;
 
-    assertThatThrownBy(() -> EnodeURL.fromString(enodeURLString))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(enodeURLString))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid discovery port: '" + query + "'");
   }
 
   @Test
   public void fromString_withNullEnodeURLShouldFail() {
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(null));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(null));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -350,7 +351,7 @@ public class EnodeURLTest {
 
   @Test
   public void fromString_withEmptyEnodeURLShouldFail() {
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(""));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(""));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -359,7 +360,7 @@ public class EnodeURLTest {
 
   @Test
   public void fromString_withWhitespaceEnodeURLShouldFail() {
-    final Throwable thrown = catchThrowable(() -> EnodeURL.fromString(" "));
+    final Throwable thrown = catchThrowable(() -> EnodeURLImpl.fromString(" "));
 
     assertThat(thrown)
         .isInstanceOf(IllegalArgumentException.class)
@@ -370,7 +371,7 @@ public class EnodeURLTest {
   public void fromStringInvalidNodeIdLengthHasDescriptiveMessage() {
     String invalidEnodeURL =
         String.format("enode://%s@%s:%d", VALID_NODE_ID.substring(1), IPV4_ADDRESS, P2P_PORT);
-    assertThatThrownBy(() -> EnodeURL.fromString(invalidEnodeURL))
+    assertThatThrownBy(() -> EnodeURLImpl.fromString(invalidEnodeURL))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageEndingWith(
             "Invalid node ID: node ID must have exactly 128 hexadecimal characters and should not include any '0x' hex prefix.");
@@ -383,7 +384,7 @@ public class EnodeURLTest {
 
     assertThatThrownBy(
             () ->
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     enodeURLString,
                     ImmutableEnodeDnsConfiguration.builder()
                         .dnsEnabled(false)
@@ -400,7 +401,7 @@ public class EnodeURLTest {
 
     assertThatThrownBy(
             () ->
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     enodeURLString,
                     ImmutableEnodeDnsConfiguration.builder()
                         .dnsEnabled(false)
@@ -413,7 +414,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withHostnameEnodeURLShouldWorkWhenDnsEnabled() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress("127.0.0.1")
             .listeningPort(P2P_PORT)
@@ -423,7 +424,7 @@ public class EnodeURLTest {
         "enode://" + VALID_NODE_ID + "@" + "localhost" + ":" + P2P_PORT + "?" + DISCOVERY_QUERY;
 
     final EnodeURL enodeURL =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             enodeURLString,
             ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build());
     ;
@@ -434,7 +435,7 @@ public class EnodeURLTest {
   @Test
   public void fromString_withHostnameEnodeURLShouldWorkWhenDnsEnabledAndUpdateEnabled() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress("127.0.0.1")
             .listeningPort(P2P_PORT)
@@ -444,7 +445,7 @@ public class EnodeURLTest {
         "enode://" + VALID_NODE_ID + "@" + "localhost" + ":" + P2P_PORT + "?" + DISCOVERY_QUERY;
 
     final EnodeURL enodeURL =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             enodeURLString,
             ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build());
     ;
@@ -457,7 +458,7 @@ public class EnodeURLTest {
     final String enodeURLString =
         "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + P2P_PORT + "?" + DISCOVERY_QUERY;
     final URI expectedURI = URI.create(enodeURLString);
-    final URI createdURI = EnodeURL.fromString(enodeURLString).toURI();
+    final URI createdURI = EnodeURLImpl.fromString(enodeURLString).toURI();
 
     assertThat(createdURI).isEqualTo(expectedURI);
   }
@@ -466,7 +467,7 @@ public class EnodeURLTest {
   public void toURI_WithoutDiscoveryPortCreateExpectedURI() {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + IPV4_ADDRESS + ":" + P2P_PORT;
     final URI expectedURI = URI.create(enodeURLString);
-    final URI createdURI = EnodeURL.fromString(enodeURLString).toURI();
+    final URI createdURI = EnodeURLImpl.fromString(enodeURLString).toURI();
 
     assertThat(createdURI).isEqualTo(expectedURI);
   }
@@ -477,7 +478,7 @@ public class EnodeURLTest {
     final URI expectedURI =
         URI.create("enode://" + VALID_NODE_ID + "@" + "127.0.0.1" + ":" + P2P_PORT);
     final URI createdURI =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
                 enodeURLString,
                 ImmutableEnodeDnsConfiguration.builder()
                     .dnsEnabled(true)
@@ -493,7 +494,7 @@ public class EnodeURLTest {
     final String enodeURLString = "enode://" + VALID_NODE_ID + "@" + "localhost" + ":" + P2P_PORT;
     final URI expectedURI = URI.create(enodeURLString);
     final URI createdURI =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
                 enodeURLString,
                 ImmutableEnodeDnsConfiguration.builder()
                     .dnsEnabled(true)
@@ -512,7 +513,7 @@ public class EnodeURLTest {
 
     assertThatThrownBy(
             () ->
-                EnodeURL.fromURI(
+                EnodeURLImpl.fromURI(
                     expectedURI,
                     ImmutableEnodeDnsConfiguration.builder()
                         .dnsEnabled(false)
@@ -525,7 +526,7 @@ public class EnodeURLTest {
   @Test
   public void fromURI_withHostnameEnodeURLShouldWorkWhenDnsEnabled() {
     final EnodeURL expectedEnodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress("127.0.0.1")
             .listeningPort(P2P_PORT)
@@ -537,7 +538,7 @@ public class EnodeURLTest {
     final URI expectedURI = URI.create(enodeURLString);
 
     final EnodeURL enodeURL =
-        EnodeURL.fromURI(
+        EnodeURLImpl.fromURI(
             expectedURI,
             ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build());
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);
@@ -545,8 +546,8 @@ public class EnodeURLTest {
 
   @Test
   public void builder_setInvalidPorts() {
-    final EnodeURL.Builder validBuilder =
-        EnodeURL.builder().nodeId(VALID_NODE_ID).ipAddress(IPV4_ADDRESS);
+    final EnodeURLImpl.Builder validBuilder =
+        EnodeURLImpl.builder().nodeId(VALID_NODE_ID).ipAddress(IPV4_ADDRESS);
 
     Stream.<ThrowableAssert.ThrowingCallable>of(
             () -> validBuilder.listeningPort(200_000).disableDiscovery().build(),
@@ -559,7 +560,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setEachPortExplicitly() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -577,7 +578,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setPortsTogether() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryAndListeningPorts(P2P_PORT)
@@ -594,12 +595,16 @@ public class EnodeURLTest {
   @Test
   public void builder_setDefaultPorts() {
     final EnodeURL enodeURL =
-        EnodeURL.builder().nodeId(VALID_NODE_ID).ipAddress(IPV4_ADDRESS).useDefaultPorts().build();
+        EnodeURLImpl.builder()
+            .nodeId(VALID_NODE_ID)
+            .ipAddress(IPV4_ADDRESS)
+            .useDefaultPorts()
+            .build();
 
     assertThat(enodeURL.getNodeId().toUnprefixedHexString()).isEqualTo(VALID_NODE_ID);
     assertThat(enodeURL.getIpAsString()).isEqualTo(IPV4_ADDRESS);
-    assertThat(enodeURL.getListeningPortOrZero()).isEqualTo(EnodeURL.DEFAULT_LISTENING_PORT);
-    assertThat(enodeURL.getDiscoveryPortOrZero()).isEqualTo(EnodeURL.DEFAULT_LISTENING_PORT);
+    assertThat(enodeURL.getListeningPortOrZero()).isEqualTo(EnodeURLImpl.DEFAULT_LISTENING_PORT);
+    assertThat(enodeURL.getDiscoveryPortOrZero()).isEqualTo(EnodeURLImpl.DEFAULT_LISTENING_PORT);
     assertThat(enodeURL.isListening()).isTrue();
     assertThat(enodeURL.isRunningDiscovery()).isTrue();
   }
@@ -607,7 +612,7 @@ public class EnodeURLTest {
   @Test
   public void builder_discoveryDisabled() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
@@ -625,7 +630,7 @@ public class EnodeURLTest {
   @Test
   public void builder_listeningDisabled() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryPort(P2P_PORT)
@@ -643,7 +648,7 @@ public class EnodeURLTest {
   @Test
   public void builder_listeningAndDiscoveryDisabled() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .disableDiscovery()
@@ -661,7 +666,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setPortsTo0() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryAndListeningPorts(0)
@@ -678,7 +683,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setDiscoveryPortTo0() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryPort(0)
@@ -696,7 +701,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setListeningPortTo0() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryPort(P2P_PORT)
@@ -714,7 +719,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setDiscoveryPortToEmptyValue() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryPort(Optional.empty())
@@ -732,7 +737,7 @@ public class EnodeURLTest {
   @Test
   public void builder_setListeningPortToEmptyValue() {
     final EnodeURL enodeURL =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .discoveryPort(P2P_PORT)
@@ -749,8 +754,11 @@ public class EnodeURLTest {
 
   @Test
   public void builder_discoveryNotSpecified() {
-    final EnodeURL.Builder builder =
-        EnodeURL.builder().nodeId(VALID_NODE_ID).ipAddress(IPV4_ADDRESS).listeningPort(P2P_PORT);
+    final EnodeURLImpl.Builder builder =
+        EnodeURLImpl.builder()
+            .nodeId(VALID_NODE_ID)
+            .ipAddress(IPV4_ADDRESS)
+            .listeningPort(P2P_PORT);
 
     assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalStateException.class)
@@ -759,8 +767,11 @@ public class EnodeURLTest {
 
   @Test
   public void builder_listeningPortNotSpecified() {
-    final EnodeURL.Builder builder =
-        EnodeURL.builder().nodeId(VALID_NODE_ID).ipAddress(IPV4_ADDRESS).discoveryPort(P2P_PORT);
+    final EnodeURLImpl.Builder builder =
+        EnodeURLImpl.builder()
+            .nodeId(VALID_NODE_ID)
+            .ipAddress(IPV4_ADDRESS)
+            .discoveryPort(P2P_PORT);
 
     assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalStateException.class)
@@ -769,8 +780,8 @@ public class EnodeURLTest {
 
   @Test
   public void builder_nodeIdNotSpecified() {
-    final EnodeURL.Builder builder =
-        EnodeURL.builder().ipAddress(IPV4_ADDRESS).discoveryAndListeningPorts(P2P_PORT);
+    final EnodeURLImpl.Builder builder =
+        EnodeURLImpl.builder().ipAddress(IPV4_ADDRESS).discoveryAndListeningPorts(P2P_PORT);
 
     assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalStateException.class)
@@ -779,8 +790,8 @@ public class EnodeURLTest {
 
   @Test
   public void builder_ipNotSpecified() {
-    final EnodeURL.Builder builder =
-        EnodeURL.builder().nodeId(VALID_NODE_ID).discoveryAndListeningPorts(P2P_PORT);
+    final EnodeURLImpl.Builder builder =
+        EnodeURLImpl.builder().nodeId(VALID_NODE_ID).discoveryAndListeningPorts(P2P_PORT);
 
     assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalStateException.class)
@@ -790,107 +801,107 @@ public class EnodeURLTest {
   @Test
   public void sameListeningEndpoint_forMatchingEnodes() {
     final EnodeURL enodeA =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT)
             .build();
     final EnodeURL enodeB =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT + 1)
             .build();
 
-    assertThat(EnodeURL.sameListeningEndpoint(enodeA, enodeB)).isTrue();
+    assertThat(EnodeURLImpl.sameListeningEndpoint(enodeA, enodeB)).isTrue();
   }
 
   @Test
   public void sameListeningEndpoint_differentListeningPorts() {
     final EnodeURL enodeA =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT)
             .build();
     final EnodeURL enodeB =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT + 1)
             .discoveryPort(DISCOVERY_PORT)
             .build();
 
-    assertThat(EnodeURL.sameListeningEndpoint(enodeA, enodeB)).isFalse();
+    assertThat(EnodeURLImpl.sameListeningEndpoint(enodeA, enodeB)).isFalse();
   }
 
   @Test
   public void sameListeningEndpoint_differentIps() {
     final EnodeURL enodeA =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV6_COMPACT_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT)
             .build();
     final EnodeURL enodeB =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT)
             .build();
 
-    assertThat(EnodeURL.sameListeningEndpoint(enodeA, enodeB)).isFalse();
+    assertThat(EnodeURLImpl.sameListeningEndpoint(enodeA, enodeB)).isFalse();
   }
 
   @Test
   public void sameListeningEndpoint_listeningDisabledForOne() {
     final EnodeURL enodeA =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .disableListening()
             .discoveryPort(DISCOVERY_PORT)
             .build();
     final EnodeURL enodeB =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .listeningPort(P2P_PORT)
             .discoveryPort(DISCOVERY_PORT)
             .build();
 
-    assertThat(EnodeURL.sameListeningEndpoint(enodeA, enodeB)).isFalse();
+    assertThat(EnodeURLImpl.sameListeningEndpoint(enodeA, enodeB)).isFalse();
   }
 
   @Test
   public void sameListeningEndpoint_listeningDisabledForBoth() {
     final EnodeURL enodeA =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .disableListening()
             .discoveryPort(DISCOVERY_PORT)
             .build();
     final EnodeURL enodeB =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(VALID_NODE_ID)
             .ipAddress(IPV4_ADDRESS)
             .disableListening()
             .discoveryPort(DISCOVERY_PORT)
             .build();
 
-    assertThat(EnodeURL.sameListeningEndpoint(enodeA, enodeB)).isTrue();
+    assertThat(EnodeURLImpl.sameListeningEndpoint(enodeA, enodeB)).isTrue();
   }
 
   @Test
   public void parseNodeId_invalid() {
     final String invalidId = "0x10";
-    assertThatThrownBy(() -> EnodeURL.parseNodeId(invalidId))
+    assertThatThrownBy(() -> EnodeURLImpl.parseNodeId(invalidId))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Expected 64 bytes in " + invalidId);
   }
@@ -898,8 +909,8 @@ public class EnodeURLTest {
   @Test
   public void parseNodeId_valid() {
     final String validId = VALID_NODE_ID;
-    final Bytes nodeId = EnodeURL.parseNodeId(validId);
-    assertThat(nodeId.size()).isEqualTo(EnodeURL.NODE_ID_SIZE);
+    final Bytes nodeId = EnodeURLImpl.parseNodeId(validId);
+    assertThat(nodeId.size()).isEqualTo(EnodeURLImpl.NODE_ID_SIZE);
     assertThat(nodeId.toUnprefixedHexString()).isEqualTo(validId);
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTest.java
@@ -34,14 +34,14 @@ public class PeerTest {
             "c7849b663d12a2b5bf05b1ebf5810364f4870d5f1053fbd7500d38bc54c705b453d7511ca8a4a86003d34d4c8ee0bbfcd387aa724f5b240b3ab4bbb994a1e09b");
     final Peer peer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(id)
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(5000)
                 .build());
     final Peer peer2 =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(id)
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(5001)
@@ -56,14 +56,14 @@ public class PeerTest {
             "c7849b663d12a2b5bf05b1ebf5810364f4870d5f1053fbd7500d38bc54c705b453d7511ca8a4a86003d34d4c8ee0bbfcd387aa724f5b240b3ab4bbb994a1e09b");
     final Peer peer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(id)
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(5000)
                 .build());
     final Peer peer2 =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(id)
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(5001)
@@ -75,7 +75,7 @@ public class PeerTest {
   public void getStatus() {
     final DiscoveryPeer peer =
         DiscoveryPeer.fromEnode(
-            EnodeURL.builder()
+            EnodeURLImpl.builder()
                 .nodeId(Peer.randomId())
                 .ipAddress("127.0.0.1")
                 .discoveryAndListeningPorts(5000)

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTestHelper.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.p2p.peers;
 
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 
@@ -34,8 +35,8 @@ public class PeerTestHelper {
     return enodeBuilder().build();
   }
 
-  public static EnodeURL.Builder enodeBuilder() {
-    return EnodeURL.builder().ipAddress("127.0.0.1").useDefaultPorts().nodeId(Peer.randomId());
+  public static EnodeURLImpl.Builder enodeBuilder() {
+    return EnodeURLImpl.builder().ipAddress("127.0.0.1").useDefaultPorts().nodeId(Peer.randomId());
   }
 
   /** @return A LocalNode that is setup and ready. */

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/StaticNodesParserTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/StaticNodesParserTest.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.p2p.peers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.hyperledger.besu.plugin.data.EnodeURL;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -42,25 +44,25 @@ public class StaticNodesParserTest {
   // First peer ion the valid_static_nodes file.
   private final List<EnodeURL> validFileItems =
       Lists.newArrayList(
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(
                   "50203c6bfca6874370e71aecc8958529fd723feb05013dc1abca8fc1fff845c5259faba05852e9dfe5ce172a7d6e7c2a3a5eaa8b541c8af15ea5518bbff5f2fa")
               .ipAddress("127.0.0.1")
               .useDefaultPorts()
               .build(),
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(
                   "02beb46bc17227616be44234071dfa18516684e45eed88049190b6cb56b0bae218f045fd0450f123b8f55c60b96b78c45e8e478004293a8de6818aa4e02eff97")
               .ipAddress("127.0.0.1")
               .discoveryAndListeningPorts(30304)
               .build(),
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(
                   "819e5cbd81f123516b10f04bf620daa2b385efef06d77253148b814bf1bb6197ff58ebd1fd7bf5dc765b49a4440c733bf941e479c800173f2bfeb887e4fbcbc2")
               .ipAddress("127.0.0.1")
               .discoveryAndListeningPorts(30305)
               .build(),
-          EnodeURL.builder()
+          EnodeURLImpl.builder()
               .nodeId(
                   "6cf53e25d2a98a22e7e205a86bda7077e3c8a7bc99e5ff88ddfd2037a550969ab566f069ffa455df0cfae0c21f7aec3447e414eccc473a3e8b20984b90f164ac")
               .ipAddress("127.0.0.1")
@@ -77,7 +79,7 @@ public class StaticNodesParserTest {
         StaticNodesParser.fromPath(validFile.toPath(), EnodeDnsConfiguration.DEFAULT_CONFIG);
 
     assertThat(enodes)
-        .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
+        .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURLImpl[validFileItems.size()]));
   }
 
   @Test
@@ -92,7 +94,7 @@ public class StaticNodesParserTest {
         StaticNodesParser.fromPath(validFile.toPath(), enodeDnsConfiguration);
 
     assertThat(enodes)
-        .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
+        .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURLImpl[validFileItems.size()]));
   }
 
   @Test
@@ -122,6 +124,12 @@ public class StaticNodesParserTest {
 
     assertThat(enodes)
         .containsExactlyInAnyOrder(validFileItems.toArray(new EnodeURL[validFileItems.size()]));
+    final Set<EnodeURL> actual =
+        StaticNodesParser.fromPath(validFile.toPath(), enodeDnsConfiguration);
+
+    final EnodeURL[] expected = validFileItems.toArray(new EnodeURLImpl[validFileItems.size()]);
+
+    assertThat(actual).containsExactlyInAnyOrder(expected);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsDenylistTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsDenylistTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.p2p.permissions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
 
@@ -223,10 +223,10 @@ public class PeerPermissionsDenylistTest {
 
   private Peer createPeer() {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .nodeId(Peer.randomId())
             .ipAddress("127.0.0.1")
-            .discoveryAndListeningPorts(EnodeURL.DEFAULT_LISTENING_PORT)
+            .discoveryAndListeningPorts(EnodeURLImpl.DEFAULT_LISTENING_PORT)
             .build());
   }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
 
@@ -157,7 +157,7 @@ public class PeerPermissionsTest {
 
   private Peer createPeer() {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .listeningPort(30303)
             .discoveryPort(30303)
             .nodeId(Peer.randomId())

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.MutableLocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerPrivileges;
@@ -241,8 +241,8 @@ public class RlpxAgentTest {
 
   @Test
   public void incomingConnection_deduplicatedWhenAlreadyConnected_peerWithHigherValueNodeId() {
-    final Bytes localNodeId = Bytes.fromHexString("0x01", EnodeURL.NODE_ID_SIZE);
-    final Bytes remoteNodeId = Bytes.fromHexString("0x02", EnodeURL.NODE_ID_SIZE);
+    final Bytes localNodeId = Bytes.fromHexString("0x01", EnodeURLImpl.NODE_ID_SIZE);
+    final Bytes remoteNodeId = Bytes.fromHexString("0x02", EnodeURLImpl.NODE_ID_SIZE);
 
     startAgent(localNodeId);
 
@@ -262,8 +262,8 @@ public class RlpxAgentTest {
   @Test
   public void incomingConnection_deduplicatedWhenAlreadyConnected_peerWithLowerValueNodeId()
       throws ExecutionException, InterruptedException {
-    final Bytes localNodeId = Bytes.fromHexString("0x02", EnodeURL.NODE_ID_SIZE);
-    final Bytes remoteNodeId = Bytes.fromHexString("0x01", EnodeURL.NODE_ID_SIZE);
+    final Bytes localNodeId = Bytes.fromHexString("0x02", EnodeURLImpl.NODE_ID_SIZE);
+    final Bytes remoteNodeId = Bytes.fromHexString("0x01", EnodeURLImpl.NODE_ID_SIZE);
 
     startAgent(localNodeId);
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramerTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.IncompatiblePeerExce
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.PeerDisconnectedException;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.UnexpectedPeerConnectionException;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
@@ -49,6 +49,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.PingMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.WireMessageCodes;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public class DeFramerTest {
   private final int port = 30303;
   private final List<Capability> capabilities = Arrays.asList(Capability.create("eth", 63));
   private final EnodeURL localEnode =
-      EnodeURL.builder()
+      EnodeURLImpl.builder()
           .ipAddress("127.0.0.1")
           .discoveryAndListeningPorts(port)
           .nodeId(Peer.randomId())
@@ -185,7 +186,7 @@ public class DeFramerTest {
     assertThat(peerConnection.getPeerInfo()).isEqualTo(remotePeerInfo);
 
     EnodeURL expectedEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .configureFromEnode(peer.getEnodeURL())
             // Discovery information is not available from peer info
             .disableDiscovery()
@@ -233,7 +234,7 @@ public class DeFramerTest {
     assertThat(out).isEmpty();
 
     final EnodeURL expectedEnode =
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .ipAddress(remoteAddress.getAddress())
             .nodeId(peer.getId())
             // Listening port should be disabled
@@ -370,7 +371,7 @@ public class DeFramerTest {
 
   private Peer createRemotePeer() {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .ipAddress(remoteAddress.getAddress())
             .discoveryAndListeningPorts(remotePort)
             .nodeId(Peer.randomId())

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AbstractNodeSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AbstractNodeSmartContractPermissioningController.java
@@ -15,11 +15,11 @@
 package org.hyperledger.besu.ethereum.permissioning;
 
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.permissioning.node.NodePermissioningProvider;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfiguration.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfiguration.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.ethereum.permissioning;
 
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
@@ -14,11 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.permissioning;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.AllowlistPersistor.ALLOWLIST_TYPE;
 import org.hyperledger.besu.ethereum.permissioning.node.NodeAllowlistUpdatedEvent;
 import org.hyperledger.besu.ethereum.permissioning.node.NodePermissioningProvider;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.util.Subscribers;
@@ -112,7 +113,7 @@ public class NodeLocalConfigPermissioningController implements NodePermissioning
     }
     final List<EnodeURL> peers =
         enodeURLs.stream()
-            .map(url -> EnodeURL.fromString(url, configuration.getEnodeDnsConfiguration()))
+            .map(url -> EnodeURLImpl.fromString(url, configuration.getEnodeDnsConfiguration()))
             .collect(Collectors.toList());
 
     for (EnodeURL peer : peers) {
@@ -146,7 +147,7 @@ public class NodeLocalConfigPermissioningController implements NodePermissioning
     }
     final List<EnodeURL> peers =
         enodeURLs.stream()
-            .map(url -> EnodeURL.fromString(url, configuration.getEnodeDnsConfiguration()))
+            .map(url -> EnodeURLImpl.fromString(url, configuration.getEnodeDnsConfiguration()))
             .collect(Collectors.toList());
 
     boolean anyBootnode = peers.stream().anyMatch(fixedNodes::contains);
@@ -231,14 +232,14 @@ public class NodeLocalConfigPermissioningController implements NodePermissioning
   }
 
   public boolean isPermitted(final String enodeURL) {
-    return isPermitted(EnodeURL.fromString(enodeURL, configuration.getEnodeDnsConfiguration()));
+    return isPermitted(EnodeURLImpl.fromString(enodeURL, configuration.getEnodeDnsConfiguration()));
   }
 
   public boolean isPermitted(final EnodeURL node) {
     if (Objects.equals(localNodeId, node.getNodeId())) {
       return true;
     }
-    return nodesAllowlist.stream().anyMatch(p -> EnodeURL.sameListeningEndpoint(p, node));
+    return nodesAllowlist.stream().anyMatch(p -> EnodeURLImpl.sameListeningEndpoint(p, node));
   }
 
   public List<String> getNodesAllowlist() {

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
@@ -17,11 +17,12 @@ package org.hyperledger.besu.ethereum.permissioning;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.node.NodePermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.node.NodePermissioningProvider;
 import org.hyperledger.besu.ethereum.permissioning.node.provider.SyncStatusNodePermissioningProvider;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.ArrayList;
@@ -154,9 +155,9 @@ public class NodePermissioningControllerFactory {
     try {
       // the enodeURLs don't matter. We just want to check if a call to the smart contract succeeds
       nodePermissioningController.isPermitted(
-          EnodeURL.fromString(
+          EnodeURLImpl.fromString(
               "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303"),
-          EnodeURL.fromString(
+          EnodeURLImpl.fromString(
               "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@10.3.58.6:30303"));
     } catch (Exception e) {
       final String msg =

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningController.java
@@ -18,10 +18,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.hyperledger.besu.crypto.Hash;
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.net.InetAddress;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -15,10 +15,10 @@
 package org.hyperledger.besu.ethereum.permissioning;
 
 import org.hyperledger.besu.ethereum.core.Address;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.List;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/PermissioningConfigurationBuilder.java
@@ -16,7 +16,8 @@ package org.hyperledger.besu.ethereum.permissioning;
 
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -82,7 +83,7 @@ public class PermissioningConfigurationBuilder {
                 .map(Object::toString)
                 .map(
                     url ->
-                        EnodeURL.fromString(
+                        EnodeURLImpl.fromString(
                             url, permissioningConfiguration.getEnodeDnsConfiguration()))
                 .collect(Collectors.toList());
         permissioningConfiguration.setNodeAllowlist(nodesAllowlistToml);

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/ContextualNodePermissioningProvider.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/ContextualNodePermissioningProvider.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.permissioning.node;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Optional;
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProvider.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProvider.java
@@ -15,9 +15,10 @@
 package org.hyperledger.besu.ethereum.permissioning.node;
 
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.util.Collection;
@@ -52,7 +53,7 @@ public class InsufficientPeersPermissioningProvider implements ContextualNodePer
     return bootnodeEnodes.stream()
         .noneMatch(
             (bootNode) ->
-                EnodeURL.sameListeningEndpoint(peerConnection.getRemoteEnode(), bootNode));
+                EnodeURLImpl.sameListeningEndpoint(peerConnection.getRemoteEnode(), bootNode));
   }
 
   private long countP2PNetworkNonBootnodeConnections() {
@@ -77,9 +78,9 @@ public class InsufficientPeersPermissioningProvider implements ContextualNodePer
   }
 
   private boolean checkEnode(final EnodeURL localEnode, final EnodeURL enode) {
-    return (EnodeURL.sameListeningEndpoint(localEnode, enode)
+    return (EnodeURLImpl.sameListeningEndpoint(localEnode, enode)
         || bootnodeEnodes.stream()
-            .anyMatch(bootNode -> EnodeURL.sameListeningEndpoint(bootNode, enode)));
+            .anyMatch(bootNode -> EnodeURLImpl.sameListeningEndpoint(bootNode, enode)));
   }
 
   private void handleConnect(final PeerConnection peerConnection) {

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/NodeAllowlistUpdatedEvent.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/NodeAllowlistUpdatedEvent.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.permissioning.node;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Collections;
 import java.util.List;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningController.java
@@ -14,10 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.permissioning.node;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.permissioning.GoQuorumQip714Gate;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.node.provider.SyncStatusNodePermissioningProvider;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.util.List;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapter.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapter.java
@@ -17,10 +17,10 @@ package org.hyperledger.besu.ethereum.permissioning.node;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.permissioning.node.provider.SyncStatusNodePermissioningProvider;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.List;
 import java.util.Optional;

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProvider.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProvider.java
@@ -17,9 +17,9 @@ package org.hyperledger.besu.ethereum.permissioning.node.provider;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.ethereum.core.Synchronizer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
 import org.hyperledger.besu.ethereum.permissioning.node.NodePermissioningProvider;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration.dnsDisabled;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 
 import java.io.IOException;
@@ -76,7 +76,7 @@ public class LocalPermissioningConfigurationBuilderTest {
         .containsExactly("0x0000000000000000000000000000000000000009");
     assertThat(permissioningConfiguration.isNodeAllowlistEnabled()).isTrue();
     assertThat(permissioningConfiguration.getNodeAllowlist())
-        .containsExactly(EnodeURL.fromString(uri), EnodeURL.fromString(uri2));
+        .containsExactly(EnodeURLImpl.fromString(uri), EnodeURLImpl.fromString(uri2));
   }
 
   @Test
@@ -94,7 +94,7 @@ public class LocalPermissioningConfigurationBuilderTest {
         .containsExactly("0x0000000000000000000000000000000000000009");
     assertThat(permissioningConfiguration.isNodeAllowlistEnabled()).isTrue();
     assertThat(permissioningConfiguration.getNodeAllowlist())
-        .containsExactly(EnodeURL.fromString(uri), EnodeURL.fromString(uri2));
+        .containsExactly(EnodeURLImpl.fromString(uri), EnodeURLImpl.fromString(uri2));
   }
 
   @Test
@@ -115,7 +115,7 @@ public class LocalPermissioningConfigurationBuilderTest {
     assertThat(permissioningConfiguration.isAccountAllowlistEnabled()).isFalse();
     assertThat(permissioningConfiguration.isNodeAllowlistEnabled()).isTrue();
     assertThat(permissioningConfiguration.getNodeAllowlist())
-        .containsExactly(EnodeURL.fromString(uri));
+        .containsExactly(EnodeURLImpl.fromString(uri));
   }
 
   @Test
@@ -137,7 +137,7 @@ public class LocalPermissioningConfigurationBuilderTest {
     assertThat(permissioningConfiguration.isAccountAllowlistEnabled()).isFalse();
     assertThat(permissioningConfiguration.isNodeAllowlistEnabled()).isTrue();
     assertThat(permissioningConfiguration.getNodeAllowlist())
-        .containsExactly(EnodeURL.fromString(uri));
+        .containsExactly(EnodeURLImpl.fromString(uri));
   }
 
   @Test

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationTest.java
@@ -16,7 +16,8 @@ package org.hyperledger.besu.ethereum.permissioning;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 
@@ -25,11 +26,11 @@ import org.junit.Test;
 public class LocalPermissioningConfigurationTest {
 
   final EnodeURL[] nodes = {
-    EnodeURL.fromString(
+    EnodeURLImpl.fromString(
         "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@127.0.0.1:4567"),
-    EnodeURL.fromString(
+    EnodeURLImpl.fromString(
         "enode://7f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@127.0.0.1:4568"),
-    EnodeURL.fromString(
+    EnodeURLImpl.fromString(
         "enode://8f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@127.0.0.1:4569")
   };
 

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
@@ -28,11 +28,12 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController.NodesAllowlistResult;
 import org.hyperledger.besu.ethereum.permissioning.node.NodeAllowlistUpdatedEvent;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 
@@ -65,7 +66,7 @@ public class NodeLocalConfigPermissioningControllerTest {
   private final String enode2 =
       "enode://5f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.10:4567";
   private final EnodeURL selfEnode =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://5f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.10:1111");
   private final String enodeDns =
       "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@localhost:4567";
@@ -202,7 +203,8 @@ public class NodeLocalConfigPermissioningControllerTest {
 
     verifyCountersUntouched();
 
-    assertThat(controller.isPermitted(EnodeURL.fromString(peer2), EnodeURL.fromString(peer1)))
+    assertThat(
+            controller.isPermitted(EnodeURLImpl.fromString(peer2), EnodeURLImpl.fromString(peer1)))
         .isFalse();
 
     verifyCountersUnpermitted();
@@ -303,18 +305,18 @@ public class NodeLocalConfigPermissioningControllerTest {
 
     verifyCountersUntouched();
 
-    assertThat(controller.isPermitted(EnodeURL.fromString(enode1), selfEnode)).isTrue();
+    assertThat(controller.isPermitted(EnodeURLImpl.fromString(enode1), selfEnode)).isTrue();
 
     verifyCountersPermitted();
 
-    assertThat(controller.isPermitted(selfEnode, EnodeURL.fromString(enode1))).isTrue();
+    assertThat(controller.isPermitted(selfEnode, EnodeURLImpl.fromString(enode1))).isTrue();
   }
 
   @Test
   public void stateShouldRevertIfAllowlistPersistFails()
       throws IOException, AllowlistFileSyncException {
-    List<String> newNode1 = singletonList(EnodeURL.fromString(enode1).toString());
-    List<String> newNode2 = singletonList(EnodeURL.fromString(enode2).toString());
+    List<String> newNode1 = singletonList(EnodeURLImpl.fromString(enode1).toString());
+    List<String> newNode2 = singletonList(EnodeURLImpl.fromString(enode2).toString());
 
     assertThat(controller.getNodesAllowlist().size()).isEqualTo(0);
 
@@ -344,7 +346,7 @@ public class NodeLocalConfigPermissioningControllerTest {
         .thenReturn(permissionsFile.toAbsolutePath().toString());
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(Arrays.asList(EnodeURL.fromString(expectedEnodeURL)));
+        .thenReturn(Arrays.asList(EnodeURLImpl.fromString(expectedEnodeURL)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);
@@ -364,7 +366,7 @@ public class NodeLocalConfigPermissioningControllerTest {
     when(permissioningConfig.getNodePermissioningConfigFilePath()).thenReturn("foo");
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(Arrays.asList(EnodeURL.fromString(expectedEnodeURI)));
+        .thenReturn(Arrays.asList(EnodeURLImpl.fromString(expectedEnodeURI)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);
@@ -384,7 +386,7 @@ public class NodeLocalConfigPermissioningControllerTest {
     final Consumer<NodeAllowlistUpdatedEvent> consumer = mock(Consumer.class);
     final NodeAllowlistUpdatedEvent expectedEvent =
         new NodeAllowlistUpdatedEvent(
-            Lists.newArrayList(EnodeURL.fromString(enode1)), Collections.emptyList());
+            Lists.newArrayList(EnodeURLImpl.fromString(enode1)), Collections.emptyList());
 
     controller.subscribeToListUpdatedEvent(consumer);
     controller.addNodes(Lists.newArrayList(enode1));
@@ -415,7 +417,7 @@ public class NodeLocalConfigPermissioningControllerTest {
     final Consumer<NodeAllowlistUpdatedEvent> consumer = mock(Consumer.class);
     final NodeAllowlistUpdatedEvent expectedEvent =
         new NodeAllowlistUpdatedEvent(
-            Collections.emptyList(), Lists.newArrayList(EnodeURL.fromString(enode1)));
+            Collections.emptyList(), Lists.newArrayList(EnodeURLImpl.fromString(enode1)));
 
     controller.subscribeToListUpdatedEvent(consumer);
     controller.removeNodes(Lists.newArrayList(enode1));
@@ -439,7 +441,7 @@ public class NodeLocalConfigPermissioningControllerTest {
   public void whenRemovingBootnodeShouldReturnRemoveBootnodeError() {
     NodesAllowlistResult expected =
         new NodesAllowlistResult(AllowlistOperationResult.ERROR_FIXED_NODE_CANNOT_BE_REMOVED);
-    bootnodesList.add(EnodeURL.fromString(enode1));
+    bootnodesList.add(EnodeURLImpl.fromString(enode1));
     controller.addNodes(Lists.newArrayList(enode1, enode2));
 
     NodesAllowlistResult actualResult = controller.removeNodes(Lists.newArrayList(enode1));
@@ -457,14 +459,14 @@ public class NodeLocalConfigPermissioningControllerTest {
     final Consumer<NodeAllowlistUpdatedEvent> consumer = mock(Consumer.class);
     final NodeAllowlistUpdatedEvent expectedEvent =
         new NodeAllowlistUpdatedEvent(
-            Lists.newArrayList(EnodeURL.fromString(enode2)),
-            Lists.newArrayList(EnodeURL.fromString(enode1)));
+            Lists.newArrayList(EnodeURLImpl.fromString(enode2)),
+            Lists.newArrayList(EnodeURLImpl.fromString(enode1)));
 
     when(permissioningConfig.getNodePermissioningConfigFilePath())
         .thenReturn(permissionsFile.toAbsolutePath().toString());
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(Arrays.asList(EnodeURL.fromString(enode1)));
+        .thenReturn(Arrays.asList(EnodeURLImpl.fromString(enode1)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);
@@ -488,7 +490,7 @@ public class NodeLocalConfigPermissioningControllerTest {
         .thenReturn(permissionsFile.toAbsolutePath().toString());
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(Arrays.asList(EnodeURL.fromString(enode1)));
+        .thenReturn(Arrays.asList(EnodeURLImpl.fromString(enode1)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);
@@ -513,7 +515,7 @@ public class NodeLocalConfigPermissioningControllerTest {
         .thenReturn(permissionsFile.toAbsolutePath().toString());
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(singletonList(EnodeURL.fromString(enodeDns, enodeDnsConfiguration)));
+        .thenReturn(singletonList(EnodeURLImpl.fromString(enodeDns, enodeDnsConfiguration)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);
@@ -537,7 +539,7 @@ public class NodeLocalConfigPermissioningControllerTest {
         .thenReturn(permissionsFile.toAbsolutePath().toString());
     when(permissioningConfig.isNodeAllowlistEnabled()).thenReturn(true);
     when(permissioningConfig.getNodeAllowlist())
-        .thenReturn(singletonList(EnodeURL.fromString(enodeDns, enodeDnsConfiguration)));
+        .thenReturn(singletonList(EnodeURLImpl.fromString(enodeDns, enodeDnsConfiguration)));
     controller =
         new NodeLocalConfigPermissioningController(
             permissioningConfig, bootnodesList, selfEnode.getNodeId(), metricsSystem);

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.ProtocolScheduleFixture;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -129,9 +129,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30303"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30304")))
         .isTrue();
 
@@ -149,9 +149,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30303"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30305")))
         .isFalse();
 
@@ -169,9 +169,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30302"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.1:30304")))
         .isFalse();
 
@@ -189,9 +189,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab61@[1:2:3:4:5:6:7:8]:30303"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab62@[1:2:3:4:5:6:7:8]:30304")))
         .isTrue();
 
@@ -209,9 +209,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab63@[1:2:3:4:5:6:7:8]:30303"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab62@[1:2:3:4:5:6:7:8]:30304")))
         .isFalse();
 
@@ -229,9 +229,9 @@ public class NodeSmartContractPermissioningControllerTest {
 
     assertThat(
             controller.isPermitted(
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab61@[1:2:3:4:5:6:7:8]:30303"),
-                EnodeURL.fromString(
+                EnodeURLImpl.fromString(
                     "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab63@[1:2:3:4:5:6:7:8]:30304")))
         .isFalse();
 
@@ -250,9 +250,9 @@ public class NodeSmartContractPermissioningControllerTest {
     assertThatThrownBy(
             () ->
                 controller.isPermitted(
-                    EnodeURL.fromString(
+                    EnodeURLImpl.fromString(
                         "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab61@[1:2:3:4:5:6:7:8]:30303"),
-                    EnodeURL.fromString(
+                    EnodeURLImpl.fromString(
                         "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab63@[1:2:3:4:5:6:7:8]:30304")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Permissioning contract does not exist");
@@ -272,9 +272,9 @@ public class NodeSmartContractPermissioningControllerTest {
     assertThatThrownBy(
             () ->
                 controller.isPermitted(
-                    EnodeURL.fromString(
+                    EnodeURLImpl.fromString(
                         "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab61@[1:2:3:4:5:6:7:8]:30303"),
-                    EnodeURL.fromString(
+                    EnodeURLImpl.fromString(
                         "enode://1234000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab63@[1:2:3:4:5:6:7:8]:30304")))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Permissioning transaction failed when processing");

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -26,13 +26,14 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Optional;
@@ -54,16 +55,16 @@ public class NodeSmartContractV2PermissioningControllerTest {
           "0x45a59e5b000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000009dd40000000000000000000000000000000000000000000000000000000000000080333534386338376239393230666631366161346264636630316338356632353131376132396165313537346437353962616434386363393436336438653966376333633164316539666230643238653733383938393531663930653032373134616262373730666436643232653930333731383832613435363538383030653900000000000000000000000000000000000000000000000000000000000000093132372e302e302e310000000000000000000000000000000000000000000000");
 
   private static final EnodeURL SOURCE_ENODE_IPV4 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://fcbe9f83218487b3c0b50878193880e6c25cfd86708c0a0bf0ca91f0ce633746a892fe240afa5b9a880b8bca48e8a22704ef937fdda2d7cc63e4d41ed1b417ae@127.0.0.1:30303");
   private static final EnodeURL DESTINATION_ENODE_IPV4 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@127.0.0.1:40404");
   private static final EnodeURL SOURCE_ENODE_IPV6 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://fcbe9f83218487b3c0b50878193880e6c25cfd86708c0a0bf0ca91f0ce633746a892fe240afa5b9a880b8bca48e8a22704ef937fdda2d7cc63e4d41ed1b417ae@[::ffff:7f00:0001]:30303");
   private static final EnodeURL DESTINATION_ENODE_IPV6 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@[::ffff:7f00:0001]:40404");
 
   private final BlockDataGenerator blockDataGenerator = new BlockDataGenerator();

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProviderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProviderTest.java
@@ -21,10 +21,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.rlpx.ConnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.DisconnectCallback;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,19 +43,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class InsufficientPeersPermissioningProviderTest {
   @Mock private P2PNetwork p2pNetwork;
   private final EnodeURL SELF_ENODE =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001@192.168.0.1:30303");
   private final EnodeURL ENODE_2 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002@192.168.0.2:30303");
   private final EnodeURL ENODE_3 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003@192.168.0.3:30303");
   private final EnodeURL ENODE_4 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004@192.168.0.4:30303");
   private final EnodeURL ENODE_5 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005@192.168.0.5:30303");
 
   @Before

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.LocalPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.NodePermissioningControllerFactory;
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.SmartContractPermissioningConfiguration;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class NodePermissioningControllerFactoryTest {
   private final String enode =
       "enode://5f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.10:1111";
   Collection<EnodeURL> bootnodes = Collections.emptyList();
-  EnodeURL selfEnode = EnodeURL.fromString(enode);
+  EnodeURL selfEnode = EnodeURLImpl.fromString(enode);
   LocalPermissioningConfiguration localPermissioningConfig;
   SmartContractPermissioningConfiguration smartContractPermissioningConfiguration;
   PermissioningConfiguration config;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerTest.java
@@ -24,10 +24,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.permissioning.GoQuorumQip714Gate;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.node.provider.SyncStatusNodePermissioningProvider;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,10 +45,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class NodePermissioningControllerTest {
 
   private static final EnodeURL enode1 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.168.0.2:1234");
   private static final EnodeURL enode2 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.3:5678");
 
   @Mock private SyncStatusNodePermissioningProvider syncStatusNodePermissioningProvider;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapterTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapterTest.java
@@ -23,10 +23,11 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
 import org.hyperledger.besu.ethereum.permissioning.node.provider.SyncStatusNodePermissioningProvider;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -397,7 +398,7 @@ public class PeerPermissionsAdapterTest {
 
   private Peer createPeer() {
     return DefaultPeer.fromEnodeURL(
-        EnodeURL.builder()
+        EnodeURLImpl.builder()
             .ipAddress("127.0.0.1")
             .nodeId(Peer.randomId())
             .useDefaultPorts()

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProviderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProviderTest.java
@@ -23,8 +23,9 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.Synchronizer.InSyncListener;
-import org.hyperledger.besu.ethereum.p2p.peers.EnodeURL;
+import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 
@@ -49,13 +50,13 @@ public class SyncStatusNodePermissioningProviderTest {
   private IntSupplier syncGauge;
 
   private static final EnodeURL bootnode =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://6332792c4a00e3e4ee0926ed89e0d27ef985424d97b6a45bf0f23e51f0dcb5e66b875777506458aea7af6f9e4ffb69f43f3778ee73c81ed9d34c51c4b16b0b0f@192.168.0.1:9999");
   private static final EnodeURL enode1 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09@192.168.0.2:1234");
   private static final EnodeURL enode2 =
-      EnodeURL.fromString(
+      EnodeURLImpl.fromString(
           "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.3:5678");
 
   @Mock private Synchronizer synchronizer;
@@ -238,10 +239,10 @@ public class SyncStatusNodePermissioningProviderTest {
     assertThat(provider.hasReachedSync()).isFalse();
 
     final EnodeURL bootnode =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.3:5678");
     final EnodeURL enodeWithDiscoveryPort =
-        EnodeURL.fromString(
+        EnodeURLImpl.fromString(
             "enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@192.168.0.3:5678?discport=30303");
 
     final SyncStatusNodePermissioningProvider provider =

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'Kpl9Vh8naMrXaUp+N9nDWRycQOywft4mZrjUaH1vsQY='
+  knownHash = 'B3G3nQJIZ5drUe2wsj16Q4CxrvNcUXeM50WxT4ap4IY='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/EnodeURL.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/EnodeURL.java
@@ -12,12 +12,34 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.permissioning.node;
+package org.hyperledger.besu.plugin.data;
 
-import org.hyperledger.besu.plugin.data.EnodeURL;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Optional;
 
-@FunctionalInterface
-public interface NodePermissioningProvider {
+import org.apache.tuweni.bytes.Bytes;
 
-  boolean isPermitted(final EnodeURL sourceEnode, final EnodeURL destinationEnode);
+public interface EnodeURL {
+  URI toURIWithoutDiscoveryPort();
+
+  Bytes getNodeId();
+
+  InetAddress getIp();
+
+  Optional<Integer> getListeningPort();
+
+  int getListeningPortOrZero();
+
+  URI toURI();
+
+  Optional<Integer> getDiscoveryPort();
+
+  boolean isListening();
+
+  boolean isRunningDiscovery();
+
+  String getIpAsString();
+
+  int getDiscoveryPortOrZero();
 }


### PR DESCRIPTION
Couldn't figure out a nice way of not having EnodeURLImpl.

If we kept it as EnodeURL we could add static imports in for things like `fromURI` but the problem is they are mostly used as method references. So you can either have method references with the class name or lambdas with a static import! 

I think it's the least worse option at the moment.