### PR TITLE
Exclude qbft reference-test resources from spotless check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ allprojects {
     java {
       // This path needs to be relative to each project
       target '**/src/*/java/**/*.java'
+      targetExclude '**/src/reference-test/resources/**'
       removeUnusedImports()
       googleJavaFormat('1.10.0')
       importOrder 'org.hyperledger', 'java', ''


### PR DESCRIPTION
## PR description

Exclude qbft reference-test resources from spotless check as it was causing an error on a fresh build

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).