### PR TITLE
Add ValidateFirstOutboundMessage just before DeFramer

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
@@ -114,8 +114,8 @@ abstract class AbstractHandshakeHandler extends SimpleChannelInboundHandler<Byte
 
       ctx.channel()
           .pipeline()
-          .addFirst(new ValidateFirstOutboundMessage(framer))
-          .replace(this, "DeFramer", deFramer);
+          .replace(this, "DeFramer", deFramer)
+          .addBefore("DeFramer", "validate", new ValidateFirstOutboundMessage(framer));
 
       ctx.writeAndFlush(new OutboundMessage(null, HelloMessage.create(localNode.getPeerInfo())))
           .addListener(


### PR DESCRIPTION
This takes care of the current requirements as well as provide the possibility of adding other channel handlers before that like for example a TLS handler
