### PR TITLE
Expose RLP Index in Input Decoding

### DIFF
--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
@@ -515,6 +515,11 @@ abstract class AbstractRLPInput implements RLPInput {
   }
 
   @Override
+  public int nextOffset() {
+    return Math.toIntExact(currentPayloadOffset);
+  }
+
+  @Override
   public boolean isEndOfCurrentList() {
     return depth > 0 && currentItem >= endOfListOffset[depth - 1];
   }

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
@@ -83,6 +83,13 @@ public interface RLPInput {
   int nextSize();
 
   /**
+   * Returns the offset of the next item, counting from the start of the RLP Input as a whole.
+   *
+   * @return offset from buffer start
+   */
+  int nextOffset();
+
+  /**
    * Whether the input is at the end of a currently entered list, that is if {@link #leaveList()}
    * should be the next method called.
    *

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
@@ -448,6 +448,62 @@ public class BytesValueRLPInputTest {
   }
 
   @Test
+  public void sizeAndPosition() {
+    final RLPInput in = RLP.input(h("0xc80102c51112c22122"));
+
+    assertThat(in.nextOffset()).isEqualTo(1);
+    assertThat(in.nextSize()).isEqualTo(8);
+    assertThat(in.enterList()).isEqualTo(3);
+
+    assertThat(in.nextOffset()).isEqualTo(1);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x01);
+
+    assertThat(in.nextOffset()).isEqualTo(2);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x02);
+
+    assertThat(in.nextOffset()).isEqualTo(4);
+    assertThat(in.nextSize()).isEqualTo(5);
+    assertThat(in.enterList()).isEqualTo(3);
+
+    assertThat(in.nextOffset()).isEqualTo(4);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x11);
+
+    assertThat(in.nextOffset()).isEqualTo(5);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x12);
+
+    assertThat(in.nextOffset()).isEqualTo(7);
+    assertThat(in.nextSize()).isEqualTo(2);
+    assertThat(in.enterList()).isEqualTo(2);
+
+    assertThat(in.nextOffset()).isEqualTo(7);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x21);
+
+    assertThat(in.nextOffset()).isEqualTo(8);
+    assertThat(in.nextSize()).isEqualTo(1);
+    assertThat(in.readByte()).isEqualTo((byte) 0x22);
+
+    assertThat(in.nextOffset()).isEqualTo(9);
+    assertThat(in.nextSize()).isEqualTo(0);
+    in.leaveList();
+    assertThat(in.isDone()).isFalse();
+
+    assertThat(in.nextOffset()).isEqualTo(9);
+    assertThat(in.nextSize()).isEqualTo(0);
+    in.leaveList();
+    assertThat(in.isDone()).isFalse();
+
+    assertThat(in.nextOffset()).isEqualTo(9);
+    assertThat(in.nextSize()).isEqualTo(0);
+    in.leaveList();
+    assertThat(in.isDone()).isTrue();
+  }
+
+  @Test
   public void ignoreListTail() {
     final RLPInput in = RLP.input(h("0xc80102c51112c22122"));
     assertThat(in.enterList()).isEqualTo(3);

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
@@ -199,7 +199,7 @@ public class BytesValueRLPInputTest {
   public void emptyList() {
     final RLPInput in = RLP.input(h("0xc0"));
     assertThat(in.isDone()).isFalse();
-    assertThat(in.enterList()).isEqualTo(0);
+    assertThat(in.enterList()).isZero();
     assertThat(in.isDone()).isFalse();
     in.leaveList();
     assertThat(in.isDone()).isTrue();
@@ -377,9 +377,9 @@ public class BytesValueRLPInputTest {
     final RLPInput el = RLP.input(emptyList);
     assertThat(el.readAsRlp().raw()).isEqualTo(emptyList);
     el.reset();
-    assertThat(el.readAsRlp().enterList()).isEqualTo(0);
+    assertThat(el.readAsRlp().enterList()).isZero();
     el.reset();
-    assertThat(el.enterList()).isEqualTo(0);
+    assertThat(el.enterList()).isZero();
 
     final Bytes nestedList =
         RLP.encode(
@@ -451,56 +451,49 @@ public class BytesValueRLPInputTest {
   public void sizeAndPosition() {
     final RLPInput in = RLP.input(h("0xc80102c51112c22122"));
 
-    assertThat(in.nextOffset()).isEqualTo(1);
-    assertThat(in.nextSize()).isEqualTo(8);
+    assertOffsetAndSize(in, 1, 8);
     assertThat(in.enterList()).isEqualTo(3);
 
-    assertThat(in.nextOffset()).isEqualTo(1);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 1, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x01);
 
-    assertThat(in.nextOffset()).isEqualTo(2);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 2, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x02);
 
-    assertThat(in.nextOffset()).isEqualTo(4);
-    assertThat(in.nextSize()).isEqualTo(5);
+    assertOffsetAndSize(in, 4, 5);
     assertThat(in.enterList()).isEqualTo(3);
 
-    assertThat(in.nextOffset()).isEqualTo(4);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 4, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x11);
 
-    assertThat(in.nextOffset()).isEqualTo(5);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 5, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x12);
 
-    assertThat(in.nextOffset()).isEqualTo(7);
-    assertThat(in.nextSize()).isEqualTo(2);
+    assertOffsetAndSize(in, 7, 2);
     assertThat(in.enterList()).isEqualTo(2);
 
-    assertThat(in.nextOffset()).isEqualTo(7);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 7, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x21);
 
-    assertThat(in.nextOffset()).isEqualTo(8);
-    assertThat(in.nextSize()).isEqualTo(1);
+    assertOffsetAndSize(in, 8, 1);
     assertThat(in.readByte()).isEqualTo((byte) 0x22);
 
-    assertThat(in.nextOffset()).isEqualTo(9);
-    assertThat(in.nextSize()).isEqualTo(0);
+    assertOffsetAndSize(in, 9, 0);
     in.leaveList();
     assertThat(in.isDone()).isFalse();
 
-    assertThat(in.nextOffset()).isEqualTo(9);
-    assertThat(in.nextSize()).isEqualTo(0);
+    assertOffsetAndSize(in, 9, 0);
     in.leaveList();
     assertThat(in.isDone()).isFalse();
 
-    assertThat(in.nextOffset()).isEqualTo(9);
-    assertThat(in.nextSize()).isEqualTo(0);
+    assertOffsetAndSize(in, 9, 0);
     in.leaveList();
     assertThat(in.isDone()).isTrue();
+  }
+
+  private void assertOffsetAndSize(RLPInput in, int offset, int size) {
+    assertThat(in.nextOffset()).isEqualTo(offset);
+    assertThat(in.nextSize()).isEqualTo(size);
   }
 
   @Test

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
@@ -491,7 +491,7 @@ public class BytesValueRLPInputTest {
     assertThat(in.isDone()).isTrue();
   }
 
-  private void assertOffsetAndSize(RLPInput in, int offset, int size) {
+  private void assertOffsetAndSize(final RLPInput in, final int offset, final int size) {
     assertThat(in.nextOffset()).isEqualTo(offset);
     assertThat(in.nextSize()).isEqualTo(size);
   }


### PR DESCRIPTION
## PR description

Expose the RLP index when decoding RLP input.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).