### PR TITLE
Fast sync with merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Additions and Improvements
 - Onchain node permissioning - log the enodeURL that was previously only throwing an IllegalStateException during the isPermitted check [#3697](https://github.com/hyperledger/besu/pull/3697)
 - \[EXPERIMENTAL\] Add snapsync `--sync-mode="X_SNAP"` (only as client) [#3710](https://github.com/hyperledger/besu/pull/3710)
-- Adapt Fast sync to use finalized block, from consensus layer, as pivot after the Merge [#3506](https://github.com/hyperledger/besu/issues/3506)
+- Adapt Fast sync, and Snap sync, to use finalized block, from consensus layer, as pivot after the Merge [#3506](https://github.com/hyperledger/besu/issues/3506)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Additions and Improvements
 - Onchain node permissioning - log the enodeURL that was previously only throwing an IllegalStateException during the isPermitted check [#3697](https://github.com/hyperledger/besu/pull/3697)
 - \[EXPERIMENTAL\] Add snapsync `--sync-mode="X_SNAP"` (only as client) [#3710](https://github.com/hyperledger/besu/pull/3710)
+- Adapt Fast sync to use finalized block, from consensus layer, as pivot after the Merge [#3506](https://github.com/hyperledger/besu/issues/3506)
 
 ### Bug Fixes
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -435,7 +435,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
     if (genesisConfigOptions.getTerminalTotalDifficulty().isPresent()) {
       LOG.info(
-          "TTD difficulty is present, creating initial sync phase with transition to Pos support");
+          "TTD difficulty is present, creating initial sync phase with transition to PoS support");
 
       final MergeContext mergeContext = protocolContext.getConsensusContext(MergeContext.class);
       final FinalizedBlockHashSupplier finalizedBlockHashSupplier =
@@ -451,6 +451,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
       return new TransitionPivotSelector(
           genesisConfigOptions,
+          finalizedBlockHashSupplier,
           pivotSelectorFromPeers,
           new PivotSelectorFromFinalizedBlock(
               genesisConfigOptions,

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -86,6 +86,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -336,7 +337,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             syncConfig.getComputationParallelism(),
             metricsSystem);
     final EthContext ethContext = new EthContext(ethPeers, ethMessages, snapMessages, scheduler);
-    final boolean fastSyncEnabled = SyncMode.FAST.equals(syncConfig.getSyncMode());
+    final boolean fastSyncEnabled =
+        EnumSet.of(SyncMode.FAST, SyncMode.X_SNAP).contains(syncConfig.getSyncMode());
     final SyncState syncState = new SyncState(blockchain, ethPeers, fastSyncEnabled);
 
     final TransactionPool transactionPool =

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -453,7 +453,9 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
           genesisConfigOptions,
           pivotSelectorFromPeers,
           new PivotSelectorFromFinalizedBlock(
-              finalizedBlockHashSupplier, unsubscribeFinalizedBlockHashListener));
+              genesisConfigOptions,
+              finalizedBlockHashSupplier,
+              unsubscribeFinalizedBlockHashListener));
     } else {
       LOG.info("TTD difficulty is not present, creating initial sync phase for PoW");
       return pivotSelectorFromPeers;

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -17,6 +17,9 @@ package org.hyperledger.besu.controller;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.merge.FinalizedBlockHashSupplier;
+import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.datatypes.Hash;
@@ -49,8 +52,12 @@ import org.hyperledger.besu.ethereum.eth.peervalidation.DaoForkPeerValidator;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.eth.peervalidation.RequiredBlocksPeerValidator;
 import org.hyperledger.besu.ethereum.eth.sync.DefaultSynchronizer;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.fastsync.PivotSelectorFromFinalizedBlock;
+import org.hyperledger.besu.ethereum.eth.sync.fastsync.PivotSelectorFromPeers;
+import org.hyperledger.besu.ethereum.eth.sync.fastsync.TransitionPivotSelector;
 import org.hyperledger.besu.ethereum.eth.sync.fullsync.SyncTerminationCondition;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -329,8 +336,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             syncConfig.getComputationParallelism(),
             metricsSystem);
     final EthContext ethContext = new EthContext(ethPeers, ethMessages, snapMessages, scheduler);
-    final SyncState syncState = new SyncState(blockchain, ethPeers);
     final boolean fastSyncEnabled = SyncMode.FAST.equals(syncConfig.getSyncMode());
+    final SyncState syncState = new SyncState(blockchain, ethPeers, fastSyncEnabled);
 
     final TransactionPool transactionPool =
         TransactionPoolFactory.createTransactionPool(
@@ -360,21 +367,23 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final Optional<SnapProtocolManager> maybeSnapProtocolManager =
         createSnapProtocolManager(peerValidators, ethPeers, snapMessages, worldStateArchive);
 
+    final PivotBlockSelector pivotBlockSelector = createPivotSelector(protocolContext);
+
     final Synchronizer synchronizer =
         new DefaultSynchronizer(
             syncConfig,
-            genesisConfig.getConfigOptions(),
             protocolSchedule,
             protocolContext,
             worldStateStorage,
             ethProtocolManager.getBlockBroadcaster(),
             maybePruner,
-            ethProtocolManager.ethContext(),
+            ethContext,
             syncState,
             dataDirectory,
             clock,
             metricsSystem,
-            getFullSyncTerminationCondition(protocolContext.getBlockchain()));
+            getFullSyncTerminationCondition(protocolContext.getBlockchain()),
+            pivotBlockSelector);
 
     final MiningCoordinator miningCoordinator =
         createMiningCoordinator(
@@ -417,6 +426,38 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
         nodeKey,
         closeables,
         additionalPluginServices);
+  }
+
+  private PivotBlockSelector createPivotSelector(final ProtocolContext protocolContext) {
+
+    final PivotSelectorFromPeers pivotSelectorFromPeers = new PivotSelectorFromPeers(syncConfig);
+    final GenesisConfigOptions genesisConfigOptions = genesisConfig.getConfigOptions();
+
+    if (genesisConfigOptions.getTerminalTotalDifficulty().isPresent()) {
+      LOG.info(
+          "TTD difficulty is present, creating initial sync phase with transition to Pos support");
+
+      final MergeContext mergeContext = protocolContext.getConsensusContext(MergeContext.class);
+      final FinalizedBlockHashSupplier finalizedBlockHashSupplier =
+          new FinalizedBlockHashSupplier();
+      final long subscriptionId =
+          mergeContext.addNewForkchoiceMessageListener(finalizedBlockHashSupplier);
+
+      final Runnable unsubscribeFinalizedBlockHashListener =
+          () -> {
+            mergeContext.removeNewForkchoiceMessageListener(subscriptionId);
+            LOG.info("Initial sync done, unsubscribe finalized block hash supplier");
+          };
+
+      return new TransitionPivotSelector(
+          genesisConfigOptions,
+          pivotSelectorFromPeers,
+          new PivotSelectorFromFinalizedBlock(
+              finalizedBlockHashSupplier, unsubscribeFinalizedBlockHashListener));
+    } else {
+      LOG.info("TTD difficulty is not present, creating initial sync phase for PoW");
+      return pivotSelectorFromPeers;
+    }
   }
 
   protected SyncTerminationCondition getFullSyncTerminationCondition(final Blockchain blockchain) {

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -363,6 +363,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final Synchronizer synchronizer =
         new DefaultSynchronizer(
             syncConfig,
+            genesisConfig.getConfigOptions(),
             protocolSchedule,
             protocolContext,
             worldStateStorage,

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/FinalizedBlockHashSupplier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/FinalizedBlockHashSupplier.java
@@ -27,17 +27,19 @@ public class FinalizedBlockHashSupplier
     implements Supplier<Optional<Hash>>, NewForkchoiceMessageListener {
   private static final Logger LOG = LoggerFactory.getLogger(FinalizedBlockHashSupplier.class);
 
-  private volatile Hash lastAnnouncedFinalizedBlockHash;
+  private volatile Optional<Hash> lastAnnouncedFinalizedBlockHash = Optional.empty();
 
   @Override
   public void onNewForkchoiceMessage(
-      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash) {
-    lastAnnouncedFinalizedBlockHash = finalizedBlockHash;
+      final Hash headBlockHash,
+      final Optional<Hash> maybeFinalizedBlockHash,
+      final Hash safeBlockHash) {
+    lastAnnouncedFinalizedBlockHash = maybeFinalizedBlockHash;
     LOG.debug("New finalized block hash announced {}", lastAnnouncedFinalizedBlockHash);
   }
 
   @Override
   public Optional<Hash> get() {
-    return Optional.ofNullable(lastAnnouncedFinalizedBlockHash);
+    return lastAnnouncedFinalizedBlockHash;
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/FinalizedBlockHashSupplier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/FinalizedBlockHashSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.merge;
+
+import org.hyperledger.besu.consensus.merge.MergeContext.NewForkchoiceMessageListener;
+import org.hyperledger.besu.datatypes.Hash;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FinalizedBlockHashSupplier
+    implements Supplier<Optional<Hash>>, NewForkchoiceMessageListener {
+  private static final Logger LOG = LoggerFactory.getLogger(FinalizedBlockHashSupplier.class);
+
+  private volatile Hash lastAnnouncedFinalizedBlockHash;
+
+  @Override
+  public void onNewForkchoiceMessage(
+      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash) {
+    lastAnnouncedFinalizedBlockHash = finalizedBlockHash;
+    LOG.debug("New finalized block hash announced {}", lastAnnouncedFinalizedBlockHash);
+  }
+
+  @Override
+  public Optional<Hash> get() {
+    return Optional.ofNullable(lastAnnouncedFinalizedBlockHash);
+  }
+}

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeContext.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.merge;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -37,6 +38,11 @@ public interface MergeContext extends ConsensusContext {
 
   void observeNewIsPostMergeState(final NewMergeStateCallback newMergeStateCallback);
 
+  long addNewForkchoiceMessageListener(
+      final NewForkchoiceMessageListener newForkchoiceMessageListener);
+
+  void removeNewForkchoiceMessageListener(final long subscriberId);
+
   Difficulty getTerminalTotalDifficulty();
 
   void setFinalized(final BlockHeader blockHeader);
@@ -53,7 +59,15 @@ public interface MergeContext extends ConsensusContext {
 
   Optional<Block> retrieveBlockById(final PayloadIdentifier payloadId);
 
+  void fireNewForkchoiceMessageEvent(
+      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash);
+
   interface NewMergeStateCallback {
     void onNewIsPostMergeState(final boolean newIsPostMergeState);
+  }
+
+  interface NewForkchoiceMessageListener {
+    void onNewForkchoiceMessage(
+        final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash);
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeContext.java
@@ -60,7 +60,9 @@ public interface MergeContext extends ConsensusContext {
   Optional<Block> retrieveBlockById(final PayloadIdentifier payloadId);
 
   void fireNewForkchoiceMessageEvent(
-      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash);
+      final Hash headBlockHash,
+      final Optional<Hash> maybeFinalizedBlockHash,
+      final Hash safeBlockHash);
 
   interface NewMergeStateCallback {
     void onNewIsPostMergeState(final boolean newIsPostMergeState);
@@ -68,6 +70,8 @@ public interface MergeContext extends ConsensusContext {
 
   interface NewForkchoiceMessageListener {
     void onNewForkchoiceMessage(
-        final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash);
+        final Hash headBlockHash,
+        final Optional<Hash> maybeFinalizedBlockHash,
+        final Hash safeBlockHash);
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -139,9 +139,11 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void fireNewForkchoiceMessageEvent(
-      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash) {
+      final Hash headBlockHash,
+      final Optional<Hash> maybeFinalizedBlockHash,
+      final Hash safeBlockHash) {
     newForkchoiceMessageCallbackSubscribers.forEach(
-        cb -> cb.onNewForkchoiceMessage(headBlockHash, finalizedBlockHash, safeBlockHash));
+        cb -> cb.onNewForkchoiceMessage(headBlockHash, maybeFinalizedBlockHash, safeBlockHash));
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionContext.java
@@ -85,9 +85,11 @@ public class TransitionContext implements MergeContext {
 
   @Override
   public void fireNewForkchoiceMessageEvent(
-      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash) {
+      final Hash headBlockHash,
+      final Optional<Hash> maybeFinalizedBlockHash,
+      final Hash safeBlockHash) {
     postMergeContext.fireNewForkchoiceMessageEvent(
-        headBlockHash, finalizedBlockHash, safeBlockHash);
+        headBlockHash, maybeFinalizedBlockHash, safeBlockHash);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionContext.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.merge;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ConsensusContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -69,6 +70,24 @@ public class TransitionContext implements MergeContext {
   @Override
   public void observeNewIsPostMergeState(final NewMergeStateCallback newMergeStateCallback) {
     postMergeContext.observeNewIsPostMergeState(newMergeStateCallback);
+  }
+
+  @Override
+  public long addNewForkchoiceMessageListener(
+      final NewForkchoiceMessageListener newForkchoiceMessageListener) {
+    return postMergeContext.addNewForkchoiceMessageListener(newForkchoiceMessageListener);
+  }
+
+  @Override
+  public void removeNewForkchoiceMessageListener(final long subscriberId) {
+    postMergeContext.removeNewForkchoiceMessageListener(subscriberId);
+  }
+
+  @Override
+  public void fireNewForkchoiceMessageEvent(
+      final Hash headBlockHash, final Hash finalizedBlockHash, final Hash safeBlockHash) {
+    postMergeContext.fireNewForkchoiceMessageEvent(
+        headBlockHash, finalizedBlockHash, safeBlockHash);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -67,6 +67,10 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
         requestContext.getOptionalParameter(1, EnginePayloadAttributesParameter.class);
 
     if (mergeContext.isSyncing()) {
+      mergeContext.fireNewForkchoiceMessageEvent(
+          forkChoice.getHeadBlockHash(),
+          forkChoice.getFinalizedBlockHash(),
+          forkChoice.getSafeBlockHash());
       return new JsonRpcSuccessResponse(
           requestContext.getRequest().getId(),
           new EngineUpdateForkchoiceResult(SYNCING, null, null, Optional.empty()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Executi
 import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.VALID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
@@ -228,6 +229,10 @@ public class EngineForkchoiceUpdatedTest {
       assertThat(res.getPayloadStatus().getLatestValidHash()).isEmpty();
       assertThat(res.getPayloadId()).isNull();
     }
+
+    // assert that listeners are always notified
+    verify(mergeContext).fireNewForkchoiceMessageEvent(mockHash, Optional.of(mockHash), mockHash);
+
     return res;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -273,7 +273,6 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     @Override
     public WorldStateStorage.Updater saveWorldState(
         final Bytes blockHash, final Bytes32 nodeHash, final Bytes node) {
-      trieBranchStorageTransaction.put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
       trieBranchStorageTransaction.put(Bytes.EMPTY.toArrayUnsafe(), node.toArrayUnsafe());
       trieBranchStorageTransaction.put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
       trieBranchStorageTransaction.put(WORLD_BLOCK_HASH_KEY, blockHash.toArrayUnsafe());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -273,6 +273,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     @Override
     public WorldStateStorage.Updater saveWorldState(
         final Bytes blockHash, final Bytes32 nodeHash, final Bytes node) {
+      trieBranchStorageTransaction.put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
       trieBranchStorageTransaction.put(Bytes.EMPTY.toArrayUnsafe(), node.toArrayUnsafe());
       trieBranchStorageTransaction.put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
       trieBranchStorageTransaction.put(WORLD_BLOCK_HASH_KEY, blockHash.toArrayUnsafe());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.eth.sync;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -58,6 +59,7 @@ public class DefaultSynchronizer implements Synchronizer {
 
   public DefaultSynchronizer(
       final SynchronizerConfiguration syncConfig,
+      final GenesisConfigOptions genesisConfig,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
       final WorldStateStorage worldStateStorage,
@@ -117,6 +119,7 @@ public class DefaultSynchronizer implements Synchronizer {
       this.fastSyncDownloader =
           FastDownloaderFactory.create(
               syncConfig,
+              genesisConfig,
               dataDirectory,
               protocolSchedule,
               protocolContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -161,6 +161,7 @@ public class DefaultSynchronizer implements Synchronizer {
         future = fastSyncDownloader.get().start().thenCompose(this::handleFastSyncResult);
 
       } else {
+        syncState.markInitialSyncPhaseAsDone();
         future = startFullSync();
       }
       future = future.thenApply(this::finalizeSync);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -115,6 +115,7 @@ public class DefaultSynchronizer implements Synchronizer {
     if (SyncMode.X_SNAP.equals(syncConfig.getSyncMode())) {
       this.fastSyncDownloader =
           SnapDownloaderFactory.createSnapDownloader(
+              pivotBlockSelector,
               syncConfig,
               dataDirectory,
               protocolSchedule,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
@@ -107,8 +107,7 @@ public class PipelineChainDownloader implements ChainDownloader {
       @SuppressWarnings("unused") final Void result) {
     syncState.clearSyncTarget();
     if (syncTargetManager.shouldContinueDownloading()
-        && (!syncState.isInitialSyncPhaseDone()
-            || !syncState.hasReachedTerminalDifficulty().orElse(false))) {
+        && !syncState.hasReachedTerminalDifficulty().orElse(Boolean.FALSE)) {
       return performDownload();
     } else {
       LOG.info("PipelineChain download complete");
@@ -150,7 +149,7 @@ public class PipelineChainDownloader implements ChainDownloader {
   }
 
   private synchronized CompletionStage<Void> startDownloadForSyncTarget(final SyncTarget target) {
-    if (cancelled.get() || syncState.hasReachedTerminalDifficulty().orElse(false)) {
+    if (cancelled.get() || syncState.hasReachedTerminalDifficulty().orElse(Boolean.FALSE)) {
       return CompletableFuture.failedFuture(
           new CancellationException("Chain download was cancelled"));
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
@@ -107,7 +107,8 @@ public class PipelineChainDownloader implements ChainDownloader {
       @SuppressWarnings("unused") final Void result) {
     syncState.clearSyncTarget();
     if (syncTargetManager.shouldContinueDownloading()
-        && !syncState.hasReachedTerminalDifficulty().orElse(false)) {
+        && (!syncState.isInitialSyncPhaseDone()
+            || !syncState.hasReachedTerminalDifficulty().orElse(false))) {
       return performDownload();
     } else {
       LOG.info("PipelineChain download complete");

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PivotBlockSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PivotBlockSelector.java
@@ -20,9 +20,14 @@ import org.hyperledger.besu.ethereum.eth.sync.fastsync.FastSyncState;
 import java.util.Optional;
 
 public interface PivotBlockSelector {
+
   Optional<FastSyncState> selectNewPivotBlock(EthPeer peer);
 
   default void close() {
     // do nothing by default
+  }
+
+  default long getMinRequiredBlockNumber() {
+    return 0L;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PivotBlockSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PivotBlockSelector.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync;
+
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.sync.fastsync.FastSyncState;
+
+import java.util.Optional;
+
+public interface PivotBlockSelector {
+  Optional<FastSyncState> selectNewPivotBlock(EthPeer peer);
+
+  default void close() {
+    // do nothing by default
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -179,7 +179,8 @@ public class BackwardSyncContext {
   }
 
   public boolean isReady() {
-    return syncState.hasReachedTerminalDifficulty().orElse(Boolean.FALSE);
+    return syncState.hasReachedTerminalDifficulty().orElse(Boolean.FALSE)
+        && syncState.isInitialSyncPhaseDone();
   }
 
   public CompletableFuture<Void> stop() {
@@ -242,10 +243,10 @@ public class BackwardSyncContext {
         () -> {
           try {
             if (!isReady()) {
-              LOG.info("Waiting for TTD...");
+              LOG.info("Waiting for preconditions...");
               final boolean await = latch.await(2, TimeUnit.MINUTES);
               if (await) {
-                LOG.info("TTD reached...");
+                LOG.info("Preconditions meet...");
               }
             }
           } catch (InterruptedException e) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -251,7 +251,7 @@ public class BackwardSyncContext {
             }
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new BackwardSyncException("Wait for TTD was interrupted");
+            throw new BackwardSyncException("Wait for TTD preconditions interrupted");
           } finally {
             syncState.unsubscribeTTDReached(id);
           }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -234,7 +234,7 @@ public class BackwardSyncContext {
     final long id =
         syncState.subscribeTTDReached(
             reached -> {
-              if (reached) {
+              if (reached && syncState.isInitialSyncPhaseDone()) {
                 latch.countDown();
               }
             });

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -179,8 +179,7 @@ public class BackwardSyncContext {
   }
 
   public boolean isReady() {
-    return syncState.isInitialSyncPhaseDone()
-        && syncState.hasReachedTerminalDifficulty().orElse(false);
+    return syncState.hasReachedTerminalDifficulty().orElse(Boolean.FALSE);
   }
 
   public CompletableFuture<Void> stop() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStep.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.fastsync;
 
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
+
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.core.BlockWithReceipts;
@@ -65,6 +67,7 @@ public class FastImportBlocksStep implements Consumer<List<BlockWithReceipts>> {
             blockWithReceipts.getHeader().getNumber(),
             blockWithReceipts.getHash());
       }
+      traceLambda(LOG, "Imported block {}", blockWithReceipts.getBlock()::toLogString);
     }
     if (logStartBlock.isEmpty()) {
       logStartBlock = OptionalLong.of(blocksWithReceipts.get(0).getNumber());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -61,13 +61,13 @@ public class FastSyncActions {
   private final AtomicLong pivotBlockGauge = new AtomicLong(0);
 
   public FastSyncActions(
-      final PivotBlockSelector pivotBlockSelector,
       final SynchronizerConfiguration syncConfig,
       final WorldStateStorage worldStateStorage,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
       final EthContext ethContext,
       final SyncState syncState,
+      final PivotBlockSelector pivotBlockSelector,
       final MetricsSystem metricsSystem) {
     this.syncConfig = syncConfig;
     this.worldStateStorage = worldStateStorage;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -216,18 +216,19 @@ public class FastSyncActions {
       return completedFuture(currentState);
     }
 
-    if (currentState.getPivotBlockHash().isPresent()) {
-      return downloadPivotBlockHeader(currentState.getPivotBlockHash().get());
-    }
-
-    return new PivotBlockRetriever(
-            protocolSchedule,
-            ethContext,
-            metricsSystem,
-            currentState.getPivotBlockNumber().getAsLong(),
-            syncConfig.getFastSyncMinimumPeerCount(),
-            syncConfig.getFastSyncPivotDistance())
-        .downloadPivotBlockHeader();
+    return currentState
+        .getPivotBlockHash()
+        .map(this::downloadPivotBlockHeader)
+        .orElseGet(
+            () ->
+                new PivotBlockRetriever(
+                        protocolSchedule,
+                        ethContext,
+                        metricsSystem,
+                        currentState.getPivotBlockNumber().getAsLong(),
+                        syncConfig.getFastSyncMinimumPeerCount(),
+                        syncConfig.getFastSyncPivotDistance())
+                    .downloadPivotBlockHeader());
   }
 
   private FastSyncState updateStats(final FastSyncState fastSyncState) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -252,7 +252,11 @@ public class FastSyncActions {
 
   private CompletableFuture<FastSyncState> downloadPivotBlockHeader(final Hash hash) {
     return RetryingGetHeaderFromPeerByHashTask.byHash(
-            protocolSchedule, ethContext, hash, 0L, metricsSystem)
+            protocolSchedule,
+            ethContext,
+            hash,
+            pivotBlockSelector.getMinRequiredBlockNumber(),
+            metricsSystem)
         .getHeader()
         .thenApply(
             blockHeader -> {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncState.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.fastsync;
 
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.Objects;
@@ -22,33 +23,48 @@ import java.util.OptionalLong;
 
 public class FastSyncState {
 
-  public static FastSyncState EMPTY_SYNC_STATE =
-      new FastSyncState(OptionalLong.empty(), Optional.empty());
+  public static final FastSyncState EMPTY_SYNC_STATE = new FastSyncState();
 
   private OptionalLong pivotBlockNumber;
+  private Optional<Hash> pivotBlockHash;
   private Optional<BlockHeader> pivotBlockHeader;
 
   public FastSyncState() {
     pivotBlockNumber = OptionalLong.empty();
+    pivotBlockHash = Optional.empty();
     pivotBlockHeader = Optional.empty();
   }
 
   public FastSyncState(final long pivotBlockNumber) {
-    this(OptionalLong.of(pivotBlockNumber), Optional.empty());
+    this(OptionalLong.of(pivotBlockNumber), Optional.empty(), Optional.empty());
+  }
+
+  public FastSyncState(final Hash pivotBlockHash) {
+    this(OptionalLong.empty(), Optional.of(pivotBlockHash), Optional.empty());
   }
 
   public FastSyncState(final BlockHeader pivotBlockHeader) {
-    this(OptionalLong.of(pivotBlockHeader.getNumber()), Optional.of(pivotBlockHeader));
+    this(
+        OptionalLong.of(pivotBlockHeader.getNumber()),
+        Optional.of(pivotBlockHeader.getHash()),
+        Optional.of(pivotBlockHeader));
   }
 
   protected FastSyncState(
-      final OptionalLong pivotBlockNumber, final Optional<BlockHeader> pivotBlockHeader) {
+      final OptionalLong pivotBlockNumber,
+      final Optional<Hash> pivotBlockHash,
+      final Optional<BlockHeader> pivotBlockHeader) {
     this.pivotBlockNumber = pivotBlockNumber;
+    this.pivotBlockHash = pivotBlockHash;
     this.pivotBlockHeader = pivotBlockHeader;
   }
 
   public OptionalLong getPivotBlockNumber() {
     return pivotBlockNumber;
+  }
+
+  public Optional<Hash> getPivotBlockHash() {
+    return pivotBlockHash;
   }
 
   public Optional<BlockHeader> getPivotBlockHeader() {
@@ -61,6 +77,7 @@ public class FastSyncState {
 
   public void setCurrentHeader(final BlockHeader header) {
     pivotBlockNumber = OptionalLong.of(header.getNumber());
+    pivotBlockHash = Optional.of(header.getHash());
     pivotBlockHeader = Optional.of(header);
   }
 
@@ -70,12 +87,13 @@ public class FastSyncState {
     if (o == null || getClass() != o.getClass()) return false;
     FastSyncState that = (FastSyncState) o;
     return Objects.equals(pivotBlockNumber, that.pivotBlockNumber)
+        && Objects.equals(pivotBlockHash, that.pivotBlockHash)
         && Objects.equals(pivotBlockHeader, that.pivotBlockHeader);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(pivotBlockNumber, pivotBlockHeader);
+    return Objects.hash(pivotBlockNumber, pivotBlockHash, pivotBlockHeader);
   }
 
   @Override
@@ -83,6 +101,8 @@ public class FastSyncState {
     return "FastSyncState{"
         + "pivotBlockNumber="
         + pivotBlockNumber
+        + "pivotBlockHash="
+        + pivotBlockHash
         + ", pivotBlockHeader="
         + pivotBlockHeader
         + '}';

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.fastsync;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
@@ -28,11 +29,15 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
 
   private static final Logger LOG = LoggerFactory.getLogger(PivotSelectorFromFinalizedBlock.class);
 
+  private final GenesisConfigOptions genesisConfig;
   private final Supplier<Optional<Hash>> finalizedBlockHashSupplier;
   private final Runnable cleanupAction;
 
   public PivotSelectorFromFinalizedBlock(
-      final Supplier<Optional<Hash>> finalizedBlockHashSupplier, final Runnable cleanupAction) {
+      final GenesisConfigOptions genesisConfig,
+      final Supplier<Optional<Hash>> finalizedBlockHashSupplier,
+      final Runnable cleanupAction) {
+    this.genesisConfig = genesisConfig;
     this.finalizedBlockHashSupplier = finalizedBlockHashSupplier;
     this.cleanupAction = cleanupAction;
   }
@@ -55,5 +60,10 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
   @Override
   public void close() {
     cleanupAction.run();
+  }
+
+  @Override
+  public long getMinRequiredBlockNumber() {
+    return genesisConfig.getTerminalBlockNumber().orElse(0L);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.fastsync;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PivotSelectorFromFinalizedBlock.class);
+
+  private final Supplier<Optional<Hash>> finalizedBlockHashSupplier;
+  private final Runnable cleanupAction;
+
+  public PivotSelectorFromFinalizedBlock(
+      final Supplier<Optional<Hash>> finalizedBlockHashSupplier, final Runnable cleanupAction) {
+    this.finalizedBlockHashSupplier = finalizedBlockHashSupplier;
+    this.cleanupAction = cleanupAction;
+  }
+
+  @Override
+  public Optional<FastSyncState> selectNewPivotBlock(final EthPeer peer) {
+    final Optional<Hash> maybeHash = finalizedBlockHashSupplier.get();
+    if (maybeHash.isPresent()) {
+      return Optional.of(selectLastFinalizedBlockAsPivot(maybeHash.get()));
+    }
+    LOG.info("No finalized block hash announced yet");
+    return Optional.empty();
+  }
+
+  private FastSyncState selectLastFinalizedBlockAsPivot(final Hash finalizedHash) {
+    LOG.info("Returning finalized block hash as pivot: {}", finalizedHash);
+    return new FastSyncState(finalizedHash);
+  }
+
+  @Override
+  public void close() {
+    cleanupAction.run();
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromPeers.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.fastsync;
+
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PivotSelectorFromPeers implements PivotBlockSelector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PivotSelectorFromPeers.class);
+
+  private final SynchronizerConfiguration syncConfig;
+
+  public PivotSelectorFromPeers(final SynchronizerConfiguration syncConfig) {
+    this.syncConfig = syncConfig;
+  }
+
+  @Override
+  public Optional<FastSyncState> selectNewPivotBlock(final EthPeer peer) {
+    return fromBestPeer(peer);
+  }
+
+  private Optional<FastSyncState> fromBestPeer(final EthPeer peer) {
+    final long pivotBlockNumber =
+        peer.chainState().getEstimatedHeight() - syncConfig.getFastSyncPivotDistance();
+    if (pivotBlockNumber <= BlockHeader.GENESIS_BLOCK_NUMBER) {
+      // Peer's chain isn't long enough, return an empty value so we can try again.
+      LOG.info("Waiting for peers with sufficient chain height");
+      return Optional.empty();
+    }
+    LOG.info("Selecting block number {} as fast sync pivot block.", pivotBlockNumber);
+    return Optional.of(new FastSyncState(pivotBlockNumber));
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.fastsync;
+
+import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransitionPivotSelector implements PivotBlockSelector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransitionPivotSelector.class);
+
+  private final Difficulty totalTerminalDifficulty;
+  private final PivotBlockSelector pivotSelectorFromPeers;
+  private final PivotBlockSelector pivotSelectorFromFinalizedBlock;
+
+  public TransitionPivotSelector(
+      final GenesisConfigOptions genesisConfig,
+      final PivotBlockSelector pivotSelectorFromPeers,
+      final PivotBlockSelector pivotSelectorFromFinalizedBlock) {
+    this.totalTerminalDifficulty =
+        genesisConfig
+            .getTerminalTotalDifficulty()
+            .map(Difficulty::of)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "This class can only be used when TTD is present"));
+    this.pivotSelectorFromPeers = pivotSelectorFromPeers;
+    this.pivotSelectorFromFinalizedBlock = pivotSelectorFromFinalizedBlock;
+  }
+
+  @Override
+  public Optional<FastSyncState> selectNewPivotBlock(final EthPeer peer) {
+    return routeDependingOnTotalTerminalDifficulty(peer);
+  }
+
+  private Optional<FastSyncState> routeDependingOnTotalTerminalDifficulty(final EthPeer peer) {
+
+    Difficulty bestPeerEstDifficulty = peer.chainState().getEstimatedTotalDifficulty();
+
+    if (bestPeerEstDifficulty.lessThan(totalTerminalDifficulty)) {
+      LOG.info(
+          "Chain has not yet reached TTD, best peer has estimated difficulty {},"
+              + " select pivot from peers",
+          bestPeerEstDifficulty);
+      return pivotSelectorFromPeers.selectNewPivotBlock(peer);
+    }
+
+    LOG.info(
+        "Chain has reached TTD, best peer has estimated difficulty {},"
+            + " select pivot from finalized block",
+        bestPeerEstDifficulty);
+    return pivotSelectorFromFinalizedBlock.selectNewPivotBlock(peer);
+  }
+
+  @Override
+  public void close() {
+    pivotSelectorFromFinalizedBlock.close();
+    pivotSelectorFromPeers.close();
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
@@ -77,4 +77,9 @@ public class TransitionPivotSelector implements PivotBlockSelector {
     pivotSelectorFromFinalizedBlock.close();
     pivotSelectorFromPeers.close();
   }
+
+  @Override
+  public long getMinRequiredBlockNumber() {
+    return pivotSelectorFromFinalizedBlock.getMinRequiredBlockNumber();
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
@@ -63,7 +63,7 @@ public class TransitionPivotSelector implements PivotBlockSelector {
     Difficulty bestPeerEstDifficulty = peer.chainState().getEstimatedTotalDifficulty();
 
     if (finalizedBlockHashSupplier.get().isPresent()) {
-      LOG.info("A finalized block is present, us it as pivot", bestPeerEstDifficulty);
+      LOG.info("A finalized block is present, use it as pivot");
       return pivotSelectorFromFinalizedBlock.selectNewPivotBlock(peer);
     }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/CompleteTaskStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/CompleteTaskStep.java
@@ -45,8 +45,8 @@ public class CompleteTaskStep {
                 "world_state_completed_requests_total",
                 "Total number of node data requests completed as part of fast sync world state download"),
             this::displayWorldStateSyncProgress,
-            10,
-            TimeUnit.SECONDS);
+            1,
+            TimeUnit.MINUTES);
     retriedRequestsCounter =
         metricsSystem.createCounter(
             BesuMetricCategory.SYNCHRONIZER,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/CompleteTaskStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/CompleteTaskStep.java
@@ -17,11 +17,12 @@ package org.hyperledger.besu.ethereum.eth.sync.fastsync.worldstate;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldDownloadState;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.metrics.RunnableCounter;
+import org.hyperledger.besu.metrics.RunnableTimedCounter;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.services.tasks.Task;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.LongSupplier;
 
 import org.slf4j.Logger;
@@ -29,24 +30,23 @@ import org.slf4j.LoggerFactory;
 
 public class CompleteTaskStep {
   private static final Logger LOG = LoggerFactory.getLogger(CompleteTaskStep.class);
-  private static final int DISPLAY_PROGRESS_STEP = 100000;
-  private final RunnableCounter completedRequestsCounter;
+  private final RunnableTimedCounter completedRequestsCounter;
   private final Counter retriedRequestsCounter;
   private final LongSupplier worldStatePendingRequestsCurrentSupplier;
-  private long lastLogAt = System.currentTimeMillis();
 
   public CompleteTaskStep(
       final MetricsSystem metricsSystem,
       final LongSupplier worldStatePendingRequestsCurrentSupplier) {
     this.worldStatePendingRequestsCurrentSupplier = worldStatePendingRequestsCurrentSupplier;
     completedRequestsCounter =
-        new RunnableCounter(
+        new RunnableTimedCounter(
             metricsSystem.createCounter(
                 BesuMetricCategory.SYNCHRONIZER,
                 "world_state_completed_requests_total",
                 "Total number of node data requests completed as part of fast sync world state download"),
             this::displayWorldStateSyncProgress,
-            DISPLAY_PROGRESS_STEP);
+            10,
+            TimeUnit.SECONDS);
     retriedRequestsCounter =
         metricsSystem.createCounter(
             BesuMetricCategory.SYNCHRONIZER,
@@ -72,14 +72,10 @@ public class CompleteTaskStep {
   }
 
   private void displayWorldStateSyncProgress() {
-    final long now = System.currentTimeMillis();
-    if (now - lastLogAt > 10 * 1000L) {
-      LOG.info(
-          "Downloaded {} world state nodes. At least {} nodes remaining.",
-          getCompletedRequests(),
-          worldStatePendingRequestsCurrentSupplier.getAsLong());
-      lastLogAt = now;
-    }
+    LOG.info(
+        "Downloaded {} world state nodes. At least {} nodes remaining.",
+        getCompletedRequests(),
+        worldStatePendingRequestsCurrentSupplier.getAsLong());
   }
 
   long getCompletedRequests() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -114,13 +114,13 @@ public class FastDownloaderFactory {
     final FastSyncDownloader<NodeDataRequest> fastSyncDownloader =
         new FastSyncDownloader<>(
             new FastSyncActions(
-                pivotBlockSelector,
                 syncConfig,
                 worldStateStorage,
                 protocolSchedule,
                 protocolContext,
                 ethContext,
                 syncState,
+                pivotBlockSelector,
                 metricsSystem),
             worldStateStorage,
             worldStateDownloader,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -14,11 +14,11 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.fastsync.worldstate;
 
-import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.FastSyncActions;
@@ -52,8 +52,8 @@ public class FastDownloaderFactory {
   private static final Logger LOG = LoggerFactory.getLogger(FastDownloaderFactory.class);
 
   public static Optional<FastSyncDownloader<?>> create(
+      final PivotBlockSelector pivotBlockSelector,
       final SynchronizerConfiguration syncConfig,
-      final GenesisConfigOptions genesisConfig,
       final Path dataDirectory,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
@@ -114,9 +114,9 @@ public class FastDownloaderFactory {
     final FastSyncDownloader<NodeDataRequest> fastSyncDownloader =
         new FastSyncDownloader<>(
             new FastSyncActions(
+                pivotBlockSelector,
                 syncConfig,
                 worldStateStorage,
-                genesisConfig,
                 protocolSchedule,
                 protocolContext,
                 ethContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.fastsync.worldstate;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -52,6 +53,7 @@ public class FastDownloaderFactory {
 
   public static Optional<FastSyncDownloader<?>> create(
       final SynchronizerConfiguration syncConfig,
+      final GenesisConfigOptions genesisConfig,
       final Path dataDirectory,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
@@ -114,6 +116,7 @@ public class FastDownloaderFactory {
             new FastSyncActions(
                 syncConfig,
                 worldStateStorage,
+                genesisConfig,
                 protocolSchedule,
                 protocolContext,
                 ethContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullSyncDownloader.java
@@ -35,7 +35,6 @@ public class FullSyncDownloader {
   private final SynchronizerConfiguration syncConfig;
   private final ProtocolContext protocolContext;
   private final SyncState syncState;
-  private final SyncTerminationCondition terminationCondition;
 
   public FullSyncDownloader(
       final SynchronizerConfiguration syncConfig,
@@ -48,7 +47,6 @@ public class FullSyncDownloader {
     this.syncConfig = syncConfig;
     this.protocolContext = protocolContext;
     this.syncState = syncState;
-    this.terminationCondition = terminationCondition;
 
     this.chainDownloader =
         FullSyncChainDownloader.create(
@@ -63,15 +61,7 @@ public class FullSyncDownloader {
 
   public CompletableFuture<Void> start() {
     LOG.info("Starting full sync.");
-    return chainDownloader
-        .start()
-        .thenApply(
-            unused -> {
-              if (terminationCondition.shouldStopDownload()) {
-                syncState.setReachedTerminalDifficulty(true);
-              }
-              return null;
-            });
+    return chainDownloader.start();
   }
 
   public void stop() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -104,13 +104,13 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
     final FastSyncDownloader<SnapDataRequest> fastSyncDownloader =
         new SnapSyncDownloader(
             new FastSyncActions(
-                pivotBlockSelector,
                 syncConfig,
                 worldStateStorage,
                 protocolSchedule,
                 protocolContext,
                 ethContext,
                 syncState,
+                pivotBlockSelector,
                 metricsSystem),
             worldStateStorage,
             snapWorldStateDownloader,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -14,10 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
-import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.FastSyncActions;
@@ -46,8 +46,8 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
   private static final Logger LOG = LoggerFactory.getLogger(SnapDownloaderFactory.class);
 
   public static Optional<FastSyncDownloader<?>> createSnapDownloader(
+      final PivotBlockSelector pivotBlockSelector,
       final SynchronizerConfiguration syncConfig,
-      final GenesisConfigOptions genesisConfig,
       final Path dataDirectory,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
@@ -104,9 +104,9 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
     final FastSyncDownloader<SnapDataRequest> fastSyncDownloader =
         new SnapSyncDownloader(
             new FastSyncActions(
+                pivotBlockSelector,
                 syncConfig,
                 worldStateStorage,
-                genesisConfig,
                 protocolSchedule,
                 protocolContext,
                 ethContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -46,6 +47,7 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
 
   public static Optional<FastSyncDownloader<?>> createSnapDownloader(
       final SynchronizerConfiguration syncConfig,
+      final GenesisConfigOptions genesisConfig,
       final Path dataDirectory,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
@@ -104,6 +106,7 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
             new FastSyncActions(
                 syncConfig,
                 worldStateStorage,
+                genesisConfig,
                 protocolSchedule,
                 protocolContext,
                 ethContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
@@ -23,7 +23,10 @@ public class SnapSyncState extends FastSyncState {
   private boolean isHealInProgress;
 
   public SnapSyncState(final FastSyncState fastSyncState) {
-    super(fastSyncState.getPivotBlockNumber(), fastSyncState.getPivotBlockHeader());
+    super(
+        fastSyncState.getPivotBlockNumber(),
+        fastSyncState.getPivotBlockHash(),
+        fastSyncState.getPivotBlockHeader());
   }
 
   public boolean isHealInProgress() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -165,7 +165,10 @@ public class SyncState {
   }
 
   public Optional<Boolean> hasReachedTerminalDifficulty() {
-    return reachedTerminalDifficulty;
+    if (isInitialSyncPhaseDone) {
+      return reachedTerminalDifficulty;
+    }
+    return Optional.of(Boolean.FALSE);
   }
 
   private boolean isInSync(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/RetryingGetHeaderFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/RetryingGetHeaderFromPeerByHashTask.java
@@ -77,7 +77,9 @@ public class RetryingGetHeaderFromPeerByHashTask
     return executeSubTask(task::run)
         .thenApply(
             peerResult -> {
-              result.complete(peerResult.getResult());
+              if (!peerResult.getResult().isEmpty()) {
+                result.complete(peerResult.getResult());
+              }
               return peerResult.getResult();
             });
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/RetryingGetHeaderFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/RetryingGetHeaderFromPeerByHashTask.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.tasks;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.task.AbstractGetHeadersFromPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.AbstractRetryingPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.GetHeadersFromPeerByHashTask;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.annotations.VisibleForTesting;
+
+public class RetryingGetHeaderFromPeerByHashTask
+    extends AbstractRetryingPeerTask<List<BlockHeader>> {
+
+  private final Hash referenceHash;
+  private final ProtocolSchedule protocolSchedule;
+  private final long minimumRequiredBlockNumber;
+
+  @VisibleForTesting
+  RetryingGetHeaderFromPeerByHashTask(
+      final ProtocolSchedule protocolSchedule,
+      final EthContext ethContext,
+      final Hash referenceHash,
+      final long minimumRequiredBlockNumber,
+      final MetricsSystem metricsSystem) {
+    super(ethContext, 3, List::isEmpty, metricsSystem);
+    this.protocolSchedule = protocolSchedule;
+    this.minimumRequiredBlockNumber = minimumRequiredBlockNumber;
+    checkNotNull(referenceHash);
+    this.referenceHash = referenceHash;
+  }
+
+  public static RetryingGetHeaderFromPeerByHashTask byHash(
+      final ProtocolSchedule protocolSchedule,
+      final EthContext ethContext,
+      final Hash referenceHash,
+      final long minimumRequiredBlockNumber,
+      final MetricsSystem metricsSystem) {
+    return new RetryingGetHeaderFromPeerByHashTask(
+        protocolSchedule, ethContext, referenceHash, minimumRequiredBlockNumber, metricsSystem);
+  }
+
+  @Override
+  protected CompletableFuture<List<BlockHeader>> executePeerTask(
+      final Optional<EthPeer> assignedPeer) {
+    final AbstractGetHeadersFromPeerTask task =
+        GetHeadersFromPeerByHashTask.forSingleHash(
+            protocolSchedule,
+            getEthContext(),
+            referenceHash,
+            minimumRequiredBlockNumber,
+            getMetricsSystem());
+    assignedPeer.ifPresent(task::assignPeer);
+    return executeSubTask(task::run)
+        .thenApply(
+            peerResult -> {
+              result.complete(peerResult.getResult());
+              return peerResult.getResult();
+            });
+  }
+
+  public CompletableFuture<BlockHeader> getHeader() {
+    return run().thenApply(singletonList -> singletonList.get(0));
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
@@ -144,7 +144,7 @@ public class BackwardSyncContextTest {
                 ethContext,
                 syncState,
                 backwardChain));
-    doReturn(true).when(context).isOnTTD();
+    doReturn(true).when(context).isReady();
     doReturn(2).when(context).getBatchSize();
   }
 
@@ -222,7 +222,7 @@ public class BackwardSyncContextTest {
   @Test
   public void shouldWaitWhenTTDNotReached()
       throws ExecutionException, InterruptedException, TimeoutException {
-    doReturn(false).when(context).isOnTTD();
+    doReturn(false).when(context).isReady();
     when(syncState.subscribeTTDReached(any())).thenReturn(88L);
 
     final CompletableFuture<Void> voidCompletableFuture = context.waitForTTD();
@@ -241,7 +241,7 @@ public class BackwardSyncContextTest {
   @Test
   public void shouldNotWaitWhenTTDReached()
       throws ExecutionException, InterruptedException, TimeoutException {
-    doReturn(true).when(context).isOnTTD();
+    doReturn(true).when(context).isReady();
     when(syncState.subscribeTTDReached(any())).thenReturn(88L);
     final CompletableFuture<Void> voidCompletableFuture = context.waitForTTD();
     voidCompletableFuture.get(1, TimeUnit.SECONDS);
@@ -261,7 +261,7 @@ public class BackwardSyncContextTest {
   }
 
   @Test
-  public void shouldFinishWhenWorkIsDonw() {
+  public void shouldFinishWhenWorkIsDone() {
 
     final CompletableFuture<Void> completableFuture = context.executeNextStep(null);
     assertThat(completableFuture.isDone()).isTrue();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContextTest.java
@@ -223,6 +223,7 @@ public class BackwardSyncContextTest {
   public void shouldWaitWhenTTDNotReached()
       throws ExecutionException, InterruptedException, TimeoutException {
     doReturn(false).when(context).isReady();
+    when(syncState.isInitialSyncPhaseDone()).thenReturn(Boolean.TRUE);
     when(syncState.subscribeTTDReached(any())).thenReturn(88L);
 
     final CompletableFuture<Void> voidCompletableFuture = context.waitForTTD();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -50,6 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class FastDownloaderFactoryTest {
 
   @Mock private SynchronizerConfiguration syncConfig;
+  @Mock private GenesisConfigOptions genesisConfig;
   @Mock private ProtocolSchedule protocolSchedule;
   @Mock private ProtocolContext protocolContext;
   @Mock private MetricsSystem metricsSystem;
@@ -67,6 +69,7 @@ public class FastDownloaderFactoryTest {
     when(syncConfig.getSyncMode()).thenReturn(SyncMode.FULL);
     FastDownloaderFactory.create(
         syncConfig,
+        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -86,6 +89,7 @@ public class FastDownloaderFactoryTest {
     final Optional result =
         FastDownloaderFactory.create(
             syncConfig,
+            genesisConfig,
             dataDirectory,
             protocolSchedule,
             protocolContext,
@@ -109,6 +113,7 @@ public class FastDownloaderFactoryTest {
     when(syncConfig.getSyncMode()).thenReturn(SyncMode.FAST);
     FastDownloaderFactory.create(
         syncConfig,
+        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -138,6 +143,7 @@ public class FastDownloaderFactoryTest {
 
     FastDownloaderFactory.create(
         syncConfig,
+        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -169,6 +175,7 @@ public class FastDownloaderFactoryTest {
             () ->
                 FastDownloaderFactory.create(
                     syncConfig,
+                    genesisConfig,
                     dataDirectory,
                     protocolSchedule,
                     protocolContext,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
@@ -21,10 +21,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.worldstate.FastDownloaderFactory;
@@ -51,7 +51,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class FastDownloaderFactoryTest {
 
   @Mock private SynchronizerConfiguration syncConfig;
-  @Mock private GenesisConfigOptions genesisConfig;
   @Mock private ProtocolSchedule protocolSchedule;
   @Mock private ProtocolContext protocolContext;
   @Mock private MetricsSystem metricsSystem;
@@ -60,16 +59,17 @@ public class FastDownloaderFactoryTest {
   @Mock private SyncState syncState;
   @Mock private Clock clock;
   @Mock private Path dataDirectory;
+  @Mock private PivotBlockSelector pivotBlockSelector;
 
   @SuppressWarnings("unchecked")
   @Test(expected = IllegalStateException.class)
-  public void shouldThrowIfSyncModeChangedWhileFastSyncIncomplete() throws NoSuchFieldException {
+  public void shouldThrowIfSyncModeChangedWhileFastSyncIncomplete() {
     initDataDirectory(true);
 
     when(syncConfig.getSyncMode()).thenReturn(SyncMode.FULL);
     FastDownloaderFactory.create(
+        pivotBlockSelector,
         syncConfig,
-        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -82,14 +82,14 @@ public class FastDownloaderFactoryTest {
 
   @SuppressWarnings({"unchecked", "rawtypes"})
   @Test
-  public void shouldNotThrowIfSyncModeChangedWhileFastSyncComplete() throws NoSuchFieldException {
+  public void shouldNotThrowIfSyncModeChangedWhileFastSyncComplete() {
     initDataDirectory(false);
 
     when(syncConfig.getSyncMode()).thenReturn(SyncMode.FULL);
     final Optional result =
         FastDownloaderFactory.create(
+            pivotBlockSelector,
             syncConfig,
-            genesisConfig,
             dataDirectory,
             protocolSchedule,
             protocolContext,
@@ -112,8 +112,8 @@ public class FastDownloaderFactoryTest {
 
     when(syncConfig.getSyncMode()).thenReturn(SyncMode.FAST);
     FastDownloaderFactory.create(
+        pivotBlockSelector,
         syncConfig,
-        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -142,8 +142,8 @@ public class FastDownloaderFactoryTest {
     assertThat(Files.exists(stateQueueDir)).isTrue();
 
     FastDownloaderFactory.create(
+        pivotBlockSelector,
         syncConfig,
-        genesisConfig,
         dataDirectory,
         protocolSchedule,
         protocolContext,
@@ -174,8 +174,8 @@ public class FastDownloaderFactoryTest {
     Assertions.assertThatThrownBy(
             () ->
                 FastDownloaderFactory.create(
+                    pivotBlockSelector,
                     syncConfig,
-                    genesisConfig,
                     dataDirectory,
                     protocolSchedule,
                     protocolContext,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -413,13 +413,13 @@ public class FastSyncActionsTest {
     final ProtocolContext protocolContext = blockchainSetupUtil.getProtocolContext();
     final EthContext ethContext = ethProtocolManager.ethContext();
     return new FastSyncActions(
-        new PivotSelectorFromPeers(syncConfig),
         syncConfig,
         worldStateStorage,
         protocolSchedule,
         protocolContext,
         ethContext,
         new SyncState(blockchain, ethContext.getEthPeers(), true),
+        new PivotSelectorFromPeers(syncConfig),
         new NoOpMetricsSystem());
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -19,7 +19,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -94,7 +93,6 @@ public class FastSyncActionsTest {
             blockchainSetupUtil.getTransactionPool(),
             EthProtocolConfiguration.defaultConfig());
     fastSyncActions = createFastSyncActions(syncConfig);
-    when(worldStateStorage.isWorldStateAvailable(any(), any())).thenReturn(true);
   }
 
   @Test
@@ -415,13 +413,13 @@ public class FastSyncActionsTest {
     final ProtocolContext protocolContext = blockchainSetupUtil.getProtocolContext();
     final EthContext ethContext = ethProtocolManager.ethContext();
     return new FastSyncActions(
+        new PivotSelectorFromPeers(syncConfig),
         syncConfig,
         worldStateStorage,
-        mock(GenesisConfigOptions.class),
         protocolSchedule,
         protocolContext,
         ethContext,
-        new SyncState(blockchain, ethContext.getEthPeers()),
+        new SyncState(blockchain, ethContext.getEthPeers(), true),
         new NoOpMetricsSystem());
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -19,6 +19,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -33,6 +35,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -45,6 +48,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -92,7 +96,7 @@ public class FastSyncActionsTest {
             blockchainSetupUtil.getWorldArchive(),
             blockchainSetupUtil.getTransactionPool(),
             EthProtocolConfiguration.defaultConfig());
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
   }
 
   @Test
@@ -135,7 +139,7 @@ public class FastSyncActionsTest {
     final int minPeers = 1;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
 
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 5000);
 
@@ -150,7 +154,7 @@ public class FastSyncActionsTest {
     final int minPeers = 1;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
 
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, Difficulty.of(1000), 5500);
     EthProtocolManagerTestUtil.createPeer(ethProtocolManager, Difficulty.of(2000), 4000);
@@ -167,7 +171,7 @@ public class FastSyncActionsTest {
     final int minPeers = 2;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
 
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.selectPivotBlock(FastSyncState.EMPTY_SYNC_STATE);
@@ -192,7 +196,7 @@ public class FastSyncActionsTest {
     final int minPeers = 3;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
     final long minPivotHeight = syncConfig.getFastSyncPivotDistance() + 1L;
     EthProtocolManagerTestUtil.disableEthSchedulerAutoRun(ethProtocolManager);
 
@@ -237,7 +241,7 @@ public class FastSyncActionsTest {
     final PeerValidator validator = mock(PeerValidator.class);
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
     final long minPivotHeight = syncConfig.getFastSyncPivotDistance() + 1L;
     EthProtocolManagerTestUtil.disableEthSchedulerAutoRun(ethProtocolManager);
 
@@ -298,7 +302,7 @@ public class FastSyncActionsTest {
     final int peerCount = minPeers + 1;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
     final long minPivotHeight = syncConfig.getFastSyncPivotDistance() + 1L;
     EthProtocolManagerTestUtil.disableEthSchedulerAutoRun(ethProtocolManager);
 
@@ -344,7 +348,7 @@ public class FastSyncActionsTest {
     final int minPeers = 1;
     syncConfigBuilder.fastSyncMinimumPeerCount(minPeers);
     syncConfig = syncConfigBuilder.build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
     final long pivotDistance = syncConfig.getFastSyncPivotDistance();
 
     EthProtocolManagerTestUtil.disableEthSchedulerAutoRun(ethProtocolManager);
@@ -395,7 +399,7 @@ public class FastSyncActionsTest {
   @Test
   public void downloadPivotBlockHeaderShouldRetrievePivotBlockHeader() {
     syncConfig = SynchronizerConfiguration.builder().fastSyncMinimumPeerCount(1).build();
-    fastSyncActions = createFastSyncActions(syncConfig);
+    fastSyncActions = createFastSyncActions(syncConfig, new PivotSelectorFromPeers(syncConfig));
 
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1001);
     final CompletableFuture<FastSyncState> result =
@@ -408,7 +412,32 @@ public class FastSyncActionsTest {
     assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(1).get()));
   }
 
-  private FastSyncActions createFastSyncActions(final SynchronizerConfiguration syncConfig) {
+  @Test
+  public void downloadPivotBlockHeaderShouldRetrievePivotBlockHash() {
+    syncConfig = SynchronizerConfiguration.builder().fastSyncMinimumPeerCount(1).build();
+    GenesisConfigOptions genesisConfig = mock(GenesisConfigOptions.class);
+    when(genesisConfig.getTerminalBlockNumber()).thenReturn(OptionalLong.of(10L));
+
+    final Optional<Hash> finalizedHash = blockchain.getBlockHashByNumber(2L);
+
+    fastSyncActions =
+        createFastSyncActions(
+            syncConfig,
+            new PivotSelectorFromFinalizedBlock(genesisConfig, () -> finalizedHash, () -> {}));
+
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1001);
+    final CompletableFuture<FastSyncState> result =
+        fastSyncActions.downloadPivotBlockHeader(new FastSyncState(finalizedHash.get()));
+    assertThat(result).isNotCompleted();
+
+    final RespondingEthPeer.Responder responder = RespondingEthPeer.blockchainResponder(blockchain);
+    peer.respond(responder);
+
+    assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(2).get()));
+  }
+
+  private FastSyncActions createFastSyncActions(
+      final SynchronizerConfiguration syncConfig, final PivotBlockSelector pivotBlockSelector) {
     final ProtocolSchedule protocolSchedule = blockchainSetupUtil.getProtocolSchedule();
     final ProtocolContext protocolContext = blockchainSetupUtil.getProtocolContext();
     final EthContext ethContext = ethProtocolManager.ethContext();
@@ -419,7 +448,7 @@ public class FastSyncActionsTest {
         protocolContext,
         ethContext,
         new SyncState(blockchain, ethContext.getEthPeers(), true),
-        new PivotSelectorFromPeers(syncConfig),
+        pivotBlockSelector,
         new NoOpMetricsSystem());
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -416,6 +417,7 @@ public class FastSyncActionsTest {
     return new FastSyncActions(
         syncConfig,
         worldStateStorage,
+        mock(GenesisConfigOptions.class),
         protocolSchedule,
         protocolContext,
         ethContext,

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/RunnableTimedCounter.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/RunnableTimedCounter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.metrics;
+
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Counter that triggers a specific task if the specified interval has elapsed. */
+public class RunnableTimedCounter implements Counter {
+
+  private final Counter backedCounter;
+  private final Runnable task;
+  private final long intervalMillis;
+  private final AtomicLong stepCounter;
+  private volatile long nextExecutionAtMillis;
+
+  public RunnableTimedCounter(
+      final Counter backedCounter, final Runnable task, final long interval, final TimeUnit unit) {
+    this.backedCounter = backedCounter;
+    this.task = task;
+    this.stepCounter = new AtomicLong(0);
+    this.intervalMillis = unit.toMillis(interval);
+    this.nextExecutionAtMillis = System.currentTimeMillis() + intervalMillis;
+  }
+
+  /**
+   * Increments the stepCounter by 1
+   *
+   * <p>{@link #inc(long) inc} method
+   */
+  @Override
+  public void inc() {
+    this.inc(1);
+  }
+
+  /**
+   * Increments the stepCounter by amount. Triggers the runnable if interval has elapsed
+   *
+   * @param amount the value to add to the stepCounter.
+   */
+  @Override
+  public void inc(final long amount) {
+    backedCounter.inc(amount);
+    stepCounter.addAndGet(amount);
+    final long now = System.currentTimeMillis();
+    if (nextExecutionAtMillis < now) {
+      task.run();
+      nextExecutionAtMillis = now + intervalMillis;
+    }
+  }
+
+  public long get() {
+    return stepCounter.get();
+  }
+}

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/RunnableTimedCounter.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/RunnableTimedCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/RunnableTimedCounterTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/RunnableTimedCounterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.metrics;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RunnableTimedCounterTest {
+
+  @Mock Counter backedCounter;
+
+  @Test
+  public void shouldNotRunTaskIfIntervalNotElapsed() {
+
+    RunnableTimedCounter rtc =
+        new RunnableTimedCounter(
+            backedCounter, () -> fail("Must not be called"), 1L, TimeUnit.MINUTES);
+
+    rtc.inc();
+    verify(backedCounter).inc(1L);
+  }
+
+  @Test
+  public void shouldRunTaskIfIntervalElapsed() throws InterruptedException {
+
+    Runnable task = mock(Runnable.class);
+
+    RunnableTimedCounter rtc =
+        new RunnableTimedCounter(backedCounter, task, 1L, TimeUnit.MICROSECONDS);
+
+    Thread.sleep(1L);
+
+    rtc.inc();
+
+    verify(backedCounter).inc(1L);
+    verify(task).run();
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR add the information of an initial sync phase to SyncState. Initial sync is everything that is not Full sync, we need that because when using Fast/Snap sync, we need to complete this phase before Besu can report that it is in sync, when processing CL messages, and before the Backward sync can start.

If TTD is configured, the Fast sync goes in a transition modality, that is, if the best peer has reached TTD, then Fast sync listens for a finalized block, and when it is available choses it as pivot, otherwise if best peer is still before TTD, then the previous PoW strategy is used, selecting the pivot block from peers.

Then `EngineForkchoidUpdated` API has been extended to accept listeners and inform them when a new message, that includes the last finalized block, as arrived, in this way Fast sync can use the finalized block as pivot.

Other improvements avoid to start Full sync and block propagation manager, in case at the start the network is already after TTD, because both will be stop just after the start anyway. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #3506 
fixes #3507
fixes #3724 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).