### PR TITLE
[MINOR] quorum ATs use docker executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ executors:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
       
   quorum_ats_executor_med:
-    machine:
-      image: ubuntu-2004:202101-01
+    docker:
+      - image: cimg/openjdk:11.0
     resource_class: medium
     working_directory: ~/project
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Use docker executor and jdk image as before (but keep medium resource class)

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).