### PR TITLE
[MINOR] updating enclave AT code to remove orion references

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
@@ -115,8 +115,7 @@ public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
 
     final String tesseraMessage = JsonRpcError.TESSERA_NODE_MISSING_PEER_URL.getMessage();
 
-    assertThat(throwable.getMessage())
-        .has(matchTesseraEnclaveMessage(tesseraMessage));
+    assertThat(throwable.getMessage()).has(matchTesseraEnclaveMessage(tesseraMessage));
   }
 
   @Test
@@ -198,8 +197,7 @@ public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
         catchThrowable(() -> alice.execute(privacyTransactions.createPrivacyGroup(null, null)));
     final String tesseraMessage = JsonRpcError.TESSERA_CREATE_GROUP_INCLUDE_SELF.getMessage();
 
-    assertThat(throwable.getMessage())
-        .has(matchTesseraEnclaveMessage(tesseraMessage));
+    assertThat(throwable.getMessage()).has(matchTesseraEnclaveMessage(tesseraMessage));
   }
 
   private Condition<String> matchTesseraEnclaveMessage(final String enclaveMessage) {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
@@ -113,11 +113,10 @@ public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
                         alice.getEnclaveKey(),
                         wrongPublicKey)));
 
-    final String orionMessage = JsonRpcError.NODE_MISSING_PEER_URL.getMessage();
     final String tesseraMessage = JsonRpcError.TESSERA_NODE_MISSING_PEER_URL.getMessage();
 
     assertThat(throwable.getMessage())
-        .has(matchOrionOrTesseraMessage(orionMessage, tesseraMessage));
+        .has(matchTesseraEnclaveMessage(tesseraMessage));
   }
 
   @Test
@@ -197,17 +196,15 @@ public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
   public void createPrivacyGroupReturnsCorrectError() {
     final Throwable throwable =
         catchThrowable(() -> alice.execute(privacyTransactions.createPrivacyGroup(null, null)));
-    final String orionMessage = JsonRpcError.CREATE_GROUP_INCLUDE_SELF.getMessage();
     final String tesseraMessage = JsonRpcError.TESSERA_CREATE_GROUP_INCLUDE_SELF.getMessage();
 
     assertThat(throwable.getMessage())
-        .has(matchOrionOrTesseraMessage(orionMessage, tesseraMessage));
+        .has(matchTesseraEnclaveMessage(tesseraMessage));
   }
 
-  private Condition<String> matchOrionOrTesseraMessage(
-      final String orionMessage, final String tesseraMessage) {
+  private Condition<String> matchTesseraEnclaveMessage(final String enclaveMessage) {
     return new Condition<>(
-        message -> message.contains(orionMessage) || message.contains(tesseraMessage),
-        "Message did not match either Orion or Tessera expected output");
+        message -> message.contains(enclaveMessage),
+        "Message did not match Tessera expected output");
   }
 }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Use generic language, remove reference to Orion formatted messages

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).