### PR TITLE
Remove Leading Zeros from TransactionPendingResult

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
@@ -84,8 +84,8 @@ public class TransactionPendingResult implements TransactionResult {
     this.from = transaction.getSender().toString();
     this.gas = Quantity.create(transaction.getGasLimit());
     this.maxPriorityFeePerGas =
-        transaction.getMaxPriorityFeePerGas().map(Wei::toHexString).orElse(null);
-    this.maxFeePerGas = transaction.getMaxFeePerGas().map(Wei::toHexString).orElse(null);
+        transaction.getMaxPriorityFeePerGas().map(Wei::toShortHexString).orElse(null);
+    this.maxFeePerGas = transaction.getMaxFeePerGas().map(Wei::toShortHexString).orElse(null);
     this.gasPrice = transaction.getGasPrice().map(Quantity::create).orElse(maxFeePerGas);
     this.hash = transaction.getHash().toString();
     this.input = transaction.getPayload().toString();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
@@ -29,8 +29,10 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTran
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -72,6 +74,25 @@ public class TxPoolBesuPendingTransactionsTest {
     final Set<TransactionPendingResult> result =
         (Set<TransactionPendingResult>) actualResponse.getResult();
     assertThat(result.size()).isEqualTo(4);
+  }
+
+  @Test
+  public void pendingTranasctionGasPricesDoNotHaveLeadingZeroes() {
+    final JsonRpcRequestContext request =
+        new JsonRpcRequestContext(
+            new JsonRpcRequest(
+                JSON_RPC_VERSION, TXPOOL_PENDING_TRANSACTIONS_METHOD, new Object[] {100}));
+
+    final JsonRpcSuccessResponse actualResponse = (JsonRpcSuccessResponse) method.response(request);
+    final Set<TransactionPendingResult> result =
+        (Set<TransactionPendingResult>) actualResponse.getResult();
+
+    assertThat(result).extracting(TransactionPendingResult::getGasPrice).filteredOn(
+        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
+    assertThat(result).extracting(TransactionPendingResult::getMaxFeePerGas).filteredOn(
+        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
+    assertThat(result).extracting(TransactionPendingResult::getMaxPriorityFeePerGas).filteredOn(
+        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
@@ -76,7 +76,7 @@ public class TxPoolBesuPendingTransactionsTest {
   }
 
   @Test
-  public void pendingTranasctionGasPricesDoNotHaveLeadingZeroes() {
+  public void pendingTransactionsGasPricesDoNotHaveLeadingZeroes() {
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(
             new JsonRpcRequest(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
@@ -29,7 +29,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTran
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -87,12 +86,18 @@ public class TxPoolBesuPendingTransactionsTest {
     final Set<TransactionPendingResult> result =
         (Set<TransactionPendingResult>) actualResponse.getResult();
 
-    assertThat(result).extracting(TransactionPendingResult::getGasPrice).filteredOn(
-        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
-    assertThat(result).extracting(TransactionPendingResult::getMaxFeePerGas).filteredOn(
-        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
-    assertThat(result).extracting(TransactionPendingResult::getMaxPriorityFeePerGas).filteredOn(
-        Objects::nonNull).allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
+    assertThat(result)
+        .extracting(TransactionPendingResult::getGasPrice)
+        .filteredOn(Objects::nonNull)
+        .allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
+    assertThat(result)
+        .extracting(TransactionPendingResult::getMaxFeePerGas)
+        .filteredOn(Objects::nonNull)
+        .allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
+    assertThat(result)
+        .extracting(TransactionPendingResult::getMaxPriorityFeePerGas)
+        .filteredOn(Objects::nonNull)
+        .allSatisfy(p -> assertThat(p).doesNotContain("0x0"));
   }
 
   @Test


### PR DESCRIPTION
## PR description

Currently, there is an issue with the way `TransactionPendingResult` gets serialized by in the JSON-RPC subsystem. Specifically, when responding to `eth_getTransactionByHash,` the `gasPrice`, `maxFeePerGas`, and `maxPriorityFeePerGas` values should be Quantities without leading zeros like so:

```
    "gas" : "0x11e63",
    "gasPrice" : "0x77359407",
    "maxPriorityFeePerGas" : "0x77359400",
    "maxFeePerGas" : "0xd09dc3000",
```

This is the official behavior defined in the spec and the behavior demonstrated by Geth and Nethermind.

However, in Besu, they are treated like 32-byte arrays and serialized with the leading zeros in place:

```
    "gas" : "0x10c83",
    "gasPrice" : "0x0000000000000000000000000000000000000000000000000000000ab5d04c00",
    "maxFeePerGas" : "0x0000000000000000000000000000000000000000000000000000000ab5d04c00",
```

This is a simple oversight caused by using `Wei.toHexString()` instead of `Wei.toShortHexString()`, which this PR addresses.

@frankisawesome has offered to fix the relevant unit tests that were unable to catch this, and will attach the fixes to this PR when they are ready.