### PR TITLE
After merge add a rule to check that the current block is more recent than its parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Additions and Improvements
 
+### Bug Fixes
+- Return the correct latest valid hash in case of bad block when calling engine methods [#4056](https://github.com/hyperledger/besu/pull/4056)
+- Add a PoS block header rule to check that the current block is more recent than its parent [#4066](https://github.com/hyperledger/besu/pull/4066)
+
 ## 22.7.0-RC1
 
 ### Additions and Improvements
@@ -20,7 +24,6 @@
 - Support free gas networks in the London fee market [#4003](https://github.com/hyperledger/besu/pull/4003)
 - Limit the size of outgoing eth subprotocol messages.  [#4034](https://github.com/hyperledger/besu/pull/4034)
 - Fixed a state root mismatch issue on bonsai that may appear occasionally [#4041](https://github.com/hyperledger/besu/pull/4041)
-- Return the correct latest valid hash in case of bad block when calling engine methods [#4056](https://github.com/hyperledger/besu/pull/4056)
 
 ### Download links
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC1/besu-22.7.0-RC1.tar.gz / sha256: `60ad8b53402beb62c24ad791799d9cfe444623a58f6f6cf1d0728459cb641e63`

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeValidationRulesetFactory.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeValidationRulesetFactory.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.merge;
 
 import org.hyperledger.besu.consensus.merge.headervalidationrules.ConstantOmmersHashRule;
+import org.hyperledger.besu.consensus.merge.headervalidationrules.IncrementalTimestampRule;
 import org.hyperledger.besu.consensus.merge.headervalidationrules.MergeUnfinalizedValidationRule;
 import org.hyperledger.besu.consensus.merge.headervalidationrules.NoDifficultyRule;
 import org.hyperledger.besu.consensus.merge.headervalidationrules.NoNonceRule;
@@ -59,7 +60,8 @@ public class MergeValidationRulesetFactory {
           .addRule(new MergeUnfinalizedValidationRule())
           .addRule(new ConstantOmmersHashRule())
           .addRule(new NoNonceRule())
-          .addRule(new NoDifficultyRule());
+          .addRule(new NoDifficultyRule())
+          .addRule(new IncrementalTimestampRule());
     }
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampRule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampRule.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.consensus.merge.headervalidationrules;
+
+import static org.hyperledger.besu.consensus.merge.TransitionUtils.isTerminalProofOfWorkBlock;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IncrementalTimestampRule extends MergeConsensusRule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(IncrementalTimestampRule.class);
+
+  @Override
+  public boolean validate(
+      final BlockHeader header, final BlockHeader parent, final ProtocolContext protocolContext) {
+
+    if (super.shouldUsePostMergeRules(header, protocolContext)
+        && !isTerminalProofOfWorkBlock(header, protocolContext)) {
+      final long blockTimestamp = header.getTimestamp();
+      final long parentTimestamp = parent.getTimestamp();
+      final boolean isMoreRecent = blockTimestamp > parentTimestamp;
+
+      LOG.trace(
+          "Is block timestamp more recent that its parent? {}, [block timestamp {}, parent timestamp {}]",
+          isMoreRecent,
+          blockTimestamp,
+          parentTimestamp);
+
+      return isMoreRecent;
+    } else {
+      return true;
+    }
+  }
+}

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/MergeConsensusRule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/headervalidationrules/MergeConsensusRule.java
@@ -56,7 +56,7 @@ public abstract class MergeConsensusRule implements AttachedBlockHeaderValidatio
     if (parentChainTotalDifficulty
         .get()
         .add(header.getDifficulty() == null ? Difficulty.ZERO : header.getDifficulty())
-        .greaterThan(configuredTotalTerminalDifficulty)) {
+        .greaterOrEqualThan(configuredTotalTerminalDifficulty)) {
       return true;
     } else { // still PoWing
       return false;

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
@@ -169,6 +169,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
                   0,
                   15000000))
           .gasLimit(newParent.getGasLimit())
+          .timestamp(newParent.getTimestamp() + 1)
           .stateRoot(newParent.getStateRoot());
       if (each.greaterOrEqualThan(Difficulty.ZERO)) {
         headerGenerator.difficulty(each);
@@ -194,6 +195,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
                     0,
                     15000000l))
             .gasLimit(parent.getGasLimit())
+            .timestamp(parent.getTimestamp() + 1)
             .stateRoot(parent.getStateRoot())
             .buildHeader();
     return terminal;

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampValidationTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/headervalidationrules/IncrementalTimestampValidationTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.consensus.merge.headervalidationrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IncrementalTimestampValidationTest {
+
+  @Mock private ProtocolContext protocolContext;
+  @Mock private MutableBlockchain blockchain;
+  @Mock private MergeContext mergeContext;
+
+  @Before
+  public void setUp() {
+    when(blockchain.getTotalDifficultyByHash(any())).thenReturn(Optional.of(Difficulty.ONE));
+    when(protocolContext.getBlockchain()).thenReturn(blockchain);
+    when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.ZERO);
+    when(protocolContext.getConsensusContext(MergeContext.class)).thenReturn(mergeContext);
+  }
+
+  @Test
+  public void validWhenTimestampMoreRecentThanParent() {
+    final IncrementalTimestampRule rule = new IncrementalTimestampRule();
+    final long now = System.currentTimeMillis();
+    final BlockHeader parentHeader = mock(BlockHeader.class);
+    when(parentHeader.getTimestamp()).thenReturn(now);
+    final BlockHeader validHeader = mock(BlockHeader.class);
+    when(validHeader.getNumber()).thenReturn(1337L);
+    when(validHeader.getTimestamp()).thenReturn(now + 1);
+
+    assertThat(rule.validate(validHeader, parentHeader, protocolContext)).isTrue();
+  }
+
+  @Test
+  public void invalidWhenTimestampNotMoreRecentThanParent() {
+    final IncrementalTimestampRule rule = new IncrementalTimestampRule();
+    final long now = System.currentTimeMillis();
+    final BlockHeader parentHeader = mock(BlockHeader.class);
+    when(parentHeader.getTimestamp()).thenReturn(now);
+    final BlockHeader validHeader = mock(BlockHeader.class);
+    when(validHeader.getNumber()).thenReturn(1337L);
+    when(validHeader.getTimestamp()).thenReturn(now);
+
+    assertThat(rule.validate(validHeader, parentHeader, protocolContext)).isFalse();
+  }
+
+  @Test
+  public void alwaysValidWhenTTDNotReached() {
+    when(mergeContext.getTerminalTotalDifficulty()).thenReturn(Difficulty.of(2L));
+
+    final IncrementalTimestampRule rule = new IncrementalTimestampRule();
+    final BlockHeader parentHeader = mock(BlockHeader.class);
+    final BlockHeader validHeader = mock(BlockHeader.class);
+    when(validHeader.getNumber()).thenReturn(1337L);
+
+    assertThat(rule.validate(validHeader, parentHeader, protocolContext)).isTrue();
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -261,11 +261,10 @@ public class BackwardSyncContext {
       getBackwardChain().addBadChainToManager(badBlocksManager, block.getHash());
       throw new BackwardSyncException(
           "Cannot save block "
-              + block.getHash()
+              + block.toLogString()
               + " because of "
               + optResult.errorMessage.orElseThrow());
     }
-    optResult.blockProcessingOutputs.ifPresent(result -> {});
 
     return null;
   }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

In PoS current block timestamp must be greather than its parent block timestamp, so adding a new header validation rule to check that.
There is also a fix in the `shouldUsePostMergeRules` that was not correctly checking for TD >= TTD.

With this the Hive test *Invalid Ancestor Chain Re-Org, Invalid Timestamp, Invalid P9', Reveal using sync* passes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).