### PR TITLE
Update VoteTallyCache when transitioning to blockheader validatorselectionmode

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/validator/blockbased/BlockValidatorProvider.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/validator/blockbased/BlockValidatorProvider.java
@@ -94,4 +94,9 @@ public class BlockValidatorProvider implements ValidatorProvider {
   public boolean hasValidatorOverridesForBlockNumber(final long blockNumber) {
     return bftValidatorOverrides.map(bvo -> bvo.getForBlock(blockNumber).isPresent()).orElse(false);
   }
+
+  public void setValidatorsForBlock(
+      final BlockHeader header, final Collection<Address> validators) {
+    voteTallyCache.putValidatorsForBlock(header, validators);
+  }
 }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCache.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCache.java
@@ -18,11 +18,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.EpochManager;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
@@ -119,5 +121,9 @@ class VoteTallyCache {
       voteTallyCache.put(h.getHash(), mutableVoteTally.copy());
     }
     return mutableVoteTally;
+  }
+
+  void putValidatorsForBlock(final BlockHeader header, final Collection<Address> validators) {
+    voteTallyCache.put(header.getHash(), new VoteTally(validators));
   }
 }

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ValidatorContractTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ValidatorContractTest.java
@@ -188,15 +188,18 @@ public class ValidatorContractTest {
             .buildAndStart();
 
     // block 0 uses validator contract with 1 validator
-    // block 1 onwards uses block header voting (this transitioning block reuses the previous
-    // block's validators)
+    // block 1 uses block header voting with block 0's validators
+    // block 2 uses block header voting with the cached validators
     final List<Address> block0Addresses = Stream.of(NODE_ADDRESS).collect(Collectors.toList());
 
-    createNewBlockAsProposer(context, 1);
+    createNewBlockAsProposer(context, 1L);
+    clock.step(TestContextBuilder.BLOCK_TIMER_SEC, SECONDS);
+    createNewBlockAsProposer(context, 2L);
 
     final ValidatorProvider validatorProvider = context.getValidatorProvider();
     final BlockHeader genesisBlock = context.getBlockchain().getBlockHeader(0).get();
     final BlockHeader block1 = context.getBlockchain().getBlockHeader(1).get();
+    final BlockHeader block2 = context.getBlockchain().getBlockHeader(2).get();
 
     // contract block extra data cannot contain validators or vote
     assertThat(validatorProvider.getValidatorsForBlock(genesisBlock)).isEqualTo(block0Addresses);
@@ -206,6 +209,10 @@ public class ValidatorContractTest {
     // uses previous block's validators
     assertThat(validatorProvider.getValidatorsForBlock(block1)).isEqualTo(block0Addresses);
     assertThat(extraDataCodec.decode(block1).getValidators()).containsExactly(NODE_ADDRESS);
+
+    // uses cached validators
+    assertThat(validatorProvider.getValidatorsForBlock(block2)).isEqualTo(block0Addresses);
+    assertThat(extraDataCodec.decode(block2).getValidators()).containsExactly(NODE_ADDRESS);
   }
 
   @Test
@@ -232,6 +239,7 @@ public class ValidatorContractTest {
     // block 0 uses block header voting with 1 validator
     // block 1 uses validator contract with 2 validators
     // block 2 uses block header voting with block 1's validators
+    // block 3 uses block header voting with cached validators
     final List<Address> block0Addresses = List.of(NODE_ADDRESS);
     final List<Address> block1Addresses =
         Stream.of(NODE_ADDRESS, NODE_2_ADDRESS).sorted().collect(Collectors.toList());
@@ -239,11 +247,14 @@ public class ValidatorContractTest {
     remotePeerProposesNewBlock(context, 1L);
     clock.step(TestContextBuilder.BLOCK_TIMER_SEC, SECONDS);
     createNewBlockAsProposer(context, 2L);
+    clock.step(TestContextBuilder.BLOCK_TIMER_SEC, SECONDS);
+    remotePeerProposesNewBlock(context, 3L);
 
     final ValidatorProvider validatorProvider = context.getValidatorProvider();
     final BlockHeader genesisBlock = context.getBlockchain().getBlockHeader(0).get();
     final BlockHeader block1 = context.getBlockchain().getBlockHeader(1).get();
     final BlockHeader block2 = context.getBlockchain().getBlockHeader(2).get();
+    final BlockHeader block3 = context.getBlockchain().getBlockHeader(3).get();
 
     assertThat(validatorProvider.getValidatorsForBlock(genesisBlock)).isEqualTo(block0Addresses);
     assertThat(extraDataCodec.decode(genesisBlock).getValidators()).containsExactly(NODE_ADDRESS);
@@ -256,6 +267,11 @@ public class ValidatorContractTest {
     // uses previous block's validators
     assertThat(validatorProvider.getValidatorsForBlock(block2)).isEqualTo(block1Addresses);
     assertThat(extraDataCodec.decode(block2).getValidators())
+        .containsExactly(NODE_2_ADDRESS, NODE_ADDRESS);
+
+    // uses cached validators
+    assertThat(validatorProvider.getValidatorsForBlock(block3)).isEqualTo(block1Addresses);
+    assertThat(extraDataCodec.decode(block3).getValidators())
         .containsExactly(NODE_2_ADDRESS, NODE_ADDRESS);
   }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProvider.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProvider.java
@@ -95,8 +95,13 @@ public class ForkingValidatorProvider implements ValidatorProvider {
         final long prevBlockNumber = blockNumber - 1L;
         final Optional<BlockHeader> prevBlockHeader = blockchain.getBlockHeader(prevBlockNumber);
         if (prevBlockHeader.isPresent()) {
-          return resolveValidatorProvider(prevBlockNumber)
-              .getValidatorsForBlock(prevBlockHeader.get());
+          final Collection<Address> validatorsForPreviousBlock =
+              resolveValidatorProvider(prevBlockNumber)
+                  .getValidatorsForBlock(prevBlockHeader.get());
+          // Update VoteTallyCache
+          blockValidatorProvider.setValidatorsForBlock(
+              prevBlockHeader.get(), validatorsForPreviousBlock);
+          return validatorsForPreviousBlock;
         }
       }
       return getValidators.apply(validatorProvider);

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.consensus.qbft.validator.ValidatorTestUtils.c
 import static org.hyperledger.besu.consensus.qbft.validator.ValidatorTestUtils.createContractForkSpec;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -140,6 +141,8 @@ public class ForkingValidatorProviderTest {
     assertThat(validatorProvider.getValidatorsForBlock(genesisHeader))
         .isEqualTo(CONTRACT_ADDRESSES_1);
     assertThat(validatorProvider.getValidatorsForBlock(header1)).isEqualTo(CONTRACT_ADDRESSES_1);
+    verify(blockValidatorProvider, times(1))
+        .setValidatorsForBlock(genesisHeader, CONTRACT_ADDRESSES_1);
     assertThat(validatorProvider.getValidatorsForBlock(header2)).isEqualTo(BLOCK_ADDRESSES);
   }
 


### PR DESCRIPTION
TODO:
 - discuss that the cache is overriding validators for parent block (instead of block being produced) - maybe we should only set the cache once the block is successfully created? In reality this shouldn't matter since the parent block should be a contract-mode block and therefore have no cache entry.
 - discuss cache not just getting set once, but every execution of ForkingValidatorProvider.getValidators while producing the transition block.
 - try to recreate bug where network was stopped before node2 imported block, then got InvalidBlock

https://github.com/hyperledger/besu/issues/3019