### PR TITLE
fix nullpointer on snapsync

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -189,13 +189,8 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
     worldStateStorage.clearFlatDatabase();
     pendingTrieNodeRequests.clearInternalQueues();
     pendingCodeRequests.clearInternalQueue();
-    enqueueRequest(
-        createAccountTrieNodeDataRequest(
-            snapSyncState.getPivotBlockHeader().orElseThrow().getStateRoot(),
-            Bytes.EMPTY,
-            inconsistentAccounts));
-    requestComplete(true);
-    notifyTaskAvailable();
+    snapSyncState.setHealStatus(false);
+    checkCompletion(snapSyncState.getPivotBlockHeader().orElseThrow());
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -235,5 +236,22 @@ public class SnapWorldDownloadStateTest {
     assertThat(downloadState.pendingStorageRequests.isEmpty()).isTrue();
     verify(worldStateDownloadProcess).abort();
     assertThat(downloadState.isDownloading()).isFalse();
+  }
+
+  @Test
+  public void shouldRestartHealWhenNewPivotBlock() {
+    when(snapSyncState.getPivotBlockHeader()).thenReturn(Optional.of(mock(BlockHeader.class)));
+    when(snapSyncState.isHealInProgress()).thenReturn(false);
+    assertThat(downloadState.pendingTrieNodeRequests.isEmpty()).isTrue();
+    // start heal
+    downloadState.checkCompletion(header);
+    verify(snapSyncState).setHealStatus(true);
+    assertThat(downloadState.pendingTrieNodeRequests.isEmpty()).isFalse();
+    // reload the heal
+    downloadState.reloadHeal();
+    verify(snapSyncState).setHealStatus(false);
+    spy(downloadState.pendingTrieNodeRequests).clearInternalQueues();
+    spy(downloadState).checkCompletion(header);
+    assertThat(downloadState.pendingTrieNodeRequests.isEmpty()).isFalse();
   }
 }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Fixes a bug that caused Besu to not restart healing properly when changing pivot blocks. Snapsync thought the sync was done instead of restarting on a new pivot block. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).