### PR TITLE
Add ENR to admin_nodeInfo RPC endpoint

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -126,6 +126,10 @@ public class AdminNodeInfo implements JsonRpcMethod {
                 "network",
                 networkId)));
 
+    peerNetwork
+        .getNodeRecordValues()
+        .ifPresent(nodeRecordValues -> response.put("nodeRecord", nodeRecordValues));
+
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), response);
   }
 

--- a/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
+++ b/ethereum/mock-p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetwork.java
@@ -216,6 +216,11 @@ public final class MockNetwork {
     }
 
     @Override
+    public Optional<Map<String, String>> getNodeRecordValues() {
+      return Optional.empty();
+    }
+
+    @Override
     public void updateNodeRecord() {}
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
@@ -21,6 +21,8 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import org.hyperledger.besu.plugin.data.EnodeURL;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -136,6 +138,25 @@ public class DiscoveryPeer extends DefaultPeer {
 
   public void setNodeRecord(final NodeRecord nodeRecord) {
     this.nodeRecord = nodeRecord;
+  }
+
+  public Optional<Map<String, String>> getNodeRecordValues() {
+    if (nodeRecord == null) {
+      return Optional.empty();
+    }
+
+    Map<String, String> values = new HashMap<>();
+    values.put("seq", nodeRecord.getSeq().toString());
+    nodeRecord
+        .getUdpAddress()
+        .ifPresent(udpAddress -> values.put("udpAddress", udpAddress.toString()));
+    nodeRecord
+        .getTcpAddress()
+        .ifPresent(tcpAddress -> values.put("tcpAddress", tcpAddress.toString()));
+    values.put("asBase64", nodeRecord.asBase64());
+    values.put("nodeId", nodeRecord.getNodeId().toHexString());
+
+    return Optional.of(values);
   }
 
   public boolean discoveryEndpointMatches(final DiscoveryPeer peer) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -49,6 +49,7 @@ import java.net.SocketException;
 import java.nio.channels.UnsupportedAddressTypeException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -352,6 +353,14 @@ public abstract class PeerDiscoveryAgent {
 
   public Bytes getId() {
     return id;
+  }
+
+  public Optional<Map<String, String>> getNodeRecordValues() {
+    if (localNode.isEmpty()) {
+      return Optional.empty();
+    }
+
+    return localNode.get().getNodeRecordValues();
   }
 
   /**

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
@@ -409,6 +410,11 @@ public class DefaultP2PNetwork implements P2PNetwork {
       return Optional.empty();
     }
     return Optional.of(localNode.getPeer().getEnodeURL());
+  }
+
+  @Override
+  public Optional<Map<String, String>> getNodeRecordValues() {
+    return peerDiscoveryAgent.getNodeRecordValues();
   }
 
   private void setLocalNode(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/NoopP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/NoopP2PNetwork.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -88,6 +89,11 @@ public class NoopP2PNetwork implements P2PNetwork {
 
   @Override
   public Optional<EnodeURL> getLocalEnode() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Map<String, String>> getNodeRecordValues() {
     return Optional.empty();
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetwork.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -147,6 +148,14 @@ public interface P2PNetwork extends Closeable {
    *     otherwise.
    */
   Optional<EnodeURL> getLocalEnode();
+
+  /**
+   * Returns the ENR (Ethereum Node Record) used to identify this peer in the network.
+   *
+   * @return the node record associated with this node if P2P has been enabled. Returns empty
+   *     otherwise.
+   */
+  Optional<Map<String, String>> getNodeRecordValues();
 
   void updateNodeRecord();
 }


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description
Adds the Ethereum Node Record to the `admin_nodeInfo` RPC call. This is not final and could be changed as an alternative solution could be to create a new endpoint.

## Fixed Issue(s)
fixes #3050 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).