### PR TITLE
Updating the jacoco toolVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ allprojects {
   version = rootProject.version
 
   jacoco {
-    toolVersion = '0.8.6'
+    toolVersion = '0.8.7'
     if (project.tasks.findByName('referenceTests')) {
       applyTo referenceTests
     }


### PR DESCRIPTION
Jacoco failed to instrument some tests using the old version of the tool
when build under jdk17

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes #3040

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).