### PR TITLE
Revert "upgrade vertx (#3530)"

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -93,7 +93,7 @@ dependencyManagement {
     dependency 'io.reactivex.rxjava2:rxjava:2.2.21'
 
 
-    dependencySet(group: 'io.vertx', version: '4.2.5') {
+    dependencySet(group: 'io.vertx', version: '4.2.3') {
       entry 'vertx-auth-jwt'
       entry 'vertx-codegen'
       entry 'vertx-core'


### PR DESCRIPTION
This reverts commit 9d2d87e954f5f74007d64dffd11a5f2f742d938b.

Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Revert the version of vertx just in case it is responsible for the change in behaviour of the WebSocket batch request test
## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).