### PR TITLE
log execution errors at right level, stops transition message propagation post-merge sync

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -84,7 +84,7 @@ public class PostMergeContext implements MergeContext {
 
   @Override
   public void setIsPostMerge(final Difficulty totalDifficulty) {
-    if (isPostMerge.get().orElse(Boolean.FALSE) && lastFinalized.get() != null) {
+    if (isPostMerge.get().orElse(Boolean.FALSE)) {
       // if we have finalized, we never switch back to a pre-merge once we have transitioned
       // post-TTD.
       return;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -66,7 +66,7 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
             cf.complete(
                 resp.otherwise(
                         t -> {
-                          LOG.debug(
+                          LOG.error(
                               String.format("failed to exec consensus method %s", this.getName()),
                               t);
                           return new JsonRpcErrorResponse(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -511,7 +511,8 @@ public class BlockPropagationManager {
   }
 
   private void reactToTTDReachedEvent(final boolean ttdReached) {
-    if (ttdReached) {
+    if (started.get() && ttdReached) {
+      LOG.info("Block propagation was running, then ttd reached, stopping");
       stop();
     } else if (!started.get()) {
       start();


### PR DESCRIPTION
log execution errors at right level, stops transition message propagation post-merge sync

