### PR TITLE
Eth66 protocol request id changes should only apply to the Eth protocol

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
@@ -169,4 +169,8 @@ public class EthProtocol implements SubProtocol {
     public static final int V65 = 65;
     public static final int V66 = 66;
   }
+
+  public static boolean isEth66Compatible(final Capability capability) {
+    return capability.getName().equals(NAME) && capability.getVersion() >= ETH66.getVersion();
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocol.java
@@ -171,6 +171,6 @@ public class EthProtocol implements SubProtocol {
   }
 
   public static boolean isEth66Compatible(final Capability capability) {
-    return capability.getName().equals(NAME) && capability.getVersion() >= ETH66.getVersion();
+    return NAME.equals(capability.getName()) && capability.getVersion() >= ETH66.getVersion();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -108,7 +108,10 @@ public class EthPeer {
 
     final boolean supportsRequestId =
         getAgreedCapabilities().stream()
-            .anyMatch(capability -> capability.compareTo(EthProtocol.ETH66) >= 0);
+            .anyMatch(
+                capability ->
+                    EthProtocol.NAME.equals(capability.getName())
+                        && capability.compareTo(EthProtocol.ETH66) >= 0);
     this.headersRequestManager = new RequestManager(this, supportsRequestId);
     this.bodiesRequestManager = new RequestManager(this, supportsRequestId);
     this.receiptsRequestManager = new RequestManager(this, supportsRequestId);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -107,11 +107,7 @@ public class EthPeer {
     fullyValidated.set(peerValidators.isEmpty());
 
     final boolean supportsRequestId =
-        getAgreedCapabilities().stream()
-            .anyMatch(
-                capability ->
-                    EthProtocol.NAME.equals(capability.getName())
-                        && capability.compareTo(EthProtocol.ETH66) >= 0);
+        getAgreedCapabilities().stream().anyMatch(EthProtocol::isEth66Compatible);
     this.headersRequestManager = new RequestManager(this, supportsRequestId);
     this.bodiesRequestManager = new RequestManager(this, supportsRequestId);
     this.receiptsRequestManager = new RequestManager(this, supportsRequestId);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/EthProtocolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/EthProtocolTest.java
@@ -38,4 +38,9 @@ public class EthProtocolTest {
     assertThat(EthProtocol.isEth66Compatible(Capability.create("istanbul", 66))).isFalse();
     assertThat(EthProtocol.isEth66Compatible(Capability.create("istanbul", 100))).isFalse();
   }
+
+  @Test
+  public void eth66CheckWithNullNameReturnsFalse() {
+    assertThat(EthProtocol.isEth66Compatible(Capability.create(null, 1))).isFalse();
+  }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/EthProtocolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/EthProtocolTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
+
+import org.junit.Test;
+
+public class EthProtocolTest {
+
+  @Test
+  public void eth66CheckShouldReturnTrueForCompatibleProtocols() {
+    assertThat(EthProtocol.isEth66Compatible(EthProtocol.ETH66)).isTrue();
+  }
+
+  @Test
+  public void eth66CheckShouldReturnFalseForIncompatibleProtocols() {
+    assertThat(EthProtocol.isEth66Compatible(EthProtocol.ETH62)).isFalse();
+    assertThat(EthProtocol.isEth66Compatible(EthProtocol.ETH63)).isFalse();
+    assertThat(EthProtocol.isEth66Compatible(EthProtocol.ETH64)).isFalse();
+    assertThat(EthProtocol.isEth66Compatible(EthProtocol.ETH65)).isFalse();
+
+    assertThat(EthProtocol.isEth66Compatible(Capability.create("IBF", 1))).isFalse();
+    assertThat(EthProtocol.isEth66Compatible(Capability.create("istanbul", 66))).isFalse();
+    assertThat(EthProtocol.isEth66Compatible(Capability.create("istanbul", 100))).isFalse();
+  }
+}

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/Capability.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/Capability.java
@@ -22,15 +22,13 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Represents a client capability.
  *
  * @see <a href= "https://github.com/ethereum/devp2p/blob/master/devp2p.md">Capability wire
  *     format</a>
  */
-public class Capability implements Comparable<Capability> {
+public class Capability {
   private final String name;
   private final int version;
 
@@ -86,10 +84,5 @@ public class Capability implements Comparable<Capability> {
   @Override
   public String toString() {
     return name + "/" + version;
-  }
-
-  @Override
-  public int compareTo(@NotNull final Capability that) {
-    return Integer.compare(this.getVersion(), that.getVersion());
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Besu using the instanbul/99 or instanbul/100 incorrectly encodes messages with a requestId from eth66.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #2682

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).