### PR TITLE
Only stop block propagation, not tx handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## 22.7.0
+
+### Additions and Improvements
+
+### Bug Fixes
+
+
+## 22.7.0-RC3
 Known/Outstanding issues:
 Besu requires a restart post-merge to re-enable remote transaction processing [#3890](https://github.com/hyperledger/besu/issues/3890)
 
@@ -14,6 +21,10 @@ Besu requires a restart post-merge to re-enable remote transaction processing [#
 ### Bug Fixes
 - fix for stack overflow when searching for TTD block [#4169](https://github.com/hyperledger/besu/pull/4169)
 - fix for chain stuck issue [#4175](https://github.com/hyperledger/besu/pull/4175)
+
+### Download links
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC3/besu-22.7.0-RC3.tar.gz / sha256: `6a1ee89c82db9fa782d34733d8a8c726670378bcb71befe013da48d7928490a6`
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC3/besu-22.7.0-RC3.zip / sha256: `5de22445ab2a270cf33e1850cd28f1946442b7104738f0d1ac253a009c53414e`
 
 ## 22.7.0-RC2
 
@@ -43,8 +54,8 @@ Besu requires a restart post-merge to re-enable remote transaction processing [#
 - Avoid starting or stopping the BlockPropagationManager more than once [#4122](https://github.com/hyperledger/besu/pull/4122)
 
 ### Download links
-- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC2/besu-22.7.0-RC2.tar.gz / sha256: `//FIXME`
-- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC2/besu-22.7.0-RC2.zip / sha256: `//FIXME`
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC2/besu-22.7.0-RC2.tar.gz / sha256: `befe15b893820c9c6451a74fd87b41f555ff28561494b3bebadd5da5c7ce25d3`
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC2/besu-22.7.0-RC2.zip / sha256: `d56c340f5982b882fbecca2697ca72a5bbefe0e978d2d4504211f012e2242a81`
 
 ## 22.7.0-RC1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 
 ## 22.7.0
+Known/Outstanding issues:
+Besu requires a restart post-merge to re-enable remote transaction processing [#3890](https://github.com/hyperledger/besu/issues/3890)
+
 
 ### Additions and Improvements
 - Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
+- Sepolia mergeNetSplit block [#4158](https://github.com/hyperledger/besu/pull/4158)
+- Goerli TTD [#4160](https://github.com/hyperledger/besu/pull/4160) 
+- Several logging improvements 
 
 ### Bug Fixes
+- fix for stack overflow when searching for TTD block [#4169](https://github.com/hyperledger/besu/pull/4169)
+- fix for chain stuck issue [#4175](https://github.com/hyperledger/besu/pull/4175)
 
 ## 22.7.0-RC2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Additions and Improvements
 
-### Bug Fixes
+### Bug Fixes 
+
+Fixes previous known issue [#3890](https://github.com/hyperledger/besu/issues/3890)
+from RC3 requiring a restart post-merge to continue correct transaction handling.
 
 
 ## 22.7.0-RC3

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthMessages.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthMessages.java
@@ -17,9 +17,13 @@ package org.hyperledger.besu.ethereum.eth.manager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.annotations.VisibleForTesting;
 
 public class EthMessages {
   private final Map<Integer, Subscribers<MessageCallback>> listenersByCode =
@@ -47,15 +51,24 @@ public class EthMessages {
         .subscribe(callback);
   }
 
-  public void unsubsribe(final long id) {
-    for (Subscribers<MessageCallback> subscribers : listenersByCode.values()) {
-      subscribers.unsubscribe(id);
+  public void unsubscribe(final long subscriptionId, final int messageCode) {
+    if (listenersByCode.containsKey(messageCode)) {
+      listenersByCode.get(messageCode).unsubscribe(subscriptionId);
+      listenersByCode.remove(messageCode);
     }
   }
 
   public void registerResponseConstructor(
       final int messageCode, final MessageResponseConstructor messageResponseConstructor) {
     messageResponseConstructorsByCode.put(messageCode, messageResponseConstructor);
+  }
+
+  @VisibleForTesting
+  public List<Integer> messageCodesHandled() {
+    List<Integer> retval = new ArrayList<>();
+    retval.addAll(messageResponseConstructorsByCode.keySet());
+    retval.addAll(listenersByCode.keySet());
+    return retval;
   }
 
   @FunctionalInterface

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthMessages.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthMessages.java
@@ -54,7 +54,9 @@ public class EthMessages {
   public void unsubscribe(final long subscriptionId, final int messageCode) {
     if (listenersByCode.containsKey(messageCode)) {
       listenersByCode.get(messageCode).unsubscribe(subscriptionId);
-      listenersByCode.remove(messageCode);
+      if (listenersByCode.get(messageCode).getSubscriberCount() < 1) {
+        listenersByCode.remove(messageCode);
+      }
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -107,7 +107,7 @@ public class EthPeers {
             clock,
             permissioningProviders);
     final EthPeer ethPeer = connections.putIfAbsent(peerConnection, peer);
-    LOG.debug("Adding new EthPeer {}", ethPeer);
+    LOG.debug("Adding new EthPeer {} {}", peer.getShortNodeId(), ethPeer == null ? "for the first time" : "");
   }
 
   public void registerDisconnect(final PeerConnection connection) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -107,7 +107,10 @@ public class EthPeers {
             clock,
             permissioningProviders);
     final EthPeer ethPeer = connections.putIfAbsent(peerConnection, peer);
-    LOG.debug("Adding new EthPeer {} {}", peer.getShortNodeId(), ethPeer == null ? "for the first time" : "");
+    LOG.debug(
+        "Adding new EthPeer {} {}",
+        peer.getShortNodeId(),
+        ethPeer == null ? "for the first time" : "");
   }
 
   public void registerDisconnect(final PeerConnection connection) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -144,8 +144,9 @@ public class BlockPropagationManager {
 
   private void clearListeners() {
     onBlockAddedSId.ifPresent(id -> protocolContext.getBlockchain().removeObserver(id));
-    newBlockSId.ifPresent(id -> ethContext.getEthMessages().unsubsribe(id));
-    newBlockHashesSId.ifPresent(id -> ethContext.getEthMessages().unsubsribe(id));
+    newBlockSId.ifPresent(id -> ethContext.getEthMessages().unsubscribe(id, EthPV62.NEW_BLOCK));
+    newBlockHashesSId.ifPresent(
+        id -> ethContext.getEthMessages().unsubscribe(id, EthPV62.NEW_BLOCK_HASHES));
     onBlockAddedSId = Optional.empty();
     newBlockSId = Optional.empty();
     newBlockHashesSId = Optional.empty();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer.Responder;
+import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
 import org.hyperledger.besu.ethereum.eth.messages.NewBlockHashesMessage;
 import org.hyperledger.besu.ethereum.eth.messages.NewBlockMessage;
 import org.hyperledger.besu.ethereum.eth.sync.state.PendingBlocksManager;
@@ -816,7 +817,7 @@ public abstract class AbstractBlockPropagationManagerTest {
     syncState.setReachedTerminalDifficulty(true);
     assertThat(blockPropagationManager.isRunning()).isFalse();
     assertThat(ethProtocolManager.ethContext().getEthMessages().messageCodesHandled())
-        .doesNotContain(1, 7);
+        .doesNotContain(EthPV62.NEW_BLOCK_HASHES, EthPV62.NEW_BLOCK);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
@@ -815,6 +815,8 @@ public abstract class AbstractBlockPropagationManagerTest {
     blockPropagationManager.start();
     syncState.setReachedTerminalDifficulty(true);
     assertThat(blockPropagationManager.isRunning()).isFalse();
+    assertThat(ethProtocolManager.ethContext().getEthMessages().messageCodesHandled())
+        .doesNotContain(1, 7);
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.7.0-RC3
+version=22.7.0-SNAPSHOT
 
 # Workaround for Java 16 and spotless bug 834 https://github.com/diffplug/spotless/issues/834
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.7.0-SNAPSHOT
+version=22.7.0-RC3
 
 # Workaround for Java 16 and spotless bug 834 https://github.com/diffplug/spotless/issues/834
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION

## PR description

Since there is a Subscribers for each type of message handler in EthMessages, and only on handler, they all get a subscriber id of 1.  This changes the unsubscribe logic to require the caller to specify the message code handler being unsubscribed from, and removes it from the map of handlers.

## Fixed Issue(s)
fixes #3890 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).