### PR TITLE
revert to TransactionDB to resolve 'busy' exception 

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
@@ -23,9 +23,9 @@ import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration;
 
-import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;
+import org.rocksdb.TransactionDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +54,7 @@ public class RocksDBMetricsFactory {
   public RocksDBMetrics create(
       final MetricsSystem metricsSystem,
       final RocksDBConfiguration rocksDbConfiguration,
-      final OptimisticTransactionDB db,
+      final TransactionDB db,
       final Statistics stats) {
     final OperationTimer readLatency =
         metricsSystem

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -49,11 +49,11 @@ import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
-import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.Status;
+import org.rocksdb.TransactionDB;
 import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -72,7 +72,7 @@ public class RocksDBColumnarKeyValueStorage
 
   private final DBOptions options;
   private final TransactionDBOptions txOptions;
-  private final OptimisticTransactionDB db;
+  private final TransactionDB db;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final Map<String, ColumnFamilyHandle> columnHandlesByName;
   private final RocksDBMetrics metrics;
@@ -114,8 +114,12 @@ public class RocksDBColumnarKeyValueStorage
       txOptions = new TransactionDBOptions();
       final List<ColumnFamilyHandle> columnHandles = new ArrayList<>(columnDescriptors.size());
       db =
-          OptimisticTransactionDB.open(
-              options, configuration.getDatabaseDir().toString(), columnDescriptors, columnHandles);
+          TransactionDB.open(
+              options,
+              txOptions,
+              configuration.getDatabaseDir().toString(),
+              columnDescriptors,
+              columnHandles);
       metrics = rocksDBMetricsFactory.create(metricsSystem, configuration, db, stats);
       final Map<Bytes, String> segmentsById =
           segments.stream()

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -36,12 +36,13 @@ import java.util.stream.Stream;
 
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.LRUCache;
-import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.Status;
+import org.rocksdb.TransactionDB;
+import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBKeyValueStorage.class);
 
   private final Options options;
-  private final OptimisticTransactionDB db;
+  private final TransactionDB db;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final RocksDBMetrics rocksDBMetrics;
   private final WriteOptions tryDeleteOptions = new WriteOptions().setNoSlowdown(true);
@@ -76,7 +77,9 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
               .setStatistics(stats);
       options.getEnv().setBackgroundThreads(configuration.getBackgroundThreadCount());
 
-      db = OptimisticTransactionDB.open(options, configuration.getDatabaseDir().toString());
+      db =
+          TransactionDB.open(
+              options, new TransactionDBOptions(), configuration.getDatabaseDir().toString());
       rocksDBMetrics = rocksDBMetricsFactory.create(metricsSystem, configuration, db, stats);
     } catch (final RocksDBException e) {
       throw new StorageException(e);

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsTest.java
@@ -39,8 +39,8 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Statistics;
+import org.rocksdb.TransactionDB;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RocksDBMetricsTest {
@@ -49,7 +49,7 @@ public class RocksDBMetricsTest {
   @Mock private LabelledMetric<OperationTimer> labelledMetricOperationTimerMock;
   @Mock private LabelledMetric<Counter> labelledMetricCounterMock;
   @Mock private OperationTimer operationTimerMock;
-  @Mock private OptimisticTransactionDB db;
+  @Mock private TransactionDB db;
   @Mock private Statistics stats;
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Revert to TransactionDB to resolve 'busy' exception from OptimisticTransactionDB.  

As I understand it, we originally went to OptimisticTransctionDB in order to support `deleteRange()` for our implementation of `RocksDBColumnarKeyBValueStore.clear()`.  In light of the change to the `clear` implementation in #3634, we do not need to use OptimisticTransactionDB.  

Currently in Draft while testing and while discussing the merits of sticking with OptimisticTransactionDB for locking performance.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3719

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).