### PR TITLE
Fixes for 1559 retesteth behaviors

### DIFF
--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParams.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestSetChainParams.java
@@ -143,8 +143,6 @@ public class TestSetChainParams implements JsonRpcMethod {
               .orElse(ExperimentalEIPs.EIP1559_BASEFEE_DEFAULT_VALUE);
     }
 
-    maybeMoveToNumber(params, "londonForkBlock", config, "aleutBlock");
-    maybeMoveToNumber(params, "londonForkBlock", config, "calaverasBlock");
     maybeMoveToNumber(params, "londonForkBlock", config, "londonBlock");
 
     // strip out precompiles with zero balance


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

quick pr to unblock retesteth testing, remove aleut and calaveras from retesteth chain genesis.  

Aleut config was an artifact from when we did not have London configs.