### PR TITLE
modified batch request test to avoid async complete issue

### DIFF
--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketRequestHandlerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketRequestHandlerTest.java
@@ -163,12 +163,10 @@ public class WebSocketRequestHandlerTest {
     final JsonRpcErrorResponse expectedErrorResponse1 =
         new JsonRpcErrorResponse(1, JsonRpcError.METHOD_NOT_FOUND);
 
-    final JsonArray arrayJson = new JsonArray(List.of(requestJson, ""));
-    final JsonRpcErrorResponse expectedErrorResponse2 =
-        new JsonRpcErrorResponse(null, JsonRpcError.INVALID_REQUEST);
+    final JsonArray arrayJson = new JsonArray(List.of(requestJson, requestJson));
 
     final JsonArray expectedBatchResponse =
-        new JsonArray(List.of(expectedErrorResponse1, expectedErrorResponse2));
+        new JsonArray(List.of(expectedErrorResponse1, expectedErrorResponse1));
 
     when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
 
@@ -179,6 +177,7 @@ public class WebSocketRequestHandlerTest {
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedBatchResponse))));
     verify(websocketMock).writeFrame(argThat(this::isFinalFrame));
+    verifyNoInteractions(jsonRpcMethodMock);
   }
 
   @Test
@@ -236,6 +235,7 @@ public class WebSocketRequestHandlerTest {
 
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
     verify(websocketMock).writeFrame(argThat(this::isFinalFrame));
+    verifyNoInteractions(jsonRpcMethodMock);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Send 2 x the same request as the batch. The request of "" seems to cause different behaviour.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).