### PR TITLE
Fix block import subcommand by r

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -253,7 +253,7 @@ public class BlocksSubCommand implements Runnable {
             .miningParameters(getMiningParameters())
             .build();
       } catch (final Exception e) {
-        throw new ExecutionException(new CommandLine(parentCommand), e.getMessage(), e);
+        throw new ExecutionException(parentCommand.spec.commandLine(), e.getMessage(), e);
       }
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/ConfigOptionSearchAndRunHandler.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/ConfigOptionSearchAndRunHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -47,7 +47,7 @@ public class ConfigOptionSearchAndRunHandler extends AbstractParseResultHandler<
 
   @Override
   public List<Object> handle(final ParseResult parseResult) throws ParameterException {
-    final CommandLine commandLine = parseResult.asCommandLineList().get(0);
+    final CommandLine commandLine = parseResult.commandSpec().commandLine();
     final Optional<File> configFile = findConfigFile(parseResult, commandLine);
     validatePrivacyOptions(parseResult, commandLine);
     commandLine.setDefaultValueProvider(createDefaultValueProvider(commandLine, configFile));


### PR DESCRIPTION
Some instantiation of `CommandLine` were throwing errors, because the were not using `BesuCommandCustomFactory` to create the necessary `VersionProvider`, which is recently needed by subcommands as well.

Instead of creating new `CommandLine`instances the PR reuses the existing objects, which are already correctly configured.

Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
fixes #3646

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).