### PR TITLE
no need to register peers connect/disconnect for Snap as well

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapProtocolManager.java
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 public class SnapProtocolManager implements ProtocolManager {
   private static final Logger LOG = LoggerFactory.getLogger(SnapProtocolManager.class);
 
-  private final List<PeerValidator> peerValidators;
   private final List<Capability> supportedCapabilities;
   private final EthPeers ethPeers;
   private final EthMessages snapMessages;
@@ -52,7 +51,6 @@ public class SnapProtocolManager implements ProtocolManager {
       final EthPeers ethPeers,
       final EthMessages snapMessages,
       final WorldStateArchive worldStateArchive) {
-    this.peerValidators = peerValidators;
     this.ethPeers = ethPeers;
     this.snapMessages = snapMessages;
     this.supportedCapabilities = calculateCapabilities();
@@ -136,21 +134,11 @@ public class SnapProtocolManager implements ProtocolManager {
   }
 
   @Override
-  public void handleNewConnection(final PeerConnection connection) {
-    ethPeers.registerConnection(connection, peerValidators);
-  }
+  public void handleNewConnection(final PeerConnection connection) {}
 
   @Override
   public void handleDisconnect(
       final PeerConnection connection,
       final DisconnectReason reason,
-      final boolean initiatedByPeer) {
-    ethPeers.registerDisconnect(connection);
-    LOG.debug(
-        "Disconnect - {} - {} - {} - {} peers left",
-        initiatedByPeer ? "Inbound" : "Outbound",
-        reason,
-        connection.getPeerInfo(),
-        ethPeers.peerCount());
-  }
+      final boolean initiatedByPeer) {}
 }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

SnapProtocolManager uses EthPeers so no need to handle connect/disconnect events here as well.
Eliminates some duplicated peer-related logging.

I have tested that Snap Sync works with this change

Before this change
```

2022-07-08 09:51:47.899+10:00 | nioEventLoopGroup-3-10 | TRACE | EthProtocolManager | Process message eth/66, 0
2022-07-08 09:51:47.899+10:00 | nioEventLoopGroup-3-10 | DEBUG | EthProtocolManager | Peer 0xd094aaee3baa666249... PeerReputation 100, validated? true, disconnected? false has mismatched network id: 128
2022-07-08 09:51:47.900+10:00 | nioEventLoopGroup-3-10 | TRACE | EthPeer | handleDisconnect - peer... 0xd094aaee3baa666249, PeerReputation 100
2022-07-08 09:51:47.900+10:00 | nioEventLoopGroup-3-10 | DEBUG | EthProtocolManager | Disconnect - Outbound - 0x10 SUBPROTOCOL_TRIGGERED - PeerInfo{version=5, clientId='Geth/v1.2.0-stable-9077473c/linux-amd64/go1.16.5', capabilities=[eth/65, eth/66, snap/1],
 port=0, nodeId=0xd094aaee3baa6662498e8924e26c60557b27e216ce839622fc2c123a8ea9307e4bb5a1beb108288bddeb4f04167bdcce078e89e315a4b66d0b07718fdb7930f7} - 4 peers left
2022-07-08 09:51:47.900+10:00 | nioEventLoopGroup-3-10 | DEBUG | SnapProtocolManager | Disconnect - Outbound - 0x10 SUBPROTOCOL_TRIGGERED - PeerInfo{version=5, clientId='Geth/v1.2.0-stable-9077473c/linux-amd64/go1.16.5', capabilities=[eth/65, eth/66, snap/1], port=0, nodeId=0xd094aaee3baa6662498e8924e26c60557b27e216ce839622fc2c123a8ea9307e4bb5a1beb108288bddeb4f04167bdcce078e89e315a4b66d0b07718fdb7930f7} - 4 peers left
```

After this change
```

2022-07-08 11:13:00.784+10:00 | nioEventLoopGroup-3-8 | TRACE | EthProtocolManager | Process message eth/66, 0
2022-07-08 11:13:00.784+10:00 | nioEventLoopGroup-3-8 | DEBUG | EthProtocolManager | Peer 0xbfef556cec5aa40b3e... PeerReputation 100, validated? true, disconnected? false has mismatched network id: 128
2022-07-08 11:13:00.784+10:00 | nioEventLoopGroup-3-8 | TRACE | EthPeer | handleDisconnect - peer... 0xbfef556cec5aa40b3e, PeerReputation 100
2022-07-08 11:13:00.784+10:00 | nioEventLoopGroup-3-8 | DEBUG | EthProtocolManager | Disconnect - Outbound - 0x10 SUBPROTOCOL_TRIGGERED - PeerInfo{version=5, clientId='Geth/v1.2.0-stable-d31813dc/linux-amd64/go1.16.5', capabilities=[eth/65, eth/66, snap/1],
port=0, nodeId=0xbfef556cec5aa40b3e02dd70afcac437e1689d31caaecbf68c3401f83ac9a86784c59443ff63e6e358ae7ac236f9726a620b94ba9676b899f97cb0e84a4ebcf0} - 3 peers left
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).