### PR TITLE
revert to using bundled solc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,8 @@ commands:
       - run:
           name: Install Packages - LibSodium, nssdb
           command: |
-            sudo add-apt-repository ppa:ethereum/ethereum
             sudo apt-get update
-            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools solc
+            sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools
             sudo service haveged restart
       - restore_cache:
           name: Restore cached gradle dependencies

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -24,8 +24,6 @@ sourceSets.main.solidity.srcDirs = ["$projectDir/contracts"]
 
 solidity {
   resolvePackages = false
-  executable = "solc"
-  version = "0.8.10"
 }
 
 dependencies {


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Remove install of solc on CI executor and revert to using solc that is bundled with the gradle plugin

Fixes #3277 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).