### PR TITLE
errata discovered in 21.1.6

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
@@ -30,11 +30,7 @@ public interface TransactionGasBudgetCalculator {
   }
 
   static TransactionGasBudgetCalculator eip1559(final EIP1559 eip1559) {
-    return gasBudgetCalculator(
-        (blockNumber, gasLimit, transaction) ->
-            eip1559.isEIP1559(blockNumber)
-                ? gasLimit * eip1559.getFeeMarket().getSlackCoefficient()
-                : gasLimit);
+    return gasBudgetCalculator((blockNumber, gasLimit, transaction) -> gasLimit);
   }
 
   static TransactionGasBudgetCalculator gasBudgetCalculator(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -429,7 +429,7 @@ public class PendingTransactions {
       return;
     }
     synchronized (lock) {
-      final boolean baseFeeIncreased = baseFee > this.baseFee;
+      final boolean baseFeeIncreased = baseFee > Optional.ofNullable(this.baseFee).orElse(0L);
       this.baseFee = baseFee;
       if (baseFeeIncreased) {
         // base fee increases can only cause transactions to go from static to dynamic range

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -411,7 +410,8 @@ public class PendingTransactions {
             false);
   }
 
-  private long effectivePriorityFeePerGas(final Transaction transaction, final Optional<Long> curBaseFee) {
+  private long effectivePriorityFeePerGas(
+      final Transaction transaction, final Optional<Long> curBaseFee) {
     final long maybeNegativePriorityFeePerGas;
     if (transaction.getType().equals(TransactionType.EIP1559)) {
       maybeNegativePriorityFeePerGas =
@@ -419,7 +419,8 @@ public class PendingTransactions {
               transaction.getMaxPriorityFeePerGas().get().getValue().longValue(),
               transaction.getMaxFeePerGas().get().getValue().longValue() - curBaseFee.orElse(0L));
     } else {
-      maybeNegativePriorityFeePerGas = transaction.getGasPrice().getValue().longValue() - curBaseFee.orElse(0L);
+      maybeNegativePriorityFeePerGas =
+          transaction.getGasPrice().getValue().longValue() - curBaseFee.orElse(0L);
     }
     return maybeNegativePriorityFeePerGas;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactions.java
@@ -106,7 +106,7 @@ public class PendingTransactions {
                           .orElse(transactionInfo.getGasPrice().toLong()))
               .thenComparing(TransactionInfo::getSequence)
               .reversed());
-  private Long baseFee;
+  private Optional<Long> baseFee = Optional.empty();
   private final Map<Address, TransactionsForSenderInfo> transactionsBySender =
       new ConcurrentHashMap<>();
 
@@ -138,7 +138,7 @@ public class PendingTransactions {
     this.clock = clock;
     this.newPooledHashes = EvictingQueue.create(maxPooledTransactionHashes);
     this.chainHeadHeaderSupplier = chainHeadHeaderSupplier;
-    this.baseFee = chainHeadHeaderSupplier.get().getBaseFee().orElse(null);
+    this.baseFee = chainHeadHeaderSupplier.get().getBaseFee();
     this.transactionReplacementHandler = new TransactionPoolReplacementHandler(priceBump);
     final LabelledMetric<Counter> transactionAddedCounter =
         metricsSystem.createLabelledCounter(
@@ -399,7 +399,7 @@ public class PendingTransactions {
     return ADDED;
   }
 
-  private boolean isInStaticRange(final Transaction transaction, final Long baseFee) {
+  private boolean isInStaticRange(final Transaction transaction, final Optional<Long> baseFee) {
     return transaction
         .getMaxPriorityFeePerGas()
         .map(
@@ -411,26 +411,26 @@ public class PendingTransactions {
             false);
   }
 
-  private long effectivePriorityFeePerGas(final Transaction transaction, final long baseFee) {
+  private long effectivePriorityFeePerGas(final Transaction transaction, final Optional<Long> curBaseFee) {
     final long maybeNegativePriorityFeePerGas;
     if (transaction.getType().equals(TransactionType.EIP1559)) {
       maybeNegativePriorityFeePerGas =
           Math.min(
               transaction.getMaxPriorityFeePerGas().get().getValue().longValue(),
-              transaction.getMaxFeePerGas().get().getValue().longValue() - baseFee);
+              transaction.getMaxFeePerGas().get().getValue().longValue() - curBaseFee.orElse(0L));
     } else {
-      maybeNegativePriorityFeePerGas = transaction.getGasPrice().getValue().longValue() - baseFee;
+      maybeNegativePriorityFeePerGas = transaction.getGasPrice().getValue().longValue() - curBaseFee.orElse(0L);
     }
     return maybeNegativePriorityFeePerGas;
   }
 
-  public void updateBaseFee(final Long baseFee) {
-    if (Objects.equals(this.baseFee, baseFee)) {
+  public void updateBaseFee(final Long newBaseFee) {
+    if (this.baseFee.orElse(0L).equals(newBaseFee)) {
       return;
     }
     synchronized (lock) {
-      final boolean baseFeeIncreased = baseFee > Optional.ofNullable(this.baseFee).orElse(0L);
-      this.baseFee = baseFee;
+      final boolean baseFeeIncreased = newBaseFee > this.baseFee.orElse(0L);
+      this.baseFee = Optional.of(newBaseFee);
       if (baseFeeIncreased) {
         // base fee increases can only cause transactions to go from static to dynamic range
         prioritizedTransactionsStaticRange.stream()


### PR DESCRIPTION

Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
A couple quick fixes for bugs I found In scale testing 21.1.6 pending transactions:
* baseFee = null was not handled correctly in PendingTransactions.updateBaseFee for a fork block
* the transaction gas budget calculator was 2x'ing the already 2x'd gasLimit at and past fork block

we should probably write some tests that cover these cases, but it is late and the release is already out there...

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog


- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).