### PR TITLE
[3026] Updating version of disovery dependency 

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -166,7 +166,7 @@ dependencyManagement {
 
     dependency 'org.yaml:snakeyaml:1.26'
 
-    dependency 'tech.pegasys.discovery:discovery:0.4.8'
+    dependency 'tech.pegasys.discovery:discovery:21.10.0'
 
     dependency 'tech.pegasys.ethsigner.internal:ethsigner-core:21.3.2'
     dependencySet(group: 'tech.pegasys.signers.internal', version: '1.0.17') {


### PR DESCRIPTION

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
The discovery dependency is responsible for handling the v5 version of the discovery process of peers. This PR is updating the version to the latest. The project changed versioning after 0.5.0. The following version was 21.10.0 as can be seen on
the [release page](https://github.com/ConsenSys/discovery/releases).
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3027 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).