### PR TITLE
remove TTD depth limit for ancestorIsValidTerminalProofOfWork

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -362,13 +362,11 @@ public class MergeCoordinator implements MergeMiningCoordinator {
     }
   }
 
-  // TODO: post-merge cleanup
-  static final long MAX_TTD_SEARCH_DEPTH = 131072L; // 32 * 4096 epochs
-
   // package visibility for testing
   boolean ancestorIsValidTerminalProofOfWork(final BlockHeader blockheader) {
     // this should only happen very close to the transition from PoW to PoS, prior to a finalized
-    // block
+    // block.  For example, after a full sync of an already-merged chain which does not have
+    // terminal block info in the genesis config.
 
     // check a 'cached' block which was determined to descend from terminal to short circuit
     // in the case of a long period of non-finality
@@ -382,16 +380,12 @@ public class MergeCoordinator implements MergeMiningCoordinator {
     var blockchain = protocolContext.getBlockchain();
     Optional<BlockHeader> parent = blockchain.getBlockHeader(blockheader.getParentHash());
     do {
-
       LOG.debug(
           "checking ancestor {} is valid terminal PoW for {}",
           parent.map(BlockHeader::toLogString).orElse("empty"),
           blockheader.toLogString());
 
       if (parent.isPresent()) {
-        if (MAX_TTD_SEARCH_DEPTH < blockheader.getNumber() - parent.get().getNumber()) {
-          return false;
-        }
         if (!parent.get().getDifficulty().equals(Difficulty.ZERO)) {
           break;
         }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -406,16 +406,6 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   }
 
   @Test
-  public void ancestorExceedsDepthValidTerminalProofOfWork() {
-    final long howDeep = MergeCoordinator.MAX_TTD_SEARCH_DEPTH + 2;
-    assertThat(
-            terminalAncestorMock(howDeep, true)
-                .ancestorIsValidTerminalProofOfWork(
-                    new BlockHeaderTestFixture().number(howDeep).buildHeader()))
-        .isFalse();
-  }
-
-  @Test
   public void ancestorNotFoundValidTerminalProofOfWork() {
     final long howDeep = 10L;
     assertThat(


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

remove TTD search depth limit.  Ideally we will set a recent finalized block when we finish backward sync (and fast and snap sync as well), as that will be more performant than scanning through blocks looking for TTD when we do not have a finalized block.  However, removing this limit will prevent us from incorrectly failing an `engine_forkchoiceUpdate` call post-sync when there is a significant distance between HEAD and TTD.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#3727

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).