### PR TITLE
Expose args in PicoCLIOptions

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
@@ -59,8 +59,14 @@ public class PicoCLIOptionsImpl implements PicoCLIOptions {
   }
 
   @Override
-  public Map<String, Object> getArgs() {
+  public <T> T getCommandLineArg(final Class<T> clazz, final String arg) {
+    return clazz.cast(getCommandLineArgs().get(arg));
+  }
+
+  @Override
+  public Map<String, Object> getCommandLineArgs() {
     return commandLine.getCommandSpec().options().stream()
+        .filter(x -> x.longestName() != null && x.getValue() != null)
         .collect(Collectors.toMap(OptionSpec::longestName, CommandLine.Model.ArgSpec::getValue));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
@@ -16,6 +16,9 @@ package org.hyperledger.besu.services;
 
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
@@ -53,5 +56,11 @@ public class PicoCLIOptionsImpl implements PicoCLIOptions {
     } else {
       commandLine.getCommandSpec().addMixin("Plugin " + namespace, mixin);
     }
+  }
+
+  @Override
+  public Map<String, Object> getArgs() {
+    return commandLine.getCommandSpec().options().stream()
+        .collect(Collectors.toMap(OptionSpec::longestName, CommandLine.Model.ArgSpec::getValue));
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import picocli.CommandLine;
@@ -31,6 +33,9 @@ public class PicoCLIOptionsImplTest {
 
     @Option(names = "--existing")
     String existingOption = "defaultexisting";
+
+    @Option(names = "--existing-int")
+    int existingIntOption = 42;
   }
 
   static final class MixinOptions {
@@ -78,5 +83,22 @@ public class PicoCLIOptionsImplTest {
   public void testNotExistantOptionsFail() {
     assertThatExceptionOfType(UnmatchedArgumentException.class)
         .isThrownBy(() -> commandLine.parseArgs("--does-not-exist", "1"));
+  }
+
+  @Test
+  public void getArgsReturnsValuesSetOnCommandLine() {
+    commandLine.parseArgs("--existing", "1", "--plugin-Test1-mixin", "2", "--existing-int", "100");
+    Map<String, Object> args = serviceImpl.getArgs();
+    assertThat(args.get("--existing")).isEqualTo("1");
+    assertThat(args.get("--existing-int")).isEqualTo(100);
+    assertThat(args.get("--plugin-Test1-mixin")).isEqualTo("2");
+  }
+
+  @Test
+  public void getArgsReturnsDefaultValues() {
+    Map<String, Object> args = serviceImpl.getArgs();
+    assertThat(args.get("--existing")).isEqualTo("defaultexisting");
+    assertThat(args.get("--existing-int")).isEqualTo(42);
+    assertThat(args.get("--plugin-Test1-mixin")).isEqualTo("defaultmixin");
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/PicoCLIOptionsImplTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
@@ -36,6 +37,9 @@ public class PicoCLIOptionsImplTest {
 
     @Option(names = "--existing-int")
     int existingIntOption = 42;
+
+    @Option(names = "--null-entry")
+    List<String> nullOption = null;
   }
 
   static final class MixinOptions {
@@ -88,7 +92,7 @@ public class PicoCLIOptionsImplTest {
   @Test
   public void getArgsReturnsValuesSetOnCommandLine() {
     commandLine.parseArgs("--existing", "1", "--plugin-Test1-mixin", "2", "--existing-int", "100");
-    Map<String, Object> args = serviceImpl.getArgs();
+    Map<String, Object> args = serviceImpl.getCommandLineArgs();
     assertThat(args.get("--existing")).isEqualTo("1");
     assertThat(args.get("--existing-int")).isEqualTo(100);
     assertThat(args.get("--plugin-Test1-mixin")).isEqualTo("2");
@@ -96,9 +100,21 @@ public class PicoCLIOptionsImplTest {
 
   @Test
   public void getArgsReturnsDefaultValues() {
-    Map<String, Object> args = serviceImpl.getArgs();
+    Map<String, Object> args = serviceImpl.getCommandLineArgs();
     assertThat(args.get("--existing")).isEqualTo("defaultexisting");
     assertThat(args.get("--existing-int")).isEqualTo(42);
     assertThat(args.get("--plugin-Test1-mixin")).isEqualTo("defaultmixin");
+  }
+
+  @Test
+  public void nullEntriesAreRemoved() {
+    Map<String, Object> args = serviceImpl.getCommandLineArgs();
+    assertThat(args.containsKey("--null-entry")).isEqualTo(false);
+  }
+
+  @Test
+  public void canSupportGenericType() {
+    int arg = serviceImpl.getCommandLineArg(Integer.class, "--existing-int");
+    assertThat(arg).isEqualTo(42);
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '1qg546WrFgIslMCYwBVrahqCLMdawPuhEGUHnHCkPfU='
+  knownHash = 'R7GQqUJObtALhevH17mxtmho1goY9Nr0ixYi26fGihA='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'zpv92JZmlU6gPifGcPG5ATE6Lv/ruWdJtjLk3EVXO4g='
+  knownHash = '1qg546WrFgIslMCYwBVrahqCLMdawPuhEGUHnHCkPfU='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PicoCLIOptions.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PicoCLIOptions.java
@@ -39,5 +39,7 @@ public interface PicoCLIOptions extends BesuService {
    */
   void addPicoCLIOptions(String namespace, Object optionObject);
 
-  Map<String, Object> getArgs();
+  <T> T getCommandLineArg(Class<T> clazz, String arg);
+
+  Map<String, Object> getCommandLineArgs();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PicoCLIOptions.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PicoCLIOptions.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin.services;
 
+import java.util.Map;
+
 /**
  * A service that plugins can use to add CLI options and commands to the BesuCommand. The PicoCLI
  * library annotations will be inspected and the object will be passed into a
@@ -36,4 +38,6 @@ public interface PicoCLIOptions extends BesuService {
    *     of this object to extract the CLI options.
    */
   void addPicoCLIOptions(String namespace, Object optionObject);
+
+  Map<String, Object> getArgs();
 }


### PR DESCRIPTION
## PR description

Allow plugins to see what arguments were used to start besu.

Form inside a plugin I need to be able to get access to arguments that were used to start besu, specifically 

`--rpc-http-port`
`--rpc-http-enabled`
`--rpc-http-tls-enabled`


## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).