### PR TITLE
Bft duplicate prepares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 21.7.0-RC2
+
+### Bug Fixes
+- Ibft2 could create invalid RoundChange messages in some circumstances containing duplicate prepares [\#2449](https://github.com/hyperledger/besu/pull/2449)
+
 ## 21.7.0-RC1
 
 ### Additions and Improvements

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagewrappers/BftMessage.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/messagewrappers/BftMessage.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
+import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.function.Function;
 
@@ -66,13 +67,6 @@ public class BftMessage<P extends Payload> implements Authored, RoundSpecific {
     return payload.getPayload();
   }
 
-  @Override
-  public String toString() {
-    return new StringJoiner(", ", BftMessage.class.getSimpleName() + "[", "]")
-        .add("payload=" + payload)
-        .toString();
-  }
-
   protected static <T extends Payload> SignedData<T> readPayload(
       final RLPInput rlpInput, final Function<RLPInput, T> decoder) {
     rlpInput.enterList();
@@ -82,5 +76,29 @@ public class BftMessage<P extends Payload> implements Authored, RoundSpecific {
     rlpInput.leaveList();
 
     return SignedData.create(unsignedMessageData, signature);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", BftMessage.class.getSimpleName() + "[", "]")
+        .add("payload=" + payload)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BftMessage<?> that = (BftMessage<?>) o;
+    return Objects.equals(payload, that.payload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(payload);
   }
 }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
@@ -65,6 +65,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class IbftRoundIntegrationTest {
 
   private final MessageFactory peerMessageFactory = new MessageFactory(NodeKeyUtils.generate());
+  private final MessageFactory peerMessageFactory2 = new MessageFactory(NodeKeyUtils.generate());
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();
   private ProtocolContext protocolContext;
@@ -181,7 +182,7 @@ public class IbftRoundIntegrationTest {
     verifyNoInteractions(multicaster);
 
     round.handleCommitMessage(
-        peerMessageFactory.createCommit(roundIdentifier, Hash.EMPTY, remoteCommitSeal));
+        peerMessageFactory2.createCommit(roundIdentifier, Hash.EMPTY, remoteCommitSeal));
     assertThat(roundState.isCommitted()).isTrue();
     verifyNoInteractions(multicaster);
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -65,6 +65,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QbftRoundIntegrationTest {
 
   private final MessageFactory peerMessageFactory = new MessageFactory(NodeKeyUtils.generate());
+  private final MessageFactory peerMessageFactory2 = new MessageFactory(NodeKeyUtils.generate());
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();
   private final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
@@ -184,7 +185,7 @@ public class QbftRoundIntegrationTest {
     verifyNoInteractions(multicaster);
 
     round.handleCommitMessage(
-        peerMessageFactory.createCommit(roundIdentifier, Hash.EMPTY, remoteCommitSeal));
+        peerMessageFactory2.createCommit(roundIdentifier, Hash.EMPTY, remoteCommitSeal));
     assertThat(roundState.isCommitted()).isTrue();
     verifyNoInteractions(multicaster);
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -77,8 +77,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QbftRoundTest {
 
   private final NodeKey nodeKey = NodeKeyUtils.generate();
+  private final NodeKey nodeKey2 = NodeKeyUtils.generate();
   private final ConsensusRoundIdentifier roundIdentifier = new ConsensusRoundIdentifier(1, 0);
   private final MessageFactory messageFactory = new MessageFactory(nodeKey);
+  private final MessageFactory messageFactory2 = new MessageFactory(nodeKey2);
   private final Subscribers<MinedBlockObserver> subscribers = Subscribers.create();
   private final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
   private ProtocolContext protocolContext;
@@ -243,7 +245,7 @@ public class QbftRoundTest {
     verify(blockImporter, never()).importBlock(any(), any(), any());
 
     round.handlePrepareMessage(
-        messageFactory.createPrepare(roundIdentifier, proposedBlock.getHash()));
+        messageFactory2.createPrepare(roundIdentifier, proposedBlock.getHash()));
 
     verify(transmitter, times(1))
         .multicastCommit(roundIdentifier, proposedBlock.getHash(), localCommitSeal);
@@ -321,7 +323,7 @@ public class QbftRoundTest {
     // Inject a single Prepare message, and confirm the roundState has gone to Prepared (which
     // indicates the block has entered the roundState (note: all msgs are deemed valid due to mocks)
     round.handlePrepareMessage(
-        messageFactory.createPrepare(roundIdentifier, proposedBlock.getHash()));
+        messageFactory2.createPrepare(roundIdentifier, proposedBlock.getHash()));
     assertThat(roundState.isPrepared()).isTrue();
   }
 
@@ -360,7 +362,7 @@ public class QbftRoundTest {
     // Inject a single Prepare message, and confirm the roundState has gone to Prepared (which
     // indicates the block has entered the roundState (note: all msgs are deemed valid due to mocks)
     round.handlePrepareMessage(
-        messageFactory.createPrepare(roundIdentifier, proposedBlock.getHash()));
+        messageFactory2.createPrepare(roundIdentifier, proposedBlock.getHash()));
     assertThat(roundState.isPrepared()).isTrue();
   }
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/RoundStateTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/RoundStateTest.java
@@ -21,10 +21,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
+import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
+import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.qbft.validation.MessageValidator;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
@@ -38,6 +41,8 @@ import org.hyperledger.besu.ethereum.core.Util;
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -148,7 +153,7 @@ public class RoundStateTest {
         validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
 
     final Prepare thirdPrepare =
-        validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
+        validatorMessageFactories.get(0).createPrepare(roundIdentifier, block.getHash());
 
     roundState.addPrepareMessage(firstPrepare);
     assertThat(roundState.isPrepared()).isFalse();
@@ -209,7 +214,7 @@ public class RoundStateTest {
   }
 
   @Test
-  public void prepareMessageIsValidatedAgainstExitingProposal() {
+  public void prepareMessageIsValidatedAgainstExistingProposal() {
     final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
 
     final Prepare firstPrepare =
@@ -219,7 +224,7 @@ public class RoundStateTest {
         validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
 
     final Prepare thirdPrepare =
-        validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
+        validatorMessageFactories.get(0).createPrepare(roundIdentifier, block.getHash());
 
     final Proposal proposal =
         validatorMessageFactories
@@ -286,5 +291,48 @@ public class RoundStateTest {
 
     assertThat(roundState.getCommitSeals())
         .containsOnly(firstCommit.getCommitSeal(), secondCommit.getCommitSeal());
+  }
+
+  @Test
+  public void duplicatePreparesAreNotIncludedInRoundChangeMessage() {
+    final RoundState roundState = new RoundState(roundIdentifier, 2, messageValidator);
+
+    final Prepare firstPrepare =
+        validatorMessageFactories.get(1).createPrepare(roundIdentifier, block.getHash());
+
+    final Prepare secondPrepare =
+        validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
+
+    final Prepare duplicatePrepare =
+        validatorMessageFactories.get(2).createPrepare(roundIdentifier, block.getHash());
+
+    final Proposal proposal =
+        validatorMessageFactories
+            .get(0)
+            .createProposal(
+                roundIdentifier, block, Collections.emptyList(), Collections.emptyList());
+
+    when(messageValidator.validateProposal(any())).thenReturn(true);
+    when(messageValidator.validatePrepare(any())).thenReturn(true);
+
+    roundState.setProposedBlock(proposal);
+    roundState.addPrepareMessage(firstPrepare);
+    roundState.addPrepareMessage(secondPrepare);
+    roundState.addPrepareMessage(duplicatePrepare);
+
+    assertThat(roundState.isPrepared()).isTrue();
+    assertThat(roundState.isCommitted()).isFalse();
+
+    final Optional<PreparedCertificate> preparedCertificate =
+        roundState.constructPreparedCertificate();
+    assertThat(preparedCertificate).isNotEmpty();
+    assertThat(preparedCertificate.get().getRound()).isEqualTo(roundIdentifier.getRoundNumber());
+    assertThat(preparedCertificate.get().getBlock()).isEqualTo(block);
+
+    final List<SignedData<PreparePayload>> expectedPrepares =
+        List.of(firstPrepare, secondPrepare).stream()
+            .map(BftMessage::getSignedPayload)
+            .collect(Collectors.toList());
+    assertThat(preparedCertificate.get().getPrepares()).isEqualTo(expectedPrepares);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
In IBFT2 and QBFT the round change message could be created with duplicate prepares being included in the round change message. These messages are rejected as being invalid by Besu.

This fixes the equality and hashCode on the message so that we don't add duplicate messages.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).