### PR TITLE
Switching info to trace on several noisey logs during sync.

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -262,7 +262,7 @@ public class FastSyncActions {
         .getHeader()
         .thenApply(
             blockHeader -> {
-              LOG.info(
+              LOG.trace(
                   "Successfully downloaded pivot block header by hash: {}",
                   blockHeader.toLogString());
               return new FastSyncState(blockHeader);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromFinalizedBlock.java
@@ -53,7 +53,7 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
   }
 
   private FastSyncState selectLastFinalizedBlockAsPivot(final Hash finalizedHash) {
-    LOG.info("Returning finalized block hash as pivot: {}", finalizedHash);
+    LOG.trace("Returning finalized block hash as pivot: {}", finalizedHash);
     return new FastSyncState(finalizedHash);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/TransitionPivotSelector.java
@@ -63,7 +63,7 @@ public class TransitionPivotSelector implements PivotBlockSelector {
     Difficulty bestPeerEstDifficulty = peer.chainState().getEstimatedTotalDifficulty();
 
     if (finalizedBlockHashSupplier.get().isPresent()) {
-      LOG.info("A finalized block is present, use it as pivot");
+      LOG.trace("A finalized block is present, use it as pivot");
       return pivotSelectorFromFinalizedBlock.selectNewPivotBlock(peer);
     }
 


### PR DESCRIPTION
Signed-off-by: matt-nelson-csi <matt.nelson@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
Fixes #4182 - switches info to trace on the three noisy Sync commands 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).