### PR TITLE
Bugfix/clique post merge fast sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixes off-by-one error for mainnet TTD fallback [#4223](https://github.com/hyperledger/besu/pull/4223)
 - Fix off-by-one error in AbstractRetryingPeerTask [#4254](https://github.com/hyperledger/besu/pull/4254)
 - Fix encoding of key (short hex) in eth_getProof [#4261](https://github.com/hyperledger/besu/pull/4261)
-- Fix for post-merge clique networks fast-sync [#4276](https://github.com/hyperledger/besu/pull/4276)
+- Fix for post-merge networks fast-sync [#4224](https://github.com/hyperledger/besu/pull/4224), [#4276](https://github.com/hyperledger/besu/pull/4276)
 
 ## 22.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixes off-by-one error for mainnet TTD fallback [#4223](https://github.com/hyperledger/besu/pull/4223)
 - Fix off-by-one error in AbstractRetryingPeerTask [#4254](https://github.com/hyperledger/besu/pull/4254)
 - Fix encoding of key (short hex) in eth_getProof [#4261](https://github.com/hyperledger/besu/pull/4261)
+- Fix for post-merge clique networks fast-sync [#4276](https://github.com/hyperledger/besu/pull/4276)
 
 ## 22.7.0
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.config.MergeConfigOptions;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.AncestryValidationRule;
-import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.AttachedProofOfWorkValidationRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.AttachedComposedFromDetachedRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.BaseFeeMarketBlockHeaderGasPriceValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.CalculatedDifficultyValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ConstantFieldValidationRule;
@@ -138,19 +138,17 @@ public final class MainnetBlockHeaderValidator {
             .addRule((new BaseFeeMarketBlockHeaderGasPriceValidationRule(baseFeeMarket)));
 
     // if merge is enabled, use the attached version of the proof of work validation rule
+    var powValidationRule =
+        new ProofOfWorkValidationRule(
+            new EpochCalculator.DefaultEpochCalculator(),
+            PoWHasher.ETHASH_LIGHT,
+            Optional.of(baseFeeMarket));
+
     if (MergeConfigOptions.isMergeEnabled()) {
-      builder.addRule(
-          new AttachedProofOfWorkValidationRule(
-              new EpochCalculator.DefaultEpochCalculator(),
-              PoWHasher.ETHASH_LIGHT,
-              Optional.of(baseFeeMarket)));
+      builder.addRule(new AttachedComposedFromDetachedRule(powValidationRule));
 
     } else {
-      builder.addRule(
-          new ProofOfWorkValidationRule(
-              new EpochCalculator.DefaultEpochCalculator(),
-              PoWHasher.ETHASH_LIGHT,
-              Optional.of(baseFeeMarket)));
+      builder.addRule(powValidationRule);
     }
     return builder;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMore
 
 import java.util.Optional;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 
 public final class MainnetBlockHeaderValidator {
@@ -124,6 +125,12 @@ public final class MainnetBlockHeaderValidator {
 
   public static BlockHeaderValidator.Builder createBaseFeeMarketValidator(
       final BaseFeeMarket baseFeeMarket) {
+    return createBaseFeeMarketValidator(baseFeeMarket, MergeConfigOptions.isMergeEnabled());
+  }
+
+  @VisibleForTesting
+  public static BlockHeaderValidator.Builder createBaseFeeMarketValidator(
+      final BaseFeeMarket baseFeeMarket, final boolean isMergeEnabled) {
     var builder =
         new BlockHeaderValidator.Builder()
             .addRule(CalculatedDifficultyValidationRule::new)
@@ -144,9 +151,8 @@ public final class MainnetBlockHeaderValidator {
             PoWHasher.ETHASH_LIGHT,
             Optional.of(baseFeeMarket));
 
-    if (MergeConfigOptions.isMergeEnabled()) {
+    if (isMergeEnabled) {
       builder.addRule(new AttachedComposedFromDetachedRule(powValidationRule));
-
     } else {
       builder.addRule(powValidationRule);
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedComposedFromDetachedRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/AttachedComposedFromDetachedRule.java
@@ -17,25 +17,18 @@ package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.AttachedBlockHeaderValidationRule;
-import org.hyperledger.besu.ethereum.mainnet.EpochCalculator;
-import org.hyperledger.besu.ethereum.mainnet.PoWHasher;
-import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
-
-import java.util.Optional;
+import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
 
 /**
  * An attached proof of work validation rule that wraps the detached version of the same. Suitable
  * for use in block validator stacks supporting the merge.
  */
-public class AttachedProofOfWorkValidationRule implements AttachedBlockHeaderValidationRule {
+public class AttachedComposedFromDetachedRule implements AttachedBlockHeaderValidationRule {
 
-  private final ProofOfWorkValidationRule detachedRule;
+  private final DetachedBlockHeaderValidationRule detachedRule;
 
-  public AttachedProofOfWorkValidationRule(
-      final EpochCalculator epochCalculator,
-      final PoWHasher hasher,
-      final Optional<FeeMarket> feeMarket) {
-    this.detachedRule = new ProofOfWorkValidationRule(epochCalculator, hasher, feeMarket);
+  public AttachedComposedFromDetachedRule(final DetachedBlockHeaderValidationRule detachedRule) {
+    this.detachedRule = detachedRule;
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -120,7 +120,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       clearListeners();
       started.set(false);
     } else {
-      LOG.warn("Attempted to stop when we are not even running...");
+      LOG.debug("Attempted to stop when we are not even running...");
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
similar to #4224 for PoW, there are three clique block header validation rules that need to be evaluated at block import time rather than during fast sync header validation if merge is enabled (like on goerli):
* MixHash ConstantFieldValidationRule
* VoteValidationRule
* clique-specific TimestampMoreRecentThanParent

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4272 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).