### PR TITLE
Move QBFT CMS creation to block creator

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 // too hard to coordinate with the state machine).
 public class BftBlockCreator extends AbstractBlockCreator {
 
-  protected final BftExtraDataCodec bftExtraDataCodec;
+  private final BftExtraDataCodec bftExtraDataCodec;
 
   public BftBlockCreator(
       final Address localAddress,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
@@ -34,7 +34,7 @@ import java.util.function.Supplier;
 // too hard to coordinate with the state machine).
 public class BftBlockCreator extends AbstractBlockCreator {
 
-  private final BftExtraDataCodec bftExtraDataCodec;
+  protected final BftExtraDataCodec bftExtraDataCodec;
 
   public BftBlockCreator(
       final Address localAddress,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreatorFactory.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreatorFactory.java
@@ -43,17 +43,17 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class BftBlockCreatorFactory {
 
-  protected final AbstractPendingTransactionsSorter pendingTransactions;
+  private final AbstractPendingTransactionsSorter pendingTransactions;
   protected final ProtocolContext protocolContext;
   protected final ProtocolSchedule protocolSchedule;
   protected final BftExtraDataCodec bftExtraDataCodec;
-  protected final Address localAddress;
-  protected final Address miningBeneficiary;
+  private final Address localAddress;
+  final Address miningBeneficiary;
 
   protected volatile Bytes vanityData;
-  protected volatile Wei minTransactionGasPrice;
-  protected volatile Double minBlockOccupancyRatio;
-  protected volatile Optional<AtomicLong> targetGasLimit;
+  private volatile Wei minTransactionGasPrice;
+  private volatile Double minBlockOccupancyRatio;
+  private volatile Optional<AtomicLong> targetGasLimit;
 
   public BftBlockCreatorFactory(
       final AbstractPendingTransactionsSorter pendingTransactions,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreatorFactory.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreatorFactory.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.consensus.common.bft.Vote;
 import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
 import org.hyperledger.besu.consensus.common.validator.ValidatorVote;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
@@ -42,17 +43,17 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class BftBlockCreatorFactory {
 
-  private final AbstractPendingTransactionsSorter pendingTransactions;
+  protected final AbstractPendingTransactionsSorter pendingTransactions;
   protected final ProtocolContext protocolContext;
   protected final ProtocolSchedule protocolSchedule;
   protected final BftExtraDataCodec bftExtraDataCodec;
-  private final Address localAddress;
-  final Address miningBeneficiary;
+  protected final Address localAddress;
+  protected final Address miningBeneficiary;
 
   protected volatile Bytes vanityData;
-  private volatile Wei minTransactionGasPrice;
-  private volatile Double minBlockOccupancyRatio;
-  private volatile Optional<AtomicLong> targetGasLimit;
+  protected volatile Wei minTransactionGasPrice;
+  protected volatile Double minBlockOccupancyRatio;
+  protected volatile Optional<AtomicLong> targetGasLimit;
 
   public BftBlockCreatorFactory(
       final AbstractPendingTransactionsSorter pendingTransactions,
@@ -74,7 +75,7 @@ public class BftBlockCreatorFactory {
     this.targetGasLimit = miningParams.getTargetGasLimit();
   }
 
-  public BftBlockCreator create(final BlockHeader parentHeader, final int round) {
+  public BlockCreator create(final BlockHeader parentHeader, final int round) {
     return new BftBlockCreator(
         localAddress,
         () -> targetGasLimit.map(AtomicLong::longValue),

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRound.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.BftHelpers;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
 import org.hyperledger.besu.consensus.common.bft.RoundTimer;
-import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Commit;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
@@ -33,6 +32,7 @@ import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -54,7 +54,7 @@ public class IbftRound {
 
   private final Subscribers<MinedBlockObserver> observers;
   private final RoundState roundState;
-  private final BftBlockCreator blockCreator;
+  private final BlockCreator blockCreator;
   private final ProtocolContext protocolContext;
   private final BlockImporter blockImporter;
   private final NodeKey nodeKey;
@@ -64,7 +64,7 @@ public class IbftRound {
 
   public IbftRound(
       final RoundState roundState,
-      final BftBlockCreator blockCreator,
+      final BlockCreator blockCreator,
       final ProtocolContext protocolContext,
       final BlockImporter blockImporter,
       final Subscribers<MinedBlockObserver> observers,

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundFactory.java
@@ -16,13 +16,13 @@ package org.hyperledger.besu.consensus.ibft.statemachine;
 
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
-import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
 import org.hyperledger.besu.consensus.common.bft.statemachine.BftFinalState;
 import org.hyperledger.besu.consensus.ibft.network.IbftMessageTransmitter;
 import org.hyperledger.besu.consensus.ibft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.ibft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -74,7 +74,7 @@ public class IbftRoundFactory {
   public IbftRound createNewRoundWithState(
       final BlockHeader parentHeader, final RoundState roundState) {
     final ConsensusRoundIdentifier roundIdentifier = roundState.getRoundIdentifier();
-    final BftBlockCreator blockCreator =
+    final BlockCreator blockCreator =
         blockCreatorFactory.create(parentHeader, roundIdentifier.getRoundNumber());
 
     final IbftMessageTransmitter messageTransmitter =

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
@@ -67,7 +67,7 @@ public class PkiQbftBlockCreator implements BlockCreator {
 
     checkArgument(
         bftExtraDataCodec instanceof PkiQbftExtraDataCodec,
-        "PkiQbftCreateBlockForProposalBehaviour must use PkiQbftExtraDataCodec");
+        "PkiQbftBlockCreator must use PkiQbftExtraDataCodec");
     this.pkiQbftExtraDataCodec = (PkiQbftExtraDataCodec) bftExtraDataCodec;
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
@@ -12,49 +12,53 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
-package org.hyperledger.besu.consensus.qbft.pki;
+package org.hyperledger.besu.consensus.qbft.blockcreation;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
-import org.hyperledger.besu.consensus.qbft.statemachine.CreateBlockForProposalBehaviour;
+import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraData;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.Hash;
+import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.pki.cms.CmsCreator;
+
+import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 
-public class PkiQbftCreateBlockForProposalBehaviour implements CreateBlockForProposalBehaviour {
-
+public class PkiQbftBlockCreator implements BlockCreator {
   private static final Logger LOG = LogManager.getLogger();
 
   private final BlockCreator blockCreator;
+  private final PkiQbftExtraDataCodec pkiQbftExtraDataCodec;
   private final CmsCreator cmsCreator;
-  private final PkiQbftExtraDataCodec bftExtraDataCodec;
 
-  public PkiQbftCreateBlockForProposalBehaviour(
+  public PkiQbftBlockCreator(
       final BlockCreator blockCreator,
       final PkiBlockCreationConfiguration pkiBlockCreationConfiguration,
-      final BftExtraDataCodec bftExtraDataCodec) {
+      final PkiQbftExtraDataCodec pkiQbftExtraDataCodec) {
     this(
         blockCreator,
         new CmsCreator(
             pkiBlockCreationConfiguration.getKeyStore(),
             pkiBlockCreationConfiguration.getCertificateAlias()),
-        bftExtraDataCodec);
+        pkiQbftExtraDataCodec);
   }
 
   @VisibleForTesting
-  PkiQbftCreateBlockForProposalBehaviour(
+  public PkiQbftBlockCreator(
       final BlockCreator blockCreator,
       final CmsCreator cmsCreator,
       final BftExtraDataCodec bftExtraDataCodec) {
@@ -64,30 +68,37 @@ public class PkiQbftCreateBlockForProposalBehaviour implements CreateBlockForPro
     checkArgument(
         bftExtraDataCodec instanceof PkiQbftExtraDataCodec,
         "PkiQbftCreateBlockForProposalBehaviour must use PkiQbftExtraDataCodec");
-    this.bftExtraDataCodec = (PkiQbftExtraDataCodec) bftExtraDataCodec;
+    this.pkiQbftExtraDataCodec = (PkiQbftExtraDataCodec) bftExtraDataCodec;
   }
 
   @Override
-  public Block create(final long headerTimeStampSeconds) {
-    final Block block = blockCreator.createBlock(headerTimeStampSeconds);
+  public Block createBlock(final long timestamp) {
+    final Block block = blockCreator.createBlock(timestamp);
+    return replaceCmsInBlock(block);
+  }
+
+  @Override
+  public Block createBlock(
+      final List<Transaction> transactions, final List<BlockHeader> ommers, final long timestamp) {
+    final Block block = blockCreator.createBlock(transactions, ommers, timestamp);
     return replaceCmsInBlock(block);
   }
 
   private Block replaceCmsInBlock(final Block block) {
     final BlockHeader blockHeader = block.getHeader();
     final Hash hashWithoutCms =
-        PkiQbftBlockHeaderFunctions.forCmsSignature(bftExtraDataCodec).hash(block.getHeader());
+        PkiQbftBlockHeaderFunctions.forCmsSignature(pkiQbftExtraDataCodec).hash(block.getHeader());
 
     final Bytes cms = cmsCreator.create(hashWithoutCms);
 
-    final BftExtraData previousExtraData = bftExtraDataCodec.decode(blockHeader);
+    final BftExtraData previousExtraData = pkiQbftExtraDataCodec.decode(blockHeader);
     final BftExtraData substituteExtraData = new PkiQbftExtraData(previousExtraData, cms);
-    final Bytes substituteExtraDataBytes = bftExtraDataCodec.encode(substituteExtraData);
+    final Bytes substituteExtraDataBytes = pkiQbftExtraDataCodec.encode(substituteExtraData);
 
     final BlockHeaderBuilder headerBuilder = BlockHeaderBuilder.fromHeader(blockHeader);
     headerBuilder
         .extraData(substituteExtraDataBytes)
-        .blockHeaderFunctions(BftBlockHeaderFunctions.forCommittedSeal(bftExtraDataCodec));
+        .blockHeaderFunctions(BftBlockHeaderFunctions.forCommittedSeal(pkiQbftExtraDataCodec));
     final BlockHeader newHeader = headerBuilder.buildBlockHeader();
 
     LOG.debug("Created CMS with signed hash {} for block {}", hashWithoutCms, newHeader.getHash());

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreator.java
@@ -48,7 +48,7 @@ public class PkiQbftBlockCreator implements BlockCreator {
   public PkiQbftBlockCreator(
       final BlockCreator blockCreator,
       final PkiBlockCreationConfiguration pkiBlockCreationConfiguration,
-      final PkiQbftExtraDataCodec pkiQbftExtraDataCodec) {
+      final BftExtraDataCodec pkiQbftExtraDataCodec) {
     this(
         blockCreator,
         new CmsCreator(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
 import org.hyperledger.besu.consensus.qbft.QbftContext;
-import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Address;
@@ -65,9 +64,7 @@ public class QbftBlockCreatorFactory extends BftBlockCreatorFactory {
       return blockCreator;
     } else {
       return new PkiQbftBlockCreator(
-          blockCreator,
-          qbftContext.getPkiBlockCreationConfiguration().get(),
-          (PkiQbftExtraDataCodec) bftExtraDataCodec);
+          blockCreator, qbftContext.getPkiBlockCreationConfiguration().get(), bftExtraDataCodec);
     }
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.consensus.qbft.blockcreation;
 import org.hyperledger.besu.consensus.common.ConsensusHelpers;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
-import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
 import org.hyperledger.besu.consensus.qbft.QbftContext;
 import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
@@ -31,7 +30,6 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Collections;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -61,26 +59,13 @@ public class QbftBlockCreatorFactory extends BftBlockCreatorFactory {
 
   @Override
   public BlockCreator create(final BlockHeader parentHeader, final int round) {
-    final BftBlockCreator bftBlockCreator =
-        new BftBlockCreator(
-            localAddress,
-            () -> targetGasLimit.map(AtomicLong::longValue),
-            ph -> createExtraData(round, ph),
-            pendingTransactions,
-            protocolContext,
-            protocolSchedule,
-            minTransactionGasPrice,
-            minBlockOccupancyRatio,
-            parentHeader,
-            miningBeneficiary,
-            bftExtraDataCodec);
-
+    final BlockCreator blockCreator = super.create(parentHeader, round);
     final QbftContext qbftContext = protocolContext.getConsensusState(QbftContext.class);
     if (qbftContext.getPkiBlockCreationConfiguration().isEmpty()) {
-      return bftBlockCreator;
+      return blockCreator;
     } else {
       return new PkiQbftBlockCreator(
-          bftBlockCreator,
+          blockCreator,
           qbftContext.getPkiBlockCreationConfiguration().get(),
           (PkiQbftExtraDataCodec) bftExtraDataCodec);
     }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
@@ -17,8 +17,12 @@ package org.hyperledger.besu.consensus.qbft.blockcreation;
 import org.hyperledger.besu.consensus.common.ConsensusHelpers;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
+import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
+import org.hyperledger.besu.consensus.qbft.QbftContext;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
@@ -27,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -52,6 +57,33 @@ public class QbftBlockCreatorFactory extends BftBlockCreatorFactory {
         miningBeneficiary,
         bftExtraDataCodec);
     this.extraDataWithRoundInformationOnly = extraDataWithRoundInformationOnly;
+  }
+
+  @Override
+  public BlockCreator create(final BlockHeader parentHeader, final int round) {
+    final BftBlockCreator bftBlockCreator =
+        new BftBlockCreator(
+            localAddress,
+            () -> targetGasLimit.map(AtomicLong::longValue),
+            ph -> createExtraData(round, ph),
+            pendingTransactions,
+            protocolContext,
+            protocolSchedule,
+            minTransactionGasPrice,
+            minBlockOccupancyRatio,
+            parentHeader,
+            miningBeneficiary,
+            bftExtraDataCodec);
+
+    final QbftContext qbftContext = protocolContext.getConsensusState(QbftContext.class);
+    if (qbftContext.getPkiBlockCreationConfiguration().isEmpty()) {
+      return bftBlockCreator;
+    } else {
+      return new PkiQbftBlockCreator(
+          bftBlockCreator,
+          qbftContext.getPkiBlockCreationConfiguration().get(),
+          (PkiQbftExtraDataCodec) bftExtraDataCodec);
+    }
   }
 
   @Override

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiQbftExtraData.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/pki/PkiQbftExtraData.java
@@ -40,7 +40,7 @@ public class PkiQbftExtraData extends BftExtraData {
     this.cms = cms;
   }
 
-  PkiQbftExtraData(final BftExtraData bftExtraData, final Bytes cms) {
+  public PkiQbftExtraData(final BftExtraData bftExtraData, final Bytes cms) {
     this(
         bftExtraData.getVanityData(),
         bftExtraData.getSeals(),

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundFactory.java
@@ -16,15 +16,13 @@ package org.hyperledger.besu.consensus.qbft.statemachine;
 
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
-import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
 import org.hyperledger.besu.consensus.common.bft.statemachine.BftFinalState;
-import org.hyperledger.besu.consensus.qbft.QbftContext;
 import org.hyperledger.besu.consensus.qbft.network.QbftMessageTransmitter;
 import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
-import org.hyperledger.besu.consensus.qbft.pki.PkiQbftCreateBlockForProposalBehaviour;
 import org.hyperledger.besu.consensus.qbft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -76,23 +74,11 @@ public class QbftRoundFactory {
   public QbftRound createNewRoundWithState(
       final BlockHeader parentHeader, final RoundState roundState) {
     final ConsensusRoundIdentifier roundIdentifier = roundState.getRoundIdentifier();
-    final BftBlockCreator blockCreator = blockCreatorFactory.create(parentHeader, 0);
+    final BlockCreator blockCreator = blockCreatorFactory.create(parentHeader, 0);
 
     // TODO(tmm): Why is this created everytime?!
     final QbftMessageTransmitter messageTransmitter =
         new QbftMessageTransmitter(messageFactory, finalState.getValidatorMulticaster());
-
-    final QbftContext qbftContext = protocolContext.getConsensusState(QbftContext.class);
-    final CreateBlockForProposalBehaviour createBlockForProposalBehaviour;
-    if (qbftContext.getPkiBlockCreationConfiguration().isPresent()) {
-      createBlockForProposalBehaviour =
-          new PkiQbftCreateBlockForProposalBehaviour(
-              blockCreator,
-              qbftContext.getPkiBlockCreationConfiguration().get(),
-              bftExtraDataCodec);
-    } else {
-      createBlockForProposalBehaviour = blockCreator::createBlock;
-    }
 
     return new QbftRound(
         roundState,
@@ -104,7 +90,6 @@ public class QbftRoundFactory {
         messageFactory,
         messageTransmitter,
         finalState.getRoundTimer(),
-        bftExtraDataCodec,
-        createBlockForProposalBehaviour);
+        bftExtraDataCodec);
   }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -1,18 +1,17 @@
 /*
- *  Copyright ConsenSys AG.
+ * Copyright ConsenSys AG.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- *  the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- *  specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * SPDX-License-Identifier: Apache-2.0
  */
-
 package org.hyperledger.besu.consensus.qbft.blockcreation;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -1,22 +1,19 @@
 /*
- * Copyright ConsenSys AG.
+ *  Copyright ConsenSys AG.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with
- * the License. You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See
- *  the License for the
- * specific language governing permissions and limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0
+ *  SPDX-License-Identifier: Apache-2.0
  */
 
-package org.hyperledger.besu.consensus.qbft.pki;
+package org.hyperledger.besu.consensus.qbft.blockcreation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +27,9 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.consensus.common.bft.BftBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftBlockHeaderFunctions;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraData;
+import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -44,13 +44,13 @@ import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 
-public class PkiQbftCreateBlockForProposalBehaviourTest {
+public class PkiQbftBlockCreatorTest {
 
   private final PkiQbftExtraDataCodec extraDataCodec = new PkiQbftExtraDataCodec();
 
   private BlockCreator blockCreator;
   private CmsCreator cmsCreator;
-  private PkiQbftCreateBlockForProposalBehaviour createBlockForProposalBehaviour;
+  private PkiQbftBlockCreator pkiQbftBlockCreator;
   private BlockHeaderTestFixture blockHeaderBuilder;
 
   @Before
@@ -58,8 +58,7 @@ public class PkiQbftCreateBlockForProposalBehaviourTest {
     blockCreator = mock(BlockCreator.class);
     cmsCreator = mock(CmsCreator.class);
 
-    createBlockForProposalBehaviour =
-        new PkiQbftCreateBlockForProposalBehaviour(blockCreator, cmsCreator, extraDataCodec);
+    pkiQbftBlockCreator = new PkiQbftBlockCreator(blockCreator, cmsCreator, extraDataCodec);
 
     blockHeaderBuilder = new BlockHeaderTestFixture();
   }
@@ -67,9 +66,7 @@ public class PkiQbftCreateBlockForProposalBehaviourTest {
   @Test
   public void createProposalBehaviourWithNonPkiCodecFails() {
     assertThatThrownBy(
-            () ->
-                new PkiQbftCreateBlockForProposalBehaviour(
-                    blockCreator, cmsCreator, new QbftExtraDataCodec()))
+            () -> new PkiQbftBlockCreator(blockCreator, cmsCreator, new QbftExtraDataCodec()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "PkiQbftCreateBlockForProposalBehaviour must use PkiQbftExtraDataCodec");
@@ -82,7 +79,7 @@ public class PkiQbftCreateBlockForProposalBehaviourTest {
     final Bytes cms = Bytes.random(32);
     when(cmsCreator.create(any(Bytes.class))).thenReturn(cms);
 
-    final Block proposedBlock = createBlockForProposalBehaviour.create(1L);
+    final Block proposedBlock = pkiQbftBlockCreator.createBlock(1L);
 
     final PkiQbftExtraData proposedBlockExtraData =
         (PkiQbftExtraData) extraDataCodec.decodeRaw(proposedBlock.getHeader().getExtraData());
@@ -98,7 +95,7 @@ public class PkiQbftCreateBlockForProposalBehaviourTest {
 
     when(cmsCreator.create(any(Bytes.class))).thenReturn(Bytes.random(32));
 
-    createBlockForProposalBehaviour.create(1L);
+    pkiQbftBlockCreator.createBlock(1L);
 
     verify(cmsCreator).create(eq(expectedHashForCmsCreation));
   }
@@ -108,7 +105,7 @@ public class PkiQbftCreateBlockForProposalBehaviourTest {
     createBlockBeingProposed();
     when(cmsCreator.create(any(Bytes.class))).thenReturn(Bytes.random(32));
 
-    final Block blockWithCms = createBlockForProposalBehaviour.create(1L);
+    final Block blockWithCms = pkiQbftBlockCreator.createBlock(1L);
 
     final Hash expectedBlockHash =
         BftBlockHeaderFunctions.forCommittedSeal(extraDataCodec).hash(blockWithCms.getHeader());

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -67,8 +67,7 @@ public class PkiQbftBlockCreatorTest {
     assertThatThrownBy(
             () -> new PkiQbftBlockCreator(blockCreator, cmsCreator, new QbftExtraDataCodec()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "PkiQbftCreateBlockForProposalBehaviour must use PkiQbftExtraDataCodec");
+        .hasMessageContaining("PkiQbftBlockCreator must use PkiQbftExtraDataCodec");
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Move the CMS creation out of the QbftRound and into a QBFT block creator.

This allows the CMS to be only created the once per block regardless of how many rounds and removes the need for a proposal block behaviour in the qbft round.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).