### PR TITLE
Check status of block propagation manager before starting or stopping

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -179,7 +179,12 @@ public class DefaultSynchronizer implements Synchronizer {
   public CompletableFuture<Void> start() {
     if (running.compareAndSet(false, true)) {
       LOG.info("Starting synchronizer.");
-      blockPropagationManager.ifPresent(BlockPropagationManager::start);
+      blockPropagationManager.ifPresent(
+          manager -> {
+            if (!manager.isRunning()) {
+              manager.start();
+            }
+          });
       CompletableFuture<Void> future;
       if (fastSyncDownloader.isPresent()) {
         future = fastSyncDownloader.get().start().thenCompose(this::handleSyncResult);
@@ -201,7 +206,12 @@ public class DefaultSynchronizer implements Synchronizer {
       fastSyncDownloader.ifPresent(FastSyncDownloader::stop);
       fullSyncDownloader.ifPresent(FullSyncDownloader::stop);
       maybePruner.ifPresent(Pruner::stop);
-      blockPropagationManager.ifPresent(BlockPropagationManager::stop);
+      blockPropagationManager.ifPresent(
+          manager -> {
+            if (manager.isRunning()) {
+              manager.stop();
+            }
+          });
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description
In `DefaultSynchronizer` check if the `BlockPropagationManager` is running before starting or stopping it. This avoids an exception or warning if it is started or stopped more than once respectively.

## Fixed Issue(s)
fixes #4121

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).