### PR TITLE
fix for fast sync regression on post-merge networks

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedProofOfWorkValidationRule.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedProofOfWorkValidationRule.java
@@ -1,0 +1,32 @@
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.AttachedBlockHeaderValidationRule;
+import org.hyperledger.besu.ethereum.mainnet.EpochCalculator;
+import org.hyperledger.besu.ethereum.mainnet.PoWHasher;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
+
+import java.util.Optional;
+
+/**
+ * An attached proof of work validation rule that wraps the detached version of the same. Suitable
+ * for use in block validator stacks supporting the merge.
+ */
+public class AttachedProofOfWorkValidationRule implements AttachedBlockHeaderValidationRule {
+
+  private final ProofOfWorkValidationRule detachedRule;
+
+  public AttachedProofOfWorkValidationRule(
+      final EpochCalculator epochCalculator,
+      final PoWHasher hasher,
+      final Optional<FeeMarket> feeMarket) {
+    this.detachedRule = new ProofOfWorkValidationRule(epochCalculator, hasher, feeMarket);
+  }
+
+  @Override
+  public boolean validate(
+      final BlockHeader header, final BlockHeader parent, final ProtocolContext protocolContext) {
+    return detachedRule.validate(header, parent);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.AttachedBlockHeaderValidationRule;
@@ -37,9 +36,7 @@ public class CalculatedDifficultyValidationRule implements AttachedBlockHeaderVa
   @Override
   public boolean validate(
       final BlockHeader header, final BlockHeader parent, final ProtocolContext context) {
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
-    }
+
     final BigInteger actualDifficulty = new BigInteger(1, header.getDifficulty().toArray());
     final BigInteger expectedDifficulty =
         difficultyCalculator.nextDifficulty(header.getTimestamp(), parent, context);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/ProofOfWorkValidationRule.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
 import static java.lang.Boolean.FALSE;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
@@ -68,12 +67,6 @@ public final class ProofOfWorkValidationRule implements DetachedBlockHeaderValid
     } else if (header.getBaseFee().isPresent()) {
       LOG.info("Invalid block header: presence of basefee in a non-eip1559 block");
       return false;
-    }
-
-    // TODO: remove this rule bypass, use post-merge headervalidation rules
-    // https://github.com/hyperledger/besu/issues/2898
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
     }
 
     final Hash headerHash = hashHeader(header);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/TimestampMoreRecentThanParent.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
 
@@ -36,9 +35,6 @@ public class TimestampMoreRecentThanParent implements DetachedBlockHeaderValidat
 
   @Override
   public boolean validate(final BlockHeader header, final BlockHeader parent) {
-    if (MergeConfigOptions.isMergeEnabled()) {
-      return true;
-    }
     return validateTimestamp(header.getTimestamp(), parent.getTimestamp());
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
* re-enable PoW, Timestamp, and Difficulty block header validation rules regardless of merge configuration.  
* if merge is enabled, use an AttachedBlockHeaderValidationRule version of ProofOfWorkValidationRule

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).