### PR TITLE
debug_accountAt - fixed issue with contract code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 - Reject locally-sourced transactions below the minimum gas price when not mining. [#3397](https://github.com/hyperledger/besu/pull/3397)
+- Fixed bug with contract address supplied to `debug_accountAt` [#3518](https://github.com/hyperledger/besu/pull/3518)
 
 ## 22.1.1
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
@@ -128,7 +128,7 @@ public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
   protected ImmutableDebugAccountAtResult debugAccountAtResult(
       final Bytes code, final String nonce, final String balance, final String codeHash) {
     return ImmutableDebugAccountAtResult.builder()
-        .code(code.toHexString())
+        .code(code.isEmpty() ? "0x0" : code.toHexString())
         .nonce(nonce)
         .balance(balance)
         .codehash(codeHash)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -116,11 +117,20 @@ public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
           requestContext.getRequest().getId(), JsonRpcError.NO_ACCOUNT_FOUND);
     }
 
+    return debugAccountAtResult(
+        account.get().getCode(),
+        Quantity.create(account.get().getNonce()),
+        Quantity.create(account.get().getBalance()),
+        Quantity.create(account.get().getCodeHash()));
+  }
+
+  protected ImmutableDebugAccountAtResult debugAccountAtResult(
+      final Bytes code, final String nonce, final String balance, final String codeHash) {
     return ImmutableDebugAccountAtResult.builder()
-        .code(Quantity.create(account.get().getCode()))
-        .nonce(Quantity.create(account.get().getNonce()))
-        .balance(Quantity.create(account.get().getBalance()))
-        .codehash(Quantity.create(account.get().getCodeHash()))
+        .code(Quantity.create(code))
+        .nonce(nonce)
+        .balance(balance)
+        .codehash(codeHash)
         .build();
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
@@ -127,7 +127,7 @@ public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
   protected ImmutableDebugAccountAtResult debugAccountAtResult(
       final Bytes code, final String nonce, final String balance, final String codeHash) {
     return ImmutableDebugAccountAtResult.builder()
-        .code(Quantity.create(code))
+        .code(code.toHexString())
         .nonce(nonce)
         .balance(balance)
         .codehash(codeHash)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -39,6 +38,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import org.apache.tuweni.bytes.Bytes;
 
 public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
   private final Supplier<BlockTracer> blockTracerSupplier;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
@@ -34,6 +33,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -170,7 +170,8 @@ public class DebugAccountAtTest {
 
   @Test
   public void testResult() {
-    final String codeString = "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b";
+    final String codeString =
+        "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b";
     final Bytes code = Bytes.fromHexString(codeString);
     final String nonce = "0x1";
     final String balance = "0xffff";

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
@@ -24,6 +25,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionT
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.ImmutableDebugAccountAtResult;
 import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
@@ -164,5 +166,20 @@ public class DebugAccountAtTest {
     Assertions.assertThat(response instanceof JsonRpcErrorResponse).isTrue();
     Assertions.assertThat(((JsonRpcErrorResponse) response).getError())
         .isEqualByComparingTo(JsonRpcError.NO_ACCOUNT_FOUND);
+  }
+
+  @Test
+  public void testResult() {
+    final Bytes code = Bytes.fromHexString(
+        "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b");
+    final String nonce = "0x1";
+    final String balance = "0xffff";
+    final String codeHash = "0xf5f334d41776ed2828fc910d488a05c57fe7c2352aab2d16e30539d7726e1562";
+    ImmutableDebugAccountAtResult result =
+        debugAccountAt.debugAccountAtResult(code, nonce, balance, codeHash);
+    Assertions.assertThat(result.getBalance()).isEqualTo(balance);
+    Assertions.assertThat(result.getNonce()).isEqualTo(nonce);
+    Assertions.assertThat(result.getCode()).isEqualTo(code);
+    Assertions.assertThat(result.getCodehash()).isEqualTo(codeHash);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAtTest.java
@@ -170,8 +170,8 @@ public class DebugAccountAtTest {
 
   @Test
   public void testResult() {
-    final Bytes code = Bytes.fromHexString(
-        "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b");
+    final String codeString = "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b";
+    final Bytes code = Bytes.fromHexString(codeString);
     final String nonce = "0x1";
     final String balance = "0xffff";
     final String codeHash = "0xf5f334d41776ed2828fc910d488a05c57fe7c2352aab2d16e30539d7726e1562";
@@ -179,7 +179,7 @@ public class DebugAccountAtTest {
         debugAccountAt.debugAccountAtResult(code, nonce, balance, codeHash);
     Assertions.assertThat(result.getBalance()).isEqualTo(balance);
     Assertions.assertThat(result.getNonce()).isEqualTo(nonce);
-    Assertions.assertThat(result.getCode()).isEqualTo(code);
+    Assertions.assertThat(result.getCode()).isEqualTo(codeString);
     Assertions.assertThat(result.getCodehash()).isEqualTo(codeHash);
   }
 }


### PR DESCRIPTION
If contract address supplied as the account parameter to `debug_accountAt`, I get an Internal Error with this IllegalArgumentException:
```
Expected at most 32 bytes but got 44
java.lang.IllegalArgumentException: Expected at most 32 bytes but got 168
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:299)
	at org.apache.tuweni.bytes.Bytes32.leftPad(Bytes32.java:176)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity.create(Quantity.java:54)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity.create(Quantity.java:50)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugAccountAt.debugAccountAtResult(DebugAccountAt.java:130)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugAccountAtTest.testResult(DebugAccountAtTest.java:179)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.mockito.internal.runners.DefaultInternalRunner$1$1.evaluate(DefaultInternalRunner.java:55)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.mockito.internal.runners.DefaultInternalRunner$1.run(DefaultInternalRunner.java:100)
	at org.mockito.internal.runners.DefaultInternalRunner.run(DefaultInternalRunner.java:107)
	at org.mockito.internal.runners.StrictRunner.run(StrictRunner.java:41)
```
With this fix, I get this response
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": {
        "code": "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063b27b880414610030575b600080fd5b61004a60048036038101906100459190610108565b61004c565b005b60606000806000604051935036600085376000803686885af490503d9150816000853e806000811461007d57610093565b60008311156100925761012085019350836040525b5b5060008114156100ec578473ffffffffffffffffffffffffffffffffffffffff167f410d96db3f80b0f89b36888c4d8a94004268f8d42309ac39b7bcba706293e099856040516100e3919061016e565b60405180910390a25b5050505050565b60008135905061010281610227565b92915050565b60006020828403121561011e5761011d610211565b5b600061012c848285016100f3565b91505092915050565b600061014082610190565b61014a818561019b565b935061015a8185602086016101de565b61016381610216565b840191505092915050565b600060208201905081810360008301526101888184610135565b905092915050565b600081519050919050565b600082825260208201905092915050565b60006101b7826101be565b9050919050565b600073ffffffffffffffffffffffffffffffffffffffff82169050919050565b60005b838110156101fc5780820151818401526020810190506101e1565b8381111561020b576000848401525b50505050565b600080fd5b6000601f19601f8301169050919050565b610230816101ac565b811461023b57600080fd5b5056fea2646970667358221220fdfb5c371055342507b8fb9ca7b0c234f79819bd5cb05c0d467fb605de979eb564736f6c63430008060033",
        "nonce": "0x1",
        "balance": "0x0",
        "codehash": "0xf5f334d41776ed2828fc910d488a05c57fe7c2352aab2d16e30539d7726e1562"
    }
}
```

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).