### PR TITLE
Update RocksDB default block cache size

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 public class RocksDBCLIOptions {
 
   public static final int DEFAULT_MAX_OPEN_FILES = 1024;
-  public static final long DEFAULT_CACHE_CAPACITY = 8388608;
+  public static final long DEFAULT_CACHE_CAPACITY = 134217728;
   public static final int DEFAULT_MAX_BACKGROUND_COMPACTIONS = 4;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 4;
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -42,7 +42,7 @@ public class RocksDBCLIOptions {
   @CommandLine.Option(
       names = {CACHE_CAPACITY_FLAG},
       hidden = true,
-      defaultValue = "8388608",
+      defaultValue = "134217728",
       paramLabel = "<LONG>",
       description = "Cache capacity of RocksDB (default: ${DEFAULT-VALUE})")
   long cacheCapacity;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -66,6 +66,9 @@ public class RocksDBColumnarKeyValueStorage
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBColumnarKeyValueStorage.class);
   private static final String DEFAULT_COLUMN = "default";
   private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
+  private static final int ROCKSDB_FORMAT_VERSION = 5;
+  private static final long ROCKSDB_BLOCK_SIZE = 32768;
+  private static final long ROCKSDB_BLOCK_CACHE_SIZE = 134217728;
 
   static {
     RocksDbUtil.loadNativeLibrary();
@@ -148,13 +151,13 @@ public class RocksDBColumnarKeyValueStorage
   }
 
   private BlockBasedTableConfig createBlockBasedTableConfig(final RocksDBConfiguration config) {
-    final LRUCache cache = new LRUCache(config.getCacheCapacity());
+    final LRUCache cache = new LRUCache(ROCKSDB_BLOCK_CACHE_SIZE);
     return new BlockBasedTableConfig()
         .setBlockCache(cache)
-        .setFormatVersion(5)
+        .setFormatVersion(ROCKSDB_FORMAT_VERSION)
         .setOptimizeFiltersForMemory(true)
         .setCacheIndexAndFilterBlocks(true)
-        .setBlockSize(32768);
+        .setBlockSize(ROCKSDB_BLOCK_SIZE);
   }
 
   @Override

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -68,7 +68,6 @@ public class RocksDBColumnarKeyValueStorage
   private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
   private static final int ROCKSDB_FORMAT_VERSION = 5;
   private static final long ROCKSDB_BLOCK_SIZE = 32768;
-  private static final long ROCKSDB_BLOCK_CACHE_SIZE = 134217728;
 
   static {
     RocksDbUtil.loadNativeLibrary();
@@ -151,7 +150,7 @@ public class RocksDBColumnarKeyValueStorage
   }
 
   private BlockBasedTableConfig createBlockBasedTableConfig(final RocksDBConfiguration config) {
-    final LRUCache cache = new LRUCache(ROCKSDB_BLOCK_CACHE_SIZE);
+    final LRUCache cache = new LRUCache(config.getCacheCapacity());
     return new BlockBasedTableConfig()
         .setBlockCache(cache)
         .setFormatVersion(ROCKSDB_FORMAT_VERSION)


### PR DESCRIPTION
Update RocksDB default block cache size to mitigate a performance regression from #3985.


Signed-off-by: Ameziane H <ameziane.hamlat@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

We can see in the dashboard below that we have some blocks behind with the RocksDB block cache default value 8 MB, and Besu with block cache size 128 MB is performing better (no blocks behind).

<img width="1672" alt="image" src="https://user-images.githubusercontent.com/5099602/179716882-198371bf-97d5-4ed2-a725-6a802830f4ac.png">


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#4128
## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).