### PR TITLE
Add Ryan Jones as non-code maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,18 +8,18 @@
 | ---------------- | ---------------- | ---------------- |
 | Abdel Bakhta     | abdelhamidbakhta | abdelhamidbakhta |
 | Adrian Sutton    | ajsutton         | ajsutton         |
-| Antoine Toulme   | atoulme          | atoulme          |
 | Antony Denyer    | antonydenyer     | antonydenyer     |
+| Antoine Toulme   | atoulme          | atoulme          |
 | Byron Gravenorst | bgravenorst      | bgravenorst      |
 | Daniel Lehrner   | daniellehrner    | daniellehrner    |
 | Diego López León | diega            | diega            |
 | Fabio Di Fabio   | fab-10           | fab-10           |
 | Frank Li         | frankisawesome   | frankliawesome   |
 | Gary Schulte     | garyschulte      | GarySchulte      | 
-| Jason Frame      | jframe           | jframe           |
 | Jiri Peinlich    | gezero           | JiriPeinlich     |
-| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Justin Florentine| jflo             | RoboCopsGoneMad  |
+| Jason Frame      | jframe           | jframe           |
+| Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Lucas Saldanha   | lucassaldanha    | lucassaldanha    |
 | Sally MacFarlane | macfarla         | macfarla         |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
@@ -27,12 +27,12 @@
 | Karim Taam       | matkt            | matkt            |
 | Meredith Baxter  | mbaxter          | mbaxter          |
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
+| Stefan Pingel    | pinges           | pinges           |
+| Rai Sur          | RatanRSur        | ratanraisur      |
 | Sajida Zouarhi   | sajz             | SajidaZ          |
 | Simon Dudley     | siladu           | siladu           |
-| Stefan Pingel    | pinges           | pinges           |
-| Taccat Isid      | taccatisid       | taccatisid       |
-| Rai Sur          | RatanRSur        | ratanraisur      |
 | Danno Ferrin     | shemnon          | shemnon          |
+| Taccat Isid      | taccatisid       | taccatisid       |
 | Usman Saleem     | usmansaleem      | usmansaleem      |
 | Vijay Michalik   | vmichalik        | VijayMichalik    |
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,6 +29,7 @@
 | Nicolas Massart  | NicolasMassart   | NicolasMassart   |
 | Stefan Pingel    | pinges           | pinges           |
 | Rai Sur          | RatanRSur        | ratanraisur      |
+| Ryan Jones       | ryanjjones10     | ryanjjones10     |
 | Sajida Zouarhi   | sajz             | SajidaZ          |
 | Simon Dudley     | siladu           | siladu           |
 | Danno Ferrin     | shemnon          | shemnon          |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -31,8 +31,8 @@
 | Rai Sur          | RatanRSur        | ratanraisur      |
 | Ryan Jones       | ryanjjones10     | ryanjjones10     |
 | Sajida Zouarhi   | sajz             | SajidaZ          |
-| Simon Dudley     | siladu           | siladu           |
 | Danno Ferrin     | shemnon          | shemnon          |
+| Simon Dudley     | siladu           | siladu           |
 | Taccat Isid      | taccatisid       | taccatisid       |
 | Usman Saleem     | usmansaleem      | usmansaleem      |
 | Vijay Michalik   | vmichalik        | VijayMichalik    |


### PR DESCRIPTION
## Proposal

I propose to add @ryanjjones10 as a Besu non-code maintainer.

@ryanjjones10 has contributed with roadmap planning and categorizing bugs and issues for Besu. Becoming a non-code maintainer, Ryan will be able to label bugs and close relevant tickets, helping to keep the project tidy.

Voting ends two weeks from today.

For more information on this process see the Becoming a Maintainer section in the MAINTAINERS.md file.

## Other changes

I have also taken this opportunity to fix the ordering in the maintainers list. It is supposed to be alphabetical on the Github handle, not the name.