### PR TITLE
Removing the orion acceptance tests

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/ParameterizedEnclaveTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/ParameterizedEnclaveTestBase.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.tests.acceptance.dsl.privacy;
 
 import static org.hyperledger.enclave.testutil.EnclaveType.NOOP;
-import static org.hyperledger.enclave.testutil.EnclaveType.ORION;
 import static org.hyperledger.enclave.testutil.EnclaveType.TESSERA;
 import static org.web3j.utils.Restriction.RESTRICTED;
 import static org.web3j.utils.Restriction.UNRESTRICTED;
@@ -49,7 +48,6 @@ public abstract class ParameterizedEnclaveTestBase extends PrivacyAcceptanceTest
     return Arrays.asList(
         new Object[][] {
           {RESTRICTED, TESSERA},
-          {RESTRICTED, ORION},
           {UNRESTRICTED, NOOP}
         });
   }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -44,7 +44,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 import org.hyperledger.enclave.testutil.EnclaveTestHarness;
 import org.hyperledger.enclave.testutil.EnclaveType;
 import org.hyperledger.enclave.testutil.NoopEnclaveTestHarness;
-import org.hyperledger.enclave.testutil.OrionTestHarnessFactory;
 import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 
 import java.io.IOException;
@@ -293,8 +292,7 @@ public class PrivacyNode implements AutoCloseable {
 
     switch (enclaveType) {
       case ORION:
-        return OrionTestHarnessFactory.create(
-            config.getName(), tempDir, privacyConfiguration.getKeyConfig());
+        throw new UnsupportedOperationException("The Orion tests are getting deprecated");
       case TESSERA:
         return TesseraTestHarnessFactory.create(
             config.getName(), tempDir, privacyConfiguration.getKeyConfig(), containerNetwork);

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/BftPrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/BftPrivacyClusterAcceptanceTest.java
@@ -67,11 +67,9 @@ public class BftPrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<BftPrivacyType> bftPrivacyTypes() {
     final List<BftPrivacyType> bftPrivacyTypes = new ArrayList<>();
-    for (EnclaveType x : EnclaveType.values()) {
-      if (!x.equals(EnclaveType.NOOP)) {
-        for (ConsensusType consensusType : ConsensusType.values()) {
-          bftPrivacyTypes.add(new BftPrivacyType(x, consensusType, Restriction.RESTRICTED));
-        }
+    for (EnclaveType x : EnclaveType.valuesForTests()) {
+      for (ConsensusType consensusType : ConsensusType.values()) {
+        bftPrivacyTypes.add(new BftPrivacyType(x, consensusType, Restriction.RESTRICTED));
       }
     }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
@@ -25,11 +25,9 @@ import org.hyperledger.enclave.testutil.EnclaveType;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.tuweni.crypto.sodium.Box;
 import org.assertj.core.api.Condition;
@@ -51,9 +49,7 @@ public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   @Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   public EnclaveErrorAcceptanceTest(final EnclaveType enclaveType) throws IOException {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/OnchainPrivacyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/OnchainPrivacyAcceptanceTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
@@ -59,9 +58,7 @@ public class OnchainPrivacyAcceptanceTest extends OnchainPrivacyAcceptanceTestBa
 
   @Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   private PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOnchainGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOnchainGroupAcceptanceTest.java
@@ -26,10 +26,8 @@ import org.hyperledger.enclave.testutil.EnclaveType;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
@@ -51,9 +49,7 @@ public class PrivDebugGetStateRootOnchainGroupAcceptanceTest
 
   @Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   private PrivacyNode aliceNode;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyClusterAcceptanceTest.java
@@ -29,11 +29,9 @@ import org.hyperledger.enclave.testutil.EnclaveType;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
@@ -63,9 +61,7 @@ public class PrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   @Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   public PrivacyClusterAcceptanceTest(final EnclaveType enclaveType) throws IOException {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyGroupAcceptanceTest.java
@@ -24,10 +24,8 @@ import org.hyperledger.enclave.testutil.EnclaveType;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -52,9 +50,7 @@ public class PrivacyGroupAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   @Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   public PrivacyGroupAcceptanceTest(final EnclaveType enclaveType) throws IOException {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/OnchainMultiTenancyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/OnchainMultiTenancyAcceptanceTest.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.tests.web3j.generated.EventEmitter;
 import org.hyperledger.enclave.testutil.EnclaveType;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -60,9 +59,7 @@ public class OnchainMultiTenancyAcceptanceTest extends OnchainPrivacyAcceptanceT
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<EnclaveType> enclaveTypes() {
-    return Arrays.stream(EnclaveType.values())
-        .filter(enclaveType -> enclaveType != EnclaveType.NOOP)
-        .collect(Collectors.toList());
+    return EnclaveType.valuesForTests();
   }
 
   private static final PermissioningTransactions permissioningTransactions =

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/EnclaveType.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/EnclaveType.java
@@ -14,8 +14,19 @@
  */
 package org.hyperledger.enclave.testutil;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 public enum EnclaveType {
   ORION,
   TESSERA,
-  NOOP
+  NOOP;
+
+  public static List<EnclaveType> valuesForTests() {
+    return Arrays.stream(values())
+        .filter(enclaveType -> enclaveType != NOOP)
+        .filter(enclaveType -> enclaveType != ORION)
+        .collect(Collectors.toList());
+  }
 }


### PR DESCRIPTION
ORION is getting deprecated. There is no need to run these acceptance
tests any more.

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Fixes [3030](https://github.com/hyperledger/besu/issues/3030)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).