### PR TITLE
Reduce megamorphic call sites in AbstractCallOperation

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.evm.operation;
 
+import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
+
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.Code;
@@ -57,7 +59,9 @@ public abstract class AbstractCallOperation extends AbstractOperation {
    * @param frame The current message frame
    * @return the additional gas to provide the call operation
    */
-  protected abstract long gas(MessageFrame frame);
+  protected long gas(final MessageFrame frame) {
+    return clampedToLong(frame.getStackItem(0));
+  }
 
   /**
    * Returns the account the call is being made to.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallCodeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallCodeOperation.java
@@ -30,15 +30,6 @@ public class CallCodeOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long gas(final MessageFrame frame) {
-    try {
-      return frame.getStackItem(0).trimLeadingZeros().toLong();
-    } catch (final ArithmeticException | IllegalArgumentException ae) {
-      return Long.MAX_VALUE;
-    }
-  }
-
-  @Override
   protected Address to(final MessageFrame frame) {
     return Words.toAddress(frame.getStackItem(1));
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
@@ -35,15 +35,6 @@ public class CallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long gas(final MessageFrame frame) {
-    try {
-      return frame.getStackItem(0).trimLeadingZeros().toLong();
-    } catch (final ArithmeticException | IllegalArgumentException ae) {
-      return Long.MAX_VALUE;
-    }
-  }
-
-  @Override
   protected Address to(final MessageFrame frame) {
     return Words.toAddress(frame.getStackItem(1));
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DelegateCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DelegateCallOperation.java
@@ -30,15 +30,6 @@ public class DelegateCallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long gas(final MessageFrame frame) {
-    try {
-      return frame.getStackItem(0).trimLeadingZeros().toLong();
-    } catch (final ArithmeticException | IllegalArgumentException ae) {
-      return Long.MAX_VALUE;
-    }
-  }
-
-  @Override
   protected Address to(final MessageFrame frame) {
     return Words.toAddress(frame.getStackItem(1));
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/StaticCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/StaticCallOperation.java
@@ -30,15 +30,6 @@ public class StaticCallOperation extends AbstractCallOperation {
   }
 
   @Override
-  protected long gas(final MessageFrame frame) {
-    try {
-      return frame.getStackItem(0).trimLeadingZeros().toLong();
-    } catch (final ArithmeticException | IllegalArgumentException ae) {
-      return Long.MAX_VALUE;
-    }
-  }
-
-  @Override
   protected Address to(final MessageFrame frame) {
     return Words.toAddress(frame.getStackItem(1));
   }


### PR DESCRIPTION
## PR description

The four instances of gas in the CALL operations are all implemented
identically.  Refactor the method into the abstract parent.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).