### PR TITLE
Panda print only when crossing TTD the first time

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.merge.FinalizedBlockHashSupplier;
 import org.hyperledger.besu.consensus.merge.MergeContext;
-import org.hyperledger.besu.consensus.merge.PandaPrinter;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.datatypes.Hash;
@@ -379,7 +378,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final EthContext ethContext = new EthContext(ethPeers, ethMessages, snapMessages, scheduler);
     final boolean fastSyncEnabled = !SyncMode.isFullSync(syncConfig.getSyncMode());
     final SyncState syncState = new SyncState(blockchain, ethPeers, fastSyncEnabled, checkpoint);
-    syncState.subscribeTTDReached(new PandaPrinter());
 
     final TransactionPool transactionPool =
         TransactionPoolFactory.createTransactionPool(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
@@ -16,8 +16,6 @@
 
 package org.hyperledger.besu.consensus.merge;
 
-import org.hyperledger.besu.plugin.services.BesuEvents.TTDReachedListener;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,11 +26,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PandaPrinter implements TTDReachedListener {
+public class PandaPrinter {
 
   private static final Logger LOG = LoggerFactory.getLogger(PandaPrinter.class);
   private static final String pandaBanner = PandaPrinter.loadBanner();
-  private final AtomicBoolean beenDisplayed = new AtomicBoolean();
+  private static final AtomicBoolean beenDisplayed = new AtomicBoolean();
 
   private static String loadBanner() {
     Class<PandaPrinter> c = PandaPrinter.class;
@@ -50,10 +48,19 @@ public class PandaPrinter implements TTDReachedListener {
     return resultStringBuilder.toString();
   }
 
-  @Override
-  public void onTTDReached(final boolean reached) {
-    if (reached && beenDisplayed.compareAndSet(false, true)) {
+  public static boolean printOnFirstCrossing() {
+    boolean shouldPrint = beenDisplayed.compareAndSet(false, true);
+    if (shouldPrint) {
       LOG.info("\n" + pandaBanner);
     }
+    return shouldPrint;
+  }
+
+  static boolean hasDisplayed() {
+    return beenDisplayed.get();
+  }
+
+  static void resetForTesting() {
+    beenDisplayed.set(false);
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -105,12 +105,8 @@ public class PostMergeContext implements MergeContext {
     if (oldState.isEmpty() || oldState.get() != newState) {
       newMergeStateCallbackSubscribers.forEach(
           newMergeStateCallback ->
-              newMergeStateCallback.mergeStateChanged(newState, Optional.of(totalDifficulty)));
-    }
-
-    // only print if we changed state from pre-TTD to post-TTD, not at startup/init:
-    if (newState && oldState.filter(old -> old != newState).isPresent()) {
-      PandaPrinter.printOnFirstCrossing();
+              newMergeStateCallback.mergeStateChanged(
+                  newState, oldState, Optional.of(totalDifficulty)));
     }
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -57,7 +57,12 @@ public class PostMergeContext implements MergeContext {
 
   @VisibleForTesting
   PostMergeContext() {
-    this.terminalTotalDifficulty = new AtomicReference<>(Difficulty.ZERO);
+    this(Difficulty.ZERO);
+  }
+
+  @VisibleForTesting
+  PostMergeContext(final Difficulty difficulty) {
+    this.terminalTotalDifficulty = new AtomicReference<>(difficulty);
     this.syncState = new AtomicReference<>();
   }
 
@@ -101,6 +106,11 @@ public class PostMergeContext implements MergeContext {
       newMergeStateCallbackSubscribers.forEach(
           newMergeStateCallback ->
               newMergeStateCallback.mergeStateChanged(newState, Optional.of(totalDifficulty)));
+    }
+
+    // only print if we changed state from pre-TTD to post-TTD, not at startup/init:
+    if (newState && oldState.filter(old -> old != newState).isPresent()) {
+      PandaPrinter.printOnFirstCrossing();
     }
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBestPeerComparator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionBestPeerComparator.java
@@ -56,7 +56,9 @@ public class TransitionBestPeerComparator implements Comparator<EthPeer>, MergeS
 
   @Override
   public void mergeStateChanged(
-      final boolean isPoS, final Optional<Difficulty> difficultyStoppedAt) {
+      final boolean isPoS,
+      final Optional<Boolean> oldState,
+      final Optional<Difficulty> difficultyStoppedAt) {
     if (isPoS && difficultyStoppedAt.isPresent()) {
       terminalTotalDifficulty.set(difficultyStoppedAt.get());
     }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
@@ -24,6 +24,12 @@ import org.junit.Test;
 
 public class PandaPrinterTest {
 
+  final MergeStateHandler fauxTransitionHandler =
+      (isPoS, priorState, ttd) -> {
+        if (isPoS && priorState.filter(prior -> !prior).isPresent())
+          PandaPrinter.printOnFirstCrossing();
+      };
+
   @Test
   public void printsPanda() {
     PandaPrinter.resetForTesting();
@@ -35,6 +41,8 @@ public class PandaPrinterTest {
   public void doesNotPrintAtInit() {
     PandaPrinter.resetForTesting();
     var mergeContext = new PostMergeContext(Difficulty.ONE);
+    mergeContext.observeNewIsPostMergeState(fauxTransitionHandler);
+
     assertThat(PandaPrinter.hasDisplayed()).isFalse();
     mergeContext.setIsPostMerge(Difficulty.ONE);
     assertThat(PandaPrinter.hasDisplayed()).isFalse();
@@ -44,6 +52,8 @@ public class PandaPrinterTest {
   public void printsWhenCrossingOnly() {
     PandaPrinter.resetForTesting();
     var mergeContext = new PostMergeContext(Difficulty.ONE);
+    mergeContext.observeNewIsPostMergeState(fauxTransitionHandler);
+
     assertThat(PandaPrinter.hasDisplayed()).isFalse();
     mergeContext.setIsPostMerge(Difficulty.ZERO);
     assertThat(PandaPrinter.hasDisplayed()).isFalse();

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
@@ -16,13 +16,38 @@
 
 package org.hyperledger.besu.consensus.merge;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.core.Difficulty;
+
 import org.junit.Test;
 
 public class PandaPrinterTest {
 
   @Test
   public void printsPanda() {
-    PandaPrinter panda = new PandaPrinter();
-    panda.onTTDReached(true);
+    PandaPrinter.resetForTesting();
+    assertThat(PandaPrinter.printOnFirstCrossing()).isTrue();
+    assertThat(PandaPrinter.printOnFirstCrossing()).isFalse();
+  }
+
+  @Test
+  public void doesNotPrintAtInit() {
+    PandaPrinter.resetForTesting();
+    var mergeContext = new PostMergeContext(Difficulty.ONE);
+    assertThat(PandaPrinter.hasDisplayed()).isFalse();
+    mergeContext.setIsPostMerge(Difficulty.ONE);
+    assertThat(PandaPrinter.hasDisplayed()).isFalse();
+  }
+
+  @Test
+  public void printsWhenCrossingOnly() {
+    PandaPrinter.resetForTesting();
+    var mergeContext = new PostMergeContext(Difficulty.ONE);
+    assertThat(PandaPrinter.hasDisplayed()).isFalse();
+    mergeContext.setIsPostMerge(Difficulty.ZERO);
+    assertThat(PandaPrinter.hasDisplayed()).isFalse();
+    mergeContext.setIsPostMerge(Difficulty.ONE);
+    assertThat(PandaPrinter.hasDisplayed()).isTrue();
   }
 }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
@@ -173,7 +173,9 @@ public class PostMergeContextTest {
 
     @Override
     public void mergeStateChanged(
-        final boolean isPoS, final Optional<Difficulty> difficultyStoppedAt) {
+        final boolean isPoS,
+        final Optional<Boolean> oldState,
+        final Optional<Difficulty> difficultyStoppedAt) {
       stateChanges.add(isPoS);
     }
 

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionBestPeerComparatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionBestPeerComparatorTest.java
@@ -60,7 +60,7 @@ public class TransitionBestPeerComparatorTest {
     assertThat(comparator.compare(a, b)).isEqualTo(-1);
 
     // update TTD with actual value
-    comparator.mergeStateChanged(true, Optional.of(Difficulty.of(5002)));
+    comparator.mergeStateChanged(true, Optional.empty(), Optional.of(Difficulty.of(5002)));
     assertThat(comparator.compare(a, b)).isEqualTo(1);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/consensus/merge/MergeStateHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/consensus/merge/MergeStateHandler.java
@@ -22,5 +22,8 @@ import java.util.Optional;
 
 public interface MergeStateHandler {
 
-  void mergeStateChanged(final boolean isPoS, final Optional<Difficulty> difficultyStoppedAt);
+  void mergeStateChanged(
+      final boolean isPoS,
+      final Optional<Boolean> priorState,
+      final Optional<Difficulty> difficultyStoppedAt);
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MergePeerFilter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MergePeerFilter.java
@@ -88,7 +88,9 @@ public class MergePeerFilter implements MergeStateHandler, ForkchoiceMessageList
 
   @Override
   public void mergeStateChanged(
-      final boolean isPoS, final Optional<Difficulty> difficultyStoppedAt) {
+      final boolean isPoS,
+      final Optional<Boolean> oldState,
+      final Optional<Difficulty> difficultyStoppedAt) {
     if (isPoS && difficultyStoppedAt.isPresent()) {
       LOG.debug("terminal difficulty set to {}", difficultyStoppedAt.get().getValue());
       long lockStamp = this.powTerminalDifficultyLock.writeLock();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -177,8 +177,6 @@ public class SyncState {
   }
 
   public void setReachedTerminalDifficulty(final boolean stoppedAtTerminalDifficulty) {
-    // TODO: this is an inexpensive way to stop sync when we reach TTD,
-    //      we should revisit when merge sync is better defined
     this.reachedTerminalDifficulty = Optional.of(stoppedAtTerminalDifficulty);
     ttdReachedListeners.forEach(listener -> listener.onTTDReached(stoppedAtTerminalDifficulty));
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -235,7 +235,7 @@ public final class EthProtocolManagerTest {
       ethManager.processMessage(EthProtocol.ETH63, new DefaultMessage(stakePeer, stakePeerStatus));
 
       mergePeerFilter.mergeStateChanged(
-          true, Optional.of(blockchain.getChainHead().getTotalDifficulty()));
+          true, Optional.empty(), Optional.of(blockchain.getChainHead().getTotalDifficulty()));
       mergePeerFilter.onNewForkchoiceMessage(
           Hash.EMPTY, Optional.of(Hash.hash(Bytes.of(1))), Hash.EMPTY);
       mergePeerFilter.onNewForkchoiceMessage(


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
ensure Pandas only print when we merge, not just when we initially set a new merge state (like on startup)

* make panda printer static
* add prior merge state to MergeStateHandler
* move pandas into TransitionControllerBuilder's transition watcher
*  before we print, ensure we are PoS AND the prior merge state was pre-merge



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#3954 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).