### PR TITLE
Added integration test to ensure DevP2P-over-TLS can handle large messages

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxFrameConstants.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxFrameConstants.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.ethereum.p2p.rlpx;
 
 public class RlpxFrameConstants {
 
+  private RlpxFrameConstants() {}
+
   public static final int LENGTH_MAX_MESSAGE_FRAME = 0xFFFFFF;
   public static final int LENGTH_FRAME_SIZE = 3;
 }


### PR DESCRIPTION
TLS fragments large messages into 16KB records.
Actual fix was done in an earlier commit: https://github.com/hyperledger/besu/commit/f2f7ac9af1a52e04c422f5663063ad27aad35137

This fixes https://github.com/hyperledger/besu/issues/3254