### PR TITLE
Use an improved version of the Gradle plugin used to check licenses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ import java.text.SimpleDateFormat
 plugins {
   id 'com.diffplug.spotless' version '5.14.2'
   id 'com.github.ben-manes.versions' version '0.39.0'
-  id 'com.github.hierynomus.license' version '0.16.1'
+  id 'com.github.hierynomus.license' version '0.16.1-fix'
   id 'com.jfrog.artifactory' version '4.24.14'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'me.champeau.jmh' version '0.6.6' apply false

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,6 +13,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    /*
+     *  Temporary repository to host the improved version of the
+     *  com.github.hierynomus.license plugin. Can be removed when an
+     *  official version with the fix is release upstream
+     */
+    maven {
+      url = uri("https://raw.githubusercontent.com/ConsenSys/license-gradle-plugin-fix-artifacts/main/")
+    }
+  }
+}
+
 rootProject.name='besu'
 include 'acceptance-tests:test-plugins'
 include 'acceptance-tests:dsl'


### PR DESCRIPTION
Temporary use a build of this plugin that contains the proposed PR[1],
that improve the downloadLicenses task, reducing its execution time from
about 10 minutes to under 1 minute.
The build is temporary hosted in a custom repository, until a new upstream
version with the patch is released.

[1]https://github.com/hierynomus/license-gradle-plugin/pull/203

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3094
## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).