### PR TITLE
fix ropsten consensus issue

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
@@ -61,7 +61,7 @@ public class EIP1559 {
       final BigInteger target = BigInteger.valueOf(targetGasUsed);
       final BigInteger denominator = BigInteger.valueOf(feeMarket.getBasefeeMaxChangeDenominator());
       feeDelta = pBaseFee.multiply(gDelta).divide(target).divide(denominator).longValue();
-      baseFee = max(parentBaseFee - feeDelta,0);
+      baseFee = max(parentBaseFee - feeDelta, 0);
     }
     LOG.trace(
         "block #{} parentBaseFee: {} parentGasUsed: {} parentGasTarget: {} baseFee: {}",

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
@@ -61,7 +61,7 @@ public class EIP1559 {
       final BigInteger target = BigInteger.valueOf(targetGasUsed);
       final BigInteger denominator = BigInteger.valueOf(feeMarket.getBasefeeMaxChangeDenominator());
       feeDelta = pBaseFee.multiply(gDelta).divide(target).divide(denominator).longValue();
-      baseFee = parentBaseFee - feeDelta;
+      baseFee = max(parentBaseFee - feeDelta,0);
     }
     LOG.trace(
         "block #{} parentBaseFee: {} parentGasUsed: {} parentGasTarget: {} baseFee: {}",
@@ -71,11 +71,6 @@ public class EIP1559 {
         targetGasUsed,
         baseFee);
     return baseFee;
-  }
-
-  public boolean isValidBaseFee(final long parentBaseFee, final long baseFee) {
-    return Math.abs(baseFee - parentBaseFee)
-        <= Math.max(1, parentBaseFee / feeMarket.getBasefeeMaxChangeDenominator());
   }
 
   public boolean isEIP1559(final long blockNumber) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/fees/EIP1559.java
@@ -61,7 +61,7 @@ public class EIP1559 {
       final BigInteger target = BigInteger.valueOf(targetGasUsed);
       final BigInteger denominator = BigInteger.valueOf(feeMarket.getBasefeeMaxChangeDenominator());
       feeDelta = pBaseFee.multiply(gDelta).divide(target).divide(denominator).longValue();
-      baseFee = max(parentBaseFee - feeDelta, 0);
+      baseFee = parentBaseFee - feeDelta;
     }
     LOG.trace(
         "block #{} parentBaseFee: {} parentGasUsed: {} parentGasTarget: {} baseFee: {}",

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasPriceValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/EIP1559BlockHeaderGasPriceValidationRule.java
@@ -46,17 +46,18 @@ public class EIP1559BlockHeaderGasPriceValidationRule implements DetachedBlockHe
       final Long currentBaseFee =
           header.getBaseFee().orElseThrow(EIP1559MissingBaseFeeFromBlockHeader::new);
       final long targetGasUsed = eip1559.targetGasUsed(parent);
-      final long baseFee =
+      final long expectedBaseFee =
           eip1559.computeBaseFee(
               header.getNumber(), parentBaseFee, parent.getGasUsed(), targetGasUsed);
-      if (baseFee != header.getBaseFee().orElseThrow()) {
+      if (expectedBaseFee != currentBaseFee) {
         LOG.info(
             "Invalid block header: basefee {} does not equal expected basefee {}",
             header.getBaseFee().orElseThrow(),
-            baseFee);
+            expectedBaseFee);
         return false;
       }
-      return baseFee == currentBaseFee && eip1559.isValidBaseFee(parentBaseFee, currentBaseFee);
+
+      return true;
     } catch (final EIP1559MissingBaseFeeFromBlockHeader e) {
       LOG.info("Invalid block header: " + e.getMessage());
       return false;


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

Fix a consensus issue detected on ropsten. There was a check of elasticity that seems to be related to old version of the specification. This made a double check of the elasticity in the code. I only kept the version that corresponds to the latest version of the spec.
>
		if INITIAL_FORK_BLOCK_NUMBER == block.number:
			expected_base_fee_per_gas = INITIAL_BASE_FEE
		elif parent_gas_used == parent_gas_target:
			expected_base_fee_per_gas = parent_base_fee_per_gas
		elif parent_gas_used > parent_gas_target:
			gas_used_delta = parent_gas_used - parent_gas_target
			base_fee_per_gas_delta = max(parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR, 1)
			expected_base_fee_per_gas = parent_base_fee_per_gas + base_fee_per_gas_delta
		else:
			gas_used_delta = parent_gas_target - parent_gas_used
			base_fee_per_gas_delta = parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
			expected_base_fee_per_gas = max(parent_base_fee_per_gas - base_fee_per_gas_delta, 0)
		assert expected_base_fee_per_gas == block.base_fee_per_gas, 'invalid block: base fee not correct'


## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).