### PR TITLE
CI: install a fixed version of solc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,12 @@ commands:
     steps:
       - checkout
       - run:
-          name: Install Packages - LibSodium, nssdb
+          name: Install Packages - LibSodium, nssdb, solc
           command: |
-            sudo add-apt-repository ppa:ethereum/ethereum
             sudo apt-get update
-            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools solc
+            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools software-properties-common wget
+            sudo wget https://github.com/ethereum/solc-bin/blob/gh-pages/linux-amd64/solc-linux-amd64-v0.8.9+commit.e5eed63a?raw=true -O /usr/bin/solc
+            sudo chmod +x /usr/bin/solc
             sudo service haveged restart
       - restore_cache:
           name: Restore cached gradle dependencies


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

What is currently on main is currently working - but it didn't work when we did release 21.10.4. 
This is the install that was used for release 21.10.4 - is this more reliable?

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).