### PR TITLE
Improve test coverage of autoselection of isAllowedExeceedingBalance …

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -40,6 +40,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.ImmutableTransactionValidationParams;
+import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
@@ -215,14 +217,79 @@ public class EthCallTest {
     verify(blockchainQueries).headBlockNumber();
   }
 
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToTrueWhenGasPriceIsZero() {
+    JsonCallParameter callParameters = callParameter(Wei.ZERO, null, null);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.empty(), true);
+  }
+
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToTrueWhenGasPriceIsZeroAfterEIP1559() {
+    JsonCallParameter callParameters = callParameter(Wei.ZERO, null, null);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.of(1L), true);
+  }
+
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToFalseWhenGasPriceIsNotZero() {
+    JsonCallParameter callParameters = callParameter(Wei.ONE, null, null);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.empty(), false);
+  }
+
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToFalseWhenGasPriceIsNotZeroAfterEIP1559() {
+    JsonCallParameter callParameters = callParameter(Wei.ONE, null, null);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.of(1L), false);
+  }
+
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToTrueWhenFeesAreZero() {
+    JsonCallParameter callParameters = callParameter(null, Wei.ZERO, Wei.ZERO);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.of(1L), true);
+  }
+
+  @Test
+  public void shouldAutoSelectIsAllowedExeceedingBalanceToFalseWhenFeesAreZero() {
+    JsonCallParameter callParameters = callParameter(null, Wei.ONE, Wei.ONE);
+    internalAutoSelectIsAllowedExeecdBalance(callParameters, Optional.of(1L), false);
+  }
+
+  private void internalAutoSelectIsAllowedExeecdBalance(
+      final JsonCallParameter callParameter,
+      final Optional<Long> baseFee,
+      final boolean isAllowedExeedingBalance) {
+    final JsonRpcRequestContext request = ethCallRequest(callParameter, "latest");
+
+    BlockHeader blockHeader = mock(BlockHeader.class);
+    when(blockHeader.getBaseFee()).thenReturn(baseFee);
+    when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
+    when(blockchainQueries.getBlockchain().getChainHead()).thenReturn(chainHead);
+    when(blockchainQueries.getBlockchain().getChainHead().getHash()).thenReturn(Hash.ZERO);
+    when(blockchainQueries.getBlockHeaderByHash(Hash.ZERO)).thenReturn(Optional.of(blockHeader));
+
+    method.response(request);
+
+    TransactionValidationParams transactionValidationParams =
+        ImmutableTransactionValidationParams.builder()
+            .from(TransactionValidationParams.transactionSimulator())
+            .isAllowExceedingBalance(isAllowedExeedingBalance)
+            .build();
+
+    verify(transactionSimulator).process(any(), eq(transactionValidationParams), any(), any());
+  }
+
   private JsonCallParameter callParameter() {
+    return callParameter(Wei.ZERO, null, null);
+  }
+
+  private JsonCallParameter callParameter(
+      final Wei gasPrice, final Wei maxFeesPerGas, final Wei maxPriorityFeesPerGas) {
     return new JsonCallParameter(
         Address.fromHexString("0x0"),
         Address.fromHexString("0x0"),
         Gas.ZERO,
-        Wei.ZERO,
-        null,
-        null,
+        gasPrice,
+        maxFeesPerGas,
+        maxPriorityFeesPerGas,
         Wei.ZERO,
         Bytes.EMPTY,
         null);


### PR DESCRIPTION
…validation parameter

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

eth_call has a autoselection of isAllowedExeceedingBalance validation parameter, in case the `strict` parameter is not defined in the request, but that code was not well covered by unit tests, this patch will full cover it.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
is related to #502 since it verify that the behavior is consistent with other clients
## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).