### PR TITLE
quorum ATs can run on medium executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,6 +429,9 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
+      - acceptanceTestsQuorum:
+          requires:
+            - assemble
       - buildDocker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -429,9 +429,6 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
-      - acceptanceTestsQuorum:
-          requires:
-            - assemble
       - buildDocker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ executors:
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
       
-  quorum_ats_executor_xl:
+  quorum_ats_executor_med:
     docker:
       - image: cimg/openjdk:11.0
-    resource_class: xlarge
+    resource_class: medium
     working_directory: ~/project
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -279,7 +279,7 @@ jobs:
 
   acceptanceTestsQuorum:
     parallelism: 1
-    executor: quorum_ats_executor_xl
+    executor: quorum_ats_executor_med
     steps:
       - attach_workspace:
           at: ~/project


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Change quorum ATs (nightly) from XL to medium executor. 

The job ran successfully on medium executor https://app.circleci.com/pipelines/github/hyperledger/besu/14864/workflows/e1c2b5d0-44b1-45aa-a5c6-f46eeca7f4bc/jobs/85796

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).