### PR TITLE
Fix vulnerabilities from openjdk-11 base image

### DIFF
--- a/docker/openjdk-11/Dockerfile
+++ b/docker/openjdk-11/Dockerfile
@@ -1,5 +1,6 @@
 
-FROM openjdk:11.0.7-jre-slim-buster
+FROM adoptopenjdk/openjdk11:jre-11.0.11_9
+
 ARG VERSION="dev"
 
 RUN adduser --disabled-password --gecos "" --home /opt/besu besu && \


### PR DESCRIPTION
This PR aims to fix the Issue [2451](https://github.com/hyperledger/besu/issues/2451) reported about base image vulnerabilities.

Now scan report does not show any high vulnerabilities:
```
docker scan -f docker/openjdk-11/Dockerfile docker.io/hyperledger/besu:21.7.0-RC1-SNAPSHOT-openjdk-11 --severity high

Testing docker.io/hyperledger/besu:21.7.0-RC1-SNAPSHOT-openjdk-11...

Organization:      juan.dominguez
Package manager:   deb
Target file:       docker/openjdk-11/Dockerfile
Project name:      docker-image|docker.io/hyperledger/besu
Docker image:      docker.io/hyperledger/besu:21.7.0-RC1-SNAPSHOT-openjdk-11
Base image:        adoptopenjdk/openjdk11:jre-11.0.11_9
Licenses:          enabled

✓ Tested 132 dependencies for known issues, no vulnerable paths found.
```