### PR TITLE
Refactor QbftExtraDataCodec from new instance to injection

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -166,7 +166,7 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
     final UniqueMessageMulticaster uniqueMessageMulticaster =
         new UniqueMessageMulticaster(peers, qbftConfig.getGossipedHistoryLimit());
 
-    final QbftGossip gossiper = new QbftGossip(uniqueMessageMulticaster);
+    final QbftGossip gossiper = new QbftGossip(uniqueMessageMulticaster, bftExtraDataCodec().get());
 
     final BftFinalState finalState =
         new BftFinalState(
@@ -217,7 +217,8 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
             gossiper,
             duplicateMessageTracker,
             futureMessageBuffer,
-            new EthSynchronizerUpdater(ethProtocolManager.ethContext().getEthPeers()));
+            new EthSynchronizerUpdater(ethProtocolManager.ethContext().getEthPeers()),
+            bftExtraDataCodec().get());
 
     final EventMultiplexer eventMultiplexer = new EventMultiplexer(qbftController);
     final BftProcessor bftProcessor = new BftProcessor(bftEventQueue, eventMultiplexer);

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
@@ -199,7 +199,7 @@ public class RoundSpecificPeers {
 
     switch (expectedMessage.getMessageType()) {
       case QbftV1.PROPOSAL:
-        actualSignedPayload = ProposalMessageData.fromMessageData(actual).decode();
+        actualSignedPayload = ProposalMessageData.fromMessageData(actual).decode(bftExtraDataCodec);
         break;
       case QbftV1.PREPARE:
         actualSignedPayload = PrepareMessageData.fromMessageData(actual).decode();

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
@@ -18,10 +18,12 @@ import static java.util.Optional.empty;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
+import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.messagedata.CommitMessageData;
 import org.hyperledger.besu.consensus.qbft.messagedata.PrepareMessageData;
 import org.hyperledger.besu.consensus.qbft.messagedata.ProposalMessageData;
@@ -47,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class RoundSpecificPeers {
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
 
   private final ValidatorPeer proposer;
   private final Collection<ValidatorPeer> peers;
@@ -205,7 +208,8 @@ public class RoundSpecificPeers {
         actualSignedPayload = CommitMessageData.fromMessageData(actual).decode();
         break;
       case QbftV1.ROUND_CHANGE:
-        actualSignedPayload = RoundChangeMessageData.fromMessageData(actual).decode();
+        actualSignedPayload =
+            RoundChangeMessageData.fromMessageData(actual).decode(bftExtraDataCodec);
         break;
       default:
         fail("Illegal QBFTV1 message type.");

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/RoundSpecificPeers.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.Payload;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
-import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.messagedata.CommitMessageData;
 import org.hyperledger.besu.consensus.qbft.messagedata.PrepareMessageData;
 import org.hyperledger.besu.consensus.qbft.messagedata.ProposalMessageData;
@@ -49,19 +48,21 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 public class RoundSpecificPeers {
-  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
 
   private final ValidatorPeer proposer;
   private final Collection<ValidatorPeer> peers;
   private final List<ValidatorPeer> nonProposingPeers;
+  private final BftExtraDataCodec bftExtraDataCodec;
 
   public RoundSpecificPeers(
       final ValidatorPeer proposer,
       final Collection<ValidatorPeer> peers,
-      final List<ValidatorPeer> nonProposingPeers) {
+      final List<ValidatorPeer> nonProposingPeers,
+      final BftExtraDataCodec bftExtraDataCodec) {
     this.proposer = proposer;
     this.peers = peers;
     this.nonProposingPeers = nonProposingPeers;
+    this.bftExtraDataCodec = bftExtraDataCodec;
   }
 
   public ValidatorPeer getProposer() {

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContext.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContext.java
@@ -127,7 +127,7 @@ public class TestContext {
     final List<ValidatorPeer> nonProposers = new ArrayList<>(remotePeers.values());
     nonProposers.remove(proposer);
 
-    return new RoundSpecificPeers(proposer, remotePeers.values(), nonProposers);
+    return new RoundSpecificPeers(proposer, remotePeers.values(), nonProposers, bftExtraDataCodec);
   }
 
   public NodeParams getLocalNodeParams() {

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
@@ -262,7 +262,10 @@ public class TestContextBuilder {
     final UniqueMessageMulticaster uniqueMulticaster =
         new UniqueMessageMulticaster(multicaster, GOSSIPED_HISTORY_LIMIT);
 
-    final Gossiper gossiper = useGossip ? new QbftGossip(uniqueMulticaster) : mock(Gossiper.class);
+    final Gossiper gossiper =
+        useGossip
+            ? new QbftGossip(uniqueMulticaster, BFT_EXTRA_DATA_ENCODER)
+            : mock(Gossiper.class);
 
     final StubbedSynchronizerUpdater synchronizerUpdater = new StubbedSynchronizerUpdater();
 
@@ -469,7 +472,8 @@ public class TestContextBuilder {
             gossiper,
             duplicateMessageTracker,
             futureMessageBuffer,
-            synchronizerUpdater);
+            synchronizerUpdater,
+            BFT_EXTRA_DATA_ENCODER);
 
     final EventMultiplexer eventMultiplexer = new EventMultiplexer(qbftController);
     //////////////////////////// END IBFT BesuController ////////////////////////////

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
@@ -59,7 +59,7 @@ public class QbftGossip implements Gossiper {
     final Authored decodedMessage;
     switch (messageData.getCode()) {
       case QbftV1.PROPOSAL:
-        decodedMessage = ProposalMessageData.fromMessageData(messageData).decode();
+        decodedMessage = ProposalMessageData.fromMessageData(messageData).decode(bftExtraDataCodec);
         break;
       case QbftV1.PREPARE:
         decodedMessage = PrepareMessageData.fromMessageData(messageData).decode();

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.qbft;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.Gossiper;
 import org.hyperledger.besu.consensus.common.bft.network.ValidatorMulticaster;
 import org.hyperledger.besu.consensus.common.bft.payload.Authored;
@@ -34,14 +35,17 @@ import com.google.common.collect.Lists;
 public class QbftGossip implements Gossiper {
 
   private final ValidatorMulticaster multicaster;
+  private final BftExtraDataCodec bftExtraDataCodec;
 
   /**
    * Constructor that attaches gossip logic to a set of multicaster
    *
    * @param multicaster Network connections to the remote validators
    */
-  public QbftGossip(final ValidatorMulticaster multicaster) {
+  public QbftGossip(
+      final ValidatorMulticaster multicaster, final BftExtraDataCodec bftExtraDataCodec) {
     this.multicaster = multicaster;
+    this.bftExtraDataCodec = bftExtraDataCodec;
   }
 
   /**
@@ -64,7 +68,8 @@ public class QbftGossip implements Gossiper {
         decodedMessage = CommitMessageData.fromMessageData(messageData).decode();
         break;
       case QbftV1.ROUND_CHANGE:
-        decodedMessage = RoundChangeMessageData.fromMessageData(messageData).decode();
+        decodedMessage =
+            RoundChangeMessageData.fromMessageData(messageData).decode(bftExtraDataCodec);
         break;
       default:
         throw new IllegalArgumentException(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
@@ -41,6 +41,7 @@ public class QbftGossip implements Gossiper {
    * Constructor that attaches gossip logic to a set of multicaster
    *
    * @param multicaster Network connections to the remote validators
+   * @param bftExtraDataCodec Codec used when decoding MessageData
    */
   public QbftGossip(
       final ValidatorMulticaster multicaster, final BftExtraDataCodec bftExtraDataCodec) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/ProposalMessageData.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/ProposalMessageData.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.qbft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.Proposal;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
@@ -33,8 +34,8 @@ public class ProposalMessageData extends AbstractBftMessageData {
         messageData, MESSAGE_CODE, ProposalMessageData.class, ProposalMessageData::new);
   }
 
-  public Proposal decode() {
-    return Proposal.decode(data);
+  public Proposal decode(final BftExtraDataCodec bftExtraDataCodec) {
+    return Proposal.decode(data, bftExtraDataCodec);
   }
 
   public static ProposalMessageData create(final Proposal proposal) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/RoundChangeMessageData.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagedata/RoundChangeMessageData.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.qbft.messagedata;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.messagedata.AbstractBftMessageData;
 import org.hyperledger.besu.consensus.qbft.messagewrappers.RoundChange;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
@@ -33,8 +34,8 @@ public class RoundChangeMessageData extends AbstractBftMessageData {
         messageData, MESSAGE_CODE, RoundChangeMessageData.class, RoundChangeMessageData::new);
   }
 
-  public RoundChange decode() {
-    return RoundChange.decode(data);
+  public RoundChange decode(final BftExtraDataCodec bftExtraDataCodec) {
+    return RoundChange.decode(data, bftExtraDataCodec);
   }
 
   public static RoundChangeMessageData create(final RoundChange signedPayload) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/Proposal.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
@@ -69,10 +70,11 @@ public class Proposal extends BftMessage<ProposalPayload> {
     return rlpOut.encoded();
   }
 
-  public static Proposal decode(final Bytes data) {
+  public static Proposal decode(final Bytes data, final BftExtraDataCodec bftExtraDataCodec) {
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
-    final SignedData<ProposalPayload> payload = readPayload(rlpIn, ProposalPayload::readFrom);
+    final SignedData<ProposalPayload> payload =
+        readPayload(rlpIn, rlpInput -> ProposalPayload.readFrom(rlpInput, bftExtraDataCodec));
 
     rlpIn.enterList();
     final List<SignedData<RoundChangePayload>> roundChanges =

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChange.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChange.java
@@ -15,9 +15,9 @@
 package org.hyperledger.besu.consensus.qbft.messagewrappers;
 
 import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
-import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
 import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
@@ -33,7 +33,6 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class RoundChange extends BftMessage<RoundChangePayload> {
 
-  private static final QbftExtraDataCodec QBFT_EXTRA_DATA_ENCODER = new QbftExtraDataCodec();
   private final Optional<Block> proposedBlock;
   private final List<SignedData<PreparePayload>> prepares;
 
@@ -73,7 +72,7 @@ public class RoundChange extends BftMessage<RoundChangePayload> {
     return rlpOut.encoded();
   }
 
-  public static RoundChange decode(final Bytes data) {
+  public static RoundChange decode(final Bytes data, final BftExtraDataCodec bftExtraDataCodec) {
 
     final RLPInput rlpIn = RLP.input(data);
     rlpIn.enterList();
@@ -86,8 +85,7 @@ public class RoundChange extends BftMessage<RoundChangePayload> {
     } else {
       block =
           Optional.of(
-              Block.readFrom(
-                  rlpIn, BftBlockHeaderFunctions.forCommittedSeal(QBFT_EXTRA_DATA_ENCODER)));
+              Block.readFrom(rlpIn, BftBlockHeaderFunctions.forCommittedSeal(bftExtraDataCodec)));
     }
 
     final List<SignedData<PreparePayload>> prepares =

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/ProposalPayload.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/payload/ProposalPayload.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.consensus.qbft.payload;
 
 import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
-import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.messagedata.QbftV1;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
@@ -38,12 +38,12 @@ public class ProposalPayload extends QbftPayload {
     this.proposedBlock = proposedBlock;
   }
 
-  public static ProposalPayload readFrom(final RLPInput rlpInput) {
+  public static ProposalPayload readFrom(
+      final RLPInput rlpInput, final BftExtraDataCodec bftExtraDataCodec) {
     rlpInput.enterList();
     final ConsensusRoundIdentifier roundIdentifier = readConsensusRound(rlpInput);
     final Block proposedBlock =
-        Block.readFrom(
-            rlpInput, BftBlockHeaderFunctions.forCommittedSeal(new QbftExtraDataCodec()));
+        Block.readFrom(rlpInput, BftBlockHeaderFunctions.forCommittedSeal(bftExtraDataCodec));
     rlpInput.leaveList();
 
     return new ProposalPayload(roundIdentifier, proposedBlock);

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.qbft.statemachine;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.Gossiper;
 import org.hyperledger.besu.consensus.common.bft.MessageTracker;
 import org.hyperledger.besu.consensus.common.bft.SynchronizerUpdater;
@@ -35,6 +36,7 @@ public class QbftController extends BaseBftController {
 
   private BaseQbftBlockHeightManager currentHeightManager;
   private final QbftBlockHeightManagerFactory qbftBlockHeightManagerFactory;
+  private final BftExtraDataCodec bftExtraDataCodec;
 
   public QbftController(
       final Blockchain blockchain,
@@ -43,7 +45,8 @@ public class QbftController extends BaseBftController {
       final Gossiper gossiper,
       final MessageTracker duplicateMessageTracker,
       final FutureMessageBuffer futureMessageBuffer,
-      final SynchronizerUpdater sychronizerUpdater) {
+      final SynchronizerUpdater sychronizerUpdater,
+      final BftExtraDataCodec bftExtraDataCodec) {
 
     super(
         blockchain,
@@ -53,6 +56,7 @@ public class QbftController extends BaseBftController {
         futureMessageBuffer,
         sychronizerUpdater);
     this.qbftBlockHeightManagerFactory = qbftBlockHeightManagerFactory;
+    this.bftExtraDataCodec = bftExtraDataCodec;
   }
 
   @Override
@@ -84,7 +88,7 @@ public class QbftController extends BaseBftController {
       case QbftV1.ROUND_CHANGE:
         consumeMessage(
             message,
-            RoundChangeMessageData.fromMessageData(messageData).decode(),
+            RoundChangeMessageData.fromMessageData(messageData).decode(bftExtraDataCodec),
             currentHeightManager::handleRoundChangePayload);
         break;
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
@@ -67,7 +67,7 @@ public class QbftController extends BaseBftController {
       case QbftV1.PROPOSAL:
         consumeMessage(
             message,
-            ProposalMessageData.fromMessageData(messageData).decode(),
+            ProposalMessageData.fromMessageData(messageData).decode(bftExtraDataCodec),
             currentHeightManager::handleProposalPayload);
         break;
 

--- a/consensus/qbft/src/reference-test/java/org/hyperledger/besu/consensus/qbt/support/ProposalMessage.java
+++ b/consensus/qbft/src/reference-test/java/org/hyperledger/besu/consensus/qbt/support/ProposalMessage.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.qbt.support;
 
 import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -37,6 +38,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.tuweni.bytes.Bytes;
 
 public class ProposalMessage implements RlpTestCaseMessage {
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
+
   private final SignedProposal signedProposal;
   private final List<SignedRoundChange> roundChanges;
 
@@ -54,7 +57,7 @@ public class ProposalMessage implements RlpTestCaseMessage {
 
   @Override
   public BftMessage<ProposalPayload> fromRlp(final Bytes rlp) {
-    return Proposal.decode(rlp);
+    return Proposal.decode(rlp, bftExtraDataCodec);
   }
 
   @Override

--- a/consensus/qbft/src/reference-test/java/org/hyperledger/besu/consensus/qbt/support/RoundChangeMessage.java
+++ b/consensus/qbft/src/reference-test/java/org/hyperledger/besu/consensus/qbt/support/RoundChangeMessage.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.qbt.support;
 
 import static org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions.forCommittedSeal;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.messagewrappers.BftMessage;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
@@ -40,6 +41,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.tuweni.bytes.Bytes;
 
 public class RoundChangeMessage implements RlpTestCaseMessage {
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
+
   private final SignedRoundChange signedRoundChange;
   private final Optional<String> block;
 
@@ -57,7 +60,7 @@ public class RoundChangeMessage implements RlpTestCaseMessage {
 
   @Override
   public BftMessage<RoundChangePayload> fromRlp(final Bytes rlp) {
-    return RoundChange.decode(rlp);
+    return RoundChange.decode(rlp, bftExtraDataCodec);
   }
 
   @Override

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
@@ -41,6 +42,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class ProposalTest {
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
 
   private static final BftExtraData extraData =
       new BftExtraData(
@@ -48,9 +50,7 @@ public class ProposalTest {
 
   private static final Block BLOCK =
       new Block(
-          new BlockHeaderTestFixture()
-              .extraData(new QbftExtraDataCodec().encode(extraData))
-              .buildHeader(),
+          new BlockHeaderTestFixture().extraData(bftExtraDataCodec.encode(extraData)).buildHeader(),
           new BlockBody(Collections.emptyList(), Collections.emptyList()));
 
   @Test
@@ -78,7 +78,7 @@ public class ProposalTest {
 
     final Proposal proposal = new Proposal(signedPayload, List.of(roundChange), List.of(prepare));
 
-    final Proposal decodedProposal = Proposal.decode(proposal.encode());
+    final Proposal decodedProposal = Proposal.decode(proposal.encode(), bftExtraDataCodec);
 
     assertThat(decodedProposal.getAuthor()).isEqualTo(addr);
     assertThat(decodedProposal.getMessageType()).isEqualTo(QbftV1.PROPOSAL);

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.consensus.qbft.messagewrappers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.payload.SignedData;
 import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
@@ -40,7 +41,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class RoundChangeTest {
-
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
   private static final BftExtraData extraData =
       new BftExtraData(
           Bytes32.ZERO, Collections.emptyList(), Optional.empty(), 1, Collections.emptyList());
@@ -74,7 +75,8 @@ public class RoundChangeTest {
         new RoundChange(
             signedRoundChangePayload, Optional.of(BLOCK), List.of(signedPreparePayload));
 
-    final RoundChange decodedRoundChange = RoundChange.decode(roundChange.encode());
+    final RoundChange decodedRoundChange =
+        RoundChange.decode(roundChange.encode(), bftExtraDataCodec);
 
     assertThat(decodedRoundChange.getMessageType()).isEqualTo(QbftV1.ROUND_CHANGE);
     assertThat(decodedRoundChange.getAuthor()).isEqualTo(addr);
@@ -101,7 +103,8 @@ public class RoundChangeTest {
     final RoundChange roundChange =
         new RoundChange(signedRoundChangePayload, Optional.empty(), Collections.emptyList());
 
-    final RoundChange decodedRoundChange = RoundChange.decode(roundChange.encode());
+    final RoundChange decodedRoundChange =
+        RoundChange.decode(roundChange.encode(), bftExtraDataCodec);
 
     assertThat(decodedRoundChange.getMessageType()).isEqualTo(QbftV1.ROUND_CHANGE);
     assertThat(decodedRoundChange.getAuthor()).isEqualTo(addr);

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -495,7 +495,7 @@ public class QbftBlockHeightManagerTest {
     assertThat(capturedMessageData).isInstanceOf(RoundChangeMessageData.class);
     final RoundChangeMessageData roundChange = (RoundChangeMessageData) capturedMessageData;
 
-    final RoundChange receivedRoundChange = roundChange.decode();
+    final RoundChange receivedRoundChange = roundChange.decode(bftExtraDataCodec);
 
     Assertions.assertThat(receivedRoundChange.getPreparedRoundMetadata()).isNotEmpty();
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftControllerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftControllerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.EthSynchronizerUpdater;
 import org.hyperledger.besu.consensus.common.bft.MessageTracker;
@@ -35,6 +36,7 @@ import org.hyperledger.besu.consensus.common.bft.events.NewChainHead;
 import org.hyperledger.besu.consensus.common.bft.events.RoundExpiry;
 import org.hyperledger.besu.consensus.common.bft.statemachine.BftFinalState;
 import org.hyperledger.besu.consensus.common.bft.statemachine.FutureMessageBuffer;
+import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
 import org.hyperledger.besu.consensus.qbft.QbftGossip;
 import org.hyperledger.besu.consensus.qbft.messagedata.CommitMessageData;
 import org.hyperledger.besu.consensus.qbft.messagedata.PrepareMessageData;
@@ -63,6 +65,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QbftControllerTest {
+  private static final BftExtraDataCodec bftExtraDataCodec = new QbftExtraDataCodec();
+
   @Mock private Blockchain blockChain;
   @Mock private BftFinalState bftFinalState;
   @Mock private QbftBlockHeightManagerFactory blockHeightManagerFactory;
@@ -124,7 +128,8 @@ public class QbftControllerTest {
             ibftGossip,
             messageTracker,
             futureMessageBuffer,
-            mock(EthSynchronizerUpdater.class));
+            mock(EthSynchronizerUpdater.class),
+            bftExtraDataCodec);
   }
 
   @Test
@@ -476,7 +481,7 @@ public class QbftControllerTest {
     when(roundChange.getAuthor()).thenReturn(validator);
     when(roundChange.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(roundChangeMessageData.getCode()).thenReturn(QbftV1.ROUND_CHANGE);
-    when(roundChangeMessageData.decode()).thenReturn(roundChange);
+    when(roundChangeMessageData.decode(bftExtraDataCodec)).thenReturn(roundChange);
     roundChangeMessage = new DefaultMessage(null, roundChangeMessageData);
   }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftControllerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftControllerTest.java
@@ -454,7 +454,7 @@ public class QbftControllerTest {
     when(proposal.getAuthor()).thenReturn(validator);
     when(proposal.getRoundIdentifier()).thenReturn(roundIdentifier);
     when(proposalMessageData.getCode()).thenReturn(QbftV1.PROPOSAL);
-    when(proposalMessageData.decode()).thenReturn(proposal);
+    when(proposalMessageData.decode(bftExtraDataCodec)).thenReturn(proposal);
     proposalMessage = new DefaultMessage(null, proposalMessageData);
   }
 


### PR DESCRIPTION
## PR description
- Updated `RoundChange` and `ProposalPayload` `decode()` methods to accept a `BftExtraDataCodec` implementation (instead of creating a new instance of `QbftExtraDataCodec`.
- A bit of plumbing work all the way to `QbftBesuControllerBuilder`, where we choose the concrete codec instance to use.
- For the tests, we are using the `QbftExtraDataCodec` (to keep the previous behaviour)

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).