### PR TITLE
increase the default max message size for p2p messages

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
@@ -23,7 +23,7 @@ import com.google.common.base.MoreObjects;
 
 public class EthProtocolConfiguration {
 
-  public static final int DEFAULT_MAX_MESSAGE_SIZE = 20 * ByteUnits.MEGABYTE;
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 15 * ByteUnits.MEGABYTE;
   public static final int DEFAULT_MAX_GET_BLOCK_HEADERS = 192;
   public static final int DEFAULT_MAX_GET_BLOCK_BODIES = 128;
   public static final int DEFAULT_MAX_GET_RECEIPTS = 256;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
@@ -23,7 +23,7 @@ import com.google.common.base.MoreObjects;
 
 public class EthProtocolConfiguration {
 
-  public static final int DEFAULT_MAX_MESSAGE_SIZE = 10 * ByteUnits.MEGABYTE;
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 20 * ByteUnits.MEGABYTE;
   public static final int DEFAULT_MAX_GET_BLOCK_HEADERS = 192;
   public static final int DEFAULT_MAX_GET_BLOCK_BODIES = 128;
   public static final int DEFAULT_MAX_GET_RECEIPTS = 256;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/EthProtocolConfiguration.java
@@ -23,7 +23,7 @@ import com.google.common.base.MoreObjects;
 
 public class EthProtocolConfiguration {
 
-  public static final int DEFAULT_MAX_MESSAGE_SIZE = 15 * ByteUnits.MEGABYTE;
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 10 * ByteUnits.MEGABYTE;
   public static final int DEFAULT_MAX_GET_BLOCK_HEADERS = 192;
   public static final int DEFAULT_MAX_GET_BLOCK_BODIES = 128;
   public static final int DEFAULT_MAX_GET_RECEIPTS = 256;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -71,8 +71,6 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   private final Blockchain blockchain;
   private final BlockBroadcaster blockBroadcaster;
   private final List<PeerValidator> peerValidators;
-  // The max size of messages (in bytes)
-  private final int maxMessageSize;
   private final Optional<MergePeerFilter> mergePeerFilter;
 
   public EthProtocolManager(
@@ -93,7 +91,6 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     this.peerValidators = peerValidators;
     this.scheduler = scheduler;
     this.blockchain = blockchain;
-    this.maxMessageSize = ethereumWireProtocolConfiguration.getMaxMessageSize();
     this.mergePeerFilter = mergePeerFilter;
     this.shutdown = new CountDownLatch(1);
     this.genesisHash = blockchain.getBlockHashByNumber(0L).orElse(Hash.ZERO);
@@ -250,17 +247,6 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       return;
     }
 
-    if (messageData.getSize() > maxMessageSize) {
-      LOG.warn(
-          "Received message (code: {}) exceeding size limit of {} bytes: {} bytes. Disconnecting from {}",
-          Integer.toString(code, 16),
-          maxMessageSize,
-          messageData.getSize(),
-          ethPeer);
-      ethPeer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
-      return;
-    }
-
     // Handle STATUS processing
     if (code == EthPV62.STATUS) {
       handleStatusMessage(ethPeer, messageData);
@@ -391,7 +377,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             status.genesisHash());
         peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
       } else if (mergePeerFilter.isPresent()) {
-        boolean disconnected = mergePeerFilter.get().disconnectIfPoW(status, peer);
+        final boolean disconnected = mergePeerFilter.get().disconnectIfPoW(status, peer);
         if (disconnected) {
           handleDisconnect(peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED, false);
         }
@@ -422,7 +408,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   }
 
   public List<Bytes> getForkIdAsBytesList() {
-    ForkId chainHeadForkId = forkIdManager.getForkIdForChainHead();
+    final ForkId chainHeadForkId = forkIdManager.getForkIdForChainHead();
     return chainHeadForkId == null
         ? Collections.emptyList()
         : chainHeadForkId.getForkIdAsBytesList();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -203,27 +203,8 @@ public final class EthProtocolManagerTest {
   }
 
   @Test
-  public void disconnectOnVeryLargeMessage() {
-    try (final EthProtocolManager ethManager =
-        EthProtocolManagerTestUtil.create(
-            blockchain,
-            () -> false,
-            protocolContext.getWorldStateArchive(),
-            transactionPool,
-            EthProtocolConfiguration.defaultConfig())) {
-      final MessageData messageData = mock(MessageData.class);
-      when(messageData.getSize()).thenReturn(EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE + 1);
-      when(messageData.getCode()).thenReturn(EthPV62.TRANSACTIONS);
-      final MockPeerConnection peer = setupPeer(ethManager, (cap, msg, conn) -> {});
-
-      ethManager.processMessage(EthProtocol.ETH63, new DefaultMessage(peer, messageData));
-      assertThat(peer.isDisconnected()).isTrue();
-    }
-  }
-
-  @Test
   public void disconnectNewPoWPeers() {
-    MergePeerFilter mergePeerFilter = new MergePeerFilter();
+    final MergePeerFilter mergePeerFilter = new MergePeerFilter();
     try (final EthProtocolManager ethManager =
         EthProtocolManagerTestUtil.create(
             blockchain,
@@ -1119,7 +1100,7 @@ public final class EthProtocolManagerTest {
 
   @Test
   public void forkIdForChainHeadMayBeNull() {
-    EthScheduler ethScheduler = mock(EthScheduler.class);
+    final EthScheduler ethScheduler = mock(EthScheduler.class);
     try (final EthProtocolManager ethManager =
         EthProtocolManagerTestUtil.create(
             blockchain,


### PR DESCRIPTION
The current limit means that we are disconnecting useful peers during syncing.

Signed-off-by: Stefan <stefan.pingel@consensys.net>
