### PR TITLE
Fix: getMixHashOrPrevRandao to return the value present in the block header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 - Stop the BlockPropagationManager when it receives the TTD reached event [#3809](https://github.com/hyperledger/besu/pull/3809)
+- Correct getMixHashOrPrevRandao to return the value present in the block header [#3839](https://github.com/hyperledger/besu/pull/3839)
 
 ## 22.4.0
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
@@ -141,6 +141,16 @@ public class ProcessableBlockHeader implements BlockValues {
   }
 
   /**
+   * Returns the mixHash before merge, and the prevRandao value after
+   *
+   * @return the mixHash before merge, and the prevRandao value after
+   */
+  @Override
+  public Bytes32 getMixHashOrPrevRandao() {
+    return mixHashOrPrevRandao;
+  }
+
+  /**
    * Returns the prevRandao of the block.
    *
    * @return the raw bytes of the prevRandao field


### PR DESCRIPTION
…he block header

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).