### PR TITLE
Reduce EVM library dependencies

### DIFF
--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -29,12 +29,10 @@ jar {
 
 dependencies {
   api project(':plugin-api')
-  api project(':util')
 
   api 'org.bouncycastle:bcprov-jdk15on'
   api 'org.slf4j:slf4j-api'
 
-  implementation 'com.google.guava:guava'
   implementation 'net.java.dev.jna:jna'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
@@ -44,7 +42,6 @@ dependencies {
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
-  testImplementation 'org.mockito:mockito-core'
 
   testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }

--- a/datatypes/build.gradle
+++ b/datatypes/build.gradle
@@ -35,9 +35,6 @@ dependencies {
   implementation project(':crypto')
   implementation project(':ethereum:rlp')
 
-  implementation 'org.apache.tuweni:tuweni-bytes'
-  implementation 'org.apache.tuweni:tuweni-units'
-
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.util;
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal;
 
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -20,13 +20,13 @@ import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.QosTimer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchangeTransitionConfigurationResult;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.util.QosTimer;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimerTest.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.util;
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.QosTimer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -41,7 +42,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ParsedExtraData;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
-import org.hyperledger.besu.util.QosTimer;
 
 import java.util.Map;
 import java.util.Optional;

--- a/ethereum/p2p/build.gradle
+++ b/ethereum/p2p/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   implementation project(':pki')
   implementation project(':metrics:core')
   implementation project(':nat')
+  implementation project(':util')
 
   implementation 'com.google.guava:guava'
   implementation 'dnsjava:dnsjava'

--- a/ethereum/rlp/build.gradle
+++ b/ethereum/rlp/build.gradle
@@ -35,9 +35,8 @@ dependencies {
 
   jmh project(':util')
 
-  testImplementation project(':testutil')
-  testImplementation project(':ethereum:referencetests')
   testImplementation project(path: ':ethereum:referencetests', configuration: 'testOutput')
+  testImplementation project(':testutil')
 
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'junit:junit'

--- a/ethereum/rlp/build.gradle
+++ b/ethereum/rlp/build.gradle
@@ -30,16 +30,11 @@ jar {
 dependencies {
   annotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess'
 
-  api project(':plugin-api')
-  api project(':util')
-
-  implementation 'com.google.guava:guava'
   implementation 'org.apache.tuweni:tuweni-bytes'
   implementation 'org.apache.tuweni:tuweni-units'
 
   jmh project(':util')
 
-  testImplementation project(path: ':ethereum:referencetests', configuration: 'testOutput')
   testImplementation project(':testutil')
 
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/ethereum/rlp/build.gradle
+++ b/ethereum/rlp/build.gradle
@@ -36,6 +36,8 @@ dependencies {
   jmh project(':util')
 
   testImplementation project(':testutil')
+  testImplementation project(':ethereum:referencetests')
+  testImplementation project(path: ':ethereum:referencetests', configuration: 'testOutput')
 
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'junit:junit'

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -30,17 +30,11 @@ jar {
 dependencies {
   api 'org.slf4j:slf4j-api'
 
-  implementation project(':plugin-api')
-
   implementation 'com.google.guava:guava'
-  implementation 'io.vertx:vertx-core'
   implementation 'org.apache.logging.log4j:log4j-core'
   implementation 'org.apache.logging.log4j:log4j-slf4j-impl'
-  implementation 'org.apache.tuweni:tuweni-bytes'
-  implementation 'org.apache.tuweni:tuweni-units'
   implementation 'org.xerial.snappy:snappy-java'
 
-  testImplementation 'io.vertx:vertx-unit'
   testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'


### PR DESCRIPTION
Reduce the runtime dependencies of the EVM module by moving a
class used by a single class out of util to the owned module (QosTimer)
and them removing un-used dependencies from EVM and dependant modules.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).