### PR TITLE
CI: use med executor for more steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,6 @@ executors:
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
 
-  machine_executor:
-    machine:
-      image: ubuntu-2004:202010-01
-
   xl_machine_executor:
     machine:
       image: ubuntu-2004:202101-01
@@ -127,7 +123,7 @@ jobs:
             build\distributions\besu\bin\besu.bat --version
 
   unitTests:
-    executor: besu_executor_xl
+    executor: besu_executor_med
     steps:
       - prepare
       - attach_workspace:
@@ -140,7 +136,7 @@ jobs:
       - capture_test_results
 
   integrationTests:
-    executor: besu_executor_xl
+    executor: besu_executor_med
     steps:
       - prepare
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
             build\distributions\besu\bin\besu.bat --version
 
   unitTests:
-    executor: besu_executor_med
+    executor: besu_executor_xl
     steps:
       - prepare
       - attach_workspace:


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Use medium executor where xl not needed.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).