### PR TITLE
Fix bug with value transfer

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -626,11 +626,15 @@ public class Transaction
   /**
    * Returns whether or not the transaction is a GoQuorum private transaction. <br>
    * <br>
-   * A GoQuorum private transaction has its <i>v</i> value equal to 37 or 38.
+   * A GoQuorum private transaction has its <i>v</i> value equal to 37 or 38, and does not contain a
+   * chainId.
    *
    * @return true if GoQuorum private transaction, false otherwise
    */
   public boolean isGoQuorumPrivateTransaction() {
+    if (chainId.isPresent()) {
+      return false;
+    }
     return v.map(
             value ->
                 GO_QUORUM_PRIVATE_TRANSACTION_V_VALUE_MIN.equals(value)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -47,7 +47,6 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 
-import java.math.BigInteger;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
@@ -236,7 +235,7 @@ public class TransactionPool implements BlockAddedObserver {
     final BlockHeader chainHeadBlockHeader = getChainHeadBlockHeader();
 
     // Check whether it's a GoQuorum transaction
-    if (isGoQuorumPrivateTransaction(transaction)) {
+    if (transaction.isGoQuorumPrivateTransaction()) {
       final Optional<Wei> weiValue = ofNullable(transaction.getValue());
       if (weiValue.isPresent() && !weiValue.get().isZero()) {
         return ValidationResult.invalid(TransactionInvalidReason.ETHER_VALUE_NOT_SUPPORTED);
@@ -289,11 +288,6 @@ public class TransactionPool implements BlockAddedObserver {
   private BlockHeader getChainHeadBlockHeader() {
     final MutableBlockchain blockchain = protocolContext.getBlockchain();
     return blockchain.getBlockHeader(blockchain.getChainHeadHash()).get();
-  }
-
-  private boolean isGoQuorumPrivateTransaction(final Transaction transaction) {
-    return (transaction.getV().equals(BigInteger.valueOf(37))
-        || (transaction.getV().equals(BigInteger.valueOf(38))));
   }
 
   public interface TransactionBatchAddedListener {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -160,6 +160,22 @@ public class TransactionPoolTest {
   }
 
   @Test
+  public void mainNetValueTransferSucceeds() {
+    final Transaction transaction =
+        new TransactionTestFixture()
+            .value(Wei.ONE)
+            .chainId(Optional.of(BigInteger.ONE))
+            .createTransaction(KEY_PAIR1);
+
+    givenTransactionIsValid(transaction);
+
+    final ValidationResult<TransactionInvalidReason> result =
+        transactionPool.addLocalTransaction(transaction);
+
+    assertThat(result).isEqualTo(ValidationResult.valid());
+  }
+
+  @Test
   public void shouldReturnExclusivelyLocalTransactionsWhenAppropriate() {
     final Transaction localTransaction0 = createTransaction(0);
     transactions.addLocalTransaction(localTransaction0);


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Clarify isGoQuorumPrivateTransaction method. v value is set directly for GoQuorum private transactions, and they don't have a chainId. All other tx derive their v value from the chainId.

fixes #2606 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).