### PR TITLE
[Minor] Add minBuild gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -558,6 +558,22 @@ task autocomplete(type: JavaExec) {
   }
 }
 
+// Useful for building / validating during development without running all tests
+task minBuild(dependsOn: [
+  spotlessApply,
+  build,
+  checkLicenses,
+  javadoc
+])
+// Ignore tests when running minBuild
+gradle.taskGraph.whenReady { graph ->
+  if (graph.hasTask(minBuild)) {
+    tasks.withType(Test){
+      enabled = false
+    }
+  }
+}
+
 installDist { dependsOn checkLicenses }
 
 distTar {


### PR DESCRIPTION
## PR description
Add a gradle task `minBuild` that builds without running tests.  This is useful for local development so that minor issues can be caught quickly. 

**Note to Reviewers**: I'm open to other ideas on how to implement this - I am not a gradle expert. 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).