### PR TITLE
Migrate integrationTests to Junit5

### DIFF
--- a/consensus/ibft/build.gradle
+++ b/consensus/ibft/build.gradle
@@ -64,9 +64,12 @@ dependencies {
   integrationTestImplementation project(':metrics:core')
   integrationTestImplementation project(':testutil')
 
-  integrationTestImplementation 'junit:junit'
   integrationTestImplementation 'org.assertj:assertj-core'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.mockito:mockito-core'
+  integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
+
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureHeightTest.java
@@ -35,7 +35,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FutureHeightTest {
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/FutureRoundTest.java
@@ -31,7 +31,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FutureRoundTest {
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/GossipTest.java
@@ -40,8 +40,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GossipTest {
 
@@ -65,7 +65,7 @@ public class GossipTest {
   private ValidatorPeer sender;
   private MessageFactory msgFactory;
 
-  @Before
+  @BeforeEach
   public void setup() {
     block = context.createBlockForProposalFromChainHead(roundId.getRoundNumber(), 30);
     sender = peers.getProposer();

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeIsProposerTest.java
@@ -34,8 +34,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * These tests assume the basic function of the Ibft Round State Machine has been proven via the
@@ -65,7 +65,7 @@ public class LocalNodeIsProposerTest {
   private Proposal expectedTxProposal;
   private Commit expectedTxCommit;
 
-  @Before
+  @BeforeEach
   public void setup() {
     expectedProposedBlock = context.createBlockForProposalFromChainHead(0, blockTimeStamp);
     expectedTxProposal =

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/LocalNodeNotProposerTest.java
@@ -26,8 +26,8 @@ import org.hyperledger.besu.consensus.ibft.support.TestContext;
 import org.hyperledger.besu.consensus.ibft.support.TestContextBuilder;
 import org.hyperledger.besu.ethereum.core.Block;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalNodeNotProposerTest {
 
@@ -50,7 +50,7 @@ public class LocalNodeNotProposerTest {
   private Prepare expectedTxPrepare;
   private Commit expectedTxCommit;
 
-  @Before
+  @BeforeEach
   public void setup() {
     expectedTxPrepare = localNodeMessageFactory.createPrepare(roundId, blockToPropose.getHash());
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/ReceivedFutureProposalTest.java
@@ -33,7 +33,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Ensure the Ibft component responds appropriately when a future round Proposal message is

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/RoundChangeTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/RoundChangeTest.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RoundChangeTest {
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/SpuriousBehaviourTest.java
@@ -41,8 +41,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SpuriousBehaviourTest {
 
@@ -67,7 +67,7 @@ public class SpuriousBehaviourTest {
   private Prepare expectedPrepare;
   private Commit expectedCommit;
 
-  @Before
+  @BeforeEach
   public void setup() {
 
     expectedPrepare =

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/TransitionsTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/TransitionsTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransitionsTest {
 

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
@@ -55,13 +55,16 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class IbftRoundIntegrationTest {
 
   private final MessageFactory peerMessageFactory = new MessageFactory(NodeKeyUtils.generate());
@@ -89,7 +92,7 @@ public class IbftRoundIntegrationTest {
           .createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 1);
   private final IbftExtraDataCodec bftExtraDataEncoder = new IbftExtraDataCodec();
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(messageValidator.validateProposal(any())).thenReturn(true);
     when(messageValidator.validatePrepare(any())).thenReturn(true);

--- a/consensus/qbft/build.gradle
+++ b/consensus/qbft/build.gradle
@@ -106,9 +106,12 @@ dependencies {
   integrationTestImplementation project(':metrics:core')
   integrationTestImplementation project(':testutil')
 
-  integrationTestImplementation 'junit:junit'
   integrationTestImplementation 'org.assertj:assertj-core'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.mockito:mockito-core'
+  integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
+
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 
   referenceTestImplementation 'junit:junit'
   referenceTestImplementation 'com.google.guava:guava'

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureHeightTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureHeightTest.java
@@ -35,7 +35,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FutureHeightTest {
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/FutureRoundTest.java
@@ -36,7 +36,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FutureRoundTest {
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/GossipTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/GossipTest.java
@@ -39,8 +39,8 @@ import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GossipTest {
 
@@ -64,7 +64,7 @@ public class GossipTest {
   private ValidatorPeer sender;
   private MessageFactory msgFactory;
 
-  @Before
+  @BeforeEach
   public void setup() {
     block = context.createBlockForProposalFromChainHead(30, peers.getProposer().getNodeAddress());
     sender = peers.getProposer();

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeIsProposerTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeIsProposerTest.java
@@ -35,8 +35,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collections;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * These tests assume the basic function of the Qbft Round State Machine has been proven via the
@@ -67,7 +67,7 @@ public class LocalNodeIsProposerTest {
   private Commit expectedTxCommit;
   private Prepare expectedTxPrepare;
 
-  @Before
+  @BeforeEach
   public void setup() {
     expectedProposedBlock = context.createBlockForProposalFromChainHead(blockTimeStamp);
     expectedTxProposal =

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeNotProposerTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/LocalNodeNotProposerTest.java
@@ -26,8 +26,8 @@ import org.hyperledger.besu.consensus.qbft.support.TestContext;
 import org.hyperledger.besu.consensus.qbft.support.TestContextBuilder;
 import org.hyperledger.besu.ethereum.core.Block;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalNodeNotProposerTest {
 
@@ -51,7 +51,7 @@ public class LocalNodeNotProposerTest {
   private Prepare expectedTxPrepare;
   private Commit expectedTxCommit;
 
-  @Before
+  @BeforeEach
   public void setup() {
     expectedTxPrepare = localNodeMessageFactory.createPrepare(roundId, blockToPropose.getHash());
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ReceivedFutureProposalTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ReceivedFutureProposalTest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Ensure the Qbft component responds appropriately when a future round Proposal message is

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/RoundChangeTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/RoundChangeTest.java
@@ -43,7 +43,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RoundChangeTest {
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/SpuriousBehaviourTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/SpuriousBehaviourTest.java
@@ -41,8 +41,8 @@ import java.time.Instant;
 import java.time.ZoneId;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SpuriousBehaviourTest {
 
@@ -68,7 +68,7 @@ public class SpuriousBehaviourTest {
   private Prepare expectedPrepare;
   private Commit expectedCommit;
 
-  @Before
+  @BeforeEach
   public void setup() {
 
     expectedPrepare =

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/TransitionsTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/TransitionsTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransitionsTest {
 

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ValidatorContractTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/ValidatorContractTest.java
@@ -46,8 +46,8 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ValidatorContractTest {
 
@@ -68,7 +68,7 @@ public class ValidatorContractTest {
 
   private final QbftExtraDataCodec extraDataCodec = new QbftExtraDataCodec();
 
-  @Before
+  @BeforeEach
   public void setup() {
     clock = new TestClock(Instant.EPOCH.plus(TestContextBuilder.BLOCK_TIMER_SEC, SECONDS));
   }

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -56,13 +56,16 @@ import org.hyperledger.besu.util.Subscribers;
 import java.math.BigInteger;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class QbftRoundIntegrationTest {
 
   private final MessageFactory peerMessageFactory = new MessageFactory(NodeKeyUtils.generate());
@@ -90,7 +93,7 @@ public class QbftRoundIntegrationTest {
       SignatureAlgorithmFactory.getInstance()
           .createSignature(BigInteger.ONE, BigInteger.ONE, (byte) 1);
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(messageValidator.validateProposal(any())).thenReturn(true);
     when(messageValidator.validatePrepare(any())).thenReturn(true);

--- a/enclave/build.gradle
+++ b/enclave/build.gradle
@@ -22,11 +22,12 @@ dependencies {
 
   // integration test dependencies.
   integrationTestImplementation project(':testutil')
+  integrationTestImplementation 'org.assertj:assertj-core'
   integrationTestImplementation 'org.bouncycastle:bcpkix-jdk15on'
   integrationTestImplementation 'org.awaitility:awaitility'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.testcontainers:testcontainers'
 
-  integrationTestImplementation 'junit:junit'
-  integrationTestImplementation 'org.assertj:assertj-core'
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 }

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -27,6 +27,8 @@ import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -34,15 +36,14 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.awaitility.Awaitility;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class EnclaveTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private static final String PAYLOAD = "a wonderful transaction";
   private static final String MOCK_KEY = "iOCzoGo5kwtZU0J41Z9xnGXHN6ZNukIa9MspvHtu3Jk=";
@@ -52,16 +53,15 @@ public class EnclaveTest {
 
   private static TesseraTestHarness testHarness;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     vertx = Vertx.vertx();
     factory = new EnclaveFactory(vertx);
-    folder.create();
 
     testHarness =
         TesseraTestHarnessFactory.create(
             "enclave",
-            folder.newFolder().toPath(),
+            Files.createTempDirectory(folder, "enclave"),
             new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"),
             Optional.empty());
 
@@ -70,7 +70,7 @@ public class EnclaveTest {
     enclave = factory.createVertxEnclave(testHarness.clientUrl());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     testHarness.close();
     vertx.close();

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/GoQuorumEnclaveTest.java
@@ -32,8 +32,8 @@ import java.util.Base64;
 import java.util.List;
 
 import io.vertx.core.Vertx;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 public class GoQuorumEnclaveTest {
@@ -46,7 +46,7 @@ public class GoQuorumEnclaveTest {
 
   private RequestTransmitter vertxTransmitter;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     enclave = createGoQuorumEnclaveWithMockRequestTransmitter();
   }

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/TlsEnabledEnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/TlsEnabledEnclaveTest.java
@@ -32,9 +32,9 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TlsEnabledEnclaveTest {
 
@@ -50,13 +50,13 @@ public class TlsEnabledEnclaveTest {
     vertx.close();
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     serverFactory = new TlsEnabledHttpServerFactory();
     this.vertx = Vertx.vertx();
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     serverFactory.shutdown();
     this.shutdown();

--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -110,10 +110,13 @@ dependencies {
   integrationTestImplementation project(':services:kvstore')
   integrationTestImplementation project(':testutil')
 
-  integrationTestImplementation 'junit:junit'
   integrationTestImplementation 'org.assertj:assertj-core'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.mockito:mockito-core'
+  integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
   integrationTestImplementation 'org.testcontainers:testcontainers'
+
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 }
 
 artifacts {

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugTraceTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugTraceTransactionIntegrationTest.java
@@ -32,16 +32,16 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DebugTraceTransactionIntegrationTest {
   private static final String DEBUG_TRACE_TRANSACTION = "debug_traceTransaction";
   private static JsonRpcTestMethodsFactory blockchain;
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -51,7 +51,7 @@ public class DebugTraceTransactionIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final Map<String, JsonRpcMethod> methods = blockchain.methods();
     method = methods.get(DEBUG_TRACE_TRANSACTION);

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -47,12 +47,9 @@ import java.util.Optional;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.assertj.core.api.Assertions;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class EthGetBlockByNumberLatestDesyncIntegrationTest {
 
   private static JsonRpcTestMethodsFactory methodsFactorySynced;
@@ -60,7 +57,7 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
   private static JsonRpcTestMethodsFactory methodsFactoryMidDownload;
   private static final long ARBITRARY_SYNC_BLOCK = 4L;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCallIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCallIntegrationTest.java
@@ -35,9 +35,9 @@ import java.util.Map;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthCallIntegrationTest {
 
@@ -45,7 +45,7 @@ public class EthCallIntegrationTest {
 
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -55,7 +55,7 @@ public class EthCallIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final Map<String, JsonRpcMethod> methods = BLOCKCHAIN.methods();
     method = methods.get("eth_call");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
@@ -35,9 +35,9 @@ import java.util.Map;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthEstimateGasIntegrationTest {
 
@@ -45,7 +45,7 @@ public class EthEstimateGasIntegrationTest {
 
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -55,7 +55,7 @@ public class EthEstimateGasIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final Map<String, JsonRpcMethod> methods = BLOCKCHAIN.methods();
     method = methods.get("eth_estimateGas");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByHashIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByHashIntegrationTest.java
@@ -36,9 +36,9 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthGetBlockByHashIntegrationTest {
 
@@ -49,7 +49,7 @@ public class EthGetBlockByHashIntegrationTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ZERO_HASH = String.valueOf(Hash.ZERO);
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -59,7 +59,7 @@ public class EthGetBlockByHashIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     methods = BLOCKCHAIN.methods();
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByNumberIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetBlockByNumberIntegrationTest.java
@@ -36,13 +36,10 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-@RunWith(MockitoJUnitRunner.class)
 public class EthGetBlockByNumberIntegrationTest {
 
   private static final String ETH_METHOD = "eth_getBlockByNumber";
@@ -52,7 +49,7 @@ public class EthGetBlockByNumberIntegrationTest {
   private final JsonRpcResponseUtils responseUtils = new JsonRpcResponseUtils();
   private Map<String, JsonRpcMethod> methods;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -62,7 +59,7 @@ public class EthGetBlockByNumberIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     methods = BLOCKCHAIN.methods();
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -65,13 +65,16 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthGetFilterChangesIntegrationTest {
 
   @Mock private TransactionBroadcaster batchAddedListener;
@@ -90,7 +93,7 @@ public class EthGetFilterChangesIntegrationTest {
   private EthGetFilterChanges method;
   private final SyncState syncState = mock(SyncState.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final ExecutionContextTestFixture executionContext = ExecutionContextTestFixture.create();
     blockchain = executionContext.getBlockchain();

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetUncleByBlockHashAndIndexIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetUncleByBlockHashAndIndexIntegrationTest.java
@@ -32,9 +32,9 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthGetUncleByBlockHashAndIndexIntegrationTest {
 
@@ -43,7 +43,7 @@ public class EthGetUncleByBlockHashAndIndexIntegrationTest {
   private final JsonRpcResponseUtils responseUtils = new JsonRpcResponseUtils();
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -53,7 +53,7 @@ public class EthGetUncleByBlockHashAndIndexIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = BLOCKCHAIN.methods().get("eth_getUncleByBlockHashAndIndex");
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetUncleByBlockNumberAndIndexIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetUncleByBlockNumberAndIndexIntegrationTest.java
@@ -32,9 +32,9 @@ import java.util.Map;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthGetUncleByBlockNumberAndIndexIntegrationTest {
 
@@ -43,7 +43,7 @@ public class EthGetUncleByBlockNumberAndIndexIntegrationTest {
   private final JsonRpcResponseUtils responseUtils = new JsonRpcResponseUtils();
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestGenesisUrl(), Charsets.UTF_8);
@@ -53,7 +53,7 @@ public class EthGetUncleByBlockNumberAndIndexIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = BLOCKCHAIN.methods().get("eth_getUncleByBlockNumberAndIndex");
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/PrivGetPrivateTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/PrivGetPrivateTransactionIntegrationTest.java
@@ -52,6 +52,8 @@ import org.hyperledger.enclave.testutil.TesseraTestHarness;
 import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Optional;
@@ -59,15 +61,14 @@ import java.util.Optional;
 import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class PrivGetPrivateTransactionIntegrationTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
   private static final String ENCLAVE_PUBLIC_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
 
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
@@ -118,16 +119,14 @@ public class PrivGetPrivateTransactionIntegrationTest {
   private Enclave enclave;
   private PrivacyController privacyController;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    folder.create();
-
     vertx = Vertx.vertx();
 
     testHarness =
         TesseraTestHarnessFactory.create(
             "enclave",
-            folder.newFolder().toPath(),
+            Files.createTempDirectory(folder, "enclave"),
             new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"),
             Optional.empty());
 
@@ -141,7 +140,7 @@ public class PrivGetPrivateTransactionIntegrationTest {
             blockchain, privateStateStorage, enclave, null, null, null, null, null);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     testHarness.close();
     vertx.close();

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
@@ -35,9 +35,9 @@ import java.util.Map;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthCallIntegrationTest {
 
@@ -45,7 +45,7 @@ public class EthCallIntegrationTest {
 
   private JsonRpcMethod method;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
     final String genesisJson =
         Resources.toString(BlockTestUtil.getTestLondonGenesisUrl(), Charsets.UTF_8);
@@ -55,7 +55,7 @@ public class EthCallIntegrationTest {
             new BlockchainImporter(BlockTestUtil.getTestLondonBlockchainUrl(), genesisJson));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final Map<String, JsonRpcMethod> methods = BLOCKCHAIN.methods();
     method = methods.get("eth_call");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -65,13 +65,16 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthGetFilterChangesIntegrationTest {
 
   @Mock private TransactionBroadcaster batchAddedListener;
@@ -90,7 +93,7 @@ public class EthGetFilterChangesIntegrationTest {
   private EthGetFilterChanges method;
   private final SyncState syncState = mock(SyncState.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final ExecutionContextTestFixture executionContext = ExecutionContextTestFixture.create();
     blockchain = executionContext.getBlockchain();

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -89,10 +89,12 @@ dependencies {
   integrationTestImplementation project(path: ':config', configuration: 'testSupportArtifacts')
   integrationTestImplementation project(':testutil')
 
-  integrationTestImplementation 'junit:junit'
   integrationTestImplementation 'org.assertj:assertj-core'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.testcontainers:testcontainers'
+
+  integrationTestRuntimeOnly 'org.junit.jupiter:junit-jupiter'
 
   testSupportImplementation project(path: ':config', configuration: 'testSupportArtifacts')
   testSupportImplementation project(':ethereum:eth')

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractIntegrationTest.java
@@ -54,6 +54,8 @@ import org.hyperledger.enclave.testutil.EnclaveKeyConfiguration;
 import org.hyperledger.enclave.testutil.TesseraTestHarness;
 import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -62,15 +64,14 @@ import com.google.common.collect.Lists;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class PrivacyPrecompiledContractIntegrationTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private static final Bytes VALID_PRIVATE_TRANSACTION_RLP =
       Bytes.fromHexString(
@@ -115,14 +116,13 @@ public class PrivacyPrecompiledContractIntegrationTest {
     return mockPrivateTransactionProcessor;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpOnce() throws Exception {
-    folder.create();
 
     testHarness =
         TesseraTestHarnessFactory.create(
             "enclave",
-            folder.newFolder().toPath(),
+            Files.createTempDirectory(folder, "enclave"),
             new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_1.key"),
             Optional.empty());
 
@@ -168,7 +168,7 @@ public class PrivacyPrecompiledContractIntegrationTest {
     when(privateStateStorage.updater()).thenReturn(storageUpdater);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownOnce() {
     testHarness.stop();
     vertx.close();

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/EntriesFromIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/EntriesFromIntegrationTest.java
@@ -30,7 +30,7 @@ import java.util.TreeMap;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EntriesFromIntegrationTest {
 

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/vm/TraceTransactionIntegrationTest.java
@@ -46,8 +46,8 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TraceTransactionIntegrationTest {
 
@@ -64,7 +64,7 @@ public class TraceTransactionIntegrationTest {
   private MainnetTransactionProcessor transactionProcessor;
   private BlockHashLookup blockHashLookup;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final ExecutionContextTestFixture contextTestFixture = ExecutionContextTestFixture.create();
     genesisBlock = contextTestFixture.getGenesis();

--- a/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/worldstate/PrunerIntegrationTest.java
+++ b/ethereum/core/src/integration-test/java/org/hyperledger/besu/ethereum/worldstate/PrunerIntegrationTest.java
@@ -47,7 +47,7 @@ import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PrunerIntegrationTest {
 

--- a/ethereum/eth/build.gradle
+++ b/ethereum/eth/build.gradle
@@ -89,8 +89,6 @@ dependencies {
   jmhImplementation project(':besu')
   jmhImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')
   jmhImplementation project(':plugins:rocksdb')
-
-  integrationTestImplementation project(path: ':config', configuration: 'testSupportArtifacts')
 }
 
 artifacts {

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -157,9 +157,11 @@ dependencyManagement {
     dependency 'org.jupnp:org.jupnp:2.6.0'
 
     dependency 'org.junit.jupiter:junit-jupiter:5.8.2'
+    dependency 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     dependency 'org.junit.vintage:junit-vintage-engine:5.8.2'
 
     dependency 'org.mockito:mockito-core:4.4.0'
+    dependency 'org.mockito:mockito-junit-jupiter:4.4.0'
 
     dependency 'org.openjdk.jmh:jmh-core:1.34'
     dependency 'org.openjdk.jmh:jmh-generator-annprocess:1.34'


### PR DESCRIPTION
## PR description
As an effort to modularize Junit5 migration, this PR only migrates tests ran from the `integrationTest` task.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).