### PR TITLE
Remove EIP1559 Gas budget calculator implementation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculator.java
@@ -29,10 +29,6 @@ public interface TransactionGasBudgetCalculator {
     return gasBudgetCalculator((blockNumber, gasLimit, ignored) -> gasLimit);
   }
 
-  static TransactionGasBudgetCalculator eip1559(final EIP1559 eip1559) {
-    return gasBudgetCalculator((blockNumber, gasLimit, transaction) -> gasLimit);
-  }
-
   static TransactionGasBudgetCalculator gasBudgetCalculator(
       final BlockGasLimitCalculator blockGasLimitCalculator) {
     return (transaction, blockNumber, gasLimit, gasUsed) -> {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.ethereum.core.WorldState;
 import org.hyperledger.besu.ethereum.core.WorldUpdater;
 import org.hyperledger.besu.ethereum.core.fees.CoinbaseFeePriceCalculator;
 import org.hyperledger.besu.ethereum.core.fees.EIP1559;
-import org.hyperledger.besu.ethereum.core.fees.TransactionGasBudgetCalculator;
 import org.hyperledger.besu.ethereum.core.fees.TransactionPriceCalculator;
 import org.hyperledger.besu.ethereum.goquorum.GoQuorumBlockProcessor;
 import org.hyperledger.besu.ethereum.goquorum.GoQuorumBlockValidator;
@@ -507,7 +506,6 @@ public abstract class MainnetProtocolSpecs {
         .name("Aleut")
         .transactionPriceCalculator(transactionPriceCalculator.orElseThrow())
         .eip1559(Optional.of(eip1559))
-        .gasBudgetCalculator(TransactionGasBudgetCalculator.eip1559(eip1559))
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator.createEip1559Validator(eip1559))
         .ommerHeaderValidatorBuilder(
             MainnetBlockHeaderValidator.createEip1559OmmerValidator(eip1559));
@@ -576,7 +574,6 @@ public abstract class MainnetProtocolSpecs {
         .transactionPriceCalculator(transactionPriceCalculator.orElseThrow())
         .eip1559(Optional.of(eip1559))
         .difficultyCalculator(MainnetDifficultyCalculators.LONDON)
-        .gasBudgetCalculator(TransactionGasBudgetCalculator.eip1559(eip1559))
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator.createEip1559Validator(eip1559))
         .ommerHeaderValidatorBuilder(
             MainnetBlockHeaderValidator.createEip1559OmmerValidator(eip1559))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/fees/TransactionGasBudgetCalculatorTest.java
@@ -67,6 +67,9 @@ public class TransactionGasBudgetCalculatorTest {
           {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 0L, true},
           {FRONTIER_CALCULATOR, false, 11L, 1L, 10L, 0L, false},
           {FRONTIER_CALCULATOR, false, 5L, 1L, 10L, 6L, false},
+          {FRONTIER_CALCULATOR, true, 5L, 1L, 10L, 0L, true},
+          {FRONTIER_CALCULATOR, true, 11L, 1L, 10L, 0L, false},
+          {FRONTIER_CALCULATOR, true, 5L, 1L, 10L, 6L, false},
         });
   }
 


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

The specification of the EIP1559 has changed and no longer requires a specific gasBudgetCalculator implementation. This PR clean the code by removing this unnecessary part of code

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).