### PR TITLE
change dependencies for trivy scan step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ commands:
             sudo apt-get update
             sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools
             sudo service haveged restart
-      - restoreGradleCache
-  restoreGradleCache:
+      - restore_gradle_cache
+  restore_gradle_cache:
     description: "Restore Gradle cache"
     steps:
       - restore_cache:
@@ -142,7 +142,7 @@ jobs:
     executor: trivy_executor
     steps:
       - checkout
-      - restoreGradleCache
+      - restore_gradle_cache
       - setup_remote_docker:
           docker_layer_caching: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ commands:
             sudo apt-get update
             sudo apt-get install -y libsodium23 libsodium-dev apt-transport-https haveged libnss3-tools
             sudo service haveged restart
+      - restoreGradleCache
+  restoreGradleCache:
+    description: "Restore Gradle cache"
+    steps:
       - restore_cache:
           name: Restore cached gradle dependencies
           keys:
@@ -138,6 +142,7 @@ jobs:
     executor: trivy_executor
     steps:
       - checkout
+      - restoreGradleCache
       - setup_remote_docker:
           docker_layer_caching: true
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 ---
 version: 2.1
 orbs:
-  slack: circleci/slack@3.4.2
   win: circleci/windows@2.2.0
 
 executors:
@@ -138,7 +137,7 @@ jobs:
   dockerScan:
     executor: trivy_executor
     steps:
-      - prepare
+      - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

small executor does not have sudo
but we don't need libSodium install in order to scan the docker image

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).