### PR TITLE
Merge: Backward sync re-org below TTD fix

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -55,14 +55,13 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
       final MiningParameters miningParameters,
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager) {
-
-    this.syncState.set(syncState);
-
-    return new MergeCoordinator(
-        protocolContext,
+    return createTransitionMiningCoordinator(
         protocolSchedule,
-        transactionPool.getPendingTransactions(),
+        protocolContext,
+        transactionPool,
         miningParameters,
+        syncState,
+        ethProtocolManager,
         new BackwardSyncContext(
             protocolContext,
             protocolSchedule,
@@ -72,6 +71,25 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
             new BackwardSyncLookupService(
                 protocolSchedule, ethProtocolManager.ethContext(), metricsSystem, protocolContext),
             storageProvider));
+  }
+
+  protected MiningCoordinator createTransitionMiningCoordinator(
+      final ProtocolSchedule protocolSchedule,
+      final ProtocolContext protocolContext,
+      final TransactionPool transactionPool,
+      final MiningParameters miningParameters,
+      final SyncState syncState,
+      final EthProtocolManager ethProtocolManager,
+      final BackwardSyncContext backwardSyncContext) {
+
+    this.syncState.set(syncState);
+
+    return new MergeCoordinator(
+        protocolContext,
+        protocolSchedule,
+        transactionPool.getPendingTransactions(),
+        miningParameters,
+        backwardSyncContext);
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.controller;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.consensus.merge.PostMergeContext;
+import org.hyperledger.besu.consensus.merge.TransitionBackwardSyncContext;
 import org.hyperledger.besu.consensus.merge.TransitionContext;
 import org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule;
 import org.hyperledger.besu.consensus.merge.blockcreation.TransitionCoordinator;
@@ -32,6 +33,8 @@ import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncLookupService;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
@@ -79,29 +82,46 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
       final EthProtocolManager ethProtocolManager) {
 
     // cast to transition schedule for explicit access to pre and post objects:
-    final TransitionProtocolSchedule tps = (TransitionProtocolSchedule) protocolSchedule;
+    final TransitionProtocolSchedule transitionProtocolSchedule =
+        (TransitionProtocolSchedule) protocolSchedule;
 
     // PoA consensus mines by default, get consensus-specific mining parameters for
     // TransitionCoordinator:
     MiningParameters transitionMiningParameters =
         preMergeBesuControllerBuilder.getMiningParameterOverrides(miningParameters);
 
+    // construct a transition backward sync context
+    BackwardSyncContext transitionBackwardsSyncContext =
+        new TransitionBackwardSyncContext(
+            protocolContext,
+            transitionProtocolSchedule,
+            metricsSystem,
+            ethProtocolManager.ethContext(),
+            syncState,
+            new BackwardSyncLookupService(
+                transitionProtocolSchedule,
+                ethProtocolManager.ethContext(),
+                metricsSystem,
+                protocolContext),
+            storageProvider);
+
     final TransitionCoordinator composedCoordinator =
         new TransitionCoordinator(
             preMergeBesuControllerBuilder.createMiningCoordinator(
-                tps.getPreMergeSchedule(),
+                transitionProtocolSchedule.getPreMergeSchedule(),
                 protocolContext,
                 transactionPool,
                 new MiningParameters.Builder(miningParameters).miningEnabled(false).build(),
                 syncState,
                 ethProtocolManager),
-            mergeBesuControllerBuilder.createMiningCoordinator(
-                tps.getPostMergeSchedule(),
+            mergeBesuControllerBuilder.createTransitionMiningCoordinator(
+                transitionProtocolSchedule,
                 protocolContext,
                 transactionPool,
                 transitionMiningParameters,
                 syncState,
-                ethProtocolManager));
+                ethProtocolManager,
+                transitionBackwardsSyncContext));
     initTransitionWatcher(protocolContext, composedCoordinator);
     return composedCoordinator;
   }
@@ -147,7 +167,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                 .setBlockChoiceRule((newBlockHeader, currentBlockHeader) -> -1);
 
           } else if (composedCoordinator.isMiningBeforeMerge()) {
-            // if our merge state is set to pre-merge and we are mining, start mining
+            // if our merge state is set to mine pre-merge and we are mining, start mining
             composedCoordinator.getPreMergeObject().enable();
             composedCoordinator.getPreMergeObject().start();
           }

--- a/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
@@ -71,16 +71,17 @@ public class TransitionControllerBuilderTest {
 
   @Before
   public void setup() {
-    transitionProtocolSchedule = spy(new TransitionProtocolSchedule(
-        preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext));
+    transitionProtocolSchedule =
+        spy(
+            new TransitionProtocolSchedule(
+                preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext));
     cliqueBuilder.nodeKey(NodeKeyUtils.generate());
     when(protocolContext.getBlockchain()).thenReturn(mockBlockchain);
     when(transitionProtocolSchedule.getPostMergeSchedule()).thenReturn(postMergeProtocolSchedule);
     when(transitionProtocolSchedule.getPreMergeSchedule()).thenReturn(preMergeProtocolSchedule);
     when(protocolContext.getConsensusContext(CliqueContext.class))
         .thenReturn(mock(CliqueContext.class));
-    when(protocolContext.getConsensusContext(PostMergeContext.class))
-        .thenReturn(mergeContext);
+    when(protocolContext.getConsensusContext(PostMergeContext.class)).thenReturn(mergeContext);
   }
 
   @Test
@@ -110,8 +111,7 @@ public class TransitionControllerBuilderTest {
     var preMergeProtocolSpec = mock(ProtocolSpec.class);
     when(mergeContext.isPostMerge()).thenReturn(Boolean.FALSE);
     when(mergeContext.getFinalized()).thenReturn(Optional.empty());
-    when(preMergeProtocolSchedule.getByBlockNumber(anyLong()))
-        .thenReturn(preMergeProtocolSpec);
+    when(preMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(preMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(protocolContext, mockBlock))
         .isEqualTo(preMergeProtocolSpec);
   }
@@ -120,25 +120,21 @@ public class TransitionControllerBuilderTest {
   public void assertPostMergeScheduleForAnyBlockWhenPostMergeAndFinalized() {
     var mockBlock = new BlockHeaderTestFixture().buildHeader();
     var postMergeProtocolSpec = mock(ProtocolSpec.class);
-    when(mergeContext.isPostMerge()).thenReturn(Boolean.TRUE);
     when(mergeContext.getFinalized()).thenReturn(Optional.of(mockBlock));
-    when(postMergeProtocolSchedule.getByBlockNumber(anyLong()))
-        .thenReturn(postMergeProtocolSpec);
+    when(postMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(postMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(protocolContext, mockBlock))
         .isEqualTo(postMergeProtocolSpec);
   }
 
-
   @Test
   public void assertPreMergeScheduleForBelowTerminalBlockWhenPostMergeIfNotFinalized() {
-    var mockParentBlock = new BlockHeaderTestFixture()
-        .number(100)
-        .buildHeader();
-    var mockBlock = new BlockHeaderTestFixture()
-        .number(101)
-        .difficulty(Difficulty.of(1L))
-        .parentHash(mockParentBlock.getHash())
-        .buildHeader();
+    var mockParentBlock = new BlockHeaderTestFixture().number(100).buildHeader();
+    var mockBlock =
+        new BlockHeaderTestFixture()
+            .number(101)
+            .difficulty(Difficulty.of(1L))
+            .parentHash(mockParentBlock.getHash())
+            .buildHeader();
 
     var preMergeProtocolSpec = mock(ProtocolSpec.class);
 
@@ -148,8 +144,7 @@ public class TransitionControllerBuilderTest {
     when(mockBlockchain.getTotalDifficultyByHash(any()))
         .thenReturn(Optional.of(Difficulty.of(1335L)));
 
-    when(preMergeProtocolSchedule.getByBlockNumber(anyLong()))
-        .thenReturn(preMergeProtocolSpec);
+    when(preMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(preMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(protocolContext, mockBlock))
         .isEqualTo(preMergeProtocolSpec);
   }

--- a/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
@@ -16,20 +16,25 @@ package org.hyperledger.besu.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.clique.CliqueContext;
+import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule;
 import org.hyperledger.besu.consensus.merge.blockcreation.TransitionCoordinator;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -45,28 +50,32 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TransitionControllerBuilderTest {
 
-  @Mock ProtocolSchedule protocolSchedule;
-  @Mock TransitionProtocolSchedule transitionProtocolSchedule;
+  @Mock ProtocolSchedule preMergeProtocolSchedule;
+  @Mock ProtocolSchedule postMergeProtocolSchedule;
   @Mock ProtocolContext protocolContext;
   @Mock TransactionPool transactionPool;
   @Mock SyncState syncState;
   @Mock EthProtocolManager ethProtocolManager;
+  @Mock PostMergeContext mergeContext;
 
   @Spy CliqueBesuControllerBuilder cliqueBuilder = new CliqueBesuControllerBuilder();
   @Spy BesuControllerBuilder powBuilder = new MainnetBesuControllerBuilder();
   @Spy MergeBesuControllerBuilder postMergeBuilder = new MergeBesuControllerBuilder();
   @Spy MiningParameters miningParameters = new MiningParameters.Builder().build();
 
+  TransitionProtocolSchedule transitionProtocolSchedule = spy(new TransitionProtocolSchedule(
+      preMergeProtocolSchedule, postMergeProtocolSchedule));
+
   @Before
   public void setup() {
     cliqueBuilder.nodeKey(NodeKeyUtils.generate());
     when(protocolContext.getBlockchain()).thenReturn(mock(MutableBlockchain.class));
-    when(transitionProtocolSchedule.getPostMergeSchedule()).thenReturn(protocolSchedule);
-    when(transitionProtocolSchedule.getPreMergeSchedule()).thenReturn(protocolSchedule);
+    when(transitionProtocolSchedule.getPostMergeSchedule()).thenReturn(postMergeProtocolSchedule);
+    when(transitionProtocolSchedule.getPreMergeSchedule()).thenReturn(preMergeProtocolSchedule);
     when(protocolContext.getConsensusContext(CliqueContext.class))
         .thenReturn(mock(CliqueContext.class));
     when(protocolContext.getConsensusContext(PostMergeContext.class))
-        .thenReturn(mock(PostMergeContext.class));
+        .thenReturn(mergeContext);
   }
 
   @Test
@@ -88,6 +97,27 @@ public class TransitionControllerBuilderTest {
     when(miningParameters.isMiningEnabled()).thenReturn(Boolean.TRUE);
     var transCoordinator = buildTransitionCoordinator(powBuilder, postMergeBuilder);
     assertThat(transCoordinator.isMiningBeforeMerge()).isTrue();
+  }
+
+  @Test
+  public void assertPreMergeScheduleForBlockWhenPostMergeIfNotFinalized() {
+
+  }
+
+  @Test
+  public void assertPostMergeScheduleForBlockWhenFinalized() {
+
+  }
+
+  @Test
+  public void assertPostMergeScheduleForAnyBlockWhenPostMergeAndFinalized() {
+
+    //TODO: spy/plumb mergeContext in transitionprotocolschedule
+    var mockBlock = new BlockHeaderTestFixture().buildHeader();
+    when(mergeContext.isPostMerge()).thenReturn(Boolean.TRUE);
+    when(mergeContext.getFinalized()).thenReturn(Optional.of(mockBlock));
+    assertThat(transitionProtocolSchedule.getByBlockHeader(protocolContext, mockBlock))
+        .isEqualTo(transitionProtocolSchedule.getPostMergeSchedule());
   }
 
   TransitionCoordinator buildTransitionCoordinator(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -80,8 +80,9 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void setIsPostMerge(final Difficulty totalDifficulty) {
-    if (isPostMerge.get().orElse(Boolean.FALSE)) {
-      // we never switch back to a pre-merge once we have transitioned post-TTD.
+    if (isPostMerge.get().orElse(Boolean.FALSE) && lastFinalized.get() != null) {
+      // if we have finalized, we never switch back to a pre-merge once we have transitioned
+      // post-TTD.
       return;
     }
     final boolean newState = terminalTotalDifficulty.get().lessOrEqualThan(totalDifficulty);

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBackwardSyncContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBackwardSyncContext.java
@@ -48,13 +48,13 @@ public class TransitionBackwardSyncContext extends BackwardSyncContext {
   }
 
   /**
-   * Choose the correct protocolSchedule and blockvalidator by block rather than number.
-   * This should be used in the merge transition, specifically when the chain has not
-   * yet finalized.
+   * Choose the correct protocolSchedule and blockvalidator by block rather than number. This should
+   * be used in the merge transition, specifically when the chain has not yet finalized.
    */
   @Override
   public BlockValidator getBlockValidatorForBlock(final Block block) {
-    return transitionProtocolSchedule.getByBlockHeader(protocolContext, block.getHeader())
+    return transitionProtocolSchedule
+        .getByBlockHeader(protocolContext, block.getHeader())
         .getBlockValidator();
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBackwardSyncContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBackwardSyncContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.merge;
+
+import org.hyperledger.besu.ethereum.BlockValidator;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
+import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncLookupService;
+import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.storage.StorageProvider;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+public class TransitionBackwardSyncContext extends BackwardSyncContext {
+
+  private final TransitionProtocolSchedule transitionProtocolSchedule;
+
+  public TransitionBackwardSyncContext(
+      final ProtocolContext protocolContext,
+      final TransitionProtocolSchedule transitionProtocolSchedule,
+      final MetricsSystem metricsSystem,
+      final EthContext ethContext,
+      final SyncState syncState,
+      final BackwardSyncLookupService backwardSyncLookupService,
+      final StorageProvider storageProvider) {
+    super(
+        protocolContext,
+        transitionProtocolSchedule,
+        metricsSystem,
+        ethContext,
+        syncState,
+        backwardSyncLookupService,
+        storageProvider);
+    this.transitionProtocolSchedule = transitionProtocolSchedule;
+  }
+
+  /**
+   * Choose the correct protocolSchedule and blockvalidator by block rather than number.
+   * This should be used in the merge transition, specifically when the chain has not
+   * yet finalized.
+   */
+  @Override
+  public BlockValidator getBlockValidatorForBlock(final Block block) {
+    return transitionProtocolSchedule.getByBlockHeader(protocolContext, block.getHeader())
+        .getBlockValidator();
+  }
+}

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -51,7 +51,8 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
     return getPostMergeObject();
   }
 
-  public ProtocolSpec getByBlockHeader(final ProtocolContext protocolContext, final BlockHeader blockHeader) {
+  public ProtocolSpec getByBlockHeader(
+      final ProtocolContext protocolContext, final BlockHeader blockHeader) {
     // if we do not have a finalized block we might return pre or post merge protocol schedule:
     if (mergeContext.getFinalized().isEmpty()) {
 
@@ -70,8 +71,7 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
       // if this block is pre-merge
       if (thisDifficulty.lessOrEqualThan(terminalDifficulty)
           || TransitionUtils.isTerminalProofOfWorkBlock(blockHeader, protocolContext)) {
-        return getPreMergeSchedule()
-            .getByBlockNumber(blockHeader.getNumber());
+        return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
     }
     // else return post-merge schedule

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -36,6 +36,13 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
     super(preMergeProtocolSchedule, postMergeProtocolSchedule);
   }
 
+  public TransitionProtocolSchedule(
+      final ProtocolSchedule preMergeProtocolSchedule,
+      final ProtocolSchedule postMergeProtocolSchedule,
+      final MergeContext mergeContext) {
+    super(preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext);
+  }
+
   public ProtocolSchedule getPreMergeSchedule() {
     return getPreMergeObject();
   }
@@ -67,7 +74,6 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
             .getByBlockNumber(blockHeader.getNumber());
       }
     }
-
     // else return post-merge schedule
     return getPostMergeSchedule().getByBlockNumber(blockHeader.getNumber());
   }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionUtils.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionUtils.java
@@ -30,14 +30,22 @@ import org.slf4j.LoggerFactory;
 public abstract class TransitionUtils<SwitchingObject> {
   private static final Logger LOG = LoggerFactory.getLogger(TransitionUtils.class);
 
-  protected final MergeContext mergeContext = PostMergeContext.get();
+  protected final MergeContext mergeContext;
   private final SwitchingObject preMergeObject;
   private final SwitchingObject postMergeObject;
 
   public TransitionUtils(
       final SwitchingObject preMergeObject, final SwitchingObject postMergeObject) {
+    this(preMergeObject, postMergeObject, PostMergeContext.get());
+  }
+
+  public TransitionUtils(
+      final SwitchingObject preMergeObject,
+      final SwitchingObject postMergeObject,
+      final MergeContext mergeContext) {
     this.preMergeObject = preMergeObject;
     this.postMergeObject = postMergeObject;
+    this.mergeContext = mergeContext;
   }
 
   protected void dispatchConsumerAccordingToMergeState(final Consumer<SwitchingObject> consumer) {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionUtils.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionUtils.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public abstract class TransitionUtils<SwitchingObject> {
   private static final Logger LOG = LoggerFactory.getLogger(TransitionUtils.class);
 
-  private final MergeContext mergeContext = PostMergeContext.get();
+  protected final MergeContext mergeContext = PostMergeContext.get();
   private final SwitchingObject preMergeObject;
   private final SwitchingObject postMergeObject;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -46,7 +46,7 @@ public class BackwardSyncContext {
   public static final int BATCH_SIZE = 200;
   private static final int MAX_RETRIES = 100;
 
-  private final ProtocolContext protocolContext;
+  protected final ProtocolContext protocolContext;
   private final ProtocolSchedule protocolSchedule;
   private final EthContext ethContext;
   private final MetricsSystem metricsSystem;
@@ -255,6 +255,10 @@ public class BackwardSyncContext {
 
   public BlockValidator getBlockValidator(final long blockNumber) {
     return protocolSchedule.getByBlockNumber(blockNumber).getBlockValidator();
+  }
+
+  public BlockValidator getBlockValidatorForBlock(final Block block) {
+    return getBlockValidator(block.getHeader().getNumber());
   }
 
   public Optional<BackwardChain> findCorrectChainFromPivot(final long number) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhase.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhase.java
@@ -170,7 +170,7 @@ public class ForwardSyncPhase extends BackwardSyncTask {
     debugLambda(LOG, "Going to validate block {}", () -> block.getHeader().getHash().toHexString());
     var optResult =
         context
-            .getBlockValidator(block.getHeader().getNumber())
+            .getBlockValidatorForBlock(block)
             .validateAndProcessBlock(
                 context.getProtocolContext(),
                 block,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhaseTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhaseTest.java
@@ -20,7 +20,6 @@ package org.hyperledger.besu.ethereum.eth.sync.backwardsync;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -114,7 +113,9 @@ public class ForwardSyncPhaseTest {
     EthContext ethContext = ethProtocolManager.ethContext();
     when(context.getEthContext()).thenReturn(ethContext);
 
-    when(context.getBlockValidatorForBlock(any()).validateAndProcessBlock(any(), any(), any(), any()))
+    when(context
+            .getBlockValidatorForBlock(any())
+            .validateAndProcessBlock(any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               final Object[] arguments = invocation.getArguments();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhaseTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncPhaseTest.java
@@ -114,7 +114,7 @@ public class ForwardSyncPhaseTest {
     EthContext ethContext = ethProtocolManager.ethContext();
     when(context.getEthContext()).thenReturn(ethContext);
 
-    when(context.getBlockValidator(anyLong()).validateAndProcessBlock(any(), any(), any(), any()))
+    when(context.getBlockValidatorForBlock(any()).validateAndProcessBlock(any(), any(), any(), any()))
         .thenAnswer(
             invocation -> {
               final Object[] arguments = invocation.getArguments();


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Address a post-merge case where we have transitioned to the post-merge rules, but need to import pre-merge blocks due to a reorg ahead of finalization.

BackwardSync is the only mechanism that should be able to reorg below TTD post merge, this PR creates a method In TransitionProtocolSchedule to get ProtocolSpec by block rather than by number.  

TransitionBackwardSyncContext is a transition specific subclass of BackwardSyncContext that leverages the protocol spec by block (without dragging merge consensus into the core ethereum subproject where BackwardSync lives). This backward sync subclass can be removed post-merge with the rest of the transition-by-difficulty code removal.

CURRENTLY DRAFT while writing test coverage.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3688 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).