### PR TITLE
Remove hash to append from the queue only if the step succeeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add a PoS block header rule to check that the current block is more recent than its parent [#4066](https://github.com/hyperledger/besu/pull/4066)
 - Fixed a trie log layer issue on bonsai during reorg [#4069](https://github.com/hyperledger/besu/pull/4069)
 - Fix transition protocol schedule to return the pre Merge schedule when reorg pre TTD [#4078](https://github.com/hyperledger/besu/pull/4078)
+- Remove hash to sync from the queue only if the sync step succeeds [#4105](https://github.com/hyperledger/besu/pull/4105)
 
 ## 22.7.0-RC1
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardChain.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardChain.java
@@ -188,7 +188,13 @@ public class BackwardChain {
   }
 
   public synchronized Optional<Hash> getFirstHashToAppend() {
-    return Optional.ofNullable(hashesToAppend.poll());
+    return Optional.ofNullable(hashesToAppend.peek());
+  }
+
+  public synchronized void removeFromHashToAppend(final Hash hashToRemove) {
+    if (hashesToAppend.contains(hashToRemove)) {
+      hashesToAppend.remove(hashToRemove);
+    }
   }
 
   public void addBadChainToManager(final BadBlockManager badBlocksManager, final Hash hash) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncAlgorithm.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncAlgorithm.java
@@ -56,7 +56,13 @@ public class BackwardsSyncAlgorithm {
   public CompletableFuture<Void> pickNextStep() {
     final Optional<Hash> firstHash = context.getBackwardChain().getFirstHashToAppend();
     if (firstHash.isPresent()) {
-      return executeSyncStep(firstHash.get());
+      return executeSyncStep(firstHash.get())
+          .whenComplete(
+              (result, throwable) -> {
+                if (throwable == null) {
+                  context.getBackwardChain().removeFromHashToAppend(firstHash.get());
+                }
+              });
     }
     if (!context.isReady()) {
       return waitForReady();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/InMemoryBackwardChainTest.java
@@ -138,12 +138,15 @@ public class InMemoryBackwardChainTest {
     firstHash = backwardChain.getFirstHashToAppend();
     assertThat(firstHash).isPresent();
     assertThat(firstHash.orElseThrow()).isEqualTo(blocks.get(7).getHash());
+    backwardChain.removeFromHashToAppend(firstHash.get());
     firstHash = backwardChain.getFirstHashToAppend();
     assertThat(firstHash).isPresent();
     assertThat(firstHash.orElseThrow()).isEqualTo(blocks.get(9).getHash());
+    backwardChain.removeFromHashToAppend(firstHash.get());
     firstHash = backwardChain.getFirstHashToAppend();
     assertThat(firstHash).isPresent();
     assertThat(firstHash.orElseThrow()).isEqualTo(blocks.get(11).getHash());
+    backwardChain.removeFromHashToAppend(firstHash.get());
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

In case of an error the first hash to fetch is lost, and then the backward sync tries to go ahead and start a forward sync.
Sample log 
[first-hash-not-retry.txt](https://github.com/hyperledger/besu/files/9112753/first-hash-not-retry.txt)

This PR remove the hash from the queue only when its successfully fetched

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).