### PR TITLE
Refactor(Balance/Ext-*Operations): Extract gas calculation into separate function

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/BalanceOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/BalanceOperation.java
@@ -31,14 +31,17 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class BalanceOperation extends AbstractOperation {
 
-  private final Optional<Gas> warmCost;
-  private final Optional<Gas> coldCost;
-
   public BalanceOperation(final GasCalculator gasCalculator) {
     super(0x31, "BALANCE", 1, 1, false, 1, gasCalculator);
-    final Gas baseCost = gasCalculator.getBalanceOperationGasCost();
-    warmCost = Optional.of(baseCost.plus(gasCalculator.getWarmStorageReadCost()));
-    coldCost = Optional.of(baseCost.plus(gasCalculator.getColdAccountAccessCost()));
+  }
+
+  protected Gas cost(final boolean accountIsWarm) {
+    return gasCalculator()
+        .getBalanceOperationGasCost()
+        .plus(
+            accountIsWarm
+                ? gasCalculator().getWarmStorageReadCost()
+                : gasCalculator().getColdAccountAccessCost());
   }
 
   @Override
@@ -47,7 +50,7 @@ public class BalanceOperation extends AbstractOperation {
       final Address address = Words.toAddress(frame.popStackItem());
       final boolean accountIsWarm =
           frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
-      final Optional<Gas> optionalCost = accountIsWarm ? warmCost : coldCost;
+      final Optional<Gas> optionalCost = Optional.of(cost(accountIsWarm));
       if (frame.getRemainingGas().compareTo(optionalCost.orElse(Gas.ZERO)) < 0) {
         return new OperationResult(
             optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
@@ -58,9 +61,10 @@ public class BalanceOperation extends AbstractOperation {
       }
     } catch (final UnderflowException ufe) {
       return new OperationResult(
-          warmCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+          Optional.of(cost(true)), Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
     } catch (final OverflowException ofe) {
-      return new OperationResult(warmCost, Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
+      return new OperationResult(
+          Optional.of(cost(true)), Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
@@ -35,6 +35,19 @@ public class ExtCodeCopyOperation extends AbstractOperation {
     super(0x3C, "EXTCODECOPY", 4, 0, false, 1, gasCalculator);
   }
 
+  protected Gas cost(
+      final MessageFrame frame,
+      final long memOffset,
+      final long length,
+      final boolean accountIsWarm) {
+    return gasCalculator()
+        .extCodeCopyOperationGasCost(frame, memOffset, length)
+        .plus(
+            accountIsWarm
+                ? gasCalculator().getWarmStorageReadCost()
+                : gasCalculator().getColdAccountAccessCost());
+  }
+
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     final Address address = Words.toAddress(frame.popStackItem());
@@ -44,13 +57,7 @@ public class ExtCodeCopyOperation extends AbstractOperation {
 
     final boolean accountIsWarm =
         frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
-    final Gas cost =
-        gasCalculator()
-            .extCodeCopyOperationGasCost(frame, memOffset, numBytes)
-            .plus(
-                accountIsWarm
-                    ? gasCalculator().getWarmStorageReadCost()
-                    : gasCalculator().getColdAccountAccessCost());
+    final Gas cost = cost(frame, memOffset, numBytes, accountIsWarm);
 
     final Optional<Gas> optionalCost = Optional.of(cost);
     if (frame.getRemainingGas().compareTo(cost) < 0) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperation.java
@@ -31,14 +31,17 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class ExtCodeHashOperation extends AbstractOperation {
 
-  private final Optional<Gas> warmCost;
-  private final Optional<Gas> coldCost;
-
   public ExtCodeHashOperation(final GasCalculator gasCalculator) {
     super(0x3F, "EXTCODEHASH", 1, 1, false, 1, gasCalculator);
-    final Gas baseCost = gasCalculator.extCodeHashOperationGasCost();
-    warmCost = Optional.of(baseCost.plus(gasCalculator.getWarmStorageReadCost()));
-    coldCost = Optional.of(baseCost.plus(gasCalculator.getColdAccountAccessCost()));
+  }
+
+  protected Gas cost(final boolean accountIsWarm) {
+    return gasCalculator()
+        .extCodeHashOperationGasCost()
+        .plus(
+            accountIsWarm
+                ? gasCalculator().getWarmStorageReadCost()
+                : gasCalculator().getColdAccountAccessCost());
   }
 
   @Override
@@ -47,7 +50,7 @@ public class ExtCodeHashOperation extends AbstractOperation {
       final Address address = Words.toAddress(frame.popStackItem());
       final boolean accountIsWarm =
           frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
-      final Optional<Gas> optionalCost = accountIsWarm ? warmCost : coldCost;
+      final Optional<Gas> optionalCost = Optional.of(cost(accountIsWarm));
       if (frame.getRemainingGas().compareTo(optionalCost.get()) < 0) {
         return new OperationResult(
             optionalCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
@@ -62,9 +65,10 @@ public class ExtCodeHashOperation extends AbstractOperation {
       }
     } catch (final UnderflowException ufe) {
       return new OperationResult(
-          warmCost, Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
+          Optional.of(cost(true)), Optional.of(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS));
     } catch (final OverflowException ofe) {
-      return new OperationResult(warmCost, Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
+      return new OperationResult(
+          Optional.of(cost(true)), Optional.of(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS));
     }
   }
 }


### PR DESCRIPTION
## PR description
* Extract gas cost calculation for Balance, ExtCodeCopy, ExtCodeHash, ExtCodeSize operations into `cost` function.
* Allow `cost` function to be called outside library

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).