### PR TITLE
Change chat pointers

### DIFF
--- a/DCO.md
+++ b/DCO.md
@@ -5,4 +5,4 @@ As per section 13.a of the [Hyperledger Charter](https://www.hyperledger.org/abo
 
 The sign off needs to be using your legal name, not a pseudonym.  Git has a built-in mechanism to allow this with the `-s` or `--signoff` argument to `git commit` command, providing your `user.name` and `user.email` have been setup correctly.
 
-If you have any questions, you can reach us on [Besu chat](https://chat.hyperledger.org/channel/besu).
+If you have any questions, you can reach us on Besu chat; first, [join the Discord server](https://discord.gg/hyperledger/) then [join the Besu channel](https://discord.com/channels/905194001349627914/938504958909747250).


### PR DESCRIPTION
Hyperledger has moved to Discord.

Signed-off-by: Ry Jones <ry@linux.com>

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).