### PR TITLE
Loads uncached logs on cache miss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 - Fixed a trie log layer issue on bonsai during reorg [#4069](https://github.com/hyperledger/besu/pull/4069)
+- Fixed an issue getting logs when blooms cache misses [#3921](https://github.com/hyperledger/besu/issues/3921)
 
 ## 22.7.0-RC1
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -127,7 +127,7 @@ public class BlockchainQueriesLogCacheTest {
   }
 
   /**
-   * Tests fours sets of a three block range where the seam (where the segment changes) is in all
+   * Tests four sets of a three block range where the seam (where the segment changes) is in all
    * possible positions in the range.
    *
    * <p>For this test both sides of the seam are cached.
@@ -140,10 +140,11 @@ public class BlockchainQueriesLogCacheTest {
 
     // 4 ranges of 3 hits a piece = 12 calls - 97-99, 98-00, 99-01, 00-02
     verify(blockchain, times(12)).getBlockHashByNumber(anyLong());
-    verify(blockchain, times(12)).getBlockHeader(testHash);
-    verify(blockchain, times(12)).getTxReceipts(testHash);
-    verify(blockchain, times(12)).getBlockBody(testHash);
-    verify(blockchain, times(12)).blockIsOnCanonicalChain(testHash);
+    verify(blockchain, times(24)).getBlockHeader(testHash);
+    verify(blockchain, times(12)).getBlockHeader(anyLong());
+    verify(blockchain, times(24)).getTxReceipts(testHash);
+    verify(blockchain, times(24)).getBlockBody(testHash);
+    verify(blockchain, times(24)).blockIsOnCanonicalChain(testHash);
 
     verifyNoMoreInteractions(blockchain);
   }
@@ -163,14 +164,14 @@ public class BlockchainQueriesLogCacheTest {
     // 6 sets of calls on cache side of seam: 97-99, 98-99, 99, {}
     verify(blockchain, times(6)).getBlockHashByNumber(anyLong());
 
-    // 6 sets of calls on uncached side of seam: {}, 00, 00-01, 00-02
-    verify(blockchain, times(6)).getBlockHeader(anyLong());
+    // 12 sets of calls on uncached side of seam: {}, 00, 00-01, 00-02
+    verify(blockchain, times(12)).getBlockHeader(anyLong());
 
     // called on both halves of the seam
-    verify(blockchain, times(12)).getBlockHeader(testHash);
-    verify(blockchain, times(12)).getTxReceipts(testHash);
-    verify(blockchain, times(12)).getBlockBody(testHash);
-    verify(blockchain, times(12)).blockIsOnCanonicalChain(testHash);
+    verify(blockchain, times(18)).getBlockHeader(testHash);
+    verify(blockchain, times(18)).getTxReceipts(testHash);
+    verify(blockchain, times(18)).getBlockBody(testHash);
+    verify(blockchain, times(18)).blockIsOnCanonicalChain(testHash);
 
     verifyNoMoreInteractions(blockchain);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
@@ -131,11 +131,11 @@ public class GoQuorumPrivateTransactionLogBloomCacherTest {
     blockchainQueries.matchingLogs(NUMBER_3, 3, logsQuery, () -> true);
 
     verify(blockchain, times(1)).getBlockHashByNumber(NUMBER_3);
-    verify(blockchain, times(1)).getBlockHeader(NUMBER_3);
-    verify(blockchain, times(1)).getBlockHeader(testBlockHeaderHash);
-    verify(blockchain, times(1)).getTxReceipts(testBlockHeaderHash);
-    verify(blockchain, times(1)).getBlockBody(testBlockHeaderHash);
-    verify(blockchain, times(1)).blockIsOnCanonicalChain(testBlockHeaderHash);
+    verify(blockchain, times(2)).getBlockHeader(NUMBER_3);
+    verify(blockchain, times(2)).getBlockHeader(testBlockHeaderHash);
+    verify(blockchain, times(2)).getTxReceipts(testBlockHeaderHash);
+    verify(blockchain, times(2)).getBlockBody(testBlockHeaderHash);
+    verify(blockchain, times(2)).blockIsOnCanonicalChain(testBlockHeaderHash);
 
     verifyNoMoreInteractions(blockchain);
   }


### PR DESCRIPTION

## PR description

On a miss of the on-disk logs bloom cache, we check the uncached storage, and return that if available.

## Fixed Issue(s)
fixes #3921 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).