### PR TITLE
changed for loops with int vs long comparison

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/GetAllPrivateMarkerTransactionHashes.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/transaction/GetAllPrivateMarkerTransactionHashes.java
@@ -35,7 +35,7 @@ public class GetAllPrivateMarkerTransactionHashes implements Transaction<List<St
     final List<String> toReturn = new ArrayList<>();
     try {
       final long blockchainHeight = besu.ethBlockNumber().send().getBlockNumber().longValueExact();
-      for (int i = 0; i <= blockchainHeight; i++) {
+      for (long i = 0; i <= blockchainHeight; i++) {
         besu.ethGetBlockByNumber(DefaultBlockParameter.valueOf(BigInteger.valueOf(i)), true)
             .send()
             .getBlock()

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
@@ -130,7 +130,7 @@ public class RestoreState implements Runnable {
             new RollingFileReader(this::receiptFileName, compressed)) {
       final MutableBlockchain blockchain = besuController.getProtocolContext().getBlockchain();
       // target block is "including" the target block, so LE test not LT.
-      for (int i = 0; i <= targetBlock; i++) {
+      for (long i = 0; i <= targetBlock; i++) {
         if (i % 100000 == 0) {
           LOG.info("Loading chain data {} / {}", i, targetBlock);
         }
@@ -173,7 +173,7 @@ public class RestoreState implements Runnable {
 
     try (final RollingFileReader reader =
         new RollingFileReader(this::accountFileName, compressed)) {
-      for (int i = 0; i < accountCount; i++) {
+      for (long i = 0; i < accountCount; i++) {
         if (i % 100000 == 0) {
           LOG.info("Loading account data {} / {}", i, accountCount);
         }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
@@ -149,7 +149,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
       final BlockHeader parentHeader, final long length, final Difficulty each) {
     BlockHeader newParent = parentHeader;
     List<Block> retval = new ArrayList<>();
-    for (int i = 1; i <= length; i++) {
+    for (long i = 1; i <= length; i++) {
       headerGenerator
           .parentHash(newParent.getHash())
           .number(newParent.getNumber() + 1)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
@@ -292,7 +292,7 @@ public class StateBackupService {
             new RollingFileWriter(this::bodyFileName, backupStatus.compressed);
         final RollingFileWriter receiptsWriter =
             new RollingFileWriter(this::receiptFileName, backupStatus.compressed)) {
-      for (int blockNumber = 0; blockNumber <= backupStatus.targetBlock; blockNumber++) {
+      for (long blockNumber = 0; blockNumber <= backupStatus.targetBlock; blockNumber++) {
         final Optional<Block> block = blockchain.getBlockByNumber(blockNumber);
         checkState(
             block.isPresent(), "Block data for %s was not found in the archive", blockNumber);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DirectAcyclicGraphSeed.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DirectAcyclicGraphSeed.java
@@ -47,7 +47,7 @@ public class DirectAcyclicGraphSeed {
     final byte[] seed = new byte[32];
     if (Long.compareUnsigned(startBlock, EPOCH_LENGTH) >= 0) {
       final MessageDigest keccak256 = KECCAK_256.get();
-      for (int i = 0; i < Long.divideUnsigned(startBlock, EPOCH_LENGTH); ++i) {
+      for (long i = 0; i < Long.divideUnsigned(startBlock, EPOCH_LENGTH); ++i) {
         keccak256.update(seed);
         try {
           keccak256.digest(seed, 0, seed.length);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/EthHash.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/EthHash.java
@@ -281,7 +281,7 @@ public final class EthHash {
     if (num > 2 && (num & 1) == 0) {
       return false;
     }
-    for (int i = 3; i * i <= num; i += 2) {
+    for (long i = 3; i * i <= num; i += 2) {
       if (num % i == 0) {
         return false;
       }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyController.java
@@ -205,7 +205,7 @@ public class FlexiblePrivacyController extends AbstractRestrictedPrivacyControll
     final ArrayList<String> decodedElements = new ArrayList<>();
     // first 32 bytes is dynamic list offset
     final UInt256 lengthOfList = UInt256.fromBytes(rlpEncodedList.slice(32, 32)); // length of list
-    for (int i = 0; i < lengthOfList.toLong(); ++i) {
+    for (int i = 0; i < lengthOfList.toInt(); ++i) {
       decodedElements.add(
           Bytes.wrap(rlpEncodedList.slice(64 + (32 * i), 32)).toBase64String()); // participant
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyController.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.privacy;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hyperledger.besu.ethereum.core.PrivacyParameters.FLEXIBLE_PRIVACY_PROXY;
+import static org.hyperledger.besu.ethereum.privacy.FlexiblePrivacyGroupContract.decodeList;
 import static org.hyperledger.besu.ethereum.privacy.group.FlexibleGroupManagement.GET_PARTICIPANTS_METHOD_SIGNATURE;
 import static org.hyperledger.besu.ethereum.privacy.group.FlexibleGroupManagement.GET_VERSION_METHOD_SIGNATURE;
 
@@ -48,7 +49,6 @@ import java.util.Optional;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -130,11 +130,7 @@ public class FlexiblePrivacyController extends AbstractRestrictedPrivacyControll
       if (rlpInput.nextSize() > 0) {
         return Optional.of(
             new PrivacyGroup(
-                privacyGroupId,
-                PrivacyGroup.Type.FLEXIBLE,
-                "",
-                "",
-                decodeParticipantList(rlpInput.raw())));
+                privacyGroupId, PrivacyGroup.Type.FLEXIBLE, "", "", decodeList(rlpInput.raw())));
       }
     }
     return Optional.empty();
@@ -199,17 +195,6 @@ public class FlexiblePrivacyController extends AbstractRestrictedPrivacyControll
                 "Privacy group must contain the enclave public key");
           }
         });
-  }
-
-  private List<String> decodeParticipantList(final Bytes rlpEncodedList) {
-    final ArrayList<String> decodedElements = new ArrayList<>();
-    // first 32 bytes is dynamic list offset
-    final UInt256 lengthOfList = UInt256.fromBytes(rlpEncodedList.slice(32, 32)); // length of list
-    for (int i = 0; i < lengthOfList.toInt(); ++i) {
-      decodedElements.add(
-          Bytes.wrap(rlpEncodedList.slice(64 + (32 * i), 32)).toBase64String()); // participant
-    }
-    return decodedElements;
   }
 
   private List<PrivateTransactionMetadata> buildTransactionMetadataList(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
@@ -233,8 +233,8 @@ public class FlexiblePrivacyGroupContract {
     final ArrayList<String> decodedElements = new ArrayList<>();
     // first 32 bytes is dynamic list offset
     if (rlpEncodedList.size() < 64) return decodedElements;
-    final long lengthOfList =
-        UInt256.fromBytes(rlpEncodedList.slice(32, 32)).toLong(); // length of list
+    final int lengthOfList =
+        UInt256.fromBytes(rlpEncodedList.slice(32, 32)).toInt(); // length of list
     if (rlpEncodedList.size() < 64 + lengthOfList * 32) return decodedElements;
 
     for (int i = 0; i < lengthOfList; ++i) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
@@ -47,7 +47,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /*
  This class is an abstraction on top of the privacy group management smart contract.
@@ -64,8 +63,7 @@ import org.apache.tuweni.units.bigints.UInt256;
     parameter must be supplied to subsequent method calls. All methods
     operate on the state specified by the given MessageFrame. Only
     when constructed this way, the class can be used to query state
-    that is not on a block boundary. Used this way, the object's life
-    time is intended to be short.
+    that is not on a block boundary. Used this way, the object's lifetime is intended to be short.
 */
 public class FlexiblePrivacyGroupContract {
   @FunctionalInterface
@@ -229,12 +227,12 @@ public class FlexiblePrivacyGroupContract {
         Address.ZERO, FLEXIBLE_PRIVACY_PROXY, 3000000, Wei.of(1000), Wei.ZERO, methodCall);
   }
 
-  private List<String> decodeList(final Bytes rlpEncodedList) {
+  public static List<String> decodeList(final Bytes rlpEncodedList) {
     final ArrayList<String> decodedElements = new ArrayList<>();
     // first 32 bytes is dynamic list offset
     if (rlpEncodedList.size() < 64) return decodedElements;
-    final int lengthOfList =
-        UInt256.fromBytes(rlpEncodedList.slice(32, 32)).toInt(); // length of list
+    // Bytes uses a byte[] for the content which can only have up to Integer.MAX_VALUE-5 elements
+    final int lengthOfList = rlpEncodedList.slice(32, 32).toInt(); // length of list
     if (rlpEncodedList.size() < 64 + lengthOfList * 32) return decodedElements;
 
     for (int i = 0; i < lengthOfList; ++i) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/FlexiblePrivacyGroupContract.java
@@ -47,6 +47,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 
 /*
  This class is an abstraction on top of the privacy group management smart contract.
@@ -232,7 +233,8 @@ public class FlexiblePrivacyGroupContract {
     // first 32 bytes is dynamic list offset
     if (rlpEncodedList.size() < 64) return decodedElements;
     // Bytes uses a byte[] for the content which can only have up to Integer.MAX_VALUE-5 elements
-    final int lengthOfList = rlpEncodedList.slice(32, 32).toInt(); // length of list
+    final int lengthOfList =
+        UInt256.fromBytes(rlpEncodedList.slice(32, 32)).toInt(); // length of list
     if (rlpEncodedList.size() < 64 + lengthOfList * 32) return decodedElements;
 
     for (int i = 0; i < lengthOfList; ++i) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateStorageMigration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateStorageMigration.java
@@ -80,7 +80,7 @@ public class PrivateStorageMigration {
 
     LOG.info("Migrating private storage database...");
 
-    for (int blockNumber = 0; blockNumber <= chainHeadBlockNumber; blockNumber++) {
+    for (long blockNumber = 0; blockNumber <= chainHeadBlockNumber; blockNumber++) {
       final Block block =
           blockchain
               .getBlockByNumber(blockNumber)


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Where int was being compared with long. Mostly int being used to iterate over values which could be long.
Not sure about these 2 since they are dealing with uint
- FlexiblePrivacyGroupContract
- FlexiblePrivacyGroupController

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).