### PR TITLE
Move plugin validation to happen after startPlugins

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -130,8 +130,10 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
         params.add(node.getPrivacyParameters().getEnclavePublicKeyFile().getAbsolutePath());
       }
 
-      params.add("--privacy-marker-transaction-signing-key-file");
-      params.add(node.homeDirectory().resolve("key").toString());
+      if (!node.getExtraCLIOptions().contains("--plugin-privacy-service-signing-enabled=true")) {
+        params.add("--privacy-marker-transaction-signing-key-file");
+        params.add(node.homeDirectory().resolve("key").toString());
+      }
 
       if (node.getPrivacyParameters().isOnchainPrivacyGroupsEnabled()) {
         params.add("--privacy-onchain-groups-enabled");

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -196,18 +196,23 @@ public class PrivacyNode implements AutoCloseable {
       final Path dataDir = Files.createTempDirectory("acctest-privacy");
       final Path dbDir = dataDir.resolve(DATABASE_PATH);
 
-      privacyParameters =
+      var builder =
           new PrivacyParameters.Builder()
               .setEnabled(true)
               .setEnclaveUrl(enclave.clientUrl())
-              .setPrivacyUserIdUsingFile(enclave.getPublicKeyPaths().get(0).toFile())
               .setStorageProvider(createKeyValueStorageProvider(dataDir, dbDir))
               .setPrivateKeyPath(KeyPairUtil.getDefaultKeyFile(besu.homeDirectory()).toPath())
               .setEnclaveFactory(new EnclaveFactory(vertx))
               .setOnchainPrivacyGroupsEnabled(isOnchainPrivacyEnabled)
               .setMultiTenancyEnabled(isMultitenancyEnabled)
-              .setPrivacyPluginEnabled(isPrivacyPluginEnabled)
-              .build();
+              .setPrivacyPluginEnabled(isPrivacyPluginEnabled);
+
+      if (enclave.getPublicKeyPaths().size() > 0) {
+        builder.setPrivacyUserIdUsingFile(enclave.getPublicKeyPaths().get(0).toFile());
+      }
+
+      privacyParameters = builder.build();
+
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/BadCLIOptionsPlugin.java
@@ -45,11 +45,13 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeStatus("init");
 
-    context
-        .getService(PicoCLIOptions.class)
-        .ifPresent(
-            picoCLIOptions ->
-                picoCLIOptions.addPicoCLIOptions("bad-cli", BadCLIOptionsPlugin.this));
+    if (System.getProperty("TEST_BAD_CLI", "false").equals("true")) {
+      context
+          .getService(PicoCLIOptions.class)
+          .ifPresent(
+              picoCLIOptions ->
+                  picoCLIOptions.addPicoCLIOptions("bad-cli", BadCLIOptionsPlugin.this));
+    }
 
     writeStatus("register");
   }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPrivacyServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/plugins/TestPrivacyServicePlugin.java
@@ -34,7 +34,6 @@ public class TestPrivacyServicePlugin implements BesuPlugin {
   PrivacyPluginService pluginService;
   BesuContext context;
 
-  TestPrivacyPluginPayloadProvider payloadProvider = new TestPrivacyPluginPayloadProvider();
   TestPrivacyGroupGenesisProvider privacyGroupGenesisProvider =
       new TestPrivacyGroupGenesisProvider();
   TestSigningPrivateMarkerTransactionFactory privateMarkerTransactionFactory =
@@ -46,8 +45,6 @@ public class TestPrivacyServicePlugin implements BesuPlugin {
 
     context.getService(PicoCLIOptions.class).get().addPicoCLIOptions("privacy-service", this);
     pluginService = context.getService(PrivacyPluginService.class).get();
-
-    pluginService.setPayloadProvider(payloadProvider);
     pluginService.setPrivacyGroupGenesisProvider(privacyGroupGenesisProvider);
 
     LOG.info("Registering Plugins with options " + this);
@@ -57,6 +54,9 @@ public class TestPrivacyServicePlugin implements BesuPlugin {
   public void start() {
     LOG.info("Start Plugins with options " + this);
 
+    TestPrivacyPluginPayloadProvider payloadProvider = new TestPrivacyPluginPayloadProvider();
+
+    pluginService.setPayloadProvider(payloadProvider);
     payloadProvider.setPluginPayloadPrefix(prefix);
 
     if (genesisEnabled) {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.awaitility.Awaitility;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,10 +38,17 @@ public class BadCLIOptionsPluginTest extends AcceptanceTestBase {
 
   @Before
   public void setUp() throws Exception {
+    System.setProperty("TEST_BAD_CLI", "true");
+
     node =
         besu.createPluginsNode(
             "node1", Collections.singletonList("testPlugins"), Collections.emptyList());
     cluster.start(node);
+  }
+
+  @After
+  public void tearDown() {
+    System.setProperty("TEST_BAD_CLI", "false");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -163,6 +163,7 @@ public abstract class CommandTestAbstract {
   @Mock protected MutableBlockchain mockMutableBlockchain;
   @Mock protected WorldStateArchive mockWorldStateArchive;
   @Mock protected TransactionPool mockTransactionPool;
+  @Mock protected PrivacyPluginServiceImpl privacyPluginService;
 
   @SuppressWarnings("PrivateStaticFinalLoggers") // @Mocks are inited by JUnit
   @Mock
@@ -362,7 +363,8 @@ public abstract class CommandTestAbstract {
             environment,
             storageService,
             securityModuleService,
-            mockPkiBlockCreationConfigProvider);
+            mockPkiBlockCreationConfigProvider,
+            privacyPluginService);
     besuCommands.add(besuCommand);
 
     File defaultKeyFile =
@@ -400,7 +402,8 @@ public abstract class CommandTestAbstract {
         final Map<String, String> environment,
         final StorageServiceImpl storageService,
         final SecurityModuleServiceImpl securityModuleService,
-        final PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider) {
+        final PkiBlockCreationConfigurationProvider pkiBlockCreationConfigProvider,
+        final PrivacyPluginServiceImpl privacyPluginService) {
       super(
           mockLogger,
           mockBlockImporter,
@@ -413,7 +416,7 @@ public abstract class CommandTestAbstract {
           storageService,
           securityModuleService,
           new PermissioningServiceImpl(),
-          new PrivacyPluginServiceImpl(),
+          privacyPluginService,
           pkiBlockCreationConfigProvider,
           rpcEndpointServiceImpl);
     }


### PR DESCRIPTION
This is required because plugin implementation may need to wait until cli options have been bound to decide if they wish to initialise. 

Signed-off-by: Antony Denyer <git@antonydenyer.co.uk>