### PR TITLE
Handle null forkId gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 - Prevent node from peering to itself [#3342](https://github.com/hyperledger/besu/pull/3342)
-
+- Handle legacy eth64 without throwing null pointer exceptions [#3343](https://github.com/hyperledger/besu/pull/3343)
 
 ## 22.1.0-RC3
 - Changing the order in which we traverse the word state tree during fast sync. This should improve fast sync during subsequent pivot changes.

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -394,7 +394,9 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   }
 
   public List<Bytes> getForkIdAsBytesList() {
-    ForkId chainHeadForkId = forkIdManager.getForkIdForChainHead(); 
-    return chainHeadForkId == null ? Collections.emptyList() : chainHeadForkId.getForkIdAsBytesList();
+    ForkId chainHeadForkId = forkIdManager.getForkIdForChainHead();
+    return chainHeadForkId == null
+        ? Collections.emptyList()
+        : chainHeadForkId.getForkIdAsBytesList();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -394,6 +394,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   }
 
   public List<Bytes> getForkIdAsBytesList() {
-    return forkIdManager.getForkIdForChainHead().getForkIdAsBytesList();
+    ForkId chainHeadForkId = forkIdManager.getForkIdForChainHead(); 
+    return chainHeadForkId == null ? Collections.emptyList() : chainHeadForkId.getForkIdAsBytesList();
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -1038,4 +1038,20 @@ public final class EthProtocolManagerTest {
       verify(transactions).execute(any());
     }
   }
+  
+  @Test 
+  public void forkIdForChainHeadMayBeNull() {
+    EthScheduler ethScheduler = mock(EthScheduler.class);
+    try (final EthProtocolManager ethManager =
+             EthProtocolManagerTestUtil.create(
+                 blockchain,
+                 ethScheduler,
+                 protocolContext.getWorldStateArchive(),
+                 transactionPool,
+                 EthProtocolConfiguration.defaultConfig(),
+                 new ForkIdManager(blockchain, Collections.emptyList(), true))) {
+      
+      ethManager.getForkIdAsBytesList();
+    }
+  }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -1038,19 +1038,19 @@ public final class EthProtocolManagerTest {
       verify(transactions).execute(any());
     }
   }
-  
-  @Test 
+
+  @Test
   public void forkIdForChainHeadMayBeNull() {
     EthScheduler ethScheduler = mock(EthScheduler.class);
     try (final EthProtocolManager ethManager =
-             EthProtocolManagerTestUtil.create(
-                 blockchain,
-                 ethScheduler,
-                 protocolContext.getWorldStateArchive(),
-                 transactionPool,
-                 EthProtocolConfiguration.defaultConfig(),
-                 new ForkIdManager(blockchain, Collections.emptyList(), true))) {
-      
+        EthProtocolManagerTestUtil.create(
+            blockchain,
+            ethScheduler,
+            protocolContext.getWorldStateArchive(),
+            transactionPool,
+            EthProtocolConfiguration.defaultConfig(),
+            new ForkIdManager(blockchain, Collections.emptyList(), true))) {
+
       ethManager.getForkIdAsBytesList();
     }
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
@@ -67,6 +67,29 @@ public class EthProtocolManagerTestUtil {
       final EthPeers ethPeers,
       final EthMessages ethMessages,
       final EthContext ethContext) {
+    return create(
+        blockchain,
+        ethScheduler,
+        worldStateArchive,
+        transactionPool,
+        ethereumWireProtocolConfiguration,
+        ethPeers,
+        ethMessages,
+        ethContext,
+        new ForkIdManager(blockchain, Collections.emptyList(), false));
+    }
+
+  public static EthProtocolManager create(
+      final Blockchain blockchain,
+      final EthScheduler ethScheduler,
+      final WorldStateArchive worldStateArchive,
+      final TransactionPool transactionPool,
+      final EthProtocolConfiguration ethereumWireProtocolConfiguration,
+      final EthPeers ethPeers,
+      final EthMessages ethMessages,
+      final EthContext ethContext, 
+      final ForkIdManager forkIdManager) {
+    
     final BigInteger networkId = BigInteger.ONE;
     return new EthProtocolManager(
         blockchain,
@@ -80,7 +103,7 @@ public class EthProtocolManagerTestUtil {
         Collections.emptyList(),
         false,
         ethScheduler,
-        new ForkIdManager(blockchain, Collections.emptyList(), false));
+        forkIdManager);
   }
 
   public static EthProtocolManager create(final Blockchain blockchain) {
@@ -126,6 +149,28 @@ public class EthProtocolManagerTestUtil {
         peers,
         messages,
         new EthContext(peers, messages, ethScheduler));
+  }
+
+  public static EthProtocolManager create(
+      final Blockchain blockchain,
+      final EthScheduler ethScheduler,
+      final WorldStateArchive worldStateArchive,
+      final TransactionPool transactionPool,
+      final EthProtocolConfiguration configuration,
+      final ForkIdManager forkIdManager) {
+    EthPeers peers = new EthPeers(EthProtocol.NAME, TestClock.fixed(), new NoOpMetricsSystem());
+    EthMessages messages = new EthMessages();
+
+    return create(
+        blockchain,
+        ethScheduler,
+        worldStateArchive,
+        transactionPool,
+        configuration,
+        peers,
+        messages,
+        new EthContext(peers, messages, ethScheduler),
+        forkIdManager);
   }
 
   public static EthProtocolManager create(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
@@ -77,7 +77,7 @@ public class EthProtocolManagerTestUtil {
         ethMessages,
         ethContext,
         new ForkIdManager(blockchain, Collections.emptyList(), false));
-    }
+  }
 
   public static EthProtocolManager create(
       final Blockchain blockchain,
@@ -87,9 +87,9 @@ public class EthProtocolManagerTestUtil {
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
       final EthMessages ethMessages,
-      final EthContext ethContext, 
+      final EthContext ethContext,
       final ForkIdManager forkIdManager) {
-    
+
     final BigInteger networkId = BigInteger.ONE;
     return new EthProtocolManager(
         blockchain,


### PR DESCRIPTION


## PR description

When asking for the forkId for the chain head sometimes we may return
null. In those cases return an empty list.

## Fixed Issue(s)

Fixes #3343

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).