### PR TITLE
Allow to set any value for baseFeePerGas in the genesis file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 
 ### Bug Fixes
+- Allow to set any value for baseFeePerGas in the genesis file [#4177](https://github.com/hyperledger/besu/pull/4177)
+
+### Bug Fixes
 
 ## 22.7.0-RC2
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
@@ -32,7 +32,7 @@ public class LondonFeeMarket implements BaseFeeMarket {
       GenesisConfigFile.BASEFEE_AT_GENESIS_DEFAULT_VALUE;
   static final long DEFAULT_BASEFEE_MAX_CHANGE_DENOMINATOR = 8L;
   static final long DEFAULT_SLACK_COEFFICIENT = 2L;
-  private static final Wei DEFAULT_BASEFEE_FLOOR = Wei.of(7L);
+  private static final Wei DEFAULT_BASEFEE_FLOOR = Wei.of(1L);
   private static final Logger LOG = LoggerFactory.getLogger(LondonFeeMarket.class);
 
   private final Wei baseFeeInitialValue;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
@@ -39,7 +39,7 @@ public class LondonFeeMarket implements BaseFeeMarket {
   private final Wei baseFeeInitialValue;
   private final long londonForkBlockNumber;
   private final TransactionPriceCalculator txPriceCalculator;
-  private Wei baseFeeFloor = DEFAULT_BASEFEE_FLOOR;
+  private final Wei baseFeeFloor;
 
   public LondonFeeMarket(final long londonForkBlockNumber) {
     this(londonForkBlockNumber, Optional.empty());
@@ -50,14 +50,7 @@ public class LondonFeeMarket implements BaseFeeMarket {
     this.txPriceCalculator = TransactionPriceCalculator.eip1559();
     this.londonForkBlockNumber = londonForkBlockNumber;
     this.baseFeeInitialValue = baseFeePerGasOverride.orElse(DEFAULT_BASEFEE_INITIAL_VALUE);
-    if (baseFeeInitialValue.isZero()) {
-      baseFeeFloor = Wei.ZERO;
-    } else if (baseFeeInitialValue.lessThan(DEFAULT_BASEFEE_FLOOR)) {
-      throw new IllegalStateException(
-          String.format(
-              "baseFee must be either 0 or > %s wei to avoid integer arithmetic issues",
-              DEFAULT_BASEFEE_FLOOR));
-    }
+    this.baseFeeFloor = baseFeeInitialValue.isZero() ? Wei.ZERO : DEFAULT_BASEFEE_FLOOR;
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
@@ -32,7 +32,7 @@ public class LondonFeeMarket implements BaseFeeMarket {
       GenesisConfigFile.BASEFEE_AT_GENESIS_DEFAULT_VALUE;
   static final long DEFAULT_BASEFEE_MAX_CHANGE_DENOMINATOR = 8L;
   static final long DEFAULT_SLACK_COEFFICIENT = 2L;
-  private static final Wei DEFAULT_BASEFEE_FLOOR = Wei.of(1L);
+  private static final Wei DEFAULT_BASEFEE_FLOOR = Wei.of(7L);
   private static final Logger LOG = LoggerFactory.getLogger(LondonFeeMarket.class);
 
   private final Wei baseFeeInitialValue;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarket.java
@@ -32,7 +32,6 @@ public class LondonFeeMarket implements BaseFeeMarket {
       GenesisConfigFile.BASEFEE_AT_GENESIS_DEFAULT_VALUE;
   static final long DEFAULT_BASEFEE_MAX_CHANGE_DENOMINATOR = 8L;
   static final long DEFAULT_SLACK_COEFFICIENT = 2L;
-  // required for integer arithmetic to work when baseFee > 0
   private static final Wei DEFAULT_BASEFEE_FLOOR = Wei.of(7L);
   private static final Logger LOG = LoggerFactory.getLogger(LondonFeeMarket.class);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.mainnet.feemarket;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
@@ -71,11 +70,5 @@ public class LondonFeeMarketTest {
 
     final LondonFeeMarket londonFeeMarket = new LondonFeeMarket(0, Optional.of(Wei.ZERO));
     assertThat(londonFeeMarket.satisfiesFloorTxCost(transaction)).isTrue();
-  }
-
-  @Test
-  public void throwsWhenBaseFeeOverrideIsNonZeroAndBelowFloor() {
-    assertThatThrownBy(() -> new LondonFeeMarket(0, Optional.of(Wei.of(6))))
-        .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
@@ -49,7 +49,7 @@ public class LondonFeeMarketTest {
     final Transaction transaction =
         new TransactionTestFixture()
             .type(TransactionType.EIP1559)
-            .maxFeePerGas(Optional.of(Wei.of(0)))
+            .maxFeePerGas(Optional.of(Wei.of(6)))
             .maxPriorityFeePerGas(Optional.of(Wei.of(0)))
             .gasPrice(null)
             .createTransaction(KEY_PAIR1);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/LondonFeeMarketTest.java
@@ -49,7 +49,7 @@ public class LondonFeeMarketTest {
     final Transaction transaction =
         new TransactionTestFixture()
             .type(TransactionType.EIP1559)
-            .maxFeePerGas(Optional.of(Wei.of(6)))
+            .maxFeePerGas(Optional.of(Wei.of(0)))
             .maxPriorityFeePerGas(Optional.of(Wei.of(0)))
             .gasPrice(null)
             .createTransaction(KEY_PAIR1);


### PR DESCRIPTION
Also made baseFeeFloor final.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Even if not pratical on mainnet or main testnes, in theory in the genesis file, the `baseFeePerGas` field could be set to any Wei value, for example it could be 1 Wei, as done in the Hive test `consensus/checkGasLimit_London`.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes  Hive test `consensus/checkGasLimit_London`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).