### PR TITLE
Make engine jwt auth enabled by default

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/BesuNode.java
@@ -234,6 +234,12 @@ public class BesuNode implements NodeConfiguration, RunnableNode, AutoCloseable 
     return engineRpcConfiguration.isPresent() && engineRpcConfiguration.get().isEnabled();
   }
 
+  public boolean isEngineAuthDisabled() {
+    return engineRpcConfiguration
+        .map(engineConf -> !engineConf.isAuthenticationEnabled())
+        .orElse(false);
+  }
+
   private boolean isWebSocketsRpcEnabled() {
     return webSocketConfiguration().isEnabled();
   }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -193,6 +193,10 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
     if (node.isEngineRpcEnabled()) {
       params.add("--engine-rpc-port");
       params.add(node.jsonEngineListenPort().get().toString());
+
+      if (node.isEngineAuthDisabled()) {
+        params.add("--engine-jwt-disabled");
+      }
     }
 
     if (node.wsRpcEnabled()) {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/configuration/BesuNodeConfigurationBuilder.java
@@ -147,6 +147,7 @@ public class BesuNodeConfigurationBuilder {
     this.engineRpcConfiguration.setEnabled(enabled);
     this.engineRpcConfiguration.setPort(0);
     this.engineRpcConfiguration.setHostsAllowlist(singletonList("*"));
+    this.engineRpcConfiguration.setAuthenticationEnabled(false);
 
     return this;
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -588,8 +588,15 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
     @Option(
         names = {"--engine-jwt-enabled"},
-        description = "Require authentication for Engine APIs (default: ${DEFAULT-VALUE})")
-    private final Boolean isEngineAuthEnabled = false;
+        description = "deprecated option, engine jwt auth is enabled by default",
+        hidden = true)
+    @SuppressWarnings({"FieldCanBeFinal", "UnusedVariable"})
+    private final Boolean deprecatedIsEngineAuthEnabled = true;
+
+    @Option(
+        names = {"--engine-jwt-disabled"},
+        description = "Disable authentication for Engine APIs (default: ${DEFAULT-VALUE})")
+    private final Boolean isEngineAuthDisabled = false;
 
     @Option(
         names = {"--engine-host-allowlist"},
@@ -2118,7 +2125,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
               + "Merge support is implicitly enabled by the presence of terminalTotalDifficulty in the genesis config.");
     }
     engineConfig.setEnabled(isMergeEnabled());
-    if (engineRPCOptionGroup.isEngineAuthEnabled) {
+    if (!engineRPCOptionGroup.isEngineAuthDisabled) {
       engineConfig.setAuthenticationEnabled(true);
       engineConfig.setAuthenticationAlgorithm(JwtAlgorithm.HS256);
       if (Objects.nonNull(engineRPCOptionGroup.engineJwtKeyFile)

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1992,10 +1992,33 @@ public class BesuCommandTest extends CommandTestAbstract {
 
   @Test
   public void engineApiAuthOptions() {
+    // TODO: once we have mainnet TTD, we can remove the TTD override parameter here
+    // https://github.com/hyperledger/besu/issues/3874
     parseCommand(
-        "--rpc-http-enabled", "--engine-jwt-enabled", "--engine-jwt-secret", "/tmp/fakeKey.hex");
+        "--override-genesis-config",
+        "terminalTotalDifficulty=1337",
+        "--rpc-http-enabled",
+        "--engine-jwt-secret",
+        "/tmp/fakeKey.hex");
     verify(mockRunnerBuilder).engineJsonRpcConfiguration(jsonRpcConfigArgumentCaptor.capture());
     assertThat(jsonRpcConfigArgumentCaptor.getValue().isAuthenticationEnabled()).isTrue();
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void engineApiDisableAuthOptions() {
+    // TODO: once we have mainnet TTD, we can remove the TTD override parameter here
+    // https://github.com/hyperledger/besu/issues/3874
+    parseCommand(
+        "--override-genesis-config",
+        "terminalTotalDifficulty=1337",
+        "--rpc-http-enabled",
+        "--engine-jwt-disabled",
+        "--engine-jwt-secret",
+        "/tmp/fakeKey.hex");
+    verify(mockRunnerBuilder).engineJsonRpcConfiguration(jsonRpcConfigArgumentCaptor.capture());
+    assertThat(jsonRpcConfigArgumentCaptor.getValue().isAuthenticationEnabled()).isFalse();
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -44,7 +44,7 @@ random-peer-priority-enabled=false
 host-whitelist=["all"]
 host-allowlist=["all"]
 engine-host-allowlist=["all"]
-engine-jwt-enabled=false
+engine-jwt-disabled=true
 engine-jwt-secret="/tmp/jwt.hex"
 required-blocks=["8675309=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]
 discovery-dns-url="enrtree://AM5FCQLWIZX2QFPNJAP7VUERCCRNGRHWZG3YYHIUV7BVDQ5FDPRT2@nodes.example.org"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
deprecates engine-jwt-enabled, adds engine-jwt-disabled with a default `false` value.  
This is to prevent unintentional "flipping" of this boolean for configs using the flag without a boolean value, e.g.:

`besu --network=ropsten --engine-jwt-enabled`


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3838

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).