### PR TITLE
ci/cd: Require Quorum Acceptance Tests to pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
       - run:
           name: Quorum Acceptance Tests (failures ignored)
           no_output_timeout: 40m
-          command: ./gradlew --no-daemon acceptanceTestsQuorum || true # ignore result of job for now, until all issues are fixed
+          command: ./gradlew --no-daemon acceptanceTestsQuorum
       - store_artifacts:
           path: build/quorum-at
           destination: quorum-at-artifacts
@@ -290,7 +290,7 @@ workflows:
             - assemble
       - acceptanceTestsQuorum:
           requires:
-            - buildDocker
+            - assemble
       - buildDocker:
           requires:
             - assemble
@@ -304,6 +304,7 @@ workflows:
             - integrationTests
             - unitTests
             - acceptanceTests
+            - acceptanceTestsQuorum
             - referenceTests
             - buildDocker
       - publishDocker:
@@ -316,6 +317,7 @@ workflows:
             - integrationTests
             - unitTests
             - acceptanceTests
+            - acceptanceTestsQuorum
             - referenceTests
             - buildDocker
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: Quorum Acceptance Tests (failures ignored)
+          name: Quorum Acceptance Tests
           no_output_timeout: 40m
           command: ./gradlew --no-daemon acceptanceTestsQuorum
       - store_artifacts:

--- a/build.gradle
+++ b/build.gradle
@@ -663,11 +663,11 @@ task acceptanceTestsQuorum {
    * Not available features in Besu: privacy-enhancements-disabled, extension, mps
    * Not available RPC methods in Besu: async, storage-root, get-quorum-payload, personal-api-signed
    *
-   * Ignored for now (privacy-polishing): graphql, eth-api-signed, spam
+   * Ignored for now (privacy-polishing): graphql, eth-api-signed, spam, nosupport
    *
    * LOGGING_LEVEL_COM_QUORUM_GAUGE=DEBUG -- enables HTTP JSON-RPC logging
    */
-  def tags = "(basic && !mps && !spam && !eth-api-signed && !privacy-enhancements-disabled && !graphql && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2"
+  def tags = "(basic && !nosupport && !mps && !spam && !eth-api-signed && !privacy-enhancements-disabled && !graphql && !async && !extension && !storage-root && !get-quorum-payload && !personal-api-signed) || networks/typical-besu::ibft2"
 
   doLast {
     exec {


### PR DESCRIPTION
Signed-off-by: Ricardo Silva <ricardo.silva@consensys.net>

### Summary

As the work is done for the privacy interop, we remove now the ignore of the results so if it fails, it breaks the build.

## Changes

* Removed `|| true` to make the job fail if the tests fail.
* Make the publish of docker images depend on the Quorum AT.
* Add the `nosupport` tag as privacy polishing to be done later.