### PR TITLE
Add manual approval to benchmark until fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,10 @@ workflows:
             - besu-dockerhub-ro
             - besu-dockerhub-rw
             - besu-acr-rw
+      - request-benchmark:
+          type: approval
+          requires:
+            - publishDocker
       - benchmark:
           filters:
             branches:
@@ -346,4 +350,5 @@ workflows:
                 - main
                 - /^release-.*/
           requires:
+            - request-benchmark
             - publishDocker


### PR DESCRIPTION
Add manual approval to benchmark until fixed

Alternatively we could revert https://github.com/hyperledger/besu/commit/ce28aae8b1c789298097deba0b4acc188e5088cb


Signed-off-by: Antony Denyer <git@antonydenyer.co.uk>
