### PR TITLE
Fix for multi-arch docker develop and latest tags 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,7 +454,6 @@ workflows:
               only:
                 - main
                 - /^release-.*/
-                - /.*docker-multi-arch/
           requires:
             - assemble
             - integrationTests
@@ -472,7 +471,6 @@ workflows:
               only:
                 - main
                 - /^release-.*/
-                - /.*docker-multi-arch/
           requires:
             - integrationTests
             - unitTests
@@ -489,7 +487,6 @@ workflows:
               only:
                 - master
                 - /^release-.*/
-                - /.*docker-multi-arch/
           requires:
             - publishDocker
             - publishArm64Docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,7 @@ workflows:
               only:
                 - main
                 - /^release-.*/
+                - /.*docker-multi-arch/
           requires:
             - assemble
             - integrationTests
@@ -471,6 +472,7 @@ workflows:
               only:
                 - main
                 - /^release-.*/
+                - /.*docker-multi-arch/
           requires:
             - integrationTests
             - unitTests
@@ -487,6 +489,7 @@ workflows:
               only:
                 - master
                 - /^release-.*/
+                - /.*docker-multi-arch/
           requires:
             - publishDocker
             - publishArm64Docker

--- a/build.gradle
+++ b/build.gradle
@@ -780,19 +780,19 @@ task manifestDocker {
   def image = "${dockerImage}:${dockerBuildVersion}"
   def archs = ["arm64", "amd64"]
   def tags = ["${image}"]
+
   if (project.hasProperty('branch') && project.property('branch') == 'main') {
-    tags.add("${dockerImage}-develop")
+    tags.add("${dockerImage}:develop")
   }
 
   if (!(dockerBuildVersion ==~ /.*-SNAPSHOT/)) {
-    tags.add('${dockerImage}-latest')
-    tags.add('${dockerImage}-' + dockerBuildVersion.split(/\./)[0..1].join('.'))
+    tags.add('${dockerImage}:latest')
+    tags.add('${dockerImage}:' + dockerBuildVersion.split(/\./)[0..1].join('.'))
   }
 
   doLast {
     for (baseTag in tags) {
       for (def variant in dockerVariants) {
-        // Just do variant images for now, later add tags and such
         def variantImage = "${baseTag}-${variant}"
         def targets = ""
         archs.forEach { arch -> targets += "'${variantImage}-${arch}' " }


### PR DESCRIPTION

## PR description

In the multi-arch docker build pr #2954, the manifest step is not correctly creating the `develop` and `latest` multi-arch tags.  This pr fixes the tag creation in the manifestDocker step

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).