### PR TITLE
Bugfix/suggested fee recipient

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.MergeProtocolSchedule;
 import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator;
-import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -45,9 +44,6 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager) {
 
-    BlockValidator blockValidator =
-        protocolSchedule.getByBlockNumber(Long.MAX_VALUE).getBlockValidator();
-
     // TODO: revisit how we stop/manage the synchronizer
     // https://github.com/hyperledger/besu/issues/2898
     this.syncState.set(syncState);
@@ -57,13 +53,8 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
         protocolSchedule,
         transactionPool.getPendingTransactions(),
         miningParameters,
-        blockValidator,
         new BackwardsSyncContext(
-            protocolContext,
-            protocolSchedule,
-            metricsSystem,
-            ethProtocolManager.ethContext(),
-            blockValidator));
+            protocolContext, protocolSchedule, metricsSystem, ethProtocolManager.ethContext()));
   }
 
   @Override

--- a/consensus/merge/build.gradle
+++ b/consensus/merge/build.gradle
@@ -44,6 +44,11 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 
+  testImplementation project(path: ':consensus:common', configuration: 'testArtifacts')
+  testImplementation project(path: ':crypto', configuration: 'testSupportArtifacts')
+  testImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')
+  testImplementation project(':testutil')
+
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.mockito:mockito-core'

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -22,9 +22,14 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.google.common.collect.EvictingQueue;
 
@@ -139,15 +144,22 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void putPayloadById(final PayloadIdentifier payloadId, final Block block) {
+    var priorsById = retrieveTuplesById(payloadId)
+        .collect(Collectors.toUnmodifiableList());
     blocksInProgress.add(new PayloadTuple(payloadId, block));
+    priorsById.stream().forEach(blocksInProgress::remove);
   }
 
   @Override
   public Optional<Block> retrieveBlockById(final PayloadIdentifier payloadId) {
-    return blocksInProgress.stream()
-        .filter(z -> z.payloadIdentifier.equals(payloadId))
-        .map(z -> z.block)
+    return retrieveTuplesById(payloadId)
+        .map(tuple -> tuple.block)
         .findFirst();
+  }
+
+  Stream<PayloadTuple> retrieveTuplesById(final PayloadIdentifier payloadId) {
+    return blocksInProgress.stream()
+        .filter(z -> z.payloadIdentifier.equals(payloadId));
   }
 
   static class PayloadTuple {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -22,9 +22,6 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.util.Subscribers;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -144,22 +141,18 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void putPayloadById(final PayloadIdentifier payloadId, final Block block) {
-    var priorsById = retrieveTuplesById(payloadId)
-        .collect(Collectors.toUnmodifiableList());
+    var priorsById = retrieveTuplesById(payloadId).collect(Collectors.toUnmodifiableList());
     blocksInProgress.add(new PayloadTuple(payloadId, block));
     priorsById.stream().forEach(blocksInProgress::remove);
   }
 
   @Override
   public Optional<Block> retrieveBlockById(final PayloadIdentifier payloadId) {
-    return retrieveTuplesById(payloadId)
-        .map(tuple -> tuple.block)
-        .findFirst();
+    return retrieveTuplesById(payloadId).map(tuple -> tuple.block).findFirst();
   }
 
   Stream<PayloadTuple> retrieveTuplesById(final PayloadIdentifier payloadId) {
-    return blocksInProgress.stream()
-        .filter(z -> z.payloadIdentifier.equals(payloadId));
+    return blocksInProgress.stream().filter(z -> z.payloadIdentifier.equals(payloadId));
   }
 
   static class PayloadTuple {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -48,7 +48,7 @@ public class MergeBlockCreator extends AbstractBlockCreator {
       final Double minBlockOccupancyRatio,
       final BlockHeader parentHeader) {
     super(
-        coinbase,
+        miningBeneficiary,
         targetGasLimitSupplier,
         extraDataCalculator,
         pendingTransactions,

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -65,7 +65,7 @@ public class MergeBlockCreator extends AbstractBlockCreator {
       final Bytes32 random,
       final long timestamp) {
     return createBlock(
-        Optional.empty(),
+        maybeTransactions,
         Optional.of(Collections.emptyList()),
         Optional.of(random),
         timestamp,

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.merge.blockcreation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive;
+import static org.mockito.Mockito.mock;
+
+import org.hyperledger.besu.config.experimental.MergeOptions;
+import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.GenesisState;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardsSyncContext;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
+
+  @Mock AbstractPendingTransactionsSorter mockSorter;
+
+  private MergeCoordinator coordinator;
+
+  private final MergeContext mergeContext = PostMergeContext.get();
+  private final ProtocolSchedule mockProtocolSchedule = getMergeProtocolSchedule();
+  private final GenesisState genesisState =
+      GenesisState.fromConfig(getGenesisConfigFile(), mockProtocolSchedule);
+
+  private final WorldStateArchive worldStateArchive = createInMemoryWorldStateArchive();
+  private final MutableBlockchain blockchain = createInMemoryBlockchain(genesisState.getBlock());
+
+  private final ProtocolContext protocolContext =
+      new ProtocolContext(blockchain, worldStateArchive, mergeContext);
+
+  private final Address suggestedFeeRecipient = Address.ZERO;
+  private final Address coinbase = genesisAllocations().findFirst().get();
+
+  @Before
+  public void setUp() {
+    var mutable = worldStateArchive.getMutable();
+    genesisState.writeStateTo(mutable);
+    mutable.persist(null);
+
+    MergeOptions.setMergeEnabled(true);
+    this.coordinator =
+        new MergeCoordinator(
+            protocolContext,
+            mockProtocolSchedule,
+            mockSorter,
+            new MiningParameters.Builder().coinbase(coinbase).build(),
+            mock(BackwardsSyncContext.class));
+  }
+
+  @Test
+  public void coinbaseShouldMatchSuggestedFeeRecipient() {
+    var payloadId =
+        coordinator.preparePayload(
+            genesisState.getBlock().getHeader(),
+            System.currentTimeMillis() / 1000,
+            Bytes32.ZERO,
+            suggestedFeeRecipient);
+
+    var mockBlock = mergeContext.retrieveBlockById(payloadId);
+    assertThat(mockBlock).isPresent();
+    Block proposed = mockBlock.get();
+    assertThat(proposed.getHeader().getCoinbase()).isEqualTo(suggestedFeeRecipient);
+  }
+}

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeGenesisConfigHelper.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeGenesisConfigHelper.java
@@ -1,0 +1,39 @@
+package org.hyperledger.besu.consensus.merge.blockcreation;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import org.hyperledger.besu.config.GenesisAllocation;
+import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.consensus.merge.MergeProtocolSchedule;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+
+import com.google.common.io.Resources;
+
+public interface MergeGenesisConfigHelper {
+
+  default GenesisConfigFile getGenesisConfigFile() {
+    try {
+      final URI uri = MergeGenesisConfigHelper.class.getResource("/mergeAtGenesis.json").toURI();
+      return GenesisConfigFile.fromConfig(Resources.toString(uri.toURL(), UTF_8));
+    } catch (final URISyntaxException | IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  default Stream<Address> genesisAllocations() {
+    return getGenesisConfigFile()
+        .streamAllocations()
+        .map(GenesisAllocation::getAddress)
+        .map(Address::fromHexString);
+  }
+
+  default ProtocolSchedule getMergeProtocolSchedule() {
+    return MergeProtocolSchedule.create(getGenesisConfigFile().getConfigOptions(), false);
+  }
+}

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeGenesisConfigHelper.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeGenesisConfigHelper.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.consensus.merge.blockcreation;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/consensus/merge/src/test/resources/mergeAtGenesis.json
+++ b/consensus/merge/src/test/resources/mergeAtGenesis.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "chainId": 1337,
+    "londonBlock": 0,
+    "preMergeForkBlock": 0,
+    "terminalTotalDifficulty": 0,
+    "contractSizeLimit": 2147483647,
+    "ethash": {
+      "fixeddifficulty": 100
+    }
+  },
+  "nonce": "0x42",
+  "timestamp": "0x0",
+  "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+  "gasLimit": "0x1fffffffffffff",
+  "difficulty": "0x10000",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "fe3b557e8fb62b89f4916b721be55ceb828dbd73": {
+      "privateKey": "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63",
+      "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+      "balance": "0xad78ebc5ac6200000"
+    },
+    "627306090abaB3A6e1400e9345bC60c78a8BEf57": {
+      "privateKey": "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3",
+      "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+      "balance": "90000000000000000000000"
+    },
+    "f17f52151EbEF6C7334FAD080c5704D77216b732": {
+      "privateKey": "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f",
+      "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+      "balance": "90000000000000000000000"
+    }
+  }
+}

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -300,12 +300,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
     final Bytes32 random = maybeRandom.orElse(null);
     return BlockHeaderBuilder.create()
         .parentHash(parentHeader.getHash())
-        .coinbase(
-            Optional.ofNullable(coinbase)
-                .orElseGet(
-                    () ->
-                        // supply a ZERO coinbase if unspecified AND merge is enabled:
-                        MergeOptions.isMergeEnabled() ? Address.ZERO : null))
+        .coinbase(coinbase)
         .difficulty(Difficulty.of(difficulty))
         .number(newBlockNumber)
         .gasLimit(gasLimit)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContext.java
@@ -36,7 +36,6 @@ public class BackwardsSyncContext {
 
   private final ProtocolContext protocolContext;
   private final ProtocolSchedule protocolSchedule;
-  private final BlockValidator blockValidator;
   private final EthContext ethContext;
   private final MetricsSystem metricsSystem;
 
@@ -49,12 +48,10 @@ public class BackwardsSyncContext {
       final ProtocolContext protocolContext,
       final ProtocolSchedule protocolSchedule,
       final MetricsSystem metricsSystem,
-      final EthContext ethContext,
-      final BlockValidator blockValidator) {
+      final EthContext ethContext) {
 
     this.protocolContext = protocolContext;
     this.protocolSchedule = protocolSchedule;
-    this.blockValidator = blockValidator;
     this.ethContext = ethContext;
     this.metricsSystem = metricsSystem;
   }
@@ -153,8 +150,8 @@ public class BackwardsSyncContext {
     return protocolContext;
   }
 
-  public BlockValidator getBlockValidator() {
-    return blockValidator;
+  public BlockValidator getBlockValidator(final long blockNumber) {
+    return protocolSchedule.getByBlockNumber(blockNumber).getBlockValidator();
   }
 
   public BackwardChain findCorrectChainFromPivot(final long number) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
@@ -98,7 +98,7 @@ public class ForwardSyncStep extends BackwardSyncTask {
         () -> block.getHeader().getHash().toString().substring(0, 20));
     var optResult =
         context
-            .getBlockValidator()
+            .getBlockValidator(block.getHeader().getNumber())
             .validateAndProcessBlock(
                 context.getProtocolContext(),
                 block,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
@@ -107,8 +107,7 @@ public class BackwardsSyncContextTest {
             });
 
     context =
-        new BackwardsSyncContext(
-            protocolContext, protocolSchedule, metricsSystem, ethContext, blockValidator);
+        new BackwardsSyncContext(protocolContext, protocolSchedule, metricsSystem, ethContext);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
@@ -20,6 +20,7 @@ package org.hyperledger.besu.ethereum.eth.sync.backwardsync;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
@@ -35,6 +36,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
@@ -48,6 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -56,14 +59,19 @@ public class BackwardsSyncContextTest {
   public static final int REMOTE_HEIGHT = 50;
   public static final int LOCAL_HEIGHT = 25;
   private static final BlockDataGenerator blockDataGenerator = new BlockDataGenerator();
-  private final ProtocolSchedule protocolSchedule =
-      MainnetProtocolSchedule.fromConfig(new StubGenesisConfigOptions());
 
   private BackwardsSyncContext context;
 
   private MutableBlockchain remoteBlockchain;
   private RespondingEthPeer peer;
   private MutableBlockchain localBlockchain;
+
+  @Spy
+  private ProtocolSchedule protocolSchedule =
+      MainnetProtocolSchedule.fromConfig(new StubGenesisConfigOptions());
+
+  @Spy private ProtocolSpec mockProtocolSpec = protocolSchedule.getByBlockNumber(0L);
+
   @Mock private ProtocolContext protocolContext;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -73,6 +81,8 @@ public class BackwardsSyncContextTest {
 
   @Before
   public void setup() {
+    when(mockProtocolSpec.getBlockValidator()).thenReturn(blockValidator);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(mockProtocolSpec);
     Block genesisBlock = blockDataGenerator.genesisBlock();
     remoteBlockchain = createInMemoryBlockchain(genesisBlock);
     localBlockchain = createInMemoryBlockchain(genesisBlock);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
@@ -20,6 +20,7 @@ package org.hyperledger.besu.ethereum.eth.sync.backwardsync;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,7 +97,7 @@ public class ForwardSyncStepTest {
     EthContext ethContext = ethProtocolManager.ethContext();
     when(context.getEthContext()).thenReturn(ethContext);
 
-    when(context.getBlockValidator().validateAndProcessBlock(any(), any(), any(), any()))
+    when(context.getBlockValidator(anyLong()).validateAndProcessBlock(any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               final Object[] arguments = invocation.getArguments();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
fix a defect found in kintsugi testnet where we produce blocks with the coinbase from miningParams, but use suggestedFeeRecipient for the blockheader.
* consistently use suggestedFeeRecipient and fall back to miningParams
* start MiningCoordinator test coverage with this case
* clean up of unnecessary blockValidator params to MiningCoordinator and BackwardsSyncContext
* ensure only latest (best) blockProposal is available by payloadId from MergeContext

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).