### PR TITLE
GoQuorum: Gas estimate to cover PMT

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/FrontierGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/FrontierGasCalculator.java
@@ -467,4 +467,11 @@ public class FrontierGasCalculator implements GasCalculator {
 
     return MEMORY_WORD_GAS_COST.times(len).plus(base);
   }
+
+  @Override
+  public Gas getMaximumPmtCost() {
+    // what would be the gas for PMT with hash of all non-zeros
+    int nonZeros = 64;
+    return TX_BASE_COST.plus(TX_DATA_NON_ZERO_COST.times(nonZeros));
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
@@ -161,4 +161,10 @@ public class IstanbulGasCalculator extends PetersburgGasCalculator {
   public Gas extCodeHashOperationGasCost() {
     return EXTCODE_HASH_COST;
   }
+
+  @Override
+  public Gas getMaximumPmtCost() {
+    int nonZeros = 64;
+    return TX_BASE_COST.plus(ISTANBUL_TX_DATA_NON_ZERO_COST.times(nonZeros));
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
@@ -64,6 +64,28 @@ public class IstanbulGasCalculator extends PetersburgGasCalculator {
     return new GasAndAccessedState(cost);
   }
 
+  public GasAndAccessedState transactionIntrinsicGasCostAndAccessedState(
+      final Bytes payload, final boolean isContractCreation) {
+    int zeros = 0;
+    for (int i = 0; i < payload.size(); i++) {
+      if (payload.get(i) == 0) {
+        ++zeros;
+      }
+    }
+    final int nonZeros = payload.size() - zeros;
+
+    Gas cost =
+        TX_BASE_COST
+            .plus(TX_DATA_ZERO_COST.times(zeros))
+            .plus(ISTANBUL_TX_DATA_NON_ZERO_COST.times(nonZeros));
+
+    if (isContractCreation) {
+      cost = cost.plus(txCreateExtraGasCost());
+    }
+
+    return new GasAndAccessedState(cost);
+  }
+
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public Gas calculateStorageCost(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/IstanbulGasCalculator.java
@@ -64,28 +64,6 @@ public class IstanbulGasCalculator extends PetersburgGasCalculator {
     return new GasAndAccessedState(cost);
   }
 
-  public GasAndAccessedState transactionIntrinsicGasCostAndAccessedState(
-      final Bytes payload, final boolean isContractCreation) {
-    int zeros = 0;
-    for (int i = 0; i < payload.size(); i++) {
-      if (payload.get(i) == 0) {
-        ++zeros;
-      }
-    }
-    final int nonZeros = payload.size() - zeros;
-
-    Gas cost =
-        TX_BASE_COST
-            .plus(TX_DATA_ZERO_COST.times(zeros))
-            .plus(ISTANBUL_TX_DATA_NON_ZERO_COST.times(nonZeros));
-
-    if (isContractCreation) {
-      cost = cost.plus(txCreateExtraGasCost());
-    }
-
-    return new GasAndAccessedState(cost);
-  }
-
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public Gas calculateStorageCost(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -198,9 +198,8 @@ public class TransactionSimulator {
             transactionValidationParams,
             operationTracer);
 
-    // If GoQuorum privacy enabled, and value = zero, do simulation with max non-zero bytes.
-    // It is possible to have a data field that has a lower intrinsic value than the PMT hash
-    // so this checks the tx as if we were to place a PMT hash (with all non-zero values).
+    // If GoQuorum privacy enabled, and value = zero, get max gas possible for a PMT hash.
+    // It is possible to have a data field that has a lower intrinsic value than the PMT hash.
     // This means a potential over-estimate of gas, but the tx, if sent with this gas, will not
     // fail.
     if (GoQuorumOptions.goQuorumCompatibilityMode && value.isZero()) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -212,6 +212,7 @@ public class TransactionSimulator {
       // different est
       // TODO get the right gasCalculator
       IstanbulGasCalculator gasCalculator = new IstanbulGasCalculator();
+      // TODO prob construct a new tx instead of creating this extra method
       GasAndAccessedState privateGasEstimateAndState =
           gasCalculator.transactionIntrinsicGasCostAndAccessedState(
               MAX_PRIVATE_INTRINSIC_DATA_HEX, callParams.getTo() == null);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/GasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/GasCalculator.java
@@ -440,7 +440,5 @@ public interface GasCalculator {
   };
 
   // what would be the gas for a PMT with hash of all non-zeros
-  default Gas getMaximumPmtCost() {
-    return Gas.ZERO;
-  }
+  Gas getMaximumPmtCost();
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/GasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/GasCalculator.java
@@ -59,7 +59,7 @@ public interface GasCalculator {
   // Transaction Gas Calculations
 
   /**
-   * Returns a {@link Transaction}s intrinisic gas cost
+   * Returns a {@link Transaction}s intrinsic gas cost
    *
    * @param transaction The transaction
    * @return the transaction's intrinsic gas cost
@@ -438,4 +438,9 @@ public interface GasCalculator {
   default long getMaxRefundQuotient() {
     return 2;
   };
+
+  // what would be the gas for a PMT with hash of all non-zeros
+  default Gas getMaximumPmtCost() {
+    return Gas.ZERO;
+  }
 }


### PR DESCRIPTION
If GoQuorum mode and value = 0, modify tx simulator result to return estimate which will cover a PMT transaction

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).