### PR TITLE
Remove duplicate AddOperation on MainnetEvmRegistries

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetEvmRegistries.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetEvmRegistries.java
@@ -155,7 +155,6 @@ abstract class MainnetEvmRegistries {
   private static void registerFrontierOpcodes(
       final OperationRegistry registry, final GasCalculator gasCalculator) {
     registry.put(new AddOperation(gasCalculator));
-    registry.put(new AddOperation(gasCalculator));
     registry.put(new MulOperation(gasCalculator));
     registry.put(new SubOperation(gasCalculator));
     registry.put(new DivOperation(gasCalculator));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
While familiarizing myself with the EVM code, I noticed that there is a duplicate `AddOperation` being added to the `MainnetEvmRegistries`. The `MainnetEvmRegistries#put()` function just assigns the operation to a map using the operation's opcode so removing this duplicate line has no effect on the EVM itself as it was just overwriting the previous line.

## Fixed Issue(s)


## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).