### PR TITLE
update RPC methods : fill gasPrice for post london 1559 transaction

### DIFF
--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcResponseUtils.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcResponseUtils.java
@@ -145,8 +145,10 @@ public class JsonRpcResponseUtils {
   }
 
   public TransactionResult transaction(
+      final TransactionType transactionType,
       final String blockHash,
       final String blockNumber,
+      final Long baseFee,
       final String chainId,
       final String fromAddress,
       final String gas,
@@ -164,7 +166,7 @@ public class JsonRpcResponseUtils {
       final String s) {
 
     final Transaction transaction = mock(Transaction.class);
-    when(transaction.getType()).thenReturn(TransactionType.FRONTIER);
+    when(transaction.getType()).thenReturn(transactionType);
     when(transaction.getGasPrice()).thenReturn(Optional.of(Wei.fromHexString(gasPrice)));
     when(transaction.getNonce()).thenReturn(unsignedLong(nonce));
     when(transaction.getV()).thenReturn(bigInteger(v));
@@ -193,6 +195,7 @@ public class JsonRpcResponseUtils {
         new TransactionWithMetadata(
             transaction,
             unsignedLong(blockNumber),
+            Optional.ofNullable(baseFee),
             Hash.fromHexString(blockHash),
             unsignedInt(transactionIndex)));
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByHashIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByHashIntegrationTest.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionResult;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.util.EnumMap;
@@ -121,8 +122,10 @@ public class EthGetBlockByHashIntegrationTest {
     final List<TransactionResult> transactions =
         responseUtils.transactions(
             responseUtils.transaction(
+                TransactionType.FRONTIER,
                 "0x10aaf14a53caf27552325374429d3558398a36d3682ede6603c2c6511896e9f9",
                 "0x1",
+                null,
                 null,
                 "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                 "0x2fefd8",

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByNumberIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByNumberIntegrationTest.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.TransactionResult;
+import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.util.EnumMap;
@@ -242,8 +243,10 @@ public class EthGetBlockByNumberIntegrationTest {
     final List<TransactionResult> transactions =
         responseUtils.transactions(
             responseUtils.transaction(
+                TransactionType.FRONTIER,
                 "0x71d59849ddd98543bdfbe8548f5eed559b07b8aaf196369f39134500eab68e53",
                 "0x20",
+                null,
                 null,
                 "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                 "0x4cb2f",
@@ -374,8 +377,10 @@ public class EthGetBlockByNumberIntegrationTest {
     final List<TransactionResult> transactions =
         responseUtils.transactions(
             responseUtils.transaction(
+                TransactionType.FRONTIER,
                 "0x609427ccfeae6d2a930927c9a29a0a3077cac7e4b5826159586b10e25770eef9",
                 "0x5",
+                null,
                 null,
                 "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
                 "0x4cb2f",

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
@@ -64,6 +64,7 @@ public class BlockResultFactory {
           new TransactionWithMetadata(
               block.getBody().getTransactions().get(i),
               block.getHeader().getNumber(),
+              block.getHeader().getBaseFee(),
               block.getHash(),
               i));
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
@@ -63,8 +63,6 @@ public class TransactionCompleteResult implements TransactionResult {
 
   private final String from;
   private final String gas;
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String gasPrice;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -102,7 +100,8 @@ public class TransactionCompleteResult implements TransactionResult {
         tx.getTransaction().getMaxPriorityFeePerGas().map(q -> q.toShortHexString()).orElse(null);
     this.maxFeePerGas =
         tx.getTransaction().getMaxFeePerGas().map(q -> q.toShortHexString()).orElse(null);
-    this.gasPrice = transaction.getGasPrice().map(Quantity::create).orElse(null);
+
+    this.gasPrice = Quantity.create(transaction.getEffectivePriorityFeePerGas(tx.getBaseFee()));
     this.hash = transaction.getHash().toString();
     this.input = transaction.getPayload().toString();
     this.nonce = Quantity.create(transaction.getNonce());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -386,7 +386,10 @@ public class BlockchainQueries {
                                       final List<Transaction> txs = body.getTransactions();
                                       final List<TransactionWithMetadata> formattedTxs =
                                           formatTransactions(
-                                              txs, header.getNumber(), blockHeaderHash);
+                                              txs,
+                                              header.getNumber(),
+                                              header.getBaseFee(),
+                                              blockHeaderHash);
                                       final List<Hash> ommers =
                                           body.getOmmers().stream()
                                               .map(BlockHeader::getHash)
@@ -504,7 +507,11 @@ public class BlockchainQueries {
     final Transaction transaction = blockchain.getTransactionByHash(transactionHash).orElseThrow();
     return Optional.of(
         new TransactionWithMetadata(
-            transaction, header.getNumber(), blockHash, loc.getTransactionIndex()));
+            transaction,
+            header.getNumber(),
+            header.getBaseFee(),
+            blockHash,
+            loc.getTransactionIndex()));
   }
 
   /**
@@ -555,7 +562,7 @@ public class BlockchainQueries {
       return null;
     }
     return new TransactionWithMetadata(
-        txs.get(txIndex), header.getNumber(), blockHeaderHash, txIndex);
+        txs.get(txIndex), header.getNumber(), header.getBaseFee(), blockHeaderHash, txIndex);
   }
 
   public Optional<TransactionLocation> transactionLocationByHash(final Hash transactionHash) {
@@ -854,11 +861,14 @@ public class BlockchainQueries {
   }
 
   private List<TransactionWithMetadata> formatTransactions(
-      final List<Transaction> txs, final long blockNumber, final Hash blockHash) {
+      final List<Transaction> txs,
+      final long blockNumber,
+      final Optional<Long> baseFee,
+      final Hash blockHash) {
     final int count = txs.size();
     final List<TransactionWithMetadata> result = new ArrayList<>(count);
     for (int i = 0; i < count; i++) {
-      result.add(new TransactionWithMetadata(txs.get(i), blockNumber, blockHash, i));
+      result.add(new TransactionWithMetadata(txs.get(i), blockNumber, baseFee, blockHash, i));
     }
     return result;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionWithMetadata.java
@@ -25,12 +25,14 @@ public class TransactionWithMetadata {
 
   private final Transaction transaction;
   private final Optional<Long> blockNumber;
+  private final Optional<Long> baseFee;
   private final Optional<Hash> blockHash;
   private final Optional<Integer> transactionIndex;
 
   public TransactionWithMetadata(final Transaction transaction) {
     this.transaction = transaction;
     this.blockNumber = Optional.empty();
+    this.baseFee = Optional.empty();
     this.blockHash = Optional.empty();
     this.transactionIndex = Optional.empty();
   }
@@ -38,10 +40,12 @@ public class TransactionWithMetadata {
   public TransactionWithMetadata(
       final Transaction transaction,
       final long blockNumber,
+      final Optional<Long> baseFee,
       final Hash blockHash,
       final int transactionIndex) {
     this.transaction = transaction;
     this.blockNumber = Optional.of(blockNumber);
+    this.baseFee = baseFee;
     this.blockHash = Optional.of(blockHash);
     this.transactionIndex = Optional.of(transactionIndex);
   }
@@ -52,6 +56,10 @@ public class TransactionWithMetadata {
 
   public Optional<Long> getBlockNumber() {
     return blockNumber;
+  }
+
+  public Optional<Long> getBaseFee() {
+    return baseFee;
   }
 
   public Optional<Hash> getBlockHash() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -1682,7 +1682,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
         final Hash expectedBlockHash = block.getHeader().getHash();
         final long expectedBlockNumber = block.getHeader().getNumber();
         assertTransactionResultMatchesTransaction(
-            transactionResult, transaction, expectedIndex, expectedBlockHash, expectedBlockNumber);
+            transactionResult,
+            transaction,
+            expectedIndex,
+            expectedBlockHash,
+            block.getHeader().getBaseFee(),
+            expectedBlockNumber);
       }
     }
   }
@@ -1692,6 +1697,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
       final Transaction transaction,
       final Integer index,
       final Hash blockHash,
+      final Optional<Long> baseFee,
       final Long blockNumber) {
     assertThat(Hash.fromHexString(result.getString("hash"))).isEqualTo(transaction.getHash());
     assertThat(Long.decode(result.getString("nonce"))).isEqualByComparingTo(transaction.getNonce());
@@ -1720,7 +1726,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     }
     assertThat(Wei.fromHexString(result.getString("value"))).isEqualTo(transaction.getValue());
     assertThat(Optional.ofNullable(result.getString("gasPrice")).map(Wei::fromHexString))
-        .isEqualTo(transaction.getGasPrice());
+        .isEqualTo(Optional.of(Wei.of(transaction.getEffectivePriorityFeePerGas(baseFee))));
     assertThat(Optional.ofNullable(result.getString("maxFeePerGas")).map(Wei::fromHexString))
         .isEqualTo(transaction.getMaxFeePerGas());
     assertThat(
@@ -1843,7 +1849,11 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     for (int i = 0; i < txs.size(); i++) {
       formattedTxs.add(
           new TransactionWithMetadata(
-              txs.get(i), block.getHeader().getNumber(), block.getHash(), i));
+              txs.get(i),
+              block.getHeader().getNumber(),
+              block.getHeader().getBaseFee(),
+              block.getHash(),
+              i));
     }
     final List<Hash> ommers =
         block.getBody().getOmmers().stream().map(BlockHeader::getHash).collect(Collectors.toList());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
@@ -89,7 +89,8 @@ public class DebugStorageRangeAtTest {
   @Test
   public void shouldRetrieveStorageRange_fullValues() {
     final TransactionWithMetadata transactionWithMetadata =
-        new TransactionWithMetadata(transaction, 12L, blockHash, TRANSACTION_INDEX);
+        new TransactionWithMetadata(
+            transaction, 12L, Optional.empty(), blockHash, TRANSACTION_INDEX);
     final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetadata =
         new BlockWithMetadata<>(
             blockHeader,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
@@ -70,7 +70,7 @@ public class DebugTraceTransactionTest {
   @Test
   public void shouldTraceTheTransactionUsingTheTransactionTracer() {
     final TransactionWithMetadata transactionWithMetadata =
-        new TransactionWithMetadata(transaction, 12L, blockHash, 2);
+        new TransactionWithMetadata(transaction, 12L, Optional.empty(), blockHash, 2);
     final Map<String, Boolean> map = new HashMap<>();
     map.put("disableStorage", true);
     final Object[] params = new Object[] {transactionHash, map};

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -167,7 +167,8 @@ public class EthGetUncleByBlockHashAndIndexTest {
     for (int i = 0; i < 3; i++) {
       final Transaction transaction = transactionTestFixture.createTransaction(keyPair);
       transactions.add(
-          new TransactionWithMetadata(transaction, header.getNumber(), header.getHash(), 0));
+          new TransactionWithMetadata(
+              transaction, header.getNumber(), header.getBaseFee(), header.getHash(), 0));
     }
 
     final List<Hash> ommers = new ArrayList<>();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -143,7 +143,8 @@ public class EthGetUncleByBlockNumberAndIndexTest {
     for (int i = 0; i < 3; i++) {
       final Transaction transaction = transactionTestFixture.createTransaction(keyPair);
       transactions.add(
-          new TransactionWithMetadata(transaction, header.getNumber(), header.getHash(), 0));
+          new TransactionWithMetadata(
+              transaction, header.getNumber(), Optional.empty(), header.getHash(), 0));
     }
 
     final List<Hash> ommers = new ArrayList<>();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResultTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResultTest.java
@@ -45,6 +45,7 @@ public class TransactionCompleteResultTest {
                     .maxPriorityFeePerGas(Optional.of(Wei.ZERO))
                     .createTransaction(gen.generateKeyPair()),
                 0L,
+                Optional.of(7L),
                 Hash.ZERO,
                 0));
 
@@ -57,10 +58,41 @@ public class TransactionCompleteResultTest {
     final BlockDataGenerator gen = new BlockDataGenerator();
     final Transaction transaction = gen.transaction(TransactionType.EIP1559);
     TransactionCompleteResult tcr =
-        new TransactionCompleteResult(new TransactionWithMetadata(transaction, 0L, Hash.ZERO, 0));
+        new TransactionCompleteResult(
+            new TransactionWithMetadata(transaction, 0L, Optional.of(7L), Hash.ZERO, 0));
     assertThat(tcr.getMaxFeePerGas()).isNotEmpty();
     assertThat(tcr.getMaxPriorityFeePerGas()).isNotEmpty();
-    assertThat(tcr.getGasPrice()).isNull();
+    assertThat(tcr.getGasPrice()).isNotEmpty();
+    assertThat(tcr.getGasPrice())
+        .isEqualTo(Quantity.create(transaction.getEffectivePriorityFeePerGas(Optional.of(7L))));
+  }
+
+  @Test
+  public void legacyTransactionPostLondonFields() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final Transaction transaction = gen.transaction(TransactionType.FRONTIER);
+    TransactionCompleteResult tcr =
+        new TransactionCompleteResult(
+            new TransactionWithMetadata(transaction, 0L, Optional.of(7L), Hash.ZERO, 0));
+    assertThat(tcr.getMaxFeePerGas()).isNull();
+    assertThat(tcr.getMaxPriorityFeePerGas()).isNull();
+    assertThat(tcr.getGasPrice()).isNotEmpty();
+    assertThat(tcr.getGasPrice())
+        .isEqualTo(Quantity.create(transaction.getGasPrice().orElseThrow().subtract(7L)));
+  }
+
+  @Test
+  public void legacyTransactionPreLondonFields() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final Transaction transaction = gen.transaction(TransactionType.FRONTIER);
+    TransactionCompleteResult tcr =
+        new TransactionCompleteResult(
+            new TransactionWithMetadata(transaction, 0L, Optional.empty(), Hash.ZERO, 0));
+    assertThat(tcr.getMaxFeePerGas()).isNull();
+    assertThat(tcr.getMaxPriorityFeePerGas()).isNull();
+    assertThat(tcr.getGasPrice()).isNotEmpty();
+    assertThat(tcr.getGasPrice())
+        .isEqualTo(Quantity.create(transaction.getGasPrice().orElseThrow()));
   }
 
   @Test
@@ -72,6 +104,7 @@ public class TransactionCompleteResultTest {
             new TransactionWithMetadata(
                 transaction,
                 136,
+                Optional.empty(),
                 Hash.fromHexString(
                     "0xfc84c3946cb419cbd8c2c68d5e79a3b2a03a8faff4d9e2be493f5a07eb5da95e"),
                 0));


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description

For 1559 transactions returned on the rpc, we need to fill the gasPrice field as follows:
- effectivePriorityFeePerGas


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).