### PR TITLE
Evict Transactions by sender from tail first

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -66,6 +66,7 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -144,7 +145,7 @@ public class BesuEventsImplTest {
             mockProtocolSchedule,
             mockProtocolContext,
             mockEthContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             new NoOpMetricsSystem(),
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -56,6 +56,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -133,7 +134,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -168,7 +169,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -205,7 +206,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -96,7 +97,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -140,7 +141,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -184,7 +185,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
@@ -52,6 +52,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -118,7 +119,7 @@ public class BftBlockCreatorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             blockchain::getChainHeadHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);

--- a/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -107,7 +108,7 @@ public class BftBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
@@ -60,6 +60,7 @@ import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +85,7 @@ public class BlockTransactionSelectorTest {
       new GasPricePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           5,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           BlockTransactionSelectorTest::mockBlockHeader,
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -336,7 +337,7 @@ public class BlockTransactionSelectorTest {
         new BaseFeePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             5,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             () -> {
               final BlockHeader mockBlockHeader = mock(BlockHeader.class);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class PoWMinerExecutorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             PoWMinerExecutorTest::mockBlockHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -74,7 +75,7 @@ public class PoWMinerExecutorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             PoWMinerExecutorTest::mockBlockHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
@@ -81,6 +81,7 @@ public class TransactionsForSenderInfo {
       return nextGap.isEmpty() ? OptionalLong.of(transactionsInfos.lastKey() + 1) : nextGap;
     }
   }
+
   public Optional<TransactionInfo> maybeLastTx() {
     return Optional.ofNullable(transactionsInfos.lastEntry()).map(Map.Entry::getValue);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
@@ -18,7 +18,9 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter.TransactionInfo;
 
+import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -78,6 +80,9 @@ public class TransactionsForSenderInfo {
     } else {
       return nextGap.isEmpty() ? OptionalLong.of(transactionsInfos.lastKey() + 1) : nextGap;
     }
+  }
+  public Optional<TransactionInfo> maybeLastTx() {
+    return Optional.ofNullable(transactionsInfos.lastEntry()).map(Map.Entry::getValue);
   }
 
   public Stream<TransactionInfo> streamTransactionInfos() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -424,4 +425,16 @@ public abstract class AbstractPendingTransactionsSorter {
       return invalidReason;
     }
   }
+
+  Optional<TransactionInfo> lowestValueTxForRemovalBySender(NavigableSet<TransactionInfo> txSet){
+    return txSet
+        .descendingSet()
+        .stream()
+        .filter(tx -> transactionsBySender.get(tx.getSender())
+            .maybeLastTx()
+            .filter(tx::equals)
+            .isPresent()
+        ).findFirst();
+  }
+
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -426,15 +426,15 @@ public abstract class AbstractPendingTransactionsSorter {
     }
   }
 
-  Optional<TransactionInfo> lowestValueTxForRemovalBySender(NavigableSet<TransactionInfo> txSet){
-    return txSet
-        .descendingSet()
-        .stream()
-        .filter(tx -> transactionsBySender.get(tx.getSender())
-            .maybeLastTx()
-            .filter(tx::equals)
-            .isPresent()
-        ).findFirst();
+  Optional<TransactionInfo> lowestValueTxForRemovalBySender(NavigableSet<TransactionInfo> txSet) {
+    return txSet.descendingSet().stream()
+        .filter(
+            tx ->
+                transactionsBySender
+                    .get(tx.getSender())
+                    .maybeLastTx()
+                    .filter(tx::equals)
+                    .isPresent())
+        .findFirst();
   }
-
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -213,20 +213,23 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
       if (pendingTransactions.size() > maxPendingTransactions) {
         final Stream.Builder<TransactionInfo> removalCandidates = Stream.builder();
         if (!prioritizedTransactionsDynamicRange.isEmpty())
-          removalCandidates.add(prioritizedTransactionsDynamicRange.last());
+          lowestValueTxForRemovalBySender(prioritizedTransactionsDynamicRange)
+              .ifPresent(removalCandidates::add);
         if (!prioritizedTransactionsStaticRange.isEmpty())
-          removalCandidates.add(prioritizedTransactionsStaticRange.last());
-        final TransactionInfo toRemove =
+          lowestValueTxForRemovalBySender(prioritizedTransactionsStaticRange)
+              .ifPresent(removalCandidates::add);
+
+        droppedTransaction =
             removalCandidates
                 .build()
                 .min(
                     Comparator.comparing(
                         txInfo -> txInfo.getTransaction().getEffectivePriorityFeePerGas(baseFee)))
-                // safe because we just added a tx to the pool so we're guaranteed to have one
-                .get();
-        doRemoveTransaction(toRemove.getTransaction(), false);
-        LOG.trace("Evicted {} due to transaction pool size", toRemove);
-        droppedTransaction = Optional.of(toRemove.getTransaction());
+                    .map(TransactionInfo::getTransaction);
+        droppedTransaction.ifPresent(toRemove -> {
+              doRemoveTransaction(toRemove, false);
+              LOG.trace("Evicted {} due to transaction pool size", toRemove);
+        });
       }
     }
     notifyTransactionAdded(transaction);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -84,7 +84,7 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
                           .get()
                           .getAsBigInteger()
                           .longValue())
-              .thenComparing(TransactionInfo::getSequence)
+              .thenComparing(TransactionInfo::getAddedToPoolAt)
               .reversed());
 
   private final NavigableSet<TransactionInfo> prioritizedTransactionsDynamicRange =
@@ -97,7 +97,7 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
                           .getMaxFeePerGas()
                           .map(maxFeePerGas -> maxFeePerGas.getAsBigInteger().longValue())
                           .orElse(transactionInfo.getGasPrice().toLong()))
-              .thenComparing(TransactionInfo::getSequence)
+              .thenComparing(TransactionInfo::getAddedToPoolAt)
               .reversed());
 
   @Override
@@ -225,11 +225,12 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
                 .min(
                     Comparator.comparing(
                         txInfo -> txInfo.getTransaction().getEffectivePriorityFeePerGas(baseFee)))
-                    .map(TransactionInfo::getTransaction);
-        droppedTransaction.ifPresent(toRemove -> {
+                .map(TransactionInfo::getTransaction);
+        droppedTransaction.ifPresent(
+            toRemove -> {
               doRemoveTransaction(toRemove, false);
               LOG.trace("Evicted {} due to transaction pool size", toRemove);
-        });
+            });
       }
     }
     notifyTransactionAdded(transaction);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
@@ -19,6 +19,7 @@ import static java.util.Comparator.comparing;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionsForSenderInfo;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.number.Percentage;
 
@@ -101,9 +102,10 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       pendingTransactions.put(transactionInfo.getHash(), transactionInfo);
 
       if (pendingTransactions.size() > maxPendingTransactions) {
-        final TransactionInfo toRemove = prioritizedTransactions.last();
-        doRemoveTransaction(toRemove.getTransaction(), false);
-        droppedTransaction = Optional.of(toRemove.getTransaction());
+        droppedTransaction = lowestValueTxForRemovalBySender(prioritizedTransactions)
+            .map(TransactionInfo::getTransaction);
+        droppedTransaction
+            .ifPresent(tx -> doRemoveTransaction(tx, false));
       }
     }
     notifyTransactionAdded(transactionInfo.getTransaction());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
@@ -19,7 +19,6 @@ import static java.util.Comparator.comparing;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionsForSenderInfo;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.number.Percentage;
 
@@ -42,7 +41,7 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       new TreeSet<>(
           comparing(TransactionInfo::isReceivedFromLocalSource)
               .thenComparing(TransactionInfo::getGasPrice)
-              .thenComparing(TransactionInfo::getSequence)
+              .thenComparing(TransactionInfo::getAddedToPoolAt)
               .reversed());
 
   public GasPricePendingTransactionsSorter(
@@ -102,10 +101,10 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       pendingTransactions.put(transactionInfo.getHash(), transactionInfo);
 
       if (pendingTransactions.size() > maxPendingTransactions) {
-        droppedTransaction = lowestValueTxForRemovalBySender(prioritizedTransactions)
-            .map(TransactionInfo::getTransaction);
-        droppedTransaction
-            .ifPresent(tx -> doRemoveTransaction(tx, false));
+        droppedTransaction =
+            lowestValueTxForRemovalBySender(prioritizedTransactions)
+                .map(TransactionInfo::getTransaction);
+        droppedTransaction.ifPresent(tx -> doRemoveTransaction(tx, false));
       }
     }
     notifyTransactionAdded(transactionInfo.getTransaction());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -73,6 +73,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1081,7 +1082,7 @@ public final class EthProtocolManagerTest {
           protocolSchedule,
           protocolContext,
           ethManager.ethContext(),
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           () -> true,
           new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -104,7 +105,7 @@ public abstract class AbstractMessageTaskTest<T, R> {
             protocolSchedule,
             protocolContext,
             ethContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTran
 import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class GasPricePendingTransactionsTest {
       new GasPricePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           MAX_TRANSACTIONS,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           GasPricePendingTransactionsTest::mockBlockHeader,
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -212,7 +213,6 @@ public class GasPricePendingTransactionsTest {
     for (int i = 0; i <= MAX_TRANSACTIONS; i++) {
       lastLocalTransactionForSender = createTransaction(i);
       transactions.addLocalTransaction(lastLocalTransactionForSender);
-
     }
     assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
     assertTransactionNotPending(lastLocalTransactionForSender);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
@@ -207,16 +207,15 @@ public class GasPricePendingTransactionsTest {
 
   @Test
   public void shouldStartDroppingLocalTransactionsWhenPoolIsFullOfLocalTransactions() {
+    Transaction lastLocalTransactionForSender = null;
 
-    final Transaction firstLocalTransaction = createTransaction(0);
-    transactions.addLocalTransaction(firstLocalTransaction);
+    for (int i = 0; i <= MAX_TRANSACTIONS; i++) {
+      lastLocalTransactionForSender = createTransaction(i);
+      transactions.addLocalTransaction(lastLocalTransactionForSender);
 
-    for (int i = 1; i <= MAX_TRANSACTIONS; i++) {
-      transactions.addLocalTransaction(createTransaction(i));
     }
-
     assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
-    assertTransactionNotPending(firstLocalTransaction);
+    assertTransactionNotPending(lastLocalTransactionForSender);
   }
 
   @Test
@@ -710,9 +709,11 @@ public class GasPricePendingTransactionsTest {
         .isPresent()
         .hasValue(6);
     addLocalTransactions(6, 10);
+
+    // assert that transactions are pruned by account from latest future nonces first
     assertThat(transactions.getNextNonceForSender(transaction1.getSender()))
         .isPresent()
-        .hasValue(7);
+        .hasValue(6);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,9 @@ public class PendingMultiTypesTransactionsTest {
   private static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final KeyPair KEYS3 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS4 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS5 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS6 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final String ADDED_COUNTER = "transactions_added_total";
   private static final String REMOTE = "remote";
   private static final String LOCAL = "local";
@@ -58,7 +62,7 @@ public class PendingMultiTypesTransactionsTest {
       new BaseFeePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           MAX_TRANSACTIONS,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           () -> mockBlockHeader(Wei.of(7L)),
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -83,11 +87,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldReplaceTransactionWithLowestMaxFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = create1559Transaction(1, 190, 20, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 220, 20, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = create1559Transaction(0, 190, 20, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 220, 20, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -109,11 +113,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictTransactionWithLowestMaxFeePerGasAndLowestTip() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = create1559Transaction(1, 200, 19, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = create1559Transaction(0, 200, 19, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -133,11 +137,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictLegacyTransactionWithLowestEffectiveMaxPriorityFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = createLegacyTransaction(1, 25, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = createLegacyTransaction(0, 25, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -156,11 +160,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictEIP1559TransactionWithLowestEffectiveMaxPriorityFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = createLegacyTransaction(1, 26, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = createLegacyTransaction(0, 26, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -64,6 +64,7 @@ import org.hyperledger.besu.testutil.TestClock;
 import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -141,7 +142,7 @@ public class TestNode implements Closeable {
             protocolSchedule,
             protocolContext,
             ethContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -77,6 +77,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +136,7 @@ public class TransactionPoolTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             MAX_TRANSACTIONS,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             blockchain::getChainHeadHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Ensure when besu evicts transactions by sender, that future nonces are evicted first


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to protocol-misc 629

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).