### PR TITLE
Adding filechannel name to the exception

### DIFF
--- a/services/tasks/src/main/java/org/hyperledger/besu/services/tasks/FlatFileTaskCollection.java
+++ b/services/tasks/src/main/java/org/hyperledger/besu/services/tasks/FlatFileTaskCollection.java
@@ -89,7 +89,7 @@ public class FlatFileTaskCollection<T> implements TaskCollection<T> {
           StandardOpenOption.WRITE,
           StandardOpenOption.CREATE);
     } catch (final IOException e) {
-      throw new StorageException(e);
+      throw new StorageException("There was a problem opening FileChannel " + pathForFileNumber(fileNumber),e);
     }
   }
 
@@ -106,7 +106,7 @@ public class FlatFileTaskCollection<T> implements TaskCollection<T> {
         writeFileChannel = openWriteFileChannel(writeFileNumber);
       }
     } catch (final IOException e) {
-      throw new StorageException(e);
+      throw new StorageException("There was a problem adding to FileChannel " + pathForFileNumber(writeFileNumber),e);
     }
   }
 
@@ -123,7 +123,7 @@ public class FlatFileTaskCollection<T> implements TaskCollection<T> {
       size--;
       return task;
     } catch (final IOException e) {
-      throw new StorageException(e);
+      throw new StorageException("There was a problem removing from FileChannel " + pathForFileNumber(readFileNumber),e);
     }
   }
 
@@ -248,6 +248,9 @@ public class FlatFileTaskCollection<T> implements TaskCollection<T> {
   public static class StorageException extends RuntimeException {
     StorageException(final Throwable t) {
       super(t);
+    }
+    StorageException(final String m, final Throwable t) {
+      super(m,t);
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
When syncing on a disk that was not a SDD I got into problems with the task files. This PR expands exception to include recent file numbers for write/read to give at least some clue on which files are broken.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).