### PR TITLE
Mitigate problems with web3j-sokt services being down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,11 @@ commands:
     steps:
       - checkout
       - run:
-          name: Install Packages - LibSodium, nssdb
+          name: Install Packages - LibSodium, nssdb, solc
           command: |
+            sudo add-apt-repository ppa:ethereum/ethereum
             sudo apt-get update
-            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools
+            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools solc
             sudo service haveged restart
       - restore_cache:
           name: Restore cached gradle dependencies
@@ -190,6 +191,7 @@ jobs:
           name: AcceptanceTests
           no_output_timeout: 30m
           command: |
+            export SOLC_BINARY_PATH=$(which solc)
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
               | sed 's@.*/src/test/java/@@' \
               | sed 's@/@.@g' \

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -24,6 +24,8 @@ sourceSets.main.solidity.srcDirs = ["$projectDir/contracts"]
 
 solidity {
   resolvePackages = false
+  //Note: if this is null web3j-sokt will try and download the 'right' version for you
+  executable = System.getenv('SOLC_BINARY_PATH') ?: null
 }
 
 dependencies {


### PR DESCRIPTION
- this only mitigates the problem for automated builds on circle-ci
- I didn't want to add any external dependencies
    ie you need to manually install solc to run acceptanceTests
    web3j-sokt should take care of it for you and only needs to work once

Signed-off-by: Antony Denyer <git@antonydenyer.co.uk>