### PR TITLE
WIP EthPeers - remove if disconnected

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -550,8 +550,12 @@ public class EthPeer implements Comparable<EthPeer> {
   @Override
   public String toString() {
     return String.format(
-        "Peer %s... %s, validated? %s, disconnected? %s",
-        getShortNodeId(), reputation, isFullyValidated(), isDisconnected());
+        "Peer %s %s... %s, validated? %s, disconnected? %s",
+        System.identityHashCode(connection),
+        getShortNodeId(),
+        reputation,
+        isFullyValidated(),
+        isDisconnected());
   }
 
   @Nonnull

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -99,6 +99,11 @@ public class EthPeers {
             clock,
             permissioningProviders);
     connections.putIfAbsent(peerConnection, peer);
+    // it is common for the peer to be disconnected at this point
+    // if duplicate inbound and outbound connections are established at the same time
+    if (peer.isDisconnected()) {
+      connections.remove(peerConnection);
+    }
   }
 
   public void registerDisconnect(final PeerConnection connection) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/DiscoveryProtocolLogger.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/DiscoveryProtocolLogger.java
@@ -47,7 +47,7 @@ public class DiscoveryProtocolLogger {
   void logSendingPacket(final Peer peer, final Packet packet) {
     outgoingMessageCounter.labels(packet.getType().name()).inc();
     LOG.trace(
-        "<<< Sending  {} packet to peer {} ({}): {}",
+        "<<< Sending {} packet to peer {} ({}): {}",
         shortenPacketType(packet),
         peer.getId().slice(0, 16),
         peer.getEnodeURL(),

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -394,7 +394,10 @@ public class RlpxAgent {
         (nodeId, existingConnection) -> {
           if (existingConnection == null) {
             // The new connection is unique, set it and return
-            LOG.debug("Inbound connection established with {}", peerConnection.getPeer().getId());
+            LOG.debug(
+                "Inbound connection {} established with {}",
+                System.identityHashCode(peerConnection),
+                peerConnection.getPeer().getId());
             newConnectionAccepted.set(true);
             return inboundConnection;
           }
@@ -402,7 +405,9 @@ public class RlpxAgent {
           if (compareDuplicateConnections(inboundConnection, existingConnection) < 0) {
             // Keep the inbound connection
             LOG.debug(
-                "Duplicate connection detected, disconnecting previously established connection in favor of new inbound connection for peer:  {}",
+                "Duplicate connection detected, disconnecting previously established connection {} in favor of new inbound connection {} for peer: {}",
+                System.identityHashCode(existingConnection.getPeerConnection()),
+                System.identityHashCode(peerConnection),
                 peerConnection.getPeer().getId());
             disconnectAction.set(
                 () -> existingConnection.disconnect(DisconnectReason.ALREADY_CONNECTED));
@@ -411,7 +416,9 @@ public class RlpxAgent {
           } else {
             // Keep the existing connection
             LOG.debug(
-                "Duplicate connection detected, disconnecting inbound connection in favor of previously established connection for peer:  {}",
+                "Duplicate connection detected, disconnecting inbound connection {} in favor of previously established connection {} for peer: {}",
+                System.identityHashCode(peerConnection),
+                System.identityHashCode(existingConnection.getPeerConnection()),
                 peerConnection.getPeer().getId());
             disconnectAction.set(
                 () -> inboundConnection.disconnect(DisconnectReason.ALREADY_CONNECTED));

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/RlpxConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/RlpxConnection.java
@@ -148,6 +148,8 @@ public abstract class RlpxConnection {
     public String toString() {
       return "RemotelyInitiatedRlpxConnection initiatedAt:"
           + getInitiatedAt()
+          + " on connection "
+          + System.identityHashCode(peerConnection)
           + " to "
           + peerConnection.getPeer().getId();
     }
@@ -226,6 +228,8 @@ public abstract class RlpxConnection {
     public String toString() {
       return "LocallyInitiatedRlpxConnection initiatedAt:"
           + getInitiatedAt()
+          + " on connection "
+          + System.identityHashCode(getPeerConnection())
           + " to "
           + getPeer().getId()
           + " disconnected? "


### PR DESCRIPTION
Testing a theory with EthPeer disconnects. From looking at logs, there's a spot in the code where it seems that duplicate connection is detected and disconnected, while the EthPeer is being created and added, so that by the time it is added, it's already disconnected.

This may not be the most elegant solution but I'm running it up and it seems to work but does create an issue with the callbacks - but I think the callback issue might be there anyway.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).