### PR TITLE
Return GOQUORUM_PRIVATE_STORAGE where it was

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
@@ -30,6 +30,7 @@ public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
   TRIE_BRANCH_STORAGE(new byte[] {9}, new int[] {2}),
   TRIE_LOG_STORAGE(new byte[] {10}, new int[] {2}),
   GOQUORUM_PRIVATE_WORLD_STATE(new byte[] {11}),
+  GOQUORUM_PRIVATE_STORAGE(new byte[] {12}),
   BACKWARD_SYNC_HEADERS(new byte[] {13}),
   BACKWARD_SYNC_BLOCKS(new byte[] {14});
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
@@ -102,7 +102,7 @@ public class KeyValueStorageProvider implements StorageProvider {
   @Override
   public GoQuorumPrivateStorage createGoQuorumPrivateStorage() {
     return new GoQuorumPrivateKeyValueStorage(
-        getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.BACKWARD_SYNC_HEADERS));
+        getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.GOQUORUM_PRIVATE_STORAGE));
   }
 
   @Override


### PR DESCRIPTION
This PR should put back a missing GOQUORUM_PRIVATE_STORAGE enum that I accidentally removed.

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).