### PR TITLE
correct fallback ttd to correct value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Additions and Improvements
 
 ### Bug Fixes
-- Fix one-off error for mainnet TTD fallback [#4223](https://github.com/hyperledger/besu/pull/4223)
+- Fixes off-by-one error for mainnet TTD fallback [#4223](https://github.com/hyperledger/besu/pull/4223)
 
 
 ## 22.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+- Fix one-off error for mainnet TTD fallback [#4223](https://github.com/hyperledger/besu/pull/4223)
+
 
 ## 22.7.0
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -34,7 +34,6 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,9 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
 
   // use (2^256 - 2^10) if engine is enabled in the absence of a TTD configuration
   static final Difficulty FALLBACK_TTD_DEFAULT =
-      Difficulty.MAX_VALUE.subtract(UInt256.valueOf(1024L));
+      Difficulty.fromHexString(
+          "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc00");
+
   static final long QOS_TIMEOUT_MILLIS = 120000L;
 
   private final QosTimer qosTimer;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineExchangeTransitionConfiguration.FALLBACK_TTD_DEFAULT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -44,6 +43,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ParsedExtraData;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,6 +56,7 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -126,7 +127,12 @@ public class EngineExchangeTransitionConfigurationTest {
                 "0", Hash.ZERO.toHexString(), new UnsignedLongParameter(0L)));
 
     var result = fromSuccessResp(response);
-    assertThat(result.getTerminalTotalDifficulty()).isEqualTo(FALLBACK_TTD_DEFAULT);
+    assertThat(result.getTerminalTotalDifficulty())
+        .isEqualTo(
+            UInt256.valueOf(
+                new BigInteger(
+                    "115792089237316195423570985008687907853269984665640564039457584007913129638912",
+                    10)));
     assertThat(result.getTerminalBlockHash()).isEqualTo(Hash.ZERO);
     assertThat(result.getTerminalBlockNumber()).isEqualTo(0L);
   }


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

The fallback TTD for mainnet had off-by-one error. We need to set it to `2^256 - 2^10`, but our code was 
```
Difficulty.MAX_VALUE.subtract(UInt256.valueOf(1024L)
````

The problem is that `MAX_VALUE` is `2^256 - 1`, not `2^256`. So we were calculating in the end `2^256 - 1 - 2^10`.

This PR replaces the calculation with the hard coded value as hex in the config and as decimal in the test.

I confirmed the value with the mainnet genesis file for the consensus clients: https://github.com/ethereum/consensus-specs/blob/981b05afb01d5b19be3a5a60ccb12c3582e4c0cf/configs/mainnet.yaml#L16

## Fixed Issue(s)
fixes #4220

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).