### PR TITLE
[#2925] Update JDK 11 to latest version in Besu Docker images 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Additions and Improvements
 - Upgrade CircleCI OpenJDK docker image to version 11.0.12. [#2928](https://github.com/hyperledger/besu/pull/2928)
+- Update JDK 11 to latest version in Besu Docker images. [#2925](https://github.com/hyperledger/besu/pull/2925)
 
 ### Bug Fixes
 - Do not change the sender balance, but set gas fee to zero, when simulating a transaction without enforcing balance checks. [#2454](https://github.com/hyperledger/besu/pull/2454)

--- a/docker/graalvm/Dockerfile
+++ b/docker/graalvm/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ghcr.io/graalvm/graalvm-ce:ol7-java11-21.0.0
+FROM ghcr.io/graalvm/graalvm-ce:ol7-java11
 ARG VERSION="dev"
 
 RUN adduser --home /opt/besu besu && \

--- a/docker/openjdk-11/Dockerfile
+++ b/docker/openjdk-11/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9
+FROM openjdk:11-slim-buster
 
 ARG VERSION="dev"
 


### PR DESCRIPTION
AdoptOpenJDK project is now deprecated.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Replace AdoptOpenJDK base image for Java 11, with the updated base image provided by Eclipse Temurin.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2925

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).