### PR TITLE
change BlockResult to use baseFeePerGas per eth1 json-rpc spec

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.databind.JsonNode;
   "difficulty",
   "totalDifficulty",
   "extraData",
-  "baseFee",
+  "baseFeePerGas",
   "size",
   "gasLimit",
   "gasUsed",
@@ -65,7 +65,7 @@ public class BlockResult implements JsonRpcResult {
   private final String difficulty;
   private final String totalDifficulty;
   private final String extraData;
-  private final String baseFee;
+  private final String baseFeePerGas;
   private final String size;
   private final String gasLimit;
   private final String gasUsed;
@@ -104,7 +104,7 @@ public class BlockResult implements JsonRpcResult {
     this.difficulty = Quantity.create(header.getDifficulty());
     this.totalDifficulty = Quantity.create(totalDifficulty);
     this.extraData = header.getExtraData().toString();
-    this.baseFee = header.getBaseFee().map(Quantity::create).orElse(null);
+    this.baseFeePerGas = header.getBaseFee().map(Quantity::create).orElse(null);
     this.size = Quantity.create(size);
     this.gasLimit = Quantity.create(header.getGasLimit());
     this.gasUsed = Quantity.create(header.getGasUsed());
@@ -184,9 +184,9 @@ public class BlockResult implements JsonRpcResult {
     return extraData;
   }
 
-  @JsonGetter(value = "baseFee")
-  public String getBaseFee() {
-    return baseFee;
+  @JsonGetter(value = "baseFeePerGas")
+  public String getBaseFeePerGas() {
+    return baseFeePerGas;
   }
 
   @JsonGetter(value = "size")

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -109,7 +109,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
   public void shouldReturnExpectedBlockResult() {
     final JsonRpcRequestContext request =
         getUncleByBlockNumberAndIndex(new Object[] {"0x1", "0x0"});
-    final BlockHeader header = blockHeaderTestFixture.buildHeader();
+    final BlockHeader header = blockHeaderTestFixture.baseFeePerGas(7L).buildHeader();
     final BlockResult expectedBlockResult = blockResult(header);
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, expectedBlockResult);
 
@@ -117,7 +117,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
 
     final JsonRpcResponse response = method.response(request);
 
-    assertThat(response).isEqualToComparingFieldByFieldRecursively(expectedResponse);
+    assertThat(response).usingRecursiveComparison().isEqualTo(expectedResponse);
   }
 
   private BlockResult blockResult(final BlockHeader header) {

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockHeaderTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockHeaderTestFixture.java
@@ -122,7 +122,7 @@ public class BlockHeaderTestFixture {
     return this;
   }
 
-  public BlockHeaderTestFixture baseFee(final long baseFee) {
+  public BlockHeaderTestFixture baseFeePerGas(final long baseFee) {
     this.baseFee = Optional.of(baseFee);
     return this;
   }


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
make blockresult conform to json-rpc spec ; use `baseFeePerGas` instead of `baseFee`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#2369 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).