### PR TITLE
Vert.x upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Additions and Improvements
 - Adding support of the NO_COLOR environment variable as described in the [NO_COLOR](https://no-color.org/) standard [#3085](https://github.com/hyperledger/besu/pull/3085)
 - Add `privx_findFlexiblePrivacyGroup` RPC Method, `privx_findOnchainPrivacyGroup` will be removed in a future release [#3075](https://github.com/hyperledger/besu/pull/3075)
-- The invalid value is now shown when `--bootnodes` cannot parse an item to make it easier to identify which option is invalid. 
+- The invalid value is now shown when `--bootnodes` cannot parse an item to make it easier to identify which option is invalid.
 ### Bug Fixes
 
 ### Early Access Features

--- a/besu/build.gradle
+++ b/besu/build.gradle
@@ -94,4 +94,5 @@ dependencies {
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'commons-io:commons-io'
+  testImplementation 'org.testcontainers:testcontainers'
 }

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -140,6 +140,7 @@ public class PrivacyReorgTest {
 
   @Before
   public void setUp() throws IOException {
+
     mockEnclave = mock(Enclave.class);
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
     PRIVATE_TRANSACTION.writeTo(rlpOutput);

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -140,7 +140,6 @@ public class PrivacyReorgTest {
 
   @Before
   public void setUp() throws IOException {
-
     mockEnclave = mock(Enclave.class);
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
     PRIVATE_TRANSACTION.writeTo(rlpOutput);

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -376,13 +376,10 @@ public final class RunnerTest {
           .atMost(5L, TimeUnit.MINUTES)
           .until(future::isComplete);
     } finally {
-      System.out.println("OMG STAAAAHP!!");
       if (runnerBehind != null) {
         runnerBehind.close();
         runnerBehind.awaitStop();
       }
-      runnerAhead.close();
-      runnerAhead.awaitStop();
     }
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -366,7 +366,7 @@ public final class RunnerTest {
                       if (matches) {
                         promise.complete(payload);
                       } else {
-                        promise.fail("Unexpected result: "+ payload);
+                        promise.fail("Unexpected result: " + payload);
                       }
                     });
           });

--- a/consensus/clique/build.gradle
+++ b/consensus/clique/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 

--- a/consensus/ibft/build.gradle
+++ b/consensus/ibft/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 

--- a/consensus/ibftlegacy/build.gradle
+++ b/consensus/ibftlegacy/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 

--- a/consensus/qbft/build.gradle
+++ b/consensus/qbft/build.gradle
@@ -72,6 +72,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.web3j:abi'

--- a/enclave/build.gradle
+++ b/enclave/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'io.vertx:vertx-web'
   implementation 'org.apache.tuweni:tuweni-net'
   implementation 'org.apache.logging.log4j:log4j-api'
 
@@ -21,8 +22,8 @@ dependencies {
   integrationTestImplementation 'org.bouncycastle:bcpkix-jdk15on'
   integrationTestImplementation 'org.awaitility:awaitility'
   integrationTestImplementation 'org.mockito:mockito-core'
+  integrationTestImplementation 'org.testcontainers:testcontainers'
 
   integrationTestImplementation 'junit:junit'
-  integrationTestImplementation 'net.consensys:orion'
   integrationTestImplementation 'org.assertj:assertj-core'
 }

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -22,17 +22,18 @@ import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.enclave.types.SendResponse;
 import org.hyperledger.enclave.testutil.EnclaveKeyConfiguration;
-import org.hyperledger.enclave.testutil.OrionTestHarness;
-import org.hyperledger.enclave.testutil.OrionTestHarnessFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.awaitility.Awaitility;
+import org.hyperledger.enclave.testutil.TesseraTestHarness;
+import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -49,7 +50,7 @@ public class EnclaveTest {
   private Vertx vertx;
   private EnclaveFactory factory;
 
-  private static OrionTestHarness testHarness;
+  private static TesseraTestHarness testHarness;
 
   @Before
   public void setUp() throws Exception {
@@ -58,10 +59,10 @@ public class EnclaveTest {
     folder.create();
 
     testHarness =
-        OrionTestHarnessFactory.create(
+        TesseraTestHarnessFactory.create(
             "enclave",
             folder.newFolder().toPath(),
-            new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"));
+            new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"), Optional.empty());
 
     testHarness.start();
 
@@ -85,7 +86,7 @@ public class EnclaveTest {
 
     final Throwable t = catchThrowable(() -> enclave.receive(MOCK_KEY, publicKey));
 
-    assertThat(t.getMessage()).isEqualTo("EnclavePayloadNotFound");
+    assertThat(t.getMessage()).isEqualTo("Message with hash was not found");
   }
 
   @Test

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.enclave.types.SendResponse;
 import org.hyperledger.enclave.testutil.EnclaveKeyConfiguration;
+import org.hyperledger.enclave.testutil.TesseraTestHarness;
+import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -32,8 +34,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.awaitility.Awaitility;
-import org.hyperledger.enclave.testutil.TesseraTestHarness;
-import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -62,7 +62,8 @@ public class EnclaveTest {
         TesseraTestHarnessFactory.create(
             "enclave",
             folder.newFolder().toPath(),
-            new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"), Optional.empty());
+            new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"),
+            Optional.empty());
 
     testHarness.start();
 

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-unit'
   implementation 'io.vertx:vertx-web'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-net'

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -59,6 +59,7 @@ dependencies {
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-unit'
   implementation 'io.vertx:vertx-web'
+  implementation 'io.vertx:vertx-codegen'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'org.apache.tuweni:tuweni-bytes'
@@ -85,12 +86,13 @@ dependencies {
   testResourceGeneration project(':besu')
 
   testImplementation 'com.squareup.okhttp3:okhttp'
-  testImplementation 'io.vertx:vertx-codegen'
+
   testImplementation 'io.vertx:vertx-unit'
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'
-
+  testImplementation 'io.vertx:vertx-web-client'
+  testImplementation 'io.vertx:vertx-auth-jwt'
   testSupportImplementation 'org.bouncycastle:bcpkix-jdk15on'
 
   integrationTestImplementation project(':config')

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -213,7 +213,8 @@ public class GraphQLHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
+    final Iterable<String> splitHostHeader =
+        Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -213,8 +213,11 @@ public class GraphQLHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader =
-        Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
+    String hostname =
+        event.request().getHeader(HttpHeaders.HOST) != null
+            ? event.request().getHeader(HttpHeaders.HOST)
+            : event.request().host();
+    final Iterable<String> splitHostHeader = Splitter.on(':').split(hostname);
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -213,7 +213,7 @@ public class GraphQLHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().host());
+    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -153,7 +153,8 @@ public class GraphQLHttpService {
         .handler(
             BodyHandler.create()
                 .setUploadsDirectory(dataDir.resolve("uploads").toString())
-                .setDeleteUploadedFilesOnEnd(true));
+                .setDeleteUploadedFilesOnEnd(true)
+                .setPreallocateBodyBuffer(true));
     router.route("/").method(GET).method(POST).handler(this::handleEmptyRequestAndRedirect);
     router
         .route(GRAPH_QL_ROUTE)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -60,6 +60,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.jackson.JacksonCodec;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
@@ -285,19 +286,19 @@ public class GraphQLHttpService {
       final Map<String, Object> variables;
       final HttpServerRequest request = routingContext.request();
 
-      switch (request.method()) {
-        case GET:
+      switch (request.method().name()) {
+        case "GET":
           final String queryString = request.getParam("query");
           query = Objects.requireNonNullElse(queryString, "");
           operationName = request.getParam("operationName");
           final String variableString = request.getParam("variables");
           if (variableString != null) {
-            variables = Json.decodeValue(variableString, MAP_TYPE);
+            variables = JacksonCodec.decodeValue(variableString, MAP_TYPE);
           } else {
             variables = Collections.emptyMap();
           }
           break;
-        case POST:
+        case "POST":
           final String contentType = request.getHeader(HttpHeaders.CONTENT_TYPE);
           if (contentType != null && MediaType.parse(contentType).is(MEDIA_TYPE_JUST_JSON)) {
             final String requestBody = routingContext.getBodyAsString().trim();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -20,7 +20,6 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.tuweni.net.tls.VertxTrustOptions.allowlistClients;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INVALID_REQUEST;
 
-import io.vertx.core.http.HttpHeaders;
 import org.hyperledger.besu.ethereum.api.handlers.HandlerFactory;
 import org.hyperledger.besu.ethereum.api.handlers.TimeoutOptions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
@@ -86,6 +85,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -480,7 +480,8 @@ public class JsonRpcHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
+    final Iterable<String> splitHostHeader =
+        Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -480,8 +480,11 @@ public class JsonRpcHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader =
-        Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
+    String hostname =
+        event.request().getHeader(HttpHeaders.HOST) != null
+            ? event.request().getHeader(HttpHeaders.HOST)
+            : event.request().host();
+    final Iterable<String> splitHostHeader = Splitter.on(':').split(hostname);
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -649,23 +649,13 @@ public class JsonRpcHttpService {
                   }
 
                   final JsonObject req = (JsonObject) obj;
-                  final Future<JsonRpcResponse> fut = Future.future();
-                  vertx.executeBlocking(
-                      future -> future.complete(process(routingContext, req, user)),
-                      false,
-                      ar -> {
-                        if (ar.failed()) {
-                          fut.fail(ar.cause());
-                        } else {
-                          fut.complete((JsonRpcResponse) ar.result());
-                        }
-                      });
-                  return fut;
+                  return vertx.executeBlocking(
+                      future -> future.complete(process(routingContext, req, user)));
                 })
             .collect(toList());
 
     CompositeFuture.all(responses)
-        .setHandler(
+        .onComplete(
             (res) -> {
               final HttpServerResponse response = routingContext.response();
               if (response.closed() || response.headWritten()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -53,7 +53,6 @@ import org.hyperledger.besu.util.ExceptionUtils;
 import org.hyperledger.besu.util.NetworkUtility;
 
 import java.net.InetSocketAddress;
-import java.net.SocketException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -446,11 +445,12 @@ public class JsonRpcHttpService {
 
   private Throwable getFailureException(final Throwable listenFailure) {
 
-      JsonRpcServiceException servFail = new JsonRpcServiceException(
-          String.format(
-              "Failed to bind Ethereum JSON-RPC listener to %s:%s: %s",
-              config.getHost(), config.getPort(), listenFailure.getMessage()));
-      servFail.initCause(listenFailure);
+    JsonRpcServiceException servFail =
+        new JsonRpcServiceException(
+            String.format(
+                "Failed to bind Ethereum JSON-RPC listener to %s:%s: %s",
+                config.getHost(), config.getPort(), listenFailure.getMessage()));
+    servFail.initCause(listenFailure);
 
     return servFail;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.tuweni.net.tls.VertxTrustOptions.allowlistClients;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INVALID_REQUEST;
 
+import io.vertx.core.http.HttpHeaders;
 import org.hyperledger.besu.ethereum.api.handlers.HandlerFactory;
 import org.hyperledger.besu.ethereum.api.handlers.TimeoutOptions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
@@ -479,7 +480,7 @@ public class JsonRpcHttpService {
   }
 
   private Optional<String> getAndValidateHostHeader(final RoutingContext event) {
-    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().host());
+    final Iterable<String> splitHostHeader = Splitter.on(':').split(event.request().getHeader(HttpHeaders.HOST));
     final long hostPieces = stream(splitHostHeader).count();
     if (hostPieces > 1) {
       // If the host contains a colon, verify the host is correctly formed - host [ ":" port ]

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -445,13 +445,14 @@ public class JsonRpcHttpService {
   }
 
   private Throwable getFailureException(final Throwable listenFailure) {
-    if (listenFailure instanceof SocketException) {
-      return new JsonRpcServiceException(
+
+      JsonRpcServiceException servFail = new JsonRpcServiceException(
           String.format(
               "Failed to bind Ethereum JSON-RPC listener to %s:%s: %s",
               config.getHost(), config.getPort(), listenFailure.getMessage()));
-    }
-    return listenFailure;
+      servFail.initCause(listenFailure);
+
+    return servFail;
   }
 
   private Handler<RoutingContext> checkAllowlistHostHeader() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
@@ -14,12 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
-import io.vertx.ext.auth.impl.jose.JWK;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 
 import java.io.File;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
@@ -14,10 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
+import io.vertx.ext.auth.impl.jose.JWK;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 
 import java.io.File;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
@@ -82,7 +82,7 @@ public class AuthenticationUtils {
             .get()
             .getJwtAuthProvider()
             .authenticate(
-                new JsonObject().put("jwt", token),
+                new JsonObject().put("token", token),
                 (r) -> {
                   if (r.succeeded()) {
                     final Optional<User> user = Optional.ofNullable(r.result());
@@ -100,7 +100,7 @@ public class AuthenticationUtils {
   }
 
   private static void validateExpiryExists(final Optional<User> user) {
-    if (!user.map(User::principal).map(p -> p.containsKey("exp")).orElse(false)) {
+    if (!user.map(User::attributes).map(a -> a.containsKey("exp")).orElse(false)) {
       throw new IllegalStateException("Invalid JWT doesn't have expiry");
     }
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
@@ -62,12 +61,11 @@ public class JWTAuthOptionsFactory {
   public JWTAuthOptions createWithGeneratedKeyPair() {
     final KeyPair keypair = generateJwtKeyPair();
     return new JWTAuthOptions()
-        //.setPermissionsClaimKey(PERMISSIONS)
+        // .setPermissionsClaimKey(PERMISSIONS)
         .addPubSecKey(
             new PubSecKeyOptions()
                 .setAlgorithm(ALGORITHM)
-                .setBuffer(keyPairToPublicPemString(keypair))
-                )
+                .setBuffer(keyPairToPublicPemString(keypair)))
         .addPubSecKey(
             new PubSecKeyOptions()
                 .setAlgorithm(ALGORITHM)
@@ -99,27 +97,23 @@ public class JWTAuthOptionsFactory {
     return keyGenerator.generateKeyPair();
   }
 
-
-
   private String keyPairToPublicPemString(final KeyPair kp) {
     StringBuilder pemBuffer = new StringBuilder();
     pemBuffer.append("-----BEGIN PUBLIC KEY-----\r\n");
     pemBuffer.append(Codec.base64MimeEncode(kp.getPublic().getEncoded()));
-    //pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPublic().getEncoded()));
+    // pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPublic().getEncoded()));
     pemBuffer.append("\r\n");
     pemBuffer.append("-----END PUBLIC KEY-----\r\n");
     return pemBuffer.toString();
   }
 
-
   private String keyPairToPrivatePemString(final KeyPair kp) {
     StringBuilder pemBuffer = new StringBuilder();
     pemBuffer.append("-----BEGIN PRIVATE KEY-----\r\n");
-    //pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()));
+    // pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()));
     pemBuffer.append(Codec.base64MimeEncode(kp.getPrivate().getEncoded()));
     pemBuffer.append("\r\n");
     pemBuffer.append("-----END PRIVATE KEY-----\r\n");
     return pemBuffer.toString();
   }
-
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -61,14 +61,14 @@ public class JWTAuthOptionsFactory {
   public JWTAuthOptions createWithGeneratedKeyPair() {
     final KeyPair keypair = generateJwtKeyPair();
     return new JWTAuthOptions()
-        // .setPermissionsClaimKey(PERMISSIONS)
+        .setPermissionsClaimKey(PERMISSIONS)
         .addPubSecKey(
             new PubSecKeyOptions()
-                .setAlgorithm(ALGORITHM)
+                .setAlgorithm(DEFAULT_ALGORITHM)
                 .setBuffer(keyPairToPublicPemString(keypair)))
         .addPubSecKey(
             new PubSecKeyOptions()
-                .setAlgorithm(ALGORITHM)
+                .setAlgorithm(DEFAULT_ALGORITHM)
                 .setBuffer(keyPairToPrivatePemString(keypair)));
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
@@ -61,7 +62,7 @@ public class JWTAuthOptionsFactory {
   public JWTAuthOptions createWithGeneratedKeyPair() {
     final KeyPair keypair = generateJwtKeyPair();
     return new JWTAuthOptions()
-        .setPermissionsClaimKey(PERMISSIONS)
+        //.setPermissionsClaimKey(PERMISSIONS)
         .addPubSecKey(
             new PubSecKeyOptions()
                 .setAlgorithm(DEFAULT_ALGORITHM)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
@@ -62,7 +61,7 @@ public class JWTAuthOptionsFactory {
   public JWTAuthOptions createWithGeneratedKeyPair() {
     final KeyPair keypair = generateJwtKeyPair();
     return new JWTAuthOptions()
-        //.setPermissionsClaimKey(PERMISSIONS)
+        // .setPermissionsClaimKey(PERMISSIONS)
         .addPubSecKey(
             new PubSecKeyOptions()
                 .setAlgorithm(DEFAULT_ALGORITHM)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -101,7 +101,6 @@ public class JWTAuthOptionsFactory {
     StringBuilder pemBuffer = new StringBuilder();
     pemBuffer.append("-----BEGIN PUBLIC KEY-----\r\n");
     pemBuffer.append(Codec.base64MimeEncode(kp.getPublic().getEncoded()));
-    // pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPublic().getEncoded()));
     pemBuffer.append("\r\n");
     pemBuffer.append("-----END PUBLIC KEY-----\r\n");
     return pemBuffer.toString();
@@ -110,7 +109,6 @@ public class JWTAuthOptionsFactory {
   private String keyPairToPrivatePemString(final KeyPair kp) {
     StringBuilder pemBuffer = new StringBuilder();
     pemBuffer.append("-----BEGIN PRIVATE KEY-----\r\n");
-    // pemBuffer.append(Base64.getEncoder().encodeToString(kp.getPrivate().getEncoded()));
     pemBuffer.append(Codec.base64MimeEncode(kp.getPrivate().getEncoded()));
     pemBuffer.append("\r\n");
     pemBuffer.append("-----END PRIVATE KEY-----\r\n");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
@@ -93,7 +93,7 @@ public class TomlAuth implements AuthProvider {
         false,
         res -> {
           if (res.succeeded()) {
-            resultHandler.handle(Future.succeededFuture());
+            resultHandler.handle(Future.succeededFuture((User)res.result()));
           } else {
             resultHandler.handle(Future.failedFuture(res.cause()));
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
@@ -93,7 +93,7 @@ public class TomlAuth implements AuthProvider {
         false,
         res -> {
           if (res.succeeded()) {
-            resultHandler.handle(Future.succeededFuture((User)res.result()));
+            resultHandler.handle(Future.succeededFuture((User) res.result()));
           } else {
             resultHandler.handle(Future.failedFuture(res.cause()));
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
@@ -93,7 +93,7 @@ public class TomlAuth implements AuthProvider {
         false,
         res -> {
           if (res.succeeded()) {
-            resultHandler.handle(Future.succeededFuture((TomlUser) res.result()));
+            resultHandler.handle(Future.succeededFuture());
           } else {
             resultHandler.handle(Future.failedFuture(res.cause()));
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
@@ -20,10 +20,9 @@ import java.util.Optional;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.AbstractUser;
 import io.vertx.ext.auth.AuthProvider;
 
-public class TomlUser extends AbstractUser {
+public class TomlUser {
 
   private final String username;
   private final String password;
@@ -47,7 +46,6 @@ public class TomlUser extends AbstractUser {
     this.privacyPublicKey = privacyPublicKey;
   }
 
-  @Override
   public JsonObject principal() {
     final JsonObject principle =
         new JsonObject()
@@ -60,13 +58,11 @@ public class TomlUser extends AbstractUser {
     return principle;
   }
 
-  @Override
   public void setAuthProvider(final AuthProvider authProvider) {
     // we only use Toml for authentication
     throw new UnsupportedOperationException("Not implemented");
   }
 
-  @Override
   protected void doIsPermitted(
       final String permission, final Handler<AsyncResult<Boolean>> resultHandler) {
     // we only use Toml for authentication

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
@@ -21,8 +21,11 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.AuthProvider;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.authorization.Authorization;
+import io.vertx.ext.auth.authorization.Authorizations;
 
-public class TomlUser {
+public class TomlUser implements User {
 
   private final String username;
   private final String password;
@@ -46,6 +49,37 @@ public class TomlUser {
     this.privacyPublicKey = privacyPublicKey;
   }
 
+  @Override
+  public JsonObject attributes() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public boolean expired() {
+    return false;
+  }
+
+  @Override
+  public boolean expired(final int leeway) {
+    return false;
+  }
+
+  @Override
+  public boolean containsKey(final String key) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public Authorizations authorizations() {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public User isAuthorized(final Authorization authority, final Handler<AsyncResult<Boolean>> resultHandler) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
   public JsonObject principal() {
     final JsonObject principle =
         new JsonObject()
@@ -60,6 +94,11 @@ public class TomlUser {
 
   public void setAuthProvider(final AuthProvider authProvider) {
     // we only use Toml for authentication
+    throw new UnsupportedOperationException("Not implemented");
+  }
+
+  @Override
+  public User merge(final User other) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
@@ -75,7 +75,8 @@ public class TomlUser implements User {
   }
 
   @Override
-  public User isAuthorized(final Authorization authority, final Handler<AsyncResult<Boolean>> resultHandler) {
+  public User isAuthorized(
+      final Authorization authority, final Handler<AsyncResult<Boolean>> resultHandler) {
     throw new UnsupportedOperationException("Not implemented");
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketRequestHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketRequestHandler.java
@@ -174,25 +174,16 @@ public class WebSocketRequestHandler {
                   }
 
                   final JsonObject req = (JsonObject) obj;
-                  final Future<JsonRpcResponse> fut = Future.future();
-                  vertx.executeBlocking(
+                  return vertx.<JsonRpcResponse>executeBlocking(
                       future ->
                           future.complete(
-                              process(authenticationService, id, user, getRequest(req.toString()))),
-                      false,
-                      ar -> {
-                        if (ar.failed()) {
-                          fut.fail(ar.cause());
-                        } else {
-                          fut.complete((JsonRpcResponse) ar.result());
-                        }
-                      });
-                  return fut;
+                              process(
+                                  authenticationService, id, user, getRequest(req.toString()))));
                 })
             .collect(toList());
 
     CompositeFuture.all(responses)
-        .setHandler(
+        .onComplete(
             (res) -> {
               final JsonRpcResponse[] completed =
                   res.result().list().stream()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -35,7 +35,6 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -152,8 +151,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
             .url(baseUrl + "/graphql")
             .addHeader("Host", hostname)
             .build();
-    Response resp = client.newCall(build).execute();
-    return resp.code();
+    return client.newCall(build).execute().code();
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -14,11 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.graphql;
 
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
@@ -36,6 +31,11 @@ import java.util.Set;
 
 import graphql.GraphQL;
 import io.vertx.core.Vertx;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -152,8 +152,8 @@ public class GraphQLHttpServiceHostWhitelistTest {
             .url(baseUrl + "/graphql")
             .addHeader("Host", hostname)
             .build();
-     Response resp = client.newCall(build).execute();
-     return resp.code();
+    Response resp = client.newCall(build).execute();
+    return resp.code();
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -14,6 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.api.graphql;
 
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
@@ -31,10 +36,6 @@ import java.util.Set;
 
 import graphql.GraphQL;
 import io.vertx.core.Vertx;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
@@ -151,7 +152,8 @@ public class GraphQLHttpServiceHostWhitelistTest {
             .url(baseUrl + "/graphql")
             .addHeader("Host", hostname)
             .build();
-    return client.newCall(build).execute().code();
+     Response resp = client.newCall(build).execute();
+     return resp.code();
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -223,7 +223,7 @@ public class JsonRpcHttpServiceLoginTest {
       assertThat(token).isNotNull();
 
       jwtAuth.authenticate(
-          new JsonObject().put("jwt", token),
+          new JsonObject().put("token", token),
           (r) -> {
             assertThat(r.succeeded()).isTrue();
             final User user = r.result();
@@ -257,7 +257,7 @@ public class JsonRpcHttpServiceLoginTest {
       assertThat(token).isNotNull();
 
       jwtAuth.authenticate(
-          new JsonObject().put("jwt", token),
+          new JsonObject().put("token", token),
           (r) -> {
             assertThat(r.succeeded()).isTrue();
             final User user = r.result();
@@ -388,7 +388,7 @@ public class JsonRpcHttpServiceLoginTest {
       final JsonRpcMethod web3ClientVersion = new Web3ClientVersion("777");
 
       jwtAuth.authenticate(
-          new JsonObject().put("jwt", token),
+          new JsonObject().put("token", token),
           (r) -> {
             assertThat(r.succeeded()).isTrue();
             final User user = r.result();
@@ -448,7 +448,7 @@ public class JsonRpcHttpServiceLoginTest {
 
       // adminuser has *:* permissions so everything should be allowed
       jwtAuth.authenticate(
-          new JsonObject().put("jwt", token),
+          new JsonObject().put("token", token),
           (r) -> {
             assertThat(r.succeeded()).isTrue();
             final User user = r.result();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
@@ -133,6 +133,7 @@ public class JsonRpcHttpServiceTlsMisconfigurationTest {
 
   @Test
   public void exceptionRaisedWhenNonExistentKeystoreFileIsSpecified() throws IOException {
+    Assertions.setMaxStackTraceElementsDisplayed(60);
     service =
         createJsonRpcHttpService(
             rpcMethods, createJsonRpcConfig(invalidKeystorePathTlsConfiguration()));
@@ -157,7 +158,7 @@ public class JsonRpcHttpServiceTlsMisconfigurationTest {
               Assertions.fail("service.start should have failed");
             })
         .withCauseInstanceOf(JsonRpcServiceException.class)
-        .withMessageContaining("failed to decrypt safe contents entry");
+        .withMessageContaining("keystore password was incorrect");
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import io.vertx.core.Handler;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.auth.jwt.JWTAuthOptions;
@@ -36,8 +35,8 @@ public class AuthenticationUtilsTest {
   private static final String VALID_TOKEN =
       "ewogICJhbGciOiAibm9uZSIsCiAgInR5cCI6ICJKV1QiCn0.eyJpYXQiOjE1"
           + "MTYyMzkwMjIsImV4cCI6NDcyOTM2MzIwMCwicGVybWlzc2lvbnMiOlsibmV0OnBlZXJDb3VudCJdfQ";
-  //private static final String VALID_TOKEN_DECODED_PAYLOAD =
-    //  "{\"iat\": 1516239022,\"exp\": 4729363200," + "\"permissions\": [\"net:peerCount\"]}";
+  // private static final String VALID_TOKEN_DECODED_PAYLOAD =
+  //  "{\"iat\": 1516239022,\"exp\": 4729363200," + "\"permissions\": [\"net:peerCount\"]}";
 
   @Test
   public void getJwtTokenFromNullStringShouldReturnNull() {
@@ -100,9 +99,10 @@ public class AuthenticationUtilsTest {
     User successKid = handler.getEvent().get();
     assertThat(successKid.attributes().getLong("exp")).isEqualTo(4729363200L);
     assertThat(successKid.attributes().getLong("iat")).isEqualTo(1516239022L);
-    assertThat(successKid.principal().getJsonArray("permissions").getString(0)).isEqualTo("net:peerCount");
-    //assertThat(handler.getEvent().get().principal())
-      //  .isEqualTo(new JsonObject(VALID_TOKEN_DECODED_PAYLOAD));
+    assertThat(successKid.principal().getJsonArray("permissions").getString(0))
+        .isEqualTo("net:peerCount");
+    // assertThat(handler.getEvent().get().principal())
+    //  .isEqualTo(new JsonObject(VALID_TOKEN_DECODED_PAYLOAD));
   }
 
   private static class StubUserHandler implements Handler<Optional<User>> {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
@@ -35,8 +35,6 @@ public class AuthenticationUtilsTest {
   private static final String VALID_TOKEN =
       "ewogICJhbGciOiAibm9uZSIsCiAgInR5cCI6ICJKV1QiCn0.eyJpYXQiOjE1"
           + "MTYyMzkwMjIsImV4cCI6NDcyOTM2MzIwMCwicGVybWlzc2lvbnMiOlsibmV0OnBlZXJDb3VudCJdfQ";
-  // private static final String VALID_TOKEN_DECODED_PAYLOAD =
-  //  "{\"iat\": 1516239022,\"exp\": 4729363200," + "\"permissions\": [\"net:peerCount\"]}";
 
   @Test
   public void getJwtTokenFromNullStringShouldReturnNull() {
@@ -101,8 +99,6 @@ public class AuthenticationUtilsTest {
     assertThat(successKid.attributes().getLong("iat")).isEqualTo(1516239022L);
     assertThat(successKid.principal().getJsonArray("permissions").getString(0))
         .isEqualTo("net:peerCount");
-    // assertThat(handler.getEvent().get().principal())
-    //  .isEqualTo(new JsonObject(VALID_TOKEN_DECODED_PAYLOAD));
   }
 
   private static class StubUserHandler implements Handler<Optional<User>> {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
@@ -36,8 +36,8 @@ public class AuthenticationUtilsTest {
   private static final String VALID_TOKEN =
       "ewogICJhbGciOiAibm9uZSIsCiAgInR5cCI6ICJKV1QiCn0.eyJpYXQiOjE1"
           + "MTYyMzkwMjIsImV4cCI6NDcyOTM2MzIwMCwicGVybWlzc2lvbnMiOlsibmV0OnBlZXJDb3VudCJdfQ";
-  private static final String VALID_TOKEN_DECODED_PAYLOAD =
-      "{\"iat\": 1516239022,\"exp\": 4729363200," + "\"permissions\": [\"net:peerCount\"]}";
+  //private static final String VALID_TOKEN_DECODED_PAYLOAD =
+    //  "{\"iat\": 1516239022,\"exp\": 4729363200," + "\"permissions\": [\"net:peerCount\"]}";
 
   @Test
   public void getJwtTokenFromNullStringShouldReturnNull() {
@@ -97,8 +97,12 @@ public class AuthenticationUtilsTest {
 
     AuthenticationUtils.getUser(Optional.of(authenticationService), VALID_TOKEN, handler);
 
-    assertThat(handler.getEvent().get().principal())
-        .isEqualTo(new JsonObject(VALID_TOKEN_DECODED_PAYLOAD));
+    User successKid = handler.getEvent().get();
+    assertThat(successKid.attributes().getLong("exp")).isEqualTo(4729363200L);
+    assertThat(successKid.attributes().getLong("iat")).isEqualTo(1516239022L);
+    assertThat(successKid.principal().getJsonArray("permissions").getString(0)).isEqualTo("net:peerCount");
+    //assertThat(handler.getEvent().get().principal())
+      //  .isEqualTo(new JsonObject(VALID_TOKEN_DECODED_PAYLOAD));
   }
 
   private static class StubUserHandler implements Handler<Optional<User>> {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactoryTest.java
@@ -51,10 +51,11 @@ public class JWTAuthOptionsFactoryTest {
     final JWTAuthOptions jwtAuthOptions = jwtAuthOptionsFactory.createWithGeneratedKeyPair();
 
     assertThat(jwtAuthOptions.getPubSecKeys()).isNotNull();
-    assertThat(jwtAuthOptions.getPubSecKeys()).hasSize(1);
+    assertThat(jwtAuthOptions.getPubSecKeys()).hasSize(2);
     assertThat(jwtAuthOptions.getPubSecKeys().get(0).getAlgorithm()).isEqualTo("RS256");
-    assertThat(jwtAuthOptions.getPubSecKeys().get(0).getPublicKey()).isNotEmpty();
-    assertThat(jwtAuthOptions.getPubSecKeys().get(0).getSecretKey()).isNotEmpty();
+    assertThat(jwtAuthOptions.getPubSecKeys().get(0).getBuffer()).isNotNull();
+    assertThat(jwtAuthOptions.getPubSecKeys().get(1).getAlgorithm()).isEqualTo("RS256");
+    assertThat(jwtAuthOptions.getPubSecKeys().get(1).getBuffer()).isNotNull();
   }
 
   @Test
@@ -65,8 +66,7 @@ public class JWTAuthOptionsFactoryTest {
 
     final PubSecKeyOptions pubSecKeyOptions1 = jwtAuthOptions1.getPubSecKeys().get(0);
     final PubSecKeyOptions pubSecKeyOptions2 = jwtAuthOptions2.getPubSecKeys().get(0);
-    assertThat(pubSecKeyOptions1.getPublicKey()).isNotEqualTo(pubSecKeyOptions2.getPublicKey());
-    assertThat(pubSecKeyOptions1.getSecretKey()).isNotEqualTo(pubSecKeyOptions2.getSecretKey());
+    assertThat(pubSecKeyOptions1.getBuffer()).isNotEqualTo(pubSecKeyOptions2.getBuffer());
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
@@ -28,7 +28,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcUnauthorizedResponse;
 
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -44,7 +45,7 @@ public class MultiTenancyRpcMethodDecoratorTest {
   public void delegatesWhenHasValidToken() {
     final JsonObject principle = new JsonObject();
     principle.put("privacyPublicKey", "ABC123");
-    final JWTUser user = new JWTUser(principle, "");
+    final UserImpl user = new UserImpl(principle);
     final JsonRpcRequestContext rpcRequestContext = new JsonRpcRequestContext(rpcRequest, user);
 
     when(jsonRpcMethod.response(rpcRequestContext))
@@ -79,7 +80,7 @@ public class MultiTenancyRpcMethodDecoratorTest {
 
   @Test
   public void failsWhenTokenDoesNotHavePrivacyPublicKey() {
-    final JWTUser user = new JWTUser(new JsonObject(), "");
+    final User user = new UserImpl(new JsonObject());
     final JsonRpcRequestContext rpcRequestContext = new JsonRpcRequestContext(rpcRequest, user);
     final MultiTenancyRpcMethodDecorator tokenRpcDecorator =
         new MultiTenancyRpcMethodDecorator(jsonRpcMethod);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtilTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtilTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Test;
 
 public class MultiTenancyUserUtilTest {
@@ -35,7 +35,7 @@ public class MultiTenancyUserUtilTest {
   @Test
   public void noEnclavePublicKeyWhenUserWithoutEnclavePublicKeyClaimProvided() {
     final JsonObject token = new JsonObject();
-    final Optional<User> user = Optional.of(new JWTUser(token, ""));
+    final Optional<User> user = Optional.of(new UserImpl(token));
 
     assertThat(privacyUserId(user)).isEmpty();
   }
@@ -44,7 +44,7 @@ public class MultiTenancyUserUtilTest {
   public void enclavePublicKeyKeyReturnedForUserWithEnclavePublicKeyClaim() {
     final JsonObject principle = new JsonObject();
     principle.put("privacyPublicKey", "ABC123");
-    final Optional<User> user = Optional.of(new JWTUser(principle, ""));
+    final Optional<User> user = Optional.of(new UserImpl(principle));
 
     assertThat(privacyUserId(user)).contains("ABC123");
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
@@ -39,7 +39,7 @@ import java.util.List;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,7 +56,7 @@ public class PrivCreatePrivacyGroupTest {
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
   private final PrivacyController privacyController = mock(PrivacyController.class);
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY));
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
   @Before

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,7 +46,7 @@ public class PrivDeletePrivacyGroupTest {
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
   private final PrivacyController privacyController = mock(PrivacyController.class);
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY));
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
   private JsonRpcRequestContext request;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
@@ -37,7 +37,7 @@ import java.util.Base64;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,7 +59,7 @@ public class PrivDistributeRawTransactionTest {
   private static final String ENCLAVE_PUBLIC_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
 
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY)) {};
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
   @Mock private PrivDistributeRawTransaction method;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class PrivFindPrivacyGroupTest {
   private final PrivacyParameters privacyParameters = mock(PrivacyParameters.class);
   private final PrivacyController privacyController = mock(PrivacyController.class);
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY));
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
   private JsonRpcRequestContext request;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,8 +54,8 @@ public class PrivGetPrivateTransactionTest {
   @Mock private PrivacyController privacyController;
 
   private final User user =
-      new JWTUser(
-          new JsonObject().put("privacyPublicKey", VALID_BASE64_ENCLAVE_KEY.toBase64String()), "");
+      new UserImpl(
+          new JsonObject().put("privacyPublicKey", VALID_BASE64_ENCLAVE_KEY.toBase64String()));
   private final PrivacyIdProvider privacyIdProvider =
       (user) -> VALID_BASE64_ENCLAVE_KEY.toBase64String();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCountTest.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,7 +50,7 @@ public class PrivGetTransactionCountTest {
       Address.fromHexString("0x627306090abab3a6e1400e9345bc60c78a8bef57");
   private final long NONCE = 5;
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY)) {};
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
   @Before

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
@@ -66,8 +66,8 @@ public class PrivGetTransactionReceiptTest {
   private PrivGetTransactionReceipt privGetTransactionReceipt;
 
   private final User user =
-      new JWTUser(
-          new JsonObject().put("privacyPublicKey", VALID_BASE64_ENCLAVE_KEY.toBase64String()), "");
+      new UserImpl(
+          new JsonObject().put("privacyPublicKey", VALID_BASE64_ENCLAVE_KEY.toBase64String()));
   private final PrivacyIdProvider privacyIdProvider =
       (user) -> VALID_BASE64_ENCLAVE_KEY.toBase64String();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroupTest.java
@@ -37,7 +37,7 @@ import java.util.List;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,7 +54,7 @@ public class PrivxFindFlexiblePrivacyGroupTest {
   private final PrivacyController privacyController = mock(PrivacyController.class);
 
   private final User user =
-      new JWTUser(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), "");
+      new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY));
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
   private JsonRpcRequestContext request;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
-import io.vertx.ext.auth.jwt.impl.JWTUser;
+import io.vertx.ext.auth.impl.UserImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -158,7 +158,7 @@ public class PrivacyApiGroupJsonRpcMethodsTest {
   }
 
   private User createUser(final String enclavePublicKey) {
-    return new JWTUser(new JsonObject().put("privacyPublicKey", enclavePublicKey), "");
+    return new UserImpl(new JsonObject().put("privacyPublicKey", enclavePublicKey)) {};
   }
 
   private static class TestPrivacyApiGroupJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -278,7 +278,7 @@ public class WebSocketServiceLoginTest {
                   });
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS*10);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -39,13 +39,11 @@ import java.util.Map;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
-import io.vertx.core.http.RequestOptions;
-import io.vertx.core.http.impl.headers.VertxHttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
@@ -109,6 +107,7 @@ public class WebSocketServiceLoginTest {
         new HttpClientOptions()
             .setDefaultHost(websocketConfiguration.getHost())
             .setDefaultPort(websocketConfiguration.getPort());
+    ;
 
     httpClient = vertx.createHttpClient(httpClientOptions);
   }
@@ -122,76 +121,91 @@ public class WebSocketServiceLoginTest {
   @Test
   public void loginWithBadCredentials(final TestContext context) {
     final Async async = context.async();
-    final HttpClientRequest request =
-        httpClient.post(
-            websocketConfiguration.getPort(),
-            websocketConfiguration.getHost(),
-            "/login",
-            response -> {
-              assertThat(response.statusCode()).isEqualTo(401);
-              assertThat(response.statusMessage()).isEqualTo("Unauthorized");
-              async.complete();
-            });
-    request.putHeader("Content-Type", "application/json; charset=utf-8");
-    request.end("{\"username\":\"user\",\"password\":\"pass\"}");
+    httpClient.request(
+        HttpMethod.POST,
+        websocketConfiguration.getPort(),
+        websocketConfiguration.getHost(),
+        "/login",
+        request -> {
+          request.result().putHeader("Content-Type", "application/json; charset=utf-8");
+          request.result().end("{\"username\":\"user\",\"password\":\"pass\"}");
+          request
+              .result()
+              .send(
+                  response -> {
+                    assertThat(response.result().statusCode()).isEqualTo(401);
+                    assertThat(response.result().statusMessage()).isEqualTo("Unauthorized");
+                    async.complete();
+                  });
+        });
+
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }
 
   @Test
   public void loginWithGoodCredentials(final TestContext context) {
     final Async async = context.async();
-    final HttpClientRequest request =
-        httpClient.post(
-            websocketConfiguration.getPort(),
-            websocketConfiguration.getHost(),
-            "/login",
-            response -> {
-              assertThat(response.statusCode()).isEqualTo(200);
-              assertThat(response.statusMessage()).isEqualTo("OK");
-              assertThat(response.getHeader("Content-Type")).isNotNull();
-              assertThat(response.getHeader("Content-Type")).isEqualTo("application/json");
-              response.bodyHandler(
-                  buffer -> {
-                    final String body = buffer.toString();
-                    assertThat(body).isNotBlank();
+    httpClient.request(
+        HttpMethod.POST,
+        websocketConfiguration.getPort(),
+        websocketConfiguration.getHost(),
+        "/login",
+        request -> {
+          request.result().putHeader("Content-Type", "application/json; charset=utf-8");
+          request.result().end("{\"username\":\"user\",\"password\":\"pegasys\"}");
+          request
+              .result()
+              .send(
+                  response -> {
+                    assertThat(response.result().statusCode()).isEqualTo(200);
+                    assertThat(response.result().statusMessage()).isEqualTo("OK");
+                    assertThat(response.result().getHeader("Content-Type")).isNotNull();
+                    assertThat(response.result().getHeader("Content-Type"))
+                        .isEqualTo("application/json");
+                    response
+                        .result()
+                        .bodyHandler(
+                            buffer -> {
+                              final String body = buffer.toString();
+                              assertThat(body).isNotBlank();
 
-                    final JsonObject respBody = new JsonObject(body);
-                    final String token = respBody.getString("token");
-                    assertThat(token).isNotNull();
+                              final JsonObject respBody = new JsonObject(body);
+                              final String token = respBody.getString("token");
+                              assertThat(token).isNotNull();
+                              assertThat(token).isNotEmpty();
 
-                    websocketService
-                        .authenticationService
-                        .get()
-                        .getJwtAuthProvider()
-                        .authenticate(
-                            new JsonObject().put("jwt", token),
-                            (r) -> {
-                              Assertions.assertThat(r.succeeded()).isTrue();
-                              final User user = r.result();
-                              user.isAuthorized(
-                                  "noauths",
-                                  (authed) -> {
-                                    assertThat(authed.succeeded()).isTrue();
-                                    assertThat(authed.result()).isFalse();
-                                  });
-                              user.isAuthorized(
-                                  "fakePermission",
-                                  (authed) -> {
-                                    assertThat(authed.succeeded()).isTrue();
-                                    assertThat(authed.result()).isTrue();
-                                  });
-                              user.isAuthorized(
-                                  "eth:subscribe",
-                                  (authed) -> {
-                                    assertThat(authed.succeeded()).isTrue();
-                                    assertThat(authed.result()).isTrue();
-                                    async.complete();
-                                  });
+                              websocketService
+                                  .authenticationService
+                                  .get()
+                                  .getJwtAuthProvider()
+                                  .authenticate(
+                                      new JsonObject().put("token", token),
+                                      (r) -> {
+                                        Assertions.assertThat(r.succeeded()).isTrue();
+                                        final User user = r.result();
+                                        user.isAuthorized(
+                                            "noauths",
+                                            (authed) -> {
+                                              assertThat(authed.succeeded()).isTrue();
+                                              assertThat(authed.result()).isFalse();
+                                            });
+                                        user.isAuthorized(
+                                            "fakePermission",
+                                            (authed) -> {
+                                              assertThat(authed.succeeded()).isTrue();
+                                              assertThat(authed.result()).isTrue();
+                                            });
+                                        user.isAuthorized(
+                                            "eth:subscribe",
+                                            (authed) -> {
+                                              assertThat(authed.succeeded()).isTrue();
+                                              assertThat(authed.result()).isTrue();
+                                              async.complete();
+                                            });
+                                      });
                             });
                   });
-            });
-    request.putHeader("Content-Type", "application/json; charset=utf-8");
-    request.end("{\"username\":\"user\",\"password\":\"pegasys\"}");
+        });
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }
@@ -204,26 +218,26 @@ public class WebSocketServiceLoginTest {
     final String expectedResponse =
         "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-40100,\"message\":\"Unauthorized\"}}";
 
-    RequestOptions options = new RequestOptions();
+    WebSocketConnectOptions options = new WebSocketConnectOptions();
     options.setURI("/");
     options.setHost(websocketConfiguration.getHost());
     options.setPort(websocketConfiguration.getPort());
-    final MultiMap headers = new VertxHttpHeaders();
     String badtoken = "badtoken";
     if (badtoken != null) {
-      headers.add("Authorization", "Bearer " + badtoken);
+      options.addHeader("Authorization", "Bearer " + badtoken);
     }
-    httpClient.websocket(
+    httpClient.webSocket(
         options,
-        headers,
         webSocket -> {
-          webSocket.writeTextMessage(request);
+          webSocket.result().writeTextMessage(request);
 
-          webSocket.handler(
-              buffer -> {
-                context.assertEquals(expectedResponse, buffer.toString());
-                async.complete();
-              });
+          webSocket
+              .result()
+              .handler(
+                  buffer -> {
+                    context.assertEquals(expectedResponse, buffer.toString());
+                    async.complete();
+                  });
         });
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
@@ -234,6 +248,7 @@ public class WebSocketServiceLoginTest {
     final Async async = context.async();
 
     final JWTOptions jwtOptions = new JWTOptions().setExpiresInMinutes(5).setAlgorithm("RS256");
+
     final JsonObject jwtContents =
         new JsonObject().put("permissions", Lists.newArrayList("eth:*")).put("username", "user");
     final String goodToken = jwtAuth.generateToken(jwtContents, jwtOptions);
@@ -242,25 +257,25 @@ public class WebSocketServiceLoginTest {
         "{\"id\": 1, \"method\": \"eth_subscribe\", \"params\": [\"syncing\"]}";
     final String expectedResponse = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0x1\"}";
 
-    RequestOptions options = new RequestOptions();
+    WebSocketConnectOptions options = new WebSocketConnectOptions();
     options.setURI("/");
     options.setHost(websocketConfiguration.getHost());
     options.setPort(websocketConfiguration.getPort());
-    final MultiMap headers = new VertxHttpHeaders();
     if (goodToken != null) {
-      headers.add("Authorization", "Bearer " + goodToken);
+      options.addHeader("Authorization", "Bearer " + goodToken);
     }
-    httpClient.websocket(
+    httpClient.webSocket(
         options,
-        headers,
         webSocket -> {
-          webSocket.writeTextMessage(requestSub);
+          webSocket.result().writeTextMessage(requestSub);
 
-          webSocket.handler(
-              buffer -> {
-                context.assertEquals(expectedResponse, buffer.toString());
-                async.complete();
-              });
+          webSocket
+              .result()
+              .handler(
+                  buffer -> {
+                    context.assertEquals(expectedResponse, buffer.toString());
+                    async.complete();
+                  });
         });
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
@@ -269,42 +284,52 @@ public class WebSocketServiceLoginTest {
   @Test
   public void loginPopulatesJWTPayloadWithRequiredValues(final TestContext context) {
     final Async async = context.async();
-    final HttpClientRequest request =
-        httpClient.post(
-            websocketConfiguration.getPort(),
-            websocketConfiguration.getHost(),
-            "/login",
-            response -> {
-              response.bodyHandler(
-                  buffer -> {
-                    final String body = buffer.toString();
-                    assertThat(body).isNotBlank();
+    httpClient.request(
+        HttpMethod.POST,
+        websocketConfiguration.getPort(),
+        websocketConfiguration.getHost(),
+        "/login",
+        request -> {
+          request.result().putHeader("Content-Type", "application/json; charset=utf-8");
+          request.result().end("{\"username\":\"user\",\"password\":\"pegasys\"}");
+          request
+              .result()
+              .send(
+                  response -> {
+                    response
+                        .result()
+                        .bodyHandler(
+                            buffer -> {
+                              final String body = buffer.toString();
+                              assertThat(body).isNotBlank();
 
-                    final JsonObject respBody = new JsonObject(body);
-                    final String token = respBody.getString("token");
+                              final JsonObject respBody = new JsonObject(body);
+                              final String token = respBody.getString("token");
 
-                    final JsonObject jwtPayload = decodeJwtPayload(token);
-                    assertThat(jwtPayload.getString("username")).isEqualTo("user");
-                    assertThat(jwtPayload.getJsonArray("permissions"))
-                        .isEqualTo(
-                            new JsonArray(
-                                list(
-                                    "fakePermission",
-                                    "eth:blockNumber",
-                                    "eth:subscribe",
-                                    "web3:*")));
-                    assertThat(jwtPayload.getString("privacyPublicKey"))
-                        .isEqualTo("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=");
-                    assertThat(jwtPayload.containsKey("iat")).isTrue();
-                    assertThat(jwtPayload.containsKey("exp")).isTrue();
-                    final long tokenExpiry = jwtPayload.getLong("exp") - jwtPayload.getLong("iat");
-                    assertThat(tokenExpiry).isEqualTo(MINUTES.toSeconds(5));
+                              final JsonObject jwtPayload = decodeJwtPayload(token);
+                              assertThat(jwtPayload.getString("username")).isEqualTo("user");
+                              assertThat(jwtPayload.getJsonArray("permissions"))
+                                  .isEqualTo(
+                                      new JsonArray(
+                                          list(
+                                              "fakePermission",
+                                              "eth:blockNumber",
+                                              "eth:subscribe",
+                                              "web3:*")));
 
-                    async.complete();
+                              assertThat(jwtPayload.getString("privacyPublicKey"))
+                                  .isEqualTo("A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=");
+
+                              assertThat(jwtPayload.containsKey("iat")).isTrue();
+                              assertThat(jwtPayload.containsKey("exp")).isTrue();
+                              final long tokenExpiry =
+                                  jwtPayload.getLong("exp") - jwtPayload.getLong("iat");
+                              assertThat(tokenExpiry).isEqualTo(MINUTES.toSeconds(5));
+
+                              async.complete();
+                            });
                   });
-            });
-    request.putHeader("Content-Type", "application/json; charset=utf-8");
-    request.end("{\"username\":\"user\",\"password\":\"pegasys\"}");
+        });
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -278,7 +278,7 @@ public class WebSocketServiceLoginTest {
                   });
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS*10);
+    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -107,7 +107,6 @@ public class WebSocketServiceLoginTest {
         new HttpClientOptions()
             .setDefaultHost(websocketConfiguration.getHost())
             .setDefaultPort(websocketConfiguration.getPort());
-    ;
 
     httpClient = vertx.createHttpClient(httpClientOptions);
   }
@@ -248,7 +247,6 @@ public class WebSocketServiceLoginTest {
     final Async async = context.async();
 
     final JWTOptions jwtOptions = new JWTOptions().setExpiresInMinutes(5).setAlgorithm("RS256");
-
     final JsonObject jwtContents =
         new JsonObject().put("permissions", Lists.newArrayList("eth:*")).put("username", "user");
     final String goodToken = jwtAuth.generateToken(jwtContents, jwtOptions);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -107,6 +107,7 @@ public class WebSocketServiceLoginTest {
         new HttpClientOptions()
             .setDefaultHost(websocketConfiguration.getHost())
             .setDefaultPort(websocketConfiguration.getPort());
+    ;
 
     httpClient = vertx.createHttpClient(httpClientOptions);
   }
@@ -247,6 +248,7 @@ public class WebSocketServiceLoginTest {
     final Async async = context.async();
 
     final JWTOptions jwtOptions = new JWTOptions().setExpiresInMinutes(5).setAlgorithm("RS256");
+
     final JsonObject jwtContents =
         new JsonObject().put("permissions", Lists.newArrayList("eth:*")).put("username", "user");
     final String goodToken = jwtAuth.generateToken(jwtContents, jwtOptions);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
@@ -37,10 +37,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.WebSocket;
-import io.vertx.core.http.WebSocketBase;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
@@ -207,7 +206,13 @@ public class WebSocketServiceTest {
               context.assertNotNull(m.body());
               async.complete();
             })
-        .completionHandler(v -> httpClient.websocket("/", WebSocketBase::close));
+        .completionHandler(
+            v ->
+                httpClient.webSocket(
+                    "/",
+                    websocket -> {
+                      websocket.result().close();
+                    }));
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }
@@ -239,38 +244,50 @@ public class WebSocketServiceTest {
   public void websocketServiceMustReturnErrorOnHttpRequest(final TestContext context) {
     final Async async = context.async();
 
-    httpClient
-        .post(
-            websocketConfiguration.getPort(),
-            websocketConfiguration.getHost(),
-            "/",
-            response ->
-                response.bodyHandler(
-                    b -> {
-                      context
-                          .assertEquals(400, response.statusCode())
-                          .assertEquals(
-                              "Websocket endpoint can't handle HTTP requests", b.toString());
-                      async.complete();
-                    }))
-        .end();
-
+    httpClient.request(
+        HttpMethod.POST,
+        websocketConfiguration.getPort(),
+        websocketConfiguration.getHost(),
+        "/",
+        request -> {
+          request
+              .result()
+              .send(
+                  response ->
+                      response
+                          .result()
+                          .bodyHandler(
+                              b -> {
+                                context
+                                    .assertEquals(400, response.result().statusCode())
+                                    .assertEquals(
+                                        "Websocket endpoint can't handle HTTP requests",
+                                        b.toString());
+                                async.complete();
+                              }));
+        });
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
   }
 
   @Test
   public void handleLoginRequestWithAuthDisabled() {
-    final HttpClientRequest request =
-        httpClient.post(
-            websocketConfiguration.getPort(),
-            websocketConfiguration.getHost(),
-            "/login",
-            response -> {
-              assertThat(response.statusCode()).isEqualTo(400);
-              assertThat(response.statusMessage()).isEqualTo("Authentication not enabled");
-            });
-    request.putHeader("Content-Type", "application/json; charset=utf-8");
-    request.end("{\"username\":\"user\",\"password\":\"pass\"}");
+    httpClient.request(
+        HttpMethod.POST,
+        websocketConfiguration.getPort(),
+        websocketConfiguration.getHost(),
+        "/login",
+        request -> {
+          request.result().putHeader("Content-Type", "application/json; charset=utf-8");
+          request.result().end("{\"username\":\"user\",\"password\":\"pass\"}");
+          request
+              .result()
+              .send(
+                  response -> {
+                    assertThat(response.result().statusCode()).isEqualTo(400);
+                    assertThat(response.result().statusMessage())
+                        .isEqualTo("Authentication not enabled");
+                  });
+        });
   }
 
   @Test

--- a/ethereum/blockcreation/build.gradle
+++ b/ethereum/blockcreation/build.gradle
@@ -38,4 +38,5 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -87,7 +87,6 @@ dependencies {
   integrationTestImplementation project(':testutil')
 
   integrationTestImplementation 'junit:junit'
-  integrationTestImplementation 'net.consensys:orion'
   integrationTestImplementation 'org.assertj:assertj-core'
   integrationTestImplementation 'org.mockito:mockito-core'
 

--- a/ethereum/eth/build.gradle
+++ b/ethereum/eth/build.gradle
@@ -72,6 +72,7 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
   testSupportImplementation 'junit:junit'
   testSupportImplementation 'org.mockito:mockito-core'

--- a/ethereum/p2p/build.gradle
+++ b/ethereum/p2p/build.gradle
@@ -77,4 +77,5 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/ethereum/retesteth/build.gradle
+++ b/ethereum/retesteth/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
   implementation 'io.vertx:vertx-web'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.logging.log4j:log4j-api'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'

--- a/ethereum/stratum/build.gradle
+++ b/ethereum/stratum/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'io.vertx:vertx-core'
+  implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -83,11 +83,11 @@ dependencyManagement {
 
     dependency 'io.reactivex.rxjava2:rxjava:2.2.21'
 
-    dependency 'io.vertx:vertx-auth-jwt:3.9.8'
-    dependency 'io.vertx:vertx-codegen:3.9.8'
-    dependency 'io.vertx:vertx-core:3.9.8'
-    dependency 'io.vertx:vertx-unit:3.9.8'
-    dependency 'io.vertx:vertx-web:3.9.8'
+    dependency 'io.vertx:vertx-auth-jwt:4.2.1'
+    dependency 'io.vertx:vertx-codegen:4.2.1'
+    dependency 'io.vertx:vertx-core:4.2.1'
+    dependency 'io.vertx:vertx-unit:4.2.1'
+    dependency 'io.vertx:vertx-web:4.2.1'
 
     dependency 'junit:junit:4.13.2'
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -88,6 +88,8 @@ dependencyManagement {
     dependency 'io.vertx:vertx-core:4.2.1'
     dependency 'io.vertx:vertx-unit:4.2.1'
     dependency 'io.vertx:vertx-web:4.2.1'
+    dependency 'io.vertx:vertx-web-client:4.2.1'
+    dependency 'io.vertx:vertx-auth-jwt:4.2.1'
 
     dependency 'junit:junit:4.13.2'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Upgrades vert.x dependency. 

Notable areas of impact:

- Getting connections from an HTTP client is in itself asynchronous, so another layer of futures is added.
- The way keypairs are added to the JWTAuthProvider is different, and now they are configured using PEM strings.
- JWT attributes and principal fields are changed, for example exp (expiry) is a user attribute, not a principal property.


## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).