### PR TITLE
Change docker base images from debian to ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Implements [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) to repurpose DIFFICULTY opcode after the merge as a source of entropy from the Beacon chain. [#3081](https://github.com/hyperledger/besu/issues/3081)
 
 ### Bug Fixes
-- Change the base docker image from Debian Buster to Ubuntu 20.04 [#3171](https://github.com/hyperledger/besu/issues/3171) fixes [#3045](https://github.com/hyperledger/besu/issues/3171)
+- Change the base docker image from Debian Buster to Ubuntu 20.04 [#3171](https://github.com/hyperledger/besu/issues/3171) fixes [#3045](https://github.com/hyperledger/besu/issues/3045)
 
 ### Early Access Features
 - Add support for additional JWT authentication algorithms [#3017](https://github.com/hyperledger/besu/pull/3017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## 21.10.4
 
-### Additions and Improvements
-- Represent baseFee as Wei instead of long accordingly to the spec [#2785] (https://github.com/hyperledger/besu/issues/2785)
-
 ### 21.10.4 Breaking Changes
-- Plugin API: BlockHeader.getBaseFee() method now returns an optional Wei instead of an optional Long
+- Plugin API: BlockHeader.getBaseFee() method now returns an optional Wei instead of an optional Long [#3065](https://github.com/hyperledger/besu/issues/3065)
 
 ### Additions and Improvements
+- Represent baseFee as Wei instead of long accordingly to the spec [#2785](https://github.com/hyperledger/besu/issues/2785)
 - Adding support of the NO_COLOR environment variable as described in the [NO_COLOR](https://no-color.org/) standard [#3085](https://github.com/hyperledger/besu/pull/3085)
 - Add `privx_findFlexiblePrivacyGroup` RPC Method, `privx_findOnchainPrivacyGroup` will be removed in a future release [#3075](https://github.com/hyperledger/besu/pull/3075)
 - The invalid value is now shown when `--bootnodes` cannot parse an item to make it easier to identify which option is invalid. 
@@ -16,6 +14,7 @@
 - Implements [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) to repurpose DIFFICULTY opcode after the merge as a source of entropy from the Beacon chain. [#3081](https://github.com/hyperledger/besu/issues/3081)
 
 ### Bug Fixes
+- Change the base docker image from Debian Buster to Ubuntu 20.04 [#3171](https://github.com/hyperledger/besu/issues/3171) fixes [#3045](https://github.com/hyperledger/besu/issues/3171)
 
 ### Early Access Features
 - Add support for additional JWT authentication algorithms [#3017](https://github.com/hyperledger/besu/pull/3017)

--- a/docker/openjdk-11-debug/Dockerfile
+++ b/docker/openjdk-11-debug/Dockerfile
@@ -1,9 +1,9 @@
 
-FROM openjdk:11-slim-buster
+FROM ubuntu:20.04
 
 ARG VERSION="dev"
 RUN apt-get update  && \
- apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.20* jq=1.5* net-tools=1.60*  && \
+ apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.20* jq=1.6* net-tools=1.60* openjdk-11-jre-headless=11* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \

--- a/docker/openjdk-11/Dockerfile
+++ b/docker/openjdk-11/Dockerfile
@@ -1,9 +1,12 @@
 
-FROM openjdk:11-jre-slim-buster
-
+FROM ubuntu:20.04
 ARG VERSION="dev"
 
-RUN adduser --disabled-password --gecos "" --home /opt/besu besu && \
+RUN apt-get update && \
+ apt-get install --no-install-recommends -q --assume-yes openjdk-11-jre-headless=11* && \
+ apt-get clean  && \
+ rm -rf /var/lib/apt/lists/*  && \
+ adduser --disabled-password --gecos "" --home /opt/besu besu && \
     chown besu:besu /opt/besu
 
 USER besu

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM debian:bullseye-slim
+FROM ubuntu:20.04
 ARG VERSION="dev"
 
 RUN apt-get update && \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -1,8 +1,13 @@
 
-FROM openjdk:11.0.7-jre-slim-buster
+FROM ubuntu:20.04
+ARG VERSION="dev"
 
-RUN adduser --disabled-password --gecos "" --home /opt/besu-evmtool besu && \
-    chown besu:besu /opt/besu-evmtool
+RUN apt-get update && \
+ apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* && \
+ apt-get clean  && \
+ rm -rf /var/lib/apt/lists/*  && \
+ adduser --disabled-password --gecos "" --home /opt/besu besu && \
+    chown besu:besu /opt/besu
 
 USER besu
 WORKDIR /opt/besu-evmtool


### PR DESCRIPTION

## PR description

Change the docker base images from debian (implied by openjdk image) to
ubuntu explicitly. Ubuntu has quicker reaction time to base image
security vulnerabilities.

## Fixed Issue(s)

Fixes #3045

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).