### PR TITLE
[Flacky test] Pass vertx instance to QosTimer

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
@@ -22,14 +22,16 @@ import io.vertx.core.Vertx;
 
 public class QosTimer {
 
-  private final Vertx timerVertx = Vertx.vertx();
+  private final Vertx timerVertx;
   private final AtomicLong timerId = new AtomicLong(Long.MAX_VALUE);
   private final AtomicLong lastReset = new AtomicLong(System.currentTimeMillis());
 
   private final long periodMillis;
   private final Consumer<Long> consumerTask;
 
-  public QosTimer(final long periodMillis, final Consumer<Long> consumerTask) {
+  public QosTimer(
+      final Vertx timerVertx, final long periodMillis, final Consumer<Long> consumerTask) {
+    this.timerVertx = timerVertx;
     this.periodMillis = periodMillis;
     this.consumerTask = consumerTask;
     resetTimer();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -29,7 +29,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchange
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
@@ -42,18 +41,19 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
 
   static final long QOS_TIMEOUT_MILLIS = 120000L;
 
-  private static final AtomicReference<QosTimer> qosTimerRef =
-      new AtomicReference<>(
-          new QosTimer(
-              QOS_TIMEOUT_MILLIS,
-              lastCall ->
-                  LOG.warn(
-                      "not called in {} seconds, consensus client may not be connected",
-                      QOS_TIMEOUT_MILLIS / 1000L)));
+  private final QosTimer qosTimer;
 
   public EngineExchangeTransitionConfiguration(
       final Vertx vertx, final ProtocolContext protocolContext) {
     super(vertx, protocolContext);
+    qosTimer =
+        new QosTimer(
+            vertx,
+            QOS_TIMEOUT_MILLIS,
+            lastCall ->
+                LOG.warn(
+                    "not called in {} seconds, consensus client may not be connected",
+                    QOS_TIMEOUT_MILLIS / 1000L));
   }
 
   @Override
@@ -121,6 +121,6 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
 
   // QosTimer accessor for testing considerations
   QosTimer getQosTimer() {
-    return qosTimerRef.get();
+    return qosTimer;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimerTest.java
@@ -20,7 +20,6 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,13 +27,12 @@ import org.junit.runner.RunWith;
 public class QosTimerTest {
   static Vertx vertx = Vertx.vertx();
 
-  @Ignore("fails on CI with short timeouts and don't want to slow test suite down with longer ones")
   @Test
   public void shouldExecuteConsecutivelyAtTimeout(final TestContext ctx) {
     final long TEST_QOS_TIMEOUT = 100L;
     final Async async = ctx.async();
     final AtomicInteger execCount = new AtomicInteger(0);
-    new QosTimer(TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
+    new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
 
     vertx.setTimer(
         250L,
@@ -49,7 +47,7 @@ public class QosTimerTest {
     final long TEST_QOS_TIMEOUT = 75L;
     final Async async = ctx.async();
     final AtomicInteger execCount = new AtomicInteger(0);
-    new QosTimer(TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
+    new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
 
     vertx.setTimer(
         100L,
@@ -64,7 +62,7 @@ public class QosTimerTest {
     final long TEST_QOS_TIMEOUT = 200L;
     final Async async = ctx.async();
     final AtomicInteger execCount = new AtomicInteger(0);
-    new QosTimer(TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
+    new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
 
     vertx.setTimer(
         50L,
@@ -79,7 +77,7 @@ public class QosTimerTest {
     final long TEST_QOS_TIMEOUT = 50L;
     final Async async = ctx.async();
     final AtomicInteger execCount = new AtomicInteger(0);
-    final var timer = new QosTimer(TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
+    final var timer = new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> execCount.incrementAndGet());
 
     // reset QoS timer every 25 millis
     vertx.setPeriodic(25L, z -> timer.resetTimer());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -194,7 +194,8 @@ public class EngineExchangeTransitionConfigurationTest {
     final Async async = ctx.async();
     final AtomicInteger logCounter = new AtomicInteger(0);
     final var spyMethod = spy(method);
-    final var spyTimer = spy(new QosTimer(TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
+    final var spyTimer =
+        spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
     when(spyMethod.getQosTimer()).thenReturn(spyTimer);
     spyTimer.resetTimer();
 
@@ -219,7 +220,8 @@ public class EngineExchangeTransitionConfigurationTest {
     final Async async = ctx.async();
     final AtomicInteger logCounter = new AtomicInteger(0);
     final var spyMethod = spy(method);
-    final var spyTimer = spy(new QosTimer(TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
+    final var spyTimer =
+        spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
     when(spyMethod.getQosTimer()).thenReturn(spyTimer);
     spyTimer.resetTimer();
 
@@ -244,7 +246,8 @@ public class EngineExchangeTransitionConfigurationTest {
     final Async async = ctx.async();
     final AtomicInteger logCounter = new AtomicInteger(0);
     final var spyMethod = spy(method);
-    final var spyTimer = spy(new QosTimer(TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
+    final var spyTimer =
+        spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> logCounter.incrementAndGet()));
     when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
     when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(1337L));
     when(spyMethod.getQosTimer()).thenReturn(spyTimer);


### PR DESCRIPTION
## PR description
Passing the same vert.x instance as the one used by the test seems to fix the erratic behaviour. Also it reuses the runtime wise instance.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).