### PR TITLE
JsonUtil.normalizeKeys should handle ArrayNodes

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/JsonUtil.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonUtil.java
@@ -50,11 +50,26 @@ public class JsonUtil {
               final String normalizedKey = key.toLowerCase(Locale.US);
               if (value instanceof ObjectNode) {
                 normalized.set(normalizedKey, normalizeKeys((ObjectNode) value));
+              } else if (value instanceof ArrayNode) {
+                normalized.set(normalizedKey, normalizeKeysInArray((ArrayNode) value));
               } else {
                 normalized.set(normalizedKey, value);
               }
             });
     return normalized;
+  }
+
+  private static ArrayNode normalizeKeysInArray(final ArrayNode arrayNode) {
+    final ArrayNode normalizedArray = JsonUtil.createEmptyArrayNode();
+    arrayNode.forEach(
+        value -> {
+          if (value instanceof ObjectNode) {
+            normalizedArray.add(normalizeKeys((ObjectNode) value));
+          } else if (value instanceof ArrayNode) {
+            normalizedArray.add(normalizeKeysInArray((ArrayNode) value));
+          }
+        });
+    return normalizedArray;
   }
 
   /**
@@ -151,6 +166,11 @@ public class JsonUtil {
   public static ObjectNode createEmptyObjectNode() {
     final ObjectMapper mapper = getObjectMapper();
     return mapper.createObjectNode();
+  }
+
+  public static ArrayNode createEmptyArrayNode() {
+    final ObjectMapper mapper = getObjectMapper();
+    return mapper.createArrayNode();
   }
 
   public static ObjectNode objectNodeFromMap(final Map<String, Object> map) {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonUtil.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonUtil.java
@@ -67,6 +67,8 @@ public class JsonUtil {
             normalizedArray.add(normalizeKeys((ObjectNode) value));
           } else if (value instanceof ArrayNode) {
             normalizedArray.add(normalizeKeysInArray((ArrayNode) value));
+          } else {
+            normalizedArray.add(value);
           }
         });
     return normalizedArray;

--- a/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
@@ -94,9 +94,9 @@ public class JsonUtilTest {
                     .add(mapper.createObjectNode().put("camel", "Ziz"))
                     .add(mapper.createObjectNode().put("mixed", "LoL")));
 
-    final ObjectNode normalized = JsonUtil.normalizeKeys(originalObj);
+    final ObjectNode normalizedObj = JsonUtil.normalizeKeys(originalObj);
 
-    assertThat(normalized).isEqualTo(expectedObj);
+    assertThat(normalizedObj).isEqualTo(expectedObj);
   }
 
   @Test
@@ -125,9 +125,22 @@ public class JsonUtilTest {
                             .createArrayNode()
                             .add(mapper.createObjectNode().put("depth", "Foo"))));
 
-    final ObjectNode normalized = JsonUtil.normalizeKeys(originalObj);
+    final ObjectNode normalizedObj = JsonUtil.normalizeKeys(originalObj);
 
-    assertThat(normalized).isEqualTo(expectedObj);
+    assertThat(normalizedObj).isEqualTo(expectedObj);
+  }
+
+  @Test
+  public void normalizeKeys_arrayNode_withString() {
+    final ObjectNode originalObj =
+        mapper.createObjectNode().set("ArrAy", mapper.createArrayNode().add("StrIng"));
+
+    final ObjectNode expectedObj =
+        mapper.createObjectNode().set("array", mapper.createArrayNode().add("StrIng"));
+
+    final ObjectNode normalizedObj = JsonUtil.normalizeKeys(originalObj);
+
+    assertThat(normalizedObj).isEqualTo(expectedObj);
   }
 
   @Test

--- a/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
@@ -69,6 +69,68 @@ public class JsonUtilTest {
   }
 
   @Test
+  public void normalizeKeys_arrayNode() {
+    final ObjectNode originalObj =
+        mapper
+            .createObjectNode()
+            .set(
+                "ArrAy",
+                mapper
+                    .createArrayNode()
+                    .add(mapper.createObjectNode().put("lower", "foo"))
+                    .add(mapper.createObjectNode().put("UPPER", "BAR"))
+                    .add(mapper.createObjectNode().put("Camel", "Ziz"))
+                    .add(mapper.createObjectNode().put("MiXeD", "LoL")));
+
+    final ObjectNode expectedObj =
+        mapper
+            .createObjectNode()
+            .set(
+                "array",
+                mapper
+                    .createArrayNode()
+                    .add(mapper.createObjectNode().put("lower", "foo"))
+                    .add(mapper.createObjectNode().put("upper", "BAR"))
+                    .add(mapper.createObjectNode().put("camel", "Ziz"))
+                    .add(mapper.createObjectNode().put("mixed", "LoL")));
+
+    final ObjectNode normalized = JsonUtil.normalizeKeys(originalObj);
+
+    assertThat(normalized).isEqualTo(expectedObj);
+  }
+
+  @Test
+  public void normalizeKeys_arrayNode_depth() {
+    final ObjectNode originalObj =
+        mapper
+            .createObjectNode()
+            .set(
+                "ArrAy",
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createArrayNode()
+                            .add(mapper.createObjectNode().put("dEpTh", "Foo"))));
+
+    final ObjectNode expectedObj =
+        mapper
+            .createObjectNode()
+            .set(
+                "array",
+                mapper
+                    .createArrayNode()
+                    .add(
+                        mapper
+                            .createArrayNode()
+                            .add(mapper.createObjectNode().put("depth", "Foo"))));
+
+    final ObjectNode normalized = JsonUtil.normalizeKeys(originalObj);
+
+    assertThat(normalized).isEqualTo(expectedObj);
+  }
+
+  @Test
   public void getLong_nonExistentKey() {
     final ObjectNode node = mapper.createObjectNode();
     final OptionalLong result = JsonUtil.getLong(node, "test");


### PR DESCRIPTION
## PR description
- Updated JsonUtils to handle ArrayNode. This is important now that we have bft transitions that are specified in an array in the genesis file.

## Fixed Issue(s)
fixes #2856

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).