### PR TITLE
Update to log4j 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 - Change the base docker image from Debian Buster to Ubuntu 20.04 [#3171](https://github.com/hyperledger/besu/issues/3171) fixes [#3045](https://github.com/hyperledger/besu/issues/3045)
+- Update log4j to 2.16.0.
 
 ### Early Access Features
 - Add support for additional JWT authentication algorithms [#3017](https://github.com/hyperledger/besu/pull/3017)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -100,10 +100,10 @@ dependencyManagement {
     dependency 'org.apache.commons:commons-compress:1.21'
     dependency 'org.apache.commons:commons-text:1.9'
 
-    dependency 'org.apache.logging.log4j:log4j-api:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j-core:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j-jul:2.15.0'
-    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
+    dependency 'org.apache.logging.log4j:log4j-api:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j-core:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j-jul:2.16.0'
+    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
 
     dependency 'org.apache.tuweni:tuweni-bytes:2.0.0'
     dependency 'org.apache.tuweni:tuweni-config:2.0.0'


### PR DESCRIPTION
## PR description
Updates to log4j2 2.16.0 which identified a second vector for JNDI attacks via `ThreadContext`. Besu only uses `ThreadContext` as part of the acceptance test framework and not in production code so isn't vulnerable to this issue.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).