### PR TITLE
When on PoS the head can be only be updated by ForkchoiceUpdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Additions and Improvements
 - Version information available in metrics [#3997](https://github.com/hyperledger/besu/pull/3997)
+- Do not require a minimum block height when downloading headers or blocks [#3911](https://github.com/hyperledger/besu/pull/3911)
+- When on PoS the head can be only be updated by ForkchoiceUpdate [#3994](https://github.com/hyperledger/besu/pull/3994)
 
 ### Bug Fixes
 - Fixed a snapsync issue that can sometimes block the healing step [#3920](https://github.com/hyperledger/besu/pull/3920)
@@ -15,7 +17,6 @@
 - Support `finalized` and `safe` as tags for the block parameter in RPC APIs [#3950](https://github.com/hyperledger/besu/pull/3950)
 - Added verification of payload attributes in ForkchoiceUpdated [#3837](https://github.com/hyperledger/besu/pull/3837)
 - Add support for Gray Glacier hardfork [#3961](https://github.com/hyperledger/besu/issues/3961)
-- Do not require a minimum block height when downloading headers or blocks [#3911](https://github.com/hyperledger/besu/pull/3911)
 
 ### Bug Fixes
 - alias engine-rpc-port parameter with the former rpc param name [#3958](https://github.com/hyperledger/besu/pull/3958)

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -174,7 +174,7 @@ public class MergeCoordinator implements MergeMiningCoordinator {
     final Block emptyBlock =
         mergeBlockCreator.createBlock(Optional.of(Collections.emptyList()), random, timestamp);
 
-    Result result = executeBlock(emptyBlock);
+    Result result = validateBlock(emptyBlock);
     if (result.blockProcessingOutputs.isPresent()) {
       mergeContext.putPayloadById(payloadIdentifier, emptyBlock);
     } else {
@@ -193,7 +193,7 @@ public class MergeCoordinator implements MergeMiningCoordinator {
               if (throwable != null) {
                 LOG.warn("something went wrong creating block", throwable);
               } else {
-                final var resultBest = executeBlock(bestBlock);
+                final var resultBest = validateBlock(bestBlock);
                 if (resultBest.blockProcessingOutputs.isPresent()) {
                   mergeContext.putPayloadById(payloadIdentifier, bestBlock);
                 } else {
@@ -239,7 +239,7 @@ public class MergeCoordinator implements MergeMiningCoordinator {
   }
 
   @Override
-  public Result executeBlock(final Block block) {
+  public Result validateBlock(final Block block) {
 
     final var chain = protocolContext.getBlockchain();
     chain
@@ -256,6 +256,14 @@ public class MergeCoordinator implements MergeMiningCoordinator {
             .validateAndProcessBlock(
                 protocolContext, block, HeaderValidationMode.FULL, HeaderValidationMode.NONE);
 
+    return validationResult;
+  }
+
+  @Override
+  public Result executeBlock(final Block block) {
+    final var chain = protocolContext.getBlockchain();
+
+    final var validationResult = validateBlock(block);
     validationResult.blockProcessingOutputs.ifPresentOrElse(
         result -> {
           result.worldState.remember(block.getHeader());

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -257,7 +257,10 @@ public class MergeCoordinator implements MergeMiningCoordinator {
                 protocolContext, block, HeaderValidationMode.FULL, HeaderValidationMode.NONE);
 
     validationResult.blockProcessingOutputs.ifPresentOrElse(
-        result -> chain.appendBlock(block, result.receipts),
+        result -> {
+          result.worldState.remember(block.getHeader());
+          chain.storeBlock(block, result.receipts);
+        },
         () ->
             protocolSchedule
                 .getByBlockNumber(chain.getChainHeadBlockNumber())

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -37,6 +37,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
 
   Result executeBlock(final Block block);
 
+  Result validateBlock(final Block block);
+
   ForkchoiceResult updateForkChoice(
       final BlockHeader newHead,
       final Hash finalizedBlockHash,

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -138,6 +138,11 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
   }
 
   @Override
+  public Result validateBlock(final Block block) {
+    return mergeCoordinator.validateBlock(block);
+  }
+
+  @Override
   public ForkchoiceResult updateForkChoice(
       final BlockHeader newHead,
       final Hash finalizedBlockHash,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -87,9 +87,9 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
       Optional.ofNullable(forkChoice.getHeadBlockHash())
           .filter(hash -> !hash.equals(Hash.ZERO))
           .ifPresent(
-              blockhash ->
+              blockHash ->
                   mergeCoordinator.getOrSyncHeaderByHash(
-                      blockhash, forkChoice.getFinalizedBlockHash()));
+                      blockHash, forkChoice.getFinalizedBlockHash()));
 
       return syncingResponse(requestId);
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
@@ -36,7 +36,8 @@ public class BlockAddedEvent {
   public enum EventType {
     HEAD_ADVANCED,
     FORK,
-    CHAIN_REORG
+    CHAIN_REORG,
+    STORED_ONLY
   }
 
   private BlockAddedEvent(
@@ -90,6 +91,17 @@ public class BlockAddedEvent {
   public static BlockAddedEvent createForFork(final Block block) {
     return new BlockAddedEvent(
         EventType.FORK,
+        block,
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        Collections.emptyList(),
+        block.getHeader().getParentHash());
+  }
+
+  public static BlockAddedEvent createForStoredOnly(final Block block) {
+    return new BlockAddedEvent(
+        EventType.STORED_ONLY,
         block,
         Collections.emptyList(),
         Collections.emptyList(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BlockAddedEvent.java
@@ -115,7 +115,7 @@ public class BlockAddedEvent {
   }
 
   public boolean isNewCanonicalHead() {
-    return eventType != EventType.FORK;
+    return eventType == EventType.HEAD_ADVANCED || eventType == EventType.CHAIN_REORG;
   }
 
   public EventType getEventType() {
@@ -140,5 +140,25 @@ public class BlockAddedEvent {
 
   public Hash getCommonAncestorHash() {
     return commonAncestorHash;
+  }
+
+  @Override
+  public String toString() {
+    return "BlockAddedEvent{"
+        + "eventType="
+        + eventType
+        + ", block="
+        + block.toLogString()
+        + ", commonAncestorHash="
+        + commonAncestorHash
+        + ", addedTransactions count="
+        + addedTransactions.size()
+        + ", removedTransactions count="
+        + removedTransactions.size()
+        + ", transactionReceipts count ="
+        + transactionReceipts.size()
+        + ", logsWithMetadata count="
+        + logsWithMetadata.size()
+        + '}';
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/MutableBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/MutableBlockchain.java
@@ -37,10 +37,22 @@ public interface MutableBlockchain extends Blockchain {
    */
   void appendBlock(Block block, List<TransactionReceipt> receipts);
 
+  /**
+   * Adds a block to the blockchain, without updating the chain state.
+   *
+   * <p>Block must be connected to the existing blockchain (its parent must already be stored),
+   * otherwise an {@link IllegalArgumentException} is thrown. Blocks representing forks are allowed
+   * as long as they are connected.
+   *
+   * @param block The block to append.
+   * @param receipts The list of receipts associated with this block's transactions.
+   */
+  void storeBlock(Block block, List<TransactionReceipt> receipts);
+
   void unsafeImportBlock(
       final Block block,
       final List<TransactionReceipt> receipts,
-      final Optional<Difficulty> maybeTtalDifficulty);
+      final Optional<Difficulty> maybeTotalDifficulty);
 
   void unsafeSetChainHead(final BlockHeader blockHeader, final Difficulty totalDifficulty);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/MutableBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/MutableBlockchain.java
@@ -75,6 +75,16 @@ public interface MutableBlockchain extends Blockchain {
   boolean rewindToBlock(final Hash blockHash);
 
   /**
+   * Forward the canonical chainhead to the specified block hash. The block hash must be a child of
+   * the current chainhead, that is already stored
+   *
+   * @param blockHeader The block header to forward to.
+   * @return {@code true} on success, {@code false} if the block is not a child of the current head
+   *     {@code blockNumber}
+   */
+  boolean forwardToBlock(final BlockHeader blockHeader);
+
+  /**
    * Set the hash of the last finalized block.
    *
    * @param blockHash The hash of the last finalized block.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MutableWorldState.java
@@ -34,4 +34,15 @@ public interface MutableWorldState extends WorldState, MutableWorldView {
    *     `null` should be passed in.
    */
   void persist(BlockHeader blockHeader);
+
+  /**
+   * Remember accumulated changes to underlying storage for future use, without making this the
+   * current world state. This is useful in the PoS where can precompute a future world state, that
+   * will be committed in a later step
+   *
+   * @param blockHeader The block hash of the world state this represents. Must not be null
+   */
+  default void remember(final BlockHeader blockHeader) {
+    persist(blockHeader);
+  }
 }


### PR DESCRIPTION
When executing a newPayload or build a new block, we do not need to move
the chain head and update the world state, since this will be done by a
following forkchoice update call, but we still need to validate the block
and doing so we can also prepare everything for the future call, so we do
not need to re-execute everything, but only update the pointers, so that the
response to the forkchoice update call is quick.

Moreover on block proposal do only a validation of the block without storing or remembering nothing, to avoid saving data that could be stale, for example the empty block that is always proposed, is useless if another better block is produced later.
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #3957
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).