### PR TITLE
Making sure that the resolved DNS lists get used in full

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -55,6 +55,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -376,6 +377,7 @@ public class DefaultP2PNetwork implements P2PNetwork {
   public Stream<DiscoveryPeer> streamDiscoveredPeers() {
     List<DiscoveryPeer> peers = dnsPeers.get();
     if (peers != null) {
+      Collections.shuffle(peers);
       return Stream.concat(peerDiscoveryAgent.streamDiscoveredPeers(), peers.stream());
     }
     return peerDiscoveryAgent.streamDiscoveredPeers();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -173,12 +173,11 @@ public class RlpxAgent {
     if (!localNode.isReady()) {
       return;
     }
-    final int availablePeerSlots = Math.max(0, maxConnections - getConnectionCount());
     peerStream
+        .takeWhile(peer -> Math.max(0, maxConnections - getConnectionCount()) > 0)
         .filter(peer -> !connectionsById.containsKey(peer.getId()))
         .filter(peer -> peer.getEnodeURL().isListening())
         .filter(peerPermissions::allowNewOutboundConnectionTo)
-        .limit(availablePeerSlots)
         .forEach(this::connect);
   }
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -712,6 +712,22 @@ public class RlpxAgentTest {
   }
 
   @Test
+  public void connect_largeStreamOfPeersFirstFewImpostors() {
+    final int maxPeers = 5;
+    final int impostorsCount = 5;
+    connectionInitializer.setAutoDisconnectCounter(impostorsCount);
+    final Stream<Peer> peerStream = Stream.generate(PeerTestHelper::createPeer).limit(20);
+
+    startAgentWithMaxPeers(maxPeers);
+    agent = spy(agent);
+    agent.connect(peerStream);
+
+    assertThat(agent.getConnectionCount()).isEqualTo(maxPeers);
+    // Check that stream was not fully iterated
+    verify(agent, times(maxPeers + impostorsCount)).connect(any(Peer.class));
+  }
+
+  @Test
   public void disconnect() throws ExecutionException, InterruptedException {
     startAgent();
     final Peer peer = spy(createPeer());


### PR DESCRIPTION

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Previously we would always process the list of DNS resolved peers from the beginning. We would
at most only try `maxConnections` valid elements from the list and never try more. So the each
time we might be trying the same 25 peers, we connect with them and then drop them. This PR
firstly shuffles the peers list each time before applying it and then also takes from the list for
as long as there are free peers slots available as opposed to guess the limit upfront and hope
that all the peers connect.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).