### PR TITLE
Rename BftForkSpec to ForkSpec and make it generic

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/ForkSpec.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/ForkSpec.java
@@ -12,28 +12,26 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.consensus.common.bft;
-
-import org.hyperledger.besu.config.BftConfigOptions;
+package org.hyperledger.besu.consensus.common;
 
 import java.util.Objects;
 
-public class BftForkSpec<C extends BftConfigOptions> {
+public class ForkSpec<C> {
 
   private final long block;
-  private final C configOptions;
+  private final C value;
 
-  public BftForkSpec(final long block, final C configOptions) {
+  public ForkSpec(final long block, final C value) {
     this.block = block;
-    this.configOptions = configOptions;
+    this.value = value;
   }
 
   public long getBlock() {
     return block;
   }
 
-  public C getConfigOptions() {
-    return configOptions;
+  public C getValue() {
+    return value;
   }
 
   @Override
@@ -44,12 +42,12 @@ public class BftForkSpec<C extends BftConfigOptions> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final BftForkSpec<?> that = (BftForkSpec<?>) o;
-    return block == that.block && Objects.equals(configOptions, that.configOptions);
+    final ForkSpec<?> that = (ForkSpec<?>) o;
+    return block == that.block && Objects.equals(value, that.value);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(block, configOptions);
+    return Objects.hash(block, value);
   }
 }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolSchedule.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolSchedule.java
@@ -53,17 +53,17 @@ public abstract class BaseBftProtocolSchedule {
     bftForksSchedule
         .getForks()
         .forEach(
-            bftForkSpec ->
+            forkSpec ->
                 specMap.put(
-                    bftForkSpec.getBlock(),
+                    forkSpec.getBlock(),
                     builder ->
                         applyBftChanges(
-                            bftForkSpec.getValue(),
+                            forkSpec.getValue(),
                             builder,
                             config.isQuorum(),
-                            createBlockHeaderRuleset(bftForkSpec.getValue()),
+                            createBlockHeaderRuleset(forkSpec.getValue()),
                             bftExtraDataCodec,
-                            Optional.of(bftForkSpec.getValue().getBlockRewardWei()))));
+                            Optional.of(forkSpec.getValue().getBlockRewardWei()))));
 
     final ProtocolSpecAdapters specAdapters = new ProtocolSpecAdapters(specMap);
 

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolSchedule.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolSchedule.java
@@ -58,12 +58,12 @@ public abstract class BaseBftProtocolSchedule {
                     bftForkSpec.getBlock(),
                     builder ->
                         applyBftChanges(
-                            bftForkSpec.getConfigOptions(),
+                            bftForkSpec.getValue(),
                             builder,
                             config.isQuorum(),
-                            createBlockHeaderRuleset(bftForkSpec.getConfigOptions()),
+                            createBlockHeaderRuleset(bftForkSpec.getValue()),
                             bftExtraDataCodec,
-                            Optional.of(bftForkSpec.getConfigOptions().getBlockRewardWei()))));
+                            Optional.of(bftForkSpec.getValue().getBlockRewardWei()))));
 
     final ProtocolSpecAdapters specAdapters = new ProtocolSpecAdapters(specMap);
 

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftForksSchedule.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftForksSchedule.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.BftFork;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -32,17 +33,16 @@ import com.google.common.annotations.VisibleForTesting;
 
 public class BftForksSchedule<C extends BftConfigOptions> {
 
-  private final NavigableSet<BftForkSpec<C>> forks =
+  private final NavigableSet<ForkSpec<C>> forks =
       new TreeSet<>(
-          Comparator.comparing((Function<BftForkSpec<C>, Long>) BftForkSpec::getBlock).reversed());
+          Comparator.comparing((Function<ForkSpec<C>, Long>) ForkSpec::getBlock).reversed());
 
   public interface BftSpecCreator<T extends BftConfigOptions, U extends BftFork> {
-    T create(BftForkSpec<T> lastSpec, U fork);
+    T create(ForkSpec<T> lastSpec, U fork);
   }
 
   @VisibleForTesting
-  public BftForksSchedule(
-      final BftForkSpec<C> genesisFork, final Collection<BftForkSpec<C>> forks) {
+  public BftForksSchedule(final ForkSpec<C> genesisFork, final Collection<ForkSpec<C>> forks) {
     this.forks.add(genesisFork);
     this.forks.addAll(forks);
   }
@@ -56,9 +56,8 @@ public class BftForksSchedule<C extends BftConfigOptions> {
         forks.stream().map(BftFork::getForkBlock).distinct().count() == forks.size(),
         "Duplicate transitions cannot be created for the same block");
 
-    final NavigableSet<BftForkSpec<T>> specs =
-        new TreeSet<>(Comparator.comparing(BftForkSpec::getBlock));
-    final BftForkSpec<T> initialForkSpec = new BftForkSpec<>(0, initial);
+    final NavigableSet<ForkSpec<T>> specs = new TreeSet<>(Comparator.comparing(ForkSpec::getBlock));
+    final ForkSpec<T> initialForkSpec = new ForkSpec<>(0, initial);
     specs.add(initialForkSpec);
 
     forks.stream()
@@ -66,14 +65,14 @@ public class BftForksSchedule<C extends BftConfigOptions> {
         .forEachOrdered(
             f -> {
               final T spec = specCreator.create(specs.last(), f);
-              specs.add(new BftForkSpec<>(f.getForkBlock(), spec));
+              specs.add(new ForkSpec<>(f.getForkBlock(), spec));
             });
 
     return new BftForksSchedule<>(initialForkSpec, specs.tailSet(initialForkSpec, false));
   }
 
-  public BftForkSpec<C> getFork(final long blockNumber) {
-    for (final BftForkSpec<C> f : forks) {
+  public ForkSpec<C> getFork(final long blockNumber) {
+    for (final ForkSpec<C> f : forks) {
       if (blockNumber >= f.getBlock()) {
         return f;
       }
@@ -82,7 +81,7 @@ public class BftForksSchedule<C extends BftConfigOptions> {
     return forks.first();
   }
 
-  public Set<BftForkSpec<C>> getForks() {
+  public Set<ForkSpec<C>> getForks() {
     return Collections.unmodifiableSet(forks);
   }
 }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BlockTimer.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BlockTimer.java
@@ -81,7 +81,7 @@ public class BlockTimer {
 
     // absolute time when the timer is supposed to expire
     final int blockPeriodSeconds =
-        bftForksSchedule.getFork(round.getSequenceNumber()).getSpec().getBlockPeriodSeconds();
+        bftForksSchedule.getFork(round.getSequenceNumber()).getValue().getBlockPeriodSeconds();
     final long minimumTimeBetweenBlocksMillis = blockPeriodSeconds * 1000L;
     final long expiryTime = chainHeadHeader.getTimestamp() * 1_000 + minimumTimeBetweenBlocksMillis;
 

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BlockTimer.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BlockTimer.java
@@ -81,10 +81,7 @@ public class BlockTimer {
 
     // absolute time when the timer is supposed to expire
     final int blockPeriodSeconds =
-        bftForksSchedule
-            .getFork(round.getSequenceNumber())
-            .getConfigOptions()
-            .getBlockPeriodSeconds();
+        bftForksSchedule.getFork(round.getSequenceNumber()).getSpec().getBlockPeriodSeconds();
     final long minimumTimeBetweenBlocksMillis = blockPeriodSeconds * 1000L;
     final long expiryTime = chainHeadHeader.getTimestamp() * 1_000 + minimumTimeBetweenBlocksMillis;
 

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.JsonBftConfigOptions;
 import org.hyperledger.besu.config.TransitionsConfigOptions;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -58,7 +59,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getBftConfigOptions()).thenReturn(configOptions);
 
     final ProtocolSchedule schedule =
-        createProtocolSchedule(new BftForkSpec<>(0, configOptions), Collections.emptyList());
+        createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList());
     final ProtocolSpec spec = schedule.getByBlockNumber(1);
 
     assertThat(spec.getBlockReward()).isEqualTo(Wei.of(arbitraryBlockReward));
@@ -76,9 +77,7 @@ public class BaseBftProtocolScheduleTest {
     when(configOptions.getBlockRewardWei()).thenReturn(BigInteger.ZERO);
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
     assertThatThrownBy(
-            () ->
-                createProtocolSchedule(
-                    new BftForkSpec<>(0, configOptions), Collections.emptyList()))
+            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Mining beneficiary in config is not a valid ethereum address");
   }
@@ -94,7 +93,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
     final ProtocolSchedule schedule =
-        createProtocolSchedule(new BftForkSpec<>(0, configOptions), Collections.emptyList());
+        createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList());
     final ProtocolSpec spec = schedule.getByBlockNumber(1);
 
     final Address headerCoinbase = Address.fromHexString("0x123");
@@ -117,9 +116,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
     assertThatThrownBy(
-            () ->
-                createProtocolSchedule(
-                    new BftForkSpec<>(0, configOptions), Collections.emptyList()))
+            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Bft Block reward in config cannot be negative");
   }
@@ -135,9 +132,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
     assertThatThrownBy(
-            () ->
-                createProtocolSchedule(
-                    new BftForkSpec<>(0, configOptions), Collections.emptyList()))
+            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Epoch length in config must be greater than zero");
   }
@@ -153,9 +148,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
     assertThatThrownBy(
-            () ->
-                createProtocolSchedule(
-                    new BftForkSpec<>(0, configOptions), Collections.emptyList()))
+            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Epoch length in config must be greater than zero");
   }
@@ -179,8 +172,8 @@ public class BaseBftProtocolScheduleTest {
 
     final ProtocolSchedule schedule =
         createProtocolSchedule(
-            new BftForkSpec<>(0, configOptions),
-            List.of(new BftForkSpec<>(transitionBlock, blockRewardTransition)));
+            new ForkSpec<>(0, configOptions),
+            List.of(new ForkSpec<>(transitionBlock, blockRewardTransition)));
 
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(2);
     assertThat(schedule.getByBlockNumber(0).getBlockReward())
@@ -190,8 +183,7 @@ public class BaseBftProtocolScheduleTest {
   }
 
   private ProtocolSchedule createProtocolSchedule(
-      final BftForkSpec<BftConfigOptions> genesisFork,
-      final List<BftForkSpec<BftConfigOptions>> forks) {
+      final ForkSpec<BftConfigOptions> genesisFork, final List<ForkSpec<BftConfigOptions>> forks) {
     final BaseBftProtocolSchedule bftProtocolSchedule =
         new BaseBftProtocolSchedule() {
           @Override

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftForksScheduleTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BftForksScheduleTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.BftFork;
 import org.hyperledger.besu.config.JsonBftConfigOptions;
 import org.hyperledger.besu.config.JsonUtil;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule.BftSpecCreator;
 
 import java.util.List;
@@ -34,8 +35,8 @@ public class BftForksScheduleTest {
 
   @Test
   public void retrievesGenesisFork() {
-    final BftForkSpec<BftConfigOptions> genesisForkSpec =
-        new BftForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
+    final ForkSpec<BftConfigOptions> genesisForkSpec =
+        new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
 
     final BftForksSchedule<BftConfigOptions> schedule =
         new BftForksSchedule<>(genesisForkSpec, List.of());
@@ -45,10 +46,10 @@ public class BftForksScheduleTest {
 
   @Test
   public void retrievesLatestFork() {
-    final BftForkSpec<BftConfigOptions> genesisForkSpec =
-        new BftForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
-    final BftForkSpec<BftConfigOptions> forkSpec1 = createForkSpec(1, 10);
-    final BftForkSpec<BftConfigOptions> forkSpec2 = createForkSpec(2, 20);
+    final ForkSpec<BftConfigOptions> genesisForkSpec =
+        new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
+    final ForkSpec<BftConfigOptions> forkSpec1 = createForkSpec(1, 10);
+    final ForkSpec<BftConfigOptions> forkSpec2 = createForkSpec(2, 20);
 
     final BftForksSchedule<BftConfigOptions> schedule =
         new BftForksSchedule<>(genesisForkSpec, List.of(forkSpec1, forkSpec2));
@@ -93,8 +94,7 @@ public class BftForksScheduleTest {
   @Test
   public void createsScheduleUsingSpecCreator() {
     final BftConfigOptions genesisConfigOptions = JsonBftConfigOptions.DEFAULT;
-    final BftForkSpec<BftConfigOptions> genesisForkSpec =
-        new BftForkSpec<>(0, genesisConfigOptions);
+    final ForkSpec<BftConfigOptions> genesisForkSpec = new ForkSpec<>(0, genesisConfigOptions);
     final BftFork fork1 = createFork(1, 10);
     final BftFork fork2 = createFork(2, 20);
     final BftSpecCreator<BftConfigOptions, BftFork> specCreator =
@@ -103,20 +103,19 @@ public class BftForksScheduleTest {
     final BftConfigOptions configOptions1 = createBftConfigOptions(10);
     final BftConfigOptions configOptions2 = createBftConfigOptions(20);
     when(specCreator.create(genesisForkSpec, fork1)).thenReturn(configOptions1);
-    when(specCreator.create(new BftForkSpec<>(1, configOptions1), fork2))
-        .thenReturn(configOptions2);
+    when(specCreator.create(new ForkSpec<>(1, configOptions1), fork2)).thenReturn(configOptions2);
 
     final BftForksSchedule<BftConfigOptions> schedule =
         BftForksSchedule.create(genesisConfigOptions, List.of(fork1, fork2), specCreator);
     assertThat(schedule.getFork(0)).isEqualTo(genesisForkSpec);
-    assertThat(schedule.getFork(1)).isEqualTo(new BftForkSpec<>(1, configOptions1));
-    assertThat(schedule.getFork(2)).isEqualTo(new BftForkSpec<>(2, configOptions2));
+    assertThat(schedule.getFork(1)).isEqualTo(new ForkSpec<>(1, configOptions1));
+    assertThat(schedule.getFork(2)).isEqualTo(new ForkSpec<>(2, configOptions2));
   }
 
-  private BftForkSpec<BftConfigOptions> createForkSpec(
+  private ForkSpec<BftConfigOptions> createForkSpec(
       final long block, final int blockPeriodSeconds) {
     final MutableBftConfigOptions bftConfigOptions = createBftConfigOptions(blockPeriodSeconds);
-    return new BftForkSpec<>(block, bftConfigOptions);
+    return new ForkSpec<>(block, bftConfigOptions);
   }
 
   private MutableBftConfigOptions createBftConfigOptions(final int blockPeriodSeconds) {

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BlockTimerTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BlockTimerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.JsonBftConfigOptions;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.events.BftEvent;
 import org.hyperledger.besu.consensus.common.bft.events.BlockTimerExpiry;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -78,7 +79,7 @@ public class BlockTimerTest {
     final long EXPECTED_DELAY = 10_000L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -107,7 +108,7 @@ public class BlockTimerTest {
     final long EXPECTED_DELAY = 500;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
     when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     final BlockHeader header =
@@ -151,7 +152,7 @@ public class BlockTimerTest {
     final long BLOCK_TIME_STAMP = 500;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -181,7 +182,7 @@ public class BlockTimerTest {
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -211,7 +212,7 @@ public class BlockTimerTest {
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -239,7 +240,7 @@ public class BlockTimerTest {
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new BftForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftForksSchedulesFactory.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/IbftForksSchedulesFactory.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.consensus.ibft;
 import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.BftFork;
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.common.bft.MutableBftConfigOptions;
 
@@ -32,9 +32,9 @@ public class IbftForksSchedulesFactory {
   }
 
   private static BftConfigOptions createBftConfigOptions(
-      final BftForkSpec<BftConfigOptions> lastSpec, final BftFork fork) {
+      final ForkSpec<BftConfigOptions> lastSpec, final BftFork fork) {
     final MutableBftConfigOptions bftConfigOptions =
-        new MutableBftConfigOptions(lastSpec.getConfigOptions());
+        new MutableBftConfigOptions(lastSpec.getValue());
 
     fork.getBlockPeriodSeconds().ifPresent(bftConfigOptions::setBlockPeriodSeconds);
     fork.getBlockRewardWei().ifPresent(bftConfigOptions::setBlockRewardWei);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftForksSchedulesFactoryTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftForksSchedulesFactoryTest.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.JsonUtil;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.config.TransitionsConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.common.bft.MutableBftConfigOptions;
 
@@ -40,7 +40,7 @@ public class IbftForksSchedulesFactoryTest {
   public void createsScheduleForJustGenesisConfig() {
     final MutableBftConfigOptions bftConfigOptions =
         new MutableBftConfigOptions(JsonQbftConfigOptions.DEFAULT);
-    final BftForkSpec<BftConfigOptions> expectedForkSpec = new BftForkSpec<>(0, bftConfigOptions);
+    final ForkSpec<BftConfigOptions> expectedForkSpec = new ForkSpec<>(0, bftConfigOptions);
     final StubGenesisConfigOptions genesisConfigOptions = new StubGenesisConfigOptions();
     genesisConfigOptions.bftConfigOptions(bftConfigOptions);
 
@@ -70,7 +70,7 @@ public class IbftForksSchedulesFactoryTest {
         IbftForksSchedulesFactory.create(createGenesisConfig(configOptions, fork));
     assertThat(forksSchedule.getFork(0))
         .usingRecursiveComparison()
-        .isEqualTo(new BftForkSpec<>(0, configOptions));
+        .isEqualTo(new ForkSpec<>(0, configOptions));
 
     final Map<String, Object> forkOptions = new HashMap<>(configOptions.asMap());
     forkOptions.put(BftFork.BLOCK_PERIOD_SECONDS_KEY, 10);
@@ -80,7 +80,7 @@ public class IbftForksSchedulesFactoryTest {
         new MutableBftConfigOptions(
             new JsonQbftConfigOptions(JsonUtil.objectNodeFromMap(forkOptions)));
 
-    final BftForkSpec<BftConfigOptions> expectedFork = new BftForkSpec<>(1, expectedForkConfig);
+    final ForkSpec<BftConfigOptions> expectedFork = new ForkSpec<>(1, expectedForkConfig);
     assertThat(forksSchedule.getFork(1)).usingRecursiveComparison().isEqualTo(expectedFork);
     assertThat(forksSchedule.getFork(2)).usingRecursiveComparison().isEqualTo(expectedFork);
   }

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftProtocolScheduleTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftProtocolScheduleTest.java
@@ -26,10 +26,10 @@ import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.JsonGenesisConfigOptions;
 import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.JsonUtil;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftContext;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.common.bft.MutableBftConfigOptions;
 import org.hyperledger.besu.crypto.NodeKey;
@@ -79,10 +79,10 @@ public class IbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new BftForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
+            new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
             List.of(
-                new BftForkSpec<>(1, arbitraryTransition),
-                new BftForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
+                new ForkSpec<>(1, arbitraryTransition),
+                new ForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 0)).isTrue();
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 1)).isTrue();
@@ -91,8 +91,8 @@ public class IbftProtocolScheduleTest {
 
   private ProtocolSchedule createProtocolSchedule(
       final GenesisConfigOptions genesisConfig,
-      final BftForkSpec<BftConfigOptions> genesisFork,
-      final List<BftForkSpec<BftConfigOptions>> forks) {
+      final ForkSpec<BftConfigOptions> genesisFork,
+      final List<ForkSpec<BftConfigOptions>> forks) {
     return IbftProtocolSchedule.create(
         genesisConfig,
         new BftForksSchedule<>(genesisFork, forks),

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BaseBftProtocolSchedule;
 import org.hyperledger.besu.consensus.common.bft.BftBlockHashing;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreator;
 import org.hyperledger.besu.consensus.ibft.IbftBlockHeaderValidationRulesetFactory;
@@ -98,8 +98,7 @@ public class BftBlockCreatorTest {
         GenesisConfigFile.fromConfig("{\"config\": {\"spuriousDragonBlock\":0}}")
             .getConfigOptions();
     final BftForksSchedule<BftConfigOptions> bftForksSchedule =
-        new BftForksSchedule<>(
-            new BftForkSpec<>(0, configOptions.getBftConfigOptions()), List.of());
+        new BftForksSchedule<>(new ForkSpec<>(0, configOptions.getBftConfigOptions()), List.of());
     final ProtocolSchedule protocolSchedule =
         bftProtocolSchedule.createProtocolSchedule(
             configOptions,

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftForksSchedulesFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftForksSchedulesFactory.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.QbftConfigOptions;
 import org.hyperledger.besu.config.QbftFork;
 import org.hyperledger.besu.config.QbftFork.VALIDATOR_SELECTION_MODE;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 
 import java.util.List;
@@ -35,9 +35,9 @@ public class QbftForksSchedulesFactory {
   }
 
   private static QbftConfigOptions createQbftConfigOptions(
-      final BftForkSpec<QbftConfigOptions> lastSpec, final QbftFork fork) {
+      final ForkSpec<QbftConfigOptions> lastSpec, final QbftFork fork) {
     final MutableQbftConfigOptions bftConfigOptions =
-        new MutableQbftConfigOptions(lastSpec.getConfigOptions());
+        new MutableQbftConfigOptions(lastSpec.getValue());
 
     fork.getBlockPeriodSeconds().ifPresent(bftConfigOptions::setBlockPeriodSeconds);
     fork.getBlockRewardWei().ifPresent(bftConfigOptions::setBlockRewardWei);

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
@@ -72,10 +72,7 @@ public class QbftBlockCreatorFactory extends BftBlockCreatorFactory {
 
   @Override
   public Bytes createExtraData(final int round, final BlockHeader parentHeader) {
-    if (forksSchedule
-        .getFork(parentHeader.getNumber() + 1L)
-        .getConfigOptions()
-        .isValidatorContractMode()) {
+    if (forksSchedule.getFork(parentHeader.getNumber() + 1L).getSpec().isValidatorContractMode()) {
       // vote and validators will come from contract instead of block
       final BftExtraData extraData =
           new BftExtraData(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactory.java
@@ -72,7 +72,7 @@ public class QbftBlockCreatorFactory extends BftBlockCreatorFactory {
 
   @Override
   public Bytes createExtraData(final int round, final BlockHeader parentHeader) {
-    if (forksSchedule.getFork(parentHeader.getNumber() + 1L).getSpec().isValidatorContractMode()) {
+    if (forksSchedule.getFork(parentHeader.getNumber() + 1L).getValue().isValidatorContractMode()) {
       // vote and validators will come from contract instead of block
       final BftExtraData extraData =
           new BftExtraData(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProvider.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProvider.java
@@ -16,7 +16,7 @@
 package org.hyperledger.besu.consensus.qbft.validator;
 
 import org.hyperledger.besu.config.QbftConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
 import org.hyperledger.besu.consensus.common.validator.VoteProvider;
@@ -75,8 +75,8 @@ public class ForkingValidatorProvider implements ValidatorProvider {
   }
 
   private ValidatorProvider resolveValidatorProvider(final long block) {
-    final BftForkSpec<QbftConfigOptions> fork = forksSchedule.getFork(block);
-    return fork.getConfigOptions().isValidatorContractMode()
+    final ForkSpec<QbftConfigOptions> fork = forksSchedule.getFork(block);
+    return fork.getValue().isValidatorContractMode()
         ? transactionValidatorProvider
         : blockValidatorProvider;
   }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProvider.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProvider.java
@@ -94,7 +94,7 @@ public class TransactionValidatorProvider implements ValidatorProvider {
   private Address resolveContractAddress(final long blockNumber) {
     return forksSchedule
         .getFork(blockNumber)
-        .getConfigOptions()
+        .getValue()
         .getValidatorContractAddress()
         .map(Address::fromHexString)
         .orElseThrow(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorModeTransitionLogger.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorModeTransitionLogger.java
@@ -16,7 +16,7 @@
 package org.hyperledger.besu.consensus.qbft.validator;
 
 import org.hyperledger.besu.config.QbftConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
@@ -47,13 +47,13 @@ public class ValidatorModeTransitionLogger {
   }
 
   public void logTransitionChange(final BlockHeader parentHeader) {
-    final BftForkSpec<QbftConfigOptions> currentForkSpec =
+    final ForkSpec<QbftConfigOptions> currentForkSpec =
         bftForksSchedule.getFork(parentHeader.getNumber());
-    final BftForkSpec<QbftConfigOptions> nextForkSpec =
+    final ForkSpec<QbftConfigOptions> nextForkSpec =
         bftForksSchedule.getFork(parentHeader.getNumber() + 1L);
 
-    final QbftConfigOptions currentConfigOptions = currentForkSpec.getConfigOptions();
-    final QbftConfigOptions nextConfigOptions = nextForkSpec.getConfigOptions();
+    final QbftConfigOptions currentConfigOptions = currentForkSpec.getValue();
+    final QbftConfigOptions nextConfigOptions = nextForkSpec.getValue();
 
     if (hasChangedConfig(currentConfigOptions, nextConfigOptions)) {
       msgConsumer.accept(

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftProtocolScheduleTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftProtocolScheduleTest.java
@@ -24,8 +24,8 @@ import org.hyperledger.besu.config.JsonGenesisConfigOptions;
 import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.JsonUtil;
 import org.hyperledger.besu.config.QbftConfigOptions;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftExtraDataCodec;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
@@ -84,10 +84,8 @@ public class QbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new BftForkSpec<>(0, qbftConfigOptions),
-            List.of(
-                new BftForkSpec<>(1, arbitraryTransition),
-                new BftForkSpec<>(2, contractTransition)));
+            new ForkSpec<>(0, qbftConfigOptions),
+            List.of(new ForkSpec<>(1, arbitraryTransition), new ForkSpec<>(2, contractTransition)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 0)).isTrue();
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 1)).isTrue();
@@ -110,10 +108,10 @@ public class QbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new BftForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
+            new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
             List.of(
-                new BftForkSpec<>(1, arbitraryTransition),
-                new BftForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
+                new ForkSpec<>(1, arbitraryTransition),
+                new ForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 0)).isTrue();
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 1)).isTrue();
@@ -122,8 +120,8 @@ public class QbftProtocolScheduleTest {
 
   private ProtocolSchedule createProtocolSchedule(
       final GenesisConfigOptions genesisConfig,
-      final BftForkSpec<QbftConfigOptions> genesisFork,
-      final List<BftForkSpec<QbftConfigOptions>> forks) {
+      final ForkSpec<QbftConfigOptions> genesisFork,
+      final List<ForkSpec<QbftConfigOptions>> forks) {
     return QbftProtocolSchedule.create(
         genesisConfig,
         new BftForksSchedule<>(genesisFork, forks),

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactoryTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/QbftBlockCreatorFactoryTest.java
@@ -22,8 +22,8 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.QbftConfigOptions;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftExtraData;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.qbft.MutableQbftConfigOptions;
 import org.hyperledger.besu.consensus.qbft.QbftExtraDataCodec;
@@ -53,7 +53,7 @@ public class QbftBlockCreatorFactoryTest {
     final MutableQbftConfigOptions qbftConfigOptions =
         new MutableQbftConfigOptions(JsonQbftConfigOptions.DEFAULT);
     qbftConfigOptions.setValidatorContractAddress(Optional.of("1"));
-    final BftForkSpec<QbftConfigOptions> spec = new BftForkSpec<>(0, qbftConfigOptions);
+    final ForkSpec<QbftConfigOptions> spec = new ForkSpec<>(0, qbftConfigOptions);
     final BftForksSchedule<QbftConfigOptions> bftForksSchedule = mock(BftForksSchedule.class);
     when(bftForksSchedule.getFork(anyLong())).thenReturn(spec);
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/QbftForksSchedulesFactoryTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/QbftForksSchedulesFactoryTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.config.QbftFork;
 import org.hyperledger.besu.config.QbftFork.VALIDATOR_SELECTION_MODE;
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.config.TransitionsConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.qbft.MutableQbftConfigOptions;
 import org.hyperledger.besu.consensus.qbft.QbftForksSchedulesFactory;
@@ -49,7 +49,7 @@ public class QbftForksSchedulesFactoryTest {
   public void createsScheduleForJustGenesisConfig() {
     final MutableQbftConfigOptions qbftConfigOptions =
         new MutableQbftConfigOptions(JsonQbftConfigOptions.DEFAULT);
-    final BftForkSpec<QbftConfigOptions> expectedForkSpec = new BftForkSpec<>(0, qbftConfigOptions);
+    final ForkSpec<QbftConfigOptions> expectedForkSpec = new ForkSpec<>(0, qbftConfigOptions);
     final StubGenesisConfigOptions genesisConfigOptions = new StubGenesisConfigOptions();
     genesisConfigOptions.qbftConfigOptions(qbftConfigOptions);
 
@@ -85,7 +85,7 @@ public class QbftForksSchedulesFactoryTest {
         QbftForksSchedulesFactory.create(createGenesisConfig(configOptions, fork));
     assertThat(forksSchedule.getFork(0))
         .usingRecursiveComparison()
-        .isEqualTo(new BftForkSpec<>(0, configOptions));
+        .isEqualTo(new ForkSpec<>(0, configOptions));
 
     final Map<String, Object> forkOptions = new HashMap<>(configOptions.asMap());
     forkOptions.put(BftFork.BLOCK_PERIOD_SECONDS_KEY, 10);
@@ -96,7 +96,7 @@ public class QbftForksSchedulesFactoryTest {
         new MutableQbftConfigOptions(
             new JsonQbftConfigOptions(JsonUtil.objectNodeFromMap(forkOptions)));
 
-    final BftForkSpec<QbftConfigOptions> expectedFork = new BftForkSpec<>(1, expectedForkConfig);
+    final ForkSpec<QbftConfigOptions> expectedFork = new ForkSpec<>(1, expectedForkConfig);
     assertThat(forksSchedule.getFork(1)).usingRecursiveComparison().isEqualTo(expectedFork);
     assertThat(forksSchedule.getFork(2)).usingRecursiveComparison().isEqualTo(expectedFork);
   }
@@ -144,7 +144,7 @@ public class QbftForksSchedulesFactoryTest {
     final BftForksSchedule<QbftConfigOptions> forksSchedule =
         QbftForksSchedulesFactory.create(createGenesisConfig(configOptions, fork));
 
-    assertThat(forksSchedule.getFork(1).getConfigOptions().getValidatorContractAddress()).isEmpty();
+    assertThat(forksSchedule.getFork(1).getValue().getValidatorContractAddress()).isEmpty();
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorModeTransitionLoggerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorModeTransitionLoggerTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.config.BftConfigOptions;
 import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.QbftConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.common.bft.BftForksSchedule;
 import org.hyperledger.besu.consensus.qbft.MutableQbftConfigOptions;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -49,10 +49,10 @@ public class ValidatorModeTransitionLoggerTest {
 
   @Test
   public void doNotLogMessageWhenTransitioningFromBlockHeaderToBlockHeader() {
-    final BftForkSpec<BftConfigOptions> forkSpecA =
-        new BftForkSpec<>(0, createQbftConfigOptionsForBlockHeader());
-    final BftForkSpec<BftConfigOptions> forkSpecB =
-        new BftForkSpec<>(1, createQbftConfigOptionsForBlockHeader());
+    final ForkSpec<BftConfigOptions> forkSpecA =
+        new ForkSpec<>(0, createQbftConfigOptionsForBlockHeader());
+    final ForkSpec<BftConfigOptions> forkSpecB =
+        new ForkSpec<>(1, createQbftConfigOptionsForBlockHeader());
 
     when(bftForksSchedule.getFork(0)).thenReturn(forkSpecA);
     when(bftForksSchedule.getFork(1)).thenReturn(forkSpecB);
@@ -64,10 +64,10 @@ public class ValidatorModeTransitionLoggerTest {
 
   @Test
   public void doNotLogMessageWhenTransitioningFromContractToContractWithSameAddress() {
-    final BftForkSpec<BftConfigOptions> contractForkSpecA =
-        new BftForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
-    final BftForkSpec<BftConfigOptions> contractForkSpecB =
-        new BftForkSpec<>(1, createQbftConfigOptionsForContract("0x0"));
+    final ForkSpec<BftConfigOptions> contractForkSpecA =
+        new ForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
+    final ForkSpec<BftConfigOptions> contractForkSpecB =
+        new ForkSpec<>(1, createQbftConfigOptionsForContract("0x0"));
 
     when(bftForksSchedule.getFork(0)).thenReturn(contractForkSpecA);
     when(bftForksSchedule.getFork(1)).thenReturn(contractForkSpecB);
@@ -79,10 +79,10 @@ public class ValidatorModeTransitionLoggerTest {
 
   @Test
   public void logMessageWhenTransitioningFromContractToContractWithDifferentAddress() {
-    final BftForkSpec<BftConfigOptions> contractForkSpecA =
-        new BftForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
-    final BftForkSpec<BftConfigOptions> contractForkSpecB =
-        new BftForkSpec<>(1, createQbftConfigOptionsForContract("0x1"));
+    final ForkSpec<BftConfigOptions> contractForkSpecA =
+        new ForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
+    final ForkSpec<BftConfigOptions> contractForkSpecB =
+        new ForkSpec<>(1, createQbftConfigOptionsForContract("0x1"));
 
     when(bftForksSchedule.getFork(0)).thenReturn(contractForkSpecA);
     when(bftForksSchedule.getFork(1)).thenReturn(contractForkSpecB);
@@ -96,10 +96,10 @@ public class ValidatorModeTransitionLoggerTest {
 
   @Test
   public void logMessageWhenTransitioningFromContractToBlockHeader() {
-    final BftForkSpec<BftConfigOptions> contractForkSpec =
-        new BftForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
-    final BftForkSpec<BftConfigOptions> blockForkSpec =
-        new BftForkSpec<>(1, createQbftConfigOptionsForBlockHeader());
+    final ForkSpec<BftConfigOptions> contractForkSpec =
+        new ForkSpec<>(0, createQbftConfigOptionsForContract("0x0"));
+    final ForkSpec<BftConfigOptions> blockForkSpec =
+        new ForkSpec<>(1, createQbftConfigOptionsForBlockHeader());
 
     when(bftForksSchedule.getFork(0)).thenReturn(contractForkSpec);
     when(bftForksSchedule.getFork(1)).thenReturn(blockForkSpec);
@@ -113,10 +113,10 @@ public class ValidatorModeTransitionLoggerTest {
 
   @Test
   public void logMessageWhenTransitioningFromBlockHeaderToContract() {
-    final BftForkSpec<BftConfigOptions> blockForkSpec =
-        new BftForkSpec<>(0, createQbftConfigOptionsForBlockHeader());
-    final BftForkSpec<BftConfigOptions> contractForkSpec =
-        new BftForkSpec<>(1, createQbftConfigOptionsForContract("0x0"));
+    final ForkSpec<BftConfigOptions> blockForkSpec =
+        new ForkSpec<>(0, createQbftConfigOptionsForBlockHeader());
+    final ForkSpec<BftConfigOptions> contractForkSpec =
+        new ForkSpec<>(1, createQbftConfigOptionsForContract("0x0"));
 
     when(bftForksSchedule.getFork(0)).thenReturn(blockForkSpec);
     when(bftForksSchedule.getFork(1)).thenReturn(contractForkSpec);

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorTestUtils.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorTestUtils.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.consensus.qbft.validator;
 
 import org.hyperledger.besu.config.JsonQbftConfigOptions;
 import org.hyperledger.besu.config.QbftConfigOptions;
-import org.hyperledger.besu.consensus.common.bft.BftForkSpec;
+import org.hyperledger.besu.consensus.common.ForkSpec;
 import org.hyperledger.besu.consensus.qbft.MutableQbftConfigOptions;
 import org.hyperledger.besu.datatypes.Address;
 
@@ -24,17 +24,17 @@ import java.util.Optional;
 
 class ValidatorTestUtils {
 
-  static BftForkSpec<QbftConfigOptions> createContractForkSpec(
+  static ForkSpec<QbftConfigOptions> createContractForkSpec(
       final long block, final Address contractAddress) {
     final MutableQbftConfigOptions qbftConfigOptions =
         new MutableQbftConfigOptions(JsonQbftConfigOptions.DEFAULT);
     qbftConfigOptions.setValidatorContractAddress(Optional.of(contractAddress.toHexString()));
-    return new BftForkSpec<>(block, qbftConfigOptions);
+    return new ForkSpec<>(block, qbftConfigOptions);
   }
 
-  static BftForkSpec<QbftConfigOptions> createBlockForkSpec(final long block) {
+  static ForkSpec<QbftConfigOptions> createBlockForkSpec(final long block) {
     final MutableQbftConfigOptions qbftConfigOptions =
         new MutableQbftConfigOptions(JsonQbftConfigOptions.DEFAULT);
-    return new BftForkSpec<>(block, qbftConfigOptions);
+    return new ForkSpec<>(block, qbftConfigOptions);
   }
 }


### PR DESCRIPTION
## PR description
This was split out of #3069. Changes the BftForkSpec to more generic concept so it can be reused in the QBFT migration.

* Rename BftForkSpec to ForkSpec
* Move from consenus.common.bft package in the consensus.common package
* Allow it to hold any value not just a BftConfigOption
* Rename getConfigOption to getValue

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).