### PR TITLE
[#536] Add support for custom private key file for public-key export and public-key export-address commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - The EVM has been factored out into a standalone module, suitable for inclusion as a library. [#2790](https://github.com/hyperledger/besu/pull/2790)
 - Low level performance improvements changes to cut worst-case EVM performance in half. [#2796](https://github.com/hyperledger/besu/pull/2796)
 - Migrate `ExceptionalHaltReason` from an enum to an interface to allow downstream users of the EVM to add new exceptional halt reasons. [#2810](https://github.com/hyperledger/besu/pull/2810)
+- Add support for custom private key file for public-key export and public-key export-address commands [#2801](https://github.com/hyperledger/besu/pull/2801)
 
 ### Bug Fixes
 - Allow BESU_CONFIG_FILE environment to specify TOML file [#2455](https://github.com/hyperledger/besu/issues/2455)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1327,7 +1327,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @VisibleForTesting
   KeyPair loadKeyPair() {
-    return KeyPairUtil.loadKeyPair(nodePrivateKeyFile());
+    return KeyPairUtil.loadKeyPair(resolveNodePrivateKeyFile());
   }
 
   private void parse(
@@ -2549,7 +2549,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .get();
   }
 
-  private File nodePrivateKeyFile() {
+  private File resolveNodePrivateKeyFile() {
     return Optional.ofNullable(nodePrivateKeyFileOption.getNodePrivateKeyFile())
         .orElseGet(() -> KeyPairUtil.getDefaultKeyFile(dataDir()));
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1321,12 +1321,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private SecurityModule defaultSecurityModule() {
-    return new KeyPairSecurityModule(loadKeyPair());
+    return new KeyPairSecurityModule(loadKeyPair(nodePrivateKeyFileOption.getNodePrivateKeyFile()));
   }
 
   // loadKeyPair() is public because it is accessed by subcommands
-  public KeyPair loadKeyPair() {
-    return KeyPairUtil.loadKeyPair(resolveNodePrivateKeyFile(nodePrivateKeyFileOption.getNodePrivateKeyFile()));
+  public KeyPair loadKeyPair(final File nodePrivateKeyFile) {
+    return KeyPairUtil.loadKeyPair(resolveNodePrivateKeyFile(nodePrivateKeyFile));
   }
 
   private void parse(

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1241,8 +1241,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             rlpBlockExporterFactory,
             resultHandler.out()));
     commandLine.addSubcommand(
-        PublicKeySubCommand.COMMAND_NAME,
-        new PublicKeySubCommand(resultHandler.out(), this::buildNodeKey));
+        PublicKeySubCommand.COMMAND_NAME, new PublicKeySubCommand(resultHandler.out()));
     commandLine.addSubcommand(
         PasswordSubCommand.COMMAND_NAME, new PasswordSubCommand(resultHandler.out()));
     commandLine.addSubcommand(RetestethSubCommand.COMMAND_NAME, new RetestethSubCommand());
@@ -1325,9 +1324,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     return new KeyPairSecurityModule(loadKeyPair());
   }
 
-  @VisibleForTesting
-  KeyPair loadKeyPair() {
-    return KeyPairUtil.loadKeyPair(resolveNodePrivateKeyFile());
+  // loadKeyPair() is public because it is accessed by subcommands
+  public KeyPair loadKeyPair() {
+    return KeyPairUtil.loadKeyPair(resolveNodePrivateKeyFile(nodePrivateKeyFileOption.getNodePrivateKeyFile()));
   }
 
   private void parse(
@@ -1715,7 +1714,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
                 .maxOmmerDepth(unstableMiningOptions.getMaxOmmersDepth())
                 .build())
         .transactionPoolConfiguration(buildTransactionPoolConfiguration())
-        .nodeKey(buildNodeKey())
+        .nodeKey(new NodeKey(securityModule()))
         .metricsSystem(metricsSystem.get())
         .messagePermissioningProviders(permissioningService.getMessagePermissioningProviders())
         .privacyParameters(privacyParameters(storageProvider))
@@ -2537,11 +2536,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     }
   }
 
-  @VisibleForTesting
-  NodeKey buildNodeKey() {
-    return new NodeKey(securityModule());
-  }
-
   private SecurityModule securityModule() {
     return securityModuleService
         .getByName(securityModuleName)
@@ -2549,8 +2543,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .get();
   }
 
-  private File resolveNodePrivateKeyFile() {
-    return Optional.ofNullable(nodePrivateKeyFileOption.getNodePrivateKeyFile())
+  private File resolveNodePrivateKeyFile(final File nodePrivateKeyFile) {
+    return Optional.ofNullable(nodePrivateKeyFile)
         .orElseGet(() -> KeyPairUtil.getDefaultKeyFile(dataDir()));
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -49,6 +49,7 @@ import org.hyperledger.besu.cli.custom.JsonRPCAllowlistHostsProperty;
 import org.hyperledger.besu.cli.custom.RpcAuthFileValidator;
 import org.hyperledger.besu.cli.error.BesuExceptionHandler;
 import org.hyperledger.besu.cli.options.stable.EthstatsOptions;
+import org.hyperledger.besu.cli.options.stable.NodePrivateKeyFileOption;
 import org.hyperledger.besu.cli.options.stable.P2PTLSConfigOptions;
 import org.hyperledger.besu.cli.options.unstable.DataStorageOptions;
 import org.hyperledger.besu.cli.options.unstable.DnsOptions;
@@ -268,6 +269,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   // stable CLI options
   private final EthstatsOptions ethstatsOptions = EthstatsOptions.create();
+  private final NodePrivateKeyFileOption nodePrivateKeyFileOption =
+      NodePrivateKeyFileOption.create();
 
   private final RunnerBuilder runnerBuilder;
   private final BesuController.Builder controllerBuilderFactory;
@@ -320,13 +323,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       description =
           "Genesis file. Setting this option makes --network option ignored and requires --network-id to be set.")
   private final File genesisFile = null;
-
-  @CommandLine.Option(
-      names = {"--node-private-key-file"},
-      paramLabel = MANDATORY_PATH_FORMAT_HELP,
-      description =
-          "The node's private key file (default: a file named \"key\" in the Besu data folder)")
-  private final File nodePrivateKeyFile = null;
 
   @Option(
       names = "--identity",
@@ -1276,6 +1272,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private void handleStableOptions() {
     commandLine.addMixin("Ethstats", ethstatsOptions);
+    commandLine.addMixin("Private key file", nodePrivateKeyFileOption);
   }
 
   private void handleUnstableOptions() {
@@ -1568,7 +1565,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         !SyncMode.FAST.equals(syncMode),
         singletonList("--fast-sync-min-peers"));
 
-    if (!securityModuleName.equals(DEFAULT_SECURITY_MODULE) && nodePrivateKeyFile != null) {
+    if (!securityModuleName.equals(DEFAULT_SECURITY_MODULE)
+        && nodePrivateKeyFileOption.getNodePrivateKeyFile() != null) {
       logger.warn(
           DEPENDENCY_WARNING_MSG,
           "--node-private-key-file",
@@ -2552,7 +2550,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private File nodePrivateKeyFile() {
-    return Optional.ofNullable(nodePrivateKeyFile)
+    return Optional.ofNullable(nodePrivateKeyFileOption.getNodePrivateKeyFile())
         .orElseGet(() -> KeyPairUtil.getDefaultKeyFile(dataDir()));
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/NodePrivateKeyFileOption.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/NodePrivateKeyFileOption.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.stable;
+
+import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_PATH_FORMAT_HELP;
+
+import java.io.File;
+
+import picocli.CommandLine;
+
+public class NodePrivateKeyFileOption {
+
+  public static NodePrivateKeyFileOption create() {
+    return new NodePrivateKeyFileOption();
+  }
+
+  @CommandLine.Option(
+      names = {"--node-private-key-file"},
+      paramLabel = MANDATORY_PATH_FORMAT_HELP,
+      description =
+          "The node's private key file (default: a file named \"key\" in the Besu data directory)")
+  private final File nodePrivateKeyFile = null;
+
+  public File getNodePrivateKeyFile() {
+    return nodePrivateKeyFile;
+  }
+}


### PR DESCRIPTION
## PR description
This PR adds `--node-private-key-file` option to `public-key export-address` and `public-key export` commands.

## Fixed Issue(s)
Fixes #536

## Changelog

- [ ] Add support for custom private key file for public-key export and public-key export-address commands