### PR TITLE
Delegate all the block checks and validation to the block import phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Additions and Improvements
 - Add a block to the bad blocks if it did not descend from the terminal block [#4080](https://github.com/hyperledger/besu/pull/4080)
+- Remove block header checks during backward sync, since they will be always performed during block import phase [#4098](https://github.com/hyperledger/besu/pull/4098)
 
 ### Bug Fixes
 - Return the correct latest valid hash in case of bad block when calling engine methods [#4056](https://github.com/hyperledger/besu/pull/4056)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardChain.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardChain.java
@@ -95,22 +95,6 @@ public class BackwardChain {
       return;
     }
     BlockHeader firstHeader = firstStoredAncestor.get();
-    if (firstHeader.getNumber() != blockHeader.getNumber() + 1) {
-      throw new BackwardSyncException(
-          "Wrong height of header "
-              + blockHeader.getHash().toHexString()
-              + " is "
-              + blockHeader.getNumber()
-              + " when we were expecting "
-              + (firstHeader.getNumber() - 1));
-    }
-    if (!firstHeader.getParentHash().equals(blockHeader.getHash())) {
-      throw new BackwardSyncException(
-          "Hash of header does not match our expectations, was "
-              + blockHeader.toLogString()
-              + " when we expected "
-              + firstHeader.getParentHash().toHexString());
-    }
     headers.put(blockHeader.getHash(), blockHeader);
     chainStorage.put(blockHeader.getHash(), firstStoredAncestor.get().getHash());
     firstStoredAncestor = Optional.of(blockHeader);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
@@ -15,9 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.sync.backwardsync;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hyperledger.besu.ethereum.eth.sync.backwardsync.ChainForTestCreator.prepareChain;
-import static org.hyperledger.besu.ethereum.eth.sync.backwardsync.ChainForTestCreator.prepareWrongParentHash;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -93,32 +91,6 @@ public class InMemoryBackwardChainTest {
     backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 4).getHeader());
     BlockHeader firstHeader = backwardChain.getFirstAncestorHeader().orElseThrow();
     assertThat(firstHeader).isEqualTo(blocks.get(blocks.size() - 4).getHeader());
-  }
-
-  @Test
-  public void shouldNotSaveHeadersWhenWrongHeight() {
-    BackwardChain backwardChain = createChainFromBlock(blocks.get(blocks.size() - 1));
-    backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 2).getHeader());
-    backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 3).getHeader());
-    assertThatThrownBy(
-            () -> backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 5).getHeader()))
-        .isInstanceOf(BackwardSyncException.class)
-        .hasMessageContaining("Wrong height of header");
-    BlockHeader firstHeader = backwardChain.getFirstAncestorHeader().orElseThrow();
-    assertThat(firstHeader).isEqualTo(blocks.get(blocks.size() - 3).getHeader());
-  }
-
-  @Test
-  public void shouldNotSaveHeadersWhenWrongHash() {
-    BackwardChain backwardChain = createChainFromBlock(blocks.get(blocks.size() - 1));
-    backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 2).getHeader());
-    backwardChain.prependAncestorsHeader(blocks.get(blocks.size() - 3).getHeader());
-    BlockHeader wrongHashHeader = prepareWrongParentHash(blocks.get(blocks.size() - 4).getHeader());
-    assertThatThrownBy(() -> backwardChain.prependAncestorsHeader(wrongHashHeader))
-        .isInstanceOf(BackwardSyncException.class)
-        .hasMessageContaining("Hash of header does not match our expectations");
-    BlockHeader firstHeader = backwardChain.getFirstAncestorHeader().orElseThrow();
-    assertThat(firstHeader).isEqualTo(blocks.get(blocks.size() - 3).getHeader());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Remove preventive checks during sync, since they will be performed always performed during the import phase later, where the block will be also flagged as bad block.
With this the last failing Hive test (Invalid Ancestor Chain Re-Org, Invalid Number, Invalid P9', Reveal using sync) passes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).