### PR TITLE
fix toml parsing of Long option types

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/DataStorageOptions.java
@@ -46,6 +46,7 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
   @Option(
       names = {BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD},
       hidden = true,
+      paramLabel = "<LONG>",
       description =
           "Limit of back layers that can be loaded with BONSAI (default: ${DEFAULT-VALUE}).",
       arity = "1")

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
@@ -70,6 +70,8 @@ public class TomlConfigFileDefaultProvider implements IDefaultValueProvider {
       defaultValue = getListEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Integer.class) || optionSpec.type().equals(int.class)) {
       defaultValue = getIntegerEntryAsString(optionSpec);
+    } else if (optionSpec.type().equals(Long.class) || optionSpec.type().equals(long.class)) {
+      defaultValue = getIntegerEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Wei.class)) {
       defaultValue = getIntegerEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(BigInteger.class)) {

--- a/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
@@ -56,6 +56,7 @@ public class TomlConfigFileDefaultProviderTest {
     when(mockCommandLine.getCommandSpec()).thenReturn(mockCommandSpec);
     Map<String, OptionSpec> validOptionsMap = new HashMap<>();
     validOptionsMap.put("--a-short-option", null);
+    validOptionsMap.put("--an-actual-long-option", null);
     validOptionsMap.put("--a-longer-option", null);
     when(mockCommandSpec.optionsMap()).thenReturn(validOptionsMap);
 
@@ -64,6 +65,8 @@ public class TomlConfigFileDefaultProviderTest {
         Files.newBufferedWriter(tempConfigFile.toPath(), UTF_8)) {
 
       fileWriter.write("a-short-option='123'");
+      fileWriter.newLine();
+      fileWriter.write("an-actual-long-option=" + Long.MAX_VALUE);
       fileWriter.newLine();
       fileWriter.write("a-longer-option='1234'");
       fileWriter.flush();
@@ -85,6 +88,15 @@ public class TomlConfigFileDefaultProviderTest {
                       .type(Integer.class)
                       .build()))
           .isEqualTo("123");
+
+      // this option must be found in config as one of its names is present in the file.
+      // also this is a long.
+      assertThat(
+              providerUnderTest.defaultValue(
+                  OptionSpec.builder("an-actual-long-option", "another-name-for-the-option")
+                      .type(Long.class)
+                      .build()))
+          .isEqualTo(String.valueOf(Long.MAX_VALUE));
 
       // this option must be found in config as one of its names is present in the file.
       // also this is the longest one.


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fix toml config file parsing for options that map to type Long or long.  Previously setting a value in toml config for a long option type would result in, e.g. :
```org.apache.tuweni.toml.TomlInvalidTypeException: Value of 'Xbonsai-maximum-back-layers-to-load' is a integer```


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).