### PR TITLE
Fix admin_nodeInfo when response has jdk8 optional values

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/JsonQbftConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonQbftConfigOptions.java
@@ -46,8 +46,11 @@ public class JsonQbftConfigOptions extends JsonBftConfigOptions implements QbftC
     final Map<String, Object> map = super.asMap();
     final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
     builder.putAll(map);
-    builder.put(VALIDATOR_CONTRACT_ADDRESS, getValidatorContractAddress());
-    builder.put(START_BLOCK, getStartBlock());
+
+    getValidatorContractAddress()
+        .ifPresent((address) -> builder.put(VALIDATOR_CONTRACT_ADDRESS, address));
+    getStartBlock().ifPresent((startBlock) -> builder.put(START_BLOCK, getStartBlock()));
+
     return builder.build();
   }
 }

--- a/config/src/test/java/org/hyperledger/besu/config/JsonQbftConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonQbftConfigOptionsTest.java
@@ -38,4 +38,12 @@ public class JsonQbftConfigOptionsTest {
 
     assertThat(configOptions.getValidatorContractAddress()).hasValue("0xabc");
   }
+
+  @Test
+  public void asMapDoesNotIncludeEmptyOptionalFields() {
+    final ObjectNode objectNode = objectMapper.createObjectNode();
+    final JsonQbftConfigOptions configOptions = new JsonQbftConfigOptions(objectNode);
+
+    assertThat(configOptions.asMap()).isEmpty();
+  }
 }

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -52,6 +52,7 @@ dependencies {
 
   implementation 'com.google.guava:guava'
   implementation 'com.graphql-java:graphql-java'
+  implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
   implementation 'io.opentelemetry:opentelemetry-api'
   implementation 'io.opentelemetry:opentelemetry-extension-trace-propagators'
   implementation 'io.vertx:vertx-auth-jwt'

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -63,6 +63,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -94,6 +95,7 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.net.PfxOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.auth.User;
@@ -227,6 +229,10 @@ public class JsonRpcHttpService {
     LOG.info("Starting JSON-RPC service on {}:{}", config.getHost(), config.getPort());
     LOG.debug("max number of active connections {}", maxActiveConnections);
     this.tracer = GlobalOpenTelemetry.getTracer("org.hyperledger.besu.jsonrpc", "1.0.0");
+
+    // Handle JDK8 Optionals (de)serialization
+    DatabindCodec.mapper().registerModule(new Jdk8Module());
+    DatabindCodec.prettyMapper().registerModule(new Jdk8Module());
 
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
     try {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -37,6 +38,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
@@ -88,6 +90,10 @@ public class WebSocketService {
   public CompletableFuture<?> start() {
     LOG.info(
         "Starting Websocket service on {}:{}", configuration.getHost(), configuration.getPort());
+
+    // Handle JDK8 Optionals (de)serialization
+    DatabindCodec.mapper().registerModule(new Jdk8Module());
+    DatabindCodec.prettyMapper().registerModule(new Jdk8Module());
 
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.handlers.TimeoutOptions;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketMethodsFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
+import org.hyperledger.besu.ethereum.api.util.TestJsonRpcMethodsUtil;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
@@ -58,6 +59,7 @@ public class WebSocketServiceTest {
   private Vertx vertx;
   private WebSocketConfiguration websocketConfiguration;
   private WebSocketRequestHandler webSocketRequestHandlerSpy;
+  private Map<String, JsonRpcMethod> websocketMethods;
   private WebSocketService websocketService;
   private HttpClient httpClient;
   private final int maxConnections = 3;
@@ -71,7 +73,7 @@ public class WebSocketServiceTest {
     websocketConfiguration.setHostsAllowlist(Collections.singletonList("*"));
     websocketConfiguration.setMaxActiveConnections(maxConnections);
 
-    final Map<String, JsonRpcMethod> websocketMethods =
+    websocketMethods =
         new WebSocketMethodsFactory(
                 new SubscriptionManager(new NoOpMetricsSystem()), new HashMap<>())
             .methods();
@@ -299,5 +301,67 @@ public class WebSocketServiceTest {
         });
 
     async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+  }
+
+  @Test
+  public void handleResponseWithOptionalEmptyValue(final TestContext context) {
+    final Async async = context.async();
+    final JsonRpcMethod method = TestJsonRpcMethodsUtil.optionalEmptyResponse();
+    websocketMethods.put(method.getName(), method);
+
+    final String request =
+        "{\"id\": 1, \"method\": \"" + method.getName() + "\", \"params\": [\"syncing\"]}";
+    final String expectedResponse = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}";
+
+    httpClient.webSocket(
+        "/",
+        future -> {
+          if (future.succeeded()) {
+            WebSocket ws = future.result();
+            ws.handler(
+                buffer -> {
+                  context.assertEquals(expectedResponse, buffer.toString());
+                  async.complete();
+                });
+
+            ws.writeTextMessage(request);
+          } else {
+            context.fail("websocket connection failed");
+          }
+        });
+
+    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    async.handler((result) -> websocketMethods.remove(method.getName()));
+  }
+
+  @Test
+  public void handleResponseWithOptionalExistingValue(final TestContext context) {
+    final Async async = context.async();
+    final JsonRpcMethod method = TestJsonRpcMethodsUtil.optionalResponseWithValue("foo");
+    websocketMethods.put(method.getName(), method);
+
+    final String request =
+        "{\"id\": 1, \"method\": \"" + method.getName() + "\", \"params\": [\"syncing\"]}";
+    final String expectedResponse = "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"foo\"}";
+
+    httpClient.webSocket(
+        "/",
+        future -> {
+          if (future.succeeded()) {
+            WebSocket ws = future.result();
+            ws.handler(
+                buffer -> {
+                  context.assertEquals(expectedResponse, buffer.toString());
+                  async.complete();
+                });
+
+            ws.writeTextMessage(request);
+          } else {
+            context.fail("websocket connection failed");
+          }
+        });
+
+    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    async.handler((result) -> websocketMethods.remove(method.getName()));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/TestJsonRpcMethodsUtil.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/TestJsonRpcMethodsUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.ethereum.api.util;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+
+import java.util.Optional;
+
+public class TestJsonRpcMethodsUtil {
+
+  public static JsonRpcMethod optionalEmptyResponse() {
+    return new JsonRpcMethod() {
+      @Override
+      public String getName() {
+        return "temp_optionalEmptyResponse";
+      }
+
+      @Override
+      public JsonRpcResponse response(final JsonRpcRequestContext request) {
+        return new JsonRpcSuccessResponse(request.getRequest().getId(), Optional.empty());
+      }
+    };
+  }
+
+  public static JsonRpcMethod optionalResponseWithValue(final Object value) {
+    return new JsonRpcMethod() {
+      @Override
+      public String getName() {
+        return "temp_optionalWithValueResponse";
+      }
+
+      @Override
+      public JsonRpcResponse response(final JsonRpcRequestContext request) {
+        return new JsonRpcSuccessResponse(request.getRequest().getId(), Optional.of(value));
+      }
+    };
+  }
+}


### PR DESCRIPTION
## PR description

We were not handling JDK8 (de)serialization properly in our RPC services. This PR is using jackson-jdk8 module to handle Optional (de)serialization for responses.

This will ensure that serialization maps the value of Optional to null, if no value is present, or the wrapped value if present.

It does not make sense for the QBFT config to return null for the validator address and start block, so we are not including it into the json when these values are not present.

## Fixed Issue(s)
N/A

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).