### PR TITLE
peer count - just count the live ones

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -191,7 +191,7 @@ public class EthPeers {
   }
 
   public int peerCount() {
-    return connections.size();
+    return (int) connections.values().stream().filter(c -> !c.isDisconnected()).count();
   }
 
   public int getMaxPeers() {


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

This does not address the root cause, but will address the problem of users complaining that the logs report too many peers.

This should mean that the number of peers reported in the logs will be the correct number ie the number of connected peers

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).