### PR TITLE
update log4j 2.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 - Make 'to' field optional in eth_call method according to the spec [#3177] (https://github.com/hyperledger/besu/pull/3177)
-- Updated to log4j 2.17.1. Resolves two potential vulnerabilities which are only exploitable when using custom log4j configurations that are either writable by untrusted users or log data from the ThreadContext.
+- Updated to log4j 2.17.1. Resolves potential vulnerability only exploitable when using custom log4j configurations that are writable by untrusted users.
 
 ## 21.10.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 - Make 'to' field optional in eth_call method according to the spec [#3177] (https://github.com/hyperledger/besu/pull/3177)
+- Updated to log4j 2.17.1. Resolves two potential vulnerabilities which are only exploitable when using custom log4j configurations that are either writable by untrusted users or log data from the ThreadContext.
 
 ## 21.10.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 - Make 'to' field optional in eth_call method according to the spec [#3177] (https://github.com/hyperledger/besu/pull/3177)
-- Updated to log4j 2.17.1. Resolves potential vulnerability only exploitable when using custom log4j configurations that are writable by untrusted users.
+- Update to log4j 2.17.1. Resolves potential vulnerability only exploitable when using custom log4j configurations that are writable by untrusted users.
 
 ## 21.10.5
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -112,10 +112,10 @@ dependencyManagement {
     dependency 'org.apache.commons:commons-compress:1.21'
     dependency 'org.apache.commons:commons-text:1.9'
 
-    dependency 'org.apache.logging.log4j:log4j-api:2.17.0'
-    dependency 'org.apache.logging.log4j:log4j-core:2.17.0'
-    dependency 'org.apache.logging.log4j:log4j-jul:2.17.0'
-    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+    dependency 'org.apache.logging.log4j:log4j-api:2.17.1'
+    dependency 'org.apache.logging.log4j:log4j-core:2.17.1'
+    dependency 'org.apache.logging.log4j:log4j-jul:2.17.1'
+    dependency 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
 
     dependency 'org.apache.tuweni:tuweni-bytes:2.0.0'
     dependency 'org.apache.tuweni:tuweni-config:2.0.0'


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Update log4j to 2.17.1
https://logging.apache.org/log4j/2.x/security.html

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).