### PR TITLE
bump besu-native deps to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Additions and Improvements
 - Engine API Update: Replace deprecated INVALID_TERMINAL_BLOCK with INVALID last valid hash 0x0 [#3882](https://github.com/hyperledger/besu/pull/3882)
+- Deprecate experimental merge flag and engine-rpc-enabled flag [#3875](https://github.com/hyperledger/besu/pull/3875)
+- update besu-native dependencies to 0.5.0 for linux arm64 support 
 
 ### Bug Fixes
 - Stop backward sync if genesis block has been reached [#3869](https://github.com/hyperledger/besu/pull/3869)
-- Deprecate experimental merge flag and engine-rpc-enabled flag [#3875](https://github.com/hyperledger/besu/pull/3875)
 - Allow to backward sync to request headers back to last finalized block if present or genesis [#3888](https://github.com/hyperledger/besu/pull/3888)
 
 ## 22.4.1

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -143,9 +143,9 @@ dependencyManagement {
 
     dependency 'org.fusesource.jansi:jansi:2.4.0'
 
-    dependency 'org.hyperledger.besu:bls12-381:0.4.3'
-    dependency 'org.hyperledger.besu:secp256k1:0.4.3'
-    dependency 'org.hyperledger.besu:secp256r1:0.4.3'
+    dependency 'org.hyperledger.besu:bls12-381:0.5.0'
+    dependency 'org.hyperledger.besu:secp256k1:0.5.0'
+    dependency 'org.hyperledger.besu:secp256r1:0.5.0'
 
     dependency 'org.immutables:value-annotations:2.9.0'
     dependency 'org.immutables:value:2.9.0'


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

bump besu-native deps to 0.5.0 for:
* libsecp256k1
* libsecp256r1
* bls12-381 (currently not part of protocol schedule)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
relates to #3859 and [besu-native #57](https://github.com/hyperledger/besu-native/issues/57)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).