### PR TITLE
fix comparison in random operation

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/RandomOperationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/operations/RandomOperationTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.evm.operation.RandomOperation;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.Test;
 
 public class RandomOperationTest {
@@ -38,7 +39,7 @@ public class RandomOperationTest {
     MessageFrame messageFrame = mock(MessageFrame.class);
     BlockValues blockHeader = mock(BlockValues.class);
     Bytes32 rand = Bytes32.fromHexString("0xb0b0face");
-    when(blockHeader.getDifficultyBytes()).thenReturn(Bytes.of(0));
+    when(blockHeader.getDifficultyBytes()).thenReturn(UInt256.ZERO);
     when(blockHeader.getMixHashOrRandom()).thenReturn(rand);
     when(messageFrame.getBlockValues()).thenReturn(blockHeader);
     EVM evm = mock(EVM.class);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RandomOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RandomOperation.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
 
 public class RandomOperation extends AbstractFixedCostOperation {
 
@@ -29,7 +29,7 @@ public class RandomOperation extends AbstractFixedCostOperation {
   @Override
   public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     if (frame.getBlockValues().getDifficultyBytes() == null
-        || frame.getBlockValues().getDifficultyBytes().equals(Bytes.of(0))) {
+        || frame.getBlockValues().getDifficultyBytes().equals(UInt256.ZERO)) {
       frame.pushStackItem(frame.getBlockValues().getMixHashOrRandom());
     } else {
       frame.pushStackItem(frame.getBlockValues().getDifficultyBytes());


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
comparison fix for random operation - compare to UInt256.ZERO rather than Bytes.of(0) when operating in the 'transition' mode between preMergeFork and terminal total difficulty

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).