### PR TITLE
PKI Block Creation cli configuration

### DIFF
--- a/besu/build.gradle
+++ b/besu/build.gradle
@@ -90,4 +90,5 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'commons-io:commons-io'
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -59,6 +59,7 @@ import org.hyperledger.besu.cli.options.unstable.MiningOptions;
 import org.hyperledger.besu.cli.options.unstable.NatOptions;
 import org.hyperledger.besu.cli.options.unstable.NativeLibraryOptions;
 import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
+import org.hyperledger.besu.cli.options.unstable.PkiBlockCreationOptions;
 import org.hyperledger.besu.cli.options.unstable.PrivacyPluginOptions;
 import org.hyperledger.besu.cli.options.unstable.RPCOptions;
 import org.hyperledger.besu.cli.options.unstable.SynchronizerOptions;
@@ -78,6 +79,8 @@ import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.GoQuorumOptions;
+import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfigurationSupplier;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.controller.TargetingGasLimitCalculator;
@@ -140,6 +143,7 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.vertx.VertxMetricsAdapterFactory;
 import org.hyperledger.besu.nat.NatMethod;
+import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
 import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;
@@ -1097,6 +1101,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @Mixin private P2PTLSConfigOptions p2pTLSConfigOptions;
 
+  @Mixin private PkiBlockCreationOptions pkiBlockCreationOptions;
+
   private EthNetworkConfig ethNetworkConfig;
   private JsonRpcConfiguration jsonRpcConfiguration;
   private GraphQLConfiguration graphQLConfiguration;
@@ -1114,6 +1120,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private EnodeDnsConfiguration enodeDnsConfiguration;
   private KeyValueStorageProvider keyValueStorageProvider;
   private Boolean isGoQuorumCompatibilityMode = false;
+  private Optional<PkiKeyStoreConfiguration> pkiBlockCreationKeyStoreConfig;
 
   public BesuCommand(
       final Logger logger,
@@ -1613,6 +1620,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
     logger.info("Security Module: {}", securityModuleName);
     instantiateSignatureAlgorithmFactory();
+
+    pkiBlockCreationKeyStoreConfig = pkiBlockCreationOptions.asDomainConfig(commandLine);
+    pkiBlockCreationKeyStoreConfig.ifPresent(PkiBlockCreationConfigurationSupplier::load);
   }
 
   private GoQuorumPrivacyParameters configureGoQuorumPrivacy(

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -79,7 +79,6 @@ import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.GoQuorumOptions;
-import org.hyperledger.besu.config.experimental.ExperimentalEIPs;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfigurationProvider;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -79,6 +79,7 @@ import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.GoQuorumOptions;
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfigurationProvider;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
@@ -1622,10 +1623,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
     logger.info("Security Module: {}", securityModuleName);
     instantiateSignatureAlgorithmFactory();
-
-    pkiBlockCreationOptions
-        .asDomainConfig(commandLine)
-        .ifPresent(pkiBlockCreationConfigProvider::load);
   }
 
   private GoQuorumPrivacyParameters configureGoQuorumPrivacy(
@@ -1724,6 +1721,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .metricsSystem(metricsSystem.get())
         .messagePermissioningProviders(permissioningService.getMessagePermissioningProviders())
         .privacyParameters(privacyParameters(storageProvider))
+        .pkiBlockCreationConfiguration(maybePkiBlockCreationConfiguration())
         .clock(Clock.systemUTC())
         .isRevertReasonEnabled(isRevertReasonEnabled)
         .storageProvider(storageProvider)
@@ -2280,6 +2278,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
               .build();
     }
     return this.keyValueStorageProvider;
+  }
+
+  private Optional<PkiBlockCreationConfiguration> maybePkiBlockCreationConfiguration() {
+    return pkiBlockCreationOptions
+        .asDomainConfig(commandLine)
+        .map(pkiBlockCreationConfigProvider::load);
   }
 
   private SynchronizerConfiguration buildSyncConfig() {

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.cli.options.unstable;
+
+import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
+
+import org.hyperledger.besu.ethereum.api.tls.FileBasedPasswordProvider;
+import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParameterException;
+
+public class PkiBlockCreationOptions {
+
+  @Option(
+      names = {"--pki-block-creation-enabled"},
+      description = "Enable PKI integration (default: ${DEFAULT-VALUE})")
+  Boolean enabled = false;
+
+  @Option(
+      names = {"--pki-block-creation-keystore-type"},
+      paramLabel = "<NAME>",
+      description = "PKI service keystore type. Required if PKI Integration is enabled.")
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
+  String keyStoreType = PkiKeyStoreConfiguration.DEFAULT_KEYSTORE_TYPE;
+
+  @Option(
+      names = {"--pki-block-creation-keystore-file"},
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      description = "Keystore containing key/certificate for PKI Integration.")
+  Path keyStoreFile = null;
+
+  @Option(
+      names = {"--pki-block-creation-keystore-password-file"},
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      description =
+          "File containing password to unlock keystore for PKI Integration. Required if PKI Integration is enabled.")
+  Path keyStorePasswordFile = null;
+
+  @Option(
+      names = {"--pki-block-creation-keystore-certificate-alias"},
+      paramLabel = "<NAME>",
+      description =
+          "Alias of the certificate that will be included in the blocks proposed by this validator.")
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
+  String certificateAlias = PkiKeyStoreConfiguration.DEFAULT_CERTIFICATE_ALIAS;
+
+  @Option(
+      names = {"--pki-block-creation-truststore-type"},
+      paramLabel = "<NAME>",
+      description = "PKI Integration truststore type.")
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
+  String trustStoreType = PkiKeyStoreConfiguration.DEFAULT_KEYSTORE_TYPE;
+
+  @Option(
+      names = {"--pki-block-creation-truststore-file"},
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      description = "Truststore containing trusted certificates for PKI Integration.")
+  Path trustStoreFile = null;
+
+  @Option(
+      names = {"--pki-block-creation-truststore-password-file"},
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      description = "File containing password to unlock truststore for PKI Integration.")
+  Path trustStorePasswordFile = null;
+
+  @Option(
+      names = {"--pki-block-creation-crl-file"},
+      paramLabel = MANDATORY_FILE_FORMAT_HELP,
+      description = "Certificate revocation list for the PKI Integration.")
+  Path crlFile = null;
+
+  public Optional<PkiKeyStoreConfiguration> asDomainConfig(final CommandLine commandLine) {
+    if (!enabled) {
+      return Optional.empty();
+    }
+
+    if (keyStoreType == null) {
+      throw new ParameterException(
+          commandLine, "Keystore type is required when p2p SSL is enabled");
+    }
+
+    if (keyStorePasswordFile == null) {
+      throw new ParameterException(
+          commandLine,
+          "File containing password to unlock keystore is required when p2p SSL is enabled");
+    }
+
+    return Optional.of(
+        new PkiKeyStoreConfiguration.Builder()
+            .withKeyStoreType(keyStoreType)
+            .withKeyStorePath(keyStoreFile)
+            .withKeyStorePasswordSupplier(new FileBasedPasswordProvider(keyStorePasswordFile))
+            .withCertificateAlias(certificateAlias)
+            .withTrustStoreType(trustStoreType)
+            .withTrustStorePath(trustStoreFile)
+            .withTrustStorePasswordSupplier(
+                null == trustStorePasswordFile
+                    ? null
+                    : new FileBasedPasswordProvider(trustStorePasswordFile))
+            .withCrlFilePath(crlFile)
+            .build());
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
@@ -50,7 +50,7 @@ public class PkiBlockCreationOptions {
       names = {"--Xpki-block-creation-keystore-file"},
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Keystore containing key/certificate for PKI PKI Block Creation.")
+      description = "Keystore containing key/certificate for PKI Block Creation.")
   Path keyStoreFile = null;
 
   @Option(
@@ -58,7 +58,7 @@ public class PkiBlockCreationOptions {
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
       description =
-          "File containing password to unlock keystore for PKI Integration. Required if PKI PKI Block Creation is enabled.")
+          "File containing password to unlock keystore for PKI Integration. Required if PKI Block Creation is enabled.")
   Path keyStorePasswordFile = null;
 
   @Option(
@@ -82,21 +82,21 @@ public class PkiBlockCreationOptions {
       names = {"--Xpki-block-creation-truststore-file"},
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Truststore containing trusted certificates for PKI PKI Block Creation.")
+      description = "Truststore containing trusted certificates for PKI Block Creation.")
   Path trustStoreFile = null;
 
   @Option(
       names = {"--Xpki-block-creation-truststore-password-file"},
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "File containing password to unlock truststore for PKI PKI Block Creation.")
+      description = "File containing password to unlock truststore for PKI Block Creation.")
   Path trustStorePasswordFile = null;
 
   @Option(
       names = {"--Xpki-block-creation-crl-file"},
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Certificate revocation list for the PKI PKI Block Creation.")
+      description = "Certificate revocation list for the PKI Block Creation.")
   Path crlFile = null;
 
   public Optional<PkiKeyStoreConfiguration> asDomainConfig(final CommandLine commandLine) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
@@ -15,14 +15,17 @@
 
 package org.hyperledger.besu.cli.options.unstable;
 
+import static java.util.Arrays.asList;
 import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_FILE_FORMAT_HELP;
 
+import org.hyperledger.besu.cli.util.CommandLineUtils;
 import org.hyperledger.besu.ethereum.api.tls.FileBasedPasswordProvider;
 import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
 
 import java.nio.file.Path;
 import java.util.Optional;
 
+import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
@@ -30,32 +33,37 @@ import picocli.CommandLine.ParameterException;
 public class PkiBlockCreationOptions {
 
   @Option(
-      names = {"--pki-block-creation-enabled"},
+      names = {"--Xpki-block-creation-enabled"},
+      hidden = true,
       description = "Enable PKI integration (default: ${DEFAULT-VALUE})")
   Boolean enabled = false;
 
   @Option(
-      names = {"--pki-block-creation-keystore-type"},
+      names = {"--Xpki-block-creation-keystore-type"},
+      hidden = true,
       paramLabel = "<NAME>",
-      description = "PKI service keystore type. Required if PKI Integration is enabled.")
+      description = "PKI service keystore type. Required if PKI Block Creation is enabled.")
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
   String keyStoreType = PkiKeyStoreConfiguration.DEFAULT_KEYSTORE_TYPE;
 
   @Option(
-      names = {"--pki-block-creation-keystore-file"},
+      names = {"--Xpki-block-creation-keystore-file"},
+      hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Keystore containing key/certificate for PKI Integration.")
+      description = "Keystore containing key/certificate for PKI PKI Block Creation.")
   Path keyStoreFile = null;
 
   @Option(
-      names = {"--pki-block-creation-keystore-password-file"},
+      names = {"--Xpki-block-creation-keystore-password-file"},
+      hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
       description =
-          "File containing password to unlock keystore for PKI Integration. Required if PKI Integration is enabled.")
+          "File containing password to unlock keystore for PKI Integration. Required if PKI PKI Block Creation is enabled.")
   Path keyStorePasswordFile = null;
 
   @Option(
-      names = {"--pki-block-creation-keystore-certificate-alias"},
+      names = {"--Xpki-block-creation-keystore-certificate-alias"},
+      hidden = true,
       paramLabel = "<NAME>",
       description =
           "Alias of the certificate that will be included in the blocks proposed by this validator.")
@@ -63,28 +71,32 @@ public class PkiBlockCreationOptions {
   String certificateAlias = PkiKeyStoreConfiguration.DEFAULT_CERTIFICATE_ALIAS;
 
   @Option(
-      names = {"--pki-block-creation-truststore-type"},
+      names = {"--Xpki-block-creation-truststore-type"},
+      hidden = true,
       paramLabel = "<NAME>",
       description = "PKI Integration truststore type.")
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"})
   String trustStoreType = PkiKeyStoreConfiguration.DEFAULT_KEYSTORE_TYPE;
 
   @Option(
-      names = {"--pki-block-creation-truststore-file"},
+      names = {"--Xpki-block-creation-truststore-file"},
+      hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Truststore containing trusted certificates for PKI Integration.")
+      description = "Truststore containing trusted certificates for PKI PKI Block Creation.")
   Path trustStoreFile = null;
 
   @Option(
-      names = {"--pki-block-creation-truststore-password-file"},
+      names = {"--Xpki-block-creation-truststore-password-file"},
+      hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "File containing password to unlock truststore for PKI Integration.")
+      description = "File containing password to unlock truststore for PKI PKI Block Creation.")
   Path trustStorePasswordFile = null;
 
   @Option(
-      names = {"--pki-block-creation-crl-file"},
+      names = {"--Xpki-block-creation-crl-file"},
+      hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Certificate revocation list for the PKI Integration.")
+      description = "Certificate revocation list for the PKI PKI Block Creation.")
   Path crlFile = null;
 
   public Optional<PkiKeyStoreConfiguration> asDomainConfig(final CommandLine commandLine) {
@@ -92,15 +104,15 @@ public class PkiBlockCreationOptions {
       return Optional.empty();
     }
 
-    if (keyStoreType == null) {
+    if (keyStoreFile == null) {
       throw new ParameterException(
-          commandLine, "Keystore type is required when p2p SSL is enabled");
+          commandLine, "KeyStore file is required when PKI Block Creation is enabled");
     }
 
     if (keyStorePasswordFile == null) {
       throw new ParameterException(
           commandLine,
-          "File containing password to unlock keystore is required when p2p SSL is enabled");
+          "File containing password to unlock keystore is required when PKI Block Creation is enabled");
     }
 
     return Optional.of(
@@ -117,5 +129,16 @@ public class PkiBlockCreationOptions {
                     : new FileBasedPasswordProvider(trustStorePasswordFile))
             .withCrlFilePath(crlFile)
             .build());
+  }
+
+  public void checkPkiBlockCreationOptionsDependencies(
+      final Logger logger, final CommandLine commandLine) {
+    CommandLineUtils.checkOptionDependencies(
+        logger,
+        commandLine,
+        "--Xpki-block-creation-enabled",
+        !enabled,
+        asList(
+            "--Xpki-block-creation-keystore-file", "--Xpki-block-creation-keystore-password-file"));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/PkiBlockCreationOptions.java
@@ -96,7 +96,7 @@ public class PkiBlockCreationOptions {
       names = {"--Xpki-block-creation-crl-file"},
       hidden = true,
       paramLabel = MANDATORY_FILE_FORMAT_HELP,
-      description = "Certificate revocation list for the PKI Block Creation.")
+      description = "File with all CRLs for PKI Block Creation.")
   Path crlFile = null;
 
   public Optional<PkiKeyStoreConfiguration> asDomainConfig(final CommandLine commandLine) {

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.controller;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
@@ -91,6 +92,8 @@ public abstract class BesuControllerBuilder {
   protected MiningParameters miningParameters;
   protected ObservableMetricsSystem metricsSystem;
   protected PrivacyParameters privacyParameters;
+  protected Optional<PkiBlockCreationConfiguration> pkiBlockCreationConfiguration =
+      Optional.empty();
   protected Path dataDirectory;
   protected Clock clock;
   protected NodeKey nodeKey;
@@ -157,6 +160,12 @@ public abstract class BesuControllerBuilder {
 
   public BesuControllerBuilder privacyParameters(final PrivacyParameters privacyParameters) {
     this.privacyParameters = privacyParameters;
+    return this;
+  }
+
+  public BesuControllerBuilder pkiBlockCreationConfiguration(
+      final Optional<PkiBlockCreationConfiguration> pkiBlockCreationConfiguration) {
+    this.pkiBlockCreationConfiguration = pkiBlockCreationConfiguration;
     return this;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -73,13 +73,11 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.config.SubProtocolConfiguration;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
-import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -93,14 +91,12 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
   private BftEventQueue bftEventQueue;
   private QbftConfigOptions qbftConfig;
   private ValidatorPeers peers;
-  // TODO initialize this in BesuCommand as part of the PKI setup (will be done in a follow up PR)
-  private final Optional<KeyStoreWrapper> pkiKeyStore = Optional.empty();
 
   @Override
   protected Supplier<BftExtraDataCodec> bftExtraDataCodec() {
     return Suppliers.memoize(
         () -> {
-          if (pkiKeyStore.isPresent()) {
+          if (pkiBlockCreationConfiguration.isPresent()) {
             return new PkiQbftExtraDataCodec();
           } else {
             return new QbftExtraDataCodec();
@@ -295,9 +291,12 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
       validatorProvider = new TransactionValidatorProvider(blockchain, validatorContractController);
     }
 
-    if (pkiKeyStore.isPresent()) {
+    if (pkiBlockCreationConfiguration.isPresent()) {
       return new PkiQbftContext(
-          validatorProvider, epochManager, bftBlockInterface().get(), pkiKeyStore.get());
+          validatorProvider,
+          epochManager,
+          bftBlockInterface().get(),
+          pkiBlockCreationConfiguration.get());
     } else {
       return new BftContext(validatorProvider, epochManager, bftBlockInterface().get());
     }

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.cli.options.unstable.MetricsCLIOptions;
 import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
 import org.hyperledger.besu.cli.options.unstable.SynchronizerOptions;
 import org.hyperledger.besu.cli.options.unstable.TransactionPoolOptions;
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfigurationProvider;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
@@ -159,6 +160,7 @@ public abstract class CommandTestAbstract {
   protected Logger mockLogger;
 
   @Mock protected PkiBlockCreationConfigurationProvider mockPkiBlockCreationConfigProvider;
+  @Mock protected PkiBlockCreationConfiguration mockPkiBlockCreationConfiguration;
 
   @Captor protected ArgumentCaptor<Collection<Bytes>> bytesCollectionCollector;
   @Captor protected ArgumentCaptor<Path> pathArgumentCaptor;
@@ -293,7 +295,7 @@ public abstract class CommandTestAbstract {
         .thenReturn(Optional.of(storageService));
 
     lenient()
-        .doNothing()
+        .doReturn(mockPkiBlockCreationConfiguration)
         .when(mockPkiBlockCreationConfigProvider)
         .load(pkiKeyStoreConfigurationArgumentCaptor.capture());
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -203,6 +203,8 @@ public abstract class CommandTestAbstract {
     when(mockControllerBuilder.messagePermissioningProviders(any()))
         .thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.privacyParameters(any())).thenReturn(mockControllerBuilder);
+    when(mockControllerBuilder.pkiBlockCreationConfiguration(any()))
+        .thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.clock(any())).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.isRevertReasonEnabled(false)).thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.storageProvider(any())).thenReturn(mockControllerBuilder);

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfiguration.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.consensus.qbft.pki;
+
+import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
+
+public class PkiBlockCreationConfiguration {
+
+  private final KeyStoreWrapper keyStore;
+  private final KeyStoreWrapper trustStore;
+  private final String certificateAlias;
+
+  public PkiBlockCreationConfiguration(
+      final KeyStoreWrapper keyStore,
+      final KeyStoreWrapper trustStore,
+      final String certificateAlias) {
+    this.keyStore = keyStore;
+    this.trustStore = trustStore;
+    this.certificateAlias = certificateAlias;
+  }
+
+  public KeyStoreWrapper getKeyStore() {
+    return keyStore;
+  }
+
+  public KeyStoreWrapper getTrustStore() {
+    return trustStore;
+  }
+
+  public String getCertificateAlias() {
+    return certificateAlias;
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProvider.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProvider.java
@@ -31,23 +31,19 @@ public class PkiBlockCreationConfigurationProvider {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private final PkiKeyStoreConfiguration pkiKeyStoreConfiguration;
   private final KeyStoreWrapperProvider keyStoreWrapperProvider;
 
-  public PkiBlockCreationConfigurationProvider(
-      final PkiKeyStoreConfiguration pkiKeyStoreConfiguration) {
-    this(pkiKeyStoreConfiguration, SoftwareKeyStoreWrapper::new);
+  public PkiBlockCreationConfigurationProvider() {
+    this(SoftwareKeyStoreWrapper::new);
   }
 
   @VisibleForTesting
-  PkiBlockCreationConfigurationProvider(
-      final PkiKeyStoreConfiguration pkiKeyStoreConfiguration,
-      final KeyStoreWrapperProvider keyStoreWrapperProvider) {
-    this.pkiKeyStoreConfiguration = checkNotNull(pkiKeyStoreConfiguration);
+  PkiBlockCreationConfigurationProvider(final KeyStoreWrapperProvider keyStoreWrapperProvider) {
     this.keyStoreWrapperProvider = checkNotNull(keyStoreWrapperProvider);
   }
 
-  public PkiBlockCreationConfiguration load() {
+  public PkiBlockCreationConfiguration load(
+      final PkiKeyStoreConfiguration pkiKeyStoreConfiguration) {
     KeyStoreWrapper keyStore;
     try {
       keyStore =

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProvider.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.consensus.qbft.pki;
+
+import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
+import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
+import org.hyperledger.besu.pki.keystore.SoftwareKeyStoreWrapper;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class PkiBlockCreationConfigurationProvider {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private static PkiBlockCreationConfiguration pkiBlockCreationConfig;
+
+  private final KeyStoreWrapperProvider keyStoreWrapperProvider;
+
+  public PkiBlockCreationConfigurationProvider() {
+    this(SoftwareKeyStoreWrapper::new);
+  }
+
+  @VisibleForTesting
+  PkiBlockCreationConfigurationProvider(final KeyStoreWrapperProvider keyStoreWrapperProvider) {
+    this.keyStoreWrapperProvider = keyStoreWrapperProvider;
+  }
+
+  /*
+   This method is only called once during the application startup.
+  */
+  public void load(final PkiKeyStoreConfiguration configuration) {
+    KeyStoreWrapper keyStore;
+    try {
+      keyStore =
+          keyStoreWrapperProvider.apply(
+              configuration.getKeyStoreType(),
+              configuration.getKeyStorePath(),
+              configuration.getKeyStorePassword(),
+              null);
+      LOG.info("Loaded PKI Block Creation KeyStore {}", configuration.getKeyStorePath());
+    } catch (Exception e) {
+      final String message = "Error loading PKI Block Creation KeyStore";
+      LOG.error(message, e);
+      throw new RuntimeException(message, e);
+    }
+
+    KeyStoreWrapper trustStore;
+    try {
+      trustStore =
+          keyStoreWrapperProvider.apply(
+              configuration.getTrustStoreType(),
+              configuration.getTrustStorePath(),
+              configuration.getTrustStorePassword(),
+              configuration.getCrlFilePath().orElse(null));
+      LOG.info("Loaded PKI Block Creation TrustStore {}", configuration.getTrustStorePath());
+    } catch (Exception e) {
+      final String message = "Error loading PKI Block Creation TrustStore";
+      LOG.error(message, e);
+      throw new RuntimeException(message, e);
+    }
+
+    pkiBlockCreationConfig =
+        new PkiBlockCreationConfiguration(
+            keyStore, trustStore, configuration.getCertificateAlias());
+  }
+
+  public static Optional<PkiBlockCreationConfiguration> getIfLoaded() {
+    return Optional.ofNullable(pkiBlockCreationConfig);
+  }
+
+  @FunctionalInterface
+  interface KeyStoreWrapperProvider {
+
+    KeyStoreWrapper apply(
+        final String keyStoreType,
+        final Path keyStorePath,
+        final String keyStorePassword,
+        final Path crl);
+  }
+}

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiQbftContext.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiQbftContext.java
@@ -19,22 +19,21 @@ import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.bft.BftBlockInterface;
 import org.hyperledger.besu.consensus.common.bft.BftContext;
 import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
-import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
 
 public class PkiQbftContext extends BftContext {
 
-  private final KeyStoreWrapper keyStoreWrapper;
+  private final PkiBlockCreationConfiguration pkiBlockCreationConfiguration;
 
   public PkiQbftContext(
       final ValidatorProvider validatorProvider,
       final EpochManager epochManager,
       final BftBlockInterface blockInterface,
-      final KeyStoreWrapper keyStoreWrapper) {
+      final PkiBlockCreationConfiguration pkiBlockCreationConfiguration) {
     super(validatorProvider, epochManager, blockInterface);
-    this.keyStoreWrapper = keyStoreWrapper;
+    this.pkiBlockCreationConfiguration = pkiBlockCreationConfiguration;
   }
 
-  public KeyStoreWrapper getKeyStoreWrapper() {
-    return keyStoreWrapper;
+  public PkiBlockCreationConfiguration getPkiBlockCreationConfiguration() {
+    return pkiBlockCreationConfiguration;
   }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.consensus.qbft.pki;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfigurationProvider.KeyStoreWrapperProvider;
+import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
+import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PkiBlockCreationConfigurationProviderTest {
+
+  @Mock KeyStoreWrapperProvider keyStoreWrapperProvider;
+  @Mock KeyStoreWrapper keyStoreWrapper;
+  @Mock KeyStoreWrapper trustStoreWrapper;
+
+  @InjectMocks private PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider;
+
+  @Test
+  public void pkiBlockCreationConfigurationIsLoadedCorrectly() {
+    when(keyStoreWrapperProvider.apply(any(), eq(Path.of("/tmp/keystore")), eq("pwd"), isNull()))
+        .thenReturn(keyStoreWrapper);
+    when(keyStoreWrapperProvider.apply(
+            any(), eq(Path.of("/tmp/truststore")), eq("pwd"), eq(Path.of("/tmp/crl"))))
+        .thenReturn(trustStoreWrapper);
+
+    final PkiKeyStoreConfiguration pkiKeyStoreConfiguration =
+        new PkiKeyStoreConfiguration.Builder()
+            .withKeyStorePath(Path.of("/tmp/keystore"))
+            .withKeyStorePasswordSupplier(() -> "pwd")
+            .withTrustStorePath(Path.of("/tmp/truststore"))
+            .withTrustStorePasswordSupplier(() -> "pwd")
+            .withCertificateAlias("anAlias")
+            .withCrlFilePath(Path.of("/tmp/crl"))
+            .build();
+
+    pkiBlockCreationConfigProvider.load(pkiKeyStoreConfiguration);
+
+    final Optional<PkiBlockCreationConfiguration> maybePkiBlockCreationConfiguration =
+        PkiBlockCreationConfigurationProvider.getIfLoaded();
+    assertThat(maybePkiBlockCreationConfiguration).isPresent();
+
+    final PkiBlockCreationConfiguration pkiBlockCreationConfiguration =
+        maybePkiBlockCreationConfiguration.get();
+    assertThat(pkiBlockCreationConfiguration.getKeyStore()).isNotNull();
+    assertThat(pkiBlockCreationConfiguration.getTrustStore()).isNotNull();
+    assertThat(pkiBlockCreationConfiguration.getCertificateAlias()).isEqualTo("anAlias");
+  }
+}

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
@@ -58,11 +58,10 @@ public class PkiBlockCreationConfigurationProviderTest {
             .build();
 
     final PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider =
-        new PkiBlockCreationConfigurationProvider(
-            pkiKeyStoreConfiguration, keyStoreWrapperProvider);
+        new PkiBlockCreationConfigurationProvider(keyStoreWrapperProvider);
 
     final PkiBlockCreationConfiguration pkiBlockCreationConfiguration =
-        pkiBlockCreationConfigProvider.load();
+        pkiBlockCreationConfigProvider.load(pkiKeyStoreConfiguration);
 
     assertThat(pkiBlockCreationConfiguration).isNotNull();
     assertThat(pkiBlockCreationConfiguration.getKeyStore()).isNotNull();

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/pki/PkiBlockCreationConfigurationProviderTest.java
@@ -26,11 +26,9 @@ import org.hyperledger.besu.pki.config.PkiKeyStoreConfiguration;
 import org.hyperledger.besu.pki.keystore.KeyStoreWrapper;
 
 import java.nio.file.Path;
-import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -40,8 +38,6 @@ public class PkiBlockCreationConfigurationProviderTest {
   @Mock KeyStoreWrapperProvider keyStoreWrapperProvider;
   @Mock KeyStoreWrapper keyStoreWrapper;
   @Mock KeyStoreWrapper trustStoreWrapper;
-
-  @InjectMocks private PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider;
 
   @Test
   public void pkiBlockCreationConfigurationIsLoadedCorrectly() {
@@ -61,14 +57,14 @@ public class PkiBlockCreationConfigurationProviderTest {
             .withCrlFilePath(Path.of("/tmp/crl"))
             .build();
 
-    pkiBlockCreationConfigProvider.load(pkiKeyStoreConfiguration);
-
-    final Optional<PkiBlockCreationConfiguration> maybePkiBlockCreationConfiguration =
-        PkiBlockCreationConfigurationProvider.getIfLoaded();
-    assertThat(maybePkiBlockCreationConfiguration).isPresent();
+    final PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider =
+        new PkiBlockCreationConfigurationProvider(
+            pkiKeyStoreConfiguration, keyStoreWrapperProvider);
 
     final PkiBlockCreationConfiguration pkiBlockCreationConfiguration =
-        maybePkiBlockCreationConfiguration.get();
+        pkiBlockCreationConfigProvider.load();
+
+    assertThat(pkiBlockCreationConfiguration).isNotNull();
     assertThat(pkiBlockCreationConfiguration.getKeyStore()).isNotNull();
     assertThat(pkiBlockCreationConfiguration.getTrustStore()).isNotNull();
     assertThat(pkiBlockCreationConfiguration.getCertificateAlias()).isEqualTo("anAlias");

--- a/pki/src/main/java/org/hyperledger/besu/pki/config/PkiKeyStoreConfiguration.java
+++ b/pki/src/main/java/org/hyperledger/besu/pki/config/PkiKeyStoreConfiguration.java
@@ -12,14 +12,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.pki;
+package org.hyperledger.besu.pki.config;
 
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Supplier;
 
-public class PkiConfiguration {
+public class PkiKeyStoreConfiguration {
 
   public static String DEFAULT_KEYSTORE_TYPE = "PKCS12";
   public static String DEFAULT_CERTIFICATE_ALIAS = "validator";
@@ -31,15 +32,17 @@ public class PkiConfiguration {
   private final String trustStoreType;
   private final Path trustStorePath;
   private final Supplier<String> trustStorePasswordSupplier;
+  private final Optional<Path> crlFilePath;
 
-  public PkiConfiguration(
+  public PkiKeyStoreConfiguration(
       final String keyStoreType,
       final Path keyStorePath,
       final Supplier<String> keyStorePasswordSupplier,
       final String certificateAlias,
       final String trustStoreType,
       final Path trustStorePath,
-      final Supplier<String> trustStorePasswordSupplier) {
+      final Supplier<String> trustStorePasswordSupplier,
+      final Optional<Path> crlFilePath) {
     this.keyStoreType = keyStoreType;
     this.keyStorePath = keyStorePath;
     this.keyStorePasswordSupplier = keyStorePasswordSupplier;
@@ -47,6 +50,7 @@ public class PkiConfiguration {
     this.trustStoreType = trustStoreType;
     this.trustStorePath = trustStorePath;
     this.trustStorePasswordSupplier = trustStorePasswordSupplier;
+    this.crlFilePath = crlFilePath;
   }
 
   public String getKeyStoreType() {
@@ -77,6 +81,10 @@ public class PkiConfiguration {
     return trustStorePasswordSupplier.get();
   }
 
+  public Optional<Path> getCrlFilePath() {
+    return crlFilePath;
+  }
+
   public static final class Builder {
 
     private String keyStoreType = DEFAULT_KEYSTORE_TYPE;
@@ -86,6 +94,7 @@ public class PkiConfiguration {
     private String trustStoreType = DEFAULT_KEYSTORE_TYPE;
     private Path trustStorePath;
     private Supplier<String> trustStorePasswordSupplier;
+    private Path crlFilePath;
 
     public Builder() {}
 
@@ -125,17 +134,23 @@ public class PkiConfiguration {
       return this;
     }
 
-    public PkiConfiguration build() {
+    public Builder withCrlFilePath(final Path filePath) {
+      this.crlFilePath = filePath;
+      return this;
+    }
+
+    public PkiKeyStoreConfiguration build() {
       requireNonNull(keyStoreType, "Key Store Type must not be null");
       requireNonNull(keyStorePasswordSupplier, "Key Store password supplier must not be null");
-      return new PkiConfiguration(
+      return new PkiKeyStoreConfiguration(
           keyStoreType,
           keyStorePath,
           keyStorePasswordSupplier,
           certificateAlias,
           trustStoreType,
           trustStorePath,
-          trustStorePasswordSupplier);
+          trustStorePasswordSupplier,
+          Optional.ofNullable(crlFilePath));
     }
   }
 }


### PR DESCRIPTION
## PR description
- added all CLI options for PKI Block Creation as a Mixin
- created `PkiBlockCreationConfigurationProvider` that will be used to inject the PkiOptions into QBFT-related objects

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).