### PR TITLE
fix issue because parent world state is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - When on PoS the head can be only be updated by ForkchoiceUpdate [#3994](https://github.com/hyperledger/besu/pull/3994)
 - Version information available in metrics [#3997](https://github.com/hyperledger/besu/pull/3997)
 - Add TTD and DNS to Sepolia config [#4024](https://github.com/hyperledger/besu/pull/4024)
-- Add terminal block hash and number to Ropsten genesis file [#4026](https://github.com/hyperledger/besu/pull/4026)
 - Return `type` with value `0x0` when serializing legacy transactions [#4027](https://github.com/hyperledger/besu/pull/4027)
 - Ignore `ForkchoiceUpdate` if `newHead` is an ancestor of the chain head [#4055](https://github.com/hyperledger/besu/pull/4055)
 
@@ -20,6 +19,7 @@
 - Support free gas networks in the London fee market [#4003](https://github.com/hyperledger/besu/pull/4003)
 - Limit the size of outgoing eth subprotocol messages.  [#4034](https://github.com/hyperledger/besu/pull/4034)
 - Fixed a state root mismatch issue on bonsai that may appear occasionally [#4041](https://github.com/hyperledger/besu/pull/4041)
+- Fixed a trie log layer issue on bonsai during reorg [#4069](https://github.com/hyperledger/besu/pull/4069)
 - Return the correct latest valid hash in case of bad block when calling engine methods [#4056](https://github.com/hyperledger/besu/pull/4056)
 
 ### Download links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Additions and Improvements
 
+### Bug Fixes
+- Fixed a trie log layer issue on bonsai during reorg [#4069](https://github.com/hyperledger/besu/pull/4069)
+
 ## 22.7.0-RC1
 
 ### Additions and Improvements
@@ -19,7 +22,6 @@
 - Support free gas networks in the London fee market [#4003](https://github.com/hyperledger/besu/pull/4003)
 - Limit the size of outgoing eth subprotocol messages.  [#4034](https://github.com/hyperledger/besu/pull/4034)
 - Fixed a state root mismatch issue on bonsai that may appear occasionally [#4041](https://github.com/hyperledger/besu/pull/4041)
-- Fixed a trie log layer issue on bonsai during reorg [#4069](https://github.com/hyperledger/besu/pull/4069)
 - Return the correct latest valid hash in case of bad block when calling engine methods [#4056](https://github.com/hyperledger/besu/pull/4056)
 
 ### Download links

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -229,16 +229,10 @@ public class BonsaiWorldStateArchiveTest {
     // initial persisted state hash key
     when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));
     // fake trie log layer
-    final BytesValueRLPOutput rlpLogBlockA = new BytesValueRLPOutput();
-    final TrieLogLayer trieLogLayerBlockA = new TrieLogLayer();
-    trieLogLayerBlockA.setBlockHash(blockHeaderChainA.getHash());
-    trieLogLayerBlockA.writeTo(rlpLogBlockA);
     final BytesValueRLPOutput rlpLogBlockB = new BytesValueRLPOutput();
     final TrieLogLayer trieLogLayerBlockB = new TrieLogLayer();
     trieLogLayerBlockB.setBlockHash(blockHeaderChainB.getHash());
     trieLogLayerBlockB.writeTo(rlpLogBlockB);
-    when(keyValueStorage.get(blockHeaderChainA.getHash().toArrayUnsafe()))
-        .thenReturn(Optional.of(rlpLogBlockA.encoded().toArrayUnsafe()));
     when(keyValueStorage.get(blockHeaderChainB.getHash().toArrayUnsafe()))
         .thenReturn(Optional.of(rlpLogBlockB.encoded().toArrayUnsafe()));
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStora
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -199,5 +200,59 @@ public class BonsaiWorldStateArchiveTest {
     verify(layeredWorldStatesByHash).entrySet();
     verify(updater, times(1)).rollBack(any());
     verify(updater, times(1)).rollForward(any());
+  }
+
+  @SuppressWarnings({"unchecked"})
+  @Test
+  public void testGetMutableWithRollbackNotOverrideTrieLogLayer() {
+    final KeyValueStorageTransaction keyValueStorageTransaction =
+        mock(KeyValueStorageTransaction.class);
+    when(keyValueStorage.startTransaction()).thenReturn(keyValueStorageTransaction);
+    final BlockHeader genesis = blockBuilder.number(0).buildHeader();
+    final BlockHeader blockHeaderChainA =
+        blockBuilder.number(1).timestamp(1).parentHash(genesis.getHash()).buildHeader();
+    final BlockHeader blockHeaderChainB =
+        blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
+
+    final Map<Bytes32, BonsaiLayeredWorldState> layeredWorldStatesByHash = mock(HashMap.class);
+    when(layeredWorldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
+    when(layeredWorldStatesByHash.get(eq(blockHeaderChainA.getHash())))
+        .thenReturn(mock(BonsaiLayeredWorldState.class, Answers.RETURNS_MOCKS));
+    when(layeredWorldStatesByHash.get(eq(blockHeaderChainB.getHash())))
+        .thenReturn(mock(BonsaiLayeredWorldState.class, Answers.RETURNS_MOCKS));
+
+    bonsaiWorldStateArchive =
+        spy(new BonsaiWorldStateArchive(storageProvider, blockchain, 12, layeredWorldStatesByHash));
+    var updater = spy(bonsaiWorldStateArchive.getUpdater());
+    when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
+
+    // initial persisted state hash key
+    when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));
+    // fake trie log layer
+    final BytesValueRLPOutput rlpLogBlockA = new BytesValueRLPOutput();
+    final TrieLogLayer trieLogLayerBlockA = new TrieLogLayer();
+    trieLogLayerBlockA.setBlockHash(blockHeaderChainA.getHash());
+    trieLogLayerBlockA.writeTo(rlpLogBlockA);
+    final BytesValueRLPOutput rlpLogBlockB = new BytesValueRLPOutput();
+    final TrieLogLayer trieLogLayerBlockB = new TrieLogLayer();
+    trieLogLayerBlockB.setBlockHash(blockHeaderChainB.getHash());
+    trieLogLayerBlockB.writeTo(rlpLogBlockB);
+    when(keyValueStorage.get(blockHeaderChainA.getHash().toArrayUnsafe()))
+        .thenReturn(Optional.of(rlpLogBlockA.encoded().toArrayUnsafe()));
+    when(keyValueStorage.get(blockHeaderChainB.getHash().toArrayUnsafe()))
+        .thenReturn(Optional.of(rlpLogBlockB.encoded().toArrayUnsafe()));
+
+    when(blockchain.getBlockHeader(eq(blockHeaderChainB.getHash())))
+        .thenReturn(Optional.of(blockHeaderChainB));
+    when(blockchain.getBlockHeader(eq(genesis.getHash()))).thenReturn(Optional.of(genesis));
+
+    assertThat(bonsaiWorldStateArchive.getMutable(null, blockHeaderChainB.getHash()))
+        .containsInstanceOf(BonsaiPersistedWorldState.class);
+
+    // verify is not persisting if already present
+    verify(keyValueStorageTransaction, never())
+        .put(eq(blockHeaderChainA.getHash().toArrayUnsafe()), any());
+    verify(keyValueStorageTransaction, never())
+        .put(eq(blockHeaderChainB.getHash().toArrayUnsafe()), any());
   }
 }


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

We have this issue because we are replacing valid trielog by invalid trielog during a reorg. 

Can explain this strange trie log layer

>  : 0xd77f7f8868f20835fdfc8c7e851f6f23ce9f651d
   - StateTrieAccountValue{nonce=859, balance=0x00000000000000000000000000000000000000000000000006d141b0befb39fe, storageRoot=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, codeHash=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470}
   + StateTrieAccountValue{nonce=858, balance=0x00000000000000000000000000000000000000000000000006e96a274881e7b6, storageRoot=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, codeHash=0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470}

The nonce comes from 859 to 858 and it’s not possible in a normal use case. 


### How to reproduce it (it's an example)

- We import block 5. we create a trie log for this block (4->5). A trie log it’s a diff between the previous block and the last one
- We import block 6 bis. we create a trie log for this block (5->6bis)
- We import block 7 bis. we create a trie log for this block (6bis->7bis)
- We detect a reorg with 6third with a common ancestor == 4. Rollback to 4 and we persist block 4. But in this issue we replace the valid trie log layer (3-4) with an invalid trie log (7bis->4)
- We import block 5 third. we create a trie log for this block (5 third ->6 third)
- We import block 6 third. we create a trie log for this block (6 third ->7 third)
- We detect a reorg with 6 with a common ancestor == 3. Rollback to 3 is failing because of the trie log == (7bis->4). 


In the code the problem is here

We persist after a rollback/rollfoward https://github.com/hyperledger/besu/blob/main/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java#L247

We replace the trie log 
https://github.com/hyperledger/besu/blob/e79cf0e50724d7b5203708bf6b7abc24524f3dcb/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java#L257


⚠️ if we have this issue we need to resync besu . there is not way to recover

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #4068 
fixes #4052

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).