### PR TITLE
new ropsten ttd

### DIFF
--- a/config/src/main/resources/ropsten.json
+++ b/config/src/main/resources/ropsten.json
@@ -10,7 +10,7 @@
     "muirGlacierBlock": 7117117,
     "berlinBlock": 9812189,
     "londonBlock": 10499401,
-    "terminalTotalDifficulty": 43531756765713534,
+    "terminalTotalDifficulty": 100000000000000000000000,
     "ethash": {
     },
     "discovery": {

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
@@ -205,7 +205,7 @@ public class GenesisConfigFileTest {
 
     assertThat(ropstenOptions.getTerminalTotalDifficulty()).isPresent();
     assertThat(ropstenOptions.getTerminalTotalDifficulty().get())
-        .isEqualTo(UInt256.valueOf(43531756765713534L));
+        .isEqualTo(UInt256.valueOf(new BigInteger("100000000000000000000000")));
   }
 
   @Test


### PR DESCRIPTION
The problem the beacon chain is not yet ready on Ropsten. It is planned to go up on Monday and will make the fork to Bellatrix  3 days later. So we would run into a scenario where the EL clients make the transition tomorrow, but the CL clients wouldn't do it around 6 days later. So Ropsten would be stalled for around 6 days and we could have a gigantic reorg once the Merge happens, because it is assumed that some people would not have updated their clients and just continue with PoW.

In practice, this means:
1. Users who already upgraded their nodes need to do a TTD override (including most of the genesis beacon chain validators, but these are controlled by clients/testing teams)
2. Clients need to put out a new release with the 100000000000000000000000 (twice the current mainnet TD) TTD value
3. We announce this in a blog post early next week, and tell users they will need to do a TTD override ~1 week from then
4. After Bellatrix, we pick a new TTD value we expect to hit around June 8ish and communicate it to users.

Signed-off-by: Justin Florentine <justin+github@florentine.us>
