### PR TITLE
Implement eth_getBlockByNumber while downloading state.

### DIFF
--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -18,6 +18,7 @@ import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive;
 import static org.mockito.Mockito.mock;
 
+import io.vertx.core.json.Json;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
@@ -63,9 +64,10 @@ public class JsonRpcTestMethodsFactory {
 
   private final BlockchainImporter importer;
   private final MutableBlockchain blockchain;
-  private WorldStateArchive stateArchive;
+  private final WorldStateArchive stateArchive;
   private final ProtocolContext context;
-  private BlockchainQueries blockchainQueries;
+  private final BlockchainQueries blockchainQueries;
+
 
   public JsonRpcTestMethodsFactory(final BlockchainImporter importer) {
     this.importer = importer;
@@ -79,7 +81,7 @@ public class JsonRpcTestMethodsFactory {
 
     for (final Block block : importer.getBlocks()) {
       final ProtocolSpec protocolSpec =
-          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
+              protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }
@@ -102,16 +104,8 @@ public class JsonRpcTestMethodsFactory {
     return blockchainQueries;
   }
 
-  public void setBlockchainQueries(final BlockchainQueries blockchainQueries) {
-    this.blockchainQueries = blockchainQueries;
-  }
-
   public WorldStateArchive getStateArchive() {
     return stateArchive;
-  }
-
-  public void setStateArchive(final WorldStateArchive stateArchive) {
-    this.stateArchive = stateArchive;
   }
 
   public Map<String, JsonRpcMethod> methods() {
@@ -155,9 +149,9 @@ public class JsonRpcTestMethodsFactory {
             NETWORK_ID,
             new StubGenesisConfigOptions(),
             peerDiscovery,
-            blockchainQueries,
+                blockchainQueries,
             synchronizer,
-            protocolSchedule,
+            importer.getProtocolSchedule(),
             filterManager,
             transactionPool,
             miningCoordinator,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -65,7 +65,7 @@ public class JsonRpcTestMethodsFactory {
   private final MutableBlockchain blockchain;
   private final WorldStateArchive stateArchive;
   private final ProtocolContext context;
-  private BlockchainQueries blockchainQueries;
+  private final BlockchainQueries blockchainQueries;
   private final Synchronizer synchronizer;
 
   public JsonRpcTestMethodsFactory(final BlockchainImporter importer) {

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -18,7 +18,6 @@ import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive;
 import static org.mockito.Mockito.mock;
 
-import io.vertx.core.json.Json;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
@@ -77,23 +76,26 @@ public class JsonRpcTestMethodsFactory {
 
 
     final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
+
     for (final Block block : importer.getBlocks()) {
       final ProtocolSpec protocolSpec =
-              protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }
     this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
   }
 
-  public JsonRpcTestMethodsFactory(final BlockchainImporter importer, final MutableBlockchain blockchain,
-                                   final WorldStateArchive stateArchive, final ProtocolContext context) {
+  public JsonRpcTestMethodsFactory(
+      final BlockchainImporter importer,
+      final MutableBlockchain blockchain,
+      final WorldStateArchive stateArchive,
+      final ProtocolContext context) {
     this.importer = importer;
     this.blockchain = blockchain;
     this.stateArchive = stateArchive;
     this.context = context;
     this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
-
   }
 
   public Map<String, JsonRpcMethod> methods() {
@@ -137,7 +139,7 @@ public class JsonRpcTestMethodsFactory {
             NETWORK_ID,
             new StubGenesisConfigOptions(),
             peerDiscovery,
-                blockchainQueries,
+            blockchainQueries,
             synchronizer,
             protocolSchedule,
             filterManager,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -63,9 +63,9 @@ public class JsonRpcTestMethodsFactory {
 
   private final BlockchainImporter importer;
   private final MutableBlockchain blockchain;
-  private final WorldStateArchive stateArchive;
+  private WorldStateArchive stateArchive;
   private final ProtocolContext context;
-  private final BlockchainQueries blockchainQueries;
+  private BlockchainQueries blockchainQueries;
 
   public JsonRpcTestMethodsFactory(final BlockchainImporter importer) {
     this.importer = importer;
@@ -96,6 +96,22 @@ public class JsonRpcTestMethodsFactory {
     this.stateArchive = stateArchive;
     this.context = context;
     this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
+  }
+
+  public BlockchainQueries getBlockchainQueries() {
+    return blockchainQueries;
+  }
+
+  public void setBlockchainQueries(final BlockchainQueries blockchainQueries) {
+    this.blockchainQueries = blockchainQueries;
+  }
+
+  public WorldStateArchive getStateArchive() {
+    return stateArchive;
+  }
+
+  public void setStateArchive(final WorldStateArchive stateArchive) {
+    this.stateArchive = stateArchive;
   }
 
   public Map<String, JsonRpcMethod> methods() {

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -18,7 +18,6 @@ import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive;
 import static org.mockito.Mockito.mock;
 
-import io.vertx.core.json.Json;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
@@ -76,12 +75,11 @@ public class JsonRpcTestMethodsFactory {
     this.importer.getGenesisState().writeStateTo(stateArchive.getMutable());
     this.context = new ProtocolContext(blockchain, stateArchive, null);
 
-
     final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
 
     for (final Block block : importer.getBlocks()) {
       final ProtocolSpec protocolSpec =
-              protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }
@@ -149,7 +147,7 @@ public class JsonRpcTestMethodsFactory {
             NETWORK_ID,
             new StubGenesisConfigOptions(),
             peerDiscovery,
-                blockchainQueries,
+            blockchainQueries,
             synchronizer,
             importer.getProtocolSchedule(),
             filterManager,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -65,8 +65,8 @@ public class JsonRpcTestMethodsFactory {
   private final MutableBlockchain blockchain;
   private final WorldStateArchive stateArchive;
   private final ProtocolContext context;
-  private final BlockchainQueries blockchainQueries;
-
+  private BlockchainQueries blockchainQueries;
+  private final Synchronizer synchronizer;
 
   public JsonRpcTestMethodsFactory(final BlockchainImporter importer) {
     this.importer = importer;
@@ -76,6 +76,7 @@ public class JsonRpcTestMethodsFactory {
     this.context = new ProtocolContext(blockchain, stateArchive, null);
 
     final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
+    this.synchronizer = mock(Synchronizer.class);
 
     for (final Block block : importer.getBlocks()) {
       final ProtocolSpec protocolSpec =
@@ -96,6 +97,21 @@ public class JsonRpcTestMethodsFactory {
     this.stateArchive = stateArchive;
     this.context = context;
     this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
+    this.synchronizer = mock(Synchronizer.class);
+  }
+
+  public JsonRpcTestMethodsFactory(
+      final BlockchainImporter importer,
+      final MutableBlockchain blockchain,
+      final WorldStateArchive stateArchive,
+      final ProtocolContext context,
+      final Synchronizer synchronizer) {
+    this.importer = importer;
+    this.blockchain = blockchain;
+    this.stateArchive = stateArchive;
+    this.context = context;
+    this.synchronizer = synchronizer;
+    this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
   }
 
   public BlockchainQueries getBlockchainQueries() {
@@ -107,8 +123,6 @@ public class JsonRpcTestMethodsFactory {
   }
 
   public Map<String, JsonRpcMethod> methods() {
-
-    final Synchronizer synchronizer = mock(Synchronizer.class);
     final P2PNetwork peerDiscovery = mock(P2PNetwork.class);
     final EthPeers ethPeers = mock(EthPeers.class);
     final TransactionPool transactionPool = mock(TransactionPool.class);

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
 import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Hexadecimals;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
@@ -23,6 +24,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -92,14 +95,21 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
   public void shouldReturnedLatestFullSynced() {
 
     assertThat(latestFullySyncdBlockNumber.longValue()).isNotEqualTo(0L);
+    //otherwise our setup didn't work as expected
     Object[] params = {"latest", false};
     JsonRpcRequestContext ctx = new JsonRpcRequestContext(
             new JsonRpcRequest("2.0", "eth_getBlockByNumber", params));
     Assertions.assertThatNoException().isThrownBy(() -> {
       final JsonRpcResponse resp = ethGetBlockNumber.response(ctx);
       assertThat(resp).isNotNull();
-      assertThat(resp).
+      assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+      Object r = ((JsonRpcSuccessResponse)resp).getResult();
+      assertThat(r).isInstanceOf(BlockResult.class);
+      BlockResult br = (BlockResult)r;
+      assertThat(br.getNumber()).isEqualTo("0x"+Long.toHexString(latestFullySyncdBlockNumber));
     });
+
+    //TODO: what test to cover including transactions?
 
   }
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.assertj.core.api.Assertions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
@@ -42,7 +43,6 @@ import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.assertj.core.api.Assertions;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -122,5 +122,4 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
               assertThat(br.getNumber()).isEqualTo("0x0");
             });
   }
-
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -1,0 +1,46 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.testutil.BlockTestUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EthGetBlockByNumberLatestDesyncIntegrationTest {
+
+    private static JsonRpcMethod ethGetBlockNumber;
+    private static Integer latestFullySyncdBlockNumber = 0;
+
+    @BeforeClass
+    public void setUpOnce() throws Exception {
+        final String genesisJson = Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
+        final BlockchainImporter importer = new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson);
+        final WorldStateArchive state = InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive();
+        //TODO: run same test with coverage of Bonsai state?
+        importer.getGenesisState().writeStateTo(state.getMutable());
+        final MutableBlockchain blockchain = InMemoryKeyValueStorageProvider.createInMemoryBlockchain(
+                importer.getGenesisBlock());
+        final ProtocolContext ether = new ProtocolContext(blockchain, state, null);
+
+        //how to setup importer/state/chain to reflect de-syncd?
+
+        final JsonRpcTestMethodsFactory factory = new JsonRpcTestMethodsFactory(importer, blockchain, state, ether);
+        this.ethGetBlockNumber = factory.methods().get("eth_getBlockByNumber");
+
+    }
+
+    @Test
+    public void shouldReturnedLatestFullSynced() {
+
+    }
+}

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -1,7 +1,5 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
@@ -10,6 +8,9 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.testutil.BlockTestUtil;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,29 +19,43 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class EthGetBlockByNumberLatestDesyncIntegrationTest {
 
-    private static JsonRpcMethod ethGetBlockNumber;
-    private static Integer latestFullySyncdBlockNumber = 0;
+  private static JsonRpcMethod ethGetBlockNumber;
+  private static Integer latestFullySyncdBlockNumber = 0;
 
-    @BeforeClass
-    public void setUpOnce() throws Exception {
-        final String genesisJson = Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
-        final BlockchainImporter importer = new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson);
-        final WorldStateArchive state = InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive();
-        //TODO: run same test with coverage of Bonsai state?
-        importer.getGenesisState().writeStateTo(state.getMutable());
-        final MutableBlockchain blockchain = InMemoryKeyValueStorageProvider.createInMemoryBlockchain(
-                importer.getGenesisBlock());
-        final ProtocolContext ether = new ProtocolContext(blockchain, state, null);
+  @BeforeClass
+  public void setUpOnce() throws Exception {
+    final String genesisJson =
+        Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
+    final BlockchainImporter importer =
+        new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson);
+    final WorldStateArchive state =
+        InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive();
+    // TODO: run same test with coverage of Bonsai state?
+    importer.getGenesisState().writeStateTo(state.getMutable());
+    final MutableBlockchain blockchain =
+        InMemoryKeyValueStorageProvider.createInMemoryBlockchain(importer.getGenesisBlock());
+    final ProtocolContext ether = new ProtocolContext(blockchain, state, null);
 
-        //how to setup importer/state/chain to reflect de-syncd?
-
-        final JsonRpcTestMethodsFactory factory = new JsonRpcTestMethodsFactory(importer, blockchain, state, ether);
-        this.ethGetBlockNumber = factory.methods().get("eth_getBlockByNumber");
-
+    // how to setup importer/state/chain to reflect de-syncd?
+    // pseudocode idea for brainstorming:
+    /*
+    for (final Block block : importer.getBlocks().sublist(0,size/3)) {
+        final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
+        final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
+        final BlockImporter blockImporter = protocolSpec.getBlockImporter();
+        blockImporter.importBlock(context, block, HeaderValidationMode.FAST);
     }
+    //Then do a third of 'em FULL,
+    //Then do a third of 'em..... how are they imported as they are coming over the wire?
+    //is that full too?
+     */
 
-    @Test
-    public void shouldReturnedLatestFullSynced() {
+    final JsonRpcTestMethodsFactory factory =
+        new JsonRpcTestMethodsFactory(importer, blockchain, state, ether);
+    this.ethGetBlockNumber = factory.methods().get("eth_getBlockByNumber");
+  }
 
-    }
+  @Test
+  public void shouldReturnedLatestFullSynced() {}
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -1,16 +1,44 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
+import org.assertj.core.api.Assertions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,10 +48,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class EthGetBlockByNumberLatestDesyncIntegrationTest {
 
   private static JsonRpcMethod ethGetBlockNumber;
-  private static Integer latestFullySyncdBlockNumber = 0;
+  private static Long latestFullySyncdBlockNumber = 0L;
 
   @BeforeClass
-  public void setUpOnce() throws Exception {
+  public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
     final BlockchainImporter importer =
@@ -35,27 +63,43 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
     final MutableBlockchain blockchain =
         InMemoryKeyValueStorageProvider.createInMemoryBlockchain(importer.getGenesisBlock());
     final ProtocolContext ether = new ProtocolContext(blockchain, state, null);
+    final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
 
-    // how to setup importer/state/chain to reflect de-syncd?
-    // pseudocode idea for brainstorming:
-    /*
-    for (final Block block : importer.getBlocks().sublist(0,size/3)) {
-        final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
+    for (final Block block : importer.getBlocks()) {
         final ProtocolSpec protocolSpec =
           protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
         final BlockImporter blockImporter = protocolSpec.getBlockImporter();
-        blockImporter.importBlock(context, block, HeaderValidationMode.FAST);
+        blockImporter.importBlock(ether, block, HeaderValidationMode.LIGHT);
     }
-    //Then do a third of 'em FULL,
-    //Then do a third of 'em..... how are they imported as they are coming over the wire?
-    //is that full too?
-     */
+
+    int pivotBlockIndex = importer.getBlocks().size() / 3;
+    for(int i = pivotBlockIndex; i< pivotBlockIndex*2; i++) {  //Then do a third of 'em FULL,
+      Block toReimportFully = importer.getBlocks().get(i);
+      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(
+              toReimportFully.getHeader().getNumber());
+      final BlockImporter blockImporter = protocolSpec.getBlockImporter();
+      blockImporter.importBlock(ether, toReimportFully, HeaderValidationMode.FULL);
+      latestFullySyncdBlockNumber = toReimportFully.getHeader().getNumber();
+    }
 
     final JsonRpcTestMethodsFactory factory =
         new JsonRpcTestMethodsFactory(importer, blockchain, state, ether);
-    this.ethGetBlockNumber = factory.methods().get("eth_getBlockByNumber");
+
+    ethGetBlockNumber = factory.methods().get("eth_getBlockByNumber");
   }
 
   @Test
-  public void shouldReturnedLatestFullSynced() {}
+  public void shouldReturnedLatestFullSynced() {
+
+    assertThat(latestFullySyncdBlockNumber.longValue()).isNotEqualTo(0L);
+    Object[] params = {"latest", false};
+    JsonRpcRequestContext ctx = new JsonRpcRequestContext(
+            new JsonRpcRequest("2.0", "eth_getBlockByNumber", params));
+    Assertions.assertThatNoException().isThrownBy(() -> {
+      final JsonRpcResponse resp = ethGetBlockNumber.response(ctx);
+      assertThat(resp).isNotNull();
+      assertThat(resp).
+    });
+
+  }
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -43,6 +43,7 @@ import org.hyperledger.besu.testutil.BlockTestUtil;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.assertj.core.api.Assertions;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -121,4 +122,5 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
               assertThat(br.getNumber()).isEqualTo("0x0");
             });
   }
+
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.assertj.core.api.Assertions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.BlockchainImporter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcTestMethodsFactory;
@@ -47,7 +46,7 @@ import java.util.Optional;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-
+import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -23,9 +23,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
-import org.hyperledger.besu.ethereum.core.WorldState;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
@@ -86,8 +84,8 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
     Hash stateRoot = headHeader.getStateRoot();
 
     if (blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
-      //Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
-      //log.trace(worldState.get().toString());
+      // Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
+      // log.trace(worldState.get().toString());
       return resultByBlockNumber(request, headBlockNumber);
     } else {
       log.trace("no world state available for block {} returning genesis", headBlockNumber);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -15,17 +15,19 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import com.google.common.base.Suppliers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.WorldState;
 
-
+import java.util.Optional;
 import java.util.function.Supplier;
 
 
@@ -33,6 +35,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   private final BlockResultFactory blockResult;
   private final boolean includeCoinbase;
+  private static final Logger log = LogManager.getLogger();
 
   public EthGetBlockByNumber(
       final BlockchainQueries blockchain, final BlockResultFactory blockResult) {
@@ -82,8 +85,11 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
     Hash stateRoot = headHeader.getStateRoot();
 
     if(blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
+      Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
+      log.trace(worldState.get().toString());
       return resultByBlockNumber(request, headBlockNumber);
     } else {
+      log.trace("no world state available for block {} returning genesis", headBlockNumber);
       return resultByBlockNumber(request, blockchainQueries.get().getBlockchain().getGenesisBlock().getHeader().getNumber());
     }
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -64,6 +64,12 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
     return transactionHash(blockNumber);
   }
 
+  @Override
+  protected Object latestResult(final JsonRpcRequestContext request) {
+    //old behavior - throws exception when trransactions incomplete on head.
+    return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
+  }
+
   private BlockResult transactionComplete(final long blockNumber) {
     return getBlockchainQueries()
         .blockByNumber(blockNumber)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -68,6 +68,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
   protected Object latestResult(final JsonRpcRequestContext request) {
     //old behavior - throws exception when trransactions incomplete on head.
     return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
+
   }
 
   private BlockResult transactionComplete(final long blockNumber) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.WorldState;
@@ -78,15 +79,15 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
     // if head has state, return that.
 
     final long headBlockNumber = blockchainQueries.get().headBlockNumber();
-    BlockHeader headHeader =
-        blockchainQueries.get().getBlockchain().getBlockHeader(headBlockNumber).orElse(null);
+    Blockchain chain = blockchainQueries.get().getBlockchain();
+    BlockHeader headHeader = chain.getBlockHeader(headBlockNumber).orElse(null);
 
     Hash block = headHeader.getHash();
     Hash stateRoot = headHeader.getStateRoot();
 
     if (blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
-      Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
-      log.trace(worldState.get().toString());
+      //Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
+      //log.trace(worldState.get().toString());
       return resultByBlockNumber(request, headBlockNumber);
     } else {
       log.trace("no world state available for block {} returning genesis", headBlockNumber);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -35,7 +35,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   private final BlockResultFactory blockResult;
   private final boolean includeCoinbase;
-  private static final Logger log = LogManager.getLogger();
+  private static final Logger LOGGER = LogManager.getLogger();
   private final Synchronizer synchronizer;
 
   public EthGetBlockByNumber(
@@ -95,7 +95,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
       }
     }
 
-    log.trace("no world state available for block {} returning genesis", headBlockNumber);
+    LOGGER.trace("no world state available for block {} returning genesis", headBlockNumber);
     return resultByBlockNumber(
         request, blockchainQueries.get().getBlockchain().getGenesisBlock().getHeader().getNumber());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -14,16 +14,20 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
+import com.google.common.base.Suppliers;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.ChainHead;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Hash;
+
 
 import java.util.function.Supplier;
 
-import com.google.common.base.Suppliers;
 
 public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
@@ -66,9 +70,22 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   @Override
   protected Object latestResult(final JsonRpcRequestContext request) {
-    //old behavior - throws exception when trransactions incomplete on head.
-    return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
+    //old behavior - throws exception when transactions incomplete on head.
+    //return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
+    //if head has state, return that.
 
+
+    final long headBlockNumber = blockchainQueries.get().headBlockNumber();
+    BlockHeader headHeader = blockchainQueries.get().getBlockchain().getBlockHeader(headBlockNumber).orElse(null);
+
+    Hash block = headHeader.getHash();
+    Hash stateRoot = headHeader.getStateRoot();
+
+    if(blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
+      return resultByBlockNumber(request, headBlockNumber);
+    } else {
+      return resultByBlockNumber(request, blockchainQueries.get().getBlockchain().getGenesisBlock().getHeader().getNumber());
+    }
   }
 
   private BlockResult transactionComplete(final long blockNumber) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -14,9 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
-import com.google.common.base.Suppliers;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
@@ -30,6 +27,9 @@ import org.hyperledger.besu.ethereum.core.WorldState;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import com.google.common.base.Suppliers;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
@@ -73,24 +73,26 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   @Override
   protected Object latestResult(final JsonRpcRequestContext request) {
-    //old behavior - throws exception when transactions incomplete on head.
-    //return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
-    //if head has state, return that.
-
+    // old behavior - throws exception when transactions incomplete on head.
+    // return resultByBlockNumber(request, blockchainQueries.get().headBlockNumber());
+    // if head has state, return that.
 
     final long headBlockNumber = blockchainQueries.get().headBlockNumber();
-    BlockHeader headHeader = blockchainQueries.get().getBlockchain().getBlockHeader(headBlockNumber).orElse(null);
+    BlockHeader headHeader =
+        blockchainQueries.get().getBlockchain().getBlockHeader(headBlockNumber).orElse(null);
 
     Hash block = headHeader.getHash();
     Hash stateRoot = headHeader.getStateRoot();
 
-    if(blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
+    if (blockchainQueries.get().getWorldStateArchive().isWorldStateAvailable(stateRoot, block)) {
       Optional<WorldState> worldState = blockchainQueries.get().getWorldState(headBlockNumber);
       log.trace(worldState.get().toString());
       return resultByBlockNumber(request, headBlockNumber);
     } else {
       log.trace("no world state available for block {} returning genesis", headBlockNumber);
-      return resultByBlockNumber(request, blockchainQueries.get().getBlockchain().getGenesisBlock().getHeader().getNumber());
+      return resultByBlockNumber(
+          request,
+          blockchainQueries.get().getBlockchain().getGenesisBlock().getHeader().getNumber());
     }
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -119,7 +119,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new EthBlockNumber(blockchainQueries),
         new EthGetBalance(blockchainQueries),
         new EthGetBlockByHash(blockchainQueries, blockResult),
-        new EthGetBlockByNumber(blockchainQueries, blockResult),
+        new EthGetBlockByNumber(blockchainQueries, blockResult, synchronizer),
         new EthGetBlockTransactionCountByNumber(blockchainQueries),
         new EthGetBlockTransactionCountByHash(blockchainQueries),
         new EthCall(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -1060,7 +1060,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     when(blockchainQueries.blockByNumber(eq(0L))).thenReturn(Optional.of(blockWithMetadata));
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchain.getBlockHeader(blockchainQueries.headBlockNumber()))
-            .thenReturn(Optional.of(block.getHeader()));
+        .thenReturn(Optional.of(block.getHeader()));
     WorldStateArchive state = mock(WorldStateArchive.class);
     when(state.isWorldStateAvailable(any(Hash.class), any(Hash.class))).thenReturn(true);
     when(blockchainQueries.getWorldStateArchive()).thenReturn(state);
@@ -1090,12 +1090,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final BlockDataGenerator gen = new BlockDataGenerator();
     final Block block = gen.genesisBlock();
     final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetadata =
-            blockWithMetadata(block);
+        blockWithMetadata(block);
     when(blockchainQueries.headBlockNumber()).thenReturn(0L);
     when(blockchainQueries.blockByNumber(eq(0L))).thenReturn(Optional.of(blockWithMetadata));
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchain.getBlockHeader(blockchainQueries.headBlockNumber()))
-            .thenReturn(Optional.of(block.getHeader()));
+        .thenReturn(Optional.of(block.getHeader()));
     WorldStateArchive state = mock(WorldStateArchive.class);
     when(state.isWorldStateAvailable(any(Hash.class), any(Hash.class))).thenReturn(true);
     when(blockchainQueries.getWorldStateArchive()).thenReturn(state);

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -1,0 +1,54 @@
+package org.hyperledger.besu.ethereum.retesteth;
+
+import org.hyperledger.besu.ethereum.core.Synchronizer;
+import org.hyperledger.besu.plugin.data.SyncStatus;
+import org.hyperledger.besu.plugin.services.BesuEvents;
+
+import java.util.Optional;
+
+public class DummySynchronizer implements Synchronizer {
+    @Override
+    public void start() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void awaitStop() throws InterruptedException {
+
+    }
+
+    @Override
+    public Optional<SyncStatus> getSyncStatus() {
+        return Optional.empty();
+    }
+
+    @Override
+    public long subscribeSyncStatus(final BesuEvents.SyncStatusListener listener) {
+        return 0;
+    }
+
+    @Override
+    public boolean unsubscribeSyncStatus(final long observerId) {
+        return false;
+    }
+
+    @Override
+    public long subscribeInSync(final InSyncListener listener) {
+        return 0;
+    }
+
+    @Override
+    public long subscribeInSync(final InSyncListener listener, final long syncTolerance) {
+        return 0;
+    }
+
+    @Override
+    public boolean unsubscribeInSync(final long listenerId) {
+        return false;
+    }
+}

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.hyperledger.besu.ethereum.retesteth;
 
 import org.hyperledger.besu.ethereum.core.Synchronizer;
@@ -7,48 +22,42 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 import java.util.Optional;
 
 public class DummySynchronizer implements Synchronizer {
-    @Override
-    public void start() {
+  @Override
+  public void start() {}
 
-    }
+  @Override
+  public void stop() {}
 
-    @Override
-    public void stop() {
+  @Override
+  public void awaitStop() throws InterruptedException {}
 
-    }
+  @Override
+  public Optional<SyncStatus> getSyncStatus() {
+    return Optional.empty();
+  }
 
-    @Override
-    public void awaitStop() throws InterruptedException {
+  @Override
+  public long subscribeSyncStatus(final BesuEvents.SyncStatusListener listener) {
+    return 0;
+  }
 
-    }
+  @Override
+  public boolean unsubscribeSyncStatus(final long observerId) {
+    return false;
+  }
 
-    @Override
-    public Optional<SyncStatus> getSyncStatus() {
-        return Optional.empty();
-    }
+  @Override
+  public long subscribeInSync(final InSyncListener listener) {
+    return 0;
+  }
 
-    @Override
-    public long subscribeSyncStatus(final BesuEvents.SyncStatusListener listener) {
-        return 0;
-    }
+  @Override
+  public long subscribeInSync(final InSyncListener listener, final long syncTolerance) {
+    return 0;
+  }
 
-    @Override
-    public boolean unsubscribeSyncStatus(final long observerId) {
-        return false;
-    }
-
-    @Override
-    public long subscribeInSync(final InSyncListener listener) {
-        return 0;
-    }
-
-    @Override
-    public long subscribeInSync(final InSyncListener listener, final long syncTolerance) {
-        return 0;
-    }
-
-    @Override
-    public boolean unsubscribeInSync(final long listenerId) {
-        return false;
-    }
+  @Override
+  public boolean unsubscribeInSync(final long listenerId) {
+    return false;
+  }
 }

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -21,6 +21,11 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 
 import java.util.Optional;
 
+/**
+ * Naive implementation of Synchronizer used by retesteth. Because retesteth is not implemented in the test module, it
+ * has no access to mockito. This class provides a minimum implementation needed to run RPC methods which may require a
+ * Synchronizer.
+ */
 public class DummySynchronizer implements Synchronizer {
   @Override
   public void start() {}

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -22,9 +22,9 @@ import org.hyperledger.besu.plugin.services.BesuEvents;
 import java.util.Optional;
 
 /**
- * Naive implementation of Synchronizer used by retesteth. Because retesteth is not implemented in the test module, it
- * has no access to mockito. This class provides a minimum implementation needed to run RPC methods which may require a
- * Synchronizer.
+ * Naive implementation of Synchronizer used by retesteth. Because retesteth is not implemented in
+ * the test module, it has no access to mockito. This class provides a minimum implementation needed
+ * to run RPC methods which may require a Synchronizer.
  */
 public class DummySynchronizer implements Synchronizer {
   @Override

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -46,8 +46,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
-import org.hyperledger.besu.plugin.data.SyncStatus;
-import org.hyperledger.besu.plugin.services.BesuEvents;
 
 public class RetestethService {
 
@@ -66,10 +64,8 @@ public class RetestethService {
     final BlockResultFactory blockResult = new BlockResultFactory();
     final NatService natService = new NatService(Optional.empty());
 
-
-    //Synchronizer needed by RPC methods. Didn't wanna mock it, since this isn't the test module.
+    // Synchronizer needed by RPC methods. Didn't wanna mock it, since this isn't the test module.
     Synchronizer sync = new DummySynchronizer();
-
 
     final Map<String, JsonRpcMethod> jsonRpcMethods =
         mapOf(
@@ -77,7 +73,8 @@ public class RetestethService {
             new TestSetChainParams(retestethContext),
             new TestImportRawBlock(retestethContext),
             new EthBlockNumber(retestethContext::getBlockchainQueries, true),
-            new EthGetBlockByNumber(retestethContext::getBlockchainQueries, blockResult, sync,true),
+            new EthGetBlockByNumber(
+                retestethContext::getBlockchainQueries, blockResult, sync, true),
             new DebugAccountRange(retestethContext::getBlockchainQueries),
             new EthGetBalance(retestethContext::getBlockchainQueries),
             new EthGetBlockByHash(retestethContext::getBlockchainQueries, blockResult, true),

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethService.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthSendRawTran
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Web3ClientVersion;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestGetLogHash;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestImportRawBlock;
 import org.hyperledger.besu.ethereum.retesteth.methods.TestMineBlocks;
@@ -45,6 +46,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
+import org.hyperledger.besu.plugin.data.SyncStatus;
+import org.hyperledger.besu.plugin.services.BesuEvents;
 
 public class RetestethService {
 
@@ -63,13 +66,18 @@ public class RetestethService {
     final BlockResultFactory blockResult = new BlockResultFactory();
     final NatService natService = new NatService(Optional.empty());
 
+
+    //Synchronizer needed by RPC methods. Didn't wanna mock it, since this isn't the test module.
+    Synchronizer sync = new DummySynchronizer();
+
+
     final Map<String, JsonRpcMethod> jsonRpcMethods =
         mapOf(
             new Web3ClientVersion(clientVersion),
             new TestSetChainParams(retestethContext),
             new TestImportRawBlock(retestethContext),
             new EthBlockNumber(retestethContext::getBlockchainQueries, true),
-            new EthGetBlockByNumber(retestethContext::getBlockchainQueries, blockResult, true),
+            new EthGetBlockByNumber(retestethContext::getBlockchainQueries, blockResult, sync,true),
             new DebugAccountRange(retestethContext::getBlockchainQueries),
             new EthGetBalance(retestethContext::getBlockchainQueries),
             new EthGetBlockByHash(retestethContext::getBlockchainQueries, blockResult, true),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Introduces a dependency from eth_getBlockByNumber onto the Synchronizer, in order to determine download state, and current most recent block that we have state for. JsonRPC test classes also were refactored to provide a Synchronizer.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2209 

## Changelog
When asking for the latest block while downloading state, will return most recent block we have state for. While still downloading block headers, will return genesis block.

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).