### PR TITLE
ignore all unknown fields for eth_call and eth_estimateGas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added Labelled gauges for metrics [#2646](https://github.com/hyperledger/besu/pull/2646)
 - support for `eth/66` networking protocol [#2365](https://github.com/hyperledger/besu/pull/2365)
 - update RPC methods for post london 1559 transaction [#2535](https://github.com/hyperledger/besu/pull/2535)
+- Ignore `type` when supplied to eth_estimateGas or eth_call. [\#2690](https://github.com/hyperledger/besu/pull/2690)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Added Labelled gauges for metrics [#2646](https://github.com/hyperledger/besu/pull/2646)
 - support for `eth/66` networking protocol [#2365](https://github.com/hyperledger/besu/pull/2365)
 - update RPC methods for post london 1559 transaction [#2535](https://github.com/hyperledger/besu/pull/2535)
-- Ignore `type` when supplied to eth_estimateGas or eth_call. [\#2690](https://github.com/hyperledger/besu/pull/2690)
+- Ignore all unknown fields when supplied to eth_estimateGas or eth_call. [\#2690](https://github.com/hyperledger/besu/pull/2690)
 
 
 ### Bug Fixes

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.tuweni.bytes.Bytes;
 
-@JsonIgnoreProperties({"nonce", "privateFor", "timestamp"})
+@JsonIgnoreProperties({"nonce", "privateFor", "timestamp", "type"})
 public class JsonCallParameter extends CallParameter {
 
   private final Optional<Boolean> strict;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.tuweni.bytes.Bytes;
 
-@JsonIgnoreProperties({"nonce", "privateFor", "timestamp", "type"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class JsonCallParameter extends CallParameter {
 
   private final Optional<Boolean> strict;


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Changed to ignore all unknown fields in JsonCallParameter. This matches geth's behaviour. Different third-party libraries send through extra fields from time to time, for example
ethers.js 5.4.2 sends eth_estimateGas with a `type` parameter which Besu was rejecting.

```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "type" (class org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter), not marked as ignorable (11 known properties: "gasPrice", "value", "gasLimit", "gas", "from", "to", "maxFeePerGas", "strict", "maxPriorityFeePerGas", "payload", "data"])
at [Source: (StringReader); line: 1, column: 42492] (through reference chain: org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter["type"])
```

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).