### PR TITLE
Filter out disconnected peers when fetching available peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions and Improvements
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
+- Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 
 ### Bug Fixes
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -203,7 +203,9 @@ public class EthPeers {
   }
 
   public Stream<EthPeer> streamAvailablePeers() {
-    return streamAllPeers().filter(EthPeer::readyForRequests);
+    return streamAllPeers()
+        .filter(EthPeer::readyForRequests)
+        .filter(peer -> !peer.isDisconnected());
   }
 
   public Stream<EthPeer> streamBestPeers() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
@@ -52,18 +52,18 @@ public class PendingPeerRequest {
     if (result.isDone()) {
       return true;
     }
-    final Optional<EthPeer> leastBusySuitablePeer = getLeastBusySuitablePeer();
-    if (!leastBusySuitablePeer.isPresent()) {
+    final Optional<EthPeer> maybePeer = getPeerToUse();
+    if (maybePeer.isEmpty()) {
       // No peers have the required height.
       result.completeExceptionally(new NoAvailablePeersException());
       return true;
     } else {
-      // At least one peer has the required height, but we not be able to use it if it's busy
-      final Optional<EthPeer> selectedPeer =
-          leastBusySuitablePeer.filter(EthPeer::hasAvailableRequestCapacity);
+      // At least one peer has the required height, but we are not able to use it if it's busy
+      final Optional<EthPeer> maybePeerWithCapacity =
+          maybePeer.filter(EthPeer::hasAvailableRequestCapacity);
 
-      selectedPeer.ifPresent(this::sendRequest);
-      return selectedPeer.isPresent();
+      maybePeerWithCapacity.ifPresent(this::sendRequest);
+      return maybePeerWithCapacity.isPresent();
     }
   }
 
@@ -79,7 +79,8 @@ public class PendingPeerRequest {
     }
   }
 
-  private Optional<EthPeer> getLeastBusySuitablePeer() {
+  private Optional<EthPeer> getPeerToUse() {
+    // return the assigned peer if still valid, otherwise switch to another peer
     return peer.filter(p -> !p.isDisconnected()).isPresent()
         ? peer
         : ethPeers

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PendingPeerRequest.java
@@ -80,7 +80,7 @@ public class PendingPeerRequest {
   }
 
   private Optional<EthPeer> getLeastBusySuitablePeer() {
-    return peer.isPresent()
+    return peer.filter(p -> !p.isDisconnected()).isPresent()
         ? peer
         : ethPeers
             .streamAvailablePeers()

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -131,7 +131,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
     return getEthContext()
         .getEthPeers()
         .streamBestPeers()
-        .filter(peer -> !peer.isDisconnected() && !triedPeers.contains(peer));
+        .filter(peer -> !triedPeers.contains(peer));
   }
 
   private void refreshPeers() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskTest.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.EthTaskException;
+import org.hyperledger.besu.ethereum.eth.manager.exceptions.EthTaskException.FailureReason;
 import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
@@ -117,8 +118,7 @@ public class DetermineCommonAncestorTaskTest {
     assertThat(failure.get()).isNotNull();
     final Throwable error = ExceptionUtils.rootCause(failure.get());
     assertThat(error).isInstanceOf(EthTaskException.class);
-    assertThat(((EthTaskException) error).reason())
-        .isEqualTo(EthTaskException.FailureReason.PEER_DISCONNECTED);
+    assertThat(((EthTaskException) error).reason()).isEqualTo(FailureReason.NO_AVAILABLE_PEERS);
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Currently a peer that is marked as disconnected can be returned when asking `EthPeers` for available peers, but returning a disconnected peer is not useful and potentially a cause of problems since all tasks will fail on it.
Not sure how much this affect peer selection in the real world, but in unit tests it happens to choose a disconnected peer for request.
In any case it seems reasonable to add this check, and we can evaluate if we also need to require that a peer is fully validated, before returning it as available

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).