### PR TITLE
warning for clique consensus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 ## 22.4.1
 
-### Breaking Changes
-- To use clique consensus, require --Xclique-enabled option [] (https://github.com/hyperledger/besu/pull/)
-
-- ### Additions and Improvements
+### Additions and Improvements
 - GraphQL - allow null log topics in queries which match any topic [#3662](https://github.com/hyperledger/besu/pull/3662)
 - multi-arch docker builds for amd64 and arm64 [#2954](https://github.com/hyperledger/besu/pull/2954)
 - Filter Netty native lib errors likewise the pure Java implementation [#3807](https://github.com/hyperledger/besu/pull/3807)
+- Clique consensus not recommended for production, require --Xclique-enabled option to be set [#3823](https://github.com/hyperledger/besu/pull/3823)
+  - This will be made a breaking change in the future (current default is true)
 
 ### Bug Fixes
 - Stop the BlockPropagationManager when it receives the TTD reached event [#3809](https://github.com/hyperledger/besu/pull/3809)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 22.7.0
+
+### Upcoming Breaking Changes
+- Version 22.7.0 requires Java 17 to build and run.
+- Clique consensus requires --Xclique-enabled option to be set [#3824](https://github.com/hyperledger/besu/pull/3824)
+
 ## 22.4.1
 
 ### Additions and Improvements
@@ -7,7 +13,7 @@
 - multi-arch docker builds for amd64 and arm64 [#2954](https://github.com/hyperledger/besu/pull/2954)
 - Filter Netty native lib errors likewise the pure Java implementation [#3807](https://github.com/hyperledger/besu/pull/3807)
 - Clique consensus not recommended for production, require --Xclique-enabled option to be set [#3823](https://github.com/hyperledger/besu/pull/3823)
-  - This will be made a breaking change in the future (current default is true)
+  - This will be made a breaking change in the future (current default allows clique)
 
 ### Bug Fixes
 - Stop the BlockPropagationManager when it receives the TTD reached event [#3809](https://github.com/hyperledger/besu/pull/3809)
@@ -2905,7 +2911,7 @@ Public key address export subcommand was missing in 1.0 release.
 
 ## 0.9.1
 
-Built and compatible with with JDK8.
+Built and compatible with JDK8.
 
 ## 0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 22.4.1
 
-### Additions and Improvements
+### Breaking Changes
+- To use clique consensus, require --Xclique-enabled option [] (https://github.com/hyperledger/besu/pull/)
+
+- ### Additions and Improvements
 - GraphQL - allow null log topics in queries which match any topic [#3662](https://github.com/hyperledger/besu/pull/3662)
 - multi-arch docker builds for amd64 and arm64 [#2954](https://github.com/hyperledger/besu/pull/2954)
 - Filter Netty native lib errors likewise the pure Java implementation [#3807](https://github.com/hyperledger/besu/pull/3807)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -57,6 +57,7 @@ import org.hyperledger.besu.cli.options.stable.EthstatsOptions;
 import org.hyperledger.besu.cli.options.stable.LoggingLevelOption;
 import org.hyperledger.besu.cli.options.stable.NodePrivateKeyFileOption;
 import org.hyperledger.besu.cli.options.stable.P2PTLSConfigOptions;
+import org.hyperledger.besu.cli.options.unstable.CliqueOptions;
 import org.hyperledger.besu.cli.options.unstable.DnsOptions;
 import org.hyperledger.besu.cli.options.unstable.EthProtocolOptions;
 import org.hyperledger.besu.cli.options.unstable.EvmOptions;
@@ -288,6 +289,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final PrivacyPluginOptions unstablePrivacyPluginOptions = PrivacyPluginOptions.create();
   private final EvmOptions unstableEvmOptions = EvmOptions.create();
   private final IpcOptions unstableIpcOptions = IpcOptions.create();
+  private final CliqueOptions unstableCliqueOptions = CliqueOptions.create();
 
   // stable CLI options
   private final DataStorageOptions dataStorageOptions = DataStorageOptions.create();
@@ -1378,11 +1380,17 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     try {
       configureLogging(true);
 
-      // Set the goquorum compatibility mode based on the genesis file
       if (genesisFile != null) {
         genesisConfigOptions = readGenesisConfigOptions();
         if (genesisConfigOptions.isQuorum()) {
           enableGoQuorumCompatibilityMode();
+        }
+        if (genesisConfigOptions.isClique()) {
+          if (!unstableCliqueOptions.isCliqueEnabled()) {
+            throw new ParameterException(
+                commandLine,
+                "Clique consensus recommended for dev/test networks only. To force, use --Xclique-enabled");
+          }
         }
       }
 
@@ -1492,6 +1500,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .put("Merge", mergeOptions)
             .put("EVM Options", unstableEvmOptions)
             .put("IPC Options", unstableIpcOptions)
+            .put("Clique Options", unstableCliqueOptions)
             .build();
 
     UnstableOptionsSubCommand.createUnstableOptions(commandLine, unstableOptions);

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/CliqueOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/CliqueOptions.java
@@ -24,7 +24,7 @@ public class CliqueOptions {
       description =
           "Enable use of Clique consensus. Recommended for dev/test networks only. (default: ${DEFAULT-VALUE})",
       arity = "1")
-  private final Boolean cliqueEnabled = Boolean.FALSE;
+  private final Boolean cliqueEnabled = Boolean.TRUE;
 
   public static CliqueOptions create() {
     return new CliqueOptions();

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/CliqueOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/CliqueOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import picocli.CommandLine;
+
+public class CliqueOptions {
+
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xclique-enabled"},
+      description =
+          "Enable use of Clique consensus. Recommended for dev/test networks only. (default: ${DEFAULT-VALUE})",
+      arity = "1")
+  private final Boolean cliqueEnabled = Boolean.FALSE;
+
+  public static CliqueOptions create() {
+    return new CliqueOptions();
+  }
+
+  public Boolean isCliqueEnabled() {
+    return cliqueEnabled;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
@@ -208,6 +208,10 @@ public class BesuController implements java.io.Closeable {
         builder = new QbftBesuControllerBuilder();
       } else if (configOptions.isClique()) {
         builder = new CliqueBesuControllerBuilder();
+        LOG.warn(
+            "\n***************"
+                + "\nWe recommend Clique for use in development and test networks (Goerli and Rinkeby) only. For production, please use QBFT."
+                + "\n***************");
       } else {
         throw new IllegalArgumentException("Unknown consensus mechanism defined");
       }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -4943,4 +4943,22 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(pkiKeyStoreConfig.getTrustStorePassword()).isEqualTo("foo");
     assertThat(pkiKeyStoreConfig.getCrlFilePath()).hasValue(Path.of("/tmp/crl"));
   }
+
+  @Test
+  public void cliqueGenesisWithCliqueEnabledTrue_succeeds() {
+    final String cliqueGenesisFile = this.getClass().getResource("/clique.json").getFile();
+    parseCommand("--Xclique-enabled", "true", "--genesis-file", cliqueGenesisFile);
+
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void cliqueGenesisWithCliqueEnabledExplicitlyFalse_error() {
+    final String cliqueGenesisFile = this.getClass().getResource("/clique.json").getFile();
+    parseCommand("--genesis-file", cliqueGenesisFile, "--Xclique-enabled", "false");
+
+    assertThat(commandErrorOutput.toString(UTF_8))
+        .contains(
+            "Clique consensus recommended for dev/test networks only. To force, use --Xclique-enabled");
+  }
 }

--- a/besu/src/test/resources/clique.json
+++ b/besu/src/test/resources/clique.json
@@ -1,0 +1,32 @@
+{
+  "config": {
+    "chainId": 4,
+    "homesteadBlock": 1,
+    "eip150Block": 2,
+    "eip158Block": 4,
+    "byzantiumBlock": 5,
+    "constantinopleBlock": 6,
+    "petersburgBlock": 7,
+    "clique": {
+      "blockperiodseconds": 10,
+      "epochlength": 30000
+    }
+  },
+  "nonce": "0x0",
+  "timestamp": "0x58ee40ba",
+  "extraData": "%extraData%",
+  "gasLimit": "0x47b760",
+  "difficulty": "0x1",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "fe3b557e8fb62b89f4916b721be55ceb828dbd73": {
+      "privateKey": "8f2a55949038a9610f50fb23b5883af3b4ecb3c3bb792cbcefbd1542c692be63",
+      "comment": "private key and this comment are ignored.  In a real chain, the private key should NOT be stored",
+      "balance": "0xad78ebc5ac6200000"
+    }
+  },
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+}


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Since we don't recommend clique for production
* add a warning if starting Besu with clique consensus
* add a CLI option `--Xclique-enabled` which must be true for Besu to start with clique 

With default=true, not breaking change - but we probably want to do that in the future. 
With default=false, this will be a breaking change - anyone using clique will need to add this CLI option

```
➜  besu-local-nodes git:(multi-tenancy) ✗ besu --config-file=config/besu/besu1-quorum.conf  --Xclique-enabled=false
Setting logging level to INFO
Clique consensus recommended for dev/test networks only. To force, use --Xclique-enabled

To display full help:
besu [COMMAND] --help
➜  besu-local-nodes git:(multi-tenancy) ✗ besu --config-file=config/besu/besu1-quorum.conf
Setting logging level to INFO
2022-05-12 15:41:26.450+10:00 | main | INFO  | Besu | Using LibEthPairings native alt bn128
2022-05-12 15:41:26.452+10:00 | main | INFO  | Besu | Using the native implementation of the signature algorithm
2022-05-12 15:41:26.456+10:00 | main | INFO  | Besu | Starting Besu version: besu/v22.4.1-dev-46252afe/osx-x86_64/openjdk-java-11
2022-05-12 15:41:27.098+10:00 | main | WARN  | Besu | Discovery disabled: bootnodes will be ignored.
2022-05-12 15:41:27.102+10:00 | main | WARN  | Besu | Permissions are disabled. Cannot enable PERM APIs when not using Permissions.
2022-05-12 15:41:27.102+10:00 | main | INFO  | Besu | Static Nodes file = /Users/sallymacfarlane/workspace/besu-local-nodes/workdir/besu1/data/static-nodes.json
2022-05-12 15:41:27.104+10:00 | main | INFO  | StaticNodesParser | StaticNodes file /Users/sallymacfarlane/workspace/besu-local-nodes/workdir/besu1/data/static-nodes.json does not exist, no static connections will be created.
2022-05-12 15:41:27.105+10:00 | main | INFO  | Besu | Connecting to 0 static nodes.
2022-05-12 15:41:27.107+10:00 | main | INFO  | Besu | Security Module: localfile
2022-05-12 15:41:27.127+10:00 | main | INFO  | DatabaseMetadata | Lookup database metadata file in data directory: /Users/sallymacfarlane/workspace/besu-local-nodes/workdir/besu1/data
2022-05-12 15:41:27.184+10:00 | main | INFO  | RocksDBKeyValueStorageFactory | Existing database detected at /Users/sallymacfarlane/workspace/besu-local-nodes/workdir/besu1/data. Version 1
2022-05-12 15:41:28.857+10:00 | main | WARN  | Besu | Discovery disabled: bootnodes will be ignored.
2022-05-12 15:41:28.863+10:00 | main | WARN  | BesuController |
***************
We recommend Clique for use in development and test networks (Goerli and Rinkeby) only. For production, please use QBFT.
***************
2022-05-12 15:41:28.879+10:00 | main | INFO  | KeyPairUtil | Loaded public key 0xfcbe9f83218487b3c0b50878193880e6c25cfd86708c0a0bf0ca91f0ce633746a892fe240afa5b9a880b8bca48e8a22704ef937fdda2d7cc63e4d41ed1b417ae from /Users/sallymacfarlane/workspace/besu-local-nodes/workdir/besu1/keys/besu1.priv
```

## Documentation

- [] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).