### PR TITLE
Apply RocksDB documentation suggestions to reduce memory usage

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -96,6 +97,7 @@ public class RocksDBColumnarKeyValueStorage
                           segment.getId(),
                           new ColumnFamilyOptions()
                               .setTtl(0)
+                              .setOptimizeFiltersForHits(true)
                               .setTableFormatConfig(createBlockBasedTableConfig(configuration))))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -103,6 +105,7 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
+                  .setOptimizeFiltersForHits(true)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 
       final Statistics stats = new Statistics();
@@ -154,6 +157,7 @@ public class RocksDBColumnarKeyValueStorage
         .setFormatVersion(5)
         .setOptimizeFiltersForMemory(true)
         .setCacheIndexAndFilterBlocks(true)
+        .setFilterPolicy(new BloomFilter())
         .setBlockSize(32768);
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -153,7 +153,8 @@ public class RocksDBColumnarKeyValueStorage
         .setBlockCache(cache)
         .setFormatVersion(5)
         .setOptimizeFiltersForMemory(true)
-        .setBlockSize(32568);
+        .setCacheIndexAndFilterBlocks(true)
+        .setBlockSize(32768);
   }
 
   @Override

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -48,6 +48,7 @@ import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
@@ -98,6 +99,7 @@ public class RocksDBColumnarKeyValueStorage
                           new ColumnFamilyOptions()
                               .setTtl(0)
                               .setOptimizeFiltersForHits(true)
+                              .setCompressionType(CompressionType.LZ4_COMPRESSION)
                               .setTableFormatConfig(createBlockBasedTableConfig(configuration))))
               .collect(Collectors.toList());
       columnDescriptors.add(
@@ -105,6 +107,7 @@ public class RocksDBColumnarKeyValueStorage
               DEFAULT_COLUMN.getBytes(StandardCharsets.UTF_8),
               columnFamilyOptions
                   .setTtl(0)
+                  .setCompressionType(CompressionType.LZ4_COMPRESSION)
                   .setOptimizeFiltersForHits(true)
                   .setTableFormatConfig(createBlockBasedTableConfig(configuration))));
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
 import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -154,8 +154,7 @@ public class RocksDBColumnarKeyValueStorage
         .setBlockCache(cache)
         .setFormatVersion(5)
         .setOptimizeFiltersForMemory(true)
-        .setBlockSize(32568)
-        .setFilterPolicy(new BloomFilter());
+        .setBlockSize(32568);
   }
 
   @Override

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -76,8 +76,8 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
               .setCreateIfMissing(true)
               .setMaxOpenFiles(configuration.getMaxOpenFiles())
               .setTableFormatConfig(createBlockBasedTableConfig(configuration))
-                  .setCompressionType(CompressionType.LZ4_COMPRESSION)
-                  .setMaxBackgroundCompactions(configuration.getMaxBackgroundCompactions())
+              .setCompressionType(CompressionType.LZ4_COMPRESSION)
+              .setMaxBackgroundCompactions(configuration.getMaxBackgroundCompactions())
               .setStatistics(stats);
       options.getEnv().setBackgroundThreads(configuration.getBackgroundThreadCount());
 
@@ -172,12 +172,12 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   private BlockBasedTableConfig createBlockBasedTableConfig(final RocksDBConfiguration config) {
     final LRUCache cache = new LRUCache(config.getCacheCapacity());
     return new BlockBasedTableConfig()
-            .setBlockCache(cache)
-            .setFormatVersion(5)
-            .setOptimizeFiltersForMemory(true)
-            .setCacheIndexAndFilterBlocks(true)
-            .setFilterPolicy(new BloomFilter())
-            .setBlockSize(32768);
+        .setBlockCache(cache)
+        .setFormatVersion(5)
+        .setOptimizeFiltersForMemory(true)
+        .setCacheIndexAndFilterBlocks(true)
+        .setFilterPolicy(new BloomFilter())
+        .setBlockSize(32768);
   }
 
   private void throwIfClosed() {


### PR DESCRIPTION
Apply some [RocksDB documentation suggestions](https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB) to reduce memory usage.

- Set format_version to 5
- set optimize_filters_for_memory to true
- Increase block size to 32K
- set cache_index_and_filter_blocks to true (this may have a big impact on performances)

Signed-off-by: Ameziane H. <ameziane.hamlat@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).