### PR TITLE
upgrade spotless to 6.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Stop producing stack traces when a get headers response only contains the range start header [#4189](https://github.com/hyperledger/besu/pull/4189)
+- Upgrade Gradle to 6.8.0 [#4195](https://github.com/hyperledger/besu/pull/4195)
 
 ## 22.7.0-RC3
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 import java.text.SimpleDateFormat
 
 plugins {
-  id 'com.diffplug.spotless' version '6.7.2'
+  id 'com.diffplug.spotless' version '6.8.0'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'com.github.hierynomus.license' version '0.16.1-fix'
   id 'com.jfrog.artifactory' version '4.28.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,2 @@
 version=22.7.0-SNAPSHOT
 
-# Workaround for Java 16 and spotless bug 834 https://github.com/diffplug/spotless/issues/834
-org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
---add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
Signed-off-by: Antoine Toulme <antoine@lunar-ocean.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Upgrade spotless to 6.8.0, removing workaround for JDK 17 support.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).