### PR TITLE
21.10.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 21.10.9
+
+### Bug Fixes
+- Fix regression on cors-origin star value
+
 ## 21.10.8
 
 ### Additions and Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Fix regression on cors-origin star value
+- Fix for ethFeeHistory accepting hex values for blockCount
 
 ## 21.10.8
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -792,7 +792,7 @@ public class JsonRpcHttpService {
       return "";
     }
     if (config.getCorsAllowedDomains().contains("*")) {
-      return "*";
+      return ".*";
     } else {
       final StringJoiner stringJoiner = new StringJoiner("|");
       config.getCorsAllowedDomains().stream().filter(s -> !s.isEmpty()).forEach(stringJoiner::add);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -64,7 +65,11 @@ public class EthFeeHistory implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
     final Object requestId = request.getRequest().getId();
 
-    final long blockCount = request.getRequiredParameter(0, Long.class);
+    final long blockCount =
+        Optional.of(request.getRequiredParameter(0, UnsignedLongParameter.class))
+            .map(UnsignedLongParameter::getValue)
+            .orElse(0L);
+
     if (blockCount < 1 || blockCount > 1024) {
       return new JsonRpcErrorResponse(requestId, JsonRpcError.INVALID_PARAMS);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -28,6 +28,12 @@ public class UnsignedLongParameter {
     checkArgument(this.value >= 0);
   }
 
+  @JsonCreator
+  public UnsignedLongParameter(final long value) {
+    this.value = value;
+    checkArgument(this.value >= 0);
+  }
+
   public long getValue() {
     return value;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -167,6 +167,21 @@ public class JsonRpcHttpServiceCorsTest {
   }
 
   @Test
+  public void requestFromBrowserExtensionShouldSucceedWhenCorsIsStar() throws Exception {
+    jsonRpcHttpService = createJsonRpcHttpServiceWithAllowedDomains("*");
+
+    final Request request =
+        new Request.Builder()
+            .url(jsonRpcHttpService.url())
+            .header("Origin", "moz-extension://802123e4-a916-2d4e-bebf-384b0e2e86dd")
+            .build();
+
+    try (final Response response = client.newCall(request).execute()) {
+      assertThat(response.isSuccessful()).isTrue();
+    }
+  }
+
+  @Test
   public void requestWithAccessControlRequestMethodShouldReturnAllowedHeaders() throws Exception {
     jsonRpcHttpService = createJsonRpcHttpServiceWithAllowedDomains("http://foo.io");
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
@@ -76,6 +76,8 @@ public class EthFeeHistoryTest {
     feeHistoryRequest(1, "latest");
     // should pass because both required params and optional param given
     feeHistoryRequest(1, "latest", new double[] {1, 20.4});
+    // should pass because both required params and optional param given
+    feeHistoryRequest("0x1", "latest", new double[] {1, 20.4});
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=21.10.9-SNAPSHOT
+version=21.10.9
 
 # Workaround for Java 16 and spotless bug 834 https://github.com/diffplug/spotless/issues/834
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
Fixes CORS regression caused by Vert.x upgrade.

Signed-off-by: Justin Florentine <justin+github@florentine.us>


- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).