### PR TITLE
Refactor graphqlcontext since getContext() is deprecated

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.ApiConfiguration;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration;
-import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetcherContextImpl;
+import org.hyperledger.besu.ethereum.api.graphql.GraphQLContextType;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetchers;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLHttpService;
 import org.hyperledger.besu.ethereum.api.graphql.GraphQLProvider;
@@ -124,6 +124,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -668,13 +669,12 @@ public class RunnerBuilder {
       final GraphQLDataFetchers fetchers =
           new GraphQLDataFetchers(
               supportedCapabilities, privacyParameters.getGoQuorumPrivacyParameters());
-      final GraphQLDataFetcherContextImpl dataFetcherContext =
-          new GraphQLDataFetcherContextImpl(
-              blockchainQueries,
-              protocolSchedule,
-              transactionPool,
-              miningCoordinator,
-              synchronizer);
+      final Map<GraphQLContextType, Object> graphQlContextMap = new ConcurrentHashMap<>();
+      graphQlContextMap.putIfAbsent(GraphQLContextType.BLOCKCHAIN_QUERIES, blockchainQueries);
+      graphQlContextMap.putIfAbsent(GraphQLContextType.PROTOCOL_SCHEDULE, protocolSchedule);
+      graphQlContextMap.putIfAbsent(GraphQLContextType.TRANSACTION_POOL, transactionPool);
+      graphQlContextMap.putIfAbsent(GraphQLContextType.MINING_COORDINATOR, miningCoordinator);
+      graphQlContextMap.putIfAbsent(GraphQLContextType.SYNCHRONIZER, synchronizer);
       final GraphQL graphQL;
       try {
         graphQL = GraphQLProvider.buildGraphQL(fetchers);
@@ -689,7 +689,7 @@ public class RunnerBuilder {
                   dataDir,
                   graphQLConfiguration,
                   graphQL,
-                  dataFetcherContext,
+                  graphQlContextMap,
                   besuController.getProtocolManager().ethContext().getScheduler()));
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
@@ -12,15 +12,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
+package org.hyperledger.besu.ethereum.api.graphql;
 
-import org.hyperledger.besu.ethereum.api.graphql.GraphQLContextType;
-import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
-
-import graphql.schema.DataFetchingEnvironment;
-
-abstract class AdapterBase {
-  BlockchainQueries getBlockchainQueries(final DataFetchingEnvironment environment) {
-    return environment.getGraphQlContext().get(GraphQLContextType.BLOCKCHAIN_QUERIES);
-  }
+/** Internal GraphQL Context */
+public enum GraphQLContextType {
+  BLOCKCHAIN_QUERIES,
+  PROTOCOL_SCHEDULE,
+  TRANSACTION_POOL,
+  MINING_COORDINATOR,
+  SYNCHRONIZER,
+  IS_ALIVE_HANDLER
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -40,6 +40,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
@@ -88,7 +89,8 @@ public class GraphQLHttpService {
 
   private final GraphQL graphQL;
 
-  private final GraphQLDataFetcherContext dataFetcherContext;
+  private final Map<GraphQLContextType, Object> graphQlContextMap;
+
   private final EthScheduler scheduler;
 
   /**
@@ -98,7 +100,7 @@ public class GraphQLHttpService {
    * @param dataDir The data directory where requests can be buffered
    * @param config Configuration for the rpc methods being loaded
    * @param graphQL GraphQL engine
-   * @param dataFetcherContext DataFetcherContext required by GraphQL to finish it's job
+   * @param graphQlContextMap GraphQlContext Map
    * @param scheduler {@link EthScheduler} used to trigger timeout on backend queries
    */
   public GraphQLHttpService(
@@ -106,7 +108,7 @@ public class GraphQLHttpService {
       final Path dataDir,
       final GraphQLConfiguration config,
       final GraphQL graphQL,
-      final GraphQLDataFetcherContextImpl dataFetcherContext,
+      final Map<GraphQLContextType, Object> graphQlContextMap,
       final EthScheduler scheduler) {
     this.dataDir = dataDir;
 
@@ -114,7 +116,7 @@ public class GraphQLHttpService {
     this.config = config;
     this.vertx = vertx;
     this.graphQL = graphQL;
-    this.dataFetcherContext = dataFetcherContext;
+    this.graphQlContextMap = graphQlContextMap;
     this.scheduler = scheduler;
   }
 
@@ -393,14 +395,17 @@ public class GraphQLHttpService {
 
   private GraphQLResponse process(
       final String requestJson, final String operationName, final Map<String, Object> variables) {
+    Map<GraphQLContextType, Object> contextMap = new ConcurrentHashMap<>();
+    contextMap.putAll(graphQlContextMap);
+    contextMap.put(
+        GraphQLContextType.IS_ALIVE_HANDLER,
+        new IsAliveHandler(scheduler, config.getHttpTimeoutSec()));
     final ExecutionInput executionInput =
         ExecutionInput.newExecutionInput()
             .query(requestJson)
             .operationName(operationName)
             .variables(variables)
-            .context(
-                new GraphQLDataFetcherContextImpl(
-                    dataFetcherContext, new IsAliveHandler(scheduler, config.getHttpTimeoutSec())))
+            .graphQLContext(contextMap)
             .build();
     final ExecutionResult result = graphQL.execute(executionInput);
     final Map<String, Object> toSpecificationResult = result.toSpecification();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetcherContext;
+import org.hyperledger.besu.ethereum.api.graphql.GraphQLContextType;
 import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
@@ -196,7 +196,7 @@ public class BlockAdapterBase extends AdapterBase {
 
     final BlockchainQueries query = getBlockchainQueries(environment);
     final ProtocolSchedule protocolSchedule =
-        ((GraphQLDataFetcherContext) environment.getContext()).getProtocolSchedule();
+        environment.getGraphQlContext().get(GraphQLContextType.PROTOCOL_SCHEDULE);
     final long bn = header.getNumber();
 
     final TransactionSimulator transactionSimulator =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.api.graphql.GraphQLDataFetcherContext;
+import org.hyperledger.besu.ethereum.api.graphql.GraphQLContextType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
@@ -61,7 +61,7 @@ public class PendingStateAdapter extends AdapterBase {
   public Optional<AccountAdapter> getAccount(
       final DataFetchingEnvironment dataFetchingEnvironment) {
     final BlockchainQueries blockchainQuery =
-        ((GraphQLDataFetcherContext) dataFetchingEnvironment.getContext()).getBlockchainQueries();
+        dataFetchingEnvironment.getGraphQlContext().get(GraphQLContextType.BLOCKCHAIN_QUERIES);
     final Address addr = dataFetchingEnvironment.getArgument("address");
     final Long blockNumber = dataFetchingEnvironment.getArgument("blockNumber");
     final long latestBlockNumber = blockchainQuery.latestBlock().get().getHeader().getNumber();
@@ -92,7 +92,7 @@ public class PendingStateAdapter extends AdapterBase {
 
     final BlockchainQueries query = getBlockchainQueries(environment);
     final ProtocolSchedule protocolSchedule =
-        ((GraphQLDataFetcherContext) environment.getContext()).getProtocolSchedule();
+        environment.getGraphQlContext().get(GraphQLContextType.PROTOCOL_SCHEDULE);
 
     final TransactionSimulator transactionSimulator =
         new TransactionSimulator(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import java.util.Optional;
 import java.util.Set;
 
+import graphql.GraphQLContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import org.junit.Before;
@@ -37,9 +38,9 @@ public abstract class AbstractDataFetcherTest {
 
   @Mock protected DataFetchingEnvironment environment;
 
-  @Mock protected GraphQLDataFetcherContextImpl context;
-
   @Mock protected BlockchainQueries query;
+
+  @Mock protected GraphQLContext graphQLContext;
 
   @Mock protected BlockHeader header;
 
@@ -49,7 +50,7 @@ public abstract class AbstractDataFetcherTest {
   public void before() {
     final GraphQLDataFetchers fetchers = new GraphQLDataFetchers(supportedCapabilities);
     fetcher = fetchers.getBlockDataFetcher();
-    Mockito.when(environment.getContext()).thenReturn(context);
-    Mockito.when(context.getBlockchainQueries()).thenReturn(query);
+    graphQLContext.put(GraphQLContextType.BLOCKCHAIN_QUERIES, query);
+    Mockito.when(environment.getGraphQlContext()).thenReturn(graphQLContext);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -56,6 +56,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -175,14 +176,6 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
     final GraphQLConfiguration config = GraphQLConfiguration.createDefault();
 
     config.setPort(0);
-    final GraphQLDataFetcherContextImpl dataFetcherContext =
-        new GraphQLDataFetcherContextImpl(
-            blockchainQueries,
-            PROTOCOL_SCHEDULE,
-            transactionPoolMock,
-            miningCoordinatorMock,
-            synchronizerMock);
-
     final GraphQLDataFetchers dataFetchers = new GraphQLDataFetchers(supportedCapabilities);
     final GraphQL graphQL = GraphQLProvider.buildGraphQL(dataFetchers);
 
@@ -192,7 +185,17 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
             folder.newFolder().toPath(),
             config,
             graphQL,
-            dataFetcherContext,
+            Map.of(
+                GraphQLContextType.BLOCKCHAIN_QUERIES,
+                blockchainQueries,
+                GraphQLContextType.PROTOCOL_SCHEDULE,
+                PROTOCOL_SCHEDULE,
+                GraphQLContextType.TRANSACTION_POOL,
+                transactionPoolMock,
+                GraphQLContextType.MINING_COORDINATOR,
+                miningCoordinatorMock,
+                GraphQLContextType.SYNCHRONIZER,
+                synchronizerMock),
             Mockito.mock(EthScheduler.class));
     service.start().join();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/BlockDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/BlockDataFetcherTest.java
@@ -51,8 +51,8 @@ public class BlockDataFetcherTest extends AbstractDataFetcherTest {
     when(environment.getArgument(ArgumentMatchers.eq("number"))).thenReturn(1L);
     when(environment.getArgument(ArgumentMatchers.eq("hash"))).thenReturn(null);
 
-    when(environment.getContext()).thenReturn(context);
-    when(context.getBlockchainQueries()).thenReturn(query);
+    when(environment.getGraphQlContext()).thenReturn(graphQLContext);
+    when(graphQLContext.get(GraphQLContextType.BLOCKCHAIN_QUERIES)).thenReturn(query);
     when(query.blockByNumber(ArgumentMatchers.anyLong()))
         .thenReturn(Optional.of(new BlockWithMetadata<>(null, null, null, null, 0)));
 
@@ -68,8 +68,8 @@ public class BlockDataFetcherTest extends AbstractDataFetcherTest {
     when(environment.getArgument(ArgumentMatchers.eq("number"))).thenReturn(1L);
     when(environment.getArgument(ArgumentMatchers.eq("hash"))).thenReturn(null);
 
-    when(environment.getContext()).thenReturn(context);
-    when(context.getBlockchainQueries()).thenReturn(query);
+    when(environment.getGraphQlContext()).thenReturn(graphQLContext);
+    when(graphQLContext.get(GraphQLContextType.BLOCKCHAIN_QUERIES)).thenReturn(query);
     when(query.blockByNumber(ArgumentMatchers.anyLong()))
         .thenReturn(Optional.of(new BlockWithMetadata<>(header, null, null, null, 0)));
     when(header.getCoinbase()).thenReturn(testAddress);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceCorsTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Lists;
@@ -212,14 +213,17 @@ public class GraphQLHttpServiceCorsTest {
 
     final PoWMiningCoordinator miningCoordinatorMock = Mockito.mock(PoWMiningCoordinator.class);
 
-    final GraphQLDataFetcherContextImpl dataFetcherContext =
-        Mockito.mock(GraphQLDataFetcherContextImpl.class);
-    Mockito.when(dataFetcherContext.getBlockchainQueries()).thenReturn(blockchainQueries);
-    Mockito.when(dataFetcherContext.getMiningCoordinator()).thenReturn(miningCoordinatorMock);
-
-    Mockito.when(dataFetcherContext.getTransactionPool())
-        .thenReturn(Mockito.mock(TransactionPool.class));
-    Mockito.when(dataFetcherContext.getSynchronizer()).thenReturn(synchronizer);
+    // mock graphql context
+    final Map<GraphQLContextType, Object> graphQLContextMap =
+        Map.of(
+            GraphQLContextType.BLOCKCHAIN_QUERIES,
+            blockchainQueries,
+            GraphQLContextType.TRANSACTION_POOL,
+            Mockito.mock(TransactionPool.class),
+            GraphQLContextType.MINING_COORDINATOR,
+            miningCoordinatorMock,
+            GraphQLContextType.SYNCHRONIZER,
+            synchronizer);
 
     final Set<Capability> supportedCapabilities = new HashSet<>();
     supportedCapabilities.add(EthProtocol.ETH62);
@@ -233,7 +237,7 @@ public class GraphQLHttpServiceCorsTest {
             folder.newFolder().toPath(),
             config,
             graphQL,
-            dataFetcherContext,
+            graphQLContextMap,
             Mockito.mock(EthScheduler.class));
     graphQLHttpService.start().join();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import graphql.GraphQL;
@@ -73,14 +74,16 @@ public class GraphQLHttpServiceHostWhitelistTest {
 
     final PoWMiningCoordinator miningCoordinatorMock = Mockito.mock(PoWMiningCoordinator.class);
 
-    final GraphQLDataFetcherContextImpl dataFetcherContext =
-        Mockito.mock(GraphQLDataFetcherContextImpl.class);
-    Mockito.when(dataFetcherContext.getBlockchainQueries()).thenReturn(blockchainQueries);
-    Mockito.when(dataFetcherContext.getMiningCoordinator()).thenReturn(miningCoordinatorMock);
-
-    Mockito.when(dataFetcherContext.getTransactionPool())
-        .thenReturn(Mockito.mock(TransactionPool.class));
-    Mockito.when(dataFetcherContext.getSynchronizer()).thenReturn(synchronizer);
+    final Map<GraphQLContextType, Object> graphQLContextMap =
+        Map.of(
+            GraphQLContextType.BLOCKCHAIN_QUERIES,
+            blockchainQueries,
+            GraphQLContextType.TRANSACTION_POOL,
+            Mockito.mock(TransactionPool.class),
+            GraphQLContextType.MINING_COORDINATOR,
+            miningCoordinatorMock,
+            GraphQLContextType.SYNCHRONIZER,
+            synchronizer);
 
     final Set<Capability> supportedCapabilities = new HashSet<>();
     supportedCapabilities.add(EthProtocol.ETH62);
@@ -93,7 +96,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
         folder.newFolder().toPath(),
         graphQLConfig,
         graphQL,
-        dataFetcherContext,
+        graphQLContextMap,
         Mockito.mock(EthScheduler.class));
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
@@ -70,7 +70,6 @@ public class GraphQLHttpServiceTest {
   protected static final MediaType GRAPHQL = MediaType.parse("application/graphql; charset=utf-8");
   private static BlockchainQueries blockchainQueries;
   private static GraphQL graphQL;
-  //  private static GraphQLDataFetcherContextImpl dataFetcherContext;
   private static Map<GraphQLContextType, Object> graphQlContextMap;
   private static PoWMiningCoordinator miningCoordinatorMock;
 


### PR DESCRIPTION
Signed-off-by: Sandra Wang <yx97.wang@gmail.com>

## PR description
This PR is focused on resolving the deprecated dependency of graphQL context.

Deprecated: `graphql.schema.DataFetchingEnvironment#getContext`

## Fixed Issue(s)
Issue #2776