### PR TITLE
Fix ConcurrentModificationException on ReattemptPendingPeerRequests

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -26,6 +26,7 @@ import java.time.Clock;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,9 +166,14 @@ public class EthPeers {
     dispatchMessage(peer, ethMessage, protocolName);
   }
 
-  private void reattemptPendingPeerRequests() {
+  @VisibleForTesting
+  void reattemptPendingPeerRequests() {
     synchronized (this) {
-      pendingRequests.removeIf(PendingPeerRequest::attemptExecution);
+      try {
+        pendingRequests.removeIf(PendingPeerRequest::attemptExecution);
+      } catch (ConcurrentModificationException ex) {
+        LOG.warn("Failed execution of pending requests: {}", ex.getClass().getName());
+      }
     }
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
@@ -290,7 +290,7 @@ public class EthPeersTest {
                   return true;
                 });
 
-    // Sent Pending Requests - should cause a ConcurrentModificationException
+    // Sent Pending Requests
     ethPeers.reattemptPendingPeerRequests();
 
     // Request should be aborted.
@@ -327,7 +327,7 @@ public class EthPeersTest {
                   return true;
                 });
 
-    // Sent Pending Requests - should cause a ConcurrentModificationException
+    // Sent Pending Requests
     ethPeers.reattemptPendingPeerRequests();
 
     // Request Should Execute

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeersTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -40,6 +41,7 @@ import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.stubbing.Answer;
 
 public class EthPeersTest {
 
@@ -263,6 +265,76 @@ public class EthPeersTest {
     ethPeers.registerDisconnect(ethPeer.getConnection());
 
     assertRequestFailure(pendingRequest, CancellationException.class);
+  }
+
+  @Test
+  public void shouldNotFailWhenAttemptExecutionDisconnectSamePeer() throws PeerNotConnected {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = spy(peer.getEthPeer());
+
+    // Force request to be added to pending request list
+    when(ethPeer.hasAvailableRequestCapacity()).thenReturn(false);
+
+    final PendingPeerRequest pendingPeerRequest =
+        ethPeers.executePeerRequest(peerRequest, 10, Optional.of(ethPeer));
+
+    // Force Request Attempt to cause the peer to disconnect
+    when(ethPeer.hasAvailableRequestCapacity())
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  // Force Disconnect only on the first execution
+                  if (!peer.getPeerConnection().isDisconnected()) {
+                    peer.disconnect(DisconnectReason.UNKNOWN); // Force Peer to disconnect
+                  }
+                  return true;
+                });
+
+    // Sent Pending Requests - should cause a ConcurrentModificationException
+    ethPeers.reattemptPendingPeerRequests();
+
+    // Request should be aborted.
+    assertRequestFailure(pendingPeerRequest, CancellationException.class);
+
+    // Mock works
+    assertThat(peer.getEthPeer().isDisconnected()).isTrue(); // peer is disconnected
+  }
+
+  @Test
+  public void shouldNotFailWhenAttemptExecutionDisconnectAnotherPeer() throws PeerNotConnected {
+    final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+    final EthPeer ethPeer = spy(peer.getEthPeer());
+
+    // Force request to be added to pending request list
+    when(ethPeer.hasAvailableRequestCapacity()).thenReturn(false);
+
+    final PendingPeerRequest pendingPeerRequest =
+        ethPeers.executePeerRequest(peerRequest, 10, Optional.of(ethPeer));
+
+    final RespondingEthPeer peerToDisconnect =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1000);
+
+    // Force Request Attempt to cause the peer to disconnect
+    when(ethPeer.hasAvailableRequestCapacity())
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  // Force Disconnect only on the first execution
+                  if (!peerToDisconnect.getPeerConnection().isDisconnected()) {
+                    peerToDisconnect.disconnect(
+                        DisconnectReason.UNKNOWN); // Force Peer to disconnect
+                  }
+                  return true;
+                });
+
+    // Sent Pending Requests - should cause a ConcurrentModificationException
+    ethPeers.reattemptPendingPeerRequests();
+
+    // Request Should Execute
+    assertRequestSuccessful(pendingPeerRequest);
+
+    // Mock works
+    assertThat(peerToDisconnect.getEthPeer().isDisconnected()).isTrue(); // peer is disconnected
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Gabriel Trintinalia <gabriel.trintinalia@consensys.net>

## PR description
A ConcurrentModificationExpetion happens when EthPeers reattempts to execute its Pending Requests and one  request causes a peer to disconnect. This happens because RemoveIf on CopyOnWriteArrayList will test the filter for each item first and mark those who need to be removed and then throw the exception if the list was modified by any filter. 

Replacing removeIf with iterator seems to solve the issue.

## Fixed Issue(s)
#3491

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).