### PR TITLE
Extend validateAndProcessBlock to return an error message in case of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `--ec-curve` parameter to export/export-address public-key subcommands [#3333](https://github.com/hyperledger/besu/pull/3333)
 - Merge: extend block creation and mining to support The Merge [#3412](https://github.com/hyperledger/besu/pull/3412)
 - Merge: backward sync [#3410](https://github.com/hyperledger/besu/pull/3410)
+- Merge: Extend validateAndProcessBlock to return an error message in case of failure, so it can be returned to the caller of ExecutePayload API [#3411](https://github.com/hyperledger/besu/pull/3411)
 
 ### Bug Fixes
 - Prevent node from peering to itself [#3342](https://github.com/hyperledger/besu/pull/3342)

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidator.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidator.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.consensus.ibft.messagewrappers.Prepare;
 import org.hyperledger.besu.consensus.ibft.messagewrappers.Proposal;
 import org.hyperledger.besu.consensus.ibft.payload.RoundChangeCertificate;
 import org.hyperledger.besu.ethereum.BlockValidator;
-import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
@@ -78,12 +77,14 @@ public class MessageValidator {
   }
 
   private boolean validateBlock(final Block block) {
-    final Optional<BlockProcessingOutputs> validationResult =
+    final var validationResult =
         blockValidator.validateAndProcessBlock(
             protocolContext, block, HeaderValidationMode.LIGHT, HeaderValidationMode.FULL);
 
-    if (!validationResult.isPresent()) {
-      LOG.info("Invalid Proposal message, block did not pass validation.");
+    if (validationResult.blockProcessingOutputs.isEmpty()) {
+      LOG.info(
+          "Invalid Proposal message, block did not pass validation. Reason {}",
+          validationResult.errorMessage);
       return false;
     }
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/RoundChangeManagerTest.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Util;
 
@@ -78,7 +79,7 @@ public class RoundChangeManagerTest {
 
     final BlockValidator blockValidator = mock(BlockValidator.class);
     when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     final RoundChangePayloadValidator.MessageValidatorForHeightFactory messageValidatorFactory =
         mock(RoundChangePayloadValidator.MessageValidatorForHeightFactory.class);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/validation/MessageValidatorTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
@@ -98,7 +99,7 @@ public class MessageValidatorTest {
             mock(MutableBlockchain.class), mock(WorldStateArchive.class), mockBftCtx);
 
     when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     when(roundChangeCertificateValidator.validateProposalMessageMatchesLatestPrepareCertificate(
             any(), any()))
@@ -153,7 +154,7 @@ public class MessageValidatorTest {
   @Test
   public void blockValidationFailureFailsValidation() {
     when(blockValidator.validateAndProcessBlock(any(), any(), any(), any()))
-        .thenReturn(Optional.empty());
+        .thenReturn(new Result("Failed"));
 
     final Proposal proposalMsg =
         messageFactory.createProposal(roundIdentifier, block, Optional.empty());

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.consensus.merge.blockcreation;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -31,7 +32,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final Bytes32 random,
       final Address feeRecipient);
 
-  boolean executeBlock(final Block block);
+  Result executeBlock(final Block block);
 
   void updateForkChoice(final Hash headBlockHash, final Hash finalizedBlockHash);
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ProposalPayloadValidator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/ProposalPayloadValidator.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.consensus.qbft.pki.PkiQbftExtraDataCodec;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.BlockValidator;
-import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
@@ -119,12 +118,15 @@ public class ProposalPayloadValidator {
   }
 
   private boolean validateBlock(final Block block) {
-    final Optional<BlockProcessingOutputs> validationResult =
+    final var validationResult =
         blockValidator.validateAndProcessBlock(
             protocolContext, block, HeaderValidationMode.LIGHT, HeaderValidationMode.FULL);
 
-    if (validationResult.isEmpty()) {
-      LOG.info("{}: block did not pass validation.", ERROR_PREFIX);
+    if (validationResult.blockProcessingOutputs.isEmpty()) {
+      LOG.info(
+          "{}: block did not pass validation. Reason {}",
+          ERROR_PREFIX,
+          validationResult.errorMessage);
       return false;
     }
 

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangeMessageValidator.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangeMessageValidator.java
@@ -24,14 +24,12 @@ import org.hyperledger.besu.consensus.qbft.payload.PreparePayload;
 import org.hyperledger.besu.consensus.qbft.payload.PreparedRoundMetadata;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.BlockValidator;
-import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,12 +77,15 @@ public class RoundChangeMessageValidator {
   }
 
   private boolean validateBlock(final Block block) {
-    final Optional<BlockProcessingOutputs> validationResult =
+    final var validationResult =
         blockValidator.validateAndProcessBlock(
             protocolContext, block, HeaderValidationMode.LIGHT, HeaderValidationMode.FULL);
 
-    if (validationResult.isEmpty()) {
-      LOG.info("{}: block did not pass validation.", ERROR_PREFIX);
+    if (validationResult.blockProcessingOutputs.isEmpty()) {
+      LOG.info(
+          "{}: block did not pass validation. Reason {}",
+          ERROR_PREFIX,
+          validationResult.errorMessage);
       return false;
     }
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/ProposalPayloadValidatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/ProposalPayloadValidatorTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -104,7 +105,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isTrue();
   }
@@ -128,7 +129,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isTrue();
   }
@@ -151,7 +152,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.empty());
+        .thenReturn(new Result("Failed"));
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isFalse();
   }
@@ -227,7 +228,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isFalse();
   }
@@ -261,7 +262,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(cmsValidator.validate(eq(cms), eq(hashWithoutCms))).thenReturn(false);
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isFalse();
@@ -296,7 +297,7 @@ public class ProposalPayloadValidatorTest {
             eq(block),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(cmsValidator.validate(eq(cms), eq(hashWithoutCms))).thenReturn(true);
 
     assertThat(payloadValidator.validate(proposal.getSignedPayload())).isTrue();

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/ProposalValidatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/ProposalValidatorTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.consensus.qbft.payload.RoundChangePayload;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -105,7 +106,7 @@ public class ProposalValidatorTest {
             any(),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
 
     roundItems.put(ROUND_ID.ZERO, createRoundSpecificItems(0));
     roundItems.put(ROUND_ID.ONE, createRoundSpecificItems(1));
@@ -157,7 +158,7 @@ public class ProposalValidatorTest {
             any(),
             eq(HeaderValidationMode.LIGHT),
             eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.empty());
+        .thenReturn(new Result("Failed"));
 
     assertThat(roundItem.messageValidator.validate(proposal)).isFalse();
   }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangeMessageValidatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validation/RoundChangeMessageValidatorTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -107,7 +108,7 @@ public class RoundChangeMessageValidatorTest {
   public void roundChangeWithValidPiggyBackDataIsValid() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -134,7 +135,7 @@ public class RoundChangeMessageValidatorTest {
   public void roundChangeWithBlockRoundMismatchingPreparesIsValid() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -163,7 +164,7 @@ public class RoundChangeMessageValidatorTest {
   public void blockIsInvalidFailsValidation() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.empty());
+        .thenReturn(new Result("Failed"));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -206,7 +207,7 @@ public class RoundChangeMessageValidatorTest {
   public void insufficientPiggyBackedPrepareMessagesIsInvalid() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -233,7 +234,7 @@ public class RoundChangeMessageValidatorTest {
   public void prepareFromNonValidatorFails() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -262,7 +263,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfPreparedMetadataContainsDifferentRoundToBlock() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -297,7 +298,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfPreparesContainsDifferentRoundToBlock() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -334,7 +335,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfPreparesContainsWrongHeight() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -371,7 +372,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfPreparesHaveDuplicateAuthors() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -403,7 +404,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfBlockExistsButNotPreparedMetadata() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(
@@ -431,7 +432,7 @@ public class RoundChangeMessageValidatorTest {
   public void validationFailsIfBlockHashDoesNotMatchPreparedMetadata() {
     when(blockValidator.validateAndProcessBlock(
             any(), any(), eq(HeaderValidationMode.LIGHT), eq(HeaderValidationMode.FULL)))
-        .thenReturn(Optional.of(new BlockProcessingOutputs(null, null)));
+        .thenReturn(new Result(new BlockProcessingOutputs(null, null)));
     when(payloadValidator.validate(any())).thenReturn(true);
     messageValidator =
         new RoundChangeMessageValidator(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExecutePayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExecutePayload.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -128,29 +129,36 @@ public class EngineExecutePayload extends ExecutionEngineJsonRpcMethod {
               "Computed block hash %s does not match block hash parameter %s",
               newBlockHeader.getBlockHash(), blockParam.getBlockHash());
     } else {
-      // do we already have this payload
+      // do we already have this payload?
       if (protocolContext
           .getBlockchain()
           .getBlockByHash(newBlockHeader.getBlockHash())
           .isPresent()) {
-        LOG.debug("block already present");
+        LOG.debug("block {} already present", newBlockHeader.getBlockHash());
         return respondWith(reqId, blockParam.getBlockHash(), VALID, null);
       }
     }
 
-    final var block =
-        new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
     final var latestValidAncestor = mergeCoordinator.getLatestValidAncestor(newBlockHeader);
 
     if (latestValidAncestor.isEmpty()) {
       return respondWith(reqId, null, SYNCING, null);
     }
 
-    // execute block and return result response
-    if (errorMessage == null && mergeCoordinator.executeBlock(block)) {
-      return respondWith(reqId, newBlockHeader.getHash(), VALID, errorMessage);
-    } else {
+    if (errorMessage != null) {
       return respondWith(reqId, latestValidAncestor.get(), INVALID, errorMessage);
+    }
+
+    final var block =
+        new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
+
+    // execute block and return result response
+    Result result = mergeCoordinator.executeBlock(block);
+    if (result.errorMessage.isEmpty()) {
+      return respondWith(reqId, newBlockHeader.getHash(), VALID, null);
+    } else {
+      return respondWith(
+          reqId, latestValidAncestor.get(), INVALID, result.errorMessage.orElse("Unknown reason"));
     }
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExecutePayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExecutePayloadTest.java
@@ -27,6 +27,8 @@ import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.BlockValidator.BlockProcessingOutputs;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
@@ -91,7 +93,8 @@ public class EngineExecutePayloadTest {
     when(blockchain.getBlockByHash(any())).thenReturn(Optional.empty());
     when(mergeCoordinator.getLatestValidAncestor(any(BlockHeader.class)))
         .thenReturn(Optional.of(mockHash));
-    when(mergeCoordinator.executeBlock(any())).thenReturn(Boolean.TRUE);
+    when(mergeCoordinator.executeBlock(any()))
+        .thenReturn(new Result(new BlockProcessingOutputs(null, List.of())));
 
     var resp = resp(mockPayload(mockHeader, Collections.emptyList()));
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
@@ -24,6 +24,21 @@ import java.util.Optional;
 
 public interface BlockValidator {
 
+  class Result {
+    public final Optional<BlockProcessingOutputs> blockProcessingOutputs;
+    public final Optional<String> errorMessage;
+
+    public Result(final BlockProcessingOutputs blockProcessingOutputs) {
+      this.blockProcessingOutputs = Optional.of(blockProcessingOutputs);
+      this.errorMessage = Optional.empty();
+    }
+
+    public Result(final String errorMessage) {
+      this.blockProcessingOutputs = Optional.empty();
+      this.errorMessage = Optional.of(errorMessage);
+    }
+  }
+
   class BlockProcessingOutputs {
     public final MutableWorldState worldState;
     public final List<TransactionReceipt> receipts;
@@ -35,7 +50,7 @@ public interface BlockValidator {
     }
   }
 
-  Optional<BlockProcessingOutputs> validateAndProcessBlock(
+  Result validateAndProcessBlock(
       final ProtocolContext context,
       final Block block,
       final HeaderValidationMode headerValidationMode,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/goquorum/GoQuorumBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/goquorum/GoQuorumBlockValidator.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.mainnet.BlockBodyValidator;
 import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.BlockProcessor;
-import org.hyperledger.besu.ethereum.mainnet.BlockProcessor.Result;
 
 import java.util.Optional;
 
@@ -50,7 +49,7 @@ public class GoQuorumBlockValidator extends MainnetBlockValidator {
   }
 
   @Override
-  protected Result processBlock(
+  protected BlockProcessor.Result processBlock(
       final ProtocolContext context, final MutableWorldState worldState, final Block block) {
     final MutableWorldState privateWorldState =
         getPrivateWorldState(goQuorumPrivacyParameters, worldState.rootHash(), block.getHash());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockImporter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockImporter.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 
 import java.util.List;
-import java.util.Optional;
 
 public class MainnetBlockImporter implements BlockImporter {
 
@@ -41,15 +40,15 @@ public class MainnetBlockImporter implements BlockImporter {
       return true;
     }
 
-    final Optional<BlockValidator.BlockProcessingOutputs> outputs =
+    final var result =
         blockValidator.validateAndProcessBlock(
             context, block, headerValidationMode, ommerValidationMode);
 
-    outputs.ifPresent(
+    result.blockProcessingOutputs.ifPresent(
         processingOutputs ->
             context.getBlockchain().appendBlock(block, processingOutputs.receipts));
 
-    return outputs.isPresent();
+    return result.blockProcessingOutputs.isPresent();
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
@@ -110,7 +110,7 @@ public class ForwardSyncStep extends BackwardSyncTask {
                 HeaderValidationMode.FULL,
                 HeaderValidationMode.NONE);
 
-    optResult.ifPresent(
+    optResult.blockProcessingOutputs.ifPresent(
         result -> {
           debugLambda(
               LOG,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncContextTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.BlockValidator;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -41,7 +42,6 @@ import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.NotNull;
@@ -111,7 +111,7 @@ public class BackwardsSyncContextTest {
             invocation -> {
               final Object[] arguments = invocation.getArguments();
               Block block = (Block) arguments[1];
-              return Optional.of(
+              return new Result(
                   new BlockValidator.BlockProcessingOutputs(
                       new ReferenceTestWorldState(), blockDataGenerator.receipts(block)));
             });

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStepTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.config.StubGenesisConfigOptions;
 import org.hyperledger.besu.ethereum.BlockValidator;
+import org.hyperledger.besu.ethereum.BlockValidator.Result;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
@@ -102,7 +103,7 @@ public class ForwardSyncStepTest {
             invocation -> {
               final Object[] arguments = invocation.getArguments();
               Block block = (Block) arguments[1];
-              return Optional.of(
+              return new Result(
                   new BlockValidator.BlockProcessingOutputs(
                       new ReferenceTestWorldState(), blockDataGenerator.receipts(block)));
             });


### PR DESCRIPTION
…failure

This message can then be used to send a more detailed response to the RPC
caller of ExecutePayload API.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
https://github.com/hyperledger/besu/issues/3145

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).