### PR TITLE
merge of Blockheader changes to support random field

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.util.OptionalLong;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 /** A utility class for building block headers. */
 public class BlockHeaderBuilder {
@@ -58,6 +59,8 @@ public class BlockHeaderBuilder {
 
   private Long baseFee = null;
 
+  private Bytes32 random = null;
+
   private Hash mixHash;
 
   private BlockHeaderFunctions blockHeaderFunctions;
@@ -87,7 +90,8 @@ public class BlockHeaderBuilder {
         .extraData(header.getExtraData())
         .baseFee(header.getBaseFee().orElse(null))
         .mixHash(header.getMixHash())
-        .nonce(header.getNonce());
+        .nonce(header.getNonce())
+        .random(header.getRandom().orElse(null));
   }
 
   public static BlockHeaderBuilder fromBuilder(final BlockHeaderBuilder fromBuilder) {
@@ -108,6 +112,7 @@ public class BlockHeaderBuilder {
             .extraData(fromBuilder.extraData)
             .mixHash(fromBuilder.mixHash)
             .baseFee(fromBuilder.baseFee)
+            .random(fromBuilder.random)
             .blockHeaderFunctions(fromBuilder.blockHeaderFunctions);
     toBuilder.nonce = fromBuilder.nonce;
     return toBuilder;
@@ -131,7 +136,7 @@ public class BlockHeaderBuilder {
         timestamp < 0 ? Instant.now().getEpochSecond() : timestamp,
         extraData,
         baseFee,
-        mixHash,
+        random,
         nonce.getAsLong(),
         blockHeaderFunctions);
   }
@@ -140,7 +145,7 @@ public class BlockHeaderBuilder {
     validateProcessableBlockHeader();
 
     return new ProcessableBlockHeader(
-        parentHash, coinbase, difficulty, number, gasLimit, timestamp, baseFee);
+        parentHash, coinbase, difficulty, number, gasLimit, timestamp, baseFee, random);
   }
 
   public SealableBlockHeader buildSealableBlockHeader() {
@@ -160,7 +165,8 @@ public class BlockHeaderBuilder {
         gasUsed,
         timestamp,
         extraData,
-        baseFee);
+        baseFee,
+        random);
   }
 
   private void validateBlockHeader() {
@@ -199,6 +205,7 @@ public class BlockHeaderBuilder {
     gasLimit(processableBlockHeader.getGasLimit());
     timestamp(processableBlockHeader.getTimestamp());
     baseFee(processableBlockHeader.getBaseFee().orElse(null));
+    random(processableBlockHeader.getRandom().orElse(null));
     return this;
   }
 
@@ -218,6 +225,7 @@ public class BlockHeaderBuilder {
     timestamp(sealableBlockHeader.getTimestamp());
     extraData(sealableBlockHeader.getExtraData());
     baseFee(sealableBlockHeader.getBaseFee().orElse(null));
+    random(sealableBlockHeader.getRandom().orElse(null));
     return this;
   }
 
@@ -318,6 +326,11 @@ public class BlockHeaderBuilder {
 
   public BlockHeaderBuilder baseFee(final Long baseFee) {
     this.baseFee = baseFee;
+    return this;
+  }
+
+  public BlockHeaderBuilder random(final Bytes32 random) {
+    this.random = random;
     return this;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.evm.frame.BlockValues;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 /** A block header capable of being processed. */
 public class ProcessableBlockHeader implements BlockValues {
@@ -39,6 +40,8 @@ public class ProcessableBlockHeader implements BlockValues {
   protected final long timestamp;
   // base fee is included for post EIP-1559 blocks
   protected final Long baseFee;
+  // random is included for post-merge blocks
+  protected final Bytes32 mixHashOrRandom;
 
   protected ProcessableBlockHeader(
       final Hash parentHash,
@@ -47,7 +50,8 @@ public class ProcessableBlockHeader implements BlockValues {
       final long number,
       final long gasLimit,
       final long timestamp,
-      final Long baseFee) {
+      final Long baseFee,
+      final Bytes32 mixHashOrRandom) {
     this.parentHash = parentHash;
     this.coinbase = coinbase;
     this.difficulty = difficulty;
@@ -55,6 +59,7 @@ public class ProcessableBlockHeader implements BlockValues {
     this.gasLimit = gasLimit;
     this.timestamp = timestamp;
     this.baseFee = baseFee;
+    this.mixHashOrRandom = mixHashOrRandom;
   }
 
   /**
@@ -127,10 +132,19 @@ public class ProcessableBlockHeader implements BlockValues {
   /**
    * Returns the basefee of the block.
    *
-   * @return the raw bytes of the extra data field
+   * @return the optional long value for base fee
    */
   @Override
   public Optional<Long> getBaseFee() {
     return Optional.ofNullable(baseFee);
+  }
+
+  /**
+   * Returns the random of the block.
+   *
+   * @return the raw bytes of the random field
+   */
+  public Optional<Bytes32> getRandom() {
+    return Optional.ofNullable(mixHashOrRandom);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SealableBlockHeader.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 /** A block header capable of being sealed. */
 public class SealableBlockHeader extends ProcessableBlockHeader {
@@ -50,8 +51,9 @@ public class SealableBlockHeader extends ProcessableBlockHeader {
       final long gasUsed,
       final long timestamp,
       final Bytes extraData,
-      final Long baseFee) {
-    super(parentHash, coinbase, difficulty, number, gasLimit, timestamp, baseFee);
+      final Long baseFee,
+      final Bytes32 mixHashOrRandom) {
+    super(parentHash, coinbase, difficulty, number, gasLimit, timestamp, baseFee, mixHashOrRandom);
     this.ommersHash = ommersHash;
     this.stateRoot = stateRoot;
     this.transactionsRoot = transactionsRoot;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/KeccakHasherTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/KeccakHasherTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.core.SealableBlockHeader;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class KeccakHasherTest {
@@ -43,7 +44,8 @@ public class KeccakHasherTest {
         final long gasUsed,
         final long timestamp,
         final Bytes extraData,
-        final Long baseFee) {
+        final Long baseFee,
+        final Bytes32 random) {
       super(
           parentHash,
           ommersHash,
@@ -58,7 +60,8 @@ public class KeccakHasherTest {
           gasUsed,
           timestamp,
           extraData,
-          baseFee);
+          baseFee,
+          random);
     }
   }
 
@@ -103,6 +106,7 @@ public class KeccakHasherTest {
             7987824L,
             1538483791L,
             Bytes.fromHexString("0xd88301080f846765746888676f312e31302e31856c696e7578"),
+            null,
             null);
 
     PoWSolution result =

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'ZwWSOSoK7pn0RRABy24PkR4DEJJAoTR3/uJ3kIRR6oE='
+  knownHash = '/M23BAhwqtMpjhcoHDMJvbHyhJ4z39z2jJMWUGOBO14='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -64,7 +64,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'Z78NXPRIv33CBOfuUaAfgEr55ZrmxDWqVT8DVJ+FxA4='
+  knownHash = 'ZwWSOSoK7pn0RRABy24PkR4DEJJAoTR3/uJ3kIRR6oE='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockHeader.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockHeader.java
@@ -14,11 +14,10 @@
  */
 package org.hyperledger.besu.plugin.data;
 
-import org.hyperledger.besu.plugin.Unstable;
-
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 /**
  * The minimum set of data for a BlockHeader, as defined in the <a href=
@@ -164,8 +163,16 @@ public interface BlockHeader {
    *
    * @return TheBASEFEE of this header.
    */
-  @Unstable
   default Optional<Long> getBaseFee() {
+    return Optional.empty();
+  }
+
+  /**
+   * Optional 32 bytes of random data.
+   *
+   * @return Optional random bytes from this header.
+   */
+  default Optional<Bytes32> getRandom() {
     return Optional.empty();
   }
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockHeader.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockHeader.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.plugin.data;
 
+import org.hyperledger.besu.plugin.Unstable;
+
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -161,8 +163,9 @@ public interface BlockHeader {
   /**
    * The BASEFEE of this header.
    *
-   * @return TheBASEFEE of this header.
+   * @return The BASEFEE of this header.
    */
+  @Unstable
   default Optional<Long> getBaseFee() {
     return Optional.empty();
   }


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
In support of [EIP-4399](https://github.com/ethereum/EIPs/blob/979cf123558bab61e2278f3c962c9a68d1adc2f4/EIPS/eip-4399.md) this PR adds a field to block headers, `random` which is 32 bytes of randao randomness data.

In accordance with spec, we re-purpose mixHash as random in RLP encoding and decoding, since they should be mutually exclusive -  a block with `random`  will not have a `mixHash` and vice-versa

related to #2897 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).