### PR TITLE
update Tessera version and ubuntu for xl-machine-executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ executors:
 
   xl_machine_executor:
     machine:
-      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2, Google Cloud SDK updates
+      image: ubuntu-2004:202101-01
     resource_class: xlarge
 
   trivy_executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ executors:
 
   xl_machine_executor:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2, Google Cloud SDK updates
     resource_class: xlarge
 
   trivy_executor:

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ import net.ltgt.gradle.errorprone.CheckSeverity
 import java.text.SimpleDateFormat
 
 plugins {
-  id 'com.diffplug.spotless' version '6.8.0'
+  id 'com.diffplug.spotless' version '6.10.0'
   id 'com.github.ben-manes.versions' version '0.42.0'
   id 'com.github.hierynomus.license' version '0.16.1-fix'
   id 'com.jfrog.artifactory' version '4.28.3'

--- a/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
+++ b/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
@@ -49,7 +49,7 @@ public class ContainerTestBase {
   private final String besuImage = System.getProperty("containertest.imagename");
 
   public static final String GOQUORUM_VERSION = "22.4.4";
-  public static final String TESSERA_VERSION = "22.1.5";
+  public static final String TESSERA_VERSION = "22.1.6";
 
   protected final String goQuorumTesseraPubKey = "3XGBIf+x8IdVQOVfIsbRnHwTYOJP/Fx84G8gMmy8qDM=";
   protected final String besuTesseraPubKey = "8JJLEAbq6o9m4Kqm++v0Y1n9Z2ryAFtZTyhnxSKWgws=";

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
@@ -49,7 +49,7 @@ public class TesseraTestHarness implements EnclaveTestHarness {
   private URI q2TUri;
   private URI thirdPartyUri;
 
-  public static final String TESSERA_VERSION = "22.1.5";
+  public static final String TESSERA_VERSION = "22.1.6";
 
   private final int thirdPartyPort = 9081;
   private final int q2TPort = 9082;


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

* Update tessera docker image version to 22.1.6
* Update ubuntu version on xl machine executor in Circle CI config - this update is required for the tessera 22.1.6 docker image to run

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).