### PR TITLE
Updated jackson-databind to version 2.13.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Tune transaction synchronization parameter to adapt to mainnet traffic [#3610](https://github.com/hyperledger/besu/pull/3610)
 - Improve eth/66 support [#3616](https://github.com/hyperledger/besu/pull/3616)
 - Avoid reprocessing remote transactions already seen [#3626](https://github.com/hyperledger/besu/pull/3626)
+- Upgraded jackson-databind dependecy version [#3626](https://github.com/hyperledger/besu/pull/3647)
 
 ## 22.1.2
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,7 @@
 
 dependencyManagement {
   dependencies {
-    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     dependency 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.13.2'
 
     dependency 'com.github.ben-manes.caffeine:caffeine:3.0.5'


### PR DESCRIPTION
## PR description

Previsous jackson-databing version has been flagged (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).