### PR TITLE
Fix Spotless implicit dependencies warnings with Gradle 7+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,16 +116,14 @@ allprojects {
   spotless {
     java {
       // This path needs to be relative to each project
-      target fileTree('.') {
-        include '**/src/*/java/**/*.java'
-        exclude '**/generalstate/GeneralStateReferenceTest*.java'
-        exclude '**/generalstate/GeneralStateRegressionReferenceTest*.java'
-        exclude '**/generalstate/LegacyGeneralStateReferenceTest*.java'
-        exclude '**/blockchain/BlockchainReferenceTest*.java'
-        exclude '**/blockchain/LegacyBlockchainReferenceTest*.java'
-        exclude '**/reference-test/resources/docker_interop/**'
-        exclude '**/.gradle/**'
-      }
+      target '**/src/*/java/**/*.java'
+      targetExclude '**/generalstate/GeneralStateReferenceTest*.java'
+      targetExclude '**/generalstate/GeneralStateRegressionReferenceTest*.java'
+      targetExclude '**/generalstate/LegacyGeneralStateReferenceTest*.java'
+      targetExclude '**/blockchain/BlockchainReferenceTest*.java'
+      targetExclude '**/blockchain/LegacyBlockchainReferenceTest*.java'
+      targetExclude '**/reference-test/resources/docker_interop/**'
+      targetExclude '**/.gradle/**'
       removeUnusedImports()
       googleJavaFormat('1.10.0')
       importOrder 'org.hyperledger', 'java', ''


### PR DESCRIPTION
## PR description

Fix the warnings that started with Gradle 7 regarding using implicit dependencies.

https://github.com/diffplug/spotless/issues/870

## Fixed Issue(s)
N/A

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).