### PR TITLE
Remove unnecessary log when block timer expiry happens after the proposal

### DIFF
--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
@@ -105,10 +105,10 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
   @Override
   public void handleBlockTimerExpiry(final ConsensusRoundIdentifier roundIdentifier) {
     if (currentRound.isPresent()) {
-      LOG.warn(
-          "Block timer expired for round ({}) after round has already started on round ({})",
-          roundIdentifier,
-          currentRound.get().getRoundIdentifier());
+      // It is possible for the block timer to take longer than it should due to the precision of
+      // the timer in Java and the OS. This means occasionally the proposal can arrive before the
+      // block timer expiry and hence the round has already been set. There is no negative impact
+      // on the protocol in this case.
       return;
     }
 


### PR DESCRIPTION
## PR description
Removes an unnecessary warning from the QBFT logs. Due to precision of the Java timer sometimes the proposal message can be received before our block timer expiry event.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).