### PR TITLE
Trace APIs: add revert reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Adds JWT authentication to Engine APIs
 - Tracing APIs 
   - new API methods: trace_rawTransaction, trace_get, trace_callMany
-  - added revertReason to trace_call, trace_callMany and trace_get
+  - added revertReason to trace_call, trace_callMany, trace_rawTransaction and trace_get
 - Allow mining beneficiary to transition at specific blocks for ibft2 and qbft consensus mechanisms.  [#3115](https://github.com/hyperledger/besu/issues/3115)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Adds JWT authentication to Engine APIs
 - Tracing APIs 
   - new API methods: trace_rawTransaction, trace_get, trace_callMany
-  - added revertReason to trace_call, trace_callMany, trace_rawTransaction and trace_get
+  - added revertReason to trace APIs including: trace_transaction, trace_get, trace_call, trace_callMany, and trace_rawTransaction
 - Allow mining beneficiary to transition at specific blocks for ibft2 and qbft consensus mechanisms.  [#3115](https://github.com/hyperledger/besu/issues/3115)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - Execution layer (The Merge):
   - Execution specific RPC endpoint [[#3378](https://github.com/hyperledger/besu/issues/3378)
   - Adds JWT authentication to Engine APIs
-- Tracing APIs: trace_rawTransaction, trace_get, trace_callMany
-  - added revertReason
+- Tracing APIs 
+  - new API methods: trace_rawTransaction, trace_get, trace_callMany
+  - added revertReason to trace_call, trace_callMany and trace_get
 - Allow mining beneficiary to transition at specific blocks for ibft2 and qbft consensus mechanisms.  [#3115](https://github.com/hyperledger/besu/issues/3115)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Execution specific RPC endpoint [[#3378](https://github.com/hyperledger/besu/issues/3378)
   - Adds JWT authentication to Engine APIs
 - Tracing APIs: trace_rawTransaction, trace_get, trace_callMany
+  - added revertReason
 - Allow mining beneficiary to transition at specific blocks for ibft2 and qbft consensus mechanisms.  [#3115](https://github.com/hyperledger/besu/issues/3115)
 
 ### Bug Fixes

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByBlock.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.diff.S
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.diff.StateDiffTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTraceGenerator;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.MixInIgnoreRevertReason;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm.VmTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm.VmTraceGenerator;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -80,8 +79,6 @@ public abstract class AbstractTraceByBlock extends AbstractBlockParameterMethod
       final TransactionTrace transactionTrace,
       final Block block) {
     final TraceCallResult.Builder builder = TraceCallResult.builder();
-    // The trace_call specification does not output the revert reason, so we have to remove it
-    mapper.addMixIn(FlatTrace.class, MixInIgnoreRevertReason.class);
 
     transactionTrace
         .getResult()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
@@ -22,8 +22,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TraceTypeParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.MixInIgnoreRevertReason;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -46,8 +44,6 @@ public class TraceCall extends AbstractTraceByBlock implements JsonRpcMethod {
       final ProtocolSchedule protocolSchedule,
       final TransactionSimulator transactionSimulator) {
     super(blockchainQueries, protocolSchedule, transactionSimulator);
-    // The trace_call specification does not output the revert reason, so we have to remove it
-    mapper.addMixIn(FlatTrace.class, MixInIgnoreRevertReason.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionT
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.MixInIgnoreRevertReason;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -44,22 +43,18 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TraceCallMany extends TraceCall implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(TraceCallMany.class);
-  private static final ObjectMapper MAPPER_IGNORE_REVERT_REASON = new ObjectMapper();
 
   public TraceCallMany(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
       final TransactionSimulator transactionSimulator) {
     super(blockchainQueries, protocolSchedule, transactionSimulator);
-
-    MAPPER_IGNORE_REVERT_REASON.addMixIn(FlatTrace.class, MixInIgnoreRevertReason.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.TraceTypePa
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceGet.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceGet.java
@@ -22,8 +22,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.MixInIgnoreRevertReason;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
@@ -31,19 +29,13 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class TraceGet extends AbstractTraceByHash implements JsonRpcMethod {
-  private static final ObjectMapper MAPPER_IGNORE_REVERT_REASON = new ObjectMapper();
 
   public TraceGet(
       final Supplier<BlockTracer> blockTracerSupplier,
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule) {
     super(blockTracerSupplier, blockchainQueries, protocolSchedule);
-
-    // The trace_get specification does not output the revert reason, so we have to remove it
-    MAPPER_IGNORE_REVERT_REASON.addMixIn(FlatTrace.class, MixInIgnoreRevertReason.class);
   }
 
   @Override
@@ -67,10 +59,9 @@ public class TraceGet extends AbstractTraceByHash implements JsonRpcMethod {
 
     return new JsonRpcSuccessResponse(
         requestContext.getRequest().getId(),
-        MAPPER_IGNORE_REVERT_REASON.valueToTree(
-            resultByTransactionHash(transactionHash)
-                .filter(trace -> trace.getTraceAddress().equals(traceNumbers))
-                .findFirst()
-                .orElse(null)));
+        resultByTransactionHash(transactionHash)
+            .filter(trace -> trace.getTraceAddress().equals(traceNumbers))
+            .findFirst()
+            .orElse(null));
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -58,6 +58,8 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
       Pattern.compile(",*\"cost\":[0-9a-fA-F]+,*|,\"used\":[0-9a-fA-F]+");
   private static final Pattern GAS_MATCH_FOR_TRACE =
       Pattern.compile("\"gasUsed\":\"[x0-9a-fA-F]+\",");
+  private static final Pattern REVERT_REASON_MATCH =
+      Pattern.compile("\"revertReason\":\"[x0-9a-fA-F]+\",");
 
   private final URL specURL;
 
@@ -243,6 +245,8 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
                 "Unrecognized trace type (expected trace | vmTrace | stateDiff)");
         }
       }
+      expectedResult = filterRevertReason(expectedResult);
+      actualResult = filterRevertReason(actualResult);
 
       final ObjectMapper mapper = new ObjectMapper();
       mapper.configure(INDENT_OUTPUT, true);
@@ -279,6 +283,11 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
 
   private String filterStringTrace(final String expectedResult) {
     final Matcher m = GAS_MATCH_FOR_TRACE.matcher(expectedResult);
+    return m.replaceAll("");
+  }
+
+  private String filterRevertReason(final String expectedResult) {
+    final Matcher m = REVERT_REASON_MATCH.matcher(expectedResult);
     return m.replaceAll("");
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -246,7 +246,7 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
         }
       }
       expectedResult = filterRevertReason(expectedResult);
-//      actualResult = filterRevertReason(actualResult);
+      //      actualResult = filterRevertReason(actualResult);
 
       final ObjectMapper mapper = new ObjectMapper();
       mapper.configure(INDENT_OUTPUT, true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -58,8 +58,6 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
       Pattern.compile(",*\"cost\":[0-9a-fA-F]+,*|,\"used\":[0-9a-fA-F]+");
   private static final Pattern GAS_MATCH_FOR_TRACE =
       Pattern.compile("\"gasUsed\":\"[x0-9a-fA-F]+\",");
-  private static final Pattern REVERT_REASON_MATCH =
-      Pattern.compile("\"revertReason\":\"[x0-9a-fA-F]+\",");
 
   private final URL specURL;
 
@@ -245,8 +243,6 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
                 "Unrecognized trace type (expected trace | vmTrace | stateDiff)");
         }
       }
-      expectedResult = filterRevertReason(expectedResult);
-      actualResult = filterRevertReason(actualResult);
 
       final ObjectMapper mapper = new ObjectMapper();
       mapper.configure(INDENT_OUTPUT, true);
@@ -283,11 +279,6 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
 
   private String filterStringTrace(final String expectedResult) {
     final Matcher m = GAS_MATCH_FOR_TRACE.matcher(expectedResult);
-    return m.replaceAll("");
-  }
-
-  private String filterRevertReason(final String expectedResult) {
-    final Matcher m = REVERT_REASON_MATCH.matcher(expectedResult);
     return m.replaceAll("");
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -246,7 +246,7 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
         }
       }
       expectedResult = filterRevertReason(expectedResult);
-      actualResult = filterRevertReason(actualResult);
+//      actualResult = filterRevertReason(actualResult);
 
       final ObjectMapper mapper = new ObjectMapper();
       mapper.configure(INDENT_OUTPUT, true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -246,7 +246,7 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
         }
       }
       expectedResult = filterRevertReason(expectedResult);
-      //      actualResult = filterRevertReason(actualResult);
+      actualResult = filterRevertReason(actualResult);
 
       final ObjectMapper mapper = new ObjectMapper();
       mapper.configure(INDENT_OUTPUT, true);

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_12_1_trace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_12_1_trace.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "Revert.",
+  "comment" : "Revert. Note revertReason has been manually added to the response because OpenEthereum does not include it.",
   "request" : {
     "jsonrpc" : "2.0",
     "method" : "trace_call",
@@ -28,6 +28,7 @@
           "value" : "0x0"
         },
         "error" : "Reverted",
+        "revertReason" : "0x7d88c1856cc95352",
         "subtraces" : 0,
         "traceAddress" : [ ],
         "type" : "call"

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-callMany/trace_callMany_12_trace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-callMany/trace_callMany_12_trace.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "'Memory Read.', 'Revert.'",
+  "comment" : "'Memory Read.', 'Revert.' Note revertReason has been manually added to the response because OpenEthereum does not include it.",
   "request" : {
     "method" : "trace_callMany",
     "params" : [ [ [ {
@@ -54,6 +54,7 @@
           "value" : "0x0"
         },
         "error" : "Reverted",
+        "revertReason" : "0x7d88c1856cc95352",
         "subtraces" : 0,
         "traceAddress" : [ ],
         "type" : "call"

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-get/trace_get_12_1_0_trace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-get/trace_get_12_1_0_trace.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "Revert.",
+  "comment" : "Revert. Note revertReason has been manually added to the response because OpenEthereum does not include it.",
   "request" : {
     "jsonrpc" : "2.0",
     "method" : "trace_get",
@@ -20,6 +20,7 @@
       "blockHash" : "0x220bc13dc4f1ed38dcca927a5be15eca16497d279f4c40d7b8fe9704eadf1464",
       "blockNumber" : 18,
       "error" : "Reverted",
+      "revertReason" : "0x7d88c1856cc95352",
       "subtraces" : 0,
       "traceAddress" : [ ],
       "transactionHash" : "0xc388baa0e55e6b73e850b22dc7e9853700f6b995fd55d95dd6ccd5a13d63c566",

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_12_1_trace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_12_1_trace.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "Revert.",
+  "comment" : "Revert. Note revertReason has been manually added to the response because OpenEthereum does not include it.",
   "request" : {
     "jsonrpc" : "2.0",
     "method" : "trace_rawTransaction",
@@ -21,6 +21,7 @@
           "value" : "0x0"
         },
         "error" : "Reverted",
+        "revertReason" : "0x7d88c1856cc95352",
         "subtraces" : 0,
         "traceAddress" : [ ],
         "type" : "call"

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-transaction/trace_transaction_12_1_trace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-transaction/trace_transaction_12_1_trace.json
@@ -1,0 +1,33 @@
+{
+  "comment" : "Revert. Note revertReason has been manually added to the response because OpenEthereum does not include it.",
+  "request" : {
+    "jsonrpc" : "2.0",
+    "method" : "trace_transaction",
+    "params" : [ "0xc388baa0e55e6b73e850b22dc7e9853700f6b995fd55d95dd6ccd5a13d63c566" ],
+    "id" : 155
+  },
+  "response" : {
+    "jsonrpc" : "2.0",
+    "result" : [ {
+      "action" : {
+        "callType" : "call",
+        "from" : "0xfe3b557e8fb62b89f4916b721be55ceb828dbd73",
+        "gas" : "0xffadea",
+        "input" : "0x",
+        "to" : "0x0110000000000000000000000000000000000000",
+        "value" : "0x0"
+      },
+      "blockHash" : "0x220bc13dc4f1ed38dcca927a5be15eca16497d279f4c40d7b8fe9704eadf1464",
+      "blockNumber" : 18,
+      "error" : "Reverted",
+      "revertReason" : "0x7d88c1856cc95352",
+      "subtraces" : 0,
+      "traceAddress" : [ ],
+      "transactionHash" : "0xc388baa0e55e6b73e850b22dc7e9853700f6b995fd55d95dd6ccd5a13d63c566",
+      "transactionPosition" : 1,
+      "type" : "call"
+    } ],
+    "id" : 155
+  },
+  "statusCode" : 200
+}


### PR DESCRIPTION
Add revertReason to trace_transaction, trace_call, trace_callMany, trace_rawTransaction and trace_get

Note revertReason manually added to the relevant test files generated from OE.
Also added a new test file for trace_transaction.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).