### PR TITLE
handle NPE caused by empty json

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -1368,6 +1368,19 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   }
 
   @Test
+  public void emptyJson_shouldHandleNPE() throws Exception {
+    final RequestBody body = RequestBody.create(JSON, "");
+
+    try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
+      assertThat(resp.code()).isEqualTo(400);
+      final JsonObject json = new JsonObject(resp.body().string());
+      final JsonRpcError expectedError = JsonRpcError.PARSE_ERROR;
+      testHelper.assertValidJsonRpcError(
+          json, null, expectedError.getCode(), expectedError.getMessage());
+    }
+  }
+
+  @Test
   public void requestWithWrongVersionShouldSucceed() throws Exception {
     final String id = "234";
     final RequestBody body =


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

First commit adds a failing test.
Second commit handles the NPE

Fixes #3294 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).