### PR TITLE
Accept empty header set in range headers validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 
 ### Bug Fixes
+- Stop producing stack traces when a get headers response only contains the range start header [#4189](https://github.com/hyperledger/besu/pull/4189)
 
 ## 22.7.0-RC2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@
 ### Bug Fixes
 - Stop producing stack traces when a get headers response only contains the range start header [#4189](https://github.com/hyperledger/besu/pull/4189)
 
-
 ## 22.7.0-RC3
-Known/Outstanding issues:
-Besu requires a restart post-merge to re-enable remote transaction processing [#3890](https://github.com/hyperledger/besu/issues/3890)
 
+### Known/Outstanding issues:
+- Besu requires a restart post-merge to re-enable remote transaction processing [#3890](https://github.com/hyperledger/besu/issues/3890)
 
 ### Additions and Improvements
 - Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
@@ -27,7 +26,6 @@ Besu requires a restart post-merge to re-enable remote transaction processing [#
 ### Download links
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC3/besu-22.7.0-RC3.tar.gz / sha256: `6a1ee89c82db9fa782d34733d8a8c726670378bcb71befe013da48d7928490a6`
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.0-RC3/besu-22.7.0-RC3.zip / sha256: `5de22445ab2a270cf33e1850cd28f1946442b7104738f0d1ac253a009c53414e`
-
 
 ## 22.7.0-RC2
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
@@ -14,16 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.range;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.List;
 import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RangeHeaders {
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 
@@ -40,8 +41,8 @@ public class RangeHeaders {
     return headersToImport;
   }
 
-  public BlockHeader getFirstHeaderToImport() {
-    return headersToImport.size() > 0 ? headersToImport.get(0) : null;
+  public Optional<BlockHeader> getFirstHeaderToImport() {
+    return headersToImport.size() > 0 ? Optional.of(headersToImport.get(0)) : Optional.empty();
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeaders.java
@@ -26,17 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RangeHeaders {
-  private static final Logger LOG = LoggerFactory.getLogger(RangeHeaders.class);
 
   private final SyncTargetRange range;
   private final List<BlockHeader> headersToImport;
 
   public RangeHeaders(
       final SyncTargetRange checkpointRange, final List<BlockHeader> headersToImport) {
-    if (headersToImport.isEmpty()) {
-      LOG.debug(String.format("Headers list empty. Range: %s", checkpointRange.toString()));
-    }
-    checkArgument(!headersToImport.isEmpty(), "Must have at least one header to import");
     this.range = checkpointRange;
     this.headersToImport = headersToImport;
   }
@@ -50,7 +45,7 @@ public class RangeHeaders {
   }
 
   public BlockHeader getFirstHeaderToImport() {
-    return headersToImport.get(0);
+    return headersToImport.size() > 0 ? headersToImport.get(0) : null;
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -43,32 +44,35 @@ public class RangeHeadersValidationStep implements Function<RangeHeaders, Stream
   @Override
   public Stream<BlockHeader> apply(final RangeHeaders rangeHeaders) {
     final BlockHeader rangeStart = rangeHeaders.getRange().getStart();
-    final BlockHeader firstHeaderToImport = rangeHeaders.getFirstHeaderToImport();
 
-    if (firstHeaderToImport == null) {
-      return Stream.empty();
-    } else if (isValid(rangeStart, firstHeaderToImport)) {
-      return rangeHeaders.getHeadersToImport().stream();
-    } else {
-      final String rangeEndDescription;
-      if (rangeHeaders.getRange().hasEnd()) {
-        final BlockHeader rangeEnd = rangeHeaders.getRange().getEnd();
-        rangeEndDescription =
-            String.format("#%d (%s)", rangeEnd.getNumber(), rangeEnd.getBlockHash());
-      } else {
-        rangeEndDescription = "chain head";
-      }
-      final String errorMessage =
-          String.format(
-              "Invalid range headers.  Headers downloaded between #%d (%s) and %s do not connect at #%d (%s)",
-              rangeStart.getNumber(),
-              rangeStart.getHash(),
-              rangeEndDescription,
-              firstHeaderToImport.getNumber(),
-              firstHeaderToImport.getHash());
-      throw new InvalidBlockException(
-          errorMessage, firstHeaderToImport.getNumber(), firstHeaderToImport.getHash());
-    }
+    return rangeHeaders
+        .getFirstHeaderToImport()
+        .map(
+            firstHeader -> {
+              if (isValid(rangeStart, firstHeader)) {
+                return rangeHeaders.getHeadersToImport().stream();
+              } else {
+                final String rangeEndDescription;
+                if (rangeHeaders.getRange().hasEnd()) {
+                  final BlockHeader rangeEnd = rangeHeaders.getRange().getEnd();
+                  rangeEndDescription =
+                      String.format("#%d (%s)", rangeEnd.getNumber(), rangeEnd.getBlockHash());
+                } else {
+                  rangeEndDescription = "chain head";
+                }
+                final String errorMessage =
+                    String.format(
+                        "Invalid range headers.  Headers downloaded between #%d (%s) and %s do not connect at #%d (%s)",
+                        rangeStart.getNumber(),
+                        rangeStart.getHash(),
+                        rangeEndDescription,
+                        firstHeader.getNumber(),
+                        firstHeader.getHash());
+                throw new InvalidBlockException(
+                    errorMessage, firstHeader.getNumber(), firstHeader.getHash());
+              }
+            })
+        .orElse(Stream.empty());
   }
 
   private boolean isValid(final BlockHeader expectedParent, final BlockHeader firstHeaderToImport) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
@@ -45,7 +45,9 @@ public class RangeHeadersValidationStep implements Function<RangeHeaders, Stream
     final BlockHeader rangeStart = rangeHeaders.getRange().getStart();
     final BlockHeader firstHeaderToImport = rangeHeaders.getFirstHeaderToImport();
 
-    if (isValid(rangeStart, firstHeaderToImport)) {
+    if (firstHeaderToImport == null) {
+      return Stream.empty();
+    } else if (isValid(rangeStart, firstHeaderToImport)) {
       return rangeHeaders.getHeadersToImport().stream();
     } else {
       final String rangeEndDescription;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersValidationStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersValidationStepTest.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.Before;
@@ -106,5 +107,22 @@ public class RangeHeadersValidationStepTest {
                 + " ("
                 + firstHeader.getHash()
                 + ")");
+  }
+
+  @Test
+  public void acceptResponseWithNoHeaders() {
+    var emptyRangeHeaders =
+        new RangeHeaders(new SyncTargetRange(syncTarget, rangeStart, rangeEnd), List.of());
+
+    final Stream<BlockHeader> result = validationStep.apply(emptyRangeHeaders);
+    assertThat(result).isEmpty();
+
+    verifyNoMoreInteractions(
+        protocolSchedule,
+        protocolSpec,
+        protocolContext,
+        headerValidator,
+        validationPolicy,
+        syncTarget);
   }
 }


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

If a response to the get header P2P request only returns the header that
is the start of the range we may need to trim it to an empty response,
this is breaking the validation response. One client has started
returning only the range header start in some circumstances (which is a
valid response per spec). Because we sometimes request an overlapping
header this results in an empty stream once we cut the duplicates.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).