### PR TITLE
Make pandas thread safe

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,7 @@ public class PandaPrinter implements TTDReachedListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(PandaPrinter.class);
   private static final String pandaBanner = PandaPrinter.loadBanner();
-  private boolean beenDisplayed = false;
+  private final AtomicBoolean beenDisplayed = new AtomicBoolean();
 
   private static String loadBanner() {
     Class<PandaPrinter> c = PandaPrinter.class;
@@ -51,9 +52,8 @@ public class PandaPrinter implements TTDReachedListener {
 
   @Override
   public void onTTDReached(final boolean reached) {
-    if (reached && !beenDisplayed) {
+    if (reached && beenDisplayed.compareAndSet(false, true)) {
       LOG.info("\n" + pandaBanner);
-      this.beenDisplayed = true;
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

It still happens that merge pandas are printed twice, by 2 different threads, for example:
```
2022-05-19 13:06:59.984+00:00 | pool-9-thread-1 | INFO  | PandaPrinter |
[...]
2022-05-19 13:07:00.599+00:00 | main | INFO  | PandaPrinter |
```
so PandaPrinter should be made thread safe

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).