### PR TITLE
Consume optional boolean for merge-support param

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MergeOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MergeOptions.java
@@ -49,6 +49,7 @@ public class MergeOptions implements Options {
       LOG.warn(
           "--Xmerge-support parameter has been deprecated and will be removed in a future release.  "
               + "Merge support is implicitly enabled by the presence of terminalTotalDifficulty in the genesis config.");
+      Boolean.parseBoolean(args.pop());
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
consume optional boolean argument for deprecated `--Xmerge-support` param

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3648  

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).