### PR TITLE
Reinstate Tessera tests with a fixed version

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/BftPrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/BftPrivacyClusterAcceptanceTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,7 +38,6 @@ import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.utils.Restriction;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class BftPrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
   private final BftPrivacyType bftPrivacyType;
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/DeployPrivateSmartContractAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/DeployPrivateSmartContractAcceptanceTest.java
@@ -26,11 +26,9 @@ import org.hyperledger.enclave.testutil.EnclaveType;
 import java.io.IOException;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class DeployPrivateSmartContractAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode minerNode;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/EnclaveErrorAcceptanceTest.java
@@ -49,7 +49,6 @@ import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.utils.Restriction;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class EnclaveErrorAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   private final PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/FlexiblePrivacyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/FlexiblePrivacyAcceptanceTest.java
@@ -38,7 +38,6 @@ import java.util.function.Supplier;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,7 +50,6 @@ import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.tx.Contract;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class FlexiblePrivacyAcceptanceTest extends FlexiblePrivacyAcceptanceTestBase {
 
   private final EnclaveType enclaveType;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.TypeReference;
@@ -49,7 +48,6 @@ import org.web3j.protocol.http.HttpService;
 import org.web3j.tx.Contract;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private static final int VALUE = 1024;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootFlexibleGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootFlexibleGroupAcceptanceTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -40,7 +39,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.testcontainers.containers.Network;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivDebugGetStateRootFlexibleGroupAcceptanceTest
     extends FlexiblePrivacyAcceptanceTestBase {
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOffchainGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivDebugGetStateRootOffchainGroupAcceptanceTest.java
@@ -29,12 +29,10 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.Network;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivDebugGetStateRootOffchainGroupAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode aliceNode;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetCodeAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetCodeAcceptanceTest.java
@@ -29,11 +29,9 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivGetCodeAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetLogsAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetLogsAcceptanceTest.java
@@ -30,14 +30,12 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthLog.LogResult;
 import org.web3j.utils.Restriction;
 
 @SuppressWarnings("rawtypes")
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivGetLogsAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   /*

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetPrivateTransactionAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivGetPrivateTransactionAcceptanceTest.java
@@ -32,12 +32,10 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.Network;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivGetPrivateTransactionAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyClusterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyClusterAcceptanceTest.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,7 +57,6 @@ import org.web3j.utils.Base64String;
 import org.web3j.utils.Numeric;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivacyClusterAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   private final PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyGroupAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyGroupAcceptanceTest.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Optional;
 
 import org.apache.logging.log4j.Level;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -46,7 +45,6 @@ import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.utils.Base64String;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivacyGroupAcceptanceTest extends PrivacyAcceptanceTestBase {
 
   private final PrivacyNode alice;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyReceiptAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivacyReceiptAcceptanceTest.java
@@ -34,11 +34,9 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivacyReceiptAcceptanceTest extends ParameterizedEnclaveTestBase {
   final MinerTransactions minerTransactions = new MinerTransactions();
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateContractPublicStateAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateContractPublicStateAcceptanceTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.testcontainers.containers.Network;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
@@ -43,7 +42,6 @@ import org.web3j.protocol.exceptions.TransactionException;
 import org.web3j.tx.exceptions.ContractCallException;
 import org.web3j.utils.Restriction;
 
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivateContractPublicStateAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode transactionNode;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateGenesisAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateGenesisAcceptanceTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -37,7 +36,6 @@ import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.utils.Restriction;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivateGenesisAcceptanceTest extends ParameterizedEnclaveTestBase {
   private final PrivacyNode alice;
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateLogFilterAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivateLogFilterAcceptanceTest.java
@@ -31,14 +31,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.web3j.protocol.besu.response.privacy.PrivateTransactionReceipt;
 import org.web3j.protocol.core.methods.response.EthLog.LogResult;
 import org.web3j.utils.Restriction;
 
 @SuppressWarnings("rawtypes")
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class PrivateLogFilterAcceptanceTest extends ParameterizedEnclaveTestBase {
 
   private final PrivacyNode node;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/FlexibleMultiTenancyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/FlexibleMultiTenancyAcceptanceTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,7 +50,6 @@ import org.web3j.utils.Base64String;
 import org.web3j.utils.Restriction;
 
 @RunWith(Parameterized.class)
-@Ignore("Ignored since Tessera/Docker container startup causing errors")
 public class FlexibleMultiTenancyAcceptanceTest extends FlexiblePrivacyAcceptanceTestBase {
 
   private final EnclaveType enclaveType;

--- a/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
+++ b/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
@@ -48,8 +48,8 @@ public class ContainerTestBase {
   //  private final String besuImage = "hyperledger/besu:21.7.0-SNAPSHOT";
   private final String besuImage = System.getProperty("containertest.imagename");
 
-  private final String goQuorumVersion = "22.4.4";
-  private final String tesseraVersion = "22.1.3";
+  public static final String GOQUORUM_VERSION = "22.4.4";
+  public static final String TESSERA_VERSION = "22.1.5";
 
   protected final String goQuorumTesseraPubKey = "3XGBIf+x8IdVQOVfIsbRnHwTYOJP/Fx84G8gMmy8qDM=";
   protected final String besuTesseraPubKey = "8JJLEAbq6o9m4Kqm++v0Y1n9Z2ryAFtZTyhnxSKWgws=";
@@ -127,7 +127,7 @@ public class ContainerTestBase {
             goQuorumContainer.getMappedPort(goQuorumRpcPort));
 
     waitFor(10, () -> assertClientVersion(besuWeb3j, "besu"));
-    waitFor(10, () -> assertClientVersion(goQuorumWeb3j, goQuorumVersion));
+    waitFor(10, () -> assertClientVersion(goQuorumWeb3j, GOQUORUM_VERSION));
 
     // Tell GoQuorum to peer to Besu
     goQuorumContainer.execInContainer(
@@ -187,7 +187,7 @@ public class ContainerTestBase {
       final String containerIpcPath,
       final String privKeyPath,
       final String pubKeyPath) {
-    return new GenericContainer("quorumengineering/tessera:" + tesseraVersion)
+    return new GenericContainer("quorumengineering/tessera:" + TESSERA_VERSION)
         .withNetwork(containerNetwork)
         .withNetworkAliases("goQuorumTessera")
         .withClasspathResourceMapping(
@@ -209,7 +209,7 @@ public class ContainerTestBase {
 
   private GenericContainer buildBesuTesseraContainer(
       final String privKeyPath, final String pubKeyPath) {
-    return new GenericContainer("quorumengineering/tessera:" + tesseraVersion)
+    return new GenericContainer("quorumengineering/tessera:" + TESSERA_VERSION)
         .withNetwork(containerNetwork)
         .withNetworkAliases("besuTessera")
         .withClasspathResourceMapping(
@@ -230,7 +230,7 @@ public class ContainerTestBase {
 
   private GenericContainer buildGoQuorumContainer(
       final String ipcPath, final String ipcBindDir, final String containerIpcPath) {
-    return new GenericContainer("quorumengineering/quorum:" + goQuorumVersion)
+    return new GenericContainer("quorumengineering/quorum:" + GOQUORUM_VERSION)
         .withNetwork(containerNetwork)
         .dependsOn(tesseraGoQuorumContainer)
         .withExposedPorts(goQuorumRpcPort, goQuorumP2pPort)

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
@@ -49,7 +49,7 @@ public class TesseraTestHarness implements EnclaveTestHarness {
   private URI q2TUri;
   private URI thirdPartyUri;
 
-  private final String tesseraVersion = "latest";
+  public static final String TESSERA_VERSION = "22.1.5";
 
   private final int thirdPartyPort = 9081;
   private final int q2TPort = 9082;
@@ -264,7 +264,7 @@ public class TesseraTestHarness implements EnclaveTestHarness {
   private GenericContainer buildTesseraContainer(final String configFilePath) {
     final String containerConfigFilePath = "/tmp/config.json";
     final String keyDir = enclaveConfiguration.getTempDir().toString();
-    return new GenericContainer<>("quorumengineering/tessera:" + tesseraVersion)
+    return new GenericContainer<>("quorumengineering/tessera:" + TESSERA_VERSION)
         .withCopyFileToContainer(MountableFile.forHostPath(configFilePath), containerConfigFilePath)
         .withFileSystemBind(keyDir, containerKeyDir)
         .withCommand("--configfile " + containerConfigFilePath)


### PR DESCRIPTION
* Use a fixed version of Tessera docker image. 
* Enable the ignored privacy tests that use Tessera 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).