### PR TITLE
Add trace_filter API

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -151,6 +151,7 @@ public enum RpcMethod {
   TRACE_REPLAY_BLOCK_TRANSACTIONS("trace_replayBlockTransactions"),
   TRACE_BLOCK("trace_block"),
   TRACE_TRANSACTION("trace_transaction"),
+  TRACE_FILTER("trace_filter"),
   TX_POOL_BESU_STATISTICS("txpool_besuStatistics"),
   TX_POOL_BESU_TRANSACTIONS("txpool_besuTransactions"),
   TX_POOL_BESU_PENDING_TRANSACTIONS("txpool_besuPendingTransactions"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
@@ -17,11 +17,13 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTraceGenerator;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.RewardTraceGenerator;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.util.ArrayNodeWrapper;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.debug.TraceOptions;
@@ -29,16 +31,16 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 
 public class TraceBlock extends AbstractBlockParameterMethod {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private final Supplier<BlockTracer> blockTracerSupplier;
-  private final ProtocolSchedule protocolSchedule;
+  protected final ProtocolSchedule protocolSchedule;
 
   public TraceBlock(
       final Supplier<BlockTracer> blockTracerSupplier,
@@ -70,16 +72,18 @@ public class TraceBlock extends AbstractBlockParameterMethod {
     return getBlockchainQueries()
         .getBlockchain()
         .getBlockByNumber(blockNumber)
-        .map(this::traceBlock)
+        .map(block -> traceBlock(block, Optional.empty()))
+        .map(ArrayNodeWrapper::getArrayNode)
         .orElse(null);
   }
 
-  private Object traceBlock(final Block block) {
+  protected ArrayNodeWrapper traceBlock(
+      final Block block, final Optional<FilterParameter> filterParameter) {
 
     if (block == null) {
       return emptyResult();
     }
-    final ArrayNode resultArrayNode = MAPPER.createArrayNode();
+    final ArrayNodeWrapper resultArrayNode = new ArrayNodeWrapper(MAPPER.createArrayNode());
 
     blockTracerSupplier
         .get()
@@ -87,18 +91,18 @@ public class TraceBlock extends AbstractBlockParameterMethod {
         .ifPresent(
             blockTrace ->
                 generateTracesFromTransactionTraceAndBlock(
-                    blockTrace.getTransactionTraces(), block, resultArrayNode));
+                    filterParameter, blockTrace.getTransactionTraces(), block, resultArrayNode));
 
-    generateRewardsFromBlock(block, resultArrayNode);
+    generateRewardsFromBlock(filterParameter, block, resultArrayNode);
 
     return resultArrayNode;
   }
 
-  private void generateTracesFromTransactionTraceAndBlock(
+  protected void generateTracesFromTransactionTraceAndBlock(
+      final Optional<FilterParameter> filterParameter,
       final List<TransactionTrace> transactionTraces,
       final Block block,
-      final ArrayNode resultArrayNode) {
-
+      final ArrayNodeWrapper resultArrayNode) {
     transactionTraces.forEach(
         transactionTrace ->
             FlatTraceGenerator.generateFromTransactionTraceAndBlock(
@@ -106,12 +110,15 @@ public class TraceBlock extends AbstractBlockParameterMethod {
                 .forEachOrdered(resultArrayNode::addPOJO));
   }
 
-  private void generateRewardsFromBlock(final Block block, final ArrayNode resultArrayNode) {
+  protected void generateRewardsFromBlock(
+      final Optional<FilterParameter> maybeFilterParameter,
+      final Block block,
+      final ArrayNodeWrapper resultArrayNode) {
     RewardTraceGenerator.generateFromBlock(protocolSchedule, block)
         .forEachOrdered(resultArrayNode::addPOJO);
   }
 
-  private Object emptyResult() {
-    return MAPPER.createArrayNode();
+  private ArrayNodeWrapper emptyResult() {
+    return new ArrayNodeWrapper(MAPPER.createArrayNode());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
@@ -30,34 +30,47 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.base.MoreObjects;
 
 public class FilterParameter {
 
   private final BlockParameter fromBlock;
   private final BlockParameter toBlock;
+  private final List<Address> fromAddress;
+  private final List<Address> toAddress;
   private final List<Address> addresses;
   private final List<List<LogTopic>> topics;
   private final Optional<Hash> maybeBlockHash;
   private final LogsQuery logsQuery;
+  private final Optional<Integer> after, count;
   private final boolean isValid;
 
   @JsonCreator
   public FilterParameter(
       @JsonProperty("fromBlock") final BlockParameter fromBlock,
       @JsonProperty("toBlock") final BlockParameter toBlock,
+      @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+          @JsonProperty("fromAddress")
+          final List<Address> fromAddress,
+      @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("toAddress")
+          final List<Address> toAddress,
       @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("address")
           final List<Address> address,
       @JsonDeserialize(using = TopicsDeserializer.class) @JsonProperty("topics")
           final List<List<LogTopic>> topics,
-      @JsonProperty("blockHash") @JsonAlias({"blockhash"}) final Hash blockHash) {
+      @JsonProperty("blockHash") @JsonAlias({"blockhash"}) final Hash blockHash,
+      @JsonProperty("after") final Integer after,
+      @JsonProperty("count") final Integer count) {
     this.isValid = blockHash == null || (fromBlock == null && toBlock == null);
     this.fromBlock = fromBlock != null ? fromBlock : BlockParameter.LATEST;
     this.toBlock = toBlock != null ? toBlock : BlockParameter.LATEST;
+    this.fromAddress = fromAddress != null ? fromAddress : emptyList();
+    this.toAddress = toAddress != null ? toAddress : emptyList();
     this.addresses = address != null ? address : emptyList();
     this.topics = topics != null ? topics : emptyList();
     this.logsQuery = new LogsQuery(addresses, topics);
     this.maybeBlockHash = Optional.ofNullable(blockHash);
+    this.after = Optional.ofNullable(after);
+    this.count = Optional.ofNullable(count);
   }
 
   public BlockParameter getFromBlock() {
@@ -66,6 +79,14 @@ public class FilterParameter {
 
   public BlockParameter getToBlock() {
     return toBlock;
+  }
+
+  public List<Address> getFromAddress() {
+    return fromAddress;
+  }
+
+  public List<Address> getToAddress() {
+    return toAddress;
   }
 
   public List<Address> getAddresses() {
@@ -84,33 +105,74 @@ public class FilterParameter {
     return logsQuery;
   }
 
+  public Optional<Integer> getAfter() {
+    return after;
+  }
+
+  public Optional<Integer> getCount() {
+    return count;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     FilterParameter that = (FilterParameter) o;
-    return fromBlock.equals(that.fromBlock)
-        && toBlock.equals(that.toBlock)
-        && addresses.equals(that.addresses)
-        && topics.equals(that.topics)
-        && maybeBlockHash.equals(that.maybeBlockHash)
-        && logsQuery.equals(that.logsQuery);
+    return isValid == that.isValid
+        && Objects.equals(fromBlock, that.fromBlock)
+        && Objects.equals(toBlock, that.toBlock)
+        && Objects.equals(fromAddress, that.fromAddress)
+        && Objects.equals(toAddress, that.toAddress)
+        && Objects.equals(addresses, that.addresses)
+        && Objects.equals(topics, that.topics)
+        && Objects.equals(maybeBlockHash, that.maybeBlockHash)
+        && Objects.equals(logsQuery, that.logsQuery)
+        && Objects.equals(after, that.after)
+        && Objects.equals(count, that.count);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(fromBlock, toBlock, addresses, topics, maybeBlockHash, logsQuery);
+    return Objects.hash(
+        fromBlock,
+        toBlock,
+        fromAddress,
+        toAddress,
+        addresses,
+        topics,
+        maybeBlockHash,
+        logsQuery,
+        after,
+        count,
+        isValid);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("fromBlock", fromBlock)
-        .add("toBlock", toBlock)
-        .add("addresses", addresses)
-        .add("topics", topics)
-        .add("blockHash", maybeBlockHash)
-        .toString();
+    return "FilterParameter{"
+        + "fromBlock="
+        + fromBlock
+        + ", toBlock="
+        + toBlock
+        + ", fromAddress="
+        + fromAddress
+        + ", toAddress="
+        + toAddress
+        + ", addresses="
+        + addresses
+        + ", topics="
+        + topics
+        + ", maybeBlockHash="
+        + maybeBlockHash
+        + ", logsQuery="
+        + logsQuery
+        + ", after="
+        + after
+        + ", count="
+        + count
+        + ", isValid="
+        + isValid
+        + '}';
   }
 
   public boolean isValid() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceBlock;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceFilter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceReplayBlockTransactions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
@@ -53,6 +54,7 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
     return mapOf(
         new TraceReplayBlockTransactions(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
+        new TraceFilter(() -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
         new TraceTransaction(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
         new TraceBlock(() -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/TraceJsonRpcHttpBySpecTest.java
@@ -53,7 +53,8 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
           "trace/specs/replay-trace-transaction/vm-trace",
           "trace/specs/replay-trace-transaction/statediff",
           "trace/specs/replay-trace-transaction/all",
-          "trace/specs/replay-trace-transaction/halt-cases"
+          "trace/specs/replay-trace-transaction/halt-cases",
+          "trace/specs/trace-filter"
         });
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/TraceJsonRpcHttpBySpecTest.java
@@ -53,7 +53,8 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
           "trace/specs/replay-trace-transaction/vm-trace",
           "trace/specs/replay-trace-transaction/statediff",
           "trace/specs/replay-trace-transaction/all",
-          "trace/specs/replay-trace-transaction/halt-cases"
+          "trace/specs/replay-trace-transaction/halt-cases",
+          "trace/specs/trace-filter"
         });
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
@@ -66,7 +66,8 @@ public class EthNewFilterTest {
 
   @Test
   public void newFilterWithoutFromBlockParamUsesLatestAsDefault() {
-    final FilterParameter filterParameter = new FilterParameter(null, null, null, null, null);
+    final FilterParameter filterParameter =
+        new FilterParameter(null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = ethNewFilter(filterParameter);
 
     method.response(request);
@@ -76,7 +77,8 @@ public class EthNewFilterTest {
 
   @Test
   public void newFilterWithoutToBlockParamUsesLatestAsDefault() {
-    final FilterParameter filterParameter = new FilterParameter(null, null, null, null, null);
+    final FilterParameter filterParameter =
+        new FilterParameter(null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = ethNewFilter(filterParameter);
 
     method.response(request);
@@ -87,7 +89,8 @@ public class EthNewFilterTest {
   @Test
   public void newFilterWithoutAddressAndTopicsParamsInstallsEmptyLogFilter() {
     final FilterParameter filterParameter =
-        new FilterParameter(BlockParameter.LATEST, BlockParameter.LATEST, null, null, null);
+        new FilterParameter(
+            BlockParameter.LATEST, BlockParameter.LATEST, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = ethNewFilter(filterParameter);
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), "0x1");
@@ -169,8 +172,12 @@ public class EthNewFilterTest {
             BlockParameter.EARLIEST,
             BlockParameter.LATEST,
             Collections.emptyList(),
+            null,
+            null,
             Collections.emptyList(),
-            Hash.ZERO);
+            Hash.ZERO,
+            null,
+            null);
 
     final JsonRpcRequestContext request = ethNewFilter(invalidFilter);
 
@@ -195,7 +202,11 @@ public class EthNewFilterTest {
         BlockParameter.LATEST,
         BlockParameter.LATEST,
         Optional.ofNullable(address).map(Collections::singletonList).orElse(emptyList()),
+        null,
+        null,
         topics,
+        null,
+        null,
         null);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -413,6 +413,22 @@ public class FilterParameterTest {
             List.of(LogTopic.fromHexString(TOPIC_FOUR), LogTopic.fromHexString(TOPIC_FIVE)));
   }
 
+  @Test
+  public void fromAndToAddressesShouldDeserializeAsTwoListsOfAddresses()
+      throws java.io.IOException {
+    final FilterParameter filterParameter =
+        readJsonAsFilterParameter("{\"fromAddress\":[\"0x0\"], \"toAddress\":[\"0x1\"]}");
+    assertThat(filterParameter.getFromAddress()).containsExactly(Address.fromHexString("0x0"));
+    assertThat(filterParameter.getToAddress()).containsExactly(Address.fromHexString("0x1"));
+  }
+
+  @Test
+  public void countAndAfterShouldDeserializeCorrectly() throws java.io.IOException {
+    final FilterParameter filterParameter = readJsonAsFilterParameter("{\"after\":1, \"count\":2}");
+    assertThat(filterParameter.getAfter()).contains(1);
+    assertThat(filterParameter.getCount()).contains(2);
+  }
+
   private <T> FilterParameter createFilterWithTopics(final T inputTopics)
       throws JsonProcessingException {
     final Map<String, T> payload = new HashMap<>();
@@ -428,6 +444,10 @@ public class FilterParameterTest {
         BlockParameter.LATEST,
         Arrays.stream(addresses).map(Address::fromHexString).collect(toUnmodifiableList()),
         null,
+        null,
+        null,
+        null,
+        null,
         null);
   }
 
@@ -436,8 +456,12 @@ public class FilterParameterTest {
         BlockParameter.LATEST,
         BlockParameter.LATEST,
         singletonList(Address.fromHexString("0x0")),
+        null,
+        null,
         singletonList(
             Arrays.stream(topics).map(LogTopic::fromHexString).collect(toUnmodifiableList())),
+        null,
+        null,
         null);
   }
 
@@ -449,7 +473,11 @@ public class FilterParameterTest {
         BlockParameter.LATEST,
         BlockParameter.LATEST,
         singletonList(Address.fromHexString("0x0")),
+        null,
+        null,
         topicsListList,
+        null,
+        null,
         null);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
@@ -110,8 +110,12 @@ public class PrivGetLogsTest {
             BlockParameter.EARLIEST,
             BlockParameter.EARLIEST,
             Collections.emptyList(),
+            null,
+            null,
             Collections.emptyList(),
-            Hash.ZERO);
+            Hash.ZERO,
+            null,
+            null);
 
     final JsonRpcRequestContext request = privGetLogRequest(PRIVACY_GROUP_ID, invalidFilter);
 
@@ -133,7 +137,7 @@ public class PrivGetLogsTest {
     when(blockHeader.getNumber()).thenReturn(100L);
 
     final FilterParameter blockHashFilter =
-        new FilterParameter(null, null, addresses, logTopics, blockHash);
+        new FilterParameter(null, null, addresses, null, null, logTopics, blockHash, null, null);
 
     final LogsQuery expectedQuery =
         new LogsQuery.Builder().addresses(addresses).topics(logTopics).build();
@@ -149,7 +153,15 @@ public class PrivGetLogsTest {
     final Hash blockHash = Hash.hash(Bytes32.random());
     final FilterParameter blockHashFilter =
         new FilterParameter(
-            null, null, Collections.emptyList(), Collections.emptyList(), blockHash);
+            null,
+            null,
+            Collections.emptyList(),
+            null,
+            null,
+            Collections.emptyList(),
+            blockHash,
+            null,
+            null);
 
     final List<LogWithMetadata> logWithMetadataList = logWithMetadataList(3);
     final LogsResult expectedLogsResult = new LogsResult(logWithMetadataList);
@@ -175,7 +187,11 @@ public class PrivGetLogsTest {
             BlockParameter.EARLIEST,
             BlockParameter.LATEST,
             Collections.emptyList(),
+            null,
+            null,
             Collections.emptyList(),
+            null,
+            null,
             null);
     final List<LogWithMetadata> logWithMetadataList = logWithMetadataList(3);
     final LogsResult expectedLogsResult = new LogsResult(logWithMetadataList);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
@@ -100,8 +100,12 @@ public class PrivNewFilterTest {
             BlockParameter.EARLIEST,
             BlockParameter.LATEST,
             Collections.emptyList(),
+            null,
+            null,
             Collections.emptyList(),
-            Hash.ZERO);
+            Hash.ZERO,
+            null,
+            null);
 
     final JsonRpcRequestContext request = privNewFilterRequest(PRIVACY_GROUP_ID, invalidFilter);
 
@@ -122,7 +126,15 @@ public class PrivNewFilterTest {
 
     final FilterParameter filter =
         new FilterParameter(
-            BlockParameter.EARLIEST, BlockParameter.LATEST, addresses, logTopics, null);
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
+            addresses,
+            null,
+            null,
+            logTopics,
+            null,
+            null,
+            null);
 
     final LogsQuery expectedQuery =
         new LogsQuery.Builder().addresses(addresses).topics(logTopics).build();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
@@ -174,6 +174,7 @@ public class SubscriptionBuilderTest {
   }
 
   private FilterParameter filterParameter() {
-    return new FilterParameter(BlockParameter.EARLIEST, BlockParameter.LATEST, null, null, null);
+    return new FilterParameter(
+        BlockParameter.EARLIEST, BlockParameter.LATEST, null, null, null, null, null, null, null);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerTest.java
@@ -219,7 +219,16 @@ public class SubscriptionManagerTest {
   public void shouldUnsubscribeIfUserRemovedFromPrivacyGroup() {
     final String enclavePublicKey = "C1bVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
     final FilterParameter filterParameter =
-        new FilterParameter(BlockParameter.EARLIEST, BlockParameter.LATEST, null, null, null);
+        new FilterParameter(
+            BlockParameter.EARLIEST,
+            BlockParameter.LATEST,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
     final String privacyGroupId = "ZDmkMK7CyxA1F1rktItzKFTfRwApg7aWzsTtm2IOZ5Y=";
     final PrivateSubscribeRequest privateSubscribeRequest =
         new PrivateSubscribeRequest(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
@@ -400,7 +400,11 @@ public class LogsSubscriptionServiceTest {
             BlockParameter.LATEST,
             BlockParameter.LATEST,
             Arrays.asList(address),
+            null,
+            null,
             Collections.emptyList(),
+            null,
+            null,
             null),
         privacyGroupId,
         enclavePublicKey);
@@ -417,7 +421,15 @@ public class LogsSubscriptionServiceTest {
         nextSubscriptionId.incrementAndGet(),
         "conn",
         new FilterParameter(
-            BlockParameter.LATEST, BlockParameter.LATEST, addresses, logTopics, null));
+            BlockParameter.LATEST,
+            BlockParameter.LATEST,
+            addresses,
+            null,
+            null,
+            logTopics,
+            null,
+            null,
+            null));
   }
 
   private void registerSubscriptions(final LogsSubscription... subscriptions) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
@@ -177,7 +177,11 @@ public class SubscriptionRequestMapperTest {
                 BlockParameter.LATEST,
                 BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
+                null,
+                null,
                 emptyList(),
+                null,
+                null,
                 null),
             null,
             null);
@@ -206,10 +210,14 @@ public class SubscriptionRequestMapperTest {
                         "0xf17f52151EbEF6C7334FAD080c5704D77216b732")
                     .map(Address::fromHexString)
                     .collect(toUnmodifiableList()),
+                null,
+                null,
                 singletonList(
                     singletonList(
                         LogTopic.fromHexString(
                             "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"))),
+                null,
+                null,
                 null),
             null,
             null);
@@ -234,6 +242,8 @@ public class SubscriptionRequestMapperTest {
                 BlockParameter.LATEST,
                 BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
+                null,
+                null,
                 List.of(
                     singletonList(
                         LogTopic.fromHexString(
@@ -241,6 +251,8 @@ public class SubscriptionRequestMapperTest {
                     singletonList(
                         LogTopic.fromHexString(
                             "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab901"))),
+                null,
+                null,
                 null),
             null,
             null);
@@ -265,7 +277,11 @@ public class SubscriptionRequestMapperTest {
                 BlockParameter.LATEST,
                 BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
+                null,
+                null,
                 emptyList(),
+                null,
+                null,
                 null),
             null,
             null);
@@ -388,7 +404,11 @@ public class SubscriptionRequestMapperTest {
                 BlockParameter.LATEST,
                 BlockParameter.LATEST,
                 singletonList(Address.fromHexString("0x8320fe7702b96808f7bbc0d4a888ed1468216cfd")),
+                null,
+                null,
                 emptyList(),
+                null,
+                null,
                 null),
             null,
             null,


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR adds the trace_filter API. This API returns traces matching given filter

    fromBlock:  trace will start at this block (optional) .
    toBlock:race will stop at this block (optional) .
    fromAddress: only traces with this senders  (optional) .
    toAddress: only traces with this destination addresses  (optional) .
    after: the offset 
    count:  maximum number of traces to return

#### Request
```json
{
    "jsonrpc": "2.0",
    "method": "trace_filter",
    "params": [
      {
        "fromBlock": "0x1",
        "toBlock": "0x21",
        "after": 2,
        "count": 2,
        "fromAddress": [
          "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73"
        ]
      }
    ],
    "id": 415
  }
```


#### Response
```json
{
    "jsonrpc": "2.0",
    "result": [
      {
        "action": {
          "callType": "call",
          "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
          "gas": "0xffad82",
          "input": "0x0000000000000000000000000000000000000999",
          "to": "0x0020000000000000000000000000000000000000",
          "value": "0x0"
        },
        "blockHash": "0xcd5d9c7acdcbd3fb4b24a39e05a38e32235751bb0c9e4f1aa16dc598a2c2a9e4",
        "blockNumber": 6,
        "result": {
          "gasUsed": "0x7536",
          "output": "0x"
        },
        "subtraces": 1,
        "traceAddress": [],
        "transactionHash": "0x91eeabc671e2dd2b1c8ddebb46ba59e8cb3e7d189f80bcc868a9787728c6e59e",
        "transactionPosition": 0,
        "type": "call"
      },
      {
        "action": {
          "callType": "call",
          "from": "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
          "gas": "0xffad52",
          "input": "0xf000000000000000000000000000000000000000000000000000000000000001",
          "to": "0x0030000000000000000000000000000000000000",
          "value": "0x0"
        },
        "blockHash": "0xeed85fe57db751442c826cfe4fdf43b10a5c2bc8b6fd3a8ccced48eb3fb35885",
        "blockNumber": 7,
        "result": {
          "gasUsed": "0x1b",
          "output": "0xf000000000000000000000000000000000000000000000000000000000000002"
        },
        "subtraces": 0,
        "traceAddress": [],
        "transactionHash": "0x47f4d445ea1812cb1ddd3464ab23d2bfc6ed408a8a9db1c497f94e8e06e85286",
        "transactionPosition": 0,
        "type": "call"
      }
    ],
    "id": 415
  }
```

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).