### PR TITLE
Release 22.4.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.4.4-SNAPSHOT
+version=22.4.4
 
 # Workaround for Java 16 and spotless bug 834 https://github.com/diffplug/spotless/issues/834
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION
Release 22.4.4

cherry picks from main:
49e4fd860 -> worldstate not avail (#4069)
6aa88129e -> stateroot mismatch (#4041)
043191a40 -> jwt auth on websockets (#4039)
90f891b78 -> do not move head on exec and propose (#4013)
b5fa62c0b -> sync check before processing remote transactions (4035)
3baa4da99 -> upgrade for websockets (#4019)
5024c0788 -> sepolia TTD (#4024)
5ee9be837 -> heal step in snap (#3920)
261b1e03f -> remove peer block height requirements (#3911)