### PR TITLE
Useful response improves reputation

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -215,6 +215,10 @@ public class EthPeer implements Comparable<EthPeer> {
     reputation.recordUselessResponse(System.currentTimeMillis()).ifPresent(this::disconnect);
   }
 
+  public void recordUsefulResponse() {
+    reputation.recordUsefulResposne();
+  }
+
   public void disconnect(final DisconnectReason reason) {
     connection.disconnect(reason);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.manager;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer.DisconnectCallback;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.permissioning.NodeMessagePermissioningProvider;
@@ -115,6 +116,12 @@ public class EthPeers {
       disconnectCallbacks.forEach(callback -> callback.onDisconnect(peer));
       peer.handleDisconnect();
       abortPendingRequestsAssignedToDisconnectedPeers();
+      final PeerInfo peerInfo = peer.getConnection().getPeerInfo();
+      LOG.debug(
+          "Disconnected EthPeer {}, client ID: {}, {}",
+          peerInfo.getNodeId(),
+          peerInfo.getClientId(),
+          peer.getReputation());
     }
     reattemptPendingPeerRequests();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -44,7 +44,7 @@ public class PeerReputation implements Comparable<PeerReputation> {
   private static final int SMALL_ADJUSTMENT = 1;
   private static final int LARGE_ADJUSTMENT = 10;
 
-  private int score = DEFAULT_SCORE;
+  private long score = DEFAULT_SCORE;
 
   public Optional<DisconnectReason> recordRequestTimeout(final int requestCode) {
     final int newTimeoutCount = getOrCreateTimeoutCount(requestCode).incrementAndGet();
@@ -100,6 +100,6 @@ public class PeerReputation implements Comparable<PeerReputation> {
 
   @Override
   public int compareTo(final @Nonnull PeerReputation otherReputation) {
-    return Integer.compare(this.score, otherReputation.score);
+    return Long.compare(this.score, otherReputation.score);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -85,6 +85,10 @@ public class PeerReputation implements Comparable<PeerReputation> {
     }
   }
 
+  public void recordUsefulResposne() {
+    score += SMALL_ADJUSTMENT;
+  }
+
   private boolean shouldRemove(final Long timestamp, final long currentTimestamp) {
     return timestamp != null && timestamp + USELESS_RESPONSE_WINDOW_IN_MILLIS < currentTimestamp;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
@@ -105,7 +105,11 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
     }
     try {
       final Optional<R> result = processResponse(streamClosed, message, peer);
-      result.ifPresent(promise::complete);
+      result.ifPresent(
+          r -> {
+            promise.complete(r);
+            peer.recordUsefulResponse();
+          });
     } catch (final RLPException e) {
       // Peer sent us malformed data - disconnect
       LOG.debug("Disconnecting with BREACH_OF_PROTOCOL due to malformed message: {}", peer, e);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
@@ -362,6 +362,14 @@ public class EthPeerTest {
     assertThat(peer2.compareTo(peer1)).isEqualTo(-1);
   }
 
+  @Test
+  public void recordUsefullResponse() {
+    final EthPeer peer = createPeer();
+    final EthPeer peer2 = createPeer();
+    peer.recordUsefulResponse();
+    assertThat(peer.getReputation().compareTo(peer2.getReputation())).isGreaterThan(0);
+  }
+
   private void messageStream(
       final ResponseStreamSupplier getStream,
       final MessageData targetMessage,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
@@ -80,4 +80,10 @@ public class PeerReputationTest {
                 1001 + PeerReputation.USELESS_RESPONSE_WINDOW_IN_MILLIS + 1))
         .isEmpty();
   }
+
+  @Test
+  public void shouldIncreaseScore() {
+    reputation.recordUsefulResposne();
+    assertThat(reputation.compareTo(new PeerReputation())).isGreaterThan(0);
+  }
 }


### PR DESCRIPTION
Currently there is no way for peers improve their reputation. With this PR peers improve their reputation when they send a useful response.

Signed-off-by: Stefan <stefan.pingel@consensys.net>
