### PR TITLE
Feature/engine api override

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -305,7 +305,7 @@ public class RunnerBuilder {
 
   public RunnerBuilder engineJsonRpcConfiguration(
       final JsonRpcConfiguration engineJsonRpcConfiguration) {
-    this.engineJsonRpcConfiguration = Optional.of(engineJsonRpcConfiguration);
+    this.engineJsonRpcConfiguration = Optional.ofNullable(engineJsonRpcConfiguration);
     return this;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1933,9 +1933,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     jsonRpcConfiguration =
         jsonRpcConfiguration(
             jsonRPCHttpOptionGroup.rpcHttpPort, jsonRPCHttpOptionGroup.rpcHttpApis, hostsAllowlist);
-    engineJsonRpcConfiguration =
-        createEngineJsonRpcConfiguration(
-            engineRPCOptionGroup.engineRpcPort, engineRPCOptionGroup.engineHostsAllowlist);
+    if (isEngineApiEnabled()) {
+      engineJsonRpcConfiguration =
+          createEngineJsonRpcConfiguration(
+              engineRPCOptionGroup.engineRpcPort, engineRPCOptionGroup.engineHostsAllowlist);
+    }
     p2pTLSConfiguration = p2pTLSConfigOptions.p2pTLSConfiguration(commandLine);
     graphQLConfiguration = graphQLConfiguration();
     webSocketConfiguration =

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -568,9 +568,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   static class EngineRPCOptionGroup {
     @Option(
         names = {"--engine-rpc-enabled"},
-        description = "deprectaed parameter, do not use.",
-        hidden = true)
-    private final Boolean deprecatedIsEngineRpcEnabled = false;
+        description =
+            "enable the engine api, even in the absence of merge-specific configurations.")
+    private final Boolean overrideEngineRpcEnabled = false;
 
     @Option(
         names = {"--engine-rpc-port", "--engine-rpc-http-port"},
@@ -2129,12 +2129,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       final Integer listenPort, final List<String> allowCallsFrom) {
     JsonRpcConfiguration engineConfig =
         jsonRpcConfiguration(listenPort, Arrays.asList("ENGINE", "ETH"), allowCallsFrom);
-    if (engineRPCOptionGroup.deprecatedIsEngineRpcEnabled) {
-      logger.warn(
-          "--engine-api-enabled parameter has been deprecated and will be removed in a future release.  "
-              + "Merge support is implicitly enabled by the presence of terminalTotalDifficulty in the genesis config.");
-    }
-    engineConfig.setEnabled(isMergeEnabled());
+    engineConfig.setEnabled(isEngineApiEnabled());
     if (!engineRPCOptionGroup.isEngineAuthDisabled) {
       engineConfig.setAuthenticationEnabled(true);
       engineConfig.setAuthenticationAlgorithm(JwtAlgorithm.HS256);
@@ -3098,7 +3093,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         effectivePorts,
         jsonRPCWebsocketOptionGroup.rpcWsPort,
         jsonRPCWebsocketOptionGroup.isRpcWsEnabled);
-    addPortIfEnabled(effectivePorts, engineRPCOptionGroup.engineRpcPort, isMergeEnabled());
+    addPortIfEnabled(effectivePorts, engineRPCOptionGroup.engineRpcPort, isEngineApiEnabled());
     addPortIfEnabled(
         effectivePorts, metricsOptionGroup.metricsPort, metricsOptionGroup.isMetricsEnabled);
     addPortIfEnabled(
@@ -3220,6 +3215,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private boolean isMergeEnabled() {
     return MergeConfigOptions.isMergeEnabled();
+  }
+
+  private boolean isEngineApiEnabled() {
+    return engineRPCOptionGroup.overrideEngineRpcEnabled || isMergeEnabled();
   }
 
   public static List<String> getJDKEnabledCypherSuites() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2760,6 +2760,7 @@ public class BesuCommandTest extends CommandTestAbstract {
 
     parseCommand(
         "--rpc-http-enabled",
+        "--engine-rpc-enabled",
         "--rpc-http-host",
         host,
         "--rpc-http-port",

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -44,6 +44,7 @@ random-peer-priority-enabled=false
 host-whitelist=["all"]
 host-allowlist=["all"]
 engine-host-allowlist=["all"]
+engine-rpc-enabled=true
 engine-jwt-disabled=true
 engine-jwt-secret="/tmp/jwt.hex"
 required-blocks=["8675309=123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"]

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecAdapters;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
-import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
@@ -75,9 +74,6 @@ public class MergeProtocolSchedule {
   }
 
   private static BlockHeaderValidator.Builder getBlockHeaderValidator(final FeeMarket feeMarket) {
-    if (!feeMarket.implementsBaseFee()) {
-      throw new RuntimeException("Invalid configuration: missing BaseFeeMarket for merge net");
-    }
-    return MergeValidationRulesetFactory.mergeBlockHeaderValidator((BaseFeeMarket) feeMarket);
+    return MergeValidationRulesetFactory.mergeBlockHeaderValidator(feeMarket);
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecAdapters;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
@@ -74,6 +75,9 @@ public class MergeProtocolSchedule {
   }
 
   private static BlockHeaderValidator.Builder getBlockHeaderValidator(final FeeMarket feeMarket) {
-    return MergeValidationRulesetFactory.mergeBlockHeaderValidator(feeMarket);
+    if (!feeMarket.implementsBaseFee()) {
+      throw new RuntimeException("Invalid configuration: missing BaseFeeMarket for merge net");
+    }
+    return MergeValidationRulesetFactory.mergeBlockHeaderValidator((BaseFeeMarket) feeMarket);
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -36,6 +36,11 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final Bytes32 random,
       final Address feeRecipient);
 
+  @Override
+  default boolean isCompatibleWithEngineApi() {
+    return true;
+  }
+
   Result rememberBlock(final Block block);
 
   Result validateBlock(final Block block);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
 import io.vertx.core.Vertx;
 import org.slf4j.Logger;
@@ -41,13 +42,15 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
   private final Vertx syncVertx;
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
-  protected final Optional<MergeContext> mergeContext;
+  protected final Optional<MergeContext> mergeContextOptional;
+  protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolContext protocolContext;
 
   protected ExecutionEngineJsonRpcMethod(final Vertx vertx, final ProtocolContext protocolContext) {
     this.syncVertx = vertx;
     this.protocolContext = protocolContext;
-    this.mergeContext = protocolContext.safeConsensusContext(MergeContext.class);
+    this.mergeContextOptional = protocolContext.safeConsensusContext(MergeContext.class);
+    this.mergeContext = mergeContextOptional::orElseThrow;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -40,13 +41,13 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
   private final Vertx syncVertx;
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
-  protected final MergeContext mergeContext;
+  protected final Optional<MergeContext> mergeContext;
   protected final ProtocolContext protocolContext;
 
   protected ExecutionEngineJsonRpcMethod(final Vertx vertx, final ProtocolContext protocolContext) {
     this.syncVertx = vertx;
     this.protocolContext = protocolContext;
-    this.mergeContext = protocolContext.getConsensusContext(MergeContext.class);
+    this.mergeContext = protocolContext.safeConsensusContext(MergeContext.class);
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -82,11 +82,13 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
         () -> Json.encodePrettily(remoteTransitionConfiguration));
 
     final Optional<BlockHeader> maybeTerminalPoWBlockHeader =
-        mergeContext.flatMap(c -> c.getTerminalPoWBlock());
+        mergeContextOptional.get().getTerminalPoWBlock();
 
     final EngineExchangeTransitionConfigurationResult localTransitionConfiguration =
         new EngineExchangeTransitionConfigurationResult(
-            mergeContext.map(c -> c.getTerminalTotalDifficulty()).orElse(FALLBACK_TTD_DEFAULT),
+            mergeContextOptional
+                .map(c -> c.getTerminalTotalDifficulty())
+                .orElse(FALLBACK_TTD_DEFAULT),
             maybeTerminalPoWBlockHeader.map(BlockHeader::getHash).orElse(Hash.ZERO),
             maybeTerminalPoWBlockHeader.map(BlockHeader::getNumber).orElse(0L));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -27,11 +27,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchangeTransitionConfigurationResult;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,9 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
   private static final Logger LOG =
       LoggerFactory.getLogger(EngineExchangeTransitionConfiguration.class);
 
+  // use (2^256 - 2^10) if engine is enabled in the absence of a TTD configuration
+  static final Difficulty FALLBACK_TTD_DEFAULT =
+      Difficulty.MAX_VALUE.subtract(UInt256.valueOf(1024L));
   static final long QOS_TIMEOUT_MILLIS = 120000L;
 
   private final QosTimer qosTimer;
@@ -76,11 +81,12 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
         "received transitionConfiguration: {}",
         () -> Json.encodePrettily(remoteTransitionConfiguration));
 
-    final Optional<BlockHeader> maybeTerminalPoWBlockHeader = mergeContext.getTerminalPoWBlock();
+    final Optional<BlockHeader> maybeTerminalPoWBlockHeader =
+        mergeContext.flatMap(c -> c.getTerminalPoWBlock());
 
     final EngineExchangeTransitionConfigurationResult localTransitionConfiguration =
         new EngineExchangeTransitionConfigurationResult(
-            mergeContext.getTerminalTotalDifficulty(),
+            mergeContext.map(c -> c.getTerminalTotalDifficulty()).orElse(FALLBACK_TTD_DEFAULT),
             maybeTerminalPoWBlockHeader.map(BlockHeader::getHash).orElse(Hash.ZERO),
             maybeTerminalPoWBlockHeader.map(BlockHeader::getNumber).orElse(0L));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -73,12 +73,12 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
         Optional.ofNullable(forkChoice.getFinalizedBlockHash())
             .filter(finalized -> !finalized.isZero());
 
-    mergeContext.ifPresent(
-        c ->
-            c.fireNewUnverifiedForkchoiceMessageEvent(
-                forkChoice.getHeadBlockHash(), maybeFinalizedHash, forkChoice.getSafeBlockHash()));
+    mergeContext
+        .get()
+        .fireNewUnverifiedForkchoiceMessageEvent(
+            forkChoice.getHeadBlockHash(), maybeFinalizedHash, forkChoice.getSafeBlockHash());
 
-    if (mergeContext.map(c -> c.isSyncing()).orElse(Boolean.TRUE)) {
+    if (mergeContext.get().isSyncing()) {
       return syncingResponse(requestId, forkChoice);
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -73,10 +73,12 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
         Optional.ofNullable(forkChoice.getFinalizedBlockHash())
             .filter(finalized -> !finalized.isZero());
 
-    mergeContext.fireNewUnverifiedForkchoiceMessageEvent(
-        forkChoice.getHeadBlockHash(), maybeFinalizedHash, forkChoice.getSafeBlockHash());
+    mergeContext.ifPresent(
+        c ->
+            c.fireNewUnverifiedForkchoiceMessageEvent(
+                forkChoice.getHeadBlockHash(), maybeFinalizedHash, forkChoice.getSafeBlockHash()));
 
-    if (mergeContext.isSyncing()) {
+    if (mergeContext.map(c -> c.isSyncing()).orElse(Boolean.TRUE)) {
       return syncingResponse(requestId, forkChoice);
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
@@ -57,7 +57,7 @@ public class EngineGetPayload extends ExecutionEngineJsonRpcMethod {
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
     final PayloadIdentifier payloadId = request.getRequiredParameter(0, PayloadIdentifier.class);
 
-    final Optional<Block> block = mergeContext.retrieveBlockById(payloadId);
+    final Optional<Block> block = mergeContext.flatMap(c -> c.retrieveBlockById(payloadId));
     if (block.isPresent()) {
       var proposal = block.get();
       var proposalHeader = proposal.getHeader();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
@@ -57,7 +57,7 @@ public class EngineGetPayload extends ExecutionEngineJsonRpcMethod {
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
     final PayloadIdentifier payloadId = request.getRequiredParameter(0, PayloadIdentifier.class);
 
-    final Optional<Block> block = mergeContext.flatMap(c -> c.retrieveBlockById(payloadId));
+    final Optional<Block> block = mergeContext.get().retrieveBlockById(payloadId);
     if (block.isPresent()) {
       var proposal = block.get();
       var proposalHeader = proposal.getHeader();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -166,10 +166,10 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
     final var block =
         new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
 
-    if (mergeContext.map(c -> c.isSyncing()).orElse(Boolean.TRUE) || parentHeader.isEmpty()) {
+    if (mergeContext.get().isSyncing() || parentHeader.isEmpty()) {
       LOG.debug(
           "isSyncing: {} parentHeaderMissing: {}, adding {} to backwardsync",
-          mergeContext.map(c -> c.isSyncing()).orElse(null),
+          mergeContext.get().isSyncing(),
           parentHeader.isEmpty(),
           block.getHash());
       mergeCoordinator

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -166,10 +166,10 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
     final var block =
         new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
 
-    if (mergeContext.isSyncing() || parentHeader.isEmpty()) {
+    if (mergeContext.map(c -> c.isSyncing()).orElse(Boolean.TRUE) || parentHeader.isEmpty()) {
       LOG.debug(
           "isSyncing: {} parentHeaderMissing: {}, adding {} to backwardsync",
-          mergeContext.isSyncing(),
+          mergeContext.map(c -> c.isSyncing()).orElse(null),
           parentHeader.isEmpty(),
           block.getHash());
       mergeCoordinator

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.methods;
 
 import org.hyperledger.besu.config.GenesisConfigOptions;
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
@@ -95,6 +94,7 @@ public class JsonRpcMethodsFactory {
                   blockchainQueries, protocolSchedule, metricsSystem, transactionPool, dataDir),
               new EeaJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
+              new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext),
               new GoQuorumJsonRpcPrivacyMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
               new EthJsonRpcMethods(
@@ -126,11 +126,6 @@ public class JsonRpcMethodsFactory {
               new TraceJsonRpcMethods(blockchainQueries, protocolSchedule, privacyParameters),
               new TxPoolJsonRpcMethods(transactionPool),
               new PluginsJsonRpcMethods(namedPlugins));
-
-      if (MergeConfigOptions.isMergeEnabled()) {
-        enabled.putAll(
-            new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext).create(rpcApis));
-      }
 
       for (final JsonRpcMethods apiGroup : availableApiGroups) {
         enabled.putAll(apiGroup.create(rpcApis));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -71,6 +71,7 @@ public class EngineExchangeTransitionConfigurationTest {
   @Before
   public void setUp() {
     when(protocolContext.getConsensusContext(Mockito.any())).thenReturn(mergeContext);
+    when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
 
     this.method = new EngineExchangeTransitionConfiguration(vertx, protocolContext);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineExchangeTransitionConfiguration.FALLBACK_TTD_DEFAULT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -110,6 +111,21 @@ public class EngineExchangeTransitionConfigurationTest {
 
     var result = fromSuccessResp(response);
     assertThat(result.getTerminalTotalDifficulty()).isEqualTo(Difficulty.of(1337L));
+    assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.ZERO);
+    assertThat(result.getTerminalBlockNumber()).isEqualTo(0L);
+  }
+
+  @Test
+  public void shouldReturnDefaultOnNoTerminalTotalDifficultyConfigured() {
+    when(mergeContext.getTerminalPoWBlock()).thenReturn(Optional.empty());
+
+    var response =
+        resp(
+            new EngineExchangeTransitionConfigurationParameter(
+                "0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
+
+    var result = fromSuccessResp(response);
+    assertThat(result.getTerminalTotalDifficulty()).isEqualTo(FALLBACK_TTD_DEFAULT);
     assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.ZERO);
     assertThat(result.getTerminalBlockNumber()).isEqualTo(0L);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
@@ -79,7 +79,7 @@ public class EngineForkchoiceUpdatedTest {
 
   @Before
   public void before() {
-    when(protocolContext.getConsensusContext(Mockito.any())).thenReturn(mergeContext);
+    when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     this.method = new EngineForkchoiceUpdated(vertx, protocolContext, mergeCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
@@ -66,7 +66,7 @@ public class EngineGetPayloadTest {
   @Before
   public void before() {
     when(mergeContext.retrieveBlockById(mockPid)).thenReturn(Optional.of(mockBlock));
-    when(protocolContext.getConsensusContext(Mockito.any())).thenReturn(mergeContext);
+    when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     this.method = new EngineGetPayload(vertx, protocolContext, factory);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -79,7 +79,7 @@ public class EngineNewPayloadTest {
 
   @Before
   public void before() {
-    when(protocolContext.getConsensusContext(Mockito.any())).thenReturn(mergeContext);
+    when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator);
   }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.blockcreation;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -44,7 +43,6 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
@@ -191,9 +189,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final SealableBlockHeader sealableBlockHeader =
           BlockHeaderBuilder.create()
               .populateFrom(processableBlockHeader)
-              .ommersHash(
-                  BodyValidation.ommersHash(
-                      MergeConfigOptions.isMergeEnabled() ? Collections.emptyList() : ommers))
+              .ommersHash(BodyValidation.ommersHash(ommers))
               .stateRoot(disposableWorldState.rootHash())
               .transactionsRoot(
                   BodyValidation.transactionsRoot(transactionResults.getTransactions()))

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/MiningCoordinator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/MiningCoordinator.java
@@ -117,4 +117,8 @@ public interface MiningCoordinator {
   default void addEthHashObserver(final PoWObserver observer) {}
 
   void changeTargetGasLimit(final Long targetGasLimit);
+
+  default boolean isCompatibleWithEngineApi() {
+    return false;
+  }
 }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutor.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.blockcreation;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
@@ -85,7 +84,7 @@ public class PoWMinerExecutor extends AbstractMinerExecutor<PoWBlockMiner> {
     final Function<BlockHeader, PoWBlockCreator> blockCreator =
         (header) ->
             new PoWBlockCreator(
-                coinbase.orElseGet(() -> MergeConfigOptions.isMergeEnabled() ? Address.ZERO : null),
+                coinbase.orElse(Address.ZERO),
                 () -> targetGasLimit.map(AtomicLong::longValue),
                 parent -> extraData,
                 pendingTransactions,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/ProtocolContext.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/ProtocolContext.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
+import java.util.Optional;
+
 /**
  * Holds the mutable state used to track the current context of the protocol. This is primarily the
  * blockchain and world state archive, but can also hold arbitrary context required by a particular
@@ -58,5 +60,11 @@ public class ProtocolContext {
 
   public <C extends ConsensusContext> C getConsensusContext(final Class<C> klass) {
     return consensusContext.as(klass);
+  }
+
+  public <C extends ConsensusContext> Optional<C> safeConsensusContext(final Class<C> klass) {
+    return Optional.ofNullable(consensusContext)
+        .filter(c -> klass.isAssignableFrom(c.getClass()))
+        .map(klass::cast);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -34,8 +34,8 @@ import org.apache.tuweni.bytes.Bytes;
 public final class MainnetBlockHeaderValidator {
 
   public static final Bytes DAO_EXTRA_DATA = Bytes.fromHexString("0x64616f2d686172642d666f726b");
-  private static final int MIN_GAS_LIMIT = 5000;
-  private static final long MAX_GAS_LIMIT = 0x7fffffffffffffffL;
+  public static final int MIN_GAS_LIMIT = 5000;
+  public static final long MAX_GAS_LIMIT = 0x7fffffffffffffffL;
   public static final int TIMESTAMP_TOLERANCE_S = 15;
   public static final int MINIMUM_SECONDS_SINCE_PARENT = 1;
   public static final Bytes CLASSIC_FORK_BLOCK_HEADER =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.AttachedBlockHeaderValidationRule;
@@ -37,9 +36,7 @@ public class CalculatedDifficultyValidationRule implements AttachedBlockHeaderVa
   @Override
   public boolean validate(
       final BlockHeader header, final BlockHeader parent, final ProtocolContext context) {
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
-    }
+
     final BigInteger actualDifficulty = new BigInteger(1, header.getDifficulty().toArray());
     final BigInteger expectedDifficulty =
         difficultyCalculator.nextDifficulty(header.getTimestamp(), parent, context);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
 import static java.lang.Boolean.FALSE;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
@@ -68,12 +67,6 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
     } else if (header.getBaseFee().isPresent()) {
       LOG.info("Invalid block header: presence of basefee in a non-eip1559 block");
       return false;
-    }
-
-    // TODO: remove this rule bypass, use post-merge headervalidation rules
-    // https://github.com/hyperledger/besu/issues/2898
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
     }
 
     final Hash headerHash = hashHeader(header);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
 
@@ -36,9 +35,6 @@ public class TimestampMoreRecentThanParent implements DetachedBlockHeaderValidat
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
-    }
     return validateTimestamp(header.getTimestamp(), parent.getTimestamp());
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Allow besu to have the engine api enabled, when there are not merge configs.  includes:
* un-hiding/un-deprecating `--engine-rpc-enabled`
* remove old isMergeEnabled checks in a few block header validators
* use merge-specific block header validator, rather than appending to MainnetBlockHeaderValidator
* disable all engine api methods except engine_exchangeTransitionConfigurationV1 in the absence of an engine-api-compatible coordinator
* add "placeholder" TTD in the absence of a TTD configuration

Tested with Hive and Kurtosis since this affects block validation.  Both are 🟢 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4172 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).