### PR TITLE
[regression] Reenable cors-origin to support any protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update to block header validation for IBFT and QBFT to support London fork EIP-1559 [#3251](https://github.com/hyperledger/besu/pull/3251)
 
 ### Bug Fixes
+- Fix regression on cors-origin star value
 
 ## 22.1.0-RC2
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -819,7 +819,7 @@ public class JsonRpcHttpService {
       return "";
     }
     if (config.getCorsAllowedDomains().contains("*")) {
-      return "*";
+      return ".*";
     } else {
       final StringJoiner stringJoiner = new StringJoiner("|");
       config.getCorsAllowedDomains().stream().filter(s -> !s.isEmpty()).forEach(stringJoiner::add);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -167,6 +167,21 @@ public class JsonRpcHttpServiceCorsTest {
   }
 
   @Test
+  public void requestFromBrowserExtensionShouldSucceedWhenCorsIsStar() throws Exception {
+    jsonRpcHttpService = createJsonRpcHttpServiceWithAllowedDomains("*");
+
+    final Request request =
+        new Request.Builder()
+            .url(jsonRpcHttpService.url())
+            .header("Origin", "moz-extension://802123e4-a916-2d4e-bebf-384b0e2e86dd")
+            .build();
+
+    try (final Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+  }
+
+  @Test
   public void requestWithAccessControlRequestMethodShouldReturnAllowedHeaders() throws Exception {
     jsonRpcHttpService = createJsonRpcHttpServiceWithAllowedDomains("http://foo.io");
 


### PR DESCRIPTION
Signed-off-by: Diego López León <dieguitoll@gmail.com>

## PR description
Before the vert.x upgrade (#3135), the usage of `*` in the Cors-Origin [allowed any string](https://github.com/vert-x3/vertx-web/blob/3.9.8/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java#L169) to pass. Meanwhile the [current version](https://github.com/vert-x3/vertx-web/blob/4.2.1/vertx-web/src/main/java/io/vertx/ext/web/handler/impl/CorsHandlerImpl.java#L231) performs a series of validations for the same wildcard, which allows only a fixed set of protocols (i.e. ftp, http, https). To return the original semantics of `*` according the documentation, an actual regex must be used.

This causes problems when a browser extension, like [Metamask](https://metamask.io/), tries to connect to a Besu client because they tend to use custom protocols. E.g. Chrome uses `chrome-extension` and Firefox `moz-extension`

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).