### PR TITLE
fixed manifest generation for latest docker tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -786,8 +786,8 @@ task manifestDocker {
   }
 
   if (!(dockerBuildVersion ==~ /.*-SNAPSHOT/)) {
-    tags.add('${dockerImage}:latest')
-    tags.add('${dockerImage}:' + dockerBuildVersion.split(/\./)[0..1].join('.'))
+    tags.add("${dockerImage}:latest")
+    tags.add("${dockerImage}:" + dockerBuildVersion.split(/\./)[0..1].join('.'))
   }
 
   doLast {


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

double quotes

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).