### PR TITLE
Always shutdown the mining executor on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)
+- Properly shutdown the miner executor, to avoid waiting 30 seconds when stopping [#4353](https://github.com/hyperledger/besu/pull/4353)
 
 
 ## 22.7.1

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinator.java
@@ -95,11 +95,10 @@ public abstract class AbstractMiningCoordinator<
   @Override
   public void stop() {
     synchronized (this) {
-      if (state != State.RUNNING) {
-        return;
+      if (state == State.RUNNING) {
+        haltCurrentMiningOperation();
       }
       state = State.STOPPED;
-      haltCurrentMiningOperation();
       executor.shutDown();
     }
   }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

There is an issue that prevents the PoWMiner to stop cleanly, with the effect of taking 30 seconds before the timeout expires and Besu can stop.

Basically the miner executor was only shutdown when running, but not when it was idle, this PR always shutdown the executor when the mining is stopped


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4313

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).