### PR TITLE
Upgrade log4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Additions and Improvements
 - Represent baseFee as Wei instead of long accordingly to the spec [#2785] (https://github.com/hyperledger/besu/issues/2785)
 
+### Bug Fixes
+- Updated log4j to 2.15.0 and disabled JNDI message format lookups to improve security.
+
 ### <Next RC> Breaking Changes
 - Plugin API: BlockHeader.getBaseFee() method now returns an optional Wei instead of an optional Long
 

--- a/build.gradle
+++ b/build.gradle
@@ -471,6 +471,8 @@ applicationDefaultJvmArgs = [
   // We shutdown log4j ourselves, as otherwise this shutdown hook runs before our own and whatever
   // happens during shutdown is not logged.
   '-Dlog4j.shutdownHookEnabled=false',
+  // Disable JNI lookups in log4j messages to improve security
+  '-Dlog4j2.formatMsgNoLookups=true',
   // Redirect java.util.logging loggers to use log4j2.
   '-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager',
   // Suppress Java JPMS warnings.  Document the reason for each suppression.

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -100,10 +100,10 @@ dependencyManagement {
     dependency 'org.apache.commons:commons-compress:1.21'
     dependency 'org.apache.commons:commons-text:1.9'
 
-    dependency 'org.apache.logging.log4j:log4j-api:2.14.1'
-    dependency 'org.apache.logging.log4j:log4j-core:2.14.1'
-    dependency 'org.apache.logging.log4j:log4j-jul:2.14.1'
-    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    dependency 'org.apache.logging.log4j:log4j-api:2.15.0'
+    dependency 'org.apache.logging.log4j:log4j-core:2.15.0'
+    dependency 'org.apache.logging.log4j:log4j-jul:2.15.0'
+    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
 
     dependency 'org.apache.tuweni:tuweni-bytes:2.0.0'
     dependency 'org.apache.tuweni:tuweni-config:2.0.0'


### PR DESCRIPTION
## PR description
Upgrades log4j and explicitly disables JNDI message format lookups to improve security.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).