### PR TITLE
Fix for TransitionProtocolSchedule by header when terminal block exactly at TTD

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -66,7 +66,7 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
       if (!mergeContext.isPostMerge()) {
         debugLambda(
             LOG,
-            "for {} returning a pre-merge schedule because we are not post merge",
+            "for {} returning a pre-merge schedule because we are not post-merge",
             blockHeader::toLogString);
         return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
@@ -91,7 +91,7 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
           || TransitionUtils.isTerminalProofOfWorkBlock(blockHeader, protocolContext)) {
         debugLambda(
             LOG,
-            "returning a pre-merge schedule because block {} is pre merge or TTD",
+            "returning a pre-merge schedule because block {} is pre-merge or TTD",
             blockHeader::toLogString);
         return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.consensus.merge;
 
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
+
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -27,8 +29,12 @@ import java.math.BigInteger;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule>
     implements ProtocolSchedule {
+  private static final Logger LOG = LoggerFactory.getLogger(TransitionProtocolSchedule.class);
 
   public TransitionProtocolSchedule(
       final ProtocolSchedule preMergeProtocolSchedule,
@@ -58,23 +64,40 @@ public class TransitionProtocolSchedule extends TransitionUtils<ProtocolSchedule
 
       // if head is not post-merge, return pre-merge schedule:
       if (!mergeContext.isPostMerge()) {
+        debugLambda(
+            LOG,
+            "for {} returning a pre-merge schedule because we are not post merge",
+            blockHeader::toLogString);
         return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
 
-      // otherwise check to see if this block represents a re-org below TTD:
+      // otherwise check to see if this block represents a re-org TTD block:
       MutableBlockchain blockchain = protocolContext.getBlockchain();
       Difficulty parentDifficulty =
           blockchain.getTotalDifficultyByHash(blockHeader.getParentHash()).orElseThrow();
       Difficulty thisDifficulty = parentDifficulty.add(blockHeader.getDifficulty());
       Difficulty terminalDifficulty = mergeContext.getTerminalTotalDifficulty();
+      debugLambda(
+          LOG,
+          " block {} ttd is: {}, parent total diff is: {}, this total diff is: {}",
+          blockHeader::toLogString,
+          () -> terminalDifficulty,
+          () -> parentDifficulty,
+          () -> thisDifficulty);
 
-      // if this block is pre-merge
-      if (thisDifficulty.lessOrEqualThan(terminalDifficulty)
+      // if this block is pre-merge or a TTD block
+      if ((thisDifficulty.lessOrEqualThan(terminalDifficulty)
+              && thisDifficulty.greaterThan(parentDifficulty))
           || TransitionUtils.isTerminalProofOfWorkBlock(blockHeader, protocolContext)) {
+        debugLambda(
+            LOG,
+            "returning a pre-merge schedule because block {} is pre merge or TTD",
+            blockHeader::toLogString);
         return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
     }
     // else return post-merge schedule
+    debugLambda(LOG, " for {} returning a post-merge schedule", blockHeader::toLogString);
     return getPostMergeSchedule().getByBlockNumber(blockHeader.getNumber());
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
hive engine test "Sync Client Post Merge" highlighted a corner case with a method in TransitionProtocolSchedule which supported backward sync below/around TTD block.  

`getByBlockHeader` defers to the block header to find the appropriate pre or post merge protocol schedule, but in the case where we do not have a finalized block, and the terminal block difficulty was *exactly* the TTD value, we would erroneously return a pre-merge protocol schedule for blocks which were children of the terminal block.

PR fixes this behavior, adds some additional logging, and fixes the hive engine test.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
relates to #3841

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).