### PR TITLE
fix manifestDocker develop tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ jobs:
           name: Create and publish docker manifest
           command: |
             docker login --username "${DOCKER_USER_RW}" --password "${DOCKER_PASSWORD_RW}"
-            ./gradlew --no-daemon --parallel manifestDocker
+            ./gradlew --no-daemon "-Pbranch=${CIRCLE_BRANCH}" --parallel manifestDocker
 
 workflows:
   version: 2


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
currently we are not publishing multi-arch `develop` besu docker images.  The most recent `develop` tagged image is 8 days old.  The dockerManifest task which combines specific-arch images (like *-amd64 and *-arm64)  into a single multi-arch image is missing a gradle define for the branch name.

This PR adds circle-ci branch define to dockerManifest task to fix multi-arch `develop` tagged docker publishing. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).