### PR TITLE
Skip seen transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Additions and Improvements
 - Tune transaction synchronization parameter to adapt to mainnet traffic [#3610](https://github.com/hyperledger/besu/pull/3610)
 - Improve eth/66 support [#3616](https://github.com/hyperledger/besu/pull/3616)
+- Avoid reprocessing remote transactions already seen [#3626](https://github.com/hyperledger/besu/pull/3626)
 
 ## 22.1.2
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
@@ -43,12 +43,16 @@ public class GetPooledTransactionsFromPeerTask extends AbstractPeerRequestTask<L
   private GetPooledTransactionsFromPeerTask(
       final EthContext ethContext, final List<Hash> hashes, final MetricsSystem metricsSystem) {
     super(ethContext, EthPV65.GET_POOLED_TRANSACTIONS, metricsSystem);
-    this.hashes = new ArrayList<>(hashes);
+    this.hashes = List.copyOf(hashes);
   }
 
   public static GetPooledTransactionsFromPeerTask forHashes(
       final EthContext ethContext, final List<Hash> hashes, final MetricsSystem metricsSystem) {
     return new GetPooledTransactionsFromPeerTask(ethContext, hashes, metricsSystem);
+  }
+
+  public List<Hash> getTransactionHashes() {
+    return hashes;
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
@@ -51,7 +51,7 @@ public class NewPooledTransactionHashesMessageProcessor {
       scheduledTasks;
 
   private final PeerTransactionTracker transactionTracker;
-  private final Counter totalSkippedTransactionsMessageCounter;
+  private final Counter totalSkippedNewPooledTransactionHashesMessageCounter;
   private final TransactionPool transactionPool;
   private final TransactionPoolConfiguration transactionPoolConfiguration;
   private final EthContext ethContext;
@@ -71,15 +71,15 @@ public class NewPooledTransactionHashesMessageProcessor {
     this.ethContext = ethContext;
     this.metricsSystem = metricsSystem;
     this.syncState = syncState;
-    this.totalSkippedTransactionsMessageCounter =
+    this.totalSkippedNewPooledTransactionHashesMessageCounter =
         new RunnableCounter(
             metricsSystem.createCounter(
                 BesuMetricCategory.TRANSACTION_POOL,
-                "pending_transactions_messages_skipped_total",
-                "Total number of pending transactions messages skipped by the processor."),
+                "new_pooled_transaction_hashes_messages_skipped_total",
+                "Total number of new pooled transaction hashes messages skipped by the processor."),
             () ->
                 LOG.warn(
-                    "{} expired transaction messages have been skipped.",
+                    "{} expired new pooled transaction hashes messages have been skipped.",
                     SKIPPED_MESSAGES_LOGGING_THRESHOLD),
             SKIPPED_MESSAGES_LOGGING_THRESHOLD);
     this.scheduledTasks = new ConcurrentHashMap<>();
@@ -94,7 +94,7 @@ public class NewPooledTransactionHashesMessageProcessor {
     if (startedAt.plus(keepAlive).isAfter(now())) {
       this.processNewPooledTransactionHashesMessage(peer, transactionsMessage);
     } else {
-      totalSkippedTransactionsMessageCounter.inc();
+      totalSkippedNewPooledTransactionHashesMessageCounter.inc();
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
@@ -118,14 +118,12 @@ public class NewPooledTransactionHashesMessageProcessor {
                       .scheduleFutureTask(
                           new FetcherCreatorTask(peer),
                           transactionPoolConfiguration.getEth65TrxAnnouncedBufferingPeriod());
-                  return new BufferedGetPooledTransactionsFromPeerFetcher(peer, this);
+
+                  return new BufferedGetPooledTransactionsFromPeerFetcher(
+                      ethContext, peer, transactionPool, transactionTracker, metricsSystem);
                 });
 
-        for (final Hash hash : incomingTransactionHashes) {
-          if (transactionPool.getTransactionByHash(hash).isEmpty()) {
-            bufferedTask.addHash(hash);
-          }
-        }
+        incomingTransactionHashes.forEach(bufferedTask::addHash);
       }
     } catch (final RLPException ex) {
       if (peer != null) {
@@ -134,18 +132,6 @@ public class NewPooledTransactionHashesMessageProcessor {
         peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
       }
     }
-  }
-
-  public TransactionPool getTransactionPool() {
-    return transactionPool;
-  }
-
-  public EthContext getEthContext() {
-    return ethContext;
-  }
-
-  public MetricsSystem getMetricsSystem() {
-    return metricsSystem;
   }
 
   public class FetcherCreatorTask implements Runnable {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -65,10 +65,7 @@ public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
   }
 
   public boolean hasSeenTransaction(final Hash txHash) {
-    return seenTransactions.values().stream()
-        .filter(seen -> seen.contains(txHash))
-        .findAny()
-        .isPresent();
+    return seenTransactions.values().stream().anyMatch(seen -> seen.contains(txHash));
   }
 
   private Set<Hash> getOrCreateSeenTransactionsForPeer(final EthPeer peer) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -64,6 +64,13 @@ public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
     }
   }
 
+  public boolean hasSeenTransaction(final Hash txHash) {
+    return seenTransactions.values().stream()
+        .filter(seen -> seen.contains(txHash))
+        .findAny()
+        .isPresent();
+  }
+
   private Set<Hash> getOrCreateSeenTransactionsForPeer(final EthPeer peer) {
     return seenTransactions.computeIfAbsent(peer, key -> createTransactionsSet());
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTran
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.time.Clock;
@@ -100,13 +99,7 @@ public class TransactionPoolFactory {
     final TransactionsMessageHandler transactionsMessageHandler =
         new TransactionsMessageHandler(
             ethContext.getScheduler(),
-            new TransactionsMessageProcessor(
-                transactionTracker,
-                transactionPool,
-                metricsSystem.createCounter(
-                    BesuMetricCategory.TRANSACTION_POOL,
-                    "transactions_messages_skipped_total",
-                    "Total number of transactions messages skipped by the processor.")),
+            new TransactionsMessageProcessor(transactionTracker, transactionPool, metricsSystem),
             transactionPoolConfiguration.getTxMessageKeepAliveSeconds());
     ethContext.getEthMessages().subscribe(EthPV62.TRANSACTIONS, transactionsMessageHandler);
     final NewPooledTransactionHashesMessageHandler pooledTransactionsMessageHandler =
@@ -116,10 +109,6 @@ public class TransactionPoolFactory {
                 transactionTracker,
                 transactionPool,
                 transactionPoolConfiguration,
-                metricsSystem.createCounter(
-                    BesuMetricCategory.TRANSACTION_POOL,
-                    "pending_transactions_messages_skipped_total",
-                    "Total number of pending transactions messages skipped by the processor."),
                 ethContext,
                 metricsSystem,
                 syncState),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -96,6 +96,7 @@ public class TransactionPoolFactory {
             miningParameters,
             metricsSystem,
             transactionPoolConfiguration);
+
     final TransactionsMessageHandler transactionsMessageHandler =
         new TransactionsMessageHandler(
             ethContext.getScheduler(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.RunnableCounter;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -46,7 +45,7 @@ class TransactionsMessageProcessor {
   private final PeerTransactionTracker transactionTracker;
   private final TransactionPool transactionPool;
   private final Counter totalSkippedTransactionsMessageCounter;
-  private final LabelledMetric<Counter> alreadySeenTransactionsCounter;
+  private final Counter alreadySeenTransactionsCounter;
 
   public TransactionsMessageProcessor(
       final PeerTransactionTracker transactionTracker,
@@ -67,11 +66,13 @@ class TransactionsMessageProcessor {
             SKIPPED_MESSAGES_LOGGING_THRESHOLD);
 
     alreadySeenTransactionsCounter =
-        metricsSystem.createLabelledCounter(
-            BesuMetricCategory.TRANSACTION_POOL,
-            "remote_already_seen_total",
-            "Total number of received transactions already seen",
-            "source");
+        metricsSystem
+            .createLabelledCounter(
+                BesuMetricCategory.TRANSACTION_POOL,
+                "remote_already_seen_total",
+                "Total number of received transactions already seen",
+                "source")
+            .labels(TRANSACTIONS);
   }
 
   void processTransactionsMessage(
@@ -95,9 +96,8 @@ class TransactionsMessageProcessor {
 
       transactionTracker.markTransactionsAsSeen(peer, incomingTransactions);
 
-      alreadySeenTransactionsCounter
-          .labels(TRANSACTIONS)
-          .inc((long) incomingTransactions.size() - freshTransactions.size());
+      alreadySeenTransactionsCounter.inc(
+          (long) incomingTransactions.size() - freshTransactions.size());
       traceLambda(
           LOG,
           "Received transactions message from {}, incoming transactions {}, incoming list {}"

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
@@ -97,7 +97,7 @@ class TransactionsMessageProcessor {
 
       alreadySeenTransactionsCounter
           .labels(TRANSACTIONS)
-          .inc((long)incomingTransactions.size() - freshTransactions.size());
+          .inc((long) incomingTransactions.size() - freshTransactions.size());
       traceLambda(
           LOG,
           "Received transactions message from {}, incoming transactions {}, incoming list {}"

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -86,7 +86,6 @@ public abstract class AbstractPendingTransactionsSorter {
   protected final LabelledMetric<Counter> transactionRemovedCounter;
   protected final Counter localTransactionAddedCounter;
   protected final Counter remoteTransactionAddedCounter;
-  protected final Counter localTransactionHashesAddedCounter;
 
   protected final long maxPendingTransactions;
   protected final TransactionPoolReplacementHandler transactionReplacementHandler;
@@ -112,7 +111,6 @@ public abstract class AbstractPendingTransactionsSorter {
             "source");
     localTransactionAddedCounter = transactionAddedCounter.labels("local");
     remoteTransactionAddedCounter = transactionAddedCounter.labels("remote");
-    localTransactionHashesAddedCounter = transactionAddedCounter.labels("pool");
 
     transactionRemovedCounter =
         metricsSystem.createLabelledCounter(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
@@ -14,8 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager.task;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,20 +29,18 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
-import org.hyperledger.besu.ethereum.eth.transactions.NewPooledTransactionHashesMessageProcessor;
+import org.hyperledger.besu.ethereum.eth.transactions.PeerTransactionTracker;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.metrics.StubMetricsSystem;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -50,47 +48,57 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class BufferedGetPooledTransactionsFromPeerFetcherTest {
 
   @Mock EthPeer ethPeer;
-  @Mock NewPooledTransactionHashesMessageProcessor processor;
   @Mock TransactionPool transactionPool;
   @Mock EthContext ethContext;
   @Mock EthScheduler ethScheduler;
-  @Mock MetricsSystem metricsSystem;
-
-  @InjectMocks BufferedGetPooledTransactionsFromPeerFetcher fetcher;
 
   private final BlockDataGenerator generator = new BlockDataGenerator();
 
+  private BufferedGetPooledTransactionsFromPeerFetcher fetcher;
+  private StubMetricsSystem metricsSystem;
+  private PeerTransactionTracker transactionTracker;
+
   @Before
   public void setup() {
+    metricsSystem = new StubMetricsSystem();
+    transactionTracker = new PeerTransactionTracker();
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
+
+    fetcher =
+        new BufferedGetPooledTransactionsFromPeerFetcher(
+            ethContext, ethPeer, transactionPool, transactionTracker, metricsSystem);
   }
 
   @Test
   public void requestTransactionShouldStartTaskWhenUnknownTransaction() {
 
-    final Hash hash = generator.transaction().getHash();
-    final List<Transaction> taskResult = Collections.singletonList(Transaction.builder().build());
+    final Transaction transaction = generator.transaction();
+    final Hash hash = transaction.getHash();
+    final List<Transaction> taskResult = List.of(transaction);
     final AbstractPeerTask.PeerTaskResult<List<Transaction>> peerTaskResult =
         new AbstractPeerTask.PeerTaskResult<>(ethPeer, taskResult);
     when(ethScheduler.scheduleSyncWorkerTask(any(GetPooledTransactionsFromPeerTask.class)))
         .thenReturn(CompletableFuture.completedFuture(peerTaskResult));
 
-    fetcher.addHash(hash);
+    fetcher.addHashes(List.of(hash));
     fetcher.requestTransactions();
 
     verify(ethScheduler).scheduleSyncWorkerTask(any(GetPooledTransactionsFromPeerTask.class));
     verifyNoMoreInteractions(ethScheduler);
 
     verify(transactionPool, times(1)).addRemoteTransactions(taskResult);
+    assertThat(transactionTracker.hasSeenTransaction(hash)).isTrue();
   }
 
   @Test
   public void requestTransactionShouldSplitRequestIntoSeveralTasks() {
-    for (int i = 0; i < 257; i++) {
-      fetcher.addHash(generator.transaction().getHash());
-    }
+    fetcher.addHashes(
+        IntStream.range(0, 257)
+            .mapToObj(unused -> generator.transaction().getHash())
+            .collect(Collectors.toList()));
+
     final AbstractPeerTask.PeerTaskResult<List<Transaction>> peerTaskResult =
-        new AbstractPeerTask.PeerTaskResult<>(ethPeer, new ArrayList<>());
+        new AbstractPeerTask.PeerTaskResult<>(ethPeer, List.of());
     when(ethScheduler.scheduleSyncWorkerTask(any(GetPooledTransactionsFromPeerTask.class)))
         .thenReturn(CompletableFuture.completedFuture(peerTaskResult));
 
@@ -102,16 +110,17 @@ public class BufferedGetPooledTransactionsFromPeerFetcherTest {
   }
 
   @Test
-  public void requestTransactionShouldNotStartTaskWhenTransactionAlreadyInPool() {
+  public void requestTransactionShouldNotStartTaskWhenTransactionAlreadySeen() {
 
-    final Hash hash = generator.transaction().getHash();
-    when(transactionPool.getTransactionByHash(hash))
-        .thenReturn(Optional.of(Transaction.builder().build()));
+    final Transaction transaction = generator.transaction();
+    final Hash hash = transaction.getHash();
+    transactionTracker.markTransactionHashesAsSeen(ethPeer, List.of(hash));
 
-    fetcher.addHash(hash);
+    fetcher.addHashes(List.of(hash));
     fetcher.requestTransactions();
 
     verifyNoInteractions(ethScheduler);
-    verify(transactionPool, never()).addRemoteTransactions(anyList());
+    verify(transactionPool, never()).addRemoteTransactions(List.of(transaction));
+    assertThat(metricsSystem.getCounterValue("remote_already_seen_total", "hashes")).isEqualTo(1);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.transactions.NewPooledTransactionHashesMessageProcessor;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
-import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.ArrayList;
@@ -55,18 +54,14 @@ public class BufferedGetPooledTransactionsFromPeerFetcherTest {
   @Mock TransactionPool transactionPool;
   @Mock EthContext ethContext;
   @Mock EthScheduler ethScheduler;
+  @Mock MetricsSystem metricsSystem;
 
   @InjectMocks BufferedGetPooledTransactionsFromPeerFetcher fetcher;
-
-  private final MetricsSystem metricsSystem = new NoOpMetricsSystem();
 
   private final BlockDataGenerator generator = new BlockDataGenerator();
 
   @Before
   public void setup() {
-    when(processor.getTransactionPool()).thenReturn(transactionPool);
-    when(processor.getMetricsSystem()).thenReturn(metricsSystem);
-    when(processor.getEthContext()).thenReturn(ethContext);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
@@ -115,7 +115,6 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         now(),
         ofMinutes(1));
 
-    //    verify(transactionPool).addTransactionHash(hash3);
     verify(transactionPool).getTransactionByHash(hash1);
     verify(transactionPool).getTransactionByHash(hash2);
     verify(transactionPool).getTransactionByHash(hash3);
@@ -142,7 +141,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionTracker);
-    assertThat(metricsSystem.getCounterValue("pending_transactions_messages_skipped_total"))
+    assertThat(
+            metricsSystem.getCounterValue("new_pooled_transaction_hashes_messages_skipped_total"))
         .isEqualTo(1);
   }
 
@@ -154,7 +154,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionPool);
-    assertThat(metricsSystem.getCounterValue("pending_transactions_messages_skipped_total"))
+    assertThat(
+            metricsSystem.getCounterValue("new_pooled_transaction_hashes_messages_skipped_total"))
         .isEqualTo(1);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
@@ -18,6 +18,7 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofMinutes;
 import static java.time.Instant.now;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -36,11 +37,9 @@ import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.messages.NewPooledTransactionHashesMessage;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.NewPooledTransactionHashesMessageProcessor.FetcherCreatorTask;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.metrics.StubMetricsSystem;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -56,22 +55,22 @@ public class NewPooledTransactionHashesMessageProcessorTest {
   @Mock private TransactionPool transactionPool;
   @Mock private TransactionPoolConfiguration transactionPoolConfiguration;
   @Mock private PeerTransactionTracker transactionTracker;
-  @Mock private Counter totalSkippedTransactionsMessageCounter;
   @Mock private EthPeer peer1;
-  @Mock private MetricsSystem metricsSystem;
   @Mock private SyncState syncState;
   @Mock private EthContext ethContext;
   @Mock private EthScheduler ethScheduler;
-
-  private NewPooledTransactionHashesMessageProcessor messageHandler;
 
   private final BlockDataGenerator generator = new BlockDataGenerator();
   private final Hash hash1 = generator.transaction().getHash();
   private final Hash hash2 = generator.transaction().getHash();
   private final Hash hash3 = generator.transaction().getHash();
 
+  private NewPooledTransactionHashesMessageProcessor messageHandler;
+  private StubMetricsSystem metricsSystem;
+
   @Before
   public void setup() {
+    metricsSystem = new StubMetricsSystem();
     when(transactionPoolConfiguration.getEth65TrxAnnouncedBufferingPeriod())
         .thenReturn(Duration.ofMillis(500));
     messageHandler =
@@ -79,24 +78,10 @@ public class NewPooledTransactionHashesMessageProcessorTest {
             transactionTracker,
             transactionPool,
             transactionPoolConfiguration,
-            totalSkippedTransactionsMessageCounter,
             ethContext,
             metricsSystem,
             syncState);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
-  }
-
-  @Test
-  public void shouldMarkAllReceivedTransactionsAsSeen() {
-    messageHandler.processNewPooledTransactionHashesMessage(
-        peer1,
-        NewPooledTransactionHashesMessage.create(asList(hash1, hash2, hash3)),
-        now(),
-        ofMinutes(1));
-
-    verify(transactionTracker)
-        .markTransactionHashesAsSeen(peer1, Arrays.asList(hash1, hash2, hash3));
-    verifyNoMoreInteractions(transactionTracker);
   }
 
   @Test
@@ -157,8 +142,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionTracker);
-    verify(totalSkippedTransactionsMessageCounter).inc(1);
-    verifyNoMoreInteractions(totalSkippedTransactionsMessageCounter);
+    assertThat(metricsSystem.getCounterValue("pending_transactions_messages_skipped_total"))
+        .isEqualTo(1);
   }
 
   @Test
@@ -169,8 +154,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionPool);
-    verify(totalSkippedTransactionsMessageCounter).inc(1);
-    verifyNoMoreInteractions(totalSkippedTransactionsMessageCounter);
+    assertThat(metricsSystem.getCounterValue("pending_transactions_messages_skipped_total"))
+        .isEqualTo(1);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
@@ -73,6 +73,7 @@ public class NewPooledTransactionHashesMessageProcessorTest {
     metricsSystem = new StubMetricsSystem();
     when(transactionPoolConfiguration.getEth65TrxAnnouncedBufferingPeriod())
         .thenReturn(Duration.ofMillis(500));
+
     messageHandler =
         new NewPooledTransactionHashesMessageProcessor(
             transactionTracker,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessorTest.java
@@ -18,6 +18,7 @@ import static java.time.Duration.ofMillis;
 import static java.time.Duration.ofMinutes;
 import static java.time.Instant.now;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -25,11 +26,11 @@ import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.messages.TransactionsMessage;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.metrics.StubMetricsSystem;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -38,14 +39,23 @@ public class TransactionsMessageProcessorTest {
 
   @Mock private TransactionPool transactionPool;
   @Mock private PeerTransactionTracker transactionTracker;
-  @Mock private Counter totalSkippedTransactionsMessageCounter;
   @Mock private EthPeer peer1;
-  @InjectMocks private TransactionsMessageProcessor messageHandler;
 
   private final BlockDataGenerator generator = new BlockDataGenerator();
   private final Transaction transaction1 = generator.transaction();
   private final Transaction transaction2 = generator.transaction();
   private final Transaction transaction3 = generator.transaction();
+
+  private TransactionsMessageProcessor messageHandler;
+  private StubMetricsSystem metricsSystem;
+
+  @Before
+  public void setup() {
+    metricsSystem = new StubMetricsSystem();
+
+    messageHandler =
+        new TransactionsMessageProcessor(transactionTracker, transactionPool, metricsSystem);
+  }
 
   @Test
   public void shouldMarkAllReceivedTransactionsAsSeen() {
@@ -77,7 +87,7 @@ public class TransactionsMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionTracker);
-    verify(totalSkippedTransactionsMessageCounter).inc(1);
+    assertThat(metricsSystem.getCounterValue("transactions_messages_skipped_total")).isEqualTo(1);
   }
 
   @Test
@@ -88,6 +98,6 @@ public class TransactionsMessageProcessorTest {
         now().minus(ofMinutes(1)),
         ofMillis(1));
     verifyNoInteractions(transactionPool);
-    verify(totalSkippedTransactionsMessageCounter).inc(1);
+    assertThat(metricsSystem.getCounterValue("transactions_messages_skipped_total")).isEqualTo(1);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This is the last PR in the series to review and optimize transaction synchronization, and its goal is to avoid reprocessing transactions, that Besu have already seen recently.

The currently way Besu has to spot if a transaction has already been process, is to look if the transaction is present in the transaction pool, that by default is 4K, while the amount of pending transactions on the mainnet, is much more, the order of hundred of thousands, so basically even if a transaction has been already processed, the chances that it gets reprocessed is very high, with the result of doing a lot of useless work, that affects Besu performance.

A trivial solution could be to just raise the transaction pool size, but that is not always advisable, because it is critical for block production to keep it fast, and incresing its size could negatively affect the perfomance of the strategy choosen to select transactions to include in the block.

A better option, implemented in this PR, is to leverage data that we already have, and that keeps the history of the transactions exchanged with other peers. This data is just a collection of transaction hashes that we have received or seen, and in any case if a transaction is in that collection, it means that it has already been processed by Besu, so it is possible to directly skip it.

Tests show a reduced CPU usage:
![image](https://user-images.githubusercontent.com/91944855/159903502-35ad0aff-bfc8-4ab0-98c7-c0fdbc2503a5.png)
![image](https://user-images.githubusercontent.com/91944855/159903608-57ea1bdc-332f-42fc-aa35-7c3021e30d29.png)

due to the much less turnover in the transaction pool
![image](https://user-images.githubusercontent.com/91944855/159903959-c4bc1de1-ee3e-45ed-8f2f-6149a885a070.png)
![image](https://user-images.githubusercontent.com/91944855/159904240-adafdd71-4ad9-4f7b-8782-3770fb3f9479.png)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).