### PR TITLE
large executor for qats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ executors:
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
       
-  quorum_ats_executor_med:
+  quorum_ats_executor:
     docker:
       - image: cimg/openjdk:11.0
-    resource_class: medium
+    resource_class: large
     working_directory: ~/project
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -276,7 +276,7 @@ jobs:
 
   acceptanceTestsQuorum:
     parallelism: 1
-    executor: quorum_ats_executor_med
+    executor: quorum_ats_executor
     steps:
       - attach_workspace:
           at: ~/project


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Seeing periodic failures on the Quorum ATs which can pass after re-running. Changing to large executor should help this.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).