### PR TITLE
checkpoint sync retry download block when we did not get receipts

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloadBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloadBlockStep.java
@@ -71,10 +71,10 @@ public class CheckpointDownloadBlockStep {
         .run()
         .thenCompose(
             receiptTaskResult -> {
-              final List<TransactionReceipt> transactionReceipts =
-                  receiptTaskResult.getResult().get(block.getHeader());
+              final Optional<List<TransactionReceipt>> transactionReceipts =
+                  Optional.ofNullable(receiptTaskResult.getResult().get(block.getHeader()));
               return CompletableFuture.completedFuture(
-                  Optional.of(new BlockWithReceipts(block, transactionReceipts)));
+                  transactionReceipts.map(receipts -> new BlockWithReceipts(block, receipts)));
             })
         .exceptionally(throwable -> Optional.empty());
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Fixes a mostly benign error during checkpoint sync which causes the pipeline to pause and restart upon failure to import blocks.  If during the CheckpointDownloadBlockStep we fail to get receipts for the block we are importing, CheckpointBlockImportStep will throw an NPE when attempting to save receipts.

```
2022-07-01 15:14:59.361+00:00 | EthScheduler-Services-29 (importBlock) | ERROR | PipelineChainDownloader | Chain download failed. Restarting after short delay.
java.util.concurrent.CompletionException: java.lang.NullPointerException
...
Caused by: java.lang.NullPointerException
        at org.hyperledger.besu.ethereum.rlp.RLPOutput.writeList(RLPOutput.java:245)
        at org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage$Updater.lambda$rlpEncode$2(KeyValueStoragePrefixedKeyBlockchainStorage.java:230)
        at org.hyperledger.besu.ethereum.rlp.RLP.encode(RLP.java:85)
        at org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage$Updater.rlpEncode(KeyValueStoragePrefixedKeyBlockchainStorage.java:230)
        at org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage$Updater.putTransactionReceipts(KeyValueStoragePrefixedKeyBlockchainStorage.java:166)
        at org.hyperledger.besu.ethereum.chain.DefaultBlockchain.unsafeImportBlock(DefaultBlockchain.java:355)
        at org.hyperledger.besu.ethereum.eth.sync.checkpointsync.CheckpointBlockImportStep.lambda$accept$0(CheckpointBlockImportStep.java:43)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at org.hyperledger.besu.ethereum.eth.sync.checkpointsync.CheckpointBlockImportStep.accept(CheckpointBlockImportStep.java:41)
        at org.hyperledger.besu.ethereum.eth.sync.checkpointsync.CheckpointBlockImportStep.accept(CheckpointBlockImportStep.java:24)
        at org.hyperledger.besu.services.pipeline.CompleterStage.run(CompleterStage.java:37)
        at org.hyperledger.besu.services.pipeline.Pipeline.lambda$runWithErrorHandling$3(Pipeline.java:152)
        ... 5 more

```

This pr will cause the pipeline to retry the block download step if we were unable to get the receipts for the block.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).