### PR TITLE
Fix for optimistic sync behavior

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockImporter.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockImporter.java
@@ -32,10 +32,15 @@ public class MergeBlockImporter extends MainnetBlockImporter {
       final Block block,
       final HeaderValidationMode headerValidationMode,
       final HeaderValidationMode ommerValidationMode) {
-    if (context.getConsensusContext(MergeContext.class).isPostMerge()) {
-      // TODO: for now optimistically import, this should only come from initial sync pre-TTD
-      // return true;
+
+    var res = super.importBlock(context, block, headerValidationMode, ommerValidationMode);
+
+    // TODO: for now optimistically import blocks post-TTD, this should only come from initial sync
+    // pre-TTD
+    if (res && context.getConsensusContext(MergeContext.class).isPostMerge()) {
+      context.getConsensusContext(MergeContext.class).setConsensusValidated(block.getHash());
     }
-    return super.importBlock(context, block, headerValidationMode, ommerValidationMode);
+
+    return res;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fix for post-terminal-total-difficulty optimistic sync behavior.   Once we are past TTD we use MergeBlockValidator, and need to explicitly validate consensus in order to persist the world state.

This was causing a problem on pithos testnet when we hit block 44524 which is the first block to include transactions and update worldstate.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Possibly fixes #2940 - will attempt to reproduce 


## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).