### PR TITLE
2742: Fix flaky timestamp unit test

### DIFF
--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
@@ -92,6 +92,12 @@ public class PeerDiscoveryTimestampsTest {
     firstDiscovered.set(fd);
 
     // Send another packet and ensure that timestamps are updated accordingly.
+    // Sleep beforehand to make sure timestamps will be different.
+    try {
+      Thread.sleep(1);
+    } catch (InterruptedException e) {
+      // Swallow exception because we only want to pause the test.
+    }
     helper.sendMessageBetweenAgents(testAgent, agent, ping);
 
     peer = agent.streamDiscoveredPeers().iterator().next();


### PR DESCRIPTION
Signed-off-by: Caitlin Harding <chardingcs@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
The unit test `PeerDiscoveryTimestampsTest.lastContactedTimestampUpdatedOnOutboundMessage()` fails intermittently due to a timestamp precision issue. In the unit tests, we are comparing the before and after state of a timestamp to ensure it was updated. When the test runs too quickly, the before and after states appear equal due to a loss of precision.

I tried the following solutions:
1. Fixing the precision issue by using the `org.hyperledger.besu.testutil.TestClock` test fixture.
- This did not solve the problem because the underlying class used in the SUT (`DiscoveryPeer`) stores the timestamps as longs, so we are constrained by the precision of longs.
2. Using Mockito to spy on the peer and assert that the `setLastSeen` and `setLastContacted` setters are called.
- This did not solve the problem because the SUT creates the peer object under the hood, and there is no easy way to inject my spy version in there.

So I landed on a simple, albeit not fancy or elegant, solution of adding a 1 ms `sleep` in the test between the two send message calls to ensure the timestamps will be at least 1 ms different.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes https://github.com/hyperledger/besu/issues/2742

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog). - Since this is "Internal technical improvements with no user impact", I think no changelog update is required.