### PR TITLE
Improve logging in NatService

### DIFF
--- a/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/NatService.java
@@ -95,10 +95,12 @@ public class NatService {
       try {
         getNatManager().orElseThrow().start();
       } catch (Exception e) {
-        LOG.debug(
+        LOG.warn(
             "Nat manager failed to configure itself automatically due to the following reason : {}. {}",
             e.getMessage(),
-            (fallbackEnabled) ? "NONE mode will be used" : "");
+            (fallbackEnabled)
+                ? "NONE mode will be used as a fallback (set --Xnat-method-fallback-enabled=false to disable)"
+                : "");
         if (fallbackEnabled) {
           disableNatManager();
         } else {


### PR DESCRIPTION
## PR description

Improve logging in NatService to clarify what's happening. Increase log severity as it can cause peers to fail to connect when running in k8s.

Signed-off-by: Antony Denyer <git@antonydenyer.co.uk>
