### PR TITLE
Onchain Node Permissioning: log enode being checked with IllegalStateException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## 22.4.0-RC2
 
 ### Additions and Improvements
+- Onchain node permissioning - log the enode that was being checked with IllegalStateException. [#3697](https://github.com/hyperledger/besu/pull/3697)
 
 ### Bug Fixes
 
@@ -19,7 +20,7 @@
 
 ### Bug Fixes
 - Flexible Privacy Precompile handles null payload ID [#3664](https://github.com/hyperledger/besu/pull/3664)
-- Subcommand blocks import throws execption [#3646](https://github.com/hyperledger/besu/pull/3646)
+- Subcommand blocks import throws exception [#3646](https://github.com/hyperledger/besu/pull/3646)
 
 ## Download Links
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.4.0-RC1/besu-22.4.0-RC1.zip / SHA256 0779082acc20a98eb810eb08778e0c0e1431046c07bc89019a2761fd1baa4c25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ## 22.4.0-RC2
 
 ### Additions and Improvements
-- Onchain node permissioning - log the enode that was being checked with IllegalStateException. [#3697](https://github.com/hyperledger/besu/pull/3697)
+- Onchain node permissioning - log the enodeURL that was previously only throwing an IllegalStateException during the isPermitted check [#3697](https://github.com/hyperledger/besu/pull/3697)
 
 ### Bug Fixes
 

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -61,13 +61,18 @@ public class NodeSmartContractV2PermissioningController
   }
 
   private boolean isPermitted(final EnodeURL enode) {
-    final boolean isIpEnodePermitted = getCallResult(enode);
-    LOG.trace("Permitted? {} for IP {}", isIpEnodePermitted, enode);
-    if (isIpEnodePermitted) return true;
-    final EnodeURL ipToDNSEnode = ipToDNS(enode);
-    final boolean isIpToDNSEnodePermitted = getCallResult(ipToDNSEnode);
-    LOG.trace("Permitted? {} for DNS {}", isIpToDNSEnodePermitted, ipToDNSEnode);
-    return isIpToDNSEnodePermitted;
+    try {
+      final boolean isIpEnodePermitted = getCallResult(enode);
+      LOG.trace("Permitted? {} for IP {}", isIpEnodePermitted, enode);
+      if (isIpEnodePermitted) return true;
+      final EnodeURL ipToDNSEnode = ipToDNS(enode);
+      final boolean isIpToDNSEnodePermitted = getCallResult(ipToDNSEnode);
+      LOG.trace("Permitted? {} for DNS {}", isIpToDNSEnodePermitted, ipToDNSEnode);
+      return isIpToDNSEnodePermitted;
+    } catch (IllegalStateException illegalStateException) {
+      LOG.info("Unable to check permissions for enode {} ", enode, illegalStateException);
+      return false;
+    }
   }
 
   @NotNull

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -69,7 +69,7 @@ public class NodeSmartContractV2PermissioningController
       final boolean isIpToDNSEnodePermitted = getCallResult(ipToDNSEnode);
       LOG.trace("Permitted? {} for DNS {}", isIpToDNSEnodePermitted, ipToDNSEnode);
       return isIpToDNSEnodePermitted;
-    } catch (IllegalStateException illegalStateException) {
+    } catch (final IllegalStateException illegalStateException) {
       LOG.info("Unable to check permissions for enode {} ", enode, illegalStateException);
       return false;
     }

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.permissioning;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -85,18 +84,16 @@ public class NodeSmartContractV2PermissioningControllerTest {
   }
 
   @Test
-  public void nonExpectedCallOutputThrowsIllegalState() {
-    final TransactionSimulatorResult txSimulatorResult =
+  public void nonExpectedCallOutputReturnsNotPermitted() {
+    final TransactionSimulatorResult nonExpectedTxSimulatorResult =
         transactionSimulatorResult(Bytes.random(10), ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
-        .thenReturn(Optional.of(txSimulatorResult));
+        .thenReturn(Optional.of(nonExpectedTxSimulatorResult));
 
-    assertThatIllegalStateException()
-        .isThrownBy(
-            () ->
-                permissioningController.checkSmartContractRules(
-                    SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4));
+    boolean isPermitted =
+        permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4);
+    assertThat(isPermitted).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Instead of throwing, log IllegalStateException and the enode that was being checked. and return notPermitted

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).