### PR TITLE
Quorum ATs nightly CI task: setup docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
+      - setup_remote_docker
       - run:
           name: Quorum Acceptance Tests
           no_output_timeout: 30m


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Add docker setup step

Job is currently failing with this error:
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.

eg https://app.circleci.com/pipelines/github/hyperledger/besu/14269/workflows/87252694-72a0-4c5e-845d-0c5be9d09848/jobs/81171

The last time this job passed https://app.circleci.com/pipelines/github/hyperledger/besu/13644/workflows/0fb32713-e855-4cec-b079-680b67f14aa8/jobs/76357

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).