### PR TITLE
make ethFeeHistory accept hex values for blockCount

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -65,7 +66,11 @@ public class EthFeeHistory implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
     final Object requestId = request.getRequest().getId();
 
-    final long blockCount = request.getRequiredParameter(0, Long.class);
+    final long blockCount =
+        Optional.of(request.getRequiredParameter(0, UnsignedLongParameter.class))
+            .map(UnsignedLongParameter::getValue)
+            .orElse(0L);
+
     if (blockCount < 1 || blockCount > 1024) {
       return new JsonRpcErrorResponse(requestId, JsonRpcError.INVALID_PARAMS);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -28,6 +28,12 @@ public class UnsignedLongParameter {
     checkArgument(this.value >= 0);
   }
 
+  @JsonCreator
+  public UnsignedLongParameter(final long value) {
+    this.value = value;
+    checkArgument(this.value >= 0);
+  }
+
   public long getValue() {
     return value;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
@@ -77,6 +77,8 @@ public class EthFeeHistoryTest {
     feeHistoryRequest(1, "latest");
     // should pass because both required params and optional param given
     feeHistoryRequest(1, "latest", new double[] {1, 20.4});
+    // should pass because both required params and optional param given
+    feeHistoryRequest("0x1", "latest", new double[] {1, 20.4});
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Correctly parse hex parameters for ethFeeHistory blockCount

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #3301

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).