### PR TITLE
non-existent genesis file: clarify error

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1484,8 +1484,13 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private GenesisConfigOptions readGenesisConfigOptions() {
     final GenesisConfigOptions genesisConfigOptions;
-    final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfig(genesisConfig());
-    genesisConfigOptions = genesisConfigFile.getConfigOptions(genesisConfigOverrides);
+    try {
+      final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfig(genesisConfig());
+      genesisConfigOptions = genesisConfigFile.getConfigOptions(genesisConfigOverrides);
+    } catch (final Exception e) {
+      throw new ParameterException(
+          this.commandLine, "Unable to read genesis file. " + e.getCause());
+    }
     return genesisConfigOptions;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1489,7 +1489,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       genesisConfigOptions = genesisConfigFile.getConfigOptions(genesisConfigOverrides);
     } catch (final Exception e) {
       throw new ParameterException(
-          this.commandLine, "Unable to read genesis file. " + e.getCause());
+          this.commandLine, "Unable to load genesis file. " + e.getCause());
     }
     return genesisConfigOptions;
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1484,12 +1484,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private GenesisConfigOptions readGenesisConfigOptions() {
     final GenesisConfigOptions genesisConfigOptions;
-    try {
-      final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfig(genesisConfig());
-      genesisConfigOptions = genesisConfigFile.getConfigOptions(genesisConfigOverrides);
-    } catch (final Exception e) {
-      throw new IllegalStateException("Unable to read genesis file for GoQuorum options", e);
-    }
+    final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfig(genesisConfig());
+    genesisConfigOptions = genesisConfigFile.getConfigOptions(genesisConfigOverrides);
     return genesisConfigOptions;
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1002,7 +1002,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     Mockito.verifyZeroInteractions(mockRunnerBuilder);
 
     assertThat(commandOutput.toString()).isEmpty();
-    assertThat(commandErrorOutput.toString()).startsWith("Unable to read genesis file");
+    assertThat(commandErrorOutput.toString()).startsWith("Unable to load genesis file");
     assertThat(commandErrorOutput.toString()).contains(nonExistentGenesis);
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -995,6 +995,17 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void nonExistentGenesisGivesError() throws Exception {
+    parseCommand("--genesis-file", "non-existent-genesis.json");
+
+    Mockito.verifyZeroInteractions(mockRunnerBuilder);
+
+    assertThat(commandOutput.toString()).isEmpty();
+    assertThat(commandErrorOutput.toString())
+        .startsWith("Unable to read genesis file. java.io.FileNotFoundException");
+  }
+
+  @Test
   public void testDnsDiscoveryUrlEthConfig() throws Exception {
     final ArgumentCaptor<EthNetworkConfig> networkArg =
         ArgumentCaptor.forClass(EthNetworkConfig.class);

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -996,13 +996,14 @@ public class BesuCommandTest extends CommandTestAbstract {
 
   @Test
   public void nonExistentGenesisGivesError() throws Exception {
-    parseCommand("--genesis-file", "non-existent-genesis.json");
+    final String nonExistentGenesis = "non-existent-genesis.json";
+    parseCommand("--genesis-file", nonExistentGenesis);
 
     Mockito.verifyZeroInteractions(mockRunnerBuilder);
 
     assertThat(commandOutput.toString()).isEmpty();
-    assertThat(commandErrorOutput.toString())
-        .startsWith("Unable to read genesis file. java.io.FileNotFoundException");
+    assertThat(commandErrorOutput.toString()).startsWith("Unable to read genesis file");
+    assertThat(commandErrorOutput.toString()).contains(nonExistentGenesis);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Add error message and remove reference to GoQuorum options.
```
$ besu --genesis-file=xyz.json
Unable to read genesis file. java.io.FileNotFoundException: /Users/sallymacfarlane/workspace/besu/xyz.json (No such file or directory)

To display full help:
besu [COMMAND] --help
$ besu --genesis-file=bob.json
Unable to read genesis file. com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'bob': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
 at [Source: (String)"bob
"; line: 1, column: 4]

To display full help:
besu [COMMAND] --help
$ cat bob.json
bob
```

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).