### PR TITLE
Proposal for breaking change to the way plugins load cli options

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -120,6 +120,7 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
   private boolean isDnsEnabled = false;
   private Optional<Integer> exitCode = Optional.empty();
   private Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration = Optional.empty();
+  private final boolean signPmtWithPlugin;
 
   public BesuNode(
       final String name,
@@ -148,9 +149,11 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
       final Optional<PrivacyParameters> privacyParameters,
       final List<String> runCommand,
       final Optional<KeyPair> keyPair,
-      final Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration)
+      final Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration,
+      final boolean signPmtWithPlugin)
       throws IOException {
     this.homeDirectory = dataPath.orElseGet(BesuNode::createTmpDataDirectory);
+    this.signPmtWithPlugin = signPmtWithPlugin;
     keyfilePath.ifPresent(
         path -> {
           try {
@@ -597,6 +600,10 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
 
   public void setPrivacyParameters(final PrivacyParameters privacyParameters) {
     this.privacyParameters = privacyParameters;
+  }
+
+  public boolean getSignPmtWithPlugin() {
+    return signPmtWithPlugin;
   }
 
   public boolean isDevMode() {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.tests.acceptance.dsl.node;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
+import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApi;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty.TLSConfiguration;
@@ -244,9 +244,17 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
       params.add("--p2p-enabled");
       params.add("false");
     } else {
-      final List<String> networkConfigParams =
-          NetworkingOptions.fromConfig(node.getNetworkingConfiguration()).getCLIOptions();
-      params.addAll(networkConfigParams);
+
+      params.add("--Xp2p-check-maintained-connections-frequency");
+      params.add(
+          OptionParser.format(
+              node.getNetworkingConfiguration().getCheckMaintainedConnectionsFrequencySec()));
+
+      params.add("--Xp2p-initiate-connections-frequency");
+      params.add(
+          OptionParser.format(
+              node.getNetworkingConfiguration().getInitiateConnectionsFrequencySec()));
+
       if (node.getTLSConfiguration().isPresent()) {
         final TLSConfiguration config = node.getTLSConfiguration().get();
         params.add("--Xp2p-tls-enabled");

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -132,8 +132,10 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
         params.add(node.getPrivacyParameters().getEnclavePublicKeyFile().getAbsolutePath());
       }
 
-      params.add("--privacy-marker-transaction-signing-key-file");
-      params.add(node.homeDirectory().resolve("key").toString());
+      if (!node.getSignPmtWithPlugin()) {
+        params.add("--privacy-marker-transaction-signing-key-file");
+        params.add(node.homeDirectory().resolve("key").toString());
+      }
 
       if (node.getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
         params.add("--privacy-onchain-groups-enabled");

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -81,10 +81,6 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
       final SecurityModuleServiceImpl securityModuleService,
       final BesuConfiguration commonPluginConfiguration) {
     final CommandLine commandLine = new CommandLine(CommandSpec.create());
-    final BesuPluginContextImpl besuPluginContext = new BesuPluginContextImpl();
-    besuPluginContext.addService(StorageService.class, storageService);
-    besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
-    besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
 
     final Path pluginsPath = node.homeDirectory().resolve("plugins");
     final File pluginsDirFile = pluginsPath.toFile();
@@ -92,8 +88,14 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
       pluginsDirFile.mkdirs();
       pluginsDirFile.deleteOnExit();
     }
-    System.setProperty("besu.plugins.dir", pluginsPath.toString());
-    besuPluginContext.registerPlugins(pluginsPath);
+    final BesuPluginContextImpl besuPluginContext =
+        new BesuPluginContextImpl(pluginsPath.toString());
+
+    besuPluginContext.addService(StorageService.class, storageService);
+    besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
+    besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
+
+    besuPluginContext.registerPlugins();
 
     commandLine.parseArgs(node.getConfiguration().getExtraCLIOptions().toArray(new String[0]));
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfiguration.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfiguration.java
@@ -60,6 +60,7 @@ public class BesuNodeConfiguration {
   private final NetworkName network;
   private final Optional<KeyPair> keyPair;
   private final Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration;
+  private final boolean signPmtWithPlugin;
 
   BesuNodeConfiguration(
       final String name,
@@ -88,7 +89,8 @@ public class BesuNodeConfiguration {
       final Optional<PrivacyParameters> privacyParameters,
       final List<String> runCommand,
       final Optional<KeyPair> keyPair,
-      final Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration) {
+      final Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration,
+      final boolean signPmtWithPlugin) {
     this.name = name;
     this.miningParameters = miningParameters;
     this.jsonRpcConfiguration = jsonRpcConfiguration;
@@ -116,6 +118,7 @@ public class BesuNodeConfiguration {
     this.runCommand = runCommand;
     this.keyPair = keyPair;
     this.pkiKeyStoreConfiguration = pkiKeyStoreConfiguration;
+    this.signPmtWithPlugin = signPmtWithPlugin;
   }
 
   public String getName() {
@@ -224,5 +227,9 @@ public class BesuNodeConfiguration {
 
   public Optional<PkiKeyStoreConfiguration> getPkiKeyStoreConfiguration() {
     return pkiKeyStoreConfiguration;
+  }
+
+  public boolean getSignPmtWithPlugin() {
+    return signPmtWithPlugin;
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
@@ -82,6 +82,7 @@ public class BesuNodeConfigurationBuilder {
   private List<String> runCommand = new ArrayList<>();
   private Optional<KeyPair> keyPair = Optional.empty();
   private Optional<PkiKeyStoreConfiguration> pkiKeyStoreConfiguration = Optional.empty();
+  private boolean signPmtWithPlugin;
 
   public BesuNodeConfigurationBuilder() {
     // Check connections more frequently during acceptance tests to cut down on
@@ -410,6 +411,11 @@ public class BesuNodeConfigurationBuilder {
     return this;
   }
 
+  public BesuNodeConfigurationBuilder signPmtWithPlugin() {
+    signPmtWithPlugin = true;
+    return this;
+  }
+
   public BesuNodeConfigurationBuilder run(final String... commands) {
     this.runCommand = List.of(commands);
     return this;
@@ -443,6 +449,7 @@ public class BesuNodeConfigurationBuilder {
         privacyParameters,
         runCommand,
         keyPair,
-        pkiKeyStoreConfiguration);
+        pkiKeyStoreConfiguration,
+        signPmtWithPlugin);
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeFactory.java
@@ -86,7 +86,8 @@ public class BesuNodeFactory {
         config.getPrivacyParameters(),
         config.getRunCommand(),
         config.getKeyPair(),
-        config.getPkiKeyStoreConfiguration());
+        config.getPkiKeyStoreConfiguration(),
+        config.getSignPmtWithPlugin());
   }
 
   public BesuNode createMinerNode(final String name) throws IOException {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -124,7 +124,8 @@ public class PrivacyNode implements AutoCloseable {
             besuConfig.getPrivacyParameters(),
             List.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            config.getSignPmtWithPlugin());
   }
 
   public void testEnclaveConnection(final List<PrivacyNode> otherNodes) {

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
@@ -19,11 +19,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 import org.apache.logging.log4j.LogManager;
@@ -44,12 +44,6 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
     LOG.info("Registering BadCliOptionsPlugin");
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeStatus("init");
-
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(
-            picoCLIOptions ->
-                picoCLIOptions.addPicoCLIOptions("bad-cli", BadCLIOptionsPlugin.this));
 
     writeStatus("register");
   }
@@ -80,5 +74,10 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
     } catch (final IOException ioe) {
       throw new RuntimeException(ioe);
     }
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of("bad-cli");
   }
 }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPermissioningPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPermissioningPlugin.java
@@ -18,7 +18,8 @@ package org.hyperledger.besu.plugins;
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.PermissioningService;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+
+import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 import org.apache.logging.log4j.LogManager;
@@ -42,7 +43,6 @@ public class TestPermissioningPlugin implements BesuPlugin {
 
   @Override
   public void register(final BesuContext context) {
-    context.getService(PicoCLIOptions.class).get().addPicoCLIOptions("permissioning", this);
     service = context.getService(PermissioningService.class).get();
   }
 
@@ -88,4 +88,9 @@ public class TestPermissioningPlugin implements BesuPlugin {
 
   @Option(names = "--plugin-permissioning-test-enabled")
   boolean enabled = false;
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of("permissioning");
+  }
 }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
@@ -16,12 +16,12 @@ package org.hyperledger.besu.plugins;
 
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.Optional;
 
 import com.google.auto.service.AutoService;
 import org.apache.logging.log4j.LogManager;
@@ -56,11 +56,6 @@ public class TestPicoCLIPlugin implements BesuPlugin {
       state = "failregister";
       throw new RuntimeException("I was told to fail at registration");
     }
-
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(
-            picoCLIOptions -> picoCLIOptions.addPicoCLIOptions("test", TestPicoCLIPlugin.this));
 
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeSignal("registered");
@@ -117,5 +112,10 @@ public class TestPicoCLIPlugin implements BesuPlugin {
     } catch (final IOException ioe) {
       throw new RuntimeException(ioe);
     }
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of("test");
   }
 }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyGroupGenesisProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyGroupGenesisProvider.java
@@ -30,16 +30,9 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
 public class TestPrivacyGroupGenesisProvider implements PrivacyGroupGenesisProvider {
-  private boolean genesisEnabled = false;
-
-  public void setGenesisEnabled() {
-    this.genesisEnabled = true;
-  }
 
   @Override
   public PrivacyGenesis getPrivacyGenesis(final Bytes privacyGroupId, final long blockNumber) {
-    if (!genesisEnabled) return Collections::emptyList;
-
     return () ->
         List.of(
             new PrivacyGenesisAccount() {

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyPluginPayloadProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/privacy/TestPrivacyPluginPayloadProvider.java
@@ -31,9 +31,9 @@ import org.apache.tuweni.bytes.Bytes;
 
 public class TestPrivacyPluginPayloadProvider implements PrivacyPluginPayloadProvider {
   private static final Logger LOG = LogManager.getLogger();
-  private String prefix;
+  private final String prefix;
 
-  public void setPluginPayloadPrefix(final String prefix) {
+  public TestPrivacyPluginPayloadProvider(final String prefix) {
     this.prefix = prefix;
   }
 

--- a/acceptance-tests/test-plugins/src/test/java/org/hyperledger/besu/plugins/BesuPluginContextImplTest.java
+++ b/acceptance-tests/test-plugins/src/test/java/org/hyperledger/besu/plugins/BesuPluginContextImplTest.java
@@ -49,16 +49,14 @@ public class BesuPluginContextImplTest {
 
   @Test
   public void verifyEverythingGoesSmoothly() {
-    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl(".");
-
-    assertThat(contextImpl.getNamedPlugins()).isEmpty();
-    contextImpl.registerPlugins();
-    assertThat(contextImpl.getNamedPlugins()).isNotEmpty();
+    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
 
     final Optional<TestPicoCLIPlugin> testPluginOptional =
         findTestPlugin(contextImpl.getNamedPlugins());
     assertThat(testPluginOptional).isPresent();
     final TestPicoCLIPlugin testPicoCLIPlugin = testPluginOptional.get();
+
+    contextImpl.registerPlugins();
     assertThat(testPicoCLIPlugin.getState()).isEqualTo("registered");
 
     contextImpl.startPlugins();
@@ -70,10 +68,10 @@ public class BesuPluginContextImplTest {
 
   @Test
   public void registrationErrorsHandledSmoothly() {
-    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl(".");
     System.setProperty("testPicoCLIPlugin.testOption", "FAILREGISTER");
 
-    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
+
     contextImpl.registerPlugins();
     assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
 
@@ -86,10 +84,10 @@ public class BesuPluginContextImplTest {
 
   @Test
   public void startErrorsHandledSmoothly() {
-    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl(".");
     System.setProperty("testPicoCLIPlugin.testOption", "FAILSTART");
 
-    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
+
     contextImpl.registerPlugins();
     assertThat(contextImpl.getNamedPlugins().values())
         .extracting("class")
@@ -111,10 +109,10 @@ public class BesuPluginContextImplTest {
 
   @Test
   public void stopErrorsHandledSmoothly() {
-    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl(".");
     System.setProperty("testPicoCLIPlugin.testOption", "FAILSTOP");
 
-    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
+
     contextImpl.registerPlugins();
     assertThat(contextImpl.getNamedPlugins().values())
         .extracting("class")
@@ -135,7 +133,7 @@ public class BesuPluginContextImplTest {
 
   @Test
   public void lifecycleExceptions() throws Throwable {
-    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl(".");
+    final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
     final ThrowableAssert.ThrowingCallable registerPlugins = () -> contextImpl.registerPlugins();
 
     assertThatExceptionOfType(IllegalStateException.class).isThrownBy(contextImpl::startPlugins);

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
@@ -54,9 +54,8 @@ public class PicoCLIOptionsPluginTest extends AcceptanceTestBase {
         node.homeDirectory().resolve("plugins/pluginLifecycle.registered");
     waitForFile(registrationFile);
 
-    // this assert is false as CLI will not be parsed at this point
     assertThat(Files.readAllLines(registrationFile).stream().anyMatch(s -> s.contains(MAGIC_WORDS)))
-        .isFalse();
+        .isTrue();
   }
 
   @Test

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PluginPrivacySigningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PluginPrivacySigningAcceptanceTest.java
@@ -53,6 +53,7 @@ public class PluginPrivacySigningAcceptanceTest extends PrivacyAcceptanceTestBas
                     .enablePrivateTransactions()
                     .keyFilePath(BOB.getPrivateKeyPath())
                     .plugins(Collections.singletonList("testPlugins"))
+                    .signPmtWithPlugin()
                     .extraCLIOptions(
                         List.of(
                             "--plugin-privacy-service-encryption-prefix=0xAA",

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1313,7 +1313,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     new RocksDBPlugin().register(besuPluginContext);
     new InMemoryStoragePlugin().register(besuPluginContext);
 
-    besuPluginContext.registerPlugins(pluginsDir());
+    besuPluginContext.registerPlugins();
 
     metricCategoryRegistry
         .getMetricCategories()
@@ -2529,15 +2529,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   // dataDir() is public because it is accessed by subcommands
   public Path dataDir() {
     return dataPath.toAbsolutePath();
-  }
-
-  private Path pluginsDir() {
-    final String pluginsDir = System.getProperty("besu.plugins.dir");
-    if (pluginsDir == null) {
-      return new File(System.getProperty("besu.home", "."), "plugins").toPath();
-    } else {
-      return new File(pluginsDir).toPath();
-    }
   }
 
   @VisibleForTesting

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1321,7 +1321,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     UnstableOptionsSubCommand.createUnstableOptions(commandLine, unstableOptions);
   }
 
-  private void preparePlugins() {
+  public void preparePlugins() {
     besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
     besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
     besuPluginContext.addService(StorageService.class, storageService);
@@ -1705,7 +1705,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   public BesuController buildController() {
     try {
-      preparePlugins();
       return getControllerBuilder().build();
     } catch (final Exception e) {
       throw new ExecutionException(this.commandLine, e.getMessage(), e);

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/CLIOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/CLIOptions.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.cli.options;
 
-import java.util.List;
-
 /**
  * This interface represents logic that translates between CLI options and a domain object.
  *
@@ -29,11 +27,4 @@ public interface CLIOptions<T> {
    * @return A domain object representing these CLI options.
    */
   T toDomainObject();
-
-  /**
-   * Return The list of CLI options corresponding to this class.
-   *
-   * @return The list of CLI options corresponding to this class.
-   */
-  List<String> getCLIOptions();
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/EthstatsOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/EthstatsOptions.java
@@ -17,9 +17,6 @@ package org.hyperledger.besu.cli.options.stable;
 import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.ethstats.util.NetstatsUrl;
 
-import java.util.Arrays;
-import java.util.List;
-
 import picocli.CommandLine;
 
 public class EthstatsOptions implements CLIOptions<NetstatsUrl> {
@@ -59,10 +56,5 @@ public class EthstatsOptions implements CLIOptions<NetstatsUrl> {
 
   public String getEthstatsContact() {
     return ethstatsContact;
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(ETHSTATS + "=" + ethstatsUrl, ETHSTATS_CONTACT + "=" + ethstatsContact);
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DataStorageOptions.java
@@ -23,8 +23,6 @@ import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguration;
 
-import java.util.List;
-
 import picocli.CommandLine.Option;
 
 public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> {
@@ -61,14 +59,5 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
         .dataStorageFormat(dataStorageFormat)
         .bonsaiMaxLayersToLoad(bonsaiMaxLayersToLoad)
         .build();
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return List.of(
-        DATA_STORAGE_FORMAT,
-        dataStorageFormat.toString(),
-        BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD,
-        bonsaiMaxLayersToLoad.toString());
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DnsOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DnsOptions.java
@@ -18,15 +18,9 @@ import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 
-import java.util.Arrays;
-import java.util.List;
-
 import picocli.CommandLine;
 
 public class DnsOptions implements CLIOptions<EnodeDnsConfiguration> {
-
-  private final String DNS_ENABLED = "--Xdns-enabled";
-  private final String DNS_UPDATE_ENABLED = "--Xdns-update-enabled";
 
   @CommandLine.Option(
       hidden = true,
@@ -67,11 +61,5 @@ public class DnsOptions implements CLIOptions<EnodeDnsConfiguration> {
         .updateEnabled(dnsUpdateEnabled)
         .dnsEnabled(dnsEnabled)
         .build();
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        DNS_ENABLED, dnsEnabled.toString(), DNS_UPDATE_ENABLED, dnsUpdateEnabled.toString());
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthProtocolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EthProtocolOptions.java
@@ -15,12 +15,8 @@
 package org.hyperledger.besu.cli.options.unstable;
 
 import org.hyperledger.besu.cli.options.CLIOptions;
-import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.util.number.PositiveNumber;
-
-import java.util.Arrays;
-import java.util.List;
 
 import picocli.CommandLine;
 
@@ -112,21 +108,5 @@ public class EthProtocolOptions implements CLIOptions<EthProtocolConfiguration> 
         .maxGetPooledTransactions(maxGetPooledTransactions)
         .legacyEth64ForkIdEnabled(legacyEth64ForkIdEnabled)
         .build();
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        MAX_GET_HEADERS_FLAG,
-        OptionParser.format(maxGetBlockHeaders.getValue()),
-        MAX_GET_BODIES_FLAG,
-        OptionParser.format(maxGetBlockBodies.getValue()),
-        MAX_GET_RECEIPTS_FLAG,
-        OptionParser.format(maxGetReceipts.getValue()),
-        MAX_GET_NODE_DATA_FLAG,
-        OptionParser.format(maxGetNodeData.getValue()),
-        MAX_GET_POOLED_TRANSACTIONS,
-        OptionParser.format(maxGetPooledTransactions.getValue()),
-        LEGACY_ETH_64_FORK_ID_ENABLED + "=" + legacyEth64ForkIdEnabled);
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
@@ -17,9 +17,6 @@ package org.hyperledger.besu.cli.options.unstable;
 import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 
-import java.util.Arrays;
-import java.util.List;
-
 import picocli.CommandLine;
 
 public class MetricsCLIOptions implements CLIOptions<MetricsConfiguration.Builder> {
@@ -57,12 +54,5 @@ public class MetricsCLIOptions implements CLIOptions<MetricsConfiguration.Builde
   @Override
   public MetricsConfiguration.Builder toDomainObject() {
     return MetricsConfiguration.builder().timersEnabled(timersEnabled).idleTimeout(idleTimeout);
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        TIMERS_ENABLED_FLAG + "=" + timersEnabled.toString(),
-        IDLE_TIMEOUT_FLAG + "=" + idleTimeout);
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
@@ -15,11 +15,7 @@
 package org.hyperledger.besu.cli.options.unstable;
 
 import org.hyperledger.besu.cli.options.CLIOptions;
-import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
 
 import picocli.CommandLine;
 
@@ -70,14 +66,5 @@ public class NetworkingOptions implements CLIOptions<NetworkingConfiguration> {
     config.setCheckMaintainedConnectionsFrequency(checkMaintainedConnectionsFrequencySec);
     config.setInitiateConnectionsFrequency(initiateConnectionsFrequencySec);
     return config;
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        CHECK_MAINTAINED_CONNECTIONS_FREQUENCY_FLAG,
-        OptionParser.format(checkMaintainedConnectionsFrequencySec),
-        INITIATE_CONNECTIONS_FREQUENCY_FLAG,
-        OptionParser.format(initiateConnectionsFrequencySec));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/SynchronizerOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/SynchronizerOptions.java
@@ -18,9 +18,6 @@ import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.google.common.collect.Range;
 import org.apache.tuweni.units.bigints.UInt256;
 import picocli.CommandLine;
@@ -261,42 +258,5 @@ public class SynchronizerOptions implements CLIOptions<SynchronizerConfiguration
     builder.worldStateMinMillisBeforeStalling(worldStateMinMillisBeforeStalling);
     builder.worldStateTaskCacheSize(worldStateTaskCacheSize);
     return builder;
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        BLOCK_PROPAGATION_RANGE_FLAG,
-        OptionParser.format(blockPropagationRange),
-        DOWNLOADER_CHANGE_TARGET_THRESHOLD_BY_HEIGHT_FLAG,
-        OptionParser.format(downloaderChangeTargetThresholdByHeight),
-        DOWNLOADER_CHANGE_TARGET_THRESHOLD_BY_TD_FLAG,
-        OptionParser.format(downloaderChangeTargetThresholdByTd),
-        DOWNLOADER_HEADER_REQUEST_SIZE_FLAG,
-        OptionParser.format(downloaderHeaderRequestSize),
-        DOWNLOADER_CHECKPOINT_TIMEOUTS_PERMITTED_FLAG,
-        OptionParser.format(downloaderCheckpointTimeoutsPermitted),
-        DOWNLOADER_CHAIN_SEGMENT_SIZE_FLAG,
-        OptionParser.format(downloaderChainSegmentSize),
-        DOWNLOADER_PARALLELISM_FLAG,
-        OptionParser.format(downloaderParallelism),
-        TRANSACTIONS_PARALLELISM_FLAG,
-        OptionParser.format(transactionsParallelism),
-        COMPUTATION_PARALLELISM_FLAG,
-        OptionParser.format(computationParallelism),
-        PIVOT_DISTANCE_FROM_HEAD_FLAG,
-        OptionParser.format(fastSyncPivotDistance),
-        FULL_VALIDATION_RATE_FLAG,
-        OptionParser.format(fastSyncFullValidationRate),
-        WORLD_STATE_HASH_COUNT_PER_REQUEST_FLAG,
-        OptionParser.format(worldStateHashCountPerRequest),
-        WORLD_STATE_REQUEST_PARALLELISM_FLAG,
-        OptionParser.format(worldStateRequestParallelism),
-        WORLD_STATE_MAX_REQUESTS_WITHOUT_PROGRESS_FLAG,
-        OptionParser.format(worldStateMaxRequestsWithoutProgress),
-        WORLD_STATE_MIN_MILLIS_BEFORE_STALLING_FLAG,
-        OptionParser.format(worldStateMinMillisBeforeStalling),
-        WORLD_STATE_TASK_CACHE_SIZE_FLAG,
-        OptionParser.format(worldStateTaskCacheSize));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/TransactionPoolOptions.java
@@ -15,13 +15,10 @@
 package org.hyperledger.besu.cli.options.unstable;
 
 import org.hyperledger.besu.cli.options.CLIOptions;
-import org.hyperledger.besu.cli.options.OptionParser;
 import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
 
 import picocli.CommandLine;
 
@@ -72,14 +69,5 @@ public class TransactionPoolOptions
     return ImmutableTransactionPoolConfiguration.builder()
         .txMessageKeepAliveSeconds(txMessageKeepAliveSeconds)
         .eth65TrxAnnouncedBufferingPeriod(Duration.ofMillis(eth65TrxAnnouncedBufferingPeriod));
-  }
-
-  @Override
-  public List<String> getCLIOptions() {
-    return Arrays.asList(
-        TX_MESSAGE_KEEP_ALIVE_SEC_FLAG,
-        OptionParser.format(txMessageKeepAliveSeconds),
-        ETH65_TX_ANNOUNCED_BUFFERING_PERIOD_FLAG,
-        OptionParser.format(eth65TrxAnnouncedBufferingPeriod));
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -368,6 +368,7 @@ public class BlocksSubCommand implements Runnable {
     }
 
     private BesuController createBesuController() {
+      parentCommand.parentCommand.preparePlugins();
       return parentCommand.parentCommand.buildController();
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -242,6 +242,7 @@ public class BlocksSubCommand implements Runnable {
     private BesuController createController() {
       try {
         // Set some defaults
+        parentCommand.parentCommand.preparePlugins();
         return parentCommand
             .parentCommand
             .getControllerBuilder()

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
@@ -121,6 +121,7 @@ public class BackupState implements Runnable {
   }
 
   private BesuController createBesuController() {
+    parentCommand.parentCommand.preparePlugins();
     return parentCommand.parentCommand.buildController();
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
@@ -91,6 +91,7 @@ public class GenerateLogBloomCache implements Runnable {
   }
 
   private BesuController createBesuController() {
+    parentCommand.parentCommand.preparePlugins();
     return parentCommand.parentCommand.buildController();
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
@@ -278,6 +278,7 @@ public class RestoreState implements Runnable {
   }
 
   private BesuController createBesuController() {
+    parentCommand.parentCommand.preparePlugins();
     return parentCommand.parentCommand.buildController();
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -101,7 +101,8 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
   public void registerPlugins() {
     checkState(
         state == Lifecycle.UNINITIALIZED,
-        "Besu plugins have already been registered.  Cannot register additional plugins.");
+        "Besu plugins have already been registered {}.  Cannot register additional plugins.",
+        state);
 
     state = Lifecycle.REGISTERING;
 

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.services.BesuService;
 import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -41,7 +41,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,6 +49,7 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
   private static final Logger LOG = LogManager.getLogger();
 
   private enum Lifecycle {
+    LOADING,
     UNINITIALIZED,
     REGISTERING,
     REGISTERED,
@@ -59,10 +59,31 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
     STOPPED
   }
 
-  private Lifecycle state = Lifecycle.UNINITIALIZED;
+  private Lifecycle state;
   private final Map<Class<?>, ? super BesuService> serviceRegistry = new HashMap<>();
   private final List<BesuPlugin> plugins = new ArrayList<>();
-  private final List<String> pluginVersions = new ArrayList<>();
+  private final ServiceLoader<BesuPlugin> serviceLoader;
+
+  public BesuPluginContextImpl() {
+    this(System.getProperty("besu.plugins.dir"));
+  }
+
+  public BesuPluginContextImpl(final String pluginsDir) {
+    Path pluginsDirPath;
+    if (pluginsDir == null) {
+      pluginsDirPath = new File(System.getProperty("besu.home", "."), "plugins").toPath();
+    } else {
+      pluginsDirPath = new File(pluginsDir).toPath();
+    }
+
+    final ClassLoader pluginLoader =
+        pluginDirectoryLoader(pluginsDirPath).orElse(this.getClass().getClassLoader());
+
+    serviceLoader = ServiceLoader.load(BesuPlugin.class, pluginLoader);
+    serviceLoader.forEach(plugins::add);
+
+    state = Lifecycle.UNINITIALIZED;
+  }
 
   public <T extends BesuService> void addService(final Class<T> serviceType, final T service) {
     checkArgument(serviceType.isInterface(), "Services must be Java interfaces.");
@@ -78,24 +99,17 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
     return Optional.ofNullable((T) serviceRegistry.get(serviceType));
   }
 
-  public void registerPlugins(final Path pluginsDir) {
+  public void registerPlugins() {
     checkState(
         state == Lifecycle.UNINITIALIZED,
         "Besu plugins have already been registered.  Cannot register additional plugins.");
 
-    final ClassLoader pluginLoader =
-        pluginDirectoryLoader(pluginsDir).orElse(this.getClass().getClassLoader());
-
     state = Lifecycle.REGISTERING;
-
-    final ServiceLoader<BesuPlugin> serviceLoader =
-        ServiceLoader.load(BesuPlugin.class, pluginLoader);
 
     for (final BesuPlugin plugin : serviceLoader) {
       try {
         plugin.register(this);
         LOG.debug("Registered plugin of type {}.", plugin.getClass().getName());
-        addPluginVersion(plugin);
       } catch (final Exception e) {
         LOG.error(
             "Error registering plugin of type "
@@ -104,26 +118,11 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
             e);
         continue;
       }
-      plugins.add(plugin);
     }
 
     LOG.debug("Plugin registration complete.");
 
     state = Lifecycle.REGISTERED;
-  }
-
-  private void addPluginVersion(final BesuPlugin plugin) {
-    final Package pluginPackage = plugin.getClass().getPackage();
-    final String implTitle =
-        Optional.ofNullable(pluginPackage.getImplementationTitle())
-            .filter(Predicate.not(String::isBlank))
-            .orElse(plugin.getClass().getSimpleName());
-    final String implVersion =
-        Optional.ofNullable(pluginPackage.getImplementationVersion())
-            .filter(Predicate.not(String::isBlank))
-            .orElse("<Unknown Version>");
-    final String pluginVersion = implTitle + "/v" + implVersion;
-    pluginVersions.add(pluginVersion);
   }
 
   public void startPlugins() {
@@ -176,9 +175,22 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
     state = Lifecycle.STOPPED;
   }
 
+  private String getPluginVersion(final BesuPlugin plugin) {
+    final Package pluginPackage = plugin.getClass().getPackage();
+    final String implTitle =
+        Optional.ofNullable(pluginPackage.getImplementationTitle())
+            .filter(Predicate.not(String::isBlank))
+            .orElse(plugin.getClass().getSimpleName());
+    final String implVersion =
+        Optional.ofNullable(pluginPackage.getImplementationVersion())
+            .filter(Predicate.not(String::isBlank))
+            .orElse("<Unknown Version>");
+    return implTitle + "/v" + implVersion;
+  }
+
   @Override
   public Collection<String> getPluginVersions() {
-    return Collections.unmodifiableList(pluginVersions);
+    return plugins.stream().map(this::getPluginVersion).collect(Collectors.toList());
   }
 
   private static URL pathToURIOrNull(final Path p) {
@@ -187,11 +199,6 @@ public class BesuPluginContextImpl implements BesuContext, PluginVersionsProvide
     } catch (final MalformedURLException e) {
       return null;
     }
-  }
-
-  @VisibleForTesting
-  List<BesuPlugin> getPlugins() {
-    return Collections.unmodifiableList(plugins);
   }
 
   private Optional<ClassLoader> pluginDirectoryLoader(final Path pluginsDir) {

--- a/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PicoCLIOptionsImpl.java
@@ -34,9 +34,16 @@ public class PicoCLIOptionsImpl implements PicoCLIOptions {
 
   @Override
   public void addPicoCLIOptions(final String namespace, final Object optionObject) {
+    addPicoCLIOptions(commandLine, namespace, optionObject);
+  }
+
+  public static void addPicoCLIOptions(
+      final CommandLine commandLine, final String namespace, final Object optionObject) {
     final String pluginPrefix = "--plugin-" + namespace + "-";
     final String unstablePrefix = "--Xplugin-" + namespace + "-";
+
     final CommandSpec mixin = CommandSpec.forAnnotatedObject(optionObject);
+
     boolean badOptionName = false;
 
     for (final OptionSpec optionSpec : mixin.options()) {
@@ -49,7 +56,7 @@ public class PicoCLIOptionsImpl implements PicoCLIOptions {
       }
     }
     if (badOptionName) {
-      throw new RuntimeException("Error loading CLI options");
+      LOG.error("Error loading CLI options");
     } else {
       commandLine.getCommandSpec().addMixin("Plugin " + namespace, mixin);
     }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
@@ -45,29 +45,6 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
   }
 
   @Test
-  public void getCLIOptions_default() {
-    getCLIOptions(createDefaultDomainObject());
-  }
-
-  @Test
-  public void getCLIOptions_custom() {
-    getCLIOptions(createCustomizedDomainObject());
-  }
-
-  private void getCLIOptions(final D domainObject) {
-    T options = optionsFromDomainObject(domainObject);
-    final String[] cliOptions = options.getCLIOptions().toArray(new String[0]);
-
-    final TestBesuCommand cmd = parseCommand(cliOptions);
-    final T optionsFromCommand = getOptionsFromBesuCommand(cmd);
-
-    assertThat(optionsFromCommand).isEqualToComparingFieldByField(options);
-
-    assertThat(commandOutput.toString()).isEmpty();
-    assertThat(commandErrorOutput.toString()).isEmpty();
-  }
-
-  @Test
   public void defaultValues() {
     final TestBesuCommand cmd = parseCommand();
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.StorageService;
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
@@ -50,14 +49,6 @@ public class RocksDBPlugin implements BesuPlugin {
     LOG.debug("Registering plugin");
     this.context = context;
 
-    final Optional<PicoCLIOptions> cmdlineOptions = context.getService(PicoCLIOptions.class);
-
-    if (cmdlineOptions.isEmpty()) {
-      throw new IllegalStateException(
-          "Expecting a PicoCLIO options to register CLI options with, but none found.");
-    }
-
-    cmdlineOptions.get().addPicoCLIOptions(NAME, options);
     createFactoriesAndRegisterWithStorageService();
 
     LOG.debug("Plugin registered.");
@@ -115,5 +106,10 @@ public class RocksDBPlugin implements BesuPlugin {
         .ifPresentOrElse(
             this::createAndRegister,
             () -> LOG.error("Failed to register KeyValueFactory due to missing StorageService."));
+  }
+
+  @Override
+  public Optional<String> getName() {
+    return Optional.of(NAME);
   }
 }


### PR DESCRIPTION
# Description 

https://wiki.hyperledger.org/display/BESU/DRAFT+-+Pico+CLI+Plugin+Integration

The main change is to move preparePlugins into the begging of the run method. This means that all the cli parsing will happen before any plugins are called. The only way to register cli options will be to have them on the `BesuPlugin` e.g

https://github.com/hyperledger/besu/pull/2768/files#diff-2080ac0bf38c1e492921f4191b738b729195e0b1ad82657abc9103f19ac87cd8L1195

```
@AutoService(BesuPlugin.class)
public class MyPlugin implements BesuPlugin {

  @Option(
    names = {"--Xplugin-my-option"},
    defaultValue = "foo")
  String myOption;

  @Override
  public Optional<String> getName() {
    return Optional.of("my");
  }
}
```

The other breaking change is that you should override getName and provide a meaningful plugin name. This is used for the namespace when registering the cli arguments.

https://github.com/hyperledger/besu/pull/2768/files#diff-2080ac0bf38c1e492921f4191b738b729195e0b1ad82657abc9103f19ac87cd8R1204


