### PR TITLE
A plugin implementer may register the payload provider in start or register

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2138,8 +2138,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
       if (unstablePrivacyPluginOptions.isPrivacyPluginEnabled()
           && privacyPluginPluginService.getPayloadProvider() == null) {
-        throw new ParameterException(
-            commandLine, "Privacy Plugin must be registered when enabling privacy plugin!");
+        // The plugin may register the payload provider in start or register.
+        // At this point we have only called start.
+        logger.warn(
+            "No Payload Provider has been provided. You must register one when enabling privacy plugin!");
       }
 
       if (unstablePrivacyPluginOptions.isPrivacyPluginEnabled() && isFlexiblePrivacyGroupsEnabled) {


### PR DESCRIPTION
## PR description

When registering a PrivacyPluginService you need to call setPayloadProvider before blocks get mined. You have two opportunities to do this, once when besu calls register in your plugin and once when besu calls start in your plugin.

Ideally, you would setPayloadProvider when register is called. That way Besu can confirm that you've set the various command line options correctly in BesuCommand. But the problem is when Besu calls register it hasn't yet parsed the command line args into. So if you've got some cli arguments set in your plugin they will not be populated yet.


## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).