### PR TITLE
Log host and port when starting metrics service.

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -109,9 +109,7 @@ public class MetricsHttpService implements MetricsService {
                 final int actualPort = httpServer.actualPort();
                 config.setActualPort(actualPort);
                 LOG.info(
-                    "Metrics service started and listening on {}:{}",
-                    config.getHost(),
-                    actualPort);
+                    "Metrics service started and listening on {}:{}", config.getHost(), actualPort);
                 return;
               }
               httpServer = null;

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -110,8 +110,8 @@ public class MetricsHttpService implements MetricsService {
                 config.setActualPort(actualPort);
                 LOG.info(
                     "Metrics service started and listening on {}:{}",
-                    actualPort,
-                    httpServer.actualPort());
+                    config.getHost(),
+                    actualPort);
                 return;
               }
               httpServer = null;


### PR DESCRIPTION
## PR description

The metrics service start message was logging the port twice, rather than the host and port as expected.  This changes the log message to print the correct information in standard host:port format.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).