### PR TITLE
[3011] Calling SignatureAlgorithmFactory::resetInstance before test

### DIFF
--- a/crypto/src/test/java/org/hyperledger/besu/crypto/NodeKeyTest.java
+++ b/crypto/src/test/java/org/hyperledger/besu/crypto/NodeKeyTest.java
@@ -17,9 +17,15 @@ package org.hyperledger.besu.crypto;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.Assertions;
+import org.junit.Before;
 import org.junit.Test;
 
 public class NodeKeyTest {
+
+  @Before
+  public void resetInstance() {
+    SignatureAlgorithmFactory.resetInstance();
+  }
 
   @Test
   public void publicKeyShouldMatch() {


### PR DESCRIPTION

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
The NodeKeyTest might fail in case the SignatureAlgorithmFactory has an
instance already set from some previous test.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
fixes #3011 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).