### PR TITLE
Alternative proposal for breaking change to the way plugins load cli options

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -39,7 +39,6 @@ import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.BesuEvents;
-import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.SecurityModuleService;
 import org.hyperledger.besu.plugin.services.StorageService;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBPlugin;
@@ -91,9 +90,9 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
     final BesuPluginContextImpl besuPluginContext =
         new BesuPluginContextImpl(pluginsPath.toString());
+    besuPluginContext.initialize(new PicoCLIOptionsImpl(commandLine));
     besuPluginContext.addService(StorageService.class, storageService);
     besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
-    besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
 
     besuPluginContext.registerPlugins();
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -81,10 +81,6 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
       final SecurityModuleServiceImpl securityModuleService,
       final BesuConfiguration commonPluginConfiguration) {
     final CommandLine commandLine = new CommandLine(CommandSpec.create());
-    final BesuPluginContextImpl besuPluginContext = new BesuPluginContextImpl();
-    besuPluginContext.addService(StorageService.class, storageService);
-    besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
-    besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
 
     final Path pluginsPath = node.homeDirectory().resolve("plugins");
     final File pluginsDirFile = pluginsPath.toFile();
@@ -92,8 +88,14 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
       pluginsDirFile.mkdirs();
       pluginsDirFile.deleteOnExit();
     }
-    System.setProperty("besu.plugins.dir", pluginsPath.toString());
-    besuPluginContext.registerPlugins(pluginsPath);
+
+    final BesuPluginContextImpl besuPluginContext =
+        new BesuPluginContextImpl(pluginsPath.toString());
+    besuPluginContext.addService(StorageService.class, storageService);
+    besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
+    besuPluginContext.addService(PicoCLIOptions.class, new PicoCLIOptionsImpl(commandLine));
+
+    besuPluginContext.registerPlugins();
 
     commandLine.parseArgs(node.getConfiguration().getExtraCLIOptions().toArray(new String[0]));
 

--- a/acceptance-tests/test-plugins/build.gradle
+++ b/acceptance-tests/test-plugins/build.gradle
@@ -13,6 +13,7 @@ dependencies {
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'junit:junit'
+  testImplementation 'org.mockito:mockito-core'
 }
 
 task testPluginsJar(type: Jar) {

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
@@ -40,17 +40,14 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
+  public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    cliOptions.addPicoCLIOptions("bad-cli", this);
+  }
+
+  @Override
   public void register(final BesuContext context) {
     LOG.info("Registering BadCliOptionsPlugin");
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
-    writeStatus("init");
-
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(
-            picoCLIOptions ->
-                picoCLIOptions.addPicoCLIOptions("bad-cli", BadCLIOptionsPlugin.this));
-
     writeStatus("register");
   }
 

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
@@ -41,13 +41,14 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
 
   @Override
   public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
+    writeStatus("init");
     cliOptions.addPicoCLIOptions("bad-cli", this);
   }
 
   @Override
   public void register(final BesuContext context) {
     LOG.info("Registering BadCliOptionsPlugin");
-    callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeStatus("register");
   }
 

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPermissioningPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPermissioningPlugin.java
@@ -41,8 +41,12 @@ public class TestPermissioningPlugin implements BesuPlugin {
   PermissioningService service;
 
   @Override
+  public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    cliOptions.addPicoCLIOptions("permissioning", this);
+  }
+
+  @Override
   public void register(final BesuContext context) {
-    context.getService(PicoCLIOptions.class).get().addPicoCLIOptions("permissioning", this);
     service = context.getService(PermissioningService.class).get();
   }
 

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPicoCLIPlugin.java
@@ -48,6 +48,11 @@ public class TestPicoCLIPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
+  public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    cliOptions.addPicoCLIOptions("test", this);
+  }
+
+  @Override
   public void register(final BesuContext context) {
     LOG.info("Registering.  Test Option is '{}'", testOption);
     state = "registering";
@@ -56,11 +61,6 @@ public class TestPicoCLIPlugin implements BesuPlugin {
       state = "failregister";
       throw new RuntimeException("I was told to fail at registration");
     }
-
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(
-            picoCLIOptions -> picoCLIOptions.addPicoCLIOptions("test", TestPicoCLIPlugin.this));
 
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeSignal("registered");

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPrivacyServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPrivacyServicePlugin.java
@@ -41,10 +41,14 @@ public class TestPrivacyServicePlugin implements BesuPlugin {
       new TestSigningPrivateMarkerTransactionFactory();
 
   @Override
+  public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    cliOptions.addPicoCLIOptions("privacy-service", this);
+  }
+
+  @Override
   public void register(final BesuContext context) {
     this.context = context;
 
-    context.getService(PicoCLIOptions.class).get().addPicoCLIOptions("privacy-service", this);
     pluginService = context.getService(PrivacyPluginService.class).get();
 
     pluginService.setPayloadProvider(payloadProvider);

--- a/acceptance-tests/test-plugins/src/test/java/org/hyperledger/besu/plugins/BesuPluginContextImplTest.java
+++ b/acceptance-tests/test-plugins/src/test/java/org/hyperledger/besu/plugins/BesuPluginContextImplTest.java
@@ -20,11 +20,10 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugins.TestPicoCLIPlugin;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.assertj.core.api.ThrowableAssert;
@@ -52,11 +51,12 @@ public class BesuPluginContextImplTest {
   public void verifyEverythingGoesSmoothly() {
     final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
 
-    assertThat(contextImpl.getPlugins()).isEmpty();
-    contextImpl.registerPlugins(new File(".").toPath());
-    assertThat(contextImpl.getPlugins()).isNotEmpty();
+    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    contextImpl.registerPlugins();
+    assertThat(contextImpl.getNamedPlugins()).isNotEmpty();
 
-    final Optional<TestPicoCLIPlugin> testPluginOptional = findTestPlugin(contextImpl.getPlugins());
+    final Optional<TestPicoCLIPlugin> testPluginOptional =
+        findTestPlugin(contextImpl.getNamedPlugins());
     assertThat(testPluginOptional).isPresent();
     final TestPicoCLIPlugin testPicoCLIPlugin = testPluginOptional.get();
     assertThat(testPicoCLIPlugin.getState()).isEqualTo("registered");
@@ -73,15 +73,15 @@ public class BesuPluginContextImplTest {
     final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
     System.setProperty("testPicoCLIPlugin.testOption", "FAILREGISTER");
 
-    assertThat(contextImpl.getPlugins()).isEmpty();
-    contextImpl.registerPlugins(new File(".").toPath());
-    assertThat(contextImpl.getPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    contextImpl.registerPlugins();
+    assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
 
     contextImpl.startPlugins();
-    assertThat(contextImpl.getPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
 
     contextImpl.stopPlugins();
-    assertThat(contextImpl.getPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
   }
 
   @Test
@@ -89,21 +89,24 @@ public class BesuPluginContextImplTest {
     final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
     System.setProperty("testPicoCLIPlugin.testOption", "FAILSTART");
 
-    assertThat(contextImpl.getPlugins()).isEmpty();
-    contextImpl.registerPlugins(new File(".").toPath());
-    assertThat(contextImpl.getPlugins()).extracting("class").contains(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    contextImpl.registerPlugins();
+    assertThat(contextImpl.getNamedPlugins().values())
+        .extracting("class")
+        .contains(TestPicoCLIPlugin.class);
 
-    final Optional<TestPicoCLIPlugin> testPluginOptional = findTestPlugin(contextImpl.getPlugins());
+    final Optional<TestPicoCLIPlugin> testPluginOptional =
+        findTestPlugin(contextImpl.getNamedPlugins());
     assertThat(testPluginOptional).isPresent();
     final TestPicoCLIPlugin testPicoCLIPlugin = testPluginOptional.get();
     assertThat(testPicoCLIPlugin.getState()).isEqualTo("registered");
 
     contextImpl.startPlugins();
     assertThat(testPicoCLIPlugin.getState()).isEqualTo("failstart");
-    assertThat(contextImpl.getPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
 
     contextImpl.stopPlugins();
-    assertThat(contextImpl.getPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isNotInstanceOfAny(TestPicoCLIPlugin.class);
   }
 
   @Test
@@ -111,11 +114,14 @@ public class BesuPluginContextImplTest {
     final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
     System.setProperty("testPicoCLIPlugin.testOption", "FAILSTOP");
 
-    assertThat(contextImpl.getPlugins()).isEmpty();
-    contextImpl.registerPlugins(new File(".").toPath());
-    assertThat(contextImpl.getPlugins()).extracting("class").contains(TestPicoCLIPlugin.class);
+    assertThat(contextImpl.getNamedPlugins()).isEmpty();
+    contextImpl.registerPlugins();
+    assertThat(contextImpl.getNamedPlugins().values())
+        .extracting("class")
+        .contains(TestPicoCLIPlugin.class);
 
-    final Optional<TestPicoCLIPlugin> testPluginOptional = findTestPlugin(contextImpl.getPlugins());
+    final Optional<TestPicoCLIPlugin> testPluginOptional =
+        findTestPlugin(contextImpl.getNamedPlugins());
     assertThat(testPluginOptional).isPresent();
     final TestPicoCLIPlugin testPicoCLIPlugin = testPluginOptional.get();
     assertThat(testPicoCLIPlugin.getState()).isEqualTo("registered");
@@ -130,8 +136,7 @@ public class BesuPluginContextImplTest {
   @Test
   public void lifecycleExceptions() throws Throwable {
     final BesuPluginContextImpl contextImpl = new BesuPluginContextImpl();
-    final ThrowableAssert.ThrowingCallable registerPlugins =
-        () -> contextImpl.registerPlugins(new File(".").toPath());
+    final ThrowableAssert.ThrowingCallable registerPlugins = () -> contextImpl.registerPlugins();
 
     assertThatExceptionOfType(IllegalStateException.class).isThrownBy(contextImpl::startPlugins);
     assertThatExceptionOfType(IllegalStateException.class).isThrownBy(contextImpl::stopPlugins);
@@ -150,8 +155,8 @@ public class BesuPluginContextImplTest {
     assertThatExceptionOfType(IllegalStateException.class).isThrownBy(contextImpl::stopPlugins);
   }
 
-  private Optional<TestPicoCLIPlugin> findTestPlugin(final List<BesuPlugin> plugins) {
-    return plugins.stream()
+  private Optional<TestPicoCLIPlugin> findTestPlugin(final Map<String, BesuPlugin> plugins) {
+    return plugins.values().stream()
         .filter(p -> p instanceof TestPicoCLIPlugin)
         .map(p -> (TestPicoCLIPlugin) p)
         .findFirst();

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PicoCLIOptionsPluginTest.java
@@ -54,9 +54,8 @@ public class PicoCLIOptionsPluginTest extends AcceptanceTestBase {
         node.homeDirectory().resolve("plugins/pluginLifecycle.registered");
     waitForFile(registrationFile);
 
-    // this assert is false as CLI will not be parsed at this point
     assertThat(Files.readAllLines(registrationFile).stream().anyMatch(s -> s.contains(MAGIC_WORDS)))
-        .isFalse();
+        .isTrue();
   }
 
   @Test

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1300,7 +1300,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     UnstableOptionsSubCommand.createUnstableOptions(commandLine, unstableOptions);
   }
 
-  private void preparePlugins() {
+  public void preparePlugins() {
     besuPluginContext.addService(SecurityModuleService.class, securityModuleService);
     besuPluginContext.addService(StorageService.class, storageService);
     besuPluginContext.addService(MetricCategoryRegistry.class, metricCategoryRegistry);

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -242,6 +242,7 @@ public class BlocksSubCommand implements Runnable {
     private BesuController createController() {
       try {
         // Set some defaults
+        parentCommand.parentCommand.preparePlugins();
         return parentCommand
             .parentCommand
             .getControllerBuilder()
@@ -368,6 +369,7 @@ public class BlocksSubCommand implements Runnable {
     }
 
     private BesuController createBesuController() {
+      parentCommand.parentCommand.preparePlugins();
       return parentCommand.parentCommand.buildController();
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
@@ -75,7 +75,7 @@ public class BackupState implements Runnable {
     checkArgument(
         backupDir.exists() || backupDir.mkdirs(),
         "Backup directory does not exist and cannot be created.");
-
+    parentCommand.parentCommand.preparePlugins();
     final BesuController besuController = createBesuController();
     final MutableBlockchain blockchain = besuController.getProtocolContext().getBlockchain();
     final WorldStateStorage worldStateStorage =

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateLogBloomCache.java
@@ -61,9 +61,11 @@ public class GenerateLogBloomCache implements Runnable {
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override
   public void run() {
+    parentCommand.parentCommand.preparePlugins();
     checkPreconditions();
     final Path cacheDir = parentCommand.parentCommand.dataDir().resolve(BesuController.CACHE_PATH);
     cacheDir.toFile().mkdirs();
+
     final MutableBlockchain blockchain =
         createBesuController().getProtocolContext().getBlockchain();
     final EthScheduler scheduler = new EthScheduler(1, 1, 1, 1, new NoOpMetricsSystem());

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
@@ -278,6 +278,7 @@ public class RestoreState implements Runnable {
   }
 
   private BesuController createBesuController() {
+    parentCommand.parentCommand.preparePlugins();
     return parentCommand.parentCommand.buildController();
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'zpv92JZmlU6gPifGcPG5ATE6Lv/ruWdJtjLk3EVXO4g='
+  knownHash = 'jrGM84B8Oja7edSZuiHVLNGy1Xm33vAEKdU5KBanz5o='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin;
 
+import org.hyperledger.besu.plugin.services.PicoCLIOptions;
+
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -34,6 +36,16 @@ public interface BesuPlugin {
    */
   default Optional<String> getName() {
     return Optional.of(this.getClass().getName());
+  }
+
+  /**
+   * Called when the plugin is loaded so that you can register cli options to be parsed
+   *
+   * @param cliOptions the hook to register PicoCLIOptions.
+   */
+  default void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    //    maybe do something like this as a default?
+    //    cliOptions.addPicoCLIOptions(getName().get(), this);
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -46,18 +45,15 @@ public class RocksDBPlugin implements BesuPlugin {
   }
 
   @Override
+  public void registerPicoCLIOptions(final PicoCLIOptions cliOptions) {
+    cliOptions.addPicoCLIOptions(NAME, options);
+  }
+
+  @Override
   public void register(final BesuContext context) {
     LOG.debug("Registering plugin");
     this.context = context;
 
-    final Optional<PicoCLIOptions> cmdlineOptions = context.getService(PicoCLIOptions.class);
-
-    if (cmdlineOptions.isEmpty()) {
-      throw new IllegalStateException(
-          "Expecting a PicoCLIO options to register CLI options with, but none found.");
-    }
-
-    cmdlineOptions.get().addPicoCLIOptions(NAME, options);
     createFactoriesAndRegisterWithStorageService();
 
     LOG.debug("Plugin registered.");


### PR DESCRIPTION
https://wiki.hyperledger.org/display/BESU/DRAFT+-+Pico+CLI+Plugin+Integration

The main change is to move preparePlugins into the begging of the run method. This means that all the cli parsing will happen before the method register is called. 

The only way to register cli options is to use the extra hook provided by `BesuPlugins::registerPicoCLIOptions`