### PR TITLE
Handle TTD and mining pre and post merge 

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -22,6 +22,7 @@ import static org.hyperledger.besu.cli.DefaultCommandValues.getDefaultBesuDataPa
 import static org.hyperledger.besu.cli.config.NetworkName.MAINNET;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPENDENCY_WARNING_MSG;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPRECATION_WARNING_MSG;
+import static org.hyperledger.besu.config.experimental.MergeConfigOptions.isMergeEnabled;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 import static org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration.DEFAULT_GRAPHQL_HTTP_PORT;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration.DEFAULT_ENGINE_JSON_RPC_PORT;
@@ -1718,6 +1719,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private void issueOptionWarnings() {
+
     // Check that P2P options are able to work
     CommandLineUtils.checkOptionDependencies(
         logger,
@@ -1734,6 +1736,20 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             "--p2p-interface",
             "--p2p-port",
             "--remote-connections-max-percentage"));
+
+    // Check that block producer options work
+    if (!isMergeEnabled()) {
+      CommandLineUtils.checkOptionDependencies(
+          logger,
+          commandLine,
+          "--miner-enabled",
+          !isMiningEnabled,
+          asList(
+              "--miner-coinbase",
+              "--min-gas-price",
+              "--min-block-occupancy-ratio",
+              "--miner-extra-data"));
+    }
     // Check that mining options are able to work
     CommandLineUtils.checkOptionDependencies(
         logger,
@@ -1741,10 +1757,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         "--miner-enabled",
         !isMiningEnabled,
         asList(
-            "--miner-coinbase",
-            "--min-gas-price",
-            "--min-block-occupancy-ratio",
-            "--miner-extra-data",
             "--miner-stratum-enabled",
             "--Xminer-remote-sealers-limit",
             "--Xminer-remote-sealers-hashrate-ttl"));

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -86,7 +86,7 @@ import java.util.OptionalLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class BesuControllerBuilder {
+public abstract class BesuControllerBuilder implements MiningParameterOverrides {
   private static final Logger LOG = LoggerFactory.getLogger(BesuControllerBuilder.class);
 
   protected GenesisConfigFile genesisConfig;

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -100,8 +100,8 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder {
             new CliqueMiningTracker(localAddress, protocolContext));
     miningCoordinator.addMinedBlockObserver(ethProtocolManager);
 
-    // Clique mining is implicitly enabled.
     miningCoordinator.enable();
+
     return miningCoordinator;
   }
 
@@ -143,5 +143,11 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder {
             blockInterface);
     installCliqueBlockChoiceRule(blockchain, cliqueContext);
     return cliqueContext;
+  }
+
+  @Override
+  public MiningParameters getMiningParameterOverrides(final MiningParameters fromCli) {
+    // Clique mines by default, reflect that with in the mining parameters:
+    return new MiningParameters.Builder(fromCli).enabled(true).build();
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -100,8 +100,8 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder {
             new CliqueMiningTracker(localAddress, protocolContext));
     miningCoordinator.addMinedBlockObserver(ethProtocolManager);
 
+    // Clique mining is implicitly enabled.
     miningCoordinator.enable();
-
     return miningCoordinator;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -55,8 +55,6 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager) {
 
-    // TODO: revisit how we stop/manage the synchronizer
-    // https://github.com/hyperledger/besu/issues/2898
     this.syncState.set(syncState);
 
     return new MergeCoordinator(

--- a/besu/src/main/java/org/hyperledger/besu/controller/MiningParameterOverrides.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MiningParameterOverrides.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.controller;
+
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+
+/**
+ * This interface wraps the provided MiningParameters to enable controller-specific parameter
+ * overrides.
+ */
+public interface MiningParameterOverrides {
+  default MiningParameters getMiningParameterOverrides(final MiningParameters fromCli) {
+    return fromCli;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -81,20 +81,25 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
     // cast to transition schedule for explicit access to pre and post objects:
     final TransitionProtocolSchedule tps = (TransitionProtocolSchedule) protocolSchedule;
 
+    // PoA consensus mines by default, get consensus-specific mining parameters for
+    // TransitionCoordinator:
+    MiningParameters transitionMiningParameters =
+        preMergeBesuControllerBuilder.getMiningParameterOverrides(miningParameters);
+
     final TransitionCoordinator composedCoordinator =
         new TransitionCoordinator(
             preMergeBesuControllerBuilder.createMiningCoordinator(
                 tps.getPreMergeSchedule(),
                 protocolContext,
                 transactionPool,
-                new MiningParameters.Builder(miningParameters).enabled(false).build(),
+                transitionMiningParameters,
                 syncState,
                 ethProtocolManager),
             mergeBesuControllerBuilder.createMiningCoordinator(
                 tps.getPostMergeSchedule(),
                 protocolContext,
                 transactionPool,
-                miningParameters,
+                transitionMiningParameters,
                 syncState,
                 ethProtocolManager));
     initTransitionWatcher(protocolContext, composedCoordinator);
@@ -137,7 +142,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
             composedCoordinator.getPreMergeObject().disable();
             composedCoordinator.getPreMergeObject().stop();
           } else if (composedCoordinator.isMiningBeforeMerge()) {
-            // if we transitioned back to pre-merge and were mining, restart mining
+            // if our merge state is set to pre-merge and we are mining, start mining
             composedCoordinator.getPreMergeObject().enable();
             composedCoordinator.getPreMergeObject().start();
           }

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -141,6 +141,11 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
             // if we transitioned to post-merge, stop and disable any mining
             composedCoordinator.getPreMergeObject().disable();
             composedCoordinator.getPreMergeObject().stop();
+            // set the blockchoiceRule to never reorg, rely on forkchoiceUpdated instead
+            protocolContext
+                .getBlockchain()
+                .setBlockChoiceRule((newBlockHeader, currentBlockHeader) -> -1);
+
           } else if (composedCoordinator.isMiningBeforeMerge()) {
             // if our merge state is set to pre-merge and we are mining, start mining
             composedCoordinator.getPreMergeObject().enable();

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -44,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -3335,7 +3336,20 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
-  public void miningOptionsRequiresServiceToBeEnabled() {
+  public void stratumMiningOptionsRequiresServiceToBeEnabled() {
+
+    parseCommand("--miner-stratum-enabled");
+
+    verifyOptionsConstraintLoggerCall("--miner-enabled", "--miner-stratum-enabled");
+
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8))
+        .startsWith(
+            "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled) or specify mining is enabled (--miner-enabled)");
+  }
+
+  @Test
+  public void blockProducingOptionsWarnsMinerShouldBeEnabled() {
 
     final Address requestedCoinbase = Address.fromHexString("0000011111222223333344444");
     parseCommand(
@@ -3344,16 +3358,37 @@ public class BesuCommandTest extends CommandTestAbstract {
         "--min-gas-price",
         "42",
         "--miner-extra-data",
-        "0x1122334455667788990011223344556677889900112233445566778899001122",
-        "--miner-stratum-enabled");
+        "0x1122334455667788990011223344556677889900112233445566778899001122");
 
     verifyOptionsConstraintLoggerCall(
-        "--miner-enabled", "--miner-coinbase", "--miner-extra-data", "--miner-stratum-enabled");
+        "--miner-enabled", "--miner-coinbase", "--min-gas-price", "--miner-extra-data");
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
-    assertThat(commandErrorOutput.toString(UTF_8))
-        .startsWith(
-            "Unable to mine with Stratum if mining is disabled. Either disable Stratum mining (remove --miner-stratum-enabled) or specify mining is enabled (--miner-enabled)");
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void blockProducingOptionsDoNotWarnWhenMergeEnabled() {
+
+    final Address requestedCoinbase = Address.fromHexString("0000011111222223333344444");
+    parseCommand(
+        "--Xmerge-support",
+        "true",
+        "--miner-coinbase",
+        requestedCoinbase.toString(),
+        "--min-gas-price",
+        "42",
+        "--miner-extra-data",
+        "0x1122334455667788990011223344556677889900112233445566778899001122");
+
+    verify(mockLogger, atMost(0))
+        .warn(
+            stringArgumentCaptor.capture(),
+            stringArgumentCaptor.capture(),
+            stringArgumentCaptor.capture());
+
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -23,10 +23,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.config.EthashConfigOptions;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.config.Keccak256ConfigOptions;
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.datatypes.Hash;
@@ -83,8 +81,6 @@ public class MergeBesuControllerBuilderTest {
 
   @Mock GenesisConfigFile genesisConfigFile;
   @Mock GenesisConfigOptions genesisConfigOptions;
-  @Mock EthashConfigOptions ethashConfigOptions;
-  @Mock Keccak256ConfigOptions keccak256ConfigOptions;
   @Mock SynchronizerConfiguration synchronizerConfiguration;
   @Mock EthProtocolConfiguration ethProtocolConfiguration;
   @Mock MiningParameters miningParameters;

--- a/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.clique.CliqueContext;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
+import org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule;
+import org.hyperledger.besu.consensus.merge.blockcreation.TransitionCoordinator;
+import org.hyperledger.besu.crypto.NodeKeyUtils;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * We only bother testing transitionControllerBuilder for PoW and Clique since those are the only
+ * network types that are transitioning to PoS.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TransitionControllerBuilderTest {
+
+  @Mock ProtocolSchedule protocolSchedule;
+  @Mock TransitionProtocolSchedule transitionProtocolSchedule;
+  @Mock ProtocolContext protocolContext;
+  @Mock TransactionPool transactionPool;
+  @Mock SyncState syncState;
+  @Mock EthProtocolManager ethProtocolManager;
+
+  @Spy CliqueBesuControllerBuilder cliqueBuilder = new CliqueBesuControllerBuilder();
+  @Spy BesuControllerBuilder powBuilder = new MainnetBesuControllerBuilder();
+  @Spy MergeBesuControllerBuilder postMergeBuilder = new MergeBesuControllerBuilder();
+  @Spy MiningParameters miningParameters = new MiningParameters.Builder().build();
+
+  @Before
+  public void setup() {
+    cliqueBuilder.nodeKey(NodeKeyUtils.generate());
+    when(protocolContext.getBlockchain()).thenReturn(mock(MutableBlockchain.class));
+    when(transitionProtocolSchedule.getPostMergeSchedule()).thenReturn(protocolSchedule);
+    when(transitionProtocolSchedule.getPreMergeSchedule()).thenReturn(protocolSchedule);
+    when(protocolContext.getConsensusContext(CliqueContext.class))
+        .thenReturn(mock(CliqueContext.class));
+    when(protocolContext.getConsensusContext(PostMergeContext.class))
+        .thenReturn(mock(PostMergeContext.class));
+  }
+
+  @Test
+  public void assertCliqueMiningOverridePreMerge() {
+    assertThat(miningParameters.isMiningEnabled()).isFalse();
+    var transCoordinator = buildTransitionCoordinator(cliqueBuilder, postMergeBuilder);
+    assertThat(transCoordinator.isMiningBeforeMerge()).isTrue();
+  }
+
+  @Test
+  public void assertPoWIsNotMiningPreMerge() {
+    assertThat(miningParameters.isMiningEnabled()).isFalse();
+    var transCoordinator = buildTransitionCoordinator(powBuilder, postMergeBuilder);
+    assertThat(transCoordinator.isMiningBeforeMerge()).isFalse();
+  }
+
+  @Test
+  public void assertPowMiningPreMerge() {
+    when(miningParameters.isMiningEnabled()).thenReturn(Boolean.TRUE);
+    var transCoordinator = buildTransitionCoordinator(powBuilder, postMergeBuilder);
+    assertThat(transCoordinator.isMiningBeforeMerge()).isTrue();
+  }
+
+  TransitionCoordinator buildTransitionCoordinator(
+      final BesuControllerBuilder preMerge, final MergeBesuControllerBuilder postMerge) {
+    var builder = new TransitionBesuControllerBuilder(preMerge, postMerge);
+    var coordinator =
+        builder.createMiningCoordinator(
+            transitionProtocolSchedule,
+            protocolContext,
+            transactionPool,
+            miningParameters,
+            syncState,
+            ethProtocolManager);
+
+    assertThat(coordinator).isInstanceOf(TransitionCoordinator.class);
+    var transCoordinator = (TransitionCoordinator) coordinator;
+    return transCoordinator;
+  }
+}

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -33,7 +33,7 @@ import com.google.common.collect.EvictingQueue;
 public class PostMergeContext implements MergeContext {
   static final int MAX_BLOCKS_IN_PROGRESS = 12;
 
-  private static PostMergeContext singleton;
+  private static final AtomicReference<PostMergeContext> singleton = new AtomicReference<>();
 
   private final AtomicReference<SyncState> syncState;
   private final AtomicReference<Difficulty> terminalTotalDifficulty;
@@ -57,12 +57,11 @@ public class PostMergeContext implements MergeContext {
     this.syncState = new AtomicReference<>();
   }
 
-  public static synchronized PostMergeContext get() {
-    // TODO: get rid of singleton if possible: https://github.com/hyperledger/besu/issues/2898
-    if (singleton == null) {
-      singleton = new PostMergeContext();
+  public static PostMergeContext get() {
+    if (singleton.get() == null) {
+      singleton.set(new PostMergeContext());
     }
-    return singleton;
+    return singleton.get();
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -80,10 +80,8 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void setIsPostMerge(final Difficulty totalDifficulty) {
-    if (isPostMerge.get().orElse(Boolean.FALSE)
-        && Optional.ofNullable(lastFinalized.get()).isPresent()) {
-      // we check this condition because if we've received a finalized block, we never want to
-      // switch back to a pre-merge
+    if (isPostMerge.get().orElse(Boolean.FALSE)) {
+      // we never switch back to a pre-merge once we have transitioned post-TTD.
       return;
     }
     final boolean newState = terminalTotalDifficulty.get().lessOrEqualThan(totalDifficulty);

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -59,7 +59,7 @@ public class PostMergeContext implements MergeContext {
 
   public static PostMergeContext get() {
     if (singleton.get() == null) {
-      singleton.set(new PostMergeContext());
+      singleton.compareAndSet(null, new PostMergeContext());
     }
     return singleton.get();
   }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.util.Subscribers;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -38,9 +37,9 @@ public class PostMergeContext implements MergeContext {
 
   private final AtomicReference<SyncState> syncState;
   private final AtomicReference<Difficulty> terminalTotalDifficulty;
-  // transition miners are created disabled by default, so reflect that default:
-  private final AtomicBoolean isPostMerge = new AtomicBoolean(true);
-  private final AtomicBoolean isAtGenesis = new AtomicBoolean(true);
+  // initial postMerge state is indeterminate until it is set:
+  private final AtomicReference<Optional<Boolean>> isPostMerge =
+      new AtomicReference<>(Optional.empty());
   private final Subscribers<NewMergeStateCallback> newMergeStateCallbackSubscribers =
       Subscribers.create();
 
@@ -73,27 +72,30 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public PostMergeContext setTerminalTotalDifficulty(final Difficulty newTerminalTotalDifficulty) {
+    if (newTerminalTotalDifficulty == null) {
+      throw new IllegalStateException("cannot set null terminal total difficulty");
+    }
     terminalTotalDifficulty.set(newTerminalTotalDifficulty);
     return this;
   }
 
   @Override
   public void setIsPostMerge(final Difficulty totalDifficulty) {
-    if (Optional.ofNullable(lastFinalized.get()).isPresent()) {
+    if (isPostMerge.get().orElse(Boolean.FALSE)
+        && Optional.ofNullable(lastFinalized.get()).isPresent()) {
       // we check this condition because if we've received a finalized block, we never want to
       // switch back to a pre-merge
       return;
     }
     final boolean newState = terminalTotalDifficulty.get().lessOrEqualThan(totalDifficulty);
-    final boolean oldState = isPostMerge.getAndSet(newState);
-    final boolean atGenesis = isAtGenesis.getAndSet(Boolean.FALSE);
+    final Optional<Boolean> oldState = isPostMerge.getAndSet(Optional.of(newState));
 
     // if we are past TTD, set it:
     if (newState)
       Optional.ofNullable(syncState.get())
-          .ifPresent(ss -> ss.setStoppedAtTerminalDifficulty(newState));
+          .ifPresent(ss -> ss.setReachedTerminalDifficulty(newState));
 
-    if (oldState != newState || atGenesis) {
+    if (oldState.isEmpty() || oldState.get() != newState) {
       newMergeStateCallbackSubscribers.forEach(
           newMergeStateCallback -> newMergeStateCallback.onNewIsPostMergeState(newState));
     }
@@ -101,7 +103,7 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public boolean isPostMerge() {
-    return isPostMerge.get();
+    return isPostMerge.get().orElse(Boolean.FALSE);
   }
 
   @Override
@@ -115,7 +117,7 @@ public class PostMergeContext implements MergeContext {
     return Optional.ofNullable(syncState.get()).map(s -> !s.isInSync()).orElse(Boolean.TRUE)
         // this is necessary for when we do not have a sync target yet, like at startup.
         // not being stopped at ttd implies we are syncing.
-        && !syncState.get().isStoppedAtTerminalDifficulty().orElse(Boolean.FALSE);
+        && !syncState.get().hasReachedTerminalDifficulty().orElse(Boolean.FALSE);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -361,12 +361,13 @@ public class MergeCoordinator implements MergeMiningCoordinator {
         if (MAX_TTD_SEARCH_DEPTH < blockheader.getNumber() - parent.get().getNumber()) {
           return false;
         }
+        if (!parent.get().getDifficulty().equals(Difficulty.ZERO)) {
+          break;
+        }
         parent = blockchain.getBlockHeader(parent.get().getParentHash());
       }
 
-    } while (parent.isPresent()
-        && parent.get().getNumber() >= 0
-        && parent.get().getDifficulty().equals(Difficulty.ZERO));
+    } while (parent.isPresent());
 
     boolean resp =
         parent.filter(header -> isTerminalProofOfWorkBlock(header, protocolContext)).isPresent();

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
@@ -59,11 +59,11 @@ public class PostMergeContextTest {
 
   @Test
   public void switchFromPoWToPoSStopSyncAndCallsSubscribers() {
-    when(mockSyncState.isStoppedAtTerminalDifficulty()).thenReturn(Optional.of(Boolean.TRUE));
+    when(mockSyncState.hasReachedTerminalDifficulty()).thenReturn(Optional.of(Boolean.TRUE));
 
     postMergeContext.setIsPostMerge(Difficulty.of(10L));
 
-    verify(mockSyncState).setStoppedAtTerminalDifficulty(true);
+    verify(mockSyncState).setReachedTerminalDifficulty(true);
     assertThat(postMergeContext.isPostMerge()).isTrue();
     assertThat(postMergeContext.isSyncing()).isFalse();
     assertThat(mergeStateChangeCollector.stateChanges).containsExactly(true);
@@ -71,11 +71,11 @@ public class PostMergeContextTest {
 
   @Test
   public void setPrePoSStateNotStopSync() {
-    when(mockSyncState.isStoppedAtTerminalDifficulty()).thenReturn(Optional.of(Boolean.FALSE));
+    when(mockSyncState.hasReachedTerminalDifficulty()).thenReturn(Optional.of(Boolean.FALSE));
 
     postMergeContext.setIsPostMerge(Difficulty.of(9L));
 
-    verify(mockSyncState, never()).setStoppedAtTerminalDifficulty(false);
+    verify(mockSyncState, never()).setReachedTerminalDifficulty(false);
     assertThat(postMergeContext.isPostMerge()).isFalse();
     assertThat(postMergeContext.isSyncing()).isTrue();
     assertThat(mergeStateChangeCollector.stateChanges).containsExactly(false);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-import org.hyperledger.besu.config.experimental.MergeConfigOptions;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -143,13 +142,7 @@ public class DefaultBlockchain implements MutableBlockchain {
         () -> chainHeadOmmerCount);
 
     this.reorgLoggingThreshold = reorgLoggingThreshold;
-    // TODO: FROMRAYONISM, need to account for fixed total difficulty
-    this.blockChoiceRule =
-        MergeConfigOptions.isMergeEnabled()
-            ? // always regard the new block as "worse" because we don't reorg anymore; the
-            // consensus node tells us what the head is through `setHead`
-            (newBlockHeader, currentBlockHeader) -> -1
-            : heaviestChainBlockChoiceRule;
+    this.blockChoiceRule = heaviestChainBlockChoiceRule;
   }
 
   public static MutableBlockchain createMutable(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
@@ -107,7 +107,7 @@ public class PipelineChainDownloader implements ChainDownloader {
       @SuppressWarnings("unused") final Void result) {
     syncState.clearSyncTarget();
     if (syncTargetManager.shouldContinueDownloading()
-        && !syncState.isStoppedAtTerminalDifficulty().orElse(false)) {
+        && !syncState.hasReachedTerminalDifficulty().orElse(false)) {
       return performDownload();
     } else {
       LOG.info("Chain download complete");
@@ -149,7 +149,7 @@ public class PipelineChainDownloader implements ChainDownloader {
   }
 
   private synchronized CompletionStage<Void> startDownloadForSyncTarget(final SyncTarget target) {
-    if (cancelled.get() || syncState.isStoppedAtTerminalDifficulty().orElse(false)) {
+    if (cancelled.get() || syncState.hasReachedTerminalDifficulty().orElse(false)) {
       return CompletableFuture.failedFuture(
           new CancellationException("Chain download was cancelled"));
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -46,7 +46,7 @@ public class SyncState {
   private volatile Optional<SyncTarget> syncTarget = Optional.empty();
   private Optional<WorldStateDownloadStatus> worldStateDownloadStatus = Optional.empty();
   private Optional<Long> newPeerListenerId;
-  private Optional<Boolean> stoppedAtTerminalDifficulty = Optional.empty();
+  private Optional<Boolean> reachedTerminalDifficulty = Optional.empty();
 
   public SyncState(final Blockchain blockchain, final EthPeers ethPeers) {
     this.blockchain = blockchain;
@@ -139,14 +139,14 @@ public class SyncState {
         getLocalChainHead(), getSyncTargetChainHead(), getBestPeerChainHead(), syncTolerance);
   }
 
-  public void setStoppedAtTerminalDifficulty(final boolean stoppedAtTerminalDifficulty) {
+  public void setReachedTerminalDifficulty(final boolean stoppedAtTerminalDifficulty) {
     // TODO: this is an inexpensive way to stop sync when we reach TTD,
     //      we should revisit when merge sync is better defined
-    this.stoppedAtTerminalDifficulty = Optional.of(stoppedAtTerminalDifficulty);
+    this.reachedTerminalDifficulty = Optional.of(stoppedAtTerminalDifficulty);
   }
 
-  public Optional<Boolean> isStoppedAtTerminalDifficulty() {
-    return stoppedAtTerminalDifficulty;
+  public Optional<Boolean> hasReachedTerminalDifficulty() {
+    return reachedTerminalDifficulty;
   }
 
   private boolean isInSync(
@@ -154,7 +154,7 @@ public class SyncState {
       final Optional<ChainHeadEstimate> syncTargetChain,
       final Optional<ChainHeadEstimate> bestPeerChain,
       final long syncTolerance) {
-    return stoppedAtTerminalDifficulty.orElse(true)
+    return reachedTerminalDifficulty.orElse(true)
         // Sync target may be temporarily empty while we switch sync targets during a sync, so
         // check both the sync target and our best peer to determine if we're in sync or not
         && isInSync(localChain, syncTargetChain, syncTolerance)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolEvictionService.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolEvictionService.java
@@ -39,7 +39,9 @@ public class TransactionPoolEvictionService {
   }
 
   public void stop() {
-    vertx.cancelTimer(timerId.get());
-    timerId = Optional.empty();
+    if (timerId.isPresent()) {
+      vertx.cancelTimer(timerId.get());
+      timerId = Optional.empty();
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Correctly and consistently handle mining pre/post merge for PoW and Clique networks.  The majority of this PR is code from the merge branch which needed some 'treatment' in order to not cause regressions in behavior on main.

* for clarity, rename isStoppedAtTerminalDifficulty to hasReachedTerminalDifficulty 
* use AtomicReference for PostMergeContext rather than synchronized
* add mining parameter override for consensus mechanisms that mine regardless of miningParameters
* merge parameter validation from `merge` branch which allows mining parameters without PoW mining (if merge is enabled)
* merge fix for optional in TxPoolEvictionService
* fix for ancestorIsValidTerminalProofOfWork in MergeCoordinator when close to TTD
* address Rayonism tech-debt, use setBlockChoiceRule at TTD rather than disabling reorg behavior entirely pre-merge


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #2898 

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).