### PR TITLE
4328 quiet cors errors

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TimedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TracedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.tls.TlsClientAuthConfiguration;
 import org.hyperledger.besu.ethereum.api.tls.TlsConfiguration;
@@ -298,16 +299,7 @@ public class JsonRpcHttpService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(checkAllowlistHostHeader());
-    router.errorHandler(
-        403,
-        event -> {
-          LOG.error(event.failure().getMessage());
-          LOG.debug(event.failure().getMessage(), event.failure());
-          int statusCode = event.statusCode();
-
-          HttpServerResponse response = event.response();
-          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
-        });
+    router.errorHandler(403, new Logging403ErrorHandler());
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -301,13 +301,13 @@ public class JsonRpcHttpService {
     router
         .route()
         .failureHandler(
-            new Handler<RoutingContext>() {
-              @Override
-              public void handle(final RoutingContext event) {
-                LOG.error(event.failure().getMessage());
-                LOG.debug(event.failure().getMessage(), event.failure());
-                event.fail(403);
-              }
+            event -> {
+              LOG.error(event.failure().getMessage());
+              LOG.debug(event.failure().getMessage(), event.failure());
+              int statusCode = event.statusCode();
+
+              HttpServerResponse response = event.response();
+              response.setStatusCode(statusCode).end("Exception thrown handling RPC");
             });
     router
         .route()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -298,13 +298,17 @@ public class JsonRpcHttpService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(checkAllowlistHostHeader());
-    router.route().failureHandler(new Handler<RoutingContext>() {
-      @Override
-      public void handle(final RoutingContext event) {
-        LOG.error(event.failure().getMessage());
-        LOG.debug(event.failure().getMessage(), event.failure());
-      }
-    });
+    router
+        .route()
+        .failureHandler(
+            new Handler<RoutingContext>() {
+              @Override
+              public void handle(final RoutingContext event) {
+                LOG.error(event.failure().getMessage());
+                LOG.debug(event.failure().getMessage(), event.failure());
+                event.fail(403);
+              }
+            });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -298,17 +298,16 @@ public class JsonRpcHttpService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(checkAllowlistHostHeader());
-    router
-        .route()
-        .failureHandler(
-            event -> {
-              LOG.error(event.failure().getMessage());
-              LOG.debug(event.failure().getMessage(), event.failure());
-              int statusCode = event.statusCode();
+    router.errorHandler(
+        403,
+        event -> {
+          LOG.error(event.failure().getMessage());
+          LOG.debug(event.failure().getMessage(), event.failure());
+          int statusCode = event.statusCode();
 
-              HttpServerResponse response = event.response();
-              response.setStatusCode(statusCode).end("Exception thrown handling RPC");
-            });
+          HttpServerResponse response = event.response();
+          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
+        });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -298,7 +298,13 @@ public class JsonRpcHttpService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(checkAllowlistHostHeader());
-
+    router.route().failureHandler(new Handler<RoutingContext>() {
+      @Override
+      public void handle(final RoutingContext event) {
+        LOG.error(event.failure().getMessage());
+        LOG.debug(event.failure().getMessage(), event.failure());
+      }
+    });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TimedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TracedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketMessageHandler;
@@ -402,16 +403,7 @@ public class JsonRpcService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(denyRouteToBlockedHost());
-    router.errorHandler(
-        403,
-        event -> {
-          LOG.error(event.failure().getMessage());
-          LOG.debug(event.failure().getMessage(), event.failure());
-          int statusCode = event.statusCode();
-
-          HttpServerResponse response = event.response();
-          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
-        });
+    router.errorHandler(403, new Logging403ErrorHandler());
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -405,12 +405,13 @@ public class JsonRpcService {
     router
         .route()
         .failureHandler(
-            new Handler<RoutingContext>() {
-              @Override
-              public void handle(final RoutingContext event) {
-                LOG.error(event.failure().getMessage());
-                LOG.debug(event.failure().getMessage(), event.failure());
-              }
+            event -> {
+              LOG.error(event.failure().getMessage());
+              LOG.debug(event.failure().getMessage(), event.failure());
+              int statusCode = event.statusCode();
+
+              HttpServerResponse response = event.response();
+              response.setStatusCode(statusCode).end("Exception thrown handling RPC");
             });
     router
         .route()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -402,13 +402,16 @@ public class JsonRpcService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(denyRouteToBlockedHost());
-    router.route().failureHandler(new Handler<RoutingContext>() {
-      @Override
-      public void handle(final RoutingContext event) {
-        LOG.error(event.failure().getMessage());
-        LOG.debug(event.failure().getMessage(), event.failure());
-      }
-    });
+    router
+        .route()
+        .failureHandler(
+            new Handler<RoutingContext>() {
+              @Override
+              public void handle(final RoutingContext event) {
+                LOG.error(event.failure().getMessage());
+                LOG.debug(event.failure().getMessage(), event.failure());
+              }
+            });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -402,17 +402,16 @@ public class JsonRpcService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(denyRouteToBlockedHost());
-    router
-        .route()
-        .failureHandler(
-            event -> {
-              LOG.error(event.failure().getMessage());
-              LOG.debug(event.failure().getMessage(), event.failure());
-              int statusCode = event.statusCode();
+    router.errorHandler(
+        403,
+        event -> {
+          LOG.error(event.failure().getMessage());
+          LOG.debug(event.failure().getMessage(), event.failure());
+          int statusCode = event.statusCode();
 
-              HttpServerResponse response = event.response();
-              response.setStatusCode(statusCode).end("Exception thrown handling RPC");
-            });
+          HttpServerResponse response = event.response();
+          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
+        });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -402,7 +402,13 @@ public class JsonRpcService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(denyRouteToBlockedHost());
-
+    router.route().failureHandler(new Handler<RoutingContext>() {
+      @Override
+      public void handle(final RoutingContext event) {
+        LOG.error(event.failure().getMessage());
+        LOG.debug(event.failure().getMessage(), event.failure());
+      }
+    });
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Logging403ErrorHandler implements Handler<RoutingContext> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Logging403ErrorHandler.class);
+
+  @Override
+  public void handle(final RoutingContext event) {
+    LOG.error(event.failure().getMessage());
+    LOG.debug(event.failure().getMessage(), event.failure());
+    int statusCode = event.statusCode();
+
+    HttpServerResponse response = event.response();
+    response.setStatusCode(statusCode).end("Exception thrown handling RPC");
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -222,7 +222,16 @@ public class WebSocketService {
           .produces(APPLICATION_JSON)
           .handler(DefaultAuthenticationService::handleDisabledLogin);
     }
+    router.errorHandler(
+        403,
+        event -> {
+          LOG.error(event.failure().getMessage());
+          LOG.debug(event.failure().getMessage(), event.failure());
+          int statusCode = event.statusCode();
 
+          HttpServerResponse response = event.response();
+          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
+        });
     router.route().handler(WebSocketService::handleHttpNotSupported);
     return router;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Streams.stream;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.DefaultAuthenticationService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -222,16 +223,7 @@ public class WebSocketService {
           .produces(APPLICATION_JSON)
           .handler(DefaultAuthenticationService::handleDisabledLogin);
     }
-    router.errorHandler(
-        403,
-        event -> {
-          LOG.error(event.failure().getMessage());
-          LOG.debug(event.failure().getMessage(), event.failure());
-          int statusCode = event.statusCode();
-
-          HttpServerResponse response = event.response();
-          response.setStatusCode(statusCode).end("Exception thrown handling RPC");
-        });
+    router.errorHandler(403, new Logging403ErrorHandler());
     router.route().handler(WebSocketService::handleHttpNotSupported);
     return router;
   }


### PR DESCRIPTION
Open question as to if this is overly broad: This will log the error message for all failed RPC calls, but not the stack trace, unless logging is turned up to debug.

This _seems_ to be the preferred way to do this in Vert.x, but I'm open to solutions that are more narrowly aimed at the CORS handling case.

## PR description

## Fixed Issue(s)
fixes #4328 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).