### PR TITLE
Test LZ4_COMPRESSION on all RocksDB column families

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -51,6 +51,7 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
+import org.rocksdb.RateLimiter;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
@@ -96,6 +97,11 @@ public class RocksDBColumnarKeyValueStorage
                           segment.getId(),
                           new ColumnFamilyOptions()
                               .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                              .setWriteBufferSize(1_073_741_824L)
+                              .setMaxBytesForLevelBase(67_108_864L)
+                              .setLevel0SlowdownWritesTrigger(10_485_760)
+                              .setHardPendingCompactionBytesLimit(549_755_813_888L)
+                              .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -103,6 +109,11 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
+                  .setWriteBufferSize(1_073_741_824L)
+                  .setMaxBytesForLevelBase(67_108_864L)
+                  .setLevel0SlowdownWritesTrigger(10_485_760)
+                  .setHardPendingCompactionBytesLimit(549_755_813_888L)
+                  .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                   .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
@@ -114,6 +125,9 @@ public class RocksDBColumnarKeyValueStorage
               .setMaxSubcompactions(Runtime.getRuntime().availableProcessors())
               .setStatistics(stats)
               .setCreateMissingColumnFamilies(true)
+              .setWalBytesPerSync(1_048_576L)
+              .setBytesPerSync(1_048_576L)
+              .setRateLimiter(new RateLimiter(1_024_000L))
               .setEnv(
                   Env.getDefault().setBackgroundThreads(configuration.getBackgroundThreadCount()));
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.services.kvstore.SegmentedKeyValueStorageTransaction
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,8 +93,9 @@ public class RocksDBColumnarKeyValueStorage
       final List<ColumnFamilyDescriptor> columnDescriptors =
           segments.stream()
               .map(
-                  segment ->
-                      new ColumnFamilyDescriptor(
+                  segment -> {
+                    if ((Arrays.equals(segment.getId(), new byte[] {2}))) {
+                      return new ColumnFamilyDescriptor(
                           segment.getId(),
                           new ColumnFamilyOptions()
                               .setCompressionType(CompressionType.LZ4_COMPRESSION)
@@ -102,7 +104,15 @@ public class RocksDBColumnarKeyValueStorage
                               .setLevel0SlowdownWritesTrigger(10_485_760)
                               .setHardPendingCompactionBytesLimit(549_755_813_888L)
                               .setSoftPendingCompactionBytesLimit(274_877_906_944L)
-                              .setTtl(0)))
+                              .setTtl(0));
+                    } else {
+                      return new ColumnFamilyDescriptor(
+                          segment.getId(),
+                          new ColumnFamilyOptions()
+                              .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                              .setTtl(0));
+                    }
+                  })
               .collect(Collectors.toList());
       columnDescriptors.add(
           new ColumnFamilyDescriptor(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -95,7 +95,7 @@ public class RocksDBColumnarKeyValueStorage
                       new ColumnFamilyDescriptor(
                           segment.getId(),
                           new ColumnFamilyOptions()
-                              .setCompressionType(CompressionType.ZSTD_COMPRESSION)
+                              .setCompressionType(CompressionType.LZ4_COMPRESSION)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -103,7 +103,7 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
-                  .setCompressionType(CompressionType.ZSTD_COMPRESSION)
+                  .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
       final Statistics stats = new Statistics();
@@ -111,7 +111,7 @@ public class RocksDBColumnarKeyValueStorage
           new DBOptions()
               .setCreateIfMissing(true)
               .setMaxOpenFiles(configuration.getMaxOpenFiles())
-              .setMaxBackgroundCompactions(configuration.getMaxBackgroundCompactions())
+              .setMaxSubcompactions(Runtime.getRuntime().availableProcessors())
               .setStatistics(stats)
               .setCreateMissingColumnFamilies(true)
               .setEnv(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -97,6 +97,11 @@ public class RocksDBColumnarKeyValueStorage
                           segment.getId(),
                           new ColumnFamilyOptions()
                               .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                              .setWriteBufferSize(1_073_741_824L)
+                              .setMaxBytesForLevelBase(67_108_864L)
+                              .setLevel0SlowdownWritesTrigger(10_485_760)
+                              .setHardPendingCompactionBytesLimit(549_755_813_888L)
+                              .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -104,6 +109,11 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
+                  .setWriteBufferSize(1_073_741_824L)
+                  .setMaxBytesForLevelBase(67_108_864L)
+                  .setLevel0SlowdownWritesTrigger(10_485_760)
+                  .setHardPendingCompactionBytesLimit(549_755_813_888L)
+                  .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                   .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -47,6 +47,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
@@ -92,13 +93,17 @@ public class RocksDBColumnarKeyValueStorage
               .map(
                   segment ->
                       new ColumnFamilyDescriptor(
-                          segment.getId(), new ColumnFamilyOptions().setTtl(0)))
+                          segment.getId(),
+                          new ColumnFamilyOptions()
+                              .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                              .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
           new ColumnFamilyDescriptor(
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
+                  .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
       final Statistics stats = new Statistics();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -97,11 +97,6 @@ public class RocksDBColumnarKeyValueStorage
                           segment.getId(),
                           new ColumnFamilyOptions()
                               .setCompressionType(CompressionType.LZ4_COMPRESSION)
-                              .setWriteBufferSize(1_073_741_824L)
-                              .setMaxBytesForLevelBase(67_108_864L)
-                              .setLevel0SlowdownWritesTrigger(10_485_760)
-                              .setHardPendingCompactionBytesLimit(549_755_813_888L)
-                              .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -109,11 +104,6 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
-                  .setWriteBufferSize(1_073_741_824L)
-                  .setMaxBytesForLevelBase(67_108_864L)
-                  .setLevel0SlowdownWritesTrigger(10_485_760)
-                  .setHardPendingCompactionBytesLimit(549_755_813_888L)
-                  .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                   .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -95,7 +95,7 @@ public class RocksDBColumnarKeyValueStorage
                       new ColumnFamilyDescriptor(
                           segment.getId(),
                           new ColumnFamilyOptions()
-                              .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                              .setCompressionType(CompressionType.LZ4HC_COMPRESSION)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -103,7 +103,7 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
-                  .setCompressionType(CompressionType.LZ4_COMPRESSION)
+                  .setCompressionType(CompressionType.LZ4HC_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
       final Statistics stats = new Statistics();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -95,7 +95,7 @@ public class RocksDBColumnarKeyValueStorage
                       new ColumnFamilyDescriptor(
                           segment.getId(),
                           new ColumnFamilyOptions()
-                              .setCompressionType(CompressionType.LZ4HC_COMPRESSION)
+                              .setCompressionType(CompressionType.ZSTD_COMPRESSION)
                               .setTtl(0)))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -103,7 +103,7 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
-                  .setCompressionType(CompressionType.LZ4HC_COMPRESSION)
+                  .setCompressionType(CompressionType.ZSTD_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
       final Statistics stats = new Statistics();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -109,11 +109,6 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
-                  .setWriteBufferSize(1_073_741_824L)
-                  .setMaxBytesForLevelBase(67_108_864L)
-                  .setLevel0SlowdownWritesTrigger(10_485_760)
-                  .setHardPendingCompactionBytesLimit(549_755_813_888L)
-                  .setSoftPendingCompactionBytesLimit(274_877_906_944L)
                   .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 


### PR DESCRIPTION
By default, RocksDB uses Snappy compression algorithm, but from[ RocksDB documentation](https://github.com/facebook/rocksdb/wiki/Compression#configuration), we can read that "LZ4 is almost always better than Snappy".

Signed-off-by: Ameziane H <ameziane.hamlat@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).