### PR TITLE
Fix save worldstate issue on bonsai and fastsync

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -274,6 +274,8 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     public WorldStateStorage.Updater saveWorldState(
         final Bytes blockHash, final Bytes32 nodeHash, final Bytes node) {
       trieBranchStorageTransaction.put(Bytes.EMPTY.toArrayUnsafe(), node.toArrayUnsafe());
+      trieBranchStorageTransaction.put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
+      trieBranchStorageTransaction.put(WORLD_BLOCK_HASH_KEY, blockHash.toArrayUnsafe());
       return this;
     }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorageTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorageTest.java
@@ -273,6 +273,24 @@ public class BonsaiWorldStateKeyValueStorageTest {
         .isTrue();
   }
 
+  @Test
+  public void isWorldStateAvailable_afterCallingSaveWorldstate() {
+
+    final BonsaiWorldStateKeyValueStorage storage = emptyStorage();
+    final BonsaiWorldStateKeyValueStorage.Updater updater = storage.updater();
+
+    final Bytes blockHash = Bytes32.fromHexString("0x01");
+    final Bytes32 nodeHashKey = Bytes32.fromHexString("0x02");
+    final Bytes nodeValue = Bytes32.fromHexString("0x03");
+
+    assertThat(storage.isWorldStateAvailable(Bytes32.wrap(nodeHashKey), Hash.EMPTY)).isFalse();
+
+    updater.saveWorldState(blockHash, nodeHashKey, nodeValue);
+    updater.commit();
+
+    assertThat(storage.isWorldStateAvailable(Bytes32.wrap(nodeHashKey), Hash.EMPTY)).isTrue();
+  }
+
   private BonsaiWorldStateKeyValueStorage emptyStorage() {
     return new BonsaiWorldStateKeyValueStorage(new InMemoryKeyValueStorageProvider());
   }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Fix a bug that caused the worldstate to be missing during a fastsync and prevented it from completing properly

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).