### PR TITLE
Change the ForkSchedule to take a single argument

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
@@ -136,9 +136,7 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
                                 ethProtocolManager)))
             .collect(Collectors.toList());
     final ForksSchedule<MiningCoordinator> miningCoordinatorSchedule =
-        new ForksSchedule<>(
-            miningCoordinatorForkSpecs.get(0),
-            miningCoordinatorForkSpecs.subList(1, miningCoordinatorForkSpecs.size()));
+        new ForksSchedule<>(miningCoordinatorForkSpecs);
 
     return new MigratingMiningCoordinator(
         miningCoordinatorSchedule, protocolContext.getBlockchain());

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/ForksSchedule.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/ForksSchedule.java
@@ -28,8 +28,7 @@ public class ForksSchedule<C> {
       new TreeSet<>(
           Comparator.comparing((Function<ForkSpec<C>, Long>) ForkSpec::getBlock).reversed());
 
-  public ForksSchedule(final ForkSpec<C> genesisFork, final Collection<ForkSpec<C>> forks) {
-    this.forks.add(genesisFork);
+  public ForksSchedule(final Collection<ForkSpec<C>> forks) {
     this.forks.addAll(forks);
   }
 

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftForksScheduleFactory.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftForksScheduleFactory.java
@@ -53,6 +53,6 @@ public class BftForksScheduleFactory {
               specs.add(new ForkSpec<>(f.getForkBlock(), spec));
             });
 
-    return new ForksSchedule<>(initialForkSpec, specs.tailSet(initialForkSpec, false));
+    return new ForksSchedule<>(specs);
   }
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleTest.java
@@ -27,6 +27,18 @@ import org.junit.Test;
 public class ForksScheduleTest {
 
   @Test
+  public void retrievesGenesisFork() {
+    final ForkSpec<BftConfigOptions> genesisForkSpec =
+        new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
+    final ForkSpec<BftConfigOptions> forkSpec1 = createForkSpec(10, 10);
+
+    final ForksSchedule<BftConfigOptions> schedule =
+        new ForksSchedule<>(List.of(forkSpec1, genesisForkSpec));
+    assertThat(schedule.getFork(0)).isEqualTo(genesisForkSpec);
+    assertThat(schedule.getFork(1)).isEqualTo(genesisForkSpec);
+  }
+
+  @Test
   public void retrievesLatestFork() {
     final ForkSpec<BftConfigOptions> genesisForkSpec =
         new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleTest.java
@@ -27,17 +27,6 @@ import org.junit.Test;
 public class ForksScheduleTest {
 
   @Test
-  public void retrievesGenesisFork() {
-    final ForkSpec<BftConfigOptions> genesisForkSpec =
-        new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
-
-    final ForksSchedule<BftConfigOptions> schedule =
-        new ForksSchedule<>(genesisForkSpec, List.of());
-    assertThat(schedule.getFork(0)).isEqualTo(genesisForkSpec);
-    assertThat(schedule.getFork(1)).isEqualTo(genesisForkSpec);
-  }
-
-  @Test
   public void retrievesLatestFork() {
     final ForkSpec<BftConfigOptions> genesisForkSpec =
         new ForkSpec<>(0, JsonBftConfigOptions.DEFAULT);
@@ -45,7 +34,7 @@ public class ForksScheduleTest {
     final ForkSpec<BftConfigOptions> forkSpec2 = createForkSpec(2, 20);
 
     final ForksSchedule<BftConfigOptions> schedule =
-        new ForksSchedule<>(genesisForkSpec, List.of(forkSpec1, forkSpec2));
+        new ForksSchedule<>(List.of(genesisForkSpec, forkSpec1, forkSpec2));
 
     assertThat(schedule.getFork(0)).isEqualTo(genesisForkSpec);
     assertThat(schedule.getFork(1)).isEqualTo(forkSpec1);

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/MigratingMiningCoordinatorTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/MigratingMiningCoordinatorTest.java
@@ -60,7 +60,7 @@ public class MigratingMiningCoordinatorTest {
         new ForkSpec<>(GENESIS_BLOCK_NUMBER, coordinator1);
     final ForkSpec<MiningCoordinator> migrationFork =
         new ForkSpec<>(MIGRATION_BLOCK_NUMBER, coordinator2);
-    miningCoordinatorSchedule = new ForksSchedule<>(genesisFork, List.of(migrationFork));
+    miningCoordinatorSchedule = new ForksSchedule<>(List.of(genesisFork, migrationFork));
     this.block = new Block(blockHeader, blockBody);
     blockEvent = BlockAddedEvent.createForHeadAdvancement(this.block, emptyList(), emptyList());
   }
@@ -101,7 +101,7 @@ public class MigratingMiningCoordinatorTest {
   @Test
   public void onBlockAddedShouldNotDelegateWhenDelegateIsNoop() {
     ForksSchedule<MiningCoordinator> noopCoordinatorSchedule =
-        new ForksSchedule<>(new ForkSpec<>(GENESIS_BLOCK_NUMBER, noopCoordinator), emptyList());
+        new ForksSchedule<>(List.of(new ForkSpec<>(GENESIS_BLOCK_NUMBER, noopCoordinator)));
     when(blockHeader.getNumber()).thenReturn(GENESIS_BLOCK_NUMBER);
 
     new MigratingMiningCoordinator(noopCoordinatorSchedule, blockchain).onBlockAdded(blockEvent);

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleTest.java
@@ -35,7 +35,6 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -60,7 +59,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getBftConfigOptions()).thenReturn(configOptions);
 
     final ProtocolSchedule schedule =
-        createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList());
+        createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions)));
     final ProtocolSpec spec = schedule.getByBlockNumber(1);
 
     assertThat(spec.getBlockReward()).isEqualTo(Wei.of(arbitraryBlockReward));
@@ -77,8 +76,7 @@ public class BaseBftProtocolScheduleTest {
     when(configOptions.getEpochLength()).thenReturn(3000L);
     when(configOptions.getBlockRewardWei()).thenReturn(BigInteger.ZERO);
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
-    assertThatThrownBy(
-            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
+    assertThatThrownBy(() -> createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Mining beneficiary in config is not a valid ethereum address");
   }
@@ -94,7 +92,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
     final ProtocolSchedule schedule =
-        createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList());
+        createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions)));
     final ProtocolSpec spec = schedule.getByBlockNumber(1);
 
     final Address headerCoinbase = Address.fromHexString("0x123");
@@ -116,8 +114,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getBftConfigOptions()).thenReturn(configOptions);
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
-    assertThatThrownBy(
-            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
+    assertThatThrownBy(() -> createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Bft Block reward in config cannot be negative");
   }
@@ -132,8 +129,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getBftConfigOptions()).thenReturn(configOptions);
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
-    assertThatThrownBy(
-            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
+    assertThatThrownBy(() -> createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Epoch length in config must be greater than zero");
   }
@@ -148,8 +144,7 @@ public class BaseBftProtocolScheduleTest {
     when(genesisConfig.getBftConfigOptions()).thenReturn(configOptions);
     when(genesisConfig.getTransitions()).thenReturn(TransitionsConfigOptions.DEFAULT);
 
-    assertThatThrownBy(
-            () -> createProtocolSchedule(new ForkSpec<>(0, configOptions), Collections.emptyList()))
+    assertThatThrownBy(() -> createProtocolSchedule(List.of(new ForkSpec<>(0, configOptions))))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Epoch length in config must be greater than zero");
   }
@@ -173,8 +168,9 @@ public class BaseBftProtocolScheduleTest {
 
     final ProtocolSchedule schedule =
         createProtocolSchedule(
-            new ForkSpec<>(0, configOptions),
-            List.of(new ForkSpec<>(transitionBlock, blockRewardTransition)));
+            List.of(
+                new ForkSpec<>(0, configOptions),
+                new ForkSpec<>(transitionBlock, blockRewardTransition)));
 
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(2);
     assertThat(schedule.getByBlockNumber(0).getBlockReward())
@@ -183,8 +179,7 @@ public class BaseBftProtocolScheduleTest {
         .isEqualTo(Wei.of(forkBlockReward));
   }
 
-  private ProtocolSchedule createProtocolSchedule(
-      final ForkSpec<BftConfigOptions> genesisFork, final List<ForkSpec<BftConfigOptions>> forks) {
+  private ProtocolSchedule createProtocolSchedule(final List<ForkSpec<BftConfigOptions>> forks) {
     final BaseBftProtocolSchedule bftProtocolSchedule =
         new BaseBftProtocolSchedule() {
           @Override
@@ -195,7 +190,7 @@ public class BaseBftProtocolScheduleTest {
         };
     return bftProtocolSchedule.createProtocolSchedule(
         genesisConfig,
-        new ForksSchedule<>(genesisFork, forks),
+        new ForksSchedule<>(forks),
         PrivacyParameters.DEFAULT,
         false,
         bftExtraDataCodec,

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftProtocolScheduleTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/IbftProtocolScheduleTest.java
@@ -79,8 +79,8 @@ public class IbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
             List.of(
+                new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
                 new ForkSpec<>(1, arbitraryTransition),
                 new ForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
@@ -90,12 +90,10 @@ public class IbftProtocolScheduleTest {
   }
 
   private ProtocolSchedule createProtocolSchedule(
-      final GenesisConfigOptions genesisConfig,
-      final ForkSpec<BftConfigOptions> genesisFork,
-      final List<ForkSpec<BftConfigOptions>> forks) {
+      final GenesisConfigOptions genesisConfig, final List<ForkSpec<BftConfigOptions>> forks) {
     return IbftProtocolSchedule.create(
         genesisConfig,
-        new ForksSchedule<>(genesisFork, forks),
+        new ForksSchedule<>(forks),
         PrivacyParameters.DEFAULT,
         false,
         bftExtraDataCodec,

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
@@ -98,7 +98,7 @@ public class BftBlockCreatorTest {
         GenesisConfigFile.fromConfig("{\"config\": {\"spuriousDragonBlock\":0}}")
             .getConfigOptions();
     final ForksSchedule<BftConfigOptions> forksSchedule =
-        new ForksSchedule<>(new ForkSpec<>(0, configOptions.getBftConfigOptions()), List.of());
+        new ForksSchedule<>(List.of(new ForkSpec<>(0, configOptions.getBftConfigOptions())));
     final ProtocolSchedule protocolSchedule =
         bftProtocolSchedule.createProtocolSchedule(
             configOptions,

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftProtocolScheduleTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/QbftProtocolScheduleTest.java
@@ -84,8 +84,10 @@ public class QbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new ForkSpec<>(0, qbftConfigOptions),
-            List.of(new ForkSpec<>(1, arbitraryTransition), new ForkSpec<>(2, contractTransition)));
+            List.of(
+                new ForkSpec<>(0, qbftConfigOptions),
+                new ForkSpec<>(1, arbitraryTransition),
+                new ForkSpec<>(2, contractTransition)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 0)).isTrue();
     assertThat(validateHeader(schedule, validators, parentHeader, blockHeader, 1)).isTrue();
@@ -108,8 +110,8 @@ public class QbftProtocolScheduleTest {
     final ProtocolSchedule schedule =
         createProtocolSchedule(
             JsonGenesisConfigOptions.fromJsonObject(JsonUtil.createEmptyObjectNode()),
-            new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
             List.of(
+                new ForkSpec<>(0, JsonQbftConfigOptions.DEFAULT),
                 new ForkSpec<>(1, arbitraryTransition),
                 new ForkSpec<>(2, JsonQbftConfigOptions.DEFAULT)));
     assertThat(schedule.streamMilestoneBlocks().count()).isEqualTo(3);
@@ -119,12 +121,10 @@ public class QbftProtocolScheduleTest {
   }
 
   private ProtocolSchedule createProtocolSchedule(
-      final GenesisConfigOptions genesisConfig,
-      final ForkSpec<QbftConfigOptions> genesisFork,
-      final List<ForkSpec<QbftConfigOptions>> forks) {
+      final GenesisConfigOptions genesisConfig, final List<ForkSpec<QbftConfigOptions>> forks) {
     return QbftProtocolSchedule.create(
         genesisConfig,
-        new ForksSchedule<>(genesisFork, forks),
+        new ForksSchedule<>(forks),
         PrivacyParameters.DEFAULT,
         false,
         bftExtraDataCodec,

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
@@ -98,7 +98,7 @@ public class ForkingValidatorProviderTest {
   @Test
   public void usesInitialValidatorProviderWhenNoForks() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
-        new ForksSchedule<>(createBlockForkSpec(0), List.of());
+        new ForksSchedule<>(List.of(createBlockForkSpec(0)));
 
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
@@ -116,7 +116,7 @@ public class ForkingValidatorProviderTest {
   public void migratesFromBlockToContractValidatorProvider() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
         new ForksSchedule<>(
-            createBlockForkSpec(0), List.of(createContractForkSpec(1L, CONTRACT_ADDRESS_1)));
+            List.of(createBlockForkSpec(0), createContractForkSpec(1L, CONTRACT_ADDRESS_1)));
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
             blockChain, forksSchedule, blockValidatorProvider, contractValidatorProvider);
@@ -129,7 +129,7 @@ public class ForkingValidatorProviderTest {
   public void migratesFromContractToBlockValidatorProvider() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
         new ForksSchedule<>(
-            createContractForkSpec(0, CONTRACT_ADDRESS_1), List.of(createBlockForkSpec(1)));
+            List.of(createContractForkSpec(0, CONTRACT_ADDRESS_1), createBlockForkSpec(1)));
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
             blockChain, forksSchedule, blockValidatorProvider, contractValidatorProvider);
@@ -147,8 +147,8 @@ public class ForkingValidatorProviderTest {
   public void migratesFromContractToContractValidatorProvider() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
         new ForksSchedule<>(
-            createBlockForkSpec(0),
             List.of(
+                createBlockForkSpec(0),
                 createContractForkSpec(1L, CONTRACT_ADDRESS_1),
                 createContractForkSpec(2L, CONTRACT_ADDRESS_2)));
 
@@ -165,8 +165,10 @@ public class ForkingValidatorProviderTest {
   public void voteProviderIsDelegatesToHeadFork_whenHeadIsContractFork() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
         new ForksSchedule<>(
-            createBlockForkSpec(0),
-            List.of(createBlockForkSpec(1), createContractForkSpec(2, CONTRACT_ADDRESS_1)));
+            List.of(
+                createBlockForkSpec(0),
+                createBlockForkSpec(1),
+                createContractForkSpec(2, CONTRACT_ADDRESS_1)));
 
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
@@ -181,7 +183,7 @@ public class ForkingValidatorProviderTest {
   @Test
   public void voteProviderIsDelegatesToHeadFork_whenHeadIsBlockFork() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
-        new ForksSchedule<>(createBlockForkSpec(0), emptyList());
+        new ForksSchedule<>(List.of(createBlockForkSpec(0)));
 
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
@@ -197,8 +199,10 @@ public class ForkingValidatorProviderTest {
   public void getVoteProviderAfterBlock_correctVoteProviderIsResolved() {
     final ForksSchedule<QbftConfigOptions> forksSchedule =
         new ForksSchedule<>(
-            createBlockForkSpec(0),
-            List.of(createBlockForkSpec(1), createContractForkSpec(2, CONTRACT_ADDRESS_1)));
+            List.of(
+                createBlockForkSpec(0),
+                createBlockForkSpec(1),
+                createContractForkSpec(2, CONTRACT_ADDRESS_1)));
     final ForkingValidatorProvider validatorProvider =
         new ForkingValidatorProvider(
             blockChain, forksSchedule, blockValidatorProvider, contractValidatorProvider);

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
@@ -61,7 +61,7 @@ public class TransactionValidatorProviderTest {
 
   @Before
   public void setup() {
-    forksSchedule = new ForksSchedule<>(createContractForkSpec(0L, CONTRACT_ADDRESS), emptyList());
+    forksSchedule = new ForksSchedule<>(List.of(createContractForkSpec(0L, CONTRACT_ADDRESS)));
     genesisBlock = createEmptyBlock(0, Hash.ZERO);
     blockChain = createInMemoryBlockchain(genesisBlock);
     headerBuilder.extraData(Bytes.wrap(new byte[32]));


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Simplify the constructor for the ForkSchedule. This removes the need to seperate out a seperate ForkSpec for the genesis block.

fixes #3131 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).