### PR TITLE
More BFT tracing log messages

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/protocol/BftProtocolManager.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/protocol/BftProtocolManager.java
@@ -18,16 +18,23 @@ import org.hyperledger.besu.consensus.common.bft.BftEventQueue;
 import org.hyperledger.besu.consensus.common.bft.events.BftEvent;
 import org.hyperledger.besu.consensus.common.bft.events.BftEvents;
 import org.hyperledger.besu.consensus.common.bft.network.PeerConnectionTracker;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Message;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class BftProtocolManager implements ProtocolManager {
+  private static final Logger LOG = LogManager.getLogger();
+
   private final BftEventQueue bftEventQueue;
   private final PeerConnectionTracker peers;
   private final Capability supportedCapability;
@@ -85,6 +92,11 @@ public class BftProtocolManager implements ProtocolManager {
    */
   @Override
   public void processMessage(final Capability cap, final Message message) {
+    final MessageData messageData = message.getData();
+    final int code = messageData.getCode();
+    final Address address = message.getConnection().getPeerInfo().getAddress();
+    LOG.trace("Process message {}, {}, from = {}", cap, code, address);
+
     final BftEvent messageEvent = BftEvents.fromMessage(message);
     bftEventQueue.add(messageEvent);
   }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftGossip.java
@@ -50,7 +50,7 @@ public class QbftGossip implements Gossiper {
   }
 
   /**
-   * Retransmit a given IBFT message to other known validators nodes
+   * Retransmit a given QBFT message to other known validators nodes
    *
    * @param message The raw message to be gossiped
    */


### PR DESCRIPTION
## PR description
- Add a trace log message when `BftProtocolManager` receives a subprotocol message. This is the entry-point for BFT related logic in response to the message.

## Fixed Issue(s)
N/A

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).