### PR TITLE
allow synchronizer to just stop block propagation

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -600,4 +600,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
   protected abstract PluginServiceFactory createAdditionalPluginServices(
       final Blockchain blockchain, final ProtocolContext protocolContext);
+
+  protected void stopSynchronizer() {}
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -600,5 +600,4 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
   protected abstract PluginServiceFactory createAdditionalPluginServices(
       final Blockchain blockchain, final ProtocolContext protocolContext);
-
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -601,5 +601,4 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
   protected abstract PluginServiceFactory createAdditionalPluginServices(
       final Blockchain blockchain, final ProtocolContext protocolContext);
 
-  protected void stopSynchronizer() {}
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -117,7 +117,6 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                 syncState,
                 ethProtocolManager,
                 transitionBackwardsSyncContext));
-    // initTransitionWatcher(protocolContext, composedCoordinator, blockPropagationManager);
     return composedCoordinator;
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
@@ -85,7 +85,6 @@ public class TransitionControllerBuilderTest {
     when(transitionProtocolSchedule.getPreMergeSchedule()).thenReturn(preMergeProtocolSchedule);
     when(protocolContext.getConsensusContext(CliqueContext.class))
         .thenReturn(mock(CliqueContext.class));
-    when(protocolContext.getConsensusContext(PostMergeContext.class)).thenReturn(mergeContext);
   }
 
   @Test

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
@@ -30,6 +30,8 @@ public interface Synchronizer {
 
   void stop();
 
+  void stopBlockPropagation();
+
   void awaitStop() throws InterruptedException;
 
   /**

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -193,6 +193,11 @@ public class DefaultSynchronizer implements Synchronizer {
   }
 
   @Override
+  public void stopBlockPropagation() {
+    blockPropagationManager.ifPresent(BlockPropagationManager::stop);
+  }
+
+  @Override
   public void awaitStop() throws InterruptedException {
     if (maybePruner.isPresent()) {
       maybePruner.get().awaitStop();

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -37,6 +37,9 @@ public class DummySynchronizer implements Synchronizer {
   public void stop() {}
 
   @Override
+  public void stopBlockPropagation() {}
+
+  @Override
   public void awaitStop() throws InterruptedException {}
 
   @Override


### PR DESCRIPTION
Delays ttd callback till after controllers are built, so it can close over a handle to the block propagation manager.

fixes #3797 

Signed-off-by: Justin Florentine <justin+github@florentine.us>

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).