### PR TITLE
added trace logging for ip -> dns when checking smart contract permissioning

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -25,6 +25,8 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import java.util.List;
 
 import com.google.common.net.InetAddresses;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.jetbrains.annotations.NotNull;
 import org.web3j.abi.FunctionEncoder;
@@ -38,6 +40,8 @@ import org.web3j.abi.datatypes.Function;
  */
 public class NodeSmartContractV2PermissioningController
     extends AbstractNodeSmartContractPermissioningController {
+
+  private static final Logger LOG = LogManager.getLogger();
 
   public static final Bytes TRUE_RESPONSE = Bytes.fromHexString(TypeEncoder.encode(new Bool(true)));
   public static final Bytes FALSE_RESPONSE =
@@ -56,7 +60,13 @@ public class NodeSmartContractV2PermissioningController
   }
 
   private boolean isPermitted(final EnodeURL enode) {
-    return getCallResult(enode) || (boolean) getCallResult(ipToDNS(enode));
+    final boolean isIpEnodePermitted = getCallResult(enode);
+    LOG.info(String.format("Permitted? %s for IP %s", isIpEnodePermitted, enode));
+    if (isIpEnodePermitted) return true;
+    final EnodeURL ipToDNSEnode = ipToDNS(enode);
+    final boolean isIpToDNSEnodePermitted = getCallResult(ipToDNSEnode);
+    LOG.info(String.format("Permitted? %s for DNS %s", isIpToDNSEnodePermitted, ipToDNSEnode));
+    return isIpToDNSEnodePermitted;
   }
 
   @NotNull


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>
Added some logging so users can see more details on what is being resolved and what is being rejected/permitted with regard to IP and DNS versions of enode. This will help when troubleshooting DNS + permissioning.

```
2021-09-29 11:08:50.183+10:00 | vert.x-eventloop-thread-2 | TRACE | NodePermissioningController | Node permissioning: Checking enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@127.0.0.1:40404 -> enode://fcbe9f83218487b3c0b50878193880e6c25cfd86708c0a0bf0ca91f0ce633746a892fe240afa5b9a880b8bca48e8a22704ef937fdda2d7cc63e4d41ed1b417ae@127.0.0.1:30303
2021-09-29 11:08:50.186+10:00 | vert.x-eventloop-thread-2 | INFO  | NodeSmartContractV2PermissioningController | Permitted? false for IP enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@127.0.0.1:40404
2021-09-29 11:08:50.189+10:00 | vert.x-eventloop-thread-2 | INFO  | NodeSmartContractV2PermissioningController | Permitted? false for DNS enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@localhost:40404
2021-09-29 11:08:50.190+10:00 | vert.x-eventloop-thread-2 | TRACE | NodePermissioningController | Node permissioning - NodeSmartContractV2PermissioningController: Rejected enode://3548c87b9920ff16aa4bdcf01c85f25117a29ae1574d759bad48cc9463d8e9f7c3c1d1e9fb0d28e73898951f90e02714abb770fd6d22e90371882a45658800e9@127.0.0.1:40404 -> enode://fcbe9f83218487b3c0b50878193880e6c25cfd86708c0a0bf0ca91f0ce633746a892fe240afa5b9a880b8bca48e8a22704ef937fdda2d7cc63e4d41ed1b417ae@127.0.0.1:30303
```

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).