### PR TITLE
Log imported block info post merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 - Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
+- Log imported block info post merge [#4310](https://github.com/hyperledger/besu/pull/4310)
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Wei.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Wei.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.datatypes;
 import org.hyperledger.besu.plugin.data.Quantity;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.BaseUInt256Value;
@@ -97,5 +98,53 @@ public final class Wei extends BaseUInt256Value<Wei> implements Quantity {
 
   public static Wei fromQuantity(final Quantity quantity) {
     return Wei.wrap((Bytes) quantity);
+  }
+
+  public String toHumanReadableString() {
+    final BigInteger amount = toBigInteger();
+    final int numOfDigits = amount.toString().length();
+    final Unit preferredUnit = Unit.getPreferred(numOfDigits);
+    final double res = amount.doubleValue() / preferredUnit.divisor;
+    return String.format("%1." + preferredUnit.decimals + "f %s", res, preferredUnit);
+  }
+
+  enum Unit {
+    Wei(0, 0),
+    KWei(3),
+    MWei(6),
+    GWei(9),
+    Szabo(12),
+    Finney(15),
+    Ether(18),
+    KEther(21),
+    MEther(24),
+    GEther(27),
+    TEther(30);
+
+    final int pow;
+    final double divisor;
+    final int decimals;
+
+    Unit(final int pow) {
+      this(pow, 2);
+    }
+
+    Unit(final int pow, final int decimals) {
+      this.pow = pow;
+      this.decimals = decimals;
+      this.divisor = Math.pow(10, pow);
+    }
+
+    static Unit getPreferred(final int numOfDigits) {
+      return Arrays.stream(values())
+          .filter(u -> numOfDigits <= u.pow + 3)
+          .findFirst()
+          .orElse(TEther);
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
   }
 }

--- a/datatypes/src/test/java/org/hyperledger/besu/datatypes/WeiTest.java
+++ b/datatypes/src/test/java/org/hyperledger/besu/datatypes/WeiTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class WeiTest {
+
+  @Test
+  public void toHumanReadableString() {
+    assertThat(Wei.ZERO.toHumanReadableString()).isEqualTo("0 wei");
+    assertThat(Wei.ONE.toHumanReadableString()).isEqualTo("1 wei");
+
+    assertThat(Wei.of(999).toHumanReadableString()).isEqualTo("999 wei");
+    assertThat(Wei.of(1000).toHumanReadableString()).isEqualTo("1.00 kwei");
+
+    assertThat(Wei.of(1009).toHumanReadableString()).isEqualTo("1.01 kwei");
+    assertThat(Wei.of(1011).toHumanReadableString()).isEqualTo("1.01 kwei");
+
+    assertThat(Wei.of(new BigInteger("1000000000")).toHumanReadableString()).isEqualTo("1.00 gwei");
+
+    assertThat(Wei.of(new BigInteger("1000000000000000000")).toHumanReadableString())
+        .isEqualTo("1.00 ether");
+
+    final char[] manyZeros = new char[32];
+    Arrays.fill(manyZeros, '0');
+    assertThat(Wei.of(new BigInteger("1" + String.valueOf(manyZeros))).toHumanReadableString())
+        .isEqualTo("100.00 tether");
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.encoding.TransactionDecoder;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
@@ -63,13 +64,16 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(EngineNewPayload.class);
   private static final BlockHeaderFunctions headerFunctions = new MainnetBlockHeaderFunctions();
   private final MergeMiningCoordinator mergeCoordinator;
+  private final EthPeers ethPeers;
 
   public EngineNewPayload(
       final Vertx vertx,
       final ProtocolContext protocolContext,
-      final MergeMiningCoordinator mergeCoordinator) {
+      final MergeMiningCoordinator mergeCoordinator,
+      final EthPeers ethPeers) {
     super(vertx, protocolContext);
     this.mergeCoordinator = mergeCoordinator;
+    this.ethPeers = ethPeers;
   }
 
   @Override
@@ -259,13 +263,14 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
   private void logImportedBlockInfo(final Block block, final double timeInS) {
     LOG.info(
         String.format(
-            "Imported #%,d / %d tx / %,d (%01.1f%%) gas / base fee %s / (%s) in %01.3fs.",
+            "Imported #%,d / %d tx / base fee %s / %,d (%01.1f%%) gas / (%s) in %01.3fs. Peers: %d",
             block.getHeader().getNumber(),
             block.getBody().getTransactions().size(),
+            block.getHeader().getBaseFee().map(Wei::toHumanReadableString).orElse("N/A"),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
-            block.getHeader().getBaseFee().map(Wei::toHumanReadableString).orElse("N/A"),
             block.getHash().toHexString(),
-            timeInS));
+            timeInS,
+            ethPeers.peerCount()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -25,6 +25,7 @@ import static org.hyperledger.besu.util.Slf4jLambdaHelper.warnLambda;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockValidator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -59,7 +60,6 @@ import org.slf4j.LoggerFactory;
 public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
 
   private static final Hash OMMERS_HASH_CONSTANT = Hash.EMPTY_LIST_HASH;
-  private static final double TO_GWEI_DIVISOR = Math.pow(10, 9);
   private static final Logger LOG = LoggerFactory.getLogger(EngineNewPayload.class);
   private static final BlockHeaderFunctions headerFunctions = new MainnetBlockHeaderFunctions();
   private final MergeMiningCoordinator mergeCoordinator;
@@ -259,16 +259,12 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
   private void logImportedBlockInfo(final Block block, final double timeInS) {
     LOG.info(
         String.format(
-            "Imported #%,d / %d tx / %,d (%01.1f%%) gas / base fee %01.2f%% gwei / (%s) in %01.3fs.",
+            "Imported #%,d / %d tx / %,d (%01.1f%%) gas / base fee %s / (%s) in %01.3fs.",
             block.getHeader().getNumber(),
             block.getBody().getTransactions().size(),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
-            block
-                .getHeader()
-                .getBaseFee()
-                .map(wei -> wei.getAsBigInteger().doubleValue() / TO_GWEI_DIVISOR)
-                .orElse(Double.NaN),
+            block.getHeader().getBaseFee().map(Wei::toHumanReadableString).orElse("N/A"),
             block.getHash().toHexString(),
             timeInS));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineG
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayload;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,14 +39,19 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final Optional<MergeMiningCoordinator> mergeCoordinator;
   private final ProtocolContext protocolContext;
 
+  private final EthPeers ethPeers;
+
   ExecutionEngineJsonRpcMethods(
-      final MiningCoordinator miningCoordinator, final ProtocolContext protocolContext) {
+      final MiningCoordinator miningCoordinator,
+      final ProtocolContext protocolContext,
+      final EthPeers ethPeers) {
     this.mergeCoordinator =
         Optional.ofNullable(miningCoordinator)
             .filter(mc -> mc.isCompatibleWithEngineApi())
             .map(MergeMiningCoordinator.class::cast);
 
     this.protocolContext = protocolContext;
+    this.ethPeers = ethPeers;
   }
 
   @Override
@@ -59,7 +65,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
     if (mergeCoordinator.isPresent()) {
       return mapOf(
           new EngineGetPayload(syncVertx, protocolContext, blockResultFactory),
-          new EngineNewPayload(syncVertx, protocolContext, mergeCoordinator.get()),
+          new EngineNewPayload(syncVertx, protocolContext, mergeCoordinator.get(), ethPeers),
           new EngineForkchoiceUpdated(syncVertx, protocolContext, mergeCoordinator.get()),
           new EngineExchangeTransitionConfiguration(syncVertx, protocolContext));
     } else {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -94,7 +94,7 @@ public class JsonRpcMethodsFactory {
                   blockchainQueries, protocolSchedule, metricsSystem, transactionPool, dataDir),
               new EeaJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
-              new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext),
+              new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext, ethPeers),
               new GoQuorumJsonRpcPrivacyMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
               new EthJsonRpcMethods(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 
 import java.util.Collections;
 import java.util.List;
@@ -77,11 +78,14 @@ public class EngineNewPayloadTest {
 
   @Mock private MutableBlockchain blockchain;
 
+  @Mock private EthPeers ethPeers;
+
   @Before
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
-    this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator);
+    when(ethPeers.peerCount()).thenReturn(1);
+    this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator, ethPeers);
   }
 
   @Test


### PR DESCRIPTION
After the switch to PoS, info of the imported blocks are not more logged, this PR re-add the log when a block is imported via the NewPayload engine RPC call, and also update the info logged to remove ommers and add base fee.

Sample of the message:
`Imported #12,862,033 / 5 tx / 439,018 (1.5%) gas / base fee 7 wei / (0xb1b6d51e6382a1c88b42344f53d5321ee63bec0226fae502876af55e7109f431) in 0.028s.`

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).