### PR TITLE
Response streaming: stop on IO error and remove queue management

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
@@ -16,10 +16,11 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.net.SocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,12 +29,20 @@ class JsonResponseStreamer extends OutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(JsonResponseStreamer.class);
 
   private final HttpServerResponse response;
-  private final Semaphore paused = new Semaphore(0);
+  private final SocketAddress remoteAddress;
   private final byte[] singleByteBuf = new byte[1];
   private boolean chunked = false;
+  private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
-  public JsonResponseStreamer(final HttpServerResponse response) {
+  public JsonResponseStreamer(
+      final HttpServerResponse response, final SocketAddress socketAddress) {
     this.response = response;
+    this.remoteAddress = socketAddress;
+    this.response.exceptionHandler(
+        event -> {
+          LOG.debug("Write to remote address {} failed", remoteAddress, event);
+          failure.set(event);
+        });
   }
 
   @Override
@@ -44,31 +53,33 @@ class JsonResponseStreamer extends OutputStream {
 
   @Override
   public void write(final byte[] bbuf, final int off, final int len) throws IOException {
+    stopOnFailure();
+
     if (!chunked) {
       response.setChunked(true);
       chunked = true;
     }
 
-    if (response.writeQueueFull()) {
-      LOG.debug("HttpResponse write queue is full pausing streaming");
-      response.drainHandler(e -> paused.release());
-      try {
-        paused.acquire();
-        LOG.debug("HttpResponse write queue is not accepting more data, resuming streaming");
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        throw new IOException(
-            "Interrupted while waiting for HttpServerResponse to drain the write queue", ex);
-      }
-    }
-
     Buffer buf = Buffer.buffer(len);
     buf.appendBytes(bbuf, off, len);
-    response.write(buf);
+    response.write(buf).onFailure(this::handleFailure);
   }
 
   @Override
   public void close() throws IOException {
     response.end();
+  }
+
+  private void stopOnFailure() throws IOException {
+    Throwable t = failure.get();
+    if (t != null) {
+      LOG.debug("Stop writing to remote address {} due to a failure", remoteAddress, t);
+      throw (t instanceof IOException) ? (IOException) t : new IOException(t);
+    }
+  }
+
+  private void handleFailure(final Throwable t) {
+    LOG.debug("Write to remote address {} failed", remoteAddress, t);
+    failure.set(t);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -626,7 +626,9 @@ public class JsonRpcHttpService {
               response.end(EMPTY_RESPONSE);
             } else {
               try {
-                JSON_OBJECT_WRITER.writeValue(new JsonResponseStreamer(response), jsonRpcResponse);
+                JSON_OBJECT_WRITER.writeValue(
+                    new JsonResponseStreamer(response, routingContext.request().remoteAddress()),
+                    jsonRpcResponse);
               } catch (IOException ex) {
                 LOG.error("Error streaming JSON-RPC response", ex);
               }
@@ -695,7 +697,9 @@ public class JsonRpcHttpService {
                       .toArray(JsonRpcResponse[]::new);
 
               try {
-                JSON_OBJECT_WRITER.writeValue(new JsonResponseStreamer(response), completed);
+                JSON_OBJECT_WRITER.writeValue(
+                    new JsonResponseStreamer(response, routingContext.request().remoteAddress()),
+                    completed);
               } catch (IOException ex) {
                 LOG.error("Error streaming JSON-RPC response", ex);
               }


### PR DESCRIPTION
Queue management is removed, since it is not working at the moment,
and can cause deadlock, will be reimplemented later if needed.
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3381
## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).