### PR TITLE
Do not exit ChainDownloader in case of a generic CancellationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 - Fix regression on cors-origin star value
 - Fix for ethFeeHistory accepting hex values for blockCount
+- Fix a sync issue, when the chain downloader incorrectly shutdown when a task in the pipeline is cancelled. [#3319](https://github.com/hyperledger/besu/pull/3319)
 
 ## 22.1.0-RC2
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
@@ -123,9 +123,7 @@ public class PipelineChainDownloader implements ChainDownloader {
       syncState.disconnectSyncTarget(DisconnectReason.BREACH_OF_PROTOCOL);
     }
 
-    if (!cancelled.get()
-        && syncTargetManager.shouldContinueDownloading()
-        && !(ExceptionUtils.rootCause(error) instanceof CancellationException)) {
+    if (!cancelled.get() && syncTargetManager.shouldContinueDownloading()) {
       logDownloadFailure("Chain download failed. Restarting after short delay.", error);
       // Allowing the normal looping logic to retry after a brief delay.
       return scheduler.scheduleFutureTask(() -> completedFuture(null), PAUSE_AFTER_ERROR_DURATION);
@@ -138,9 +136,9 @@ public class PipelineChainDownloader implements ChainDownloader {
 
   private void logDownloadFailure(final String message, final Throwable error) {
     final Throwable rootCause = ExceptionUtils.rootCause(error);
-    if (rootCause instanceof CancellationException || rootCause instanceof InterruptedException) {
-      LOG.trace(message, error);
-    } else if (rootCause instanceof EthTaskException) {
+    if (rootCause instanceof CancellationException
+        || rootCause instanceof InterruptedException
+        || rootCause instanceof EthTaskException) {
       LOG.debug(message, error);
     } else if (rootCause instanceof InvalidBlockException) {
       LOG.warn(message, error);


### PR DESCRIPTION
There right way of halting a ChainDownloader is only via the cancel method,
no special action should be taken on a generic CancellationException, that
could be triggered by peer tasks that run in the pipeline, since in that
case the error is transient and the download should restart.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

For example this exception that is triggered by a timeout talking with a peer, causes the ChainDownloader to completely exit, while it should restart after the configured timeout.

To correctly shutdown the ChainDownloader, the method `cancel()` must be used, and it aborts the underlying pipeline, that  triggers a `CancellationException`, but the downloader exits anyway since the `cancelled.get()` now returns `true`

```
{
	"timestamp": "2022-01-23T01:04:14,278",
	"level": "DEBUG",
	"thread": "EthScheduler-Services-1410 (downloadHeaders)",
	"class": "Pipeline",
	"message": "Unhandled exception in pipeline. Aborting.",
	"throwable": "java.lang.RuntimeException: Async operation failed. java.util.concurrent.CancellationException
	at org.hyperledger.besu.services.pipeline.AsyncOperationProcessor.outputNextCompletedTask(AsyncOperationProcessor.java:86)
	at org.hyperledger.besu.services.pipeline.AsyncOperationProcessor.attemptFinalization(AsyncOperationProcessor.java:70)
	at org.hyperledger.besu.services.pipeline.ProcessingStage.run(ProcessingStage.java:43)
	at org.hyperledger.besu.services.pipeline.Pipeline.lambda$runWithErrorHandling$3(Pipeline.java:152)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.util.concurrent.ExecutionException: java.util.concurrent.CancellationException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022)
	at org.hyperledger.besu.services.pipeline.AsyncOperationProcessor.waitForAnyFutureToComplete(AsyncOperationProcessor.java:94)
	at org.hyperledger.besu.services.pipeline.AsyncOperationProcessor.outputNextCompletedTask(AsyncOperationProcessor.java:81)
	... 8 more
Caused by: java.util.concurrent.CancellationException
	at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2396)
	at org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest.abort(PendingPeerRequest.java:116)
	at org.hyperledger.besu.ethereum.eth.manager.EthPeers.abortPendingRequestsAssignedToDisconnectedPeers(EthPeers.java:108)
	at org.hyperledger.besu.ethereum.eth.manager.EthPeers.registerDisconnect(EthPeers.java:97)
	at org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager.handleDisconnect(EthProtocolManager.java:343)
	at org.hyperledger.besu.ethereum.p2p.network.NetworkRunner.lambda$setupHandlers$2(NetworkRunner.java:157)
	at org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnectionEvents.lambda$dispatchDisconnect$0(PeerConnectionEvents.java:55)
	at org.hyperledger.besu.util.Subscribers.lambda$forEach$0(Subscribers.java:112)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.hyperledger.besu.util.Subscribers.forEach(Subscribers.java:109)
	at org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnectionEvents.dispatchDisconnect(PeerConnectionEvents.java:55)
	at org.hyperledger.besu.ethereum.p2p.rlpx.connections.AbstractPeerConnection.disconnect(AbstractPeerConnection.java:159)
	at org.hyperledger.besu.ethereum.eth.manager.EthPeer.disconnect(EthPeer.java:158)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at org.hyperledger.besu.ethereum.eth.manager.EthPeer.recordRequestTimeout(EthPeer.java:149)
	at org.hyperledger.besu.ethereum.eth.manager.task.AbstractPeerRequestTask.lambda$executeTask$2(AbstractPeerRequestTask.java:78)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:859)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:837)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at org.hyperledger.besu.ethereum.eth.manager.EthScheduler.lambda$failAfterTimeout$11(EthScheduler.java:278)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	... 3 more
"
}
```


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#3300
## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).