### PR TITLE
besu-3259 Add Compression to TLS P2P

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializer.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 import static org.hyperledger.besu.ethereum.p2p.rlpx.RlpxFrameConstants.LENGTH_FRAME_SIZE;
 import static org.hyperledger.besu.ethereum.p2p.rlpx.RlpxFrameConstants.LENGTH_MAX_MESSAGE_FRAME;
 
+import io.netty.handler.codec.compression.SnappyFrameDecoder;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
@@ -59,6 +61,8 @@ public class NettyTLSConnectionInitializer extends NettyConnectionInitializer {
       SslContext sslContext =
           TLSContextFactory.buildFrom(p2pTLSConfiguration.get()).createNettyClientSslContext();
       ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
+      ch.pipeline().addLast(new SnappyFrameDecoder());
+      ch.pipeline().addLast(new SnappyFrameEncoder());
       ch.pipeline()
           .addLast(
               new LengthFieldBasedFrameDecoder(
@@ -74,6 +78,8 @@ public class NettyTLSConnectionInitializer extends NettyConnectionInitializer {
       SslContext sslContext =
           TLSContextFactory.buildFrom(p2pTLSConfiguration.get()).createNettyServerSslContext();
       ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
+      ch.pipeline().addLast(new SnappyFrameDecoder());
+      ch.pipeline().addLast(new SnappyFrameEncoder());
       ch.pipeline()
           .addLast(
               new LengthFieldBasedFrameDecoder(

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializer.java
@@ -17,8 +17,6 @@ package org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty;
 import static org.hyperledger.besu.ethereum.p2p.rlpx.RlpxFrameConstants.LENGTH_FRAME_SIZE;
 import static org.hyperledger.besu.ethereum.p2p.rlpx.RlpxFrameConstants.LENGTH_MAX_MESSAGE_FRAME;
 
-import io.netty.handler.codec.compression.SnappyFrameDecoder;
-import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.p2p.config.RlpxConfiguration;
 import org.hyperledger.besu.ethereum.p2p.peers.LocalNode;
@@ -37,6 +35,8 @@ import java.util.Optional;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
+import io.netty.handler.codec.compression.SnappyFrameDecoder;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import io.netty.handler.ssl.SslContext;
 
 public class NettyTLSConnectionInitializer extends NettyConnectionInitializer {


### PR DESCRIPTION
## PR description

Enabling Snappy compression for DevP2P-over-TLS. I'll follow up with a PR adding some testing around the Netty pipeline, however, this code is already being tested as part of our TLS acceptance tests so it is safe to merge.

## Fixed Issue(s)
see #3259