### PR TITLE
Add ability to expose getWork/submitWork JSON-RPC methods over the stratum port

### DIFF
--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocol.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.stratum;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
+import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
+import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.mainnet.DirectAcyclicGraphSeed;
+import org.hyperledger.besu.ethereum.mainnet.EpochCalculator;
+import org.hyperledger.besu.ethereum.mainnet.PoWSolution;
+import org.hyperledger.besu.ethereum.mainnet.PoWSolverInputs;
+
+import java.util.function.Function;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+
+/** Protocol using JSON-RPC HTTP methods to provide getWork/submitWork methods. */
+public class GetWorkProtocol implements StratumProtocol {
+  private static final Logger LOG = getLogger();
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final String CRLF = "\r\n";
+
+  private final EpochCalculator epochCalculator;
+  private volatile PoWSolverInputs currentInput;
+  private Function<PoWSolution, Boolean> submitCallback;
+  private String[] getWorkResult;
+
+  public GetWorkProtocol(final MiningCoordinator miningCoordinator) {
+    if (miningCoordinator instanceof PoWMiningCoordinator) {
+      this.epochCalculator = ((PoWMiningCoordinator) miningCoordinator).getEpochCalculator();
+    } else {
+      this.epochCalculator = new EpochCalculator.DefaultEpochCalculator();
+    }
+  }
+
+  private JsonNode readMessage(final String message) {
+    int bodyIndex = message.indexOf(CRLF + CRLF);
+    if (bodyIndex == -1) {
+      return null;
+    }
+    if (!message.startsWith("POST / HTTP")) {
+      return null;
+    }
+    String body = message.substring(bodyIndex);
+    try {
+      return mapper.readTree(body);
+    } catch (JsonProcessingException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean canHandle(final String initialMessage, final StratumConnection conn) {
+    JsonNode message = readMessage(initialMessage);
+    if (message == null) {
+      return false;
+    }
+    JsonNode methodNode = message.get("method");
+    if (methodNode != null) {
+      String method = methodNode.textValue();
+      if ("eth_getWork".equals(method) || "eth_submitWork".equals(method)) {
+        JsonNode idNode = message.get("id");
+        boolean canHandle = idNode != null && idNode.isInt();
+        handle(conn, initialMessage);
+        return canHandle;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void onClose(final StratumConnection conn) {}
+
+  @Override
+  public void handle(final StratumConnection conn, final String message) {
+    JsonNode jsonrpcMessage = readMessage(message);
+    if (jsonrpcMessage == null) {
+      LOG.warn("Invalid message {}", message);
+      conn.close();
+      return;
+    }
+    JsonNode methodNode = jsonrpcMessage.get("method");
+    JsonNode idNode = jsonrpcMessage.get("id");
+    if (methodNode == null || idNode == null) {
+      LOG.warn("Invalid message {}", message);
+      conn.close();
+      return;
+    }
+    String method = methodNode.textValue();
+    if ("eth_getWork".equals(method)) {
+      JsonRpcSuccessResponse response =
+          new JsonRpcSuccessResponse(idNode.intValue(), getWorkResult);
+      try {
+        String responseMessage = mapper.writeValueAsString(response);
+        conn.send(
+            "HTTP/1.1 200 OK\r\nConnection: Keep-Alive\r\nKeep-Alive: timeout=5, max=1000\r\nContent-Length: "
+                + responseMessage.length()
+                + CRLF
+                + CRLF
+                + responseMessage);
+      } catch (JsonProcessingException e) {
+        LOG.warn("Error sending work", e);
+        conn.close();
+      }
+    } else if ("eth_submitWork".equals(method)) {
+      JsonNode paramsNode = jsonrpcMessage.get("params");
+      if (paramsNode == null || paramsNode.size() != 3) {
+        LOG.warn("Invalid eth_submitWork params {}", message);
+        conn.close();
+        return;
+      }
+      final PoWSolution solution =
+          new PoWSolution(
+              Bytes.fromHexString(paramsNode.get(0).textValue()).getLong(0),
+              Hash.fromHexString(paramsNode.get(2).textValue()),
+              null,
+              Bytes.fromHexString(paramsNode.get(1).textValue()));
+      final boolean result = submitCallback.apply(solution);
+      try {
+        String resultMessage =
+            mapper.writeValueAsString(new JsonRpcSuccessResponse(idNode.intValue(), result));
+        conn.send(
+            "HTTP/1.1 200 OK\r\nConnection: Keep-Alive\r\nKeep-Alive: timeout=5, max=1000\r\nContent-Length: "
+                + resultMessage.length()
+                + CRLF
+                + CRLF
+                + resultMessage);
+      } catch (JsonProcessingException e) {
+        LOG.warn("Error accepting solution work", e);
+        conn.close();
+      }
+    } else {
+      LOG.warn("Unknown method {}", method);
+      conn.close();
+    }
+  }
+
+  @Override
+  public void setCurrentWorkTask(final PoWSolverInputs input) {
+    currentInput = input;
+    final byte[] dagSeed =
+        DirectAcyclicGraphSeed.dagSeed(currentInput.getBlockNumber(), epochCalculator);
+    getWorkResult =
+        new String[] {
+          currentInput.getPrePowHash().toHexString(),
+          Bytes.wrap(dagSeed).toHexString(),
+          currentInput.getTarget().toHexString(),
+          Quantity.create(currentInput.getBlockNumber())
+        };
+  }
+
+  @Override
+  public void setSubmitCallback(final Function<PoWSolution, Boolean> submitSolutionCallback) {
+    this.submitCallback = submitSolutionCallback;
+  }
+}

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocol.java
@@ -70,7 +70,7 @@ public class GetWorkProtocol implements StratumProtocol {
   }
 
   @Override
-  public boolean canHandle(final String initialMessage, final StratumConnection conn) {
+  public boolean maybeHandle(final String initialMessage, final StratumConnection conn) {
     JsonNode message = readMessage(initialMessage);
     if (message == null) {
       return false;

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
@@ -81,7 +81,7 @@ public class Stratum1EthProxyProtocol implements StratumProtocol {
       conn.send(response + "\n");
     } catch (JsonProcessingException e) {
       LOG.debug(e.getMessage(), e);
-      conn.close(null);
+      conn.close();
     }
 
     return true;
@@ -118,7 +118,7 @@ public class Stratum1EthProxyProtocol implements StratumProtocol {
       }
     } catch (IllegalArgumentException | IOException e) {
       LOG.debug(e.getMessage(), e);
-      conn.close(null);
+      conn.close();
     }
   }
 

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocol.java
@@ -63,7 +63,7 @@ public class Stratum1EthProxyProtocol implements StratumProtocol {
   }
 
   @Override
-  public boolean canHandle(final String initialMessage, final StratumConnection conn) {
+  public boolean maybeHandle(final String initialMessage, final StratumConnection conn) {
     JsonRpcRequest req;
     try {
       req = new JsonObject(initialMessage).mapTo(JsonRpcRequest.class);

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
@@ -96,7 +96,7 @@ public class Stratum1Protocol implements StratumProtocol {
   }
 
   @Override
-  public boolean canHandle(final String initialMessage, final StratumConnection conn) {
+  public boolean maybeHandle(final String initialMessage, final StratumConnection conn) {
     final JsonRpcRequest requestBody;
     try {
       requestBody = new JsonObject(initialMessage).mapTo(JsonRpcRequest.class);

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
@@ -37,6 +37,7 @@ import java.util.function.Supplier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -99,7 +100,7 @@ public class Stratum1Protocol implements StratumProtocol {
     final JsonRpcRequest requestBody;
     try {
       requestBody = new JsonObject(initialMessage).mapTo(JsonRpcRequest.class);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | DecodeException e) {
       LOG.debug(e.getMessage(), e);
       return false;
     }
@@ -123,7 +124,7 @@ public class Stratum1Protocol implements StratumProtocol {
       conn.send(notify + "\n");
     } catch (JsonProcessingException e) {
       LOG.debug(e.getMessage(), e);
-      conn.close(null);
+      conn.close();
     }
     return true;
   }
@@ -171,7 +172,7 @@ public class Stratum1Protocol implements StratumProtocol {
       }
     } catch (IllegalArgumentException | IOException e) {
       LOG.debug(e.getMessage(), e);
-      conn.close(null);
+      conn.close();
     }
   }
 

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumConnection.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumConnection.java
@@ -19,6 +19,8 @@ import static org.apache.logging.log4j.LogManager.getLogger;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Splitter;
 import io.vertx.core.buffer.Buffer;
@@ -32,12 +34,16 @@ final class StratumConnection {
   private static final Logger LOG = getLogger();
 
   private String incompleteMessage = "";
+  private boolean httpDetected = false;
 
   private final StratumProtocol[] protocols;
   private final Runnable closeHandle;
   private final Consumer<String> sender;
 
   private StratumProtocol protocol;
+
+  private static final Pattern contentLengthPattern =
+      Pattern.compile("\r\nContent-Length: (\\d+)\r\n");
 
   StratumConnection(
       final StratumProtocol[] protocols,
@@ -50,8 +56,6 @@ final class StratumConnection {
 
   void handleBuffer(final Buffer buffer) {
     LOG.trace("Buffer received {}", buffer);
-    Splitter splitter = Splitter.on('\n');
-    boolean firstMessage = false;
     String messagesString;
     try {
       messagesString = buffer.toString(StandardCharsets.UTF_8);
@@ -60,23 +64,49 @@ final class StratumConnection {
       closeHandle.run();
       return;
     }
-    Iterator<String> messages = splitter.split(messagesString).iterator();
-    while (messages.hasNext()) {
-      String message = messages.next();
-      if (!firstMessage) {
-        message = incompleteMessage + message;
-        firstMessage = true;
+
+    if (httpDetected) {
+      httpDetected = false;
+      messagesString = incompleteMessage + messagesString;
+    }
+    Matcher match = contentLengthPattern.matcher(messagesString);
+    if (match.find()) {
+      try {
+        int contentLength = Integer.parseInt(match.group(1));
+        String body = messagesString.substring(messagesString.indexOf("\r\n\r\n") + 4);
+        if (body.length() < contentLength) {
+          incompleteMessage = messagesString;
+          httpDetected = true;
+          return;
+        }
+      } catch (NumberFormatException e) {
+        close();
+        return;
       }
-      if (!messages.hasNext()) {
-        incompleteMessage = message;
-      } else {
-        LOG.trace("Dispatching message {}", message);
-        handleMessage(message);
+
+      LOG.trace("Dispatching HTTP message {}", messagesString);
+      handleMessage(messagesString);
+    } else {
+      boolean firstMessage = false;
+      Splitter splitter = Splitter.on('\n');
+      Iterator<String> messages = splitter.split(messagesString).iterator();
+      while (messages.hasNext()) {
+        String message = messages.next();
+        if (!firstMessage) {
+          message = incompleteMessage + message;
+          firstMessage = true;
+        }
+        if (!messages.hasNext()) {
+          incompleteMessage = message;
+        } else {
+          LOG.trace("Dispatching message {}", message);
+          handleMessage(message);
+        }
       }
     }
   }
 
-  void close(final Void aVoid) {
+  void close() {
     if (protocol != null) {
       protocol.onClose(this);
     }

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumConnection.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumConnection.java
@@ -115,7 +115,7 @@ final class StratumConnection {
   private void handleMessage(final String message) {
     if (protocol == null) {
       for (StratumProtocol protocol : protocols) {
-        if (protocol.canHandle(message, this)) {
+        if (protocol.maybeHandle(message, this)) {
           this.protocol = protocol;
         }
       }

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumProtocol.java
@@ -36,12 +36,13 @@ public interface StratumProtocol {
 
   /**
    * Checks if the protocol can handle a TCP connection, based on the initial message.
+   * If the protocol can handle the message, it will consume it and handle it.
    *
    * @param initialMessage the initial message sent over the TCP connection.
    * @param conn the connection itself
    * @return true if the protocol can handle this connection
    */
-  boolean canHandle(String initialMessage, StratumConnection conn);
+  boolean maybeHandle(String initialMessage, StratumConnection conn);
 
   /**
    * Callback when a stratum connection is closed.

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumProtocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumProtocol.java
@@ -35,8 +35,8 @@ import org.apache.tuweni.bytes.Bytes;
 public interface StratumProtocol {
 
   /**
-   * Checks if the protocol can handle a TCP connection, based on the initial message.
-   * If the protocol can handle the message, it will consume it and handle it.
+   * Checks if the protocol can handle a TCP connection, based on the initial message. If the
+   * protocol can handle the message, it will consume it and handle it.
    *
    * @param initialMessage the initial message sent over the TCP connection.
    * @param conn the connection itself

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumServer.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/StratumServer.java
@@ -70,6 +70,7 @@ public class StratumServer implements PoWObserver {
     this.networkInterface = networkInterface;
     protocols =
         new StratumProtocol[] {
+          new GetWorkProtocol(miningCoordinator),
           new Stratum1Protocol(extraNonce, miningCoordinator),
           new Stratum1EthProxyProtocol(miningCoordinator)
         };
@@ -122,7 +123,7 @@ public class StratumServer implements PoWObserver {
     socket.handler(conn::handleBuffer);
     socket.closeHandler(
         (aVoid) -> {
-          conn.close(aVoid);
+          conn.close();
           numberOfMiners.decrementAndGet();
           disconnectionsCount.inc();
         });

--- a/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocolTest.java
+++ b/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocolTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.stratum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.blockcreation.NoopMiningCoordinator;
+import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
+import org.hyperledger.besu.ethereum.core.Address;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.core.Wei;
+import org.hyperledger.besu.ethereum.mainnet.PoWSolution;
+import org.hyperledger.besu.ethereum.mainnet.PoWSolverInputs;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.Test;
+
+public class GetWorkProtocolTest {
+
+  @Test
+  public void testCanHandleGetWorkMessage() {
+    String message =
+        "POST / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_getWork\",\"id\":1}";
+    MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    assertThat(
+            protocol.canHandle(
+                message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isTrue();
+  }
+
+  @Test
+  public void testCanHandleSubmitWorkMessage() {
+    String message =
+        "POST / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_submitWork\",\"id\":1}";
+    MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    assertThat(
+            protocol.canHandle(
+                message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isTrue();
+  }
+
+  @Test
+  public void testCanHandleNotPost() {
+    String message =
+        "DELETE / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_getWork\",\"id\":1}";
+    MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    assertThat(
+            protocol.canHandle(
+                message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isFalse();
+  }
+
+  @Test
+  public void testCanHandleBadGet() {
+    String message = "GET / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:text/plain\r\n\r\n";
+    MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    assertThat(
+            protocol.canHandle(
+                message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isFalse();
+  }
+
+  @Test
+  public void testCanHandleNotHTTP() {
+    String message = "{\"method\":\"eth_getWork\",\"id\":1}";
+    MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    assertThat(
+            protocol.canHandle(
+                message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isFalse();
+  }
+
+  @Test
+  public void testCanGetSolutions() {
+    MiningCoordinator coordinator =
+        new NoopMiningCoordinator(
+            new MiningParameters.Builder()
+                .coinbase(Address.wrap(Bytes.random(20)))
+                .minTransactionGasPrice(Wei.of(1))
+                .extraData(Bytes.fromHexString("0xc0ffee"))
+                .enabled(true)
+                .build());
+    AtomicReference<String> messageRef = new AtomicReference<>();
+    StratumConnection connection =
+        new StratumConnection(new StratumProtocol[0], () -> {}, messageRef::set);
+
+    GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
+    AtomicReference<PoWSolution> solutionFound = new AtomicReference<>();
+    protocol.setSubmitCallback(
+        (sol) -> {
+          solutionFound.set(sol);
+          return true;
+        });
+    protocol.setCurrentWorkTask(
+        new PoWSolverInputs(UInt256.ZERO, Bytes.fromHexString("0xdeadbeef"), 123L));
+    String requestWork =
+        "POST / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_getWork\",\"id\":1}";
+    protocol.handle(connection, requestWork);
+    assertThat(messageRef.get())
+        .isEqualTo(
+            "HTTP/1.1 200 OK\r\n"
+                + "Connection: Keep-Alive\r\n"
+                + "Keep-Alive: timeout=5, max=1000\r\n"
+                + "Content-Length: 193\r\n"
+                + "\r\n"
+                + "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[\"0xdeadbeef\",\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"0x7b\"]}");
+
+    String submitWork =
+        "POST / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_submitWork\",\"id\":1,\"params\":[\"0xdeadbeefdeadbeef\", \"0x0000000000000000000000000000000000000000000000000000000000000000\", \"0x0000000000000000000000000000000000000000000000000000000000000000\"]}";
+    assertThat(
+            protocol.canHandle(
+                submitWork, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
+        .isTrue();
+    protocol.handle(connection, submitWork);
+    assertThat(messageRef.get())
+        .isEqualTo(
+            "HTTP/1.1 200 OK\r\n"
+                + "Connection: Keep-Alive\r\n"
+                + "Keep-Alive: timeout=5, max=1000\r\n"
+                + "Content-Length: 38\r\n\r\n{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":true}");
+  }
+}

--- a/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocolTest.java
+++ b/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/GetWorkProtocolTest.java
@@ -41,7 +41,7 @@ public class GetWorkProtocolTest {
     MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
     GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isTrue();
   }
@@ -53,7 +53,7 @@ public class GetWorkProtocolTest {
     MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
     GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isTrue();
   }
@@ -65,7 +65,7 @@ public class GetWorkProtocolTest {
     MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
     GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isFalse();
   }
@@ -76,7 +76,7 @@ public class GetWorkProtocolTest {
     MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
     GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isFalse();
   }
@@ -87,7 +87,7 @@ public class GetWorkProtocolTest {
     MiningCoordinator coordinator = mock(PoWMiningCoordinator.class);
     GetWorkProtocol protocol = new GetWorkProtocol(coordinator);
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 message, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isFalse();
   }
@@ -130,7 +130,7 @@ public class GetWorkProtocolTest {
     String submitWork =
         "POST / HTTP/1.1\r\nHost: localhost:8000\r\nContent-Type:application/json\r\n\r\n {\"method\":\"eth_submitWork\",\"id\":1,\"params\":[\"0xdeadbeefdeadbeef\", \"0x0000000000000000000000000000000000000000000000000000000000000000\", \"0x0000000000000000000000000000000000000000000000000000000000000000\"]}";
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 submitWork, new StratumConnection(new StratumProtocol[0], () -> {}, (msg) -> {})))
         .isTrue();
     protocol.handle(connection, submitWork);

--- a/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocolTest.java
+++ b/ethereum/stratum/src/test/java/org/hyperledger/besu/ethereum/stratum/Stratum1EthProxyProtocolTest.java
@@ -42,18 +42,18 @@ public class Stratum1EthProxyProtocolTest {
 
   @Test
   public void testCanHandleEmptyString() {
-    assertThat(protocol.canHandle("", conn)).isFalse();
+    assertThat(protocol.maybeHandle("", conn)).isFalse();
   }
 
   @Test
   public void testCanHandleMalformedJSON() {
-    assertThat(protocol.canHandle("{[\"foo\",", conn)).isFalse();
+    assertThat(protocol.maybeHandle("{[\"foo\",", conn)).isFalse();
   }
 
   @Test
   public void testCanHandleWrongMethod() {
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 "{\"id\":0,\"method\":\"eth_byebye\",\"params\":[\"0xdeadbeefdeadbeef.worker\"]}",
                 conn))
         .isFalse();
@@ -62,7 +62,7 @@ public class Stratum1EthProxyProtocolTest {
   @Test
   public void testCanHandleWellFormedRequest() {
     assertThat(
-            protocol.canHandle(
+            protocol.maybeHandle(
                 "{\"id\":0,\"method\":\"eth_submitLogin\",\"params\":[\"0xdeadbeefdeadbeef.worker\"]}",
                 conn))
         .isTrue();


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Adds the JSON-RPC methods getWork/submitWork to the stratum port, so miners can communicate with Besu over the stratum port. This allows to keep the JSON-RPC port closed to miner traffic.

## Fixed Issue(s)
Fixes #2065

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).