### PR TITLE
Added Metrics for number of open RPC connections 

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -765,7 +765,8 @@ public class RunnerBuilder {
                   privacyParameters,
                   protocolSchedule,
                   blockchainQueries,
-                  DefaultAuthenticationService.create(vertx, webSocketConfiguration)));
+                  DefaultAuthenticationService.create(vertx, webSocketConfiguration),
+                  metricsSystem));
 
       createPrivateTransactionObserver(subscriptionManager, privacyParameters);
 
@@ -816,7 +817,8 @@ public class RunnerBuilder {
                     privacyParameters,
                     protocolSchedule,
                     blockchainQueries,
-                    authToUse));
+                    authToUse,
+                    metricsSystem));
       }
     }
 
@@ -1154,7 +1156,8 @@ public class RunnerBuilder {
       final PrivacyParameters privacyParameters,
       final ProtocolSchedule protocolSchedule,
       final BlockchainQueries blockchainQueries,
-      final Optional<AuthenticationService> authenticationService) {
+      final Optional<AuthenticationService> authenticationService,
+      final ObservableMetricsSystem metricsSystem) {
 
     final WebSocketMethodsFactory websocketMethodsFactory =
         new WebSocketMethodsFactory(subscriptionManager, jsonRpcMethods);
@@ -1192,7 +1195,7 @@ public class RunnerBuilder {
             webSocketConfiguration.getTimeoutSec());
 
     return new WebSocketService(
-        vertx, configuration, websocketRequestHandler, authenticationService);
+        vertx, configuration, websocketRequestHandler, authenticationService, metricsSystem);
   }
 
   private Optional<MetricsService> createMetricsService(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -189,7 +189,7 @@ public class JsonRpcHttpService {
         BesuMetricCategory.RPC,
         "active_http_connection_count",
         "Total of active rpc http connections",
-        () -> activeConnectionsCount.intValue());
+        activeConnectionsCount::intValue);
 
     validateConfig(config);
     this.config = config;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -184,6 +184,13 @@ public class JsonRpcHttpService {
             "request_time",
             "Time taken to process a JSON-RPC request",
             "methodName");
+
+    metricsSystem.createIntegerGauge(
+        BesuMetricCategory.RPC,
+        "active_http_connection_count",
+        "Total of active rpc http connections",
+        () -> activeConnectionsCount.intValue());
+
     validateConfig(config);
     this.config = config;
     this.vertx = vertx;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -20,6 +20,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationSe
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.DefaultAuthenticationService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
@@ -67,24 +69,33 @@ public class WebSocketService {
   public WebSocketService(
       final Vertx vertx,
       final WebSocketConfiguration configuration,
-      final WebSocketRequestHandler websocketRequestHandler) {
+      final WebSocketRequestHandler websocketRequestHandler,
+      final MetricsSystem metricsSystem) {
     this(
         vertx,
         configuration,
         websocketRequestHandler,
-        DefaultAuthenticationService.create(vertx, configuration));
+        DefaultAuthenticationService.create(vertx, configuration),
+        metricsSystem);
   }
 
   public WebSocketService(
       final Vertx vertx,
       final WebSocketConfiguration configuration,
       final WebSocketRequestHandler websocketRequestHandler,
-      final Optional<AuthenticationService> authenticationService) {
+      final Optional<AuthenticationService> authenticationService,
+      final MetricsSystem metricsSystem) {
     this.vertx = vertx;
     this.configuration = configuration;
     this.websocketRequestHandler = websocketRequestHandler;
     this.authenticationService = authenticationService;
     this.maxActiveConnections = configuration.getMaxActiveConnections();
+
+    metricsSystem.createIntegerGauge(
+        BesuMetricCategory.RPC,
+        "active_ws_connection_count",
+        "Total of active rpc ws connections",
+        () -> activeConnectionsCount.intValue());
   }
 
   public CompletableFuture<?> start() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -95,7 +95,7 @@ public class WebSocketService {
         BesuMetricCategory.RPC,
         "active_ws_connection_count",
         "Total of active rpc ws connections",
-        () -> activeConnectionsCount.intValue());
+        activeConnectionsCount::intValue);
   }
 
   public CompletableFuture<?> start() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketHostAllowlistTest.java
@@ -85,7 +85,8 @@ public class WebSocketHostAllowlistTest {
                 TimeoutOptions.defaultOptions().getTimeoutSeconds()));
 
     websocketService =
-        new WebSocketService(vertx, webSocketConfiguration, webSocketRequestHandlerSpy);
+        new WebSocketService(
+            vertx, webSocketConfiguration, webSocketRequestHandlerSpy, new NoOpMetricsSystem());
     websocketService.start().join();
     final InetSocketAddress inetSocketAddress = websocketService.socketAddress();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -201,7 +201,8 @@ public class WebSocketServiceLoginTest {
                 TimeoutOptions.defaultOptions().getTimeoutSeconds()));
 
     websocketService =
-        new WebSocketService(vertx, websocketConfiguration, webSocketRequestHandlerSpy);
+        new WebSocketService(
+            vertx, websocketConfiguration, webSocketRequestHandlerSpy, new NoOpMetricsSystem());
     websocketService.start().join();
     jwtAuth = websocketService.authenticationService.get().getJwtAuthProvider();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceTest.java
@@ -88,7 +88,8 @@ public class WebSocketServiceTest {
                 TimeoutOptions.defaultOptions().getTimeoutSeconds()));
 
     websocketService =
-        new WebSocketService(vertx, websocketConfiguration, webSocketRequestHandlerSpy);
+        new WebSocketService(
+            vertx, websocketConfiguration, webSocketRequestHandlerSpy, new NoOpMetricsSystem());
     websocketService.start().join();
 
     websocketConfiguration.setPort(websocketService.socketAddress().getPort());


### PR DESCRIPTION
Add Metrics for number of open RPC connections

Signed-off-by:Sharad Gulati sharad.develop@gmail.com

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Add Metrics for number of open RPC connections
besu_rpc_active_http_connection_count
besu_rpc_active_ws_connection_count

## Fixed Issue(s)
fixes #3781 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
You might need to add the added metrics to documentation.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).