### PR TITLE
update the docker container versions for Tessera and GoQuorum

### DIFF
--- a/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
+++ b/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
@@ -48,8 +48,8 @@ public class ContainerTestBase {
   //  private final String besuImage = "hyperledger/besu:21.7.0-SNAPSHOT";
   private final String besuImage = System.getProperty("containertest.imagename");
 
-  private final String goQuorumVersion = "21.1.0";
-  private final String tesseraVersion = "21.7.0";
+  private final String goQuorumVersion = "22.4.4";
+  private final String tesseraVersion = "22.1.3";
 
   protected final String goQuorumTesseraPubKey = "3XGBIf+x8IdVQOVfIsbRnHwTYOJP/Fx84G8gMmy8qDM=";
   protected final String besuTesseraPubKey = "8JJLEAbq6o9m4Kqm++v0Y1n9Z2ryAFtZTyhnxSKWgws=";


### PR DESCRIPTION
On my new M1 mac book the Tessera docker wouldn't start. Updating the Tessera docker version fixed that.