### PR TITLE
fcU: Ignore newHead if it is an ancestor of chain head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Version information available in metrics [#3997](https://github.com/hyperledger/besu/pull/3997)
 - Add TTD and DNS to Sepolia config [#4024](https://github.com/hyperledger/besu/pull/4024)
 - Return `type` with value `0x0` when serializing legacy transactions [#4027](https://github.com/hyperledger/besu/pull/4027)
+- Ignore `ForkchoiceUpdate` if `newHead` is an ancestor of the chain head [#XXXX](https://github.com/hyperledger/besu/pull/XXXX)
 
 ### Bug Fixes
 - Fixed a snapsync issue that can sometimes block the healing step [#3920](https://github.com/hyperledger/besu/pull/3920)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Version information available in metrics [#3997](https://github.com/hyperledger/besu/pull/3997)
 - Add TTD and DNS to Sepolia config [#4024](https://github.com/hyperledger/besu/pull/4024)
 - Return `type` with value `0x0` when serializing legacy transactions [#4027](https://github.com/hyperledger/besu/pull/4027)
-- Ignore `ForkchoiceUpdate` if `newHead` is an ancestor of the chain head [#XXXX](https://github.com/hyperledger/besu/pull/XXXX)
+- Ignore `ForkchoiceUpdate` if `newHead` is an ancestor of the chain head [#4055](https://github.com/hyperledger/besu/pull/4055)
 
 ### Bug Fixes
 - Fixed a snapsync issue that can sometimes block the healing step [#3920](https://github.com/hyperledger/besu/pull/3920)

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.merge.blockcreation;
 
+import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD;
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.VALID;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -69,7 +70,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
     public enum Status {
       VALID,
       INVALID,
-      INVALID_PAYLOAD_ATTRIBUTES
+      INVALID_PAYLOAD_ATTRIBUTES,
+      IGNORE_UPDATE_TO_OLD_HEAD
     }
 
     private final Status status;
@@ -99,6 +101,15 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
           Optional.empty(),
           Optional.empty(),
           latestValid);
+    }
+
+    public static ForkchoiceResult withIgnoreUpdateToOldHead(final BlockHeader oldHead) {
+      return new ForkchoiceResult(
+          IGNORE_UPDATE_TO_OLD_HEAD,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.of(oldHead.getHash()));
     }
 
     public static ForkchoiceResult withResult(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -142,7 +142,7 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
                         payloadAttributes.getSuggestedFeeRecipient())));
 
     if (!result.isValid()) {
-      return handleForkchoiceError(requestId, result);
+      return handleNonValidForkchoiceUpdate(requestId, result);
     }
 
     // begin preparing a block if we have a non-empty payload attributes param
@@ -172,7 +172,7 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
             Optional.empty()));
   }
 
-  private JsonRpcResponse handleForkchoiceError(
+  private JsonRpcResponse handleNonValidForkchoiceUpdate(
       final Object requestId, final ForkchoiceResult result) {
     JsonRpcResponse response;
 
@@ -184,13 +184,17 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
             new JsonRpcSuccessResponse(
                 requestId,
                 new EngineUpdateForkchoiceResult(
-                    INVALID,
-                    latestValid.isPresent() ? latestValid.get() : null,
-                    null,
-                    result.getErrorMessage()));
+                    INVALID, latestValid.orElse(null), null, result.getErrorMessage()));
         break;
       case INVALID_PAYLOAD_ATTRIBUTES:
         response = new JsonRpcErrorResponse(requestId, JsonRpcError.INVALID_PAYLOAD_ATTRIBUTES);
+        break;
+      case IGNORE_UPDATE_TO_OLD_HEAD:
+        response =
+            new JsonRpcSuccessResponse(
+                requestId,
+                new EngineUpdateForkchoiceResult(
+                    VALID, latestValid.orElse(null), null, result.getErrorMessage()));
         break;
       default:
         throw new AssertionError(


### PR DESCRIPTION
## PR description
A forkchoice update will be ignored if `newHead` is an ancestor of chain head.

## Fixed Issue(s)
fixes #4051

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).