### PR TITLE
Make ExceptionalHaltReason an interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## 21.10.0-RC1
 ### Additions and Improvements
-* The EVM has been factored out into a standalone module, suitable for inclusion as a library. [#2790](https://github.com/hyperledger/besu/pull/2790)
-* Low level performance improvements changes to cut worst-case EVM performance in half. [#2796](https://github.com/hyperledger/besu/pull/2796)
+- The EVM has been factored out into a standalone module, suitable for inclusion as a library. [#2790](https://github.com/hyperledger/besu/pull/2790)
+- Low level performance improvements changes to cut worst-case EVM performance in half. [#2796](https://github.com/hyperledger/besu/pull/2796)
+- Migrate `ExceptionalHaltReason` from an enum to an interface to allow downstream users of the EVM to add new exceptional halt reasons. [#2810](https://github.com/hyperledger/besu/pull/2810)
 
 ### Bug Fixes
-*  Allow BESU_CONFIG_FILE environment to specify TOML file [#2455](https://github.com/hyperledger/besu/issues/2455)
+- Allow BESU_CONFIG_FILE environment to specify TOML file [#2455](https://github.com/hyperledger/besu/issues/2455)
 
 ### Early Access Features
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/ExceptionalHaltReason.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/ExceptionalHaltReason.java
@@ -14,24 +14,44 @@
  */
 package org.hyperledger.besu.evm.frame;
 
-public enum ExceptionalHaltReason {
-  NONE(""),
-  INSUFFICIENT_GAS("Out of gas"),
-  INSUFFICIENT_STACK_ITEMS("Stack underflow"),
-  INVALID_JUMP_DESTINATION("Bad jump destination"),
-  INVALID_OPERATION("Bad instruction"),
-  INVALID_RETURN_DATA_BUFFER_ACCESS("Out of bounds"),
-  TOO_MANY_STACK_ITEMS("Out of stack"),
-  ILLEGAL_STATE_CHANGE("Illegal state change"),
-  OUT_OF_BOUNDS("Out of bounds");
+public interface ExceptionalHaltReason {
 
-  String description;
+  ExceptionalHaltReason NONE = DefaultExceptionalHaltReason.NONE;
+  ExceptionalHaltReason INSUFFICIENT_GAS = DefaultExceptionalHaltReason.INSUFFICIENT_GAS;
+  ExceptionalHaltReason INSUFFICIENT_STACK_ITEMS =
+      DefaultExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS;
+  ExceptionalHaltReason INVALID_JUMP_DESTINATION =
+      DefaultExceptionalHaltReason.INVALID_JUMP_DESTINATION;
+  ExceptionalHaltReason INVALID_OPERATION = DefaultExceptionalHaltReason.INVALID_OPERATION;
+  ExceptionalHaltReason INVALID_RETURN_DATA_BUFFER_ACCESS =
+      DefaultExceptionalHaltReason.INVALID_RETURN_DATA_BUFFER_ACCESS;
+  ExceptionalHaltReason TOO_MANY_STACK_ITEMS = DefaultExceptionalHaltReason.TOO_MANY_STACK_ITEMS;
+  ExceptionalHaltReason ILLEGAL_STATE_CHANGE = DefaultExceptionalHaltReason.ILLEGAL_STATE_CHANGE;
+  ExceptionalHaltReason OUT_OF_BOUNDS = DefaultExceptionalHaltReason.OUT_OF_BOUNDS;
 
-  ExceptionalHaltReason(final String description) {
-    this.description = description;
-  }
+  String name();
+  String getDescription();
 
-  public String getDescription() {
-    return description;
+  enum DefaultExceptionalHaltReason implements ExceptionalHaltReason {
+    NONE(""),
+    INSUFFICIENT_GAS("Out of gas"),
+    INSUFFICIENT_STACK_ITEMS("Stack underflow"),
+    INVALID_JUMP_DESTINATION("Bad jump destination"),
+    INVALID_OPERATION("Bad instruction"),
+    INVALID_RETURN_DATA_BUFFER_ACCESS("Out of bounds"),
+    TOO_MANY_STACK_ITEMS("Out of stack"),
+    ILLEGAL_STATE_CHANGE("Illegal state change"),
+    OUT_OF_BOUNDS("Out of bounds");
+
+    String description;
+
+    DefaultExceptionalHaltReason(final String description) {
+      this.description = description;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/ExceptionalHaltReason.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/ExceptionalHaltReason.java
@@ -30,6 +30,7 @@ public interface ExceptionalHaltReason {
   ExceptionalHaltReason OUT_OF_BOUNDS = DefaultExceptionalHaltReason.OUT_OF_BOUNDS;
 
   String name();
+
   String getDescription();
 
   enum DefaultExceptionalHaltReason implements ExceptionalHaltReason {

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
@@ -99,6 +99,7 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
         LOG.trace(
             "Contract creation error: account as already been created for address {}",
             frame.getContractAddress());
+        frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
         frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
         operationTracer.traceAccountCreationResult(
             frame, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
@@ -109,7 +110,8 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
         frame.setState(MessageFrame.State.CODE_EXECUTING);
       }
     } catch (final ModificationNotAllowedException ex) {
-      LOG.trace("Contract creation error: illegal modification not allowed from private state");
+      LOG.trace("Contract creation error: atttempt to mutate an immutable account");
+      frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE));
       frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
     }
   }
@@ -129,6 +131,7 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
           depositFee);
       if (requireCodeDepositToSucceed) {
         LOG.trace("Contract creation error: insufficient funds for code deposit");
+        frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
         frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
         operationTracer.traceAccountCreationResult(
             frame, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
@@ -150,6 +153,7 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
             frame.getRemainingGas());
         frame.setState(MessageFrame.State.COMPLETED_SUCCESS);
       } else {
+        frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
         frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
         operationTracer.traceAccountCreationResult(
             frame, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));


### PR DESCRIPTION
Migrate ExceptionalHaltReason to an interface from an enum. The enum
made it difficult for downstream implementations to add custom reasons
as to why the EVM has halted. Switching to an interface is needed
because enums are final and not extensible.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).