### PR TITLE
Fixed nonce bug in EthGetTransactionCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 - Consider effective price and effective priority fee in transaction replacement rules [\#2529](https://github.com/hyperledger/besu/issues/2529)
+- GetTransactionCount should return the latest transaction count if it is greater than the transaction pool [\#2633](https://github.com/hyperledger/besu/pull/2633) 
 
 ### Early Access Features
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
@@ -61,11 +61,11 @@ public class EthGetTransactionCount extends AbstractBlockParameterOrBlockHashMet
   protected Object pendingResult(final JsonRpcRequestContext request) {
     final Address address = request.getRequiredParameter(0, Address.class);
     final OptionalLong pendingNonce = pendingTransactions.get().getNextNonceForSender(address);
-    if (pendingNonce.isPresent()) {
-      return Quantity.create(pendingNonce.getAsLong());
-    } else {
-      return latestResult(request);
-    }
+    final long latestNonce =
+        getBlockchainQueries()
+            .getTransactionCount(
+                address, getBlockchainQueries().getBlockchain().getChainHead().getHash());
+    return Quantity.create(Math.max(pendingNonce.orElse(0), latestNonce));
   }
 
   @Override


### PR DESCRIPTION
## PR description

Fixed bug where EthGetTransactionCount would return a lower value for pending than latest when there are old transactions in the transaction pool.

Wrote a failing test to show the expected behaviour and ensured that the max of latest and pending is used.


## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).