### PR TITLE
Filter out the periodic log message "Refreshing DNS records with ..."

### DIFF
--- a/besu/src/main/resources/log4j2.xml
+++ b/besu/src/main/resources/log4j2.xml
@@ -39,6 +39,9 @@
     </Appenders>
     <Loggers>
         <Logger name="org.apache.logging.log4j.status.StatusLogger" level="OFF"/>
+        <Logger name="org.apache.tuweni.discovery.DNSTimerTask">
+            <RegexFilter regex="Refreshing DNS records with .*" onMatch="DENY" onMismatch="NEUTRAL" />
+        </Logger>
         <Root level="${sys:root.log.level}">
             <AppenderRef ref="Router" />
         </Root>


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description

Filters out the log message `Refreshing DNS records with...` which is printed once per minute, to reduce the noise in the logs

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).