### PR TITLE
Hive engine suite conformance: Invalid Timestamp, Invalid Transition Payload

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -487,14 +487,15 @@ public class MergeCoordinator implements MergeMiningCoordinator {
     // check chain first
     return chain
         .getBlockHeader(parentHash)
-        .map(header -> {
-          // if block is PoW, return ZERO hash
-          if (header.getDifficulty().greaterOrEqualThan(Difficulty.ZERO)) {
-            return Hash.ZERO;
-          } else {
-            return header.getHash();
-          }
-        })
+        .map(
+            header -> {
+              // if block is PoW, return ZERO hash
+              if (header.getDifficulty().greaterOrEqualThan(Difficulty.ZERO)) {
+                return Hash.ZERO;
+              } else {
+                return header.getHash();
+              }
+            })
         .map(Optional::of)
         .orElseGet(
             () ->

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -490,7 +490,7 @@ public class MergeCoordinator implements MergeMiningCoordinator {
         .map(
             header -> {
               // if block is PoW, return ZERO hash
-              if (header.getDifficulty().greaterOrEqualThan(Difficulty.ZERO)) {
+              if (header.getDifficulty().greaterThan(Difficulty.ZERO)) {
                 return Hash.ZERO;
               } else {
                 return header.getHash();

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -487,7 +487,14 @@ public class MergeCoordinator implements MergeMiningCoordinator {
     // check chain first
     return chain
         .getBlockHeader(parentHash)
-        .map(BlockHeader::getHash)
+        .map(header -> {
+          // if block is PoW, return ZERO hash
+          if (header.getDifficulty().greaterOrEqualThan(Difficulty.ZERO)) {
+            return Hash.ZERO;
+          } else {
+            return header.getHash();
+          }
+        })
         .map(Optional::of)
         .orElseGet(
             () ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -80,6 +80,16 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
       return syncingResponse(requestId);
     }
 
+    if (mergeCoordinator.isBadBlock(forkChoice.getHeadBlockHash())) {
+      return new JsonRpcSuccessResponse(
+          requestId,
+          new EngineUpdateForkchoiceResult(
+              INVALID,
+              Hash.ZERO,
+              null,
+              Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
+    }
+
     Optional<BlockHeader> newHead =
         protocolContext.getBlockchain().getBlockHeader(forkChoice.getHeadBlockHash());
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -29,8 +29,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
@@ -149,7 +147,10 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
     if (parentHeader.isPresent()
         && (blockParam.getTimestamp() <= parentHeader.get().getTimestamp())) {
       LOG.info("method parameter timestamp not greater than parent");
-      return new JsonRpcErrorResponse(reqId, JsonRpcError.INVALID_PARAMS);
+      return respondWithInvalid(
+          reqId,
+          mergeCoordinator.getLatestValidAncestor(blockParam.getParentHash()).orElse(null),
+          "block timestamp not greater than parent");
     }
 
     final var block =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -231,7 +231,12 @@ public class EngineNewPayloadTest {
     when(blockchain.getBlockHeader(parent.getHash())).thenReturn(Optional.of(parent));
     var resp = resp(mockPayload(mockHeader, Collections.emptyList()));
 
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    var res = ((JsonRpcSuccessResponse) resp).getResult();
+    assertThat(res).isInstanceOf(EnginePayloadStatusResult.class);
+    var payloadStatusResult = (EnginePayloadStatusResult) res;
+    assertThat(payloadStatusResult.getStatus()).isEqualTo(INVALID);
+    assertThat(payloadStatusResult.getError()).isEqualTo("block timestamp not greater than parent");
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Addresses failures of hive engine test suite "Invalid Timestamp" and "Invalid Transition Payload" tests.  

* on invalid timestamp, return a success response with an INVALID status and validation error message rather than error response
* for latest valid ancestor blocks which are PoW, return Hash.ZERO rather than the PoW hash 
* check tracked bad blocks for forkchoiceUpdated head blockhash, return INVALID rather than SYNCING


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).