### PR TITLE
Change expiration for JWT authentification of engine port to 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Optimize the backward sync retry strategy [#4095](https://github.com/hyperledger/besu/pull/4095)
 - Add support for jemalloc library to better handle rocksdb memory consumption [#4126](https://github.com/hyperledger/besu/pull/4126)
 - RocksDB configuration changes to improve performance. [#4132](https://github.com/hyperledger/besu/pull/4132)
+- Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 
 ### Bug Fixes
 - Changed max message size in the p2p layer to 16.7MB from 10MB to improve peering performance [#4120](https://github.com/hyperledger/besu/pull/4120)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 22.7.0
 
 ### Additions and Improvements
+- Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 
 ### Bug Fixes
 
@@ -15,7 +16,6 @@
 - Optimize the backward sync retry strategy [#4095](https://github.com/hyperledger/besu/pull/4095)
 - Add support for jemalloc library to better handle rocksdb memory consumption [#4126](https://github.com/hyperledger/besu/pull/4126)
 - RocksDB configuration changes to improve performance. [#4132](https://github.com/hyperledger/besu/pull/4132)
-- Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 
 ### Bug Fixes
 - Changed max message size in the p2p layer to 16.7MB from 10MB to improve peering performance [#4120](https://github.com/hyperledger/besu/pull/4120)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
@@ -44,6 +44,8 @@ import org.slf4j.LoggerFactory;
 public class EngineAuthService implements AuthenticationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineAuthService.class);
+  private static final int JWT_EXPIRATION_TIME = 60;
+
   private final JWTAuth jwtAuthProvider;
 
   public EngineAuthService(final Vertx vertx, final Optional<File> signingKey, final Path datadir) {
@@ -167,6 +169,6 @@ public class EngineAuthService implements AuthenticationService {
   private boolean issuedRecently(final long iat) {
     long iatSecondsSinceEpoch = iat;
     long nowSecondsSinceEpoch = System.currentTimeMillis() / 1000;
-    return (Math.abs((nowSecondsSinceEpoch - iatSecondsSinceEpoch)) <= 5);
+    return (Math.abs((nowSecondsSinceEpoch - iatSecondsSinceEpoch)) <= JWT_EXPIRATION_TIME);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthServiceTest.java
@@ -110,15 +110,10 @@ public class EngineAuthServiceTest {
     assertThat(auth).isNotNull();
     JWTAuth jwtAuth = auth.getJwtAuthProvider();
     String token =
-        jwtAuth.generateToken(new JsonObject().put("iat", (System.currentTimeMillis() / 1000) - 6));
+        jwtAuth.generateToken(
+            new JsonObject().put("iat", (System.currentTimeMillis() / 1000) - 61));
 
-    Handler<Optional<User>> authHandler =
-        new Handler<Optional<User>>() {
-          @Override
-          public void handle(final Optional<User> event) {
-            assertThat(event).isEmpty();
-          }
-        };
+    Handler<Optional<User>> authHandler = event -> assertThat(event).isEmpty();
     auth.authenticate(token, authHandler);
   }
 }


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description

The engine specification has changed the expiration time of JWT tokens. Before it as 5 seconds, now it is 60 seconds. This PR reflects this change in the spec.

https://github.com/ethereum/execution-apis/pull/256

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).