### PR TITLE
Remove EIP-1702 account versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support for mining ommers [#2576](https://github.com/hyperledger/besu/pull/2576)
 - Updated onchain permissioning to validate permissions on transaction submission [\#2595](https://github.com/hyperledger/besu/pull/2595)
 - Removed deprecated CLI option `--privacy-precompiled-address` [#2605](https://github.com/hyperledger/besu/pull/2605)
+- Removed code supporting EIP-1702. [#2657](https://github.com/hyperledger/besu/pull/2657)
 
 ### Bug Fixes
 - Consider effective price and effective priority fee in transaction replacement rules [\#2529](https://github.com/hyperledger/besu/issues/2529)

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyGroupGenesisProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyGroupGenesisProvider.java
@@ -55,11 +55,6 @@ public class TestPrivacyGroupGenesisProvider implements PrivacyGroupGenesisProvi
               }
 
               @Override
-              public int getVersion() {
-                return 0;
-              }
-
-              @Override
               public Long getNonce() {
                 return 0L;
               }

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -55,7 +55,6 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.PrivacyQueries;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
@@ -916,7 +915,7 @@ public class RunnerBuilder {
                   .getProtocolSchedule()
                   .getByBlockNumber(1)
                   .getPrecompileContractRegistry()
-                  .get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION);
+                  .get(Address.ONCHAIN_PRIVACY);
       onchainPrivacyPrecompiledContract.addPrivateTransactionObserver(privateTransactionObserver);
     }
   }

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.enclave.EnclaveFactory;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
@@ -143,6 +142,6 @@ public class PrivacyTest {
         .getProtocolSchedule()
         .getByBlockNumber(1)
         .getPrecompileContractRegistry()
-        .get(defaultPrivacy, Account.DEFAULT_VERSION);
+        .get(defaultPrivacy);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -105,7 +105,6 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
             balance,
             Hash.EMPTY_TRIE_HASH,
             Hash.EMPTY,
-            Account.DEFAULT_VERSION,
             true);
     bonsaiValue.setUpdated(newAccount);
     return new WrappedEvmAccount(track(new UpdateTrackingAccount<>(newAccount)));
@@ -375,8 +374,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                   oldValue.getNonce(),
                   oldValue.getBalance(),
                   oldValue.getStorageRoot(),
-                  oldValue.getCodeHash(),
-                  oldValue.getVersion());
+                  oldValue.getCodeHash());
       final BonsaiAccount newValue = bonsaiValue.getUpdated();
       final StateTrieAccountValue newAccount =
           newValue == null
@@ -385,8 +383,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                   newValue.getNonce(),
                   newValue.getBalance(),
                   newValue.getStorageRoot(),
-                  newValue.getCodeHash(),
-                  newValue.getVersion());
+                  newValue.getCodeHash());
       layer.addAccountChange(updatedAccount.getKey(), oldAccount, newAccount);
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.chain;
 
 import org.hyperledger.besu.config.GenesisAllocation;
 import org.hyperledger.besu.config.GenesisConfigFile;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -116,7 +115,6 @@ public final class GenesisState {
           account.setNonce(genesisAccount.nonce);
           account.setBalance(genesisAccount.balance);
           account.setCode(genesisAccount.code);
-          account.setVersion(genesisAccount.version);
           genesisAccount.storage.forEach(account::setStorageValue);
         });
     updater.commit();
@@ -229,7 +227,6 @@ public final class GenesisState {
     final Wei balance;
     final Map<UInt256, UInt256> storage;
     final Bytes code;
-    final int version;
 
     static GenesisAccount fromAllocation(final GenesisAllocation allocation) {
       return new GenesisAccount(
@@ -237,8 +234,7 @@ public final class GenesisState {
           allocation.getAddress(),
           allocation.getBalance(),
           allocation.getStorage(),
-          allocation.getCode(),
-          allocation.getVersion());
+          allocation.getCode());
     }
 
     private GenesisAccount(
@@ -246,13 +242,11 @@ public final class GenesisState {
         final String hexAddress,
         final String balance,
         final Map<String, String> storage,
-        final String hexCode,
-        final String version) {
+        final String hexCode) {
       this.nonce = withNiceErrorMessage("nonce", hexNonce, GenesisState::parseUnsignedLong);
       this.address = withNiceErrorMessage("address", hexAddress, Address::fromHexString);
       this.balance = withNiceErrorMessage("balance", balance, this::parseBalance);
       this.code = hexCode != null ? Bytes.fromHexString(hexCode) : null;
-      this.version = version != null ? Integer.decode(version) : Account.DEFAULT_VERSION;
       this.storage = parseStorage(storage);
     }
 
@@ -291,7 +285,6 @@ public final class GenesisState {
           .add("balance", balance)
           .add("storage", storage)
           .add("code", code)
-          .add("version", version)
           .toString();
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AbstractWorldUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AbstractWorldUpdater.java
@@ -218,7 +218,6 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
         existing.setBalance(update.getBalance());
         if (update.codeWasUpdated()) {
           existing.setCode(update.getCode());
-          existing.setVersion(update.getVersion());
         }
         if (update.getStorageWasCleared()) {
           existing.clearStorage();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Account.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Account.java
@@ -25,7 +25,6 @@ public interface Account extends AccountState {
 
   long DEFAULT_NONCE = 0L;
   Wei DEFAULT_BALANCE = Wei.ZERO;
-  int DEFAULT_VERSION = 0;
 
   /**
    * The account address.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AccountState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/AccountState.java
@@ -91,13 +91,6 @@ public interface AccountState {
   }
 
   /**
-   * The version of the EVM bytecode associated with this account.
-   *
-   * @return the version of the account code. Default is zero.
-   */
-  int getVersion();
-
-  /**
    * Retrieves a value in the account storage given its key.
    *
    * @param key the key to retrieve in the account storage.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MutableAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MutableAccount.java
@@ -85,13 +85,6 @@ public interface MutableAccount extends Account {
   void setCode(Bytes code);
 
   /**
-   * Sets the version for the account.
-   *
-   * @param version the version of the code being set
-   */
-  void setVersion(int version);
-
-  /**
    * Sets a particular key-value pair in the account storage.
    *
    * <p>Note that setting the value of an entry to 0 is basically equivalent to deleting that entry.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UpdateTrackingAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/UpdateTrackingAccount.java
@@ -44,7 +44,6 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
 
   private long nonce;
   private Wei balance;
-  private int version;
 
   @Nullable private Bytes updatedCode; // Null if the underlying code has not been updated.
   @Nullable private Hash updatedCodeHash;
@@ -63,7 +62,6 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
 
     this.nonce = 0;
     this.balance = Wei.ZERO;
-    this.version = Account.DEFAULT_VERSION;
 
     this.updatedCode = Bytes.EMPTY;
     this.updatedStorage = new TreeMap<>();
@@ -81,7 +79,6 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
 
     this.nonce = account.getNonce();
     this.balance = account.getBalance();
-    this.version = account.getVersion();
 
     this.updatedStorage = new TreeMap<>();
   }
@@ -186,16 +183,6 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
   public void setCode(final Bytes code) {
     this.updatedCode = code;
     this.updatedCodeHash = null;
-  }
-
-  @Override
-  public void setVersion(final int version) {
-    this.version = version;
-  }
-
-  @Override
-  public int getVersion() {
-    return version;
   }
 
   void markTransactionBoundary() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WorldState.java
@@ -95,11 +95,6 @@ public interface WorldState extends WorldView {
     }
 
     @Override
-    public int getVersion() {
-      return accountState.getVersion();
-    }
-
-    @Override
     public UInt256 getStorageValue(final UInt256 key) {
       return accountState.getStorageValue(key);
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WrappedEvmAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/WrappedEvmAccount.java
@@ -78,11 +78,6 @@ public class WrappedEvmAccount implements EvmAccount {
   }
 
   @Override
-  public int getVersion() {
-    return mutableAccount.getVersion();
-  }
-
-  @Override
   public UInt256 getStorageValue(final UInt256 key) {
     return mutableAccount.getStorageValue(key);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.mainnet;
 import static org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSpecs.powHasher;
 
 import org.hyperledger.besu.config.PowAlgorithm;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.core.WorldState;
@@ -170,7 +169,6 @@ public class ClassicProtocolSpecs {
                     messageCallProcessor,
                     true,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     FeeMarket.legacy(),
                     CoinbaseFeePriceCalculator.frontier()))
         .name("Atlantis");

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetContractCreationProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetContractCreationProcessor.java
@@ -47,24 +47,6 @@ public class MainnetContractCreationProcessor extends AbstractMessageProcessor {
 
   private final List<ContractValidationRule> contractValidationRules;
 
-  private final int accountVersion;
-
-  public MainnetContractCreationProcessor(
-      final GasCalculator gasCalculator,
-      final EVM evm,
-      final boolean requireCodeDepositToSucceed,
-      final List<ContractValidationRule> contractValidationRules,
-      final long initialContractNonce,
-      final Collection<Address> forceCommitAddresses,
-      final int accountVersion) {
-    super(evm, forceCommitAddresses);
-    this.gasCalculator = gasCalculator;
-    this.requireCodeDepositToSucceed = requireCodeDepositToSucceed;
-    this.contractValidationRules = contractValidationRules;
-    this.initialContractNonce = initialContractNonce;
-    this.accountVersion = accountVersion;
-  }
-
   public MainnetContractCreationProcessor(
       final GasCalculator gasCalculator,
       final EVM evm,
@@ -72,14 +54,11 @@ public class MainnetContractCreationProcessor extends AbstractMessageProcessor {
       final List<ContractValidationRule> contractValidationRules,
       final long initialContractNonce,
       final Collection<Address> forceCommitAddresses) {
-    this(
-        gasCalculator,
-        evm,
-        requireCodeDepositToSucceed,
-        contractValidationRules,
-        initialContractNonce,
-        forceCommitAddresses,
-        Account.DEFAULT_VERSION);
+    super(evm, forceCommitAddresses);
+    this.gasCalculator = gasCalculator;
+    this.requireCodeDepositToSucceed = requireCodeDepositToSucceed;
+    this.contractValidationRules = contractValidationRules;
+    this.initialContractNonce = initialContractNonce;
   }
 
   public MainnetContractCreationProcessor(
@@ -94,8 +73,7 @@ public class MainnetContractCreationProcessor extends AbstractMessageProcessor {
         requireCodeDepositToSucceed,
         contractValidationRules,
         initialContractNonce,
-        ImmutableSet.of(),
-        Account.DEFAULT_VERSION);
+        ImmutableSet.of());
   }
 
   private static boolean accountExists(final Account account) {
@@ -164,7 +142,6 @@ public class MainnetContractCreationProcessor extends AbstractMessageProcessor {
         final MutableAccount contract =
             frame.getWorldState().getOrCreate(frame.getContractAddress()).getMutable();
         contract.setCode(contractCode);
-        contract.setVersion(accountVersion);
         LOG.trace(
             "Successful creation of contract {} with code of size {} (Gas remaining: {})",
             frame.getContractAddress(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetEvmRegistries.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetEvmRegistries.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.vm.EVM;
 import org.hyperledger.besu.ethereum.vm.GasCalculator;
 import org.hyperledger.besu.ethereum.vm.OperationRegistry;
@@ -108,7 +107,7 @@ abstract class MainnetEvmRegistries {
   static EVM frontier(final GasCalculator gasCalculator) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerFrontierOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION);
+    registerFrontierOpcodes(registry, gasCalculator);
 
     return new EVM(registry, gasCalculator);
   }
@@ -116,7 +115,7 @@ abstract class MainnetEvmRegistries {
   static EVM homestead(final GasCalculator gasCalculator) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerHomesteadOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION);
+    registerHomesteadOpcodes(registry, gasCalculator);
 
     return new EVM(registry, gasCalculator);
   }
@@ -124,7 +123,7 @@ abstract class MainnetEvmRegistries {
   static EVM byzantium(final GasCalculator gasCalculator) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerByzantiumOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION);
+    registerByzantiumOpcodes(registry, gasCalculator);
 
     return new EVM(registry, gasCalculator);
   }
@@ -132,7 +131,7 @@ abstract class MainnetEvmRegistries {
   static EVM constantinople(final GasCalculator gasCalculator) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerConstantinopleOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION);
+    registerConstantinopleOpcodes(registry, gasCalculator);
 
     return new EVM(registry, gasCalculator);
   }
@@ -140,7 +139,7 @@ abstract class MainnetEvmRegistries {
   static EVM istanbul(final GasCalculator gasCalculator, final BigInteger chainId) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerIstanbulOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION, chainId);
+    registerIstanbulOpcodes(registry, gasCalculator, chainId);
 
     return new EVM(registry, gasCalculator);
   }
@@ -148,152 +147,138 @@ abstract class MainnetEvmRegistries {
   static EVM london(final GasCalculator gasCalculator, final BigInteger chainId) {
     final OperationRegistry registry = new OperationRegistry();
 
-    registerLondonOpcodes(registry, gasCalculator, Account.DEFAULT_VERSION, chainId);
+    registerLondonOpcodes(registry, gasCalculator, chainId);
 
     return new EVM(registry, gasCalculator);
   }
 
   private static void registerFrontierOpcodes(
-      final OperationRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    registry.put(new AddOperation(gasCalculator), accountVersion);
-    registry.put(new AddOperation(gasCalculator), accountVersion);
-    registry.put(new MulOperation(gasCalculator), accountVersion);
-    registry.put(new SubOperation(gasCalculator), accountVersion);
-    registry.put(new DivOperation(gasCalculator), accountVersion);
-    registry.put(new SDivOperation(gasCalculator), accountVersion);
-    registry.put(new ModOperation(gasCalculator), accountVersion);
-    registry.put(new SModOperation(gasCalculator), accountVersion);
-    registry.put(new ExpOperation(gasCalculator), accountVersion);
-    registry.put(new AddModOperation(gasCalculator), accountVersion);
-    registry.put(new MulModOperation(gasCalculator), accountVersion);
-    registry.put(new SignExtendOperation(gasCalculator), accountVersion);
-    registry.put(new LtOperation(gasCalculator), accountVersion);
-    registry.put(new GtOperation(gasCalculator), accountVersion);
-    registry.put(new SLtOperation(gasCalculator), accountVersion);
-    registry.put(new SGtOperation(gasCalculator), accountVersion);
-    registry.put(new EqOperation(gasCalculator), accountVersion);
-    registry.put(new IsZeroOperation(gasCalculator), accountVersion);
-    registry.put(new AndOperation(gasCalculator), accountVersion);
-    registry.put(new OrOperation(gasCalculator), accountVersion);
-    registry.put(new XorOperation(gasCalculator), accountVersion);
-    registry.put(new NotOperation(gasCalculator), accountVersion);
-    registry.put(new ByteOperation(gasCalculator), accountVersion);
-    registry.put(new Sha3Operation(gasCalculator), accountVersion);
-    registry.put(new AddressOperation(gasCalculator), accountVersion);
-    registry.put(new BalanceOperation(gasCalculator), accountVersion);
-    registry.put(new OriginOperation(gasCalculator), accountVersion);
-    registry.put(new CallerOperation(gasCalculator), accountVersion);
-    registry.put(new CallValueOperation(gasCalculator), accountVersion);
-    registry.put(new CallDataLoadOperation(gasCalculator), accountVersion);
-    registry.put(new CallDataSizeOperation(gasCalculator), accountVersion);
-    registry.put(new CallDataCopyOperation(gasCalculator), accountVersion);
-    registry.put(new CodeSizeOperation(gasCalculator), accountVersion);
-    registry.put(new CodeCopyOperation(gasCalculator), accountVersion);
-    registry.put(new GasPriceOperation(gasCalculator), accountVersion);
-    registry.put(new ExtCodeCopyOperation(gasCalculator), accountVersion);
-    registry.put(new ExtCodeSizeOperation(gasCalculator), accountVersion);
-    registry.put(new BlockHashOperation(gasCalculator), accountVersion);
-    registry.put(new CoinbaseOperation(gasCalculator), accountVersion);
-    registry.put(new TimestampOperation(gasCalculator), accountVersion);
-    registry.put(new NumberOperation(gasCalculator), accountVersion);
-    registry.put(new DifficultyOperation(gasCalculator), accountVersion);
-    registry.put(new GasLimitOperation(gasCalculator), accountVersion);
-    registry.put(new PopOperation(gasCalculator), accountVersion);
-    registry.put(new MLoadOperation(gasCalculator), accountVersion);
-    registry.put(new MStoreOperation(gasCalculator), accountVersion);
-    registry.put(new MStore8Operation(gasCalculator), accountVersion);
-    registry.put(new SLoadOperation(gasCalculator), accountVersion);
-    registry.put(
-        new SStoreOperation(gasCalculator, SStoreOperation.FRONTIER_MINIMUM), accountVersion);
-    registry.put(new JumpOperation(gasCalculator), accountVersion);
-    registry.put(new JumpiOperation(gasCalculator), accountVersion);
-    registry.put(new PCOperation(gasCalculator), accountVersion);
-    registry.put(new MSizeOperation(gasCalculator), accountVersion);
-    registry.put(new GasOperation(gasCalculator), accountVersion);
-    registry.put(new JumpDestOperation(gasCalculator), accountVersion);
-    registry.put(new ReturnOperation(gasCalculator), accountVersion);
-    registry.put(new InvalidOperation(gasCalculator), accountVersion);
-    registry.put(new StopOperation(gasCalculator), accountVersion);
-    registry.put(new SelfDestructOperation(gasCalculator), accountVersion);
-    registry.put(new CreateOperation(gasCalculator), accountVersion);
-    registry.put(new CallOperation(gasCalculator), accountVersion);
-    registry.put(new CallCodeOperation(gasCalculator), accountVersion);
+      final OperationRegistry registry, final GasCalculator gasCalculator) {
+    registry.put(new AddOperation(gasCalculator));
+    registry.put(new AddOperation(gasCalculator));
+    registry.put(new MulOperation(gasCalculator));
+    registry.put(new SubOperation(gasCalculator));
+    registry.put(new DivOperation(gasCalculator));
+    registry.put(new SDivOperation(gasCalculator));
+    registry.put(new ModOperation(gasCalculator));
+    registry.put(new SModOperation(gasCalculator));
+    registry.put(new ExpOperation(gasCalculator));
+    registry.put(new AddModOperation(gasCalculator));
+    registry.put(new MulModOperation(gasCalculator));
+    registry.put(new SignExtendOperation(gasCalculator));
+    registry.put(new LtOperation(gasCalculator));
+    registry.put(new GtOperation(gasCalculator));
+    registry.put(new SLtOperation(gasCalculator));
+    registry.put(new SGtOperation(gasCalculator));
+    registry.put(new EqOperation(gasCalculator));
+    registry.put(new IsZeroOperation(gasCalculator));
+    registry.put(new AndOperation(gasCalculator));
+    registry.put(new OrOperation(gasCalculator));
+    registry.put(new XorOperation(gasCalculator));
+    registry.put(new NotOperation(gasCalculator));
+    registry.put(new ByteOperation(gasCalculator));
+    registry.put(new Sha3Operation(gasCalculator));
+    registry.put(new AddressOperation(gasCalculator));
+    registry.put(new BalanceOperation(gasCalculator));
+    registry.put(new OriginOperation(gasCalculator));
+    registry.put(new CallerOperation(gasCalculator));
+    registry.put(new CallValueOperation(gasCalculator));
+    registry.put(new CallDataLoadOperation(gasCalculator));
+    registry.put(new CallDataSizeOperation(gasCalculator));
+    registry.put(new CallDataCopyOperation(gasCalculator));
+    registry.put(new CodeSizeOperation(gasCalculator));
+    registry.put(new CodeCopyOperation(gasCalculator));
+    registry.put(new GasPriceOperation(gasCalculator));
+    registry.put(new ExtCodeCopyOperation(gasCalculator));
+    registry.put(new ExtCodeSizeOperation(gasCalculator));
+    registry.put(new BlockHashOperation(gasCalculator));
+    registry.put(new CoinbaseOperation(gasCalculator));
+    registry.put(new TimestampOperation(gasCalculator));
+    registry.put(new NumberOperation(gasCalculator));
+    registry.put(new DifficultyOperation(gasCalculator));
+    registry.put(new GasLimitOperation(gasCalculator));
+    registry.put(new PopOperation(gasCalculator));
+    registry.put(new MLoadOperation(gasCalculator));
+    registry.put(new MStoreOperation(gasCalculator));
+    registry.put(new MStore8Operation(gasCalculator));
+    registry.put(new SLoadOperation(gasCalculator));
+    registry.put(new SStoreOperation(gasCalculator, SStoreOperation.FRONTIER_MINIMUM));
+    registry.put(new JumpOperation(gasCalculator));
+    registry.put(new JumpiOperation(gasCalculator));
+    registry.put(new PCOperation(gasCalculator));
+    registry.put(new MSizeOperation(gasCalculator));
+    registry.put(new GasOperation(gasCalculator));
+    registry.put(new JumpDestOperation(gasCalculator));
+    registry.put(new ReturnOperation(gasCalculator));
+    registry.put(new InvalidOperation(gasCalculator));
+    registry.put(new StopOperation(gasCalculator));
+    registry.put(new SelfDestructOperation(gasCalculator));
+    registry.put(new CreateOperation(gasCalculator));
+    registry.put(new CallOperation(gasCalculator));
+    registry.put(new CallCodeOperation(gasCalculator));
 
     // Register the PUSH1, PUSH2, ..., PUSH32 operations.
     for (int i = 1; i <= 32; ++i) {
-      registry.put(new PushOperation(i, gasCalculator), accountVersion);
+      registry.put(new PushOperation(i, gasCalculator));
     }
 
     // Register the DUP1, DUP2, ..., DUP16 operations.
     for (int i = 1; i <= 16; ++i) {
-      registry.put(new DupOperation(i, gasCalculator), accountVersion);
+      registry.put(new DupOperation(i, gasCalculator));
     }
 
     // Register the SWAP1, SWAP2, ..., SWAP16 operations.
     for (int i = 1; i <= 16; ++i) {
-      registry.put(new SwapOperation(i, gasCalculator), accountVersion);
+      registry.put(new SwapOperation(i, gasCalculator));
     }
 
     // Register the LOG0, LOG1, ..., LOG4 operations.
     for (int i = 0; i < 5; ++i) {
-      registry.put(new LogOperation(i, gasCalculator), accountVersion);
+      registry.put(new LogOperation(i, gasCalculator));
     }
   }
 
   private static void registerHomesteadOpcodes(
-      final OperationRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    registerFrontierOpcodes(registry, gasCalculator, accountVersion);
-    registry.put(new DelegateCallOperation(gasCalculator), accountVersion);
+      final OperationRegistry registry, final GasCalculator gasCalculator) {
+    registerFrontierOpcodes(registry, gasCalculator);
+    registry.put(new DelegateCallOperation(gasCalculator));
   }
 
   private static void registerByzantiumOpcodes(
-      final OperationRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    registerHomesteadOpcodes(registry, gasCalculator, accountVersion);
-    registry.put(new ReturnDataCopyOperation(gasCalculator), accountVersion);
-    registry.put(new ReturnDataSizeOperation(gasCalculator), accountVersion);
-    registry.put(new RevertOperation(gasCalculator), accountVersion);
-    registry.put(new StaticCallOperation(gasCalculator), accountVersion);
+      final OperationRegistry registry, final GasCalculator gasCalculator) {
+    registerHomesteadOpcodes(registry, gasCalculator);
+    registry.put(new ReturnDataCopyOperation(gasCalculator));
+    registry.put(new ReturnDataSizeOperation(gasCalculator));
+    registry.put(new RevertOperation(gasCalculator));
+    registry.put(new StaticCallOperation(gasCalculator));
   }
 
   private static void registerConstantinopleOpcodes(
-      final OperationRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    registerByzantiumOpcodes(registry, gasCalculator, accountVersion);
-    registry.put(new Create2Operation(gasCalculator), accountVersion);
-    registry.put(new SarOperation(gasCalculator), accountVersion);
-    registry.put(new ShlOperation(gasCalculator), accountVersion);
-    registry.put(new ShrOperation(gasCalculator), accountVersion);
-    registry.put(new ExtCodeHashOperation(gasCalculator), accountVersion);
+      final OperationRegistry registry, final GasCalculator gasCalculator) {
+    registerByzantiumOpcodes(registry, gasCalculator);
+    registry.put(new Create2Operation(gasCalculator));
+    registry.put(new SarOperation(gasCalculator));
+    registry.put(new ShlOperation(gasCalculator));
+    registry.put(new ShrOperation(gasCalculator));
+    registry.put(new ExtCodeHashOperation(gasCalculator));
   }
 
   private static void registerIstanbulOpcodes(
       final OperationRegistry registry,
       final GasCalculator gasCalculator,
-      final int accountVersion,
       final BigInteger chainId) {
-    registerConstantinopleOpcodes(registry, gasCalculator, accountVersion);
+    registerConstantinopleOpcodes(registry, gasCalculator);
     registry.put(
-        new ChainIdOperation(gasCalculator, Bytes32.leftPad(Bytes.of(chainId.toByteArray()))),
-        Account.DEFAULT_VERSION);
-    registry.put(new SelfBalanceOperation(gasCalculator), Account.DEFAULT_VERSION);
-    registry.put(
-        new SStoreOperation(gasCalculator, SStoreOperation.EIP_1706_MINIMUM),
-        Account.DEFAULT_VERSION);
+        new ChainIdOperation(gasCalculator, Bytes32.leftPad(Bytes.of(chainId.toByteArray()))));
+    registry.put(new SelfBalanceOperation(gasCalculator));
+    registry.put(new SStoreOperation(gasCalculator, SStoreOperation.EIP_1706_MINIMUM));
   }
 
   private static void registerLondonOpcodes(
       final OperationRegistry registry,
       final GasCalculator gasCalculator,
-      final int accountVersion,
       final BigInteger chainId) {
-    registerIstanbulOpcodes(registry, gasCalculator, accountVersion, chainId);
-    registry.put(new BaseFeeOperation(gasCalculator), Account.DEFAULT_VERSION);
+    registerIstanbulOpcodes(registry, gasCalculator, chainId);
+    registry.put(new BaseFeeOperation(gasCalculator));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetMessageCallProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetMessageCallProcessor.java
@@ -55,8 +55,7 @@ public class MainnetMessageCallProcessor extends AbstractMessageProcessor {
       transferValue(frame);
 
       // Check first if the message call is to a pre-compile contract
-      final PrecompiledContract precompile =
-          precompiles.get(frame.getContractAddress(), frame.getContractAccountVersion());
+      final PrecompiledContract precompile = precompiles.get(frame.getContractAddress());
       if (precompile != null) {
         executePrecompile(precompile, frame, operationTracer);
       } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.mainnet.precompiles.AltBN128AddPrecompiledContract;
 import org.hyperledger.besu.ethereum.mainnet.precompiles.AltBN128MulPrecompiledContract;
@@ -45,127 +44,79 @@ public abstract class MainnetPrecompiledContractRegistries {
   private MainnetPrecompiledContractRegistries() {}
 
   private static void populateForFrontier(
-      final PrecompileContractRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    registry.put(Address.ECREC, accountVersion, new ECRECPrecompiledContract(gasCalculator));
-    registry.put(Address.SHA256, accountVersion, new SHA256PrecompiledContract(gasCalculator));
-    registry.put(
-        Address.RIPEMD160, accountVersion, new RIPEMD160PrecompiledContract(gasCalculator));
-    registry.put(Address.ID, accountVersion, new IDPrecompiledContract(gasCalculator));
+      final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
+    registry.put(Address.ECREC, new ECRECPrecompiledContract(gasCalculator));
+    registry.put(Address.SHA256, new SHA256PrecompiledContract(gasCalculator));
+    registry.put(Address.RIPEMD160, new RIPEMD160PrecompiledContract(gasCalculator));
+    registry.put(Address.ID, new IDPrecompiledContract(gasCalculator));
   }
 
   public static PrecompileContractRegistry frontier(
       final PrecompiledContractConfiguration precompiledContractConfiguration) {
     final PrecompileContractRegistry registry = new PrecompileContractRegistry();
-    populateForFrontier(
-        registry, precompiledContractConfiguration.getGasCalculator(), Account.DEFAULT_VERSION);
+    populateForFrontier(registry, precompiledContractConfiguration.getGasCalculator());
     return registry;
   }
 
   private static void populateForByzantium(
-      final PrecompileContractRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    populateForFrontier(registry, gasCalculator, accountVersion);
+      final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
+    populateForFrontier(registry, gasCalculator);
     registry.put(
-        Address.MODEXP,
-        accountVersion,
-        new BigIntegerModularExponentiationPrecompiledContract(gasCalculator));
+        Address.MODEXP, new BigIntegerModularExponentiationPrecompiledContract(gasCalculator));
+    registry.put(Address.ALTBN128_ADD, AltBN128AddPrecompiledContract.byzantium(gasCalculator));
+    registry.put(Address.ALTBN128_MUL, AltBN128MulPrecompiledContract.byzantium(gasCalculator));
     registry.put(
-        Address.ALTBN128_ADD,
-        accountVersion,
-        AltBN128AddPrecompiledContract.byzantium(gasCalculator));
-    registry.put(
-        Address.ALTBN128_MUL,
-        accountVersion,
-        AltBN128MulPrecompiledContract.byzantium(gasCalculator));
-    registry.put(
-        Address.ALTBN128_PAIRING,
-        accountVersion,
-        AltBN128PairingPrecompiledContract.byzantium(gasCalculator));
+        Address.ALTBN128_PAIRING, AltBN128PairingPrecompiledContract.byzantium(gasCalculator));
   }
 
   public static PrecompileContractRegistry byzantium(
       final PrecompiledContractConfiguration precompiledContractConfiguration) {
     final PrecompileContractRegistry registry = new PrecompileContractRegistry();
-    populateForByzantium(
-        registry, precompiledContractConfiguration.getGasCalculator(), Account.DEFAULT_VERSION);
+    populateForByzantium(registry, precompiledContractConfiguration.getGasCalculator());
     return registry;
   }
 
   private static void populateForIstanbul(
-      final PrecompileContractRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    populateForByzantium(registry, gasCalculator, accountVersion);
+      final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
+    populateForByzantium(registry, gasCalculator);
+    registry.put(Address.ALTBN128_ADD, AltBN128AddPrecompiledContract.istanbul(gasCalculator));
+    registry.put(Address.ALTBN128_MUL, AltBN128MulPrecompiledContract.istanbul(gasCalculator));
     registry.put(
-        Address.ALTBN128_ADD,
-        Account.DEFAULT_VERSION,
-        AltBN128AddPrecompiledContract.istanbul(gasCalculator));
-    registry.put(
-        Address.ALTBN128_MUL,
-        Account.DEFAULT_VERSION,
-        AltBN128MulPrecompiledContract.istanbul(gasCalculator));
-    registry.put(
-        Address.ALTBN128_PAIRING,
-        Account.DEFAULT_VERSION,
-        AltBN128PairingPrecompiledContract.istanbul(gasCalculator));
-    registry.put(
-        Address.BLAKE2B_F_COMPRESSION,
-        Account.DEFAULT_VERSION,
-        new BLAKE2BFPrecompileContract(gasCalculator));
+        Address.ALTBN128_PAIRING, AltBN128PairingPrecompiledContract.istanbul(gasCalculator));
+    registry.put(Address.BLAKE2B_F_COMPRESSION, new BLAKE2BFPrecompileContract(gasCalculator));
   }
 
   public static PrecompileContractRegistry istanbul(
       final PrecompiledContractConfiguration precompiledContractConfiguration) {
     final PrecompileContractRegistry registry = new PrecompileContractRegistry();
-    populateForIstanbul(
-        registry, precompiledContractConfiguration.getGasCalculator(), Account.DEFAULT_VERSION);
+    populateForIstanbul(registry, precompiledContractConfiguration.getGasCalculator());
     return registry;
   }
 
   private static void populateForBLS12(
-      final PrecompileContractRegistry registry,
-      final GasCalculator gasCalculator,
-      final int accountVersion) {
-    populateForIstanbul(registry, gasCalculator, accountVersion);
-    registry.put(Address.BLS12_G1ADD, Account.DEFAULT_VERSION, new BLS12G1AddPrecompiledContract());
-    registry.put(Address.BLS12_G1MUL, Account.DEFAULT_VERSION, new BLS12G1MulPrecompiledContract());
-    registry.put(
-        Address.BLS12_G1MULTIEXP,
-        Account.DEFAULT_VERSION,
-        new BLS12G1MultiExpPrecompiledContract());
-    registry.put(Address.BLS12_G2ADD, Account.DEFAULT_VERSION, new BLS12G2AddPrecompiledContract());
-    registry.put(Address.BLS12_G2MUL, Account.DEFAULT_VERSION, new BLS12G2MulPrecompiledContract());
-    registry.put(
-        Address.BLS12_G2MULTIEXP,
-        Account.DEFAULT_VERSION,
-        new BLS12G2MultiExpPrecompiledContract());
-    registry.put(
-        Address.BLS12_PAIRING, Account.DEFAULT_VERSION, new BLS12PairingPrecompiledContract());
-    registry.put(
-        Address.BLS12_MAP_FP_TO_G1,
-        Account.DEFAULT_VERSION,
-        new BLS12MapFpToG1PrecompiledContract());
-    registry.put(
-        Address.BLS12_MAP_FP2_TO_G2,
-        Account.DEFAULT_VERSION,
-        new BLS12MapFp2ToG2PrecompiledContract());
+      final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
+    populateForIstanbul(registry, gasCalculator);
+    registry.put(Address.BLS12_G1ADD, new BLS12G1AddPrecompiledContract());
+    registry.put(Address.BLS12_G1MUL, new BLS12G1MulPrecompiledContract());
+    registry.put(Address.BLS12_G1MULTIEXP, new BLS12G1MultiExpPrecompiledContract());
+    registry.put(Address.BLS12_G2ADD, new BLS12G2AddPrecompiledContract());
+    registry.put(Address.BLS12_G2MUL, new BLS12G2MulPrecompiledContract());
+    registry.put(Address.BLS12_G2MULTIEXP, new BLS12G2MultiExpPrecompiledContract());
+    registry.put(Address.BLS12_PAIRING, new BLS12PairingPrecompiledContract());
+    registry.put(Address.BLS12_MAP_FP_TO_G1, new BLS12MapFpToG1PrecompiledContract());
+    registry.put(Address.BLS12_MAP_FP2_TO_G2, new BLS12MapFp2ToG2PrecompiledContract());
   }
 
   public static PrecompileContractRegistry bls12(
       final PrecompiledContractConfiguration precompiledContractConfiguration) {
     final PrecompileContractRegistry registry = new PrecompileContractRegistry();
-    populateForBLS12(
-        registry, precompiledContractConfiguration.getGasCalculator(), Account.DEFAULT_VERSION);
+    populateForBLS12(registry, precompiledContractConfiguration.getGasCalculator());
     return registry;
   }
 
   static void appendPrivacy(
       final PrecompileContractRegistry registry,
-      final PrecompiledContractConfiguration precompiledContractConfiguration,
-      final int accountVersion) {
+      final PrecompiledContractConfiguration precompiledContractConfiguration) {
 
     if (!precompiledContractConfiguration.getPrivacyParameters().isEnabled()) {
       return;
@@ -174,7 +125,6 @@ public abstract class MainnetPrecompiledContractRegistries {
     if (precompiledContractConfiguration.getPrivacyParameters().isPrivacyPluginEnabled()) {
       registry.put(
           Address.PLUGIN_PRIVACY,
-          accountVersion,
           new PrivacyPluginPrecompiledContract(
               precompiledContractConfiguration.getGasCalculator(),
               precompiledContractConfiguration.getPrivacyParameters()));
@@ -183,14 +133,12 @@ public abstract class MainnetPrecompiledContractRegistries {
         .isOnchainPrivacyGroupsEnabled()) {
       registry.put(
           Address.ONCHAIN_PRIVACY,
-          accountVersion,
           new OnChainPrivacyPrecompiledContract(
               precompiledContractConfiguration.getGasCalculator(),
               precompiledContractConfiguration.getPrivacyParameters()));
     } else {
       registry.put(
           Address.DEFAULT_PRIVACY,
-          accountVersion,
           new PrivacyPrecompiledContract(
               precompiledContractConfiguration.getGasCalculator(),
               precompiledContractConfiguration.getPrivacyParameters(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.PowAlgorithm;
 import org.hyperledger.besu.ethereum.MainnetBlockValidator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableAccount;
@@ -122,7 +121,6 @@ public abstract class MainnetProtocolSpecs {
                     messageCallProcessor,
                     false,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     FeeMarket.legacy(),
                     CoinbaseFeePriceCalculator.frontier()))
         .privateTransactionProcessorBuilder(
@@ -138,7 +136,6 @@ public abstract class MainnetProtocolSpecs {
                     messageCallProcessor,
                     false,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     new PrivateTransactionValidator(Optional.empty())))
         .difficultyCalculator(MainnetDifficultyCalculators.FRONTIER)
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator.create())
@@ -304,7 +301,6 @@ public abstract class MainnetProtocolSpecs {
                     messageCallProcessor,
                     true,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     FeeMarket.legacy(),
                     CoinbaseFeePriceCalculator.frontier()))
         .name("SpuriousDragon");
@@ -342,7 +338,6 @@ public abstract class MainnetProtocolSpecs {
                     messageCallProcessor,
                     false,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     privateTransactionValidator))
         .name("Byzantium");
   }
@@ -504,7 +499,6 @@ public abstract class MainnetProtocolSpecs {
                     messageCallProcessor,
                     true,
                     stackSizeLimit,
-                    Account.DEFAULT_VERSION,
                     londonFeeMarket,
                     CoinbaseFeePriceCalculator.eip1559()))
         .contractCreationProcessorBuilder(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -63,8 +63,6 @@ public class MainnetTransactionProcessor {
 
   protected final boolean clearEmptyAccounts;
 
-  protected final int createContractAccountVersion;
-
   protected final FeeMarket feeMarket;
   protected final CoinbaseFeePriceCalculator coinbaseFeePriceCalculator;
 
@@ -225,7 +223,6 @@ public class MainnetTransactionProcessor {
       final AbstractMessageProcessor messageCallProcessor,
       final boolean clearEmptyAccounts,
       final int maxStackSize,
-      final int createContractAccountVersion,
       final FeeMarket feeMarket,
       final CoinbaseFeePriceCalculator coinbaseFeePriceCalculator) {
     this.gasCalculator = gasCalculator;
@@ -234,7 +231,6 @@ public class MainnetTransactionProcessor {
     this.messageCallProcessor = messageCallProcessor;
     this.clearEmptyAccounts = clearEmptyAccounts;
     this.maxStackSize = maxStackSize;
-    this.createContractAccountVersion = createContractAccountVersion;
     this.feeMarket = feeMarket;
     this.coinbaseFeePriceCalculator = coinbaseFeePriceCalculator;
   }
@@ -339,7 +335,6 @@ public class MainnetTransactionProcessor {
                 .type(MessageFrame.Type.CONTRACT_CREATION)
                 .address(contractAddress)
                 .contract(contractAddress)
-                .contractAccountVersion(createContractAccountVersion)
                 .inputData(Bytes.EMPTY)
                 .code(new Code(transaction.getPayload()))
                 .build();
@@ -351,8 +346,6 @@ public class MainnetTransactionProcessor {
                 .type(MessageFrame.Type.MESSAGE_CALL)
                 .address(to)
                 .contract(to)
-                .contractAccountVersion(
-                    maybeContract.map(AccountState::getVersion).orElse(Account.DEFAULT_VERSION))
                 .inputData(transaction.getPayload())
                 .code(new Code(maybeContract.map(AccountState::getCode).orElse(Bytes.EMPTY)))
                 .build();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/PrecompileContractRegistry.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/PrecompileContractRegistry.java
@@ -16,26 +16,23 @@ package org.hyperledger.besu.ethereum.mainnet;
 
 import org.hyperledger.besu.ethereum.core.Address;
 
-import com.google.common.collect.HashBasedTable;
-import com.google.common.collect.Table;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Encapsulates a group of {@link PrecompiledContract}s used together. */
 public class PrecompileContractRegistry {
 
-  private final Table<Address, Integer, PrecompiledContract> precompiles;
+  private final Map<Address, PrecompiledContract> precompiles;
 
   public PrecompileContractRegistry() {
-    this.precompiles = HashBasedTable.create(16, 2);
+    this.precompiles = new HashMap<>(16);
   }
 
-  public PrecompiledContract get(final Address address, final int contractAccountVersion) {
-    return precompiles.get(address, contractAccountVersion);
+  public PrecompiledContract get(final Address address) {
+    return precompiles.get(address);
   }
 
-  public void put(
-      final Address address,
-      final int contractAccountVersion,
-      final PrecompiledContract precompile) {
-    precompiles.put(address, contractAccountVersion, precompile);
+  public void put(final Address address, final PrecompiledContract precompile) {
+    precompiles.put(address, precompile);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSpecBuilder.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -154,9 +153,7 @@ public class ProtocolSpecBuilder {
               precompileContractRegistryBuilder.apply(precompiledContractConfiguration);
           if (precompiledContractConfiguration.getPrivacyParameters().isEnabled()) {
             MainnetPrecompiledContractRegistries.appendPrivacy(
-                registry, precompiledContractConfiguration, Account.DEFAULT_VERSION);
-            MainnetPrecompiledContractRegistries.appendPrivacy(
-                registry, precompiledContractConfiguration, 1);
+                registry, precompiledContractConfiguration);
           }
           return registry;
         };
@@ -316,19 +313,18 @@ public class ProtocolSpecBuilder {
       if (privacyParameters.isPrivacyPluginEnabled()) {
         final PrivacyPluginPrecompiledContract privacyPluginPrecompiledContract =
             (PrivacyPluginPrecompiledContract)
-                precompileContractRegistry.get(Address.PLUGIN_PRIVACY, Account.DEFAULT_VERSION);
+                precompileContractRegistry.get(Address.PLUGIN_PRIVACY);
         privacyPluginPrecompiledContract.setPrivateTransactionProcessor(
             privateTransactionProcessor);
       } else if (privacyParameters.isOnchainPrivacyGroupsEnabled()) {
         final OnChainPrivacyPrecompiledContract onChainPrivacyPrecompiledContract =
             (OnChainPrivacyPrecompiledContract)
-                precompileContractRegistry.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION);
+                precompileContractRegistry.get(Address.ONCHAIN_PRIVACY);
         onChainPrivacyPrecompiledContract.setPrivateTransactionProcessor(
             privateTransactionProcessor);
       } else {
         final PrivacyPrecompiledContract privacyPrecompiledContract =
-            (PrivacyPrecompiledContract)
-                precompileContractRegistry.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION);
+            (PrivacyPrecompiledContract) precompileContractRegistry.get(Address.DEFAULT_PRIVACY);
         privacyPrecompiledContract.setPrivateTransactionProcessor(privateTransactionProcessor);
       }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocator.java
@@ -79,7 +79,6 @@ public class PrivateStateGenesisAllocator {
                 account.setNonce(genesisAccount.getNonce());
                 account.setBalance(Wei.fromQuantity(genesisAccount.getBalance()));
                 account.setCode(genesisAccount.getCode());
-                account.setVersion(genesisAccount.getVersion());
 
                 genesisAccount.getStorage().forEach(account::setStorageValue);
               });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
@@ -64,8 +64,6 @@ public class PrivateTransactionProcessor {
 
   private final int maxStackSize;
 
-  private final int createContractAccountVersion;
-
   @SuppressWarnings("unused")
   private final boolean clearEmptyAccounts;
 
@@ -76,7 +74,6 @@ public class PrivateTransactionProcessor {
       final AbstractMessageProcessor messageCallProcessor,
       final boolean clearEmptyAccounts,
       final int maxStackSize,
-      final int createContractAccountVersion,
       final PrivateTransactionValidator privateTransactionValidator) {
     this.gasCalculator = gasCalculator;
     this.transactionValidator = transactionValidator;
@@ -84,7 +81,6 @@ public class PrivateTransactionProcessor {
     this.messageCallProcessor = messageCallProcessor;
     this.clearEmptyAccounts = clearEmptyAccounts;
     this.maxStackSize = maxStackSize;
-    this.createContractAccountVersion = createContractAccountVersion;
     this.privateTransactionValidator = privateTransactionValidator;
   }
 
@@ -162,7 +158,6 @@ public class PrivateTransactionProcessor {
                 .type(MessageFrame.Type.CONTRACT_CREATION)
                 .address(privateContractAddress)
                 .contract(privateContractAddress)
-                .contractAccountVersion(createContractAccountVersion)
                 .inputData(Bytes.EMPTY)
                 .code(new Code(transaction.getPayload()))
                 .build();
@@ -174,8 +169,6 @@ public class PrivateTransactionProcessor {
                 .type(MessageFrame.Type.MESSAGE_CALL)
                 .address(to)
                 .contract(to)
-                .contractAccountVersion(
-                    maybeContract.map(AccountState::getVersion).orElse(Account.DEFAULT_VERSION))
                 .inputData(transaction.getPayload())
                 .code(new Code(maybeContract.map(AccountState::getCode).orElse(Bytes.EMPTY)))
                 .build();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/AbstractCallOperation.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/AbstractCallOperation.java
@@ -194,8 +194,6 @@ public abstract class AbstractCallOperation extends AbstractOperation {
               .address(address(frame))
               .originator(frame.getOriginatorAddress())
               .contract(to)
-              .contractAccountVersion(
-                  contract != null ? contract.getVersion() : Account.DEFAULT_VERSION)
               .gasPrice(frame.getGasPrice())
               .inputData(inputData)
               .sender(sender(frame))

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/Code.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/Code.java
@@ -94,7 +94,6 @@ public class Code {
       validJumpDestinations = new BitSet(getSize());
       evm.forEachOperation(
           this,
-          frame.getContractAccountVersion(),
           (final Operation op, final Integer offset) -> {
             if (op.getOpcode() == JumpDestOperation.OPCODE) {
               validJumpDestinations.set(offset);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/EVM.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/EVM.java
@@ -56,15 +56,12 @@ public class EVM {
     }
   }
 
-  void forEachOperation(
-      final Code code,
-      final int contractAccountVersion,
-      final BiConsumer<Operation, Integer> operationDelegate) {
+  void forEachOperation(final Code code, final BiConsumer<Operation, Integer> operationDelegate) {
     int pc = 0;
     final int length = code.getSize();
 
     while (pc < length) {
-      final Operation curOp = operationAtOffset(code, contractAccountVersion, pc);
+      final Operation curOp = operationAtOffset(code, pc);
       operationDelegate.accept(curOp, pc);
       pc += curOp.getOpSize();
     }
@@ -72,8 +69,7 @@ public class EVM {
 
   private void executeNextOperation(
       final MessageFrame frame, final OperationTracer operationTracer) {
-    frame.setCurrentOperation(
-        operationAtOffset(frame.getCode(), frame.getContractAccountVersion(), frame.getPC()));
+    frame.setCurrentOperation(operationAtOffset(frame.getCode(), frame.getPC()));
     operationTracer.traceExecution(
         frame,
         () -> {
@@ -128,7 +124,7 @@ public class EVM {
   }
 
   @VisibleForTesting
-  Operation operationAtOffset(final Code code, final int contractAccountVersion, final int offset) {
+  Operation operationAtOffset(final Code code, final int offset) {
     final Bytes bytecode = code.getBytes();
     // If the length of the program code is shorter than the required offset, halt execution.
     if (offset >= bytecode.size()) {
@@ -136,7 +132,7 @@ public class EVM {
     }
 
     final byte opcode = bytecode.get(offset);
-    final Operation operation = operations.get(opcode, contractAccountVersion);
+    final Operation operation = operations.get(opcode);
     if (operation == null) {
       return new InvalidOperation(opcode, null);
     } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/MessageFrame.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.vm;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Collections.emptySet;
 
@@ -222,7 +221,6 @@ public class MessageFrame {
   private final Address recipient;
   private final Address originator;
   private final Address contract;
-  private final int contractAccountVersion;
   private final Wei gasPrice;
   private final Bytes inputData;
   private final Address sender;
@@ -262,7 +260,6 @@ public class MessageFrame {
       final Address recipient,
       final Address originator,
       final Address contract,
-      final int contractAccountVersion,
       final Wei gasPrice,
       final Bytes inputData,
       final Address sender,
@@ -302,7 +299,6 @@ public class MessageFrame {
     this.recipient = recipient;
     this.originator = originator;
     this.contract = contract;
-    this.contractAccountVersion = contractAccountVersion;
     this.gasPrice = gasPrice;
     this.inputData = inputData;
     this.sender = sender;
@@ -1069,10 +1065,6 @@ public class MessageFrame {
     this.gasCost = gasCost;
   }
 
-  public int getContractAccountVersion() {
-    return contractAccountVersion;
-  }
-
   Optional<MemoryEntry> getMaybeUpdatedMemory() {
     return maybeUpdatedMemory;
   }
@@ -1096,7 +1088,6 @@ public class MessageFrame {
     private Address address;
     private Address originator;
     private Address contract;
-    private int contractAccountVersion = -1;
     private Wei gasPrice;
     private Bytes inputData;
     private Address sender;
@@ -1155,12 +1146,6 @@ public class MessageFrame {
 
     public Builder contract(final Address contract) {
       this.contract = contract;
-      return this;
-    }
-
-    public Builder contractAccountVersion(final int contractAccountVersion) {
-      checkArgument(contractAccountVersion >= 0, "Contract account version cannot be negative");
-      this.contractAccountVersion = contractAccountVersion;
       return this;
     }
 
@@ -1285,7 +1270,6 @@ public class MessageFrame {
       checkState(miningBeneficiary != null, "Missing mining beneficiary");
       checkState(blockHashLookup != null, "Missing block hash lookup");
       checkState(isPersistingPrivateState != null, "Missing isPersistingPrivateState");
-      checkState(contractAccountVersion != -1, "Missing contractAccountVersion");
     }
 
     public MessageFrame build() {
@@ -1300,7 +1284,6 @@ public class MessageFrame {
           address,
           originator,
           contract,
-          contractAccountVersion,
           gasPrice,
           inputData,
           sender,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/OperationRegistry.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/OperationRegistry.java
@@ -14,39 +14,31 @@
  */
 package org.hyperledger.besu.ethereum.vm;
 
-import com.google.common.base.Preconditions;
-
 /** Encapsulates a group of {@link Operation}s used together. */
 public class OperationRegistry {
 
   private static final int NUM_OPERATIONS = 256;
 
-  private final Operation[][] operations;
+  private final Operation[] operations;
 
   public OperationRegistry() {
-    this(1);
+    this.operations = new Operation[NUM_OPERATIONS];
   }
 
-  public OperationRegistry(final int numVersions) {
-    Preconditions.checkArgument(numVersions >= 1);
-    this.operations = new Operation[numVersions][NUM_OPERATIONS];
+  public Operation get(final byte opcode) {
+    return get(opcode & 0xff);
   }
 
-  public Operation get(final byte opcode, final int version) {
-    return get(opcode & 0xff, version);
+  public Operation get(final int opcode) {
+    return operations[opcode];
   }
 
-  public Operation get(final int opcode, final int version) {
-    return operations[version][opcode];
+  public void put(final Operation operation) {
+    operations[operation.getOpcode()] = operation;
   }
 
-  public void put(final Operation operation, final int version) {
-    operations[version][operation.getOpcode()] = operation;
-  }
-
-  public Operation getOrDefault(
-      final byte opcode, final int version, final Operation defaultOperation) {
-    final Operation operation = get(opcode, version);
+  public Operation getOrDefault(final byte opcode, final Operation defaultOperation) {
+    final Operation operation = get(opcode);
 
     if (operation == null) {
       return defaultOperation;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/operations/AbstractCreateOperation.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/operations/AbstractCreateOperation.java
@@ -131,7 +131,6 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
             .address(contractAddress)
             .originator(frame.getOriginatorAddress())
             .contract(contractAddress)
-            .contractAccountVersion(frame.getContractAccountVersion())
             .gasPrice(frame.getGasPrice())
             .inputData(Bytes.EMPTY)
             .sender(frame.getRecipientAddress())

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldState.java
@@ -134,13 +134,9 @@ public class DefaultMutableWorldState implements MutableWorldState {
   }
 
   private static Bytes serializeAccount(
-      final long nonce,
-      final Wei balance,
-      final Hash storageRoot,
-      final Hash codeHash,
-      final int version) {
+      final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
     final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(nonce, balance, storageRoot, codeHash, version);
+        new StateTrieAccountValue(nonce, balance, storageRoot, codeHash);
     return RLP.encode(accountValue::writeTo);
   }
 
@@ -304,11 +300,6 @@ public class DefaultMutableWorldState implements MutableWorldState {
     }
 
     @Override
-    public int getVersion() {
-      return accountValue.getVersion();
-    }
-
-    @Override
     public UInt256 getStorageValue(final UInt256 key) {
       return storageTrie()
           .get(Hash.hash(key))
@@ -346,7 +337,6 @@ public class DefaultMutableWorldState implements MutableWorldState {
       builder.append("balance=").append(getBalance()).append(", ");
       builder.append("storageRoot=").append(getStorageRoot()).append(", ");
       builder.append("codeHash=").append(getCodeHash()).append(", ");
-      builder.append("version=").append(getVersion());
       return builder.append("}").toString();
     }
   }
@@ -443,12 +433,7 @@ public class DefaultMutableWorldState implements MutableWorldState {
         wrapped.newAccountKeyPreimages.put(updated.getAddressHash(), updated.getAddress());
         // Lastly, save the new account.
         final Bytes account =
-            serializeAccount(
-                updated.getNonce(),
-                updated.getBalance(),
-                storageRoot,
-                codeHash,
-                updated.getVersion());
+            serializeAccount(updated.getNonce(), updated.getBalance(), storageRoot, codeHash);
 
         wrapped.accountStateTrie.put(updated.getAddressHash(), account);
       }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValue.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.worldstate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Hash;
 import org.hyperledger.besu.ethereum.core.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
@@ -31,14 +30,9 @@ public class StateTrieAccountValue {
   private final Wei balance;
   private final Hash storageRoot;
   private final Hash codeHash;
-  private final int version;
 
   public StateTrieAccountValue(
-      final long nonce,
-      final Wei balance,
-      final Hash storageRoot,
-      final Hash codeHash,
-      final int version) {
+      final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
     checkNotNull(balance, "balance cannot be null");
     checkNotNull(storageRoot, "storageRoot cannot be null");
     checkNotNull(codeHash, "codeHash cannot be null");
@@ -46,7 +40,6 @@ public class StateTrieAccountValue {
     this.balance = balance;
     this.storageRoot = storageRoot;
     this.codeHash = codeHash;
-    this.version = version;
   }
 
   /**
@@ -85,22 +78,12 @@ public class StateTrieAccountValue {
     return codeHash;
   }
 
-  /**
-   * The version of the EVM bytecode associated with this account.
-   *
-   * @return the version of the account code.
-   */
-  public int getVersion() {
-    return version;
-  }
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     final StateTrieAccountValue that = (StateTrieAccountValue) o;
     return nonce == that.nonce
-        && version == that.version
         && balance.equals(that.balance)
         && storageRoot.equals(that.storageRoot)
         && codeHash.equals(that.codeHash);
@@ -108,7 +91,7 @@ public class StateTrieAccountValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(nonce, balance, storageRoot, codeHash, version);
+    return Objects.hash(nonce, balance, storageRoot, codeHash);
   }
 
   public void writeTo(final RLPOutput out) {
@@ -118,11 +101,6 @@ public class StateTrieAccountValue {
     out.writeUInt256Scalar(balance);
     out.writeBytes(storageRoot);
     out.writeBytes(codeHash);
-
-    if (version != Account.DEFAULT_VERSION) {
-      // version of zero is never written out.
-      out.writeIntScalar(version);
-    }
 
     out.endList();
   }
@@ -134,15 +112,9 @@ public class StateTrieAccountValue {
     final Wei balance = Wei.of(in.readUInt256Scalar());
     final Hash storageRoot = Hash.wrap(in.readBytes32());
     final Hash codeHash = Hash.wrap(in.readBytes32());
-    final int version;
-    if (!in.isEndOfCurrentList()) {
-      version = in.readIntScalar();
-    } else {
-      version = Account.DEFAULT_VERSION;
-    }
 
     in.leaveList();
 
-    return new StateTrieAccountValue(nonce, balance, storageRoot, codeHash, version);
+    return new StateTrieAccountValue(nonce, balance, storageRoot, codeHash);
   }
 }

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -174,7 +174,6 @@ public class BlockDataGenerator {
       if (random.nextFloat() < percentContractAccounts) {
         // Some percentage of accounts are contract accounts
         account.setCode(bytesValue(5, 50));
-        account.setVersion(Account.DEFAULT_VERSION);
         if (random.nextFloat() < percentContractAccountsWithNonEmptyStorage) {
           // Add some storage for contract accounts
           final int storageValues = random.nextInt(20) + 10;

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/MessageFrameTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/MessageFrameTestFixture.java
@@ -44,7 +44,6 @@ public class MessageFrameTestFixture {
   private Address sender = DEFAUT_ADDRESS;
   private Address originator = DEFAUT_ADDRESS;
   private Address contract = DEFAUT_ADDRESS;
-  private int contractAccountVersion = Account.DEFAULT_VERSION;
   private Wei gasPrice = Wei.ZERO;
   private Wei value = Wei.ZERO;
   private Bytes inputData = Bytes.EMPTY;
@@ -111,11 +110,6 @@ public class MessageFrameTestFixture {
     return this;
   }
 
-  public MessageFrameTestFixture contractAccountVersion(final int contractAccountVersion) {
-    this.contractAccountVersion = contractAccountVersion;
-    return this;
-  }
-
   public MessageFrameTestFixture gasPrice(final Wei gasPrice) {
     this.gasPrice = gasPrice;
     return this;
@@ -175,7 +169,6 @@ public class MessageFrameTestFixture {
             .value(value)
             .apparentValue(value)
             .contract(contract)
-            .contractAccountVersion(contractAccountVersion)
             .code(code)
             .blockHeader(blockHeader)
             .depth(depth)

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TestCodeExecutor.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TestCodeExecutor.java
@@ -43,10 +43,7 @@ public class TestCodeExecutor {
   }
 
   public MessageFrame executeCode(
-      final String code,
-      final int accountVersion,
-      final long gasLimit,
-      final Consumer<MutableAccount> accountSetup) {
+      final String code, final long gasLimit, final Consumer<MutableAccount> accountSetup) {
     final ProtocolSpec protocolSpec = fixture.getProtocolSchedule().getByBlockNumber(0);
     final WorldUpdater worldState =
         createInitialWorldState(accountSetup, fixture.getStateArchive());
@@ -78,7 +75,6 @@ public class TestCodeExecutor {
             .address(SENDER_ADDRESS)
             .originator(SENDER_ADDRESS)
             .contract(SENDER_ADDRESS)
-            .contractAccountVersion(accountVersion)
             .gasPrice(transaction.getGasPrice().get())
             .inputData(transaction.getPayload())
             .sender(SENDER_ADDRESS)

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/GenesisStateTest.java
@@ -88,8 +88,8 @@ public final class GenesisStateTest {
     assertThat(header.getParentHash()).isEqualTo(Hash.ZERO);
   }
 
-  private void assertContractInvariants(
-      final String sourceFile, final String blockHash, final int version) throws Exception {
+  private void assertContractInvariants(final String sourceFile, final String blockHash)
+      throws Exception {
     final GenesisState genesisState =
         GenesisState.fromJson(
             Resources.toString(GenesisStateTest.class.getResource(sourceFile), Charsets.UTF_8),
@@ -102,7 +102,6 @@ public final class GenesisStateTest {
     final Account contract =
         worldState.get(Address.fromHexString("0x3850000000000000000000000000000000000000"));
     assertThat(contract.getCode()).isEqualTo(Bytes.fromHexString(EXPECTED_CODE));
-    assertThat(contract.getVersion()).isEqualTo(version);
     assertStorageValue(
         contract,
         "c2575a0e9e593c00f959f8c92f12db2869c3395a3b0502d05e2516446f71f85d",
@@ -116,13 +115,7 @@ public final class GenesisStateTest {
   @Test
   public void createFromJsonWithContract() throws Exception {
     assertContractInvariants(
-        "genesis3.json", "0xe7fd8db206dcaf066b7c97b8a42a0abc18653613560748557ab44868652a78b6", 0);
-  }
-
-  @Test
-  public void createFromJsonWithVersion() throws Exception {
-    assertContractInvariants(
-        "genesis4.json", "0x3224ddae856381f5fb67492b4561ecbc0cb1e9e50e6cf3238f6e049fe95a8604", 1);
+        "genesis3.json", "0xe7fd8db206dcaf066b7c97b8a42a0abc18653613560748557ab44868652a78b6");
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistriesTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.OnChainPrivacyPrecompiledContract;
@@ -44,13 +43,12 @@ public class MainnetPrecompiledContractRegistriesTest {
     when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(false);
     when(privacyParameters.isEnabled()).thenReturn(true);
 
-    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    appendPrivacy(reg, config);
     verify(privacyParameters).isEnabled();
     verify(privacyParameters).isOnchainPrivacyGroupsEnabled();
 
-    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION))
-        .isInstanceOf(PrivacyPrecompiledContract.class);
-    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+    assertThat(reg.get(Address.DEFAULT_PRIVACY)).isInstanceOf(PrivacyPrecompiledContract.class);
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY)).isNull();
   }
 
   @Test
@@ -58,24 +56,24 @@ public class MainnetPrecompiledContractRegistriesTest {
     when(privacyParameters.isOnchainPrivacyGroupsEnabled()).thenReturn(true);
     when(privacyParameters.isEnabled()).thenReturn(true);
 
-    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    appendPrivacy(reg, config);
     verify(privacyParameters).isEnabled();
     verify(privacyParameters).isOnchainPrivacyGroupsEnabled();
 
-    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION))
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY))
         .isInstanceOf(OnChainPrivacyPrecompiledContract.class);
-    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+    assertThat(reg.get(Address.DEFAULT_PRIVACY)).isNull();
   }
 
   @Test
   public void whenPrivacyNotEnabled_noPrivacyPrecompileInRegistry() {
     when(privacyParameters.isEnabled()).thenReturn(false);
 
-    appendPrivacy(reg, config, Account.DEFAULT_VERSION);
+    appendPrivacy(reg, config);
     verify(privacyParameters).isEnabled();
     verifyNoMoreInteractions(privacyParameters);
 
-    assertThat(reg.get(Address.ONCHAIN_PRIVACY, Account.DEFAULT_VERSION)).isNull();
-    assertThat(reg.get(Address.DEFAULT_PRIVACY, Account.DEFAULT_VERSION)).isNull();
+    assertThat(reg.get(Address.ONCHAIN_PRIVACY)).isNull();
+    assertThat(reg.get(Address.DEFAULT_PRIVACY)).isNull();
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -65,7 +64,6 @@ public class MainnetTransactionProcessorTest {
             messageCallProcessor,
             false,
             MAX_STACK_SIZE,
-            Account.DEFAULT_VERSION,
             FeeMarket.legacy(),
             CoinbaseFeePriceCalculator.frontier());
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/AbstractPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/AbstractPrecompiledContractTest.java
@@ -16,7 +16,6 @@
 
 package org.hyperledger.besu.ethereum.mainnet.precompiles;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.mainnet.IstanbulGasCalculator;
@@ -37,6 +36,6 @@ public class AbstractPrecompiledContractTest {
             .apply(
                 new PrecompiledContractConfiguration(
                     new IstanbulGasCalculator(), PrivacyParameters.DEFAULT))
-            .get(precompiledAddress, Account.DEFAULT_VERSION);
+            .get(precompiledAddress);
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/Benchmarks.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/Benchmarks.java
@@ -72,7 +72,6 @@ public class Benchmarks {
           .code(new Code(Bytes.EMPTY))
           .depth(1)
           .completer(__ -> {})
-          .contractAccountVersion(0)
           .address(Address.ZERO)
           .blockHashLookup(mock(BlockHashLookup.class))
           .blockHeader(mock(ProcessableBlockHeader.class))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
@@ -66,11 +66,6 @@ public class PrivateStateGenesisAllocatorTest {
                 }
 
                 @Override
-                public int getVersion() {
-                  return 0;
-                }
-
-                @Override
                 public Long getNonce() {
                   return 0L;
                 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProviderTest.java
@@ -85,8 +85,7 @@ public class WorldStateProofProviderTest {
     // Define account value
     final Hash codeHash = Hash.hash(Bytes.fromHexString("0x1122"));
     final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(
-            1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash, 0);
+        new StateTrieAccountValue(1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash);
     // Save to storage
     worldStateTrie.put(addressHash, RLP.encode(accountValue::writeTo));
     worldStateTrie.commit(updater::putAccountStateTrieNode);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/EVMTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/EVMTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.vm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyByte;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.mainnet.FrontierGasCalculator;
@@ -32,7 +31,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class EVMTest {
 
-  private static final int CONTRACT_ACCOUNT_VERSION = 1;
   @Mock private OperationRegistry operationRegistry;
   private final GasCalculator gasCalculator = new FrontierGasCalculator();
   private EVM evm;
@@ -45,8 +43,7 @@ public class EVMTest {
   @Test
   public void assertThatEndOfScriptNotExplicitlySetInCodeReturnsAVirtualOperation() {
     final Code code = new Code(Bytes.fromHexString("0x60203560003555606035604035556000"));
-    final Operation operation =
-        evm.operationAtOffset(code, CONTRACT_ACCOUNT_VERSION, code.getSize());
+    final Operation operation = evm.operationAtOffset(code, code.getSize());
     assertThat(operation).isNotNull();
     assertThat(operation.isVirtualOperation()).isTrue();
   }
@@ -54,10 +51,8 @@ public class EVMTest {
   @Test
   public void assertThatEndOfScriptExplicitlySetInCodeDoesNotReturnAVirtualOperation() {
     final Code code = new Code(Bytes.fromHexString("0x6020356000355560603560403555600000"));
-    when(operationRegistry.get(anyByte(), eq(CONTRACT_ACCOUNT_VERSION)))
-        .thenReturn(new StopOperation(gasCalculator));
-    final Operation operation =
-        evm.operationAtOffset(code, CONTRACT_ACCOUNT_VERSION, code.getSize() - 1);
+    when(operationRegistry.get(anyByte())).thenReturn(new StopOperation(gasCalculator));
+    final Operation operation = evm.operationAtOffset(code, code.getSize() - 1);
     assertThat(operation).isNotNull();
     assertThat(operation.isVirtualOperation()).isFalse();
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/VMReferenceTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/VMReferenceTest.java
@@ -122,7 +122,6 @@ public class VMReferenceTest extends AbstractRetryingTest {
             .code(execEnv.getCode())
             .blockHeader(execEnv.getBlockHeader())
             .depth(execEnv.getDepth())
-            .contractAccountVersion(execEnv.getVersion())
             .completer(c -> {})
             .miningBeneficiary(execEnv.getBlockHeader().getCoinbase())
             .blockHashLookup(new BlockHashLookup(execEnv.getBlockHeader(), blockchain))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/ConstantinopleSStoreOperationGasCostTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/ConstantinopleSStoreOperationGasCostTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.vm.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.TestCodeExecutor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
@@ -87,7 +86,6 @@ public class ConstantinopleSStoreOperationGasCostTest {
     final MessageFrame frame =
         codeExecutor.executeCode(
             code,
-            Account.DEFAULT_VERSION,
             gasLimit,
             account -> account.setStorageValue(UInt256.ZERO, UInt256.valueOf(originalValue)));
     assertThat(frame.getState()).isEqualTo(State.COMPLETED_SUCCESS);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/Create2OperationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/Create2OperationTest.java
@@ -143,7 +143,6 @@ public class Create2OperationTest {
             .code(new Code(codeBytes))
             .depth(1)
             .completer(__ -> {})
-            .contractAccountVersion(0)
             .address(Address.fromHexString(sender))
             .blockHashLookup(mock(BlockHashLookup.class))
             .blockHeader(mock(ProcessableBlockHeader.class))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/ExtCodeHashOperationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/ExtCodeHashOperationTest.java
@@ -19,7 +19,6 @@ import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider
 import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -104,7 +103,6 @@ public class ExtCodeHashOperationTest {
     final Bytes code = Bytes.fromHexString("0xabcdef");
     final MutableAccount account = worldStateUpdater.getOrCreate(REQUESTED_ADDRESS).getMutable();
     account.setCode(code);
-    account.setVersion(Account.DEFAULT_VERSION);
     assertThat(executeOperation(REQUESTED_ADDRESS)).isEqualTo(Hash.hash(code));
   }
 
@@ -114,7 +112,6 @@ public class ExtCodeHashOperationTest {
     final Bytes code = Bytes.fromHexString("0xabcdef");
     final MutableAccount account = worldStateUpdater.getOrCreate(REQUESTED_ADDRESS).getMutable();
     account.setCode(code);
-    account.setVersion(Account.DEFAULT_VERSION);
     final UInt256 value =
         UInt256.fromBytes(Words.fromAddress(REQUESTED_ADDRESS))
             .add(UInt256.valueOf(2).pow(UInt256.valueOf(160)));

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/JumpOperationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/JumpOperationTest.java
@@ -74,8 +74,8 @@ public class JumpOperationTest {
     worldStateUpdater.commit();
 
     final OperationRegistry registry = new OperationRegistry();
-    registry.put(new JumpOperation(gasCalculator), 0);
-    registry.put(new JumpDestOperation(gasCalculator), 0);
+    registry.put(new JumpOperation(gasCalculator));
+    registry.put(new JumpDestOperation(gasCalculator));
     evm = new EVM(registry, gasCalculator);
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/LondonSStoreOperationGasCostTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/LondonSStoreOperationGasCostTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.vm.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Gas;
 import org.hyperledger.besu.ethereum.core.TestCodeExecutor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
@@ -88,7 +87,6 @@ public class LondonSStoreOperationGasCostTest {
     final MessageFrame frame =
         codeExecutor.executeCode(
             code,
-            Account.DEFAULT_VERSION,
             gasLimit,
             account -> account.setStorageValue(UInt256.ZERO, UInt256.valueOf(originalValue)));
     assertThat(frame.getState()).isEqualTo(State.COMPLETED_SUCCESS);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldStateTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldStateTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.worldstate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldState;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.AccountStorageEntry;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.Hash;
@@ -579,11 +578,9 @@ public class DefaultMutableWorldStateTest {
     final MutableAccount account = updater.createAccount(ADDRESS).getMutable();
     account.setBalance(Wei.of(100000));
     account.setCode(Bytes.of(1, 2, 3));
-    account.setVersion(Account.DEFAULT_VERSION);
     account.setCode(Bytes.of(3, 2, 1));
     updater.commit();
     assertThat(worldState.get(ADDRESS).getCode()).isEqualTo(Bytes.of(3, 2, 1));
-    assertThat(worldState.get(ADDRESS).getVersion()).isEqualTo(Account.DEFAULT_VERSION);
     assertThat(worldState.rootHash())
         .isEqualTo(
             Hash.fromHexString(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValueTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValueTest.java
@@ -27,50 +27,22 @@ import org.junit.Test;
 public class StateTrieAccountValueTest {
 
   @Test
-  public void roundTripMainNetAccountValueVersionZero() {
+  public void roundTripMainNetAccountValue() {
     final long nonce = 0;
     final Wei balance = Wei.ZERO;
     // Have the storageRoot and codeHash as different values to ensure the encode / decode
     // doesn't cross the values over.
     final Hash storageRoot = Hash.EMPTY_TRIE_HASH;
     final Hash codeHash = Hash.EMPTY_LIST_HASH;
-    final int version = 0;
 
-    roundTripMainNetAccountValue(nonce, balance, storageRoot, codeHash, version);
-  }
-
-  @Test
-  public void roundTripMainNetAccountValueVersionNotZero() {
-    final long nonce = 0;
-    final Wei balance = Wei.ZERO;
-    final Hash storageRoot = Hash.EMPTY_TRIE_HASH;
-    final Hash codeHash = Hash.EMPTY_LIST_HASH;
-    final int version = 1;
-
-    roundTripMainNetAccountValue(nonce, balance, storageRoot, codeHash, version);
-  }
-
-  @Test
-  public void roundTripMainNetAccountValueMax() {
-    final long nonce = (Long.MAX_VALUE >> 1);
-    final Wei balance =
-        Wei.fromHexString("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
-    final Hash storageRoot = Hash.EMPTY_TRIE_HASH;
-    final Hash codeHash = Hash.EMPTY_LIST_HASH;
-    final int version = Integer.MAX_VALUE;
-
-    roundTripMainNetAccountValue(nonce, balance, storageRoot, codeHash, version);
+    roundTripMainNetAccountValue(nonce, balance, storageRoot, codeHash);
   }
 
   private void roundTripMainNetAccountValue(
-      final long nonce,
-      final Wei balance,
-      final Hash storageRoot,
-      final Hash codeHash,
-      final int version) {
+      final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
 
     StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(nonce, balance, storageRoot, codeHash, version);
+        new StateTrieAccountValue(nonce, balance, storageRoot, codeHash);
     Bytes encoded = RLP.encode(accountValue::writeTo);
     final RLPInput in = RLP.input(encoded);
     StateTrieAccountValue roundTripAccountValue = StateTrieAccountValue.readFrom(in);
@@ -79,6 +51,5 @@ public class StateTrieAccountValueTest {
     assertThat(balance).isEqualTo(roundTripAccountValue.getBalance());
     assertThat(storageRoot).isEqualTo(roundTripAccountValue.getStorageRoot());
     assertThat(codeHash).isEqualTo(roundTripAccountValue.getCodeHash());
-    assertThat(version).isEqualTo(roundTripAccountValue.getVersion());
   }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommand.java
@@ -18,7 +18,6 @@ package org.hyperledger.besu.evmtool;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import org.hyperledger.besu.cli.config.NetworkName;
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
@@ -245,7 +244,6 @@ public class EvmToolCommand implements Runnable {
                 .completer(c -> {})
                 .miningBeneficiary(blockHeader.getCoinbase())
                 .blockHashLookup(new BlockHashLookup(blockHeader, component.getBlockchain()))
-                .contractAccountVersion(Account.DEFAULT_VERSION)
                 .build());
 
         final MainnetMessageCallProcessor mcp =

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EnvironmentInformation.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/EnvironmentInformation.java
@@ -15,7 +15,6 @@
  */
 package org.hyperledger.besu.ethereum.referencetests;
 
-import org.hyperledger.besu.ethereum.core.Account;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Gas;
@@ -48,8 +47,6 @@ public class EnvironmentInformation {
 
   private final Code code;
 
-  private final int version;
-
   private final Bytes data;
 
   private final int depth;
@@ -75,7 +72,6 @@ public class EnvironmentInformation {
    * @param origin The sender address of the original transaction. message call instruction or
    *     transaction.
    * @param value The deposited value by the instruction/transaction responsible for this execution.
-   * @param version the account version of the account
    */
   @SuppressWarnings("unused") // jackson reflected constructor
   @JsonCreator
@@ -88,8 +84,7 @@ public class EnvironmentInformation {
       @JsonProperty("gas") final String gas,
       @JsonProperty("gasPrice") final String gasPrice,
       @JsonProperty("origin") final String origin,
-      @JsonProperty("value") final String value,
-      @JsonProperty("version") final String version) {
+      @JsonProperty("value") final String value) {
     this(
         code,
         0,
@@ -100,8 +95,7 @@ public class EnvironmentInformation {
         data == null ? null : Bytes.fromHexString(data),
         value == null ? null : Wei.fromHexString(value),
         gasPrice == null ? null : Wei.fromHexString(gasPrice),
-        gas == null ? null : Gas.fromHexString(gas),
-        version == null ? Account.DEFAULT_VERSION : Integer.decode(version));
+        gas == null ? null : Gas.fromHexString(gas));
   }
 
   private EnvironmentInformation(
@@ -114,8 +108,7 @@ public class EnvironmentInformation {
       final Bytes data,
       final Wei value,
       final Wei gasPrice,
-      final Gas gas,
-      final int version) {
+      final Gas gas) {
     this.code = code;
     this.depth = depth;
     this.accountAddress = accountAddress;
@@ -126,7 +119,6 @@ public class EnvironmentInformation {
     this.value = value;
     this.gasPrice = gasPrice;
     this.gas = gas;
-    this.version = version;
   }
 
   /**
@@ -237,15 +229,6 @@ public class EnvironmentInformation {
     return originAddress;
   }
 
-  /**
-   * Returns the account version.
-   *
-   * @return the account version.
-   */
-  public int getVersion() {
-    return version;
-  }
-
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
@@ -261,9 +244,7 @@ public class EnvironmentInformation {
         .append("\nBlock header: \n  ")
         .append(blockHeader.toString().replaceAll("\n", "\n  "))
         .append("\nCaller: ")
-        .append(callerAddress)
-        .append("\nVersion: ")
-        .append(version);
+        .append(callerAddress);
 
     return builder.toString();
   }

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
@@ -41,7 +41,6 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
     private final long nonce;
     private final Wei balance;
     private final Bytes code;
-    private final int version;
     private final Map<UInt256, UInt256> storage;
 
     private static Map<UInt256, UInt256> parseStorage(final Map<String, String> values) {
@@ -56,17 +55,11 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
         @JsonProperty("nonce") final String nonce,
         @JsonProperty("balance") final String balance,
         @JsonProperty("storage") final Map<String, String> storage,
-        @JsonProperty("code") final String code,
-        @JsonProperty("version") final String version) {
+        @JsonProperty("code") final String code) {
       this.nonce = Long.decode(nonce);
       this.balance = Wei.fromHexString(balance);
       this.code = Bytes.fromHexString(code);
       this.storage = parseStorage(storage);
-      if (version != null) {
-        this.version = Integer.decode(version);
-      } else {
-        this.version = 0;
-      }
     }
 
     public long getNonce() {
@@ -81,10 +74,6 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
       return code;
     }
 
-    public int getVersion() {
-      return version;
-    }
-
     public Map<UInt256, UInt256> getStorage() {
       return storage;
     }
@@ -96,7 +85,6 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
     account.setNonce(toCopy.getNonce());
     account.setBalance(toCopy.getBalance());
     account.setCode(toCopy.getCode());
-    account.setVersion(toCopy.getVersion());
     for (final Map.Entry<UInt256, UInt256> entry : toCopy.getStorage().entrySet()) {
       account.setStorageValue(entry.getKey(), entry.getValue());
     }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'OR7Vv5zfD/qRVBs601gbEVLctGjQYNnL80iPja83+ag='
+  knownHash = 'dIKkR29FARmuawnqoO0BVlVqyrDWb6WRgQu9cfAb+o8='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/PrivacyGenesisAccount.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/PrivacyGenesisAccount.java
@@ -35,13 +35,6 @@ public interface PrivacyGenesisAccount {
   Map<UInt256, UInt256> getStorage();
 
   /**
-   * The version for the account.
-   *
-   * @return the version of the code being set
-   */
-  int getVersion();
-
-  /**
    * The initial nonce assigned to the account.
    *
    * @return the nonce


### PR DESCRIPTION
EIP-1702 versioning was a candidate for the Istanbul hard fork but was
removed prior to the first testnet. Other versioning techniques have
greater core dev mind share and one preparatory step landed in London,
EIP-3541, making EIP-1702 very unlikely to make it to mainnet.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).