### PR TITLE
Display data storage options in CLI help

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1423,6 +1423,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     commandLine.addMixin("Ethstats", ethstatsOptions);
     commandLine.addMixin("Private key file", nodePrivateKeyFileOption);
     commandLine.addMixin("Logging level", loggingLevelOption);
+    commandLine.addMixin("Data Storage Options", dataStorageOptions);
   }
 
   private void handleUnstableOptions() {
@@ -1441,7 +1442,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .put("TransactionPool", unstableTransactionPoolOptions)
             .put("Mining", unstableMiningOptions)
             .put("Native Library", unstableNativeLibraryOptions)
-            .put("Data Storage Options", dataStorageOptions)
             .put("Launcher", unstableLauncherOptions)
             .put("Merge", mergeOptions)
             .put("EVM Options", unstableEvmOptions)

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
@@ -37,7 +37,6 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
   // Use Bonsai DB
   @Option(
       names = {DATA_STORAGE_FORMAT},
-      hidden = true,
       description =
           "Format to store trie data in.  Either FOREST or BONSAI (default: ${DEFAULT-VALUE}).",
       arity = "1")
@@ -45,7 +44,6 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
 
   @Option(
       names = {BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD},
-      hidden = true,
       paramLabel = "<LONG>",
       description =
           "Limit of back layers that can be loaded with BONSAI (default: ${DEFAULT-VALUE}).",

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -187,6 +187,10 @@ auto-log-bloom-caching-enabled=true
 ethstats="nodename:secret@host:1234"
 ethstats-contact="contact@mail.n"
 
+# Data storage
+data-storage-format="BONSAI"
+bonsai-maximum-back-layers-to-load=512
+
 # feature flags
 Xsecp256k1-native-enabled=false
 Xaltbn128-native-enabled=false


### PR DESCRIPTION
Signed-off-by: Diego López León <dieguitoll@gmail.com>

## PR description
This is a leftover from #3578 to display the new stable options in the `--help` output