### PR TITLE
[MAINTAINERS] new non-code maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -39,8 +39,10 @@
 <!-- besu-triage group has Write access to besu repo -->
 
 | Name             | Github           | LFID             |
-| ---------------- | ---------------- | ---------------- |
+|------------------|------------------|------------------|
+| Helen George     | iamhsk           | hsk.geo          |
 | Madeline Murray  | MadelineMurray   | madelinemurray   |
+| Matt Nelson      | Matt-nelson-csi  | mattnelson.eth   |
 | Sajida Zouarhi   | sajz             | SajidaZ          |
 
 ## Emeritus Maintainers


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

I propose adding Helen George and Matt Nelson to Besu non-code maintainers. They have started helping manage, categorize bugs and other Github issues for Besu, as well as collaborating with the existing maintainers to help coordinate the development and roadmap planning of Besu.

Becoming non-code maintainers, they will be able to label bugs and close relevant tickets, helping to keep the project tidy.

Voting ends two weeks from today.

For more information on this process see the Becoming a non-code Maintainer section in the MAINTAINERS.md file.