### PR TITLE
Removing duplicate code from FlexiblePrivacyPrecompiledContract [#2961]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   besu_executor_med: # 2cpu, 4G ram
     docker:
-      - image: circleci/openjdk:11.0.12-jdk-buster
+      - image: cimg/openjdk:11.0
     resource_class: medium
     working_directory: ~/project
     environment:
@@ -14,7 +14,7 @@ executors:
 
   besu_executor_xl: # 8cpu, 16G ram
     docker:
-      - image: circleci/openjdk:11.0.12-jdk-buster
+      - image: cimg/openjdk:11.0
     resource_class: xlarge
     working_directory: ~/project
     environment:

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -127,7 +127,7 @@ dependencyManagement {
     dependency 'org.fusesource.jansi:jansi:2.3.4'
 
     // Not updating bls12-381 because of https://github.com/hyperledger/besu/issues/2668
-    dependency 'org.hyperledger.besu:bls12-381:0.3.0'
+    dependency 'org.hyperledger.besu:bls12-381:0.4.2'
     dependency 'org.hyperledger.besu:secp256k1:0.4.2'
     dependency 'org.hyperledger.besu:secp256r1:0.4.2'
 


### PR DESCRIPTION
## PR description
Remove duplicate code (TODO) in FlexiblePrivacyPrecompiledContract. The getParticipantsFromParameter method was copied from FlexibleUtil, this has now been removed.

## Fixed Issue(s)
#2961