### PR TITLE
Add Sajida Zouarhi to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@
 | Karim Taam       | matkt            | matkt            |
 | Meredith Baxter  | mbaxter          | mbaxter          |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
+| Sajida Zouarhi   | sajz             | SajidaZ          |
 | Stefan Pingel    | pinges           | pinges           |
 | Trent Mohay      | rain-on          | trent.mohay      |
 | Rai Sur          | RatanRSur        | ratanraisur      |


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>
Sajida has started helping manage Github issues and collaborating with the existing maintainers to help coordinate the development of Besu.

Voting ends 2 weeks from the publication of this PR.

For more information on this process see the Becoming a Maintainer section in the MAINTAINERS.md file.

## Approval of this PR

- [ ] 2 weeks voting period (ends June 3rd 2021)
- [x] at least 3 approvals
- [x] no veto
- [x] absolute majority makes it pass immediately (currently 11 approvals).