### PR TITLE
waiting blockchain before stopping snapsync

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
@@ -126,6 +126,7 @@ public class CheckpointDownloaderFactory extends SnapDownloaderFactory {
     final WorldStateDownloader snapWorldStateDownloader =
         new SnapWorldStateDownloader(
             ethContext,
+            protocolContext,
             worldStateStorage,
             snapTaskCollection,
             syncConfig.getSnapSyncConfiguration(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActions.java
@@ -268,4 +268,8 @@ public class FastSyncActions {
               return new FastSyncState(blockHeader);
             });
   }
+
+  public boolean isBlockchainBehind(final long blockNumber) {
+    return protocolContext.getBlockchain().getChainHeadHeader().getNumber() < blockNumber;
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
@@ -38,7 +38,7 @@ public class DynamicPivotBlockManager {
 
   private final FastSyncActions syncActions;
 
-  private final FastSyncState syncState;
+  private final SnapSyncState syncState;
   private final int pivotBlockWindowValidity;
   private final int pivotBlockDistanceBeforeCaching;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
@@ -102,4 +102,8 @@ public class DynamicPivotBlockManager {
         },
         () -> onSwitchDone.accept(syncState.getPivotBlockHeader().orElseThrow(), false));
   }
+
+  public boolean isBlockchainBehind() {
+    return syncActions.isBlockchainBehind(syncState.getPivotBlockNumber().orElseThrow() - 256);
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
@@ -106,9 +106,7 @@ public class DynamicPivotBlockManager {
   public boolean isBlockchainBehind() {
     return syncState
         .getPivotBlockHeader()
-        .map(
-            pivot ->
-                syncActions.isBlockchainBehind(pivot.getNumber() - (pivotBlockWindowValidity * 2L)))
+        .map(pivot -> syncActions.isBlockchainBehind(pivot.getNumber() - pivotBlockWindowValidity))
         .orElse(false);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
@@ -106,7 +106,7 @@ public class DynamicPivotBlockManager {
   public boolean isBlockchainBehind() {
     return syncState
         .getPivotBlockHeader()
-        .map(pivot -> syncActions.isBlockchainBehind(pivot.getNumber() - pivotBlockWindowValidity))
+        .map(pivot -> syncActions.isBlockchainBehind(pivot.getNumber()))
         .orElse(false);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/DynamicPivotBlockManager.java
@@ -104,6 +104,11 @@ public class DynamicPivotBlockManager {
   }
 
   public boolean isBlockchainBehind() {
-    return syncActions.isBlockchainBehind(syncState.getPivotBlockNumber().orElseThrow() - 256);
+    return syncState
+        .getPivotBlockHeader()
+        .map(
+            pivot ->
+                syncActions.isBlockchainBehind(pivot.getNumber() - (pivotBlockWindowValidity * 2L)))
+        .orElse(false);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -93,6 +93,7 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
     final WorldStateDownloader snapWorldStateDownloader =
         new SnapWorldStateDownloader(
             ethContext,
+            protocolContext,
             worldStateStorage,
             snapTaskCollection,
             syncConfig.getSnapSyncConfiguration(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 public class SnapSyncState extends FastSyncState {
 
   private boolean isHealInProgress;
+  private boolean isWaitingBlockchain;
 
   public SnapSyncState(final FastSyncState fastSyncState) {
     super(
@@ -35,6 +36,14 @@ public class SnapSyncState extends FastSyncState {
 
   public void setHealStatus(final boolean healStatus) {
     isHealInProgress = healStatus;
+  }
+
+  public boolean isWaitingBlockchain() {
+    return isWaitingBlockchain;
+  }
+
+  public void setWaitingBlockchain(boolean waitingBlockchain) {
+    isWaitingBlockchain = waitingBlockchain;
   }
 
   public boolean isExpired(final SnapDataRequest request) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapSyncState.java
@@ -42,7 +42,7 @@ public class SnapSyncState extends FastSyncState {
     return isWaitingBlockchain;
   }
 
-  public void setWaitingBlockchain(boolean waitingBlockchain) {
+  public void setWaitingBlockchain(final boolean waitingBlockchain) {
     isWaitingBlockchain = waitingBlockchain;
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 import static org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest.createAccountTrieNodeDataRequest;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.AccountRangeDataRequest;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.BytecodeRequest;
@@ -63,8 +62,6 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
 
   // metrics around the snapsync
   private final SnapsyncMetricsManager metricsManager;
-
-  private Blockchain blockchain;
 
   public SnapWorldDownloadState(
       final WorldStateStorage worldStateStorage,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -152,7 +152,6 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
           blockObserverId = OptionalLong.of(blockchain.observeBlockAdded(getBlockAddedListener()));
         snapSyncState.setWaitingBlockchain(true);
       } else {
-        blockObserverId.ifPresent(blockchain::removeObserver);
         final WorldStateStorage.Updater updater = worldStateStorage.updater();
         updater.saveWorldState(header.getHash(), header.getStateRoot(), rootNodeData);
         updater.commit();
@@ -306,6 +305,8 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
           snapSyncState.setWaitingBlockchain(false);
         }
         if (!snapSyncState.isWaitingBlockchain()) {
+          blockObserverId.ifPresent(blockchain::removeObserver);
+          blockObserverId = OptionalLong.empty();
           reloadHeal();
         }
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -283,17 +283,6 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
         List.of(pendingTrieNodeRequests));
   }
 
-  public synchronized Task<SnapDataRequest> dequeueWaitingTaskBlocking() {
-    return dequeueRequestBlocking(
-        List.of(
-            pendingAccountRequests,
-            pendingStorageRequests,
-            pendingBigStorageRequests,
-            pendingCodeRequests,
-            pendingTrieNodeRequests),
-        List.of(pendingTrieNodeRequests));
-  }
-
   public SnapsyncMetricsManager getMetricsManager() {
     return metricsManager;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadState.java
@@ -145,9 +145,6 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
         && pendingBigStorageRequests.allTasksCompleted()
         && pendingTrieNodeRequests.allTasksCompleted()) {
       if (!snapSyncState.isHealInProgress()) {
-        LOG.info(
-            "Starting world state heal process from peers with pivot block {}",
-            snapSyncState.getPivotBlockNumber());
         startHeal();
       } else if (dynamicPivotBlockManager.isBlockchainBehind()) {
         LOG.info("Pausing world state download while waiting for sync to complete");
@@ -182,10 +179,14 @@ public class SnapWorldDownloadState extends WorldDownloadState<SnapDataRequest> 
     snapSyncState.setHealStatus(true);
     // try to find new pivot block before healing
     dynamicPivotBlockManager.switchToNewPivotBlock(
-        (blockHeader, newPivotBlockFound) ->
-            enqueueRequest(
-                createAccountTrieNodeDataRequest(
-                    blockHeader.getStateRoot(), Bytes.EMPTY, inconsistentAccounts)));
+        (blockHeader, newPivotBlockFound) -> {
+          LOG.info(
+              "Running world state heal process from peers with pivot block {}",
+              blockHeader.getNumber());
+          enqueueRequest(
+              createAccountTrieNodeDataRequest(
+                  blockHeader.getStateRoot(), Bytes.EMPTY, inconsistentAccounts));
+        });
   }
 
   public synchronized void reloadHeal() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloadProcess.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloadProcess.java
@@ -373,6 +373,42 @@ public class SnapWorldStateDownloadProcess implements WorldStateDownloadProcess 
               .andFinishWith(
                   "batchTrieNodeDataDownloaded", tasks -> tasks.forEach(requestsToComplete::put));
 
+      final Pipeline<Task<SnapDataRequest>> waitingBlockchainDataPipeline =
+          createPipelineFrom(
+                  "requestTrieNodeDequeued",
+                  new TaskQueueIterator<>(
+                      downloadState, () -> downloadState.dequeueTrieNodeRequestBlocking()),
+                  bufferCapacity,
+                  outputCounter,
+                  true,
+                  "world_state_download")
+              .thenFlatMapInParallel(
+                  "requestLoadLocalTrieNodeData",
+                  task -> loadLocalDataStep.loadLocalDataTrieNode(task, requestsToComplete),
+                  3,
+                  bufferCapacity)
+              .inBatches(snapSyncConfiguration.getTrienodeCountPerRequest())
+              .thenProcess(
+                  "checkNewPivotBlock",
+                  tasks -> {
+                    pivotBlockManager.check(
+                        (blockHeader, newBlockFound) ->
+                            reloadHealWhenNeeded(snapSyncState, downloadState, newBlockFound));
+                    return tasks;
+                  })
+              .thenProcessAsync(
+                  "batchDownloadTrieNodeData",
+                  tasks -> requestDataStep.requestTrieNodeByPath(tasks),
+                  maxOutstandingRequests)
+              .thenProcess(
+                  "batchPersistTrieNodeData",
+                  tasks -> {
+                    persistDataStep.persist(tasks);
+                    return tasks;
+                  })
+              .andFinishWith(
+                  "batchTrieNodeDataDownloaded", tasks -> tasks.forEach(requestsToComplete::put));
+
       return new SnapWorldStateDownloadProcess(
           fetchAccountDataPipeline,
           fetchStorageDataPipeline,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
@@ -156,7 +156,7 @@ public class SnapsyncMetricsManager {
   public void notifySnapSyncCompleted() {
     final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startSyncTime);
     LOG.info(
-        "Finished worldstate snapsync with nodes {} (healed={}) duration {}{}:{},{}. Sync block import may still be in progress...",
+        "Finished worldstate snapsync with nodes {} (healed={}) duration {}{}:{},{}.",
         nbNodesGenerated.addAndGet(nbNodesHealed.get()),
         nbNodesHealed,
         duration.toHoursPart() > 0 ? (duration.toHoursPart() + ":") : "",

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -14,16 +14,23 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
+import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -41,6 +48,7 @@ import org.hyperledger.besu.testutil.TestClock;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -72,6 +80,8 @@ public class SnapWorldDownloadStateTest {
   private final SnapSyncState snapSyncState = mock(SnapSyncState.class);
   private final SnapsyncMetricsManager metricsManager = mock(SnapsyncMetricsManager.class);
   private final Blockchain blockchain = mock(Blockchain.class);
+  private final DynamicPivotBlockManager dynamicPivotBlockManager =
+      mock(DynamicPivotBlockManager.class);
 
   private final TestClock clock = new TestClock();
   private SnapWorldDownloadState downloadState;
@@ -263,5 +273,90 @@ public class SnapWorldDownloadStateTest {
     verify(snapSyncState).setHealStatus(false);
     assertThat(downloadState.pendingTrieNodeRequests.size()).isEqualTo(1);
     assertThat(downloadState.pendingCodeRequests.isEmpty()).isTrue();
+  }
+
+  @Test
+  public void shouldWaitingBlockchainWhenTooBehind() {
+    when(snapSyncState.isHealInProgress()).thenReturn(true);
+
+    assertThat(snapSyncState.isWaitingBlockchain()).isFalse();
+
+    downloadState.setDynamicPivotBlockManager(dynamicPivotBlockManager);
+    when(dynamicPivotBlockManager.isBlockchainBehind()).thenReturn(true);
+
+    downloadState.checkCompletion(header);
+
+    downloadState.checkCompletion(header);
+
+    // should register only one time
+    verify(blockchain, times(1)).observeBlockAdded(any());
+    verify(snapSyncState, atLeastOnce()).setWaitingBlockchain(true);
+
+    assertThat(future).isNotDone();
+    assertThat(worldStateStorage.getAccountStateTrieNode(Bytes.EMPTY, ROOT_NODE_HASH)).isEmpty();
+    assertThat(downloadState.isDownloading()).isTrue();
+  }
+
+  @Test
+  public void shouldStopWaitingBlockchainWhenNewPivotBlockAvailable() {
+
+    when(snapSyncState.isHealInProgress()).thenReturn(true);
+
+    downloadState.setDynamicPivotBlockManager(dynamicPivotBlockManager);
+    when(dynamicPivotBlockManager.isBlockchainBehind()).thenReturn(true);
+
+    downloadState.checkCompletion(header);
+
+    verify(snapSyncState).setWaitingBlockchain(true);
+    when(snapSyncState.isWaitingBlockchain()).thenReturn(true);
+
+    final BlockHeaderTestFixture blockHeaderTestFixture = new BlockHeaderTestFixture();
+    final BlockHeader newPivotBlock = blockHeaderTestFixture.number(550L).buildHeader();
+    doAnswer(
+            invocation -> {
+              BiConsumer<BlockHeader, Boolean> callback =
+                  invocation.getArgument(0, BiConsumer.class);
+              callback.accept(newPivotBlock, true);
+              return null;
+            })
+        .when(dynamicPivotBlockManager)
+        .check(any());
+
+    final BlockAddedObserver blockAddedListener = downloadState.getBlockAddedListener();
+    blockAddedListener.onBlockAdded(
+        BlockAddedEvent.createForHeadAdvancement(
+            new Block(
+                new BlockHeaderTestFixture().number(500).buildHeader(),
+                new BlockBody(emptyList(), emptyList())),
+            Collections.emptyList(),
+            Collections.emptyList()));
+
+    verify(snapSyncState).setWaitingBlockchain(false);
+  }
+
+  @Test
+  public void shouldStopWaitingBlockchainWhenCloseToTheHead() {
+
+    when(snapSyncState.isHealInProgress()).thenReturn(true);
+
+    downloadState.setDynamicPivotBlockManager(dynamicPivotBlockManager);
+    when(dynamicPivotBlockManager.isBlockchainBehind()).thenReturn(true);
+
+    downloadState.checkCompletion(header);
+
+    verify(snapSyncState).setWaitingBlockchain(true);
+    when(snapSyncState.isWaitingBlockchain()).thenReturn(true);
+
+    when(dynamicPivotBlockManager.isBlockchainBehind()).thenReturn(false);
+    final BlockAddedObserver blockAddedListener = downloadState.getBlockAddedListener();
+    blockAddedListener.onBlockAdded(
+        BlockAddedEvent.createForHeadAdvancement(
+            new Block(
+                new BlockHeaderTestFixture().number(500).buildHeader(),
+                new BlockBody(emptyList(), emptyList())),
+            Collections.emptyList(),
+            Collections.emptyList()));
+
+    verify(snapSyncState).setWaitingBlockchain(false);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -70,6 +71,7 @@ public class SnapWorldDownloadStateTest {
       mock(WorldStateDownloadProcess.class);
   private final SnapSyncState snapSyncState = mock(SnapSyncState.class);
   private final SnapsyncMetricsManager metricsManager = mock(SnapsyncMetricsManager.class);
+  private final Blockchain blockchain = mock(Blockchain.class);
 
   private final TestClock clock = new TestClock();
   private SnapWorldDownloadState downloadState;
@@ -101,6 +103,7 @@ public class SnapWorldDownloadStateTest {
     downloadState =
         new SnapWorldDownloadState(
             worldStateStorage,
+            blockchain,
             snapSyncState,
             pendingRequests,
             MAX_REQUESTS_WITHOUT_PROGRESS,


### PR DESCRIPTION
Signed-off-by: Karim TAAM <karim.t2am@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR modifies the snapsync so that the heal is done throughout the download of the blocks. As long as we haven't downloaded all the blocks we change the pivot block to get closer to the head. this reduces the number of blocks to full sync

did some tests pre and post merge and also benchmark on mainnet

- without the PR
Start sync 2022-09-09T20:53:47,926
Finish worldstate  2022-09-10T07:14:19,864
Finish all snapsync 2022-09-11T10:08:11,251
Reach the head 2022-09-11T16:23:29,213

- with the PR 
Start sync 2022-09-09T20:56:31,810
Finish worldstate 2022-09-11T14:43:43,065
Finish all snapsync 2022-09-11T14:43:44,865
Reach the head 2022-09-11T14:46:37,118

we saved 1 hour and 30 minutes with my test (aws t3.xlarge)

new logs will be like that 

```
Worldstate download in progress synced=99.92%, accounts=181151535, slots=1145130746, codes=24132459, nodes=1323894930"
Running world state heal process from peers with pivot block 15508741
Healed 2001 world state nodes
...
Pausing world state download while waiting for sync to complete
Running world state heal process from peers with pivot block 15508741
...
Pausing world state download while waiting for sync to complete
Running world state heal process from peers with pivot block 15509265
...
Finished worldstate snapsync with nodes 1341202726 (healed=15638668) duration 17:45:58,416
Sync completed successfully with pivot block 15515292

```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).