### PR TITLE
Improve ValidatorContractController result validation

### DIFF
--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
@@ -99,8 +99,16 @@ public class ValidatorContractController {
   private List<Type> decodeResult(
       final TransactionSimulatorResult result, final Function function) {
     if (result.isSuccessful()) {
-      return DefaultFunctionReturnDecoder.decode(
-          result.getResult().getOutput().toHexString(), function.getOutputParameters());
+      final List<Type> decodedList =
+          DefaultFunctionReturnDecoder.decode(
+              result.getResult().getOutput().toHexString(), function.getOutputParameters());
+
+      if (decodedList.isEmpty()) {
+        throw new IllegalStateException(
+            "Unexpected empty result from validator smart contract call");
+      }
+
+      return decodedList;
     } else {
       throw new IllegalStateException("Failed validator smart contract call");
     }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractControllerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractControllerTest.java
@@ -134,6 +134,23 @@ public class ValidatorContractControllerTest {
   }
 
   @Test
+  public void throwErrorIfUnexpectedSuccessfulEmptySimulationResult() {
+    final TransactionSimulatorResult result =
+        new TransactionSimulatorResult(
+            transaction,
+            TransactionProcessingResult.successful(
+                List.of(), 0, 0, Bytes.EMPTY, ValidationResult.valid()));
+
+    when(transactionSimulator.process(callParameter, 1)).thenReturn(Optional.of(result));
+
+    final ValidatorContractController validatorContractController =
+        new ValidatorContractController(transactionSimulator, qbftForksSchedule);
+
+    Assertions.assertThatThrownBy(() -> validatorContractController.getValidators(1))
+        .hasMessage("Unexpected empty result from validator smart contract call");
+  }
+
+  @Test
   public void throwErrorIfEmptySimulationResult() {
     when(transactionSimulator.process(callParameter, 1)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
## PR description

Add an extra check to ensure that a successful contract call with an empty result configures an error, as we never expect the validator contract to return an empty list of validators.

This is important because of the way that contract call works. It is possible to call an address that does not have a  contract deployed, and still get a successful call with an empty result.

## Fixed Issue(s)
fixes #2900

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).