### PR TITLE
Cleanup metrics connections after idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@
 
 ### Bug Fixes
 - Consider effective price and effective priority fee in transaction replacement rules [\#2529](https://github.com/hyperledger/besu/issues/2529)
-- GetTransactionCount should return the latest transaction count if it is greater than the transaction pool [\#2633](https://github.com/hyperledger/besu/pull/2633) 
+- GetTransactionCount should return the latest transaction count if it is greater than the transaction pool [\#2633](https://github.com/hyperledger/besu/pull/2633)
+- Set an idle timeout for metrics connections, to clean up ports when no longer used.
 
 ### Early Access Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### Bug Fixes
 - Consider effective price and effective priority fee in transaction replacement rules [\#2529](https://github.com/hyperledger/besu/issues/2529)
 - GetTransactionCount should return the latest transaction count if it is greater than the transaction pool [\#2633](https://github.com/hyperledger/besu/pull/2633)
-- Set an idle timeout for metrics connections, to clean up ports when no longer used.
+- Set an idle timeout for metrics connections, to clean up ports when no longer used [\#2748](https://github.com/hyperledger/besu/pull/2748)
 
 ### Early Access Features
 

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -84,6 +84,7 @@ public class MetricsHttpService implements MetricsService {
             new HttpServerOptions()
                 .setHost(config.getHost())
                 .setPort(config.getPort())
+                .setIdleTimeout(60)
                 .setHandle100ContinueAutomatically(true)
                 .setCompressionSupported(true));
 


### PR DESCRIPTION
When metrics are in use in teku (which uses besu metrics), and the prometheus service restarts, connections can be left open and never closed.

These connections should close after an idle timeout to avoid causing issues with running out of ports.

Reported in teku issue https://github.com/ConsenSys/teku/issues/4327 .

Signed-off-by: Paul Harris <paul.harris@consensys.net>

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).