### PR TITLE
Set snap sync as default for named ethereum networks

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
@@ -14,19 +14,21 @@
  */
 package org.hyperledger.besu.cli.config;
 
+import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
+
 import java.math.BigInteger;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 
 public enum NetworkName {
-  MAINNET("/mainnet.json", BigInteger.valueOf(1)),
-  RINKEBY("/rinkeby.json", BigInteger.valueOf(4)),
-  ROPSTEN("/ropsten.json", BigInteger.valueOf(3)),
-  SEPOLIA("/sepolia.json", BigInteger.valueOf(11155111)),
-  GOERLI("/goerli.json", BigInteger.valueOf(5)),
-  KILN("/kiln.json", BigInteger.valueOf(1337802), false),
-  DEV("/dev.json", BigInteger.valueOf(2018), false),
+  MAINNET("/mainnet.json", BigInteger.valueOf(1), SyncMode.X_SNAP),
+  RINKEBY("/rinkeby.json", BigInteger.valueOf(4), SyncMode.X_SNAP),
+  ROPSTEN("/ropsten.json", BigInteger.valueOf(3), SyncMode.X_SNAP),
+  SEPOLIA("/sepolia.json", BigInteger.valueOf(11155111), SyncMode.X_SNAP),
+  GOERLI("/goerli.json", BigInteger.valueOf(5), SyncMode.X_SNAP),
+  KILN("/kiln.json", BigInteger.valueOf(1337802), SyncMode.X_SNAP),
+  DEV("/dev.json", BigInteger.valueOf(2018), SyncMode.FULL),
   CLASSIC("/classic.json", BigInteger.valueOf(1)),
   KOTTI("/kotti.json", BigInteger.valueOf(6)),
   MORDOR("/mordor.json", BigInteger.valueOf(7)),
@@ -35,17 +37,18 @@ public enum NetworkName {
 
   private final String genesisFile;
   private final BigInteger networkId;
-  private final boolean canFastSync;
+  private final SyncMode defaultSyncMode;
   private final String deprecationDate;
 
   NetworkName(final String genesisFile, final BigInteger networkId) {
-    this(genesisFile, networkId, true);
+    this(genesisFile, networkId, SyncMode.FAST);
   }
 
-  NetworkName(final String genesisFile, final BigInteger networkId, final boolean canFastSync) {
+  NetworkName(
+      final String genesisFile, final BigInteger networkId, final SyncMode defaultSyncMode) {
     this.genesisFile = genesisFile;
     this.networkId = networkId;
-    this.canFastSync = canFastSync;
+    this.defaultSyncMode = defaultSyncMode;
 
     // https://blog.ethereum.org/2022/06/21/testnet-deprecation/
     switch (networkId.intValue()) {
@@ -71,8 +74,8 @@ public enum NetworkName {
     return networkId;
   }
 
-  public boolean canFastSync() {
-    return canFastSync;
+  public SyncMode defaultSyncMode() {
+    return defaultSyncMode;
   }
 
   public String humanReadableNetworkName() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -265,7 +265,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockControllerBuilder).build();
 
     assertThat(storageProviderArgumentCaptor.getValue()).isNotNull();
-    assertThat(syncConfigurationCaptor.getValue().getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfigurationCaptor.getValue().getSyncMode()).isEqualTo(SyncMode.X_SNAP);
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
     assertThat(miningArg.getValue().getCoinbase()).isEqualTo(Optional.empty());
     assertThat(miningArg.getValue().getMinTransactionGasPrice()).isEqualTo(Wei.of(1000));
@@ -877,7 +877,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
 
     final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
-    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.X_SNAP);
     assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(5);
 
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
@@ -4401,7 +4401,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     parseCommand("--sync-mode=FAST", "--privacy-enabled");
 
     assertThat(commandErrorOutput.toString(UTF_8))
-        .contains("Fast sync cannot be enabled with privacy.");
+        .contains("FAST sync cannot be enabled with privacy.");
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
   }
 


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Set snap sync as default for named ethereum networks.  No rush to merge this one ahead of the 22.7.0 release

* changes NetworkName to specify the default SyncMode, rather than just a boolean for support FAST sync or not
* sets snap sync as the default for:
  - kiln
  - goerli
  - sepolia 
  - ropsten
  - rinkeby
  - mainnet
  
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4203 


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).