### PR TITLE
MERGE: engine_exchangeTransitionConfigurationV1 API

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -243,7 +243,7 @@ public class JsonRpcHttpService {
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
     try {
       // Create the HTTP server and a router object.
-      httpServer = vertx.createHttpServer(getHttpServerOptions().setCompressionSupported(false));
+      httpServer = vertx.createHttpServer(getHttpServerOptions());
 
       httpServer.connectionHandler(connectionHandler());
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -243,7 +243,7 @@ public class JsonRpcHttpService {
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
     try {
       // Create the HTTP server and a router object.
-      httpServer = vertx.createHttpServer(getHttpServerOptions());
+      httpServer = vertx.createHttpServer(getHttpServerOptions().setCompressionSupported(false));
 
       httpServer.connectionHandler(connectionHandler());
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -48,6 +48,7 @@ public enum RpcMethod {
   ENGINE_EXECUTE_PAYLOAD("engine_executePayloadV1"),
   ENGINE_NEW_PAYLOAD("engine_newPayloadV1"),
   ENGINE_FORKCHOICE_UPDATED("engine_forkchoiceUpdatedV1"),
+  ENGINE_EXCHANGE_TRANSITION_CONFIGURATION("engine_exchangeTransitionConfigurationV1"),
 
   GOQUORUM_ETH_GET_QUORUM_PAYLOAD("eth_getQuorumPayload"),
   GOQUORUM_STORE_RAW("goquorum_storeRaw"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -14,10 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INTERNAL_ERROR;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INVALID_PARAMS;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
 
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -69,15 +69,11 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
 
     final Optional<BlockHeader> maybeTerminalPoWBlockHeader = mergeContext.getTerminalPoWBlock();
 
-    if (maybeTerminalPoWBlockHeader.isEmpty()) {
-      return respondWithError(reqId, INTERNAL_ERROR);
-    }
-
     final EngineExchangeTransitionConfigurationResult localTransitionConfiguration =
         new EngineExchangeTransitionConfigurationResult(
             mergeContext.getTerminalTotalDifficulty(),
-            maybeTerminalPoWBlockHeader.get().getHash(),
-            maybeTerminalPoWBlockHeader.get().getNumber());
+            maybeTerminalPoWBlockHeader.map(BlockHeader::getHash).orElse(Hash.ZERO),
+            maybeTerminalPoWBlockHeader.map(BlockHeader::getNumber).orElse(0L));
 
     if (!localTransitionConfiguration
         .getTerminalTotalDifficulty()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INTERNAL_ERROR;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError.INVALID_PARAMS;
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchangeTransitionConfigurationResult;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRpcMethod {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(EngineExchangeTransitionConfiguration.class);
+
+  public EngineExchangeTransitionConfiguration(
+      final Vertx vertx, final ProtocolContext protocolContext) {
+    super(vertx, protocolContext);
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ENGINE_EXCHANGE_TRANSITION_CONFIGURATION.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
+    final EngineExchangeTransitionConfigurationParameter remoteTransitionConfiguration =
+        requestContext.getRequiredParameter(
+            0, EngineExchangeTransitionConfigurationParameter.class);
+    final Object reqId = requestContext.getRequest().getId();
+
+    traceLambda(
+        LOG,
+        "received transitionConfiguration: {}",
+        () -> Json.encodePrettily(remoteTransitionConfiguration));
+
+    if (remoteTransitionConfiguration.getTerminalBlockNumber() != 0) {
+      return respondWithError(reqId, INVALID_PARAMS);
+    }
+
+    final Optional<BlockHeader> maybeFinalizedBlockHeader = mergeContext.getFinalized();
+
+    if (maybeFinalizedBlockHeader.isEmpty()) {
+      return respondWithError(reqId, INTERNAL_ERROR);
+    }
+
+    final EngineExchangeTransitionConfigurationResult localTransitionConfiguration =
+        new EngineExchangeTransitionConfigurationResult(
+            mergeContext.getTerminalTotalDifficulty(),
+            maybeFinalizedBlockHeader.get().getHash(),
+            maybeFinalizedBlockHeader.get().getNumber());
+
+    if (!localTransitionConfiguration
+        .getTerminalTotalDifficulty()
+        .equals(remoteTransitionConfiguration.getTerminalTotalDifficulty())) {
+      LOG.warn(
+          "Configured terminal total difficulty {} does not match value of consensus client {}",
+          localTransitionConfiguration.getTerminalTotalDifficulty().toInt(),
+          remoteTransitionConfiguration.getTerminalTotalDifficulty().toInt());
+    }
+
+    if (!localTransitionConfiguration
+        .getTerminalBlockHash()
+        .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
+      LOG.warn(
+          "Configured terminal block hash {} does not match value of consensus client {}",
+          localTransitionConfiguration.getTerminalBlockHash().toHexString(),
+          remoteTransitionConfiguration.getTerminalBlockHash().toHexString());
+    }
+
+    if (localTransitionConfiguration.getTerminalBlockNumber()
+        != remoteTransitionConfiguration.getTerminalBlockNumber()) {
+      LOG.warn(
+          "Configured terminal block number {} does not match value of consensus client {}",
+          localTransitionConfiguration.getTerminalBlockNumber(),
+          remoteTransitionConfiguration.getTerminalBlockNumber());
+    }
+
+    return respondWith(reqId, localTransitionConfiguration);
+  }
+
+  private JsonRpcResponse respondWith(
+      final Object requestId,
+      final EngineExchangeTransitionConfigurationResult transitionConfiguration) {
+    return new JsonRpcSuccessResponse(requestId, transitionConfiguration);
+  }
+
+  private JsonRpcResponse respondWithError(
+      final Object requestId, final JsonRpcError jsonRpcError) {
+    return new JsonRpcErrorResponse(requestId, jsonRpcError);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -67,17 +67,17 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
       return respondWithError(reqId, INVALID_PARAMS);
     }
 
-    final Optional<BlockHeader> maybeFinalizedBlockHeader = mergeContext.getFinalized();
+    final Optional<BlockHeader> maybeTerminalPoWBlockHeader = mergeContext.getTerminalPoWBlock();
 
-    if (maybeFinalizedBlockHeader.isEmpty()) {
+    if (maybeTerminalPoWBlockHeader.isEmpty()) {
       return respondWithError(reqId, INTERNAL_ERROR);
     }
 
     final EngineExchangeTransitionConfigurationResult localTransitionConfiguration =
         new EngineExchangeTransitionConfigurationResult(
             mergeContext.getTerminalTotalDifficulty(),
-            maybeFinalizedBlockHeader.get().getHash(),
-            maybeFinalizedBlockHeader.get().getNumber());
+            maybeTerminalPoWBlockHeader.get().getHash(),
+            maybeTerminalPoWBlockHeader.get().getNumber());
 
     if (!localTransitionConfiguration
         .getTerminalTotalDifficulty()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -63,7 +63,7 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
         "received transitionConfiguration: {}",
         () -> Json.encodePrettily(remoteTransitionConfiguration));
 
-    if (remoteTransitionConfiguration.getTerminalBlockNumber() != 0) {
+    if (remoteTransitionConfiguration.getTerminalBlockNumber() != 0L) {
       return respondWithError(reqId, INVALID_PARAMS);
     }
 
@@ -80,8 +80,8 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
         .equals(remoteTransitionConfiguration.getTerminalTotalDifficulty())) {
       LOG.warn(
           "Configured terminal total difficulty {} does not match value of consensus client {}",
-          localTransitionConfiguration.getTerminalTotalDifficulty().toInt(),
-          remoteTransitionConfiguration.getTerminalTotalDifficulty().toInt());
+          localTransitionConfiguration.getTerminalTotalDifficulty(),
+          remoteTransitionConfiguration.getTerminalTotalDifficulty());
     }
 
     if (!localTransitionConfiguration
@@ -89,13 +89,13 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
         .equals(remoteTransitionConfiguration.getTerminalBlockHash())) {
       LOG.warn(
           "Configured terminal block hash {} does not match value of consensus client {}",
-          localTransitionConfiguration.getTerminalBlockHash().toHexString(),
-          remoteTransitionConfiguration.getTerminalBlockHash().toHexString());
+          localTransitionConfiguration.getTerminalBlockHash(),
+          remoteTransitionConfiguration.getTerminalBlockHash());
     }
 
     if (localTransitionConfiguration.getTerminalBlockNumber()
         != remoteTransitionConfiguration.getTerminalBlockNumber()) {
-      LOG.warn(
+      LOG.debug(
           "Configured terminal block number {} does not match value of consensus client {}",
           localTransitionConfiguration.getTerminalBlockNumber(),
           remoteTransitionConfiguration.getTerminalBlockNumber());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class EngineExchangeTransitionConfigurationParameter {
+  private final Difficulty terminalTotalDifficulty;
+  private final Hash terminalBlockHash;
+  private final long terminalBlockNumber;
+
+  @JsonCreator
+  public EngineExchangeTransitionConfigurationParameter(
+      @JsonProperty("terminalTotalDifficulty") final String terminalTotalDifficulty,
+      @JsonProperty("terminalBlockHash") final String terminalBlockHash,
+      @JsonProperty("terminalBlockNumber") final long terminalBlockNumber) {
+    this.terminalTotalDifficulty = Difficulty.fromHexString(terminalTotalDifficulty);
+    this.terminalBlockHash = Hash.fromHexString(terminalBlockHash);
+    this.terminalBlockNumber = terminalBlockNumber;
+  }
+
+  public Difficulty getTerminalTotalDifficulty() {
+    return terminalTotalDifficulty;
+  }
+
+  public Hash getTerminalBlockHash() {
+    return terminalBlockHash;
+  }
+
+  public long getTerminalBlockNumber() {
+    return terminalBlockNumber;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EngineExchangeTransitionConfigurationParameter that =
+        (EngineExchangeTransitionConfigurationParameter) o;
+    return terminalTotalDifficulty.equals(that.terminalTotalDifficulty)
+        && terminalBlockHash.equals(that.terminalBlockHash)
+        && terminalBlockNumber == that.terminalBlockNumber;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
@@ -29,10 +29,10 @@ public class EngineExchangeTransitionConfigurationParameter {
   public EngineExchangeTransitionConfigurationParameter(
       @JsonProperty("terminalTotalDifficulty") final String terminalTotalDifficulty,
       @JsonProperty("terminalBlockHash") final String terminalBlockHash,
-      @JsonProperty("terminalBlockNumber") final long terminalBlockNumber) {
+      @JsonProperty("terminalBlockNumber") final UnsignedLongParameter terminalBlockNumber) {
     this.terminalTotalDifficulty = Difficulty.fromHexString(terminalTotalDifficulty);
     this.terminalBlockHash = Hash.fromHexString(terminalBlockHash);
-    this.terminalBlockNumber = terminalBlockNumber;
+    this.terminalBlockNumber = terminalBlockNumber.getValue();
   }
 
   public Difficulty getTerminalTotalDifficulty() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
@@ -17,8 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -47,21 +45,5 @@ public class EngineExchangeTransitionConfigurationParameter {
 
   public long getTerminalBlockNumber() {
     return terminalBlockNumber;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    EngineExchangeTransitionConfigurationParameter that =
-        (EngineExchangeTransitionConfigurationParameter) o;
-    return terminalTotalDifficulty.equals(that.terminalTotalDifficulty)
-        && terminalBlockHash.equals(that.terminalBlockHash)
-        && terminalBlockNumber == that.terminalBlockNumber;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"terminalTotalDifficulty", "terminalBlockHash", "terminalBlockNumber"})
+public class EngineExchangeTransitionConfigurationResult {
+  private final Difficulty terminalTotalDifficulty;
+  private final Hash terminalBlockHash;
+  private final long terminalBlockNumber;
+
+  public EngineExchangeTransitionConfigurationResult(
+      final Difficulty terminalTotalDifficulty,
+      final Hash terminalBlockHash,
+      final long terminalBlockNumber) {
+    this.terminalTotalDifficulty = terminalTotalDifficulty;
+    this.terminalBlockHash = terminalBlockHash;
+    this.terminalBlockNumber = terminalBlockNumber;
+  }
+
+  @JsonGetter(value = "terminalTotalDifficulty")
+  public Difficulty getTerminalTotalDifficulty() {
+    return terminalTotalDifficulty;
+  }
+
+  @JsonGetter(value = "terminalBlockHash")
+  public Hash getTerminalBlockHash() {
+    return terminalBlockHash;
+  }
+
+  @JsonGetter(value = "terminalBlockNumber")
+  public long getTerminalBlockNumber() {
+    return terminalBlockNumber;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    EngineExchangeTransitionConfigurationResult that =
+        (EngineExchangeTransitionConfigurationResult) o;
+    return terminalTotalDifficulty.equals(that.terminalTotalDifficulty)
+        && terminalBlockHash.equals(that.terminalBlockHash)
+        && terminalBlockNumber == that.terminalBlockNumber;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
@@ -17,8 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -50,21 +48,5 @@ public class EngineExchangeTransitionConfigurationResult {
   @JsonGetter(value = "terminalBlockNumber")
   public long getTerminalBlockNumber() {
     return terminalBlockNumber;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-    EngineExchangeTransitionConfigurationResult that =
-        (EngineExchangeTransitionConfigurationResult) o;
-    return terminalTotalDifficulty.equals(that.terminalTotalDifficulty)
-        && terminalBlockHash.equals(that.terminalBlockHash)
-        && terminalBlockNumber == that.terminalBlockNumber;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
@@ -36,17 +36,29 @@ public class EngineExchangeTransitionConfigurationResult {
   }
 
   @JsonGetter(value = "terminalTotalDifficulty")
+  public String getTerminalTotalDifficultyAsString() {
+    return terminalTotalDifficulty.toHexString();
+  }
+
   public Difficulty getTerminalTotalDifficulty() {
     return terminalTotalDifficulty;
   }
 
   @JsonGetter(value = "terminalBlockHash")
+  public String getTerminalBlockHashAsString() {
+    return terminalBlockHash.toHexString();
+  }
+
   public Hash getTerminalBlockHash() {
     return terminalBlockHash;
   }
 
   @JsonGetter(value = "terminalBlockNumber")
-  public long getTerminalBlockNumber() {
+  public String getTerminalBlockNumberAsString() {
+    return Long.toHexString(terminalBlockNumber);
+  }
+
+  public Long getTerminalBlockNumber() {
     return terminalBlockNumber;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
+import java.util.Optional;
+
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -55,7 +57,10 @@ public class EngineExchangeTransitionConfigurationResult {
 
   @JsonGetter(value = "terminalBlockNumber")
   public String getTerminalBlockNumberAsString() {
-    return Long.toHexString(terminalBlockNumber);
+    return Optional.of(terminalBlockNumber)
+        .filter(val -> val != 0L)
+        .map(Long::toHexString)
+        .orElse("0x0");
   }
 
   public Long getTerminalBlockNumber() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineExchangeTransitionConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdated;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayload;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayload;
@@ -53,6 +54,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
     return mapOf(
         new EngineGetPayload(syncVertx, protocolContext, blockResultFactory),
         new EngineNewPayload(syncVertx, protocolContext, mergeCoordinator),
-        new EngineForkchoiceUpdated(syncVertx, protocolContext, mergeCoordinator));
+        new EngineForkchoiceUpdated(syncVertx, protocolContext, mergeCoordinator),
+        new EngineExchangeTransitionConfiguration(syncVertx, protocolContext));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
+
+import io.vertx.core.Vertx;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EngineExchangeTransitionConfigurationTest {
+  private EngineExchangeTransitionConfiguration method;
+  private static final Vertx vertx = Vertx.vertx();
+
+  @Mock private ProtocolContext protocolContext;
+  @Mock private MergeContext mergeContext;
+
+  @Before
+  public void setUp() {
+    when(protocolContext.getConsensusContext(Mockito.any())).thenReturn(mergeContext);
+
+    this.method = new EngineExchangeTransitionConfiguration(vertx, protocolContext);
+  }
+
+  @Test
+  public void shouldReturnExpectedMethodName() {
+    // will break as specs change, intentional:
+    assertThat(method.getName()).isEqualTo("engine_exchangeTransitionConfigurationV1");
+  }
+
+  @Test
+  public void shouldReturnInvalidParamsOnTerminalBlockNumberNotZero() {
+    var response =
+        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), 1));
+
+    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
+    assertThat(res.getError()).isEqualTo(JsonRpcError.INVALID_PARAMS);
+  }
+
+  private JsonRpcResponse resp(final EngineExchangeTransitionConfigurationParameter param) {
+    return method.response(
+        new JsonRpcRequestContext(
+            new JsonRpcRequest(
+                "2.0",
+                RpcMethod.ENGINE_EXCHANGE_TRANSITION_CONFIGURATION.getMethodName(),
+                new Object[] {param})));
+  }
+
+  //    private EngineExchangeTransitionConfigurationResult fromSuccessResp(final JsonRpcResponse
+  // resp) {
+  //        assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+  //        return Optional.of(resp)
+  //                .map(JsonRpcSuccessResponse.class::cast)
+  //                .map(JsonRpcSuccessResponse::getResult)
+  //                .map(EngineExchangeTransitionConfigurationResult.class::cast)
+  //                .get();
+  //    }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -142,10 +142,12 @@ public class EngineExchangeTransitionConfigurationTest {
   @Test
   public void shouldAlwaysReturnResultsInHex() throws JsonProcessingException {
     var mapper = new ObjectMapper();
-    var mockResult = new EngineExchangeTransitionConfigurationResult(Difficulty.ZERO, Hash.ZERO, 0L);
+    var mockResult =
+        new EngineExchangeTransitionConfigurationResult(Difficulty.ZERO, Hash.ZERO, 0L);
 
     assertThat(mockResult.getTerminalBlockNumberAsString()).isEqualTo("0x0");
-    assertThat(mockResult.getTerminalTotalDifficultyAsString()).isEqualTo(Difficulty.ZERO.toHexString());
+    assertThat(mockResult.getTerminalTotalDifficultyAsString())
+        .isEqualTo(Difficulty.ZERO.toHexString());
     assertThat(mockResult.getTerminalBlockHashAsString()).isEqualTo(Hash.ZERO.toHexString());
 
     String json = mapper.writeValueAsString(mockResult);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -88,17 +88,19 @@ public class EngineExchangeTransitionConfigurationTest {
   }
 
   @Test
-  public void shouldReturnInternalErrorOnTerminalPoWBlockHeaderEmpty() {
+  public void shouldReturnZerosOnTerminalPoWBlockHeaderEmpty() {
     when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
+    when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(1337L));
 
     var response =
         resp(
             new EngineExchangeTransitionConfigurationParameter(
                 "0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
 
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
-    JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
-    assertThat(res.getError()).isEqualTo(JsonRpcError.INTERNAL_ERROR);
+    var result = fromSuccessResp(response);
+    assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(1337L));
+    assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.ZERO);
+    assertThat(result.getTerminalBlockNumber()).isEqualTo(0L);
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -82,8 +82,8 @@ public class EngineExchangeTransitionConfigurationTest {
   }
 
   @Test
-  public void shouldReturnInternalErrorOnFinalizedBlockHeaderEmpty() {
-    when(mergeContext.getFinalized()).thenReturn(Optional.empty());
+  public void shouldReturnInternalErrorOnTerminalPoWBlockHeaderEmpty() {
+    when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
 
     var response =
         resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), 0));
@@ -96,7 +96,7 @@ public class EngineExchangeTransitionConfigurationTest {
   @Test
   public void shouldReturnConfigurationOnConfigurationMisMatch() {
     final BlockHeader fakeBlockHeader = createBlockHeader(Hash.fromHexStringLenient("0x01"), 42);
-    when(mergeContext.getFinalized()).thenReturn(Optional.of(fakeBlockHeader));
+    when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.of(fakeBlockHeader));
     when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(24));
 
     var response =
@@ -113,7 +113,7 @@ public class EngineExchangeTransitionConfigurationTest {
   @Test
   public void shouldReturnConfigurationOnConfigurationMatch() {
     final BlockHeader fakeBlockHeader = createBlockHeader(Hash.fromHexStringLenient("0x01"), 42);
-    when(mergeContext.getFinalized()).thenReturn(Optional.of(fakeBlockHeader));
+    when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.of(fakeBlockHeader));
     when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(24));
 
     var response =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -18,7 +18,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
@@ -28,8 +30,19 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchangeTransitionConfigurationResult;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.ParsedExtraData;
+import org.hyperledger.besu.evm.log.LogsBloomFilter;
+
+import java.util.Optional;
 
 import io.vertx.core.Vertx;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,6 +81,52 @@ public class EngineExchangeTransitionConfigurationTest {
     assertThat(res.getError()).isEqualTo(JsonRpcError.INVALID_PARAMS);
   }
 
+  @Test
+  public void shouldReturnInternalErrorOnFinalizedBlockHeaderEmpty() {
+    when(mergeContext.getFinalized()).thenReturn(Optional.empty());
+
+    var response =
+        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), 0));
+
+    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
+    assertThat(res.getError()).isEqualTo(JsonRpcError.INTERNAL_ERROR);
+  }
+
+  @Test
+  public void shouldReturnConfigurationOnConfigurationMisMatch() {
+    final BlockHeader fakeBlockHeader = createBlockHeader(Hash.fromHexStringLenient("0x01"), 42);
+    when(mergeContext.getFinalized()).thenReturn(Optional.of(fakeBlockHeader));
+    when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(24));
+
+    var response =
+        resp(
+            new EngineExchangeTransitionConfigurationParameter(
+                "1", Hash.fromHexStringLenient("0xff").toHexString(), 0));
+
+    var result = fromSuccessResp(response);
+    assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));
+    assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.fromHexStringLenient("0x01"));
+    assertThat(result.getTerminalBlockNumber()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldReturnConfigurationOnConfigurationMatch() {
+    final BlockHeader fakeBlockHeader = createBlockHeader(Hash.fromHexStringLenient("0x01"), 42);
+    when(mergeContext.getFinalized()).thenReturn(Optional.of(fakeBlockHeader));
+    when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(24));
+
+    var response =
+        resp(
+            new EngineExchangeTransitionConfigurationParameter(
+                "24", Hash.fromHexStringLenient("0x01").toHexString(), 0));
+
+    var result = fromSuccessResp(response);
+    assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));
+    assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.fromHexStringLenient("0x01"));
+    assertThat(result.getTerminalBlockNumber()).isEqualTo(42);
+  }
+
   private JsonRpcResponse resp(final EngineExchangeTransitionConfigurationParameter param) {
     return method.response(
         new JsonRpcRequestContext(
@@ -77,13 +136,43 @@ public class EngineExchangeTransitionConfigurationTest {
                 new Object[] {param})));
   }
 
-  //    private EngineExchangeTransitionConfigurationResult fromSuccessResp(final JsonRpcResponse
-  // resp) {
-  //        assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
-  //        return Optional.of(resp)
-  //                .map(JsonRpcSuccessResponse.class::cast)
-  //                .map(JsonRpcSuccessResponse::getResult)
-  //                .map(EngineExchangeTransitionConfigurationResult.class::cast)
-  //                .get();
-  //    }
+  private EngineExchangeTransitionConfigurationResult fromSuccessResp(final JsonRpcResponse resp) {
+    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    return Optional.of(resp)
+        .map(JsonRpcSuccessResponse.class::cast)
+        .map(JsonRpcSuccessResponse::getResult)
+        .map(EngineExchangeTransitionConfigurationResult.class::cast)
+        .get();
+  }
+
+  private BlockHeader createBlockHeader(final Hash blockHash, final long blockNumber) {
+    return new BlockHeader(
+        Hash.EMPTY,
+        Hash.EMPTY,
+        Address.ZERO,
+        Hash.EMPTY,
+        Hash.EMPTY,
+        Hash.EMPTY,
+        LogsBloomFilter.empty(),
+        Difficulty.ZERO,
+        blockNumber,
+        0,
+        0,
+        0,
+        Bytes.EMPTY,
+        Wei.ZERO,
+        Bytes32.ZERO,
+        0,
+        new BlockHeaderFunctions() {
+          @Override
+          public Hash hash(final BlockHeader header) {
+            return blockHash;
+          }
+
+          @Override
+          public ParsedExtraData parseExtraData(final BlockHeader header) {
+            return null;
+          }
+        });
+  }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -39,8 +39,11 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ParsedExtraData;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
+import java.util.Map;
 import java.util.Optional;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -134,6 +137,24 @@ public class EngineExchangeTransitionConfigurationTest {
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));
     assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.fromHexStringLenient("0x01"));
     assertThat(result.getTerminalBlockNumber()).isEqualTo(42);
+  }
+
+  @Test
+  public void shouldAlwaysReturnResultsInHex() throws JsonProcessingException {
+    var mapper = new ObjectMapper();
+    var mockResult = new EngineExchangeTransitionConfigurationResult(Difficulty.ZERO, Hash.ZERO, 0L);
+
+    assertThat(mockResult.getTerminalBlockNumberAsString()).isEqualTo("0x0");
+    assertThat(mockResult.getTerminalTotalDifficultyAsString()).isEqualTo(Difficulty.ZERO.toHexString());
+    assertThat(mockResult.getTerminalBlockHashAsString()).isEqualTo(Hash.ZERO.toHexString());
+
+    String json = mapper.writeValueAsString(mockResult);
+    var res = mapper.readValue(json, Map.class);
+    assertThat(res.get("terminalBlockNumber")).isEqualTo("0x0");
+    assertThat(res.get("terminalBlockHash"))
+        .isEqualTo("0x0000000000000000000000000000000000000000000000000000000000000000");
+    assertThat(res.get("terminalTotalDifficulty"))
+        .isEqualTo("0x0000000000000000000000000000000000000000000000000000000000000000");
   }
 
   private JsonRpcResponse resp(final EngineExchangeTransitionConfigurationParameter param) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -74,7 +75,7 @@ public class EngineExchangeTransitionConfigurationTest {
   @Test
   public void shouldReturnInvalidParamsOnTerminalBlockNumberNotZero() {
     var response =
-        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), 1));
+        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), new UnsignedLongParameter(1L)));
 
     assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
     JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
@@ -86,7 +87,7 @@ public class EngineExchangeTransitionConfigurationTest {
     when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
 
     var response =
-        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), 0));
+        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
 
     assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
     JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
@@ -102,7 +103,7 @@ public class EngineExchangeTransitionConfigurationTest {
     var response =
         resp(
             new EngineExchangeTransitionConfigurationParameter(
-                "1", Hash.fromHexStringLenient("0xff").toHexString(), 0));
+                "1", Hash.fromHexStringLenient("0xff").toHexString(), new UnsignedLongParameter(0L)));
 
     var result = fromSuccessResp(response);
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));
@@ -119,7 +120,7 @@ public class EngineExchangeTransitionConfigurationTest {
     var response =
         resp(
             new EngineExchangeTransitionConfigurationParameter(
-                "24", Hash.fromHexStringLenient("0x01").toHexString(), 0));
+                "24", Hash.fromHexStringLenient("0x01").toHexString(), new UnsignedLongParameter(0)));
 
     var result = fromSuccessResp(response);
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -75,7 +75,9 @@ public class EngineExchangeTransitionConfigurationTest {
   @Test
   public void shouldReturnInvalidParamsOnTerminalBlockNumberNotZero() {
     var response =
-        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), new UnsignedLongParameter(1L)));
+        resp(
+            new EngineExchangeTransitionConfigurationParameter(
+                "0", Hash.ZERO.toHexString(), new UnsignedLongParameter(1L)));
 
     assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
     JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
@@ -87,7 +89,9 @@ public class EngineExchangeTransitionConfigurationTest {
     when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
 
     var response =
-        resp(new EngineExchangeTransitionConfigurationParameter("0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
+        resp(
+            new EngineExchangeTransitionConfigurationParameter(
+                "0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
 
     assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
     JsonRpcErrorResponse res = ((JsonRpcErrorResponse) response);
@@ -103,7 +107,9 @@ public class EngineExchangeTransitionConfigurationTest {
     var response =
         resp(
             new EngineExchangeTransitionConfigurationParameter(
-                "1", Hash.fromHexStringLenient("0xff").toHexString(), new UnsignedLongParameter(0L)));
+                "1",
+                Hash.fromHexStringLenient("0xff").toHexString(),
+                new UnsignedLongParameter(0L)));
 
     var result = fromSuccessResp(response);
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));
@@ -120,7 +126,9 @@ public class EngineExchangeTransitionConfigurationTest {
     var response =
         resp(
             new EngineExchangeTransitionConfigurationParameter(
-                "24", Hash.fromHexStringLenient("0x01").toHexString(), new UnsignedLongParameter(0)));
+                "24",
+                Hash.fromHexStringLenient("0x01").toHexString(),
+                new UnsignedLongParameter(0)));
 
     var result = fromSuccessResp(response);
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(24));


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description

Implements the `engine_exchangeTransitionConfigurationV1` API endpoint according to [specification](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_exchangetransitionconfigurationv1). It is part of the Kiln v2 spec.

## Fixed Issue(s)
fixes #3471 

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).