### PR TITLE
ContainerTests - use tessera 22.1.7

### DIFF
--- a/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
+++ b/container-tests/tests/src/test/java/org/hyperledger/besu/tests/container/ContainerTestBase.java
@@ -49,7 +49,7 @@ public class ContainerTestBase {
   private final String besuImage = System.getProperty("containertest.imagename");
 
   public static final String GOQUORUM_VERSION = "22.4.4";
-  public static final String TESSERA_VERSION = "22.1.6";
+  public static final String TESSERA_VERSION = "22.1.7";
 
   protected final String goQuorumTesseraPubKey = "3XGBIf+x8IdVQOVfIsbRnHwTYOJP/Fx84G8gMmy8qDM=";
   protected final String besuTesseraPubKey = "8JJLEAbq6o9m4Kqm++v0Y1n9Z2ryAFtZTyhnxSKWgws=";

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarness.java
@@ -49,7 +49,7 @@ public class TesseraTestHarness implements EnclaveTestHarness {
   private URI q2TUri;
   private URI thirdPartyUri;
 
-  public static final String TESSERA_VERSION = "22.1.6";
+  public static final String TESSERA_VERSION = "22.1.7";
 
   private final int thirdPartyPort = 9081;
   private final int q2TPort = 9082;


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Use 22.1.7 docker image for Tessera. 
Not a required update, dependency change only.
https://github.com/ConsenSys/tessera/releases/tag/tessera-22.1.7

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).