### PR TITLE
Adding support for NO_COLOR environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 21.10.3
 
 ### Additions and Improvements
-
+- Adding support of the NO_COLOR environment variable as described in the [NO_COLOR](https://no-color.org/) standard [#3085](https://github.com/hyperledger/besu/pull/3085)
 ### Bug Fixes
 
 ### Early Access Features

--- a/besu/src/main/java/org/hyperledger/besu/cli/logging/XmlExtensionConfiguration.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/logging/XmlExtensionConfiguration.java
@@ -83,7 +83,7 @@ public class XmlExtensionConfiguration extends XmlConfiguration {
     final PatternLayout patternLayout =
         PatternLayout.newBuilder()
             .withConfiguration(this)
-            .withDisableAnsi(!BesuCommand.getColorEnabled().orElse(true))
+            .withDisableAnsi(!BesuCommand.getColorEnabled().orElse(!noColorSet()))
             .withNoConsoleNoAnsi(!BesuCommand.getColorEnabled().orElse(false))
             .withPattern(
                 String.join(
@@ -98,6 +98,10 @@ public class XmlExtensionConfiguration extends XmlConfiguration {
         ConsoleAppender.newBuilder().setName("Console").setLayout(patternLayout).build();
     consoleAppender.start();
     this.getRootLogger().addAppender(consoleAppender, null, null);
+  }
+
+  private static boolean noColorSet() {
+    return System.getenv("NO_COLOR") != null;
   }
 
   private boolean customLog4jConfigFilePresent() {


### PR DESCRIPTION
Adding support of the NO_COLOR environment variable as described in
the [NO_COLOR](https://no-color.org/) standard.

The new behaviour looks like this:
1) Both NO_COLOR is not set and color-enabled options is not set => colors
will be enabled (by default we have colors on)

2) NO_COLOR is not set but color-enabled option is set to false =>
colors will be disabled (we can disable colors using an option)

3) NO_COLOR is set to any value and color-enabled option is not used =>
colors will be disabled (we can disable colors using an environment
variable this is new!)

4) NO_COLOR is set to any value but color-enabled option is set to true
=> colors will be enabled (an option has precedence over the environment
variable)

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes issue [1756](https://github.com/hyperledger/besu/issues/1756)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).