### PR TITLE
Remove shutdown latch from BftProcessor

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftProcessor.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftProcessor.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.consensus.common.bft;
 import org.hyperledger.besu.consensus.common.bft.events.BftEvent;
 
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -31,7 +30,6 @@ public class BftProcessor implements Runnable {
   private final BftEventQueue incomingQueue;
   private volatile boolean shutdown = false;
   private final EventMultiplexer eventMultiplexer;
-  private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
   /**
    * Construct a new BftProcessor
@@ -49,10 +47,6 @@ public class BftProcessor implements Runnable {
     shutdown = true;
   }
 
-  public void awaitStop() throws InterruptedException {
-    shutdownLatch.await();
-  }
-
   @Override
   public void run() {
     try {
@@ -64,7 +58,6 @@ public class BftProcessor implements Runnable {
     }
     // Clean up the executor service the round timer has been utilising
     LOG.info("Shutting down BFT event processor");
-    shutdownLatch.countDown();
   }
 
   private Optional<BftEvent> nextEvent() {

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftMiningCoordinator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftMiningCoordinator.java
@@ -88,13 +88,6 @@ public class BftMiningCoordinator implements MiningCoordinator, BlockAddedObserv
     if (state.compareAndSet(State.RUNNING, State.STOPPED)) {
       blockchain.removeObserver(blockAddedObserverId);
       bftProcessor.stop();
-      // Make sure the processor has stopped before shutting down the executors
-      try {
-        bftProcessor.awaitStop();
-      } catch (final InterruptedException e) {
-        LOG.debug("Interrupted while waiting for IbftProcessor to stop.", e);
-        Thread.currentThread().interrupt();
-      }
       bftExecutors.stop();
     }
   }


### PR DESCRIPTION
We don't want BftMiningCoordinator.stop() to wait for BftProcessor to shutdown before calling shutdown on the BftExecutor.
This prevents BftMiningCoordinator from being able to be shutdown from the same thread.
We want to enable shutdown from the same thread to support migrating from one MiningCoordinator instance to another (IBFT -> QBFT).

This is the relevant discussion as to why the latch was originally added in: https://github.com/hyperledger/besu/pull/104#discussion_r334705699

I believe the latch is unnecessary because BftExecutors.stop() (which calls bftProcessExecutor.shutdownNow) should be sufficient to safely prevent any further tasks from being accepted, whilst BftExecutors.awaitStop() (calling bftProcessExecutor.awaitTermination()) gives the current task(s) a chance to finish.

This PR is most if not all of the solution to https://github.com/hyperledger/besu/issues/3003