### PR TITLE
candidate fix for missing parent worldstate

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethods;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateArchive;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.BlockchainStorage;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
@@ -602,7 +604,12 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     switch (dataStorageConfiguration.getDataStorageFormat()) {
       case BONSAI:
         return new BonsaiWorldStateArchive(
-            storageProvider, blockchain, dataStorageConfiguration.getBonsaiMaxLayersToLoad());
+            new TrieLogManager(
+                blockchain,
+                (BonsaiWorldStateKeyValueStorage) worldStateStorage,
+                dataStorageConfiguration.getBonsaiMaxLayersToLoad()),
+            storageProvider,
+            blockchain);
       case FOREST:
       default:
         final WorldStatePreimageStorage preimageStorage =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -41,12 +41,16 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   @Override
   public void persist(final BlockHeader blockHeader) {
     final BonsaiWorldStateUpdater localUpdater = updater.copy();
+    final BonsaiWorldStateKeyValueStorage.Updater stateUpdater = worldStateStorage.updater();
     try {
       final Hash newWorldStateRootHash = rootHash();
-      prepareTrieLog(blockHeader, localUpdater, newWorldStateRootHash);
+      final TrieLogLayer trieLogLayer =
+          prepareTrieLog(blockHeader, localUpdater, newWorldStateRootHash);
+      persistTrieLog(blockHeader, newWorldStateRootHash, trieLogLayer, stateUpdater);
       worldStateBlockHash = blockHeader.getHash();
       worldStateRootHash = newWorldStateRootHash;
     } finally {
+      stateUpdater.commit();
       localUpdater.reset();
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -41,10 +41,10 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   @Override
   public void persist(final BlockHeader blockHeader) {
     boolean success = false;
+    final Hash newWorldStateRootHash = rootHash();
     final BonsaiWorldStateUpdater localUpdater = updater.copy();
     final BonsaiWorldStateKeyValueStorage.Updater stateUpdater = worldStateStorage.updater();
     try {
-      final Hash newWorldStateRootHash = rootHash();
       final TrieLogLayer trieLogLayer =
           prepareTrieLog(blockHeader, localUpdater, newWorldStateRootHash);
       persistTrieLog(blockHeader, newWorldStateRootHash, trieLogLayer, stateUpdater);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -47,10 +47,10 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
       final TrieLogLayer trieLogLayer =
           prepareTrieLog(blockHeader, localUpdater, newWorldStateRootHash);
       persistTrieLog(blockHeader, newWorldStateRootHash, trieLogLayer, stateUpdater);
+      stateUpdater.commit();
       worldStateBlockHash = blockHeader.getHash();
       worldStateRootHash = newWorldStateRootHash;
     } finally {
-      stateUpdater.commit();
       localUpdater.reset();
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -45,9 +45,8 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   @Override
   public void persist(final BlockHeader blockHeader) {
     final BonsaiWorldStateUpdater localUpdater = updater.copy();
-    final Hash newWorldStateRootHash = rootHash(localUpdater);
-    worldStateBlockHash = blockHeader.getHash();
-    worldStateRootHash = newWorldStateRootHash;
-    archive.getTrieLogManager().saveTrieLog(archive, localUpdater, worldStateRootHash, blockHeader);
+    archive
+        .getTrieLogManager()
+        .saveTrieLog(archive, localUpdater, rootHash(localUpdater), blockHeader);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.evm.account.Account;
@@ -98,10 +97,6 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
   public BonsaiWorldStateKeyValueStorage getWorldStateStorage() {
     return worldStateStorage;
-  }
-
-  protected Hash calculateRootHash(final BonsaiWorldStateKeyValueStorage.Updater stateUpdater) {
-    return calculateRootHash(stateUpdater, updater.copy());
   }
 
   protected Hash calculateRootHash(
@@ -252,14 +247,16 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
       // then persist the TrieLog for that transition.
       // If specified but not a direct descendant simply store the new block hash.
       if (blockHeader != null) {
-        // do not overwrite a trielog layer that already exists in the database.
-        // if it's only in memory we need to save it
-        // for example, like that in case of reorg we don't replace a trielog layer
-        if (worldStateStorage.getTrieLog(blockHeader.getHash()).isEmpty()) {
-          final TrieLogLayer trieLog =
-              prepareTrieLog(blockHeader, localUpdater, newWorldStateRootHash);
-          persistTrieLog(blockHeader, newWorldStateRootHash, trieLog, stateUpdater);
+        if (!newWorldStateRootHash.equals(blockHeader.getStateRoot())) {
+          throw new RuntimeException(
+              "World State Root does not match expected value, header "
+                  + blockHeader.getStateRoot().toHexString()
+                  + " calculated "
+                  + newWorldStateRootHash.toHexString());
         }
+        archive
+            .getTrieLogManager()
+            .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader);
         stateUpdater
             .getTrieBranchStorageTransaction()
             .put(WORLD_BLOCK_HASH_KEY, blockHeader.getHash().toArrayUnsafe());
@@ -283,46 +280,6 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
         updater.reset();
       }
     }
-    if (blockHeader != null) {
-      archive.scrubLayeredCache(blockHeader.getNumber());
-    }
-  }
-
-  protected TrieLogLayer prepareTrieLog(
-      final BlockHeader blockHeader,
-      final BonsaiWorldStateUpdater localUpdater,
-      final Hash currentWorldStateRootHash) {
-
-    if (!currentWorldStateRootHash.equals(blockHeader.getStateRoot())) {
-      throw new RuntimeException(
-          "World State Root does not match expected value, header "
-              + blockHeader.getStateRoot().toHexString()
-              + " calculated "
-              + currentWorldStateRootHash.toHexString());
-    }
-
-    debugLambda(LOG, "Adding layered world state for {}", blockHeader::toLogString);
-    final TrieLogLayer trieLog = localUpdater.generateTrieLog(blockHeader.getBlockHash());
-    trieLog.freeze();
-    archive.addLayeredWorldState(this, blockHeader, currentWorldStateRootHash, trieLog);
-    return trieLog;
-  }
-
-  protected void persistTrieLog(
-      final BlockHeader blockHeader,
-      final Hash worldStateRootHash,
-      final TrieLogLayer trieLog,
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater) {
-    debugLambda(
-        LOG,
-        "Persisting trie log for block hash {} and world state root {}",
-        blockHeader::toLogString,
-        worldStateRootHash::toHexString);
-    final BytesValueRLPOutput rlpLog = new BytesValueRLPOutput();
-    trieLog.writeTo(rlpLog);
-    stateUpdater
-        .getTrieLogStorageTransaction()
-        .put(blockHeader.getHash().toArrayUnsafe(), rlpLog.encoded().toArrayUnsafe());
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -308,7 +308,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     return trieLog;
   }
 
-  private void persistTrieLog(
+  protected void persistTrieLog(
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TrieLogManager {
+
+  private static final long RETAINED_LAYERS = 512; // at least 256 + typical rollbacks
+
+  private static final Logger LOG = LoggerFactory.getLogger(TrieLogManager.class);
+
+  private final Blockchain blockchain;
+  private final BonsaiWorldStateKeyValueStorage worldStateStorage;
+
+  private final Map<Bytes32, BonsaiLayeredWorldState> layeredWorldStatesByHash;
+  private final long maxLayersToLoad;
+
+  public TrieLogManager(
+      final Blockchain blockchain,
+      final BonsaiWorldStateKeyValueStorage worldStateStorage,
+      final long maxLayersToLoad,
+      final Map<Bytes32, BonsaiLayeredWorldState> layeredWorldStatesByHash) {
+    this.blockchain = blockchain;
+    this.worldStateStorage = worldStateStorage;
+    this.layeredWorldStatesByHash = layeredWorldStatesByHash;
+    this.maxLayersToLoad = maxLayersToLoad;
+  }
+
+  public TrieLogManager(
+      final Blockchain blockchain,
+      final BonsaiWorldStateKeyValueStorage worldStateStorage,
+      final long maxLayersToLoad) {
+    this(blockchain, worldStateStorage, maxLayersToLoad, new HashMap<>());
+  }
+
+  public TrieLogManager(
+      final Blockchain blockchain, final BonsaiWorldStateKeyValueStorage worldStateStorage) {
+    this(blockchain, worldStateStorage, RETAINED_LAYERS, new HashMap<>());
+  }
+
+  public synchronized void saveTrieLog(
+      final BonsaiWorldStateArchive worldStateArchive,
+      final BonsaiWorldStateUpdater localUpdater,
+      final Hash worldStateRootHash,
+      final BlockHeader blockHeader) {
+    // do not overwrite a trielog layer that already exists in the database.
+    // if it's only in memory we need to save it
+    // for example, like that in case of reorg we don't replace a trielog layer
+    if (worldStateStorage.getTrieLog(blockHeader.getHash()).isEmpty()) {
+      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater = worldStateStorage.updater();
+      boolean success = false;
+      try {
+        final TrieLogLayer trieLog =
+            prepareTrieLog(blockHeader, worldStateRootHash, localUpdater, worldStateArchive);
+        persistTrieLog(blockHeader, worldStateRootHash, trieLog, stateUpdater);
+        success = true;
+      } finally {
+        if (success) {
+          stateUpdater.commit();
+        } else {
+          stateUpdater.rollback();
+        }
+      }
+    }
+  }
+
+  public synchronized void addLayeredWorldState(
+      final BlockHeader blockHeader,
+      final Hash worldStateRootHash,
+      final TrieLogLayer trieLog,
+      final BonsaiWorldStateArchive worldStateArchive) {
+
+    final BonsaiLayeredWorldState bonsaiLayeredWorldState =
+        new BonsaiLayeredWorldState(
+            blockchain,
+            worldStateArchive,
+            Optional.of((BonsaiPersistedWorldState) worldStateArchive.getMutable()),
+            blockHeader.getNumber(),
+            worldStateRootHash,
+            trieLog);
+    debugLambda(
+        LOG,
+        "adding layered world state for block {}, state root hash {}",
+        blockHeader::toLogString,
+        worldStateRootHash::toHexString);
+    layeredWorldStatesByHash.put(blockHeader.getHash(), bonsaiLayeredWorldState);
+    scrubLayeredCache(blockHeader.getNumber());
+  }
+
+  public synchronized void updateLayeredWorldState(
+      final Hash blockParentHash, final Hash blockHash) {
+    layeredWorldStatesByHash.computeIfPresent(
+        blockParentHash,
+        (parentHash, bonsaiLayeredWorldState) -> {
+          if (layeredWorldStatesByHash.containsKey(blockHash)) {
+            bonsaiLayeredWorldState.setNextWorldView(
+                Optional.of(layeredWorldStatesByHash.get(blockHash)));
+          }
+          return bonsaiLayeredWorldState;
+        });
+  }
+
+  public synchronized void scrubLayeredCache(final long newMaxHeight) {
+    final long waterline = newMaxHeight - RETAINED_LAYERS;
+    layeredWorldStatesByHash.entrySet().removeIf(entry -> entry.getValue().getHeight() < waterline);
+  }
+
+  public long getMaxLayersToLoad() {
+    return maxLayersToLoad;
+  }
+
+  public Optional<TrieLogLayer> getTrieLogLayer(final Hash blockHash) {
+    if (layeredWorldStatesByHash.containsKey(blockHash)) {
+      return Optional.of(layeredWorldStatesByHash.get(blockHash).getTrieLog());
+    } else {
+      return worldStateStorage.getTrieLog(blockHash).map(TrieLogLayer::fromBytes);
+    }
+  }
+
+  public Optional<MutableWorldState> getBonsaiLayeredWorldState(final Hash blockHash) {
+    if (layeredWorldStatesByHash.containsKey(blockHash)) {
+      return Optional.of(layeredWorldStatesByHash.get(blockHash));
+    }
+    return Optional.empty();
+  }
+
+  private TrieLogLayer prepareTrieLog(
+      final BlockHeader blockHeader,
+      final Hash currentWorldStateRootHash,
+      final BonsaiWorldStateUpdater localUpdater,
+      final BonsaiWorldStateArchive worldStateArchive) {
+    debugLambda(LOG, "Adding layered world state for {}", blockHeader::toLogString);
+    final TrieLogLayer trieLog = localUpdater.generateTrieLog(blockHeader.getBlockHash());
+    trieLog.freeze();
+    addLayeredWorldState(blockHeader, currentWorldStateRootHash, trieLog, worldStateArchive);
+    return trieLog;
+  }
+
+  private void persistTrieLog(
+      final BlockHeader blockHeader,
+      final Hash worldStateRootHash,
+      final TrieLogLayer trieLog,
+      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater) {
+    debugLambda(
+        LOG,
+        "Persisting trie log for block hash {} and world state root {}",
+        blockHeader::toLogString,
+        worldStateRootHash::toHexString);
+    final BytesValueRLPOutput rlpLog = new BytesValueRLPOutput();
+    trieLog.writeTo(rlpLog);
+    stateUpdater
+        .getTrieLogStorageTransaction()
+        .put(blockHeader.getHash().toArrayUnsafe(), rlpLog.encoded().toArrayUnsafe());
+  }
+}

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
@@ -15,6 +15,8 @@
 package org.hyperledger.besu.ethereum.core;
 
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateArchive;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -63,7 +65,13 @@ public class InMemoryKeyValueStorageProvider extends KeyValueStorageProvider {
 
   public static BonsaiWorldStateArchive createBonsaiInMemoryWorldStateArchive(
       final Blockchain blockchain) {
-    return new BonsaiWorldStateArchive(new InMemoryKeyValueStorageProvider(), blockchain);
+    final InMemoryKeyValueStorageProvider inMemoryKeyValueStorageProvider =
+        new InMemoryKeyValueStorageProvider();
+    return new BonsaiWorldStateArchive(
+        new TrieLogManager(
+            blockchain, new BonsaiWorldStateKeyValueStorage(inMemoryKeyValueStorageProvider)),
+        inMemoryKeyValueStorageProvider,
+        blockchain);
   }
 
   public static MutableWorldState createInMemoryWorldState() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -80,7 +80,11 @@ public class BonsaiWorldStateArchiveTest {
         .thenReturn(Optional.of(chainHead.getStateRoot().toArrayUnsafe()));
     when(keyValueStorage.get(WORLD_BLOCK_HASH_KEY))
         .thenReturn(Optional.of(chainHead.getHash().toArrayUnsafe()));
-    bonsaiWorldStateArchive = new BonsaiWorldStateArchive(storageProvider, blockchain, 1);
+    bonsaiWorldStateArchive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(blockchain, new BonsaiWorldStateKeyValueStorage(storageProvider), 1),
+            storageProvider,
+            blockchain);
 
     assertThat(bonsaiWorldStateArchive.getMutable(null, chainHead.getHash(), true))
         .containsInstanceOf(BonsaiPersistedWorldState.class);
@@ -88,7 +92,12 @@ public class BonsaiWorldStateArchiveTest {
 
   @Test
   public void testGetMutableReturnEmptyWhenLoadMoreThanLimitLayersBack() {
-    bonsaiWorldStateArchive = new BonsaiWorldStateArchive(storageProvider, blockchain, 512);
+    bonsaiWorldStateArchive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(
+                blockchain, new BonsaiWorldStateKeyValueStorage(storageProvider), 512),
+            storageProvider,
+            blockchain);
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
     final BlockHeader chainHead = blockBuilder.number(512).buildHeader();
     when(blockchain.getBlockHeader(eq(blockHeader.getHash()))).thenReturn(Optional.of(blockHeader));
@@ -98,7 +107,12 @@ public class BonsaiWorldStateArchiveTest {
 
   @Test
   public void testGetMutableWhenLoadLessThanLimitLayersBack() {
-    bonsaiWorldStateArchive = new BonsaiWorldStateArchive(storageProvider, blockchain, 512);
+    bonsaiWorldStateArchive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(
+                blockchain, new BonsaiWorldStateKeyValueStorage(storageProvider), 512),
+            storageProvider,
+            blockchain);
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
     final BlockHeader chainHead = blockBuilder.number(511).buildHeader();
 
@@ -123,7 +137,14 @@ public class BonsaiWorldStateArchiveTest {
     final Map layeredWorldStatesByHash = mock(HashMap.class);
 
     bonsaiWorldStateArchive =
-        new BonsaiWorldStateArchive(storageProvider, blockchain, 12, layeredWorldStatesByHash);
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(
+                blockchain,
+                new BonsaiWorldStateKeyValueStorage(storageProvider),
+                12,
+                layeredWorldStatesByHash),
+            storageProvider,
+            blockchain);
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
 
     when(blockchain.getBlockHeader(eq(blockHeader.getHash()))).thenReturn(Optional.of(blockHeader));
@@ -143,7 +164,15 @@ public class BonsaiWorldStateArchiveTest {
     final Map layeredWorldStatesByHash = mock(HashMap.class);
 
     bonsaiWorldStateArchive =
-        spy(new BonsaiWorldStateArchive(storageProvider, blockchain, 12, layeredWorldStatesByHash));
+        spy(
+            new BonsaiWorldStateArchive(
+                new TrieLogManager(
+                    blockchain,
+                    new BonsaiWorldStateKeyValueStorage(storageProvider),
+                    12,
+                    layeredWorldStatesByHash),
+                storageProvider,
+                blockchain));
     var updater = spy(bonsaiWorldStateArchive.getUpdater());
     when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
 
@@ -179,7 +208,15 @@ public class BonsaiWorldStateArchiveTest {
         .thenReturn(mock(BonsaiLayeredWorldState.class, Answers.RETURNS_MOCKS));
 
     bonsaiWorldStateArchive =
-        spy(new BonsaiWorldStateArchive(storageProvider, blockchain, 12, layeredWorldStatesByHash));
+        spy(
+            new BonsaiWorldStateArchive(
+                new TrieLogManager(
+                    blockchain,
+                    new BonsaiWorldStateKeyValueStorage(storageProvider),
+                    12,
+                    layeredWorldStatesByHash),
+                storageProvider,
+                blockchain));
     var updater = spy(bonsaiWorldStateArchive.getUpdater());
     when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
 
@@ -222,7 +259,15 @@ public class BonsaiWorldStateArchiveTest {
         .thenReturn(mock(BonsaiLayeredWorldState.class, Answers.RETURNS_MOCKS));
 
     bonsaiWorldStateArchive =
-        spy(new BonsaiWorldStateArchive(storageProvider, blockchain, 12, layeredWorldStatesByHash));
+        spy(
+            new BonsaiWorldStateArchive(
+                new TrieLogManager(
+                    blockchain,
+                    new BonsaiWorldStateKeyValueStorage(storageProvider),
+                    12,
+                    layeredWorldStatesByHash),
+                storageProvider,
+                blockchain));
     var updater = spy(bonsaiWorldStateArchive.getUpdater());
     when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LogRollingTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LogRollingTests.java
@@ -109,7 +109,11 @@ public class LogRollingTests {
   @Before
   public void createStorage() {
     final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
-    archive = new BonsaiWorldStateArchive(provider, blockchain);
+    archive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(blockchain, new BonsaiWorldStateKeyValueStorage(provider)),
+            provider,
+            blockchain);
     accountStorage =
         (InMemoryKeyValueStorage)
             provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE);
@@ -128,7 +132,11 @@ public class LogRollingTests {
             provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
 
     final InMemoryKeyValueStorageProvider secondProvider = new InMemoryKeyValueStorageProvider();
-    secondArchive = new BonsaiWorldStateArchive(secondProvider, blockchain);
+    secondArchive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(blockchain, new BonsaiWorldStateKeyValueStorage(secondProvider)),
+            secondProvider,
+            blockchain);
     secondAccountStorage =
         (InMemoryKeyValueStorage)
             secondProvider.getStorageBySegmentIdentifier(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/RollingImport.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/RollingImport.java
@@ -38,7 +38,11 @@ public class RollingImport {
         new RollingFileReader((i, c) -> Path.of(String.format(arg[0] + "-%04d.rdat", i)), false);
 
     final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
-    final BonsaiWorldStateArchive archive = new BonsaiWorldStateArchive(provider, null);
+    final BonsaiWorldStateArchive archive =
+        new BonsaiWorldStateArchive(
+            new TrieLogManager(null, new BonsaiWorldStateKeyValueStorage(provider)),
+            provider,
+            null);
     final InMemoryKeyValueStorage accountStorage =
         (InMemoryKeyValueStorage)
             provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE);


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

when we remember block after the merge we must persist the trielog. because if we lose the trielog in the memory   (ex  restart besu) we can end up in a case where the block is saved but not the trielog. this can prevent the rollback or the rollforward to work because besu will consider that it can do it as the block is present but it will failed because trielog is missing. 

may be one of the reasons for the problem found on a ropsten test node

A possible edgecase description : 
- the head is block 5
- we remember block 6
- as we remember block 6 , we save trielog 6 only in memory
- CL is saying to go to block 7
now we have
- block5 in database + trielog 5 in database
- block6 in database + trielog 6 in memory
- block7 in database + trielog 7 in database
- we have a reorg to block 6
- we rollback 7 to 6 and we persist again block 6. as trielog 6 is not in the database we save invalid trielog 6 (7->6)

 if we restart before the reorg trielog 6 is missing
 
 this PR also fix an issue related to an invalid implementation of BonsaiInmemoryWorldstate
 
```java 
java.lang.AssertionError: Node hash 0x9289cda321472949c843ca0b1c6e08011c2608436898699468f49b72d2d8533e not equal to expected 0x03ac2557b39e96bc541432719417ca05360530f915ae8e53d8bf2591bee9c883
	at org.hyperledger.besu.ethereum.trie.StoredNodeFactory.lambda$retrieve$1(StoredNodeFactory.java:103)
	at java.base/java.util.Optional.map(Optional.java:265)
	at org.hyperledger.besu.ethereum.trie.StoredNodeFactory.retrieve(StoredNodeFactory.java:97)
	at org.hyperledger.besu.ethereum.trie.StoredNode.load(StoredNode.java:130)
	at org.hyperledger.besu.ethereum.trie.StoredNode.accept(StoredNode.java:63)
	at org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie.put(StoredMerklePatriciaTrie.java:142)
	at org.hyperledger.besu.ethereum.bonsai.BonsaiPersistedWorldState.calculateRootHash(BonsaiPersistedWorldState.java:227)
	at org.hyperledger.besu.ethereum.bonsai.BonsaiPersistedWorldState.calculateRootHash(BonsaiPersistedWorldState.java:104)
	at org.hyperledger.besu.ethereum.bonsai.BonsaiInMemoryWorldState.rootHash(BonsaiInMemoryWorldState.java:34)
	at org.hyperledger.besu.ethereum.MainnetBlockValidator.validateAndProcessBlock(MainnetBlockValidator.java:119)
	at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.validateBlock(MergeCoordinator.java:256)
	at org.hyperledger.besu.consensus.merge.blockcreation.MergeCoordinator.rememberBlock(MergeCoordinator.java:272)
	at org.hyperledger.besu.consensus.merge.blockcreation.TransitionCoordinator.rememberBlock(TransitionCoordinator.java:137)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayload.syncResponse(EngineNewPayload.java:189)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.lambda$response$0(ExecutionEngineJsonRpcMethod.java:62)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157)
	at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#4084
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).