### PR TITLE
[MINOR] typo in resource class 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
   quorum_ats_executor_med:
     machine:
       image: ubuntu-2004:202101-01
-    resource_class: med
+    resource_class: medium
     working_directory: ~/project
 
   xl_machine_executor:

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterOrBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterOrBlockHash.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  * number formatted as a hex string or a block hash.
  *
  * <p>When distinguishing between a hash and a number it is presumed that a hash won't have three
- * quarters of the leading bytes as zero. This is fined for block hashes but not for precompiled
+ * quarters of the leading bytes as zero. This is fine for block hashes but not for precompiled
  * contracts.
  */
 public class BlockParameterOrBlockHash {


### PR DESCRIPTION
* Address this error: Resource class "med" is not a valid resource class. The default resource class will be used. eg https://app.circleci.com/pipelines/github/hyperledger/besu/13609/workflows/3b159bdb-3556-4612-bb4f-3fa89c0271b4/jobs/76148
* And also fixed another typo

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).