### PR TITLE
Metrics idle timeout is now configurable

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
@@ -24,13 +24,22 @@ import picocli.CommandLine;
 
 public class MetricsCLIOptions implements CLIOptions<MetricsConfiguration.Builder> {
   private static final String TIMERS_ENABLED_FLAG = "--Xmetrics-timers-enabled";
+  private static final String IDLE_TIMEOUT_FLAG = "--Xmetrics-idle-timeout";
 
   @CommandLine.Option(
       names = TIMERS_ENABLED_FLAG,
       hidden = true,
       defaultValue = "true",
       description = "Whether to enable timer metrics (default: ${DEFAULT-VALUE}).")
-  private Boolean timersEnabled = MetricsConfiguration.DEFAULT_TIMERS_ENABLED;
+  private Boolean timersEnabled = MetricsConfiguration.DEFAULT_METRICS_TIMERS_ENABLED;
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {IDLE_TIMEOUT_FLAG},
+      paramLabel = "<INTEGER>",
+      description = "Timeout for metrics TCP connections, in seconds (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private int idleTimeout = MetricsConfiguration.DEFAULT_METRICS_IDLE_TIMEOUT_SECONDS;
 
   private MetricsCLIOptions() {}
 
@@ -41,16 +50,19 @@ public class MetricsCLIOptions implements CLIOptions<MetricsConfiguration.Builde
   public static MetricsCLIOptions fromConfiguration(final MetricsConfiguration config) {
     final MetricsCLIOptions metricsOptions = create();
     metricsOptions.timersEnabled = config.isTimersEnabled();
+    metricsOptions.idleTimeout = config.getIdleTimeout();
     return metricsOptions;
   }
 
   @Override
   public MetricsConfiguration.Builder toDomainObject() {
-    return MetricsConfiguration.builder().timersEnabled(timersEnabled);
+    return MetricsConfiguration.builder().timersEnabled(timersEnabled).idleTimeout(idleTimeout);
   }
 
   @Override
   public List<String> getCLIOptions() {
-    return Arrays.asList(TIMERS_ENABLED_FLAG + "=" + timersEnabled.toString());
+    return Arrays.asList(
+        TIMERS_ENABLED_FLAG + "=" + timersEnabled.toString(),
+        IDLE_TIMEOUT_FLAG + "=" + idleTimeout);
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsCLIOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsCLIOptionsTest.java
@@ -28,7 +28,8 @@ public class MetricsCLIOptionsTest
   @Override
   MetricsConfiguration.Builder createCustomizedDomainObject() {
     return MetricsConfiguration.builder()
-        .timersEnabled(!MetricsConfiguration.DEFAULT_TIMERS_ENABLED);
+        .timersEnabled(!MetricsConfiguration.DEFAULT_METRICS_TIMERS_ENABLED)
+        .idleTimeout(MetricsConfiguration.DEFAULT_METRICS_IDLE_TIMEOUT_SECONDS);
   }
 
   @Override

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsConfiguration.java
@@ -34,7 +34,8 @@ public class MetricsConfiguration {
   private static final MetricsProtocol DEFAULT_METRICS_PROTOCOL = MetricsProtocol.PROMETHEUS;
   private static final String DEFAULT_METRICS_PUSH_HOST = "127.0.0.1";
   public static final int DEFAULT_METRICS_PUSH_PORT = 9001;
-  public static final Boolean DEFAULT_TIMERS_ENABLED = true;
+  public static final Boolean DEFAULT_METRICS_TIMERS_ENABLED = true;
+  public static final int DEFAULT_METRICS_IDLE_TIMEOUT_SECONDS = 60;
 
   private final boolean enabled;
   private final MetricsProtocol protocol;
@@ -49,6 +50,7 @@ public class MetricsConfiguration {
   private final String prometheusJob;
   private final List<String> hostsAllowlist;
   private final boolean timersEnabled;
+  private final int idleTimeout;
 
   public static Builder builder() {
     return new Builder();
@@ -66,7 +68,8 @@ public class MetricsConfiguration {
       final int pushInterval,
       final String prometheusJob,
       final List<String> hostsAllowlist,
-      final boolean timersEnabled) {
+      final boolean timersEnabled,
+      final int idleTimeout) {
     this.enabled = enabled;
     this.port = port;
     this.protocol = protocol;
@@ -79,6 +82,7 @@ public class MetricsConfiguration {
     this.prometheusJob = prometheusJob;
     this.hostsAllowlist = hostsAllowlist;
     this.timersEnabled = timersEnabled;
+    this.idleTimeout = idleTimeout;
   }
 
   public boolean isEnabled() {
@@ -143,6 +147,10 @@ public class MetricsConfiguration {
     return timersEnabled;
   }
 
+  public int getIdleTimeout() {
+    return idleTimeout;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -157,6 +165,8 @@ public class MetricsConfiguration {
         .add("pushInterval", pushInterval)
         .add("prometheusJob", prometheusJob)
         .add("hostsAllowlist", hostsAllowlist)
+        .add("timersEnabled", timersEnabled)
+        .add("idleTimeout", idleTimeout)
         .toString();
   }
 
@@ -179,7 +189,9 @@ public class MetricsConfiguration {
         && Objects.equals(metricCategories, that.metricCategories)
         && Objects.equals(pushHost, that.pushHost)
         && Objects.equals(prometheusJob, that.prometheusJob)
-        && Objects.equals(hostsAllowlist, that.hostsAllowlist);
+        && Objects.equals(hostsAllowlist, that.hostsAllowlist)
+        && timersEnabled == that.timersEnabled
+        && idleTimeout == that.idleTimeout;
   }
 
   @Override
@@ -195,7 +207,9 @@ public class MetricsConfiguration {
         pushHost,
         pushInterval,
         prometheusJob,
-        hostsAllowlist);
+        hostsAllowlist,
+        timersEnabled,
+        idleTimeout);
   }
 
   public static class Builder {
@@ -210,7 +224,8 @@ public class MetricsConfiguration {
     private int pushInterval = 15;
     private String prometheusJob = "besu-client";
     private List<String> hostsAllowlist = Arrays.asList("localhost", "127.0.0.1");
-    private boolean timersEnabled = DEFAULT_TIMERS_ENABLED;
+    private boolean timersEnabled = DEFAULT_METRICS_TIMERS_ENABLED;
+    private int idleTimeout = DEFAULT_METRICS_IDLE_TIMEOUT_SECONDS;
 
     private Builder() {}
 
@@ -281,6 +296,11 @@ public class MetricsConfiguration {
       return this;
     }
 
+    public Builder idleTimeout(final int idleTimeout) {
+      this.idleTimeout = idleTimeout;
+      return this;
+    }
+
     public MetricsConfiguration build() {
       return new MetricsConfiguration(
           enabled,
@@ -294,7 +314,8 @@ public class MetricsConfiguration {
           pushInterval,
           prometheusJob,
           hostsAllowlist,
-          timersEnabled);
+          timersEnabled,
+          idleTimeout);
     }
   }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -84,7 +84,7 @@ public class MetricsHttpService implements MetricsService {
             new HttpServerOptions()
                 .setHost(config.getHost())
                 .setPort(config.getPort())
-                .setIdleTimeout(60)
+                .setIdleTimeout(config.getIdleTimeout())
                 .setHandle100ContinueAutomatically(true)
                 .setCompressionSupported(true));
 


### PR DESCRIPTION
## PR description
#2748 introduced a timeout for metrics TCP connections. With this PR user can set a value in seconds for that timeout.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).