### PR TITLE
Cherry pick release 22.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Refactor and fix retrying get block switching peer [#4256](https://github.com/hyperledger/besu/pull/4256)
 - Fix encoding of key (short hex) in eth_getProof [#4261](https://github.com/hyperledger/besu/pull/4261)
 - Fix for post-merge networks fast-sync [#4224](https://github.com/hyperledger/besu/pull/4224), [#4276](https://github.com/hyperledger/besu/pull/4276)
+- Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)
 
 ### Download links
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.1/besu-22.7.1.tar.gz / sha256: `7cca4c11e1d7525c172f2af9fbf456d134ada60e970d8b6abcfcd6c623b5dd36`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 22.7.2
 
 ### Additions and Improvements
+- Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
+- Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
 
 ### Bug Fixes
 
@@ -33,7 +35,7 @@
 ### Additions and Improvements
 - Deprecation warning for Ropsten, Rinkeby, Kiln [#4173](https://github.com/hyperledger/besu/pull/4173)
 
-### Bug Fixes 
+### Bug Fixes
 
 - Fixes previous known issue [#3890](https://github.com/hyperledger/besu/issues/3890)from RC3 requiring a restart post-merge to continue correct transaction handling.
 - Stop producing stack traces when a get headers response only contains the range start header [#4189](https://github.com/hyperledger/besu/pull/4189)
@@ -52,8 +54,8 @@
 ### Additions and Improvements
 - Engine API: Change expiration time for JWT tokens to 60s [#4168](https://github.com/hyperledger/besu/pull/4168)
 - Sepolia mergeNetSplit block [#4158](https://github.com/hyperledger/besu/pull/4158)
-- Goerli TTD [#4160](https://github.com/hyperledger/besu/pull/4160) 
-- Several logging improvements 
+- Goerli TTD [#4160](https://github.com/hyperledger/besu/pull/4160)
+- Several logging improvements
 
 ### Bug Fixes
 - Allow to set any value for baseFeePerGas in the genesis file [#4177](https://github.com/hyperledger/besu/pull/4177)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions and Improvements
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
+- Retry mechanism when getting a broadcasted block fail on all peers [#4271](https://github.com/hyperledger/besu/pull/4271)
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 - Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
 - Log imported block info post merge [#4310](https://github.com/hyperledger/besu/pull/4310)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 - Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
 - Log imported block info post merge [#4310](https://github.com/hyperledger/besu/pull/4310)
+- Pandas! Pandas now appear in 3 phases: The black bear and polar bear that are preparing? Those will appear when
+your client has TTD configured (which is setup by default for mainnet), is in sync, and processing Proof of Work blocks. In the second phase you will see them powering up when the Terminal Total Difficulty block is added to the blockchain.
+The final form of the Ethereum Panda will appear when the first finalized block is received from the Consensus Layer.
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)
+- Properly shutdown the miner executor, to avoid waiting 30 seconds when stopping [#4353](https://github.com/hyperledger/besu/pull/4353)
 
 
 ## 22.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 
 ### Bug Fixes
+- Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)
 
 
 ## 22.7.1
@@ -26,7 +27,6 @@
 - Refactor and fix retrying get block switching peer [#4256](https://github.com/hyperledger/besu/pull/4256)
 - Fix encoding of key (short hex) in eth_getProof [#4261](https://github.com/hyperledger/besu/pull/4261)
 - Fix for post-merge networks fast-sync [#4224](https://github.com/hyperledger/besu/pull/4224), [#4276](https://github.com/hyperledger/besu/pull/4276)
-- Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)
 
 ### Download links
 - https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.1/besu-22.7.1.tar.gz / sha256: `7cca4c11e1d7525c172f2af9fbf456d134ada60e970d8b6abcfcd6c623b5dd36`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Additions and Improvements
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
+- Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 - Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
+- Log imported block info post merge [#4310](https://github.com/hyperledger/besu/pull/4310)
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
 ## 22.7.2
+### Besu 22.7.2 is a recommended release for the Merge and Mainnet users. 22.7.1 remains Merge-ready. This release provides additional robustness before the Merge with some fixes and improvements in sync, peering, and logging.
 
 ### Additions and Improvements
-- Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
 - Retry mechanism when getting a broadcasted block fail on all peers [#4271](https://github.com/hyperledger/besu/pull/4271)
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
 - Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
 - Log imported block info post merge [#4310](https://github.com/hyperledger/besu/pull/4310)
+- Transaction pool eviction by sender from tail of transaction list [#4327](https://github.com/hyperledger/besu/pull/4327)
+- Transaction pool sender future nonce limits [#4336](https://github.com/hyperledger/besu/pull/4336) 
 - Pandas! Pandas now appear in 3 phases: The black bear and polar bear that are preparing? Those will appear when
 your client has TTD configured (which is setup by default for mainnet), is in sync, and processing Proof of Work blocks. In the second phase you will see them powering up when the Terminal Total Difficulty block is added to the blockchain.
 The final form of the Ethereum Panda will appear when the first finalized block is received from the Consensus Layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 - Better management of jemalloc presence/absence in startup script [#4237](https://github.com/hyperledger/besu/pull/4237)
 - Filter out disconnected peers when fetching available peers [#4269](https://github.com/hyperledger/besu/pull/4269)
+- Updated the default value of fast-sync-min-peers post merge [#4298](https://github.com/hyperledger/besu/pull/4298)
 
 ### Bug Fixes
 - Accept wit/80 from Nethermind [#4279](https://github.com/hyperledger/besu/pull/4279)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 22.7.1   
+## 22.7.2
+
+### Additions and Improvements
+
+### Bug Fixes
+
+
+## 22.7.1
+
 ### Merge Ready Release. Required update for The Merge on ethereum mainnet!
 
 ### Additions and Improvements
@@ -15,6 +23,10 @@
 - Refactor and fix retrying get block switching peer [#4256](https://github.com/hyperledger/besu/pull/4256)
 - Fix encoding of key (short hex) in eth_getProof [#4261](https://github.com/hyperledger/besu/pull/4261)
 - Fix for post-merge networks fast-sync [#4224](https://github.com/hyperledger/besu/pull/4224), [#4276](https://github.com/hyperledger/besu/pull/4276)
+
+### Download links
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.1/besu-22.7.1.tar.gz / sha256: `7cca4c11e1d7525c172f2af9fbf456d134ada60e970d8b6abcfcd6c623b5dd36`
+- https://hyperledger.jfrog.io/artifactory/besu-binaries/besu/22.7.1/besu-22.7.1.zip / sha256: `ba6e0b9b65ac36d041a5072392f119ff76e8e9f53a3d7b1e1a658ef1e4705d7a`
 
 ## 22.7.0
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -185,6 +185,7 @@ import org.hyperledger.besu.util.PermissioningConfigurationValidator;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
 import org.hyperledger.besu.util.number.PositiveNumber;
+import org.hyperledger.besu.util.platform.PlatformDetector;
 
 import java.io.File;
 import java.io.IOException;
@@ -1391,6 +1392,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     handleUnstableOptions();
     preparePlugins();
     parse(resultHandler, exceptionHandler, args);
+    detectJemalloc();
   }
 
   @Override
@@ -1490,6 +1492,18 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     metricCategoryConverter.addCategories(BesuMetricCategory.class);
     metricCategoryConverter.addCategories(StandardMetricCategory.class);
     commandLine.registerConverter(MetricCategory.class, metricCategoryConverter);
+  }
+
+  private void detectJemalloc() {
+    // jemalloc is only supported on Linux at the moment
+    if (PlatformDetector.getOSType().equals("linux")) {
+      Optional.ofNullable(environment.get("BESU_USING_JEMALLOC"))
+          .ifPresentOrElse(
+              present -> logger.info("Using jemalloc"),
+              () ->
+                  logger.info(
+                      "jemalloc library not found, memory usage may be reduced by installing it"));
+    }
   }
 
   private void handleStableOptions() {

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -20,6 +20,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hyperledger.besu.cli.DefaultCommandValues.getDefaultBesuDataPath;
 import static org.hyperledger.besu.cli.config.NetworkName.MAINNET;
+import static org.hyperledger.besu.cli.config.NetworkName.isMergedNetwork;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPENDENCY_WARNING_MSG;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPRECATED_AND_USELESS_WARNING_MSG;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPRECATION_WARNING_MSG;
@@ -506,8 +507,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       names = {"--fast-sync-min-peers"},
       paramLabel = MANDATORY_INTEGER_FORMAT_HELP,
       description =
-          "Minimum number of peers required before starting fast sync. (default: ${DEFAULT-VALUE})")
-  private final Integer fastSyncMinPeerCount = FAST_SYNC_MIN_PEER_COUNT;
+          "Minimum number of peers required before starting fast sync. (default pre-merge: "
+              + FAST_SYNC_MIN_PEER_COUNT
+              + " and post-merge: "
+              + FAST_SYNC_MIN_PEER_COUNT_POST_MERGE
+              + ")")
+  private final Integer fastSyncMinPeerCount = null;
 
   @Option(
       names = {"--network"},
@@ -2774,10 +2779,19 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private SynchronizerConfiguration buildSyncConfig() {
+    Integer fastSyncMinPeers = fastSyncMinPeerCount;
+    if (fastSyncMinPeers == null) {
+      if (isMergedNetwork(network)) {
+        fastSyncMinPeers = FAST_SYNC_MIN_PEER_COUNT_POST_MERGE;
+      } else {
+        fastSyncMinPeers = FAST_SYNC_MIN_PEER_COUNT;
+      }
+    }
+
     return unstableSynchronizerOptions
         .toDomainObject()
         .syncMode(syncMode)
-        .fastSyncMinimumPeerCount(fastSyncMinPeerCount)
+        .fastSyncMinimumPeerCount(fastSyncMinPeers)
         .build();
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1217,6 +1217,16 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             "Price bump percentage to replace an already existing transaction  (default: ${DEFAULT-VALUE})",
         arity = "1")
     private final Integer priceBump = TransactionPoolConfiguration.DEFAULT_PRICE_BUMP.getValue();
+
+    @Option(
+        names = {"--tx-pool-future-max-by-account"},
+        paramLabel = MANDATORY_INTEGER_FORMAT_HELP,
+        converter = PercentageConverter.class,
+        description =
+            "Maximum per account of currently unexecutable future transactions that can occupy the txpool (default: ${DEFAULT-VALUE})",
+        arity = "1")
+    private final Integer maxFutureTransactionsByAccount =
+        TransactionPoolConfiguration.MAX_FUTURE_TRANSACTION_BY_ACCOUNT;
   }
 
   @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
@@ -2801,6 +2811,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .txPoolMaxSize(txPoolOptionGroup.txPoolMaxSize)
         .pendingTxRetentionPeriod(txPoolOptionGroup.pendingTxRetentionPeriod)
         .priceBump(Percentage.fromInt(txPoolOptionGroup.priceBump))
+        .txPoolMaxFutureTransactionByAccount(txPoolOptionGroup.maxFutureTransactionsByAccount)
         .txFeeCap(txFeeCap)
         .build();
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
@@ -57,6 +57,7 @@ public interface DefaultCommandValues {
   NatMethod DEFAULT_NAT_METHOD = NatMethod.AUTO;
   JwtAlgorithm DEFAULT_JWT_ALGORITHM = JwtAlgorithm.RS256;
   int FAST_SYNC_MIN_PEER_COUNT = 5;
+  int FAST_SYNC_MIN_PEER_COUNT_POST_MERGE = 1;
   int DEFAULT_MAX_PEERS = 25;
   int DEFAULT_P2P_PEER_LOWER_BOUND = 25;
   int DEFAULT_HTTP_MAX_CONNECTIONS = 80;

--- a/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/config/NetworkName.java
@@ -86,4 +86,16 @@ public enum NetworkName {
   public Optional<String> getDeprecationDate() {
     return Optional.ofNullable(deprecationDate);
   }
+
+  public static boolean isMergedNetwork(final NetworkName networkName) {
+    switch (networkName) {
+      case GOERLI:
+      case ROPSTEN:
+      case SEPOLIA:
+      case KILN:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.merge.FinalizedBlockHashSupplier;
 import org.hyperledger.besu.consensus.merge.MergeContext;
-import org.hyperledger.besu.consensus.merge.PandaPrinter;
 import org.hyperledger.besu.consensus.qbft.pki.PkiBlockCreationConfiguration;
 import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.datatypes.Hash;
@@ -422,8 +421,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             ethProtocolManager,
             pivotBlockSelector);
 
-    synchronizer.subscribeInSync(new PandaPrinter());
-
     final MiningCoordinator miningCoordinator =
         createMiningCoordinator(
             protocolSchedule,
@@ -467,7 +464,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
         additionalPluginServices);
   }
 
-  private Synchronizer createSynchronizer(
+  protected Synchronizer createSynchronizer(
       final ProtocolSchedule protocolSchedule,
       final WorldStateStorage worldStateStorage,
       final ProtocolContext protocolContext,
@@ -476,8 +473,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
       final SyncState syncState,
       final EthProtocolManager ethProtocolManager,
       final PivotBlockSelector pivotBlockSelector) {
-
-    final GenesisConfigOptions maybeForTTD = configOptionsSupplier.get();
 
     DefaultSynchronizer toUse =
         new DefaultSynchronizer(
@@ -494,13 +489,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             metricsSystem,
             getFullSyncTerminationCondition(protocolContext.getBlockchain()),
             pivotBlockSelector);
-    if (maybeForTTD.getTerminalTotalDifficulty().isPresent()) {
-      LOG.info(
-          "TTD present, creating DefaultSynchronizer that stops propagating after finalization");
-      protocolContext
-          .getConsensusContext(MergeContext.class)
-          .addNewForkchoiceMessageListener(toUse);
-    }
 
     return toUse;
   }

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -15,6 +15,8 @@
 package org.hyperledger.besu.controller;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.PandaPrinter;
 import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.consensus.merge.TransitionBackwardSyncContext;
@@ -29,8 +31,10 @@ import org.hyperledger.besu.ethereum.GasLimitCalculator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
@@ -39,6 +43,8 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.manager.MergePeerFilter;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.DefaultSynchronizer;
+import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -47,8 +53,10 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfigurati
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.Pruner;
 import org.hyperledger.besu.ethereum.worldstate.PrunerConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.plugin.services.permissioning.NodeMessagePermissioningProvider;
@@ -61,9 +69,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
   private final BesuControllerBuilder preMergeBesuControllerBuilder;
   private final MergeBesuControllerBuilder mergeBesuControllerBuilder;
+
+  private static final Logger LOG = LoggerFactory.getLogger(TransitionBesuControllerBuilder.class);
 
   public TransitionBesuControllerBuilder(
       final BesuControllerBuilder preMergeBesuControllerBuilder,
@@ -176,6 +189,50 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
     return new NoopPluginServiceFactory();
   }
 
+  @Override
+  protected Synchronizer createSynchronizer(
+      final ProtocolSchedule protocolSchedule,
+      final WorldStateStorage worldStateStorage,
+      final ProtocolContext protocolContext,
+      final Optional<Pruner> maybePruner,
+      final EthContext ethContext,
+      final SyncState syncState,
+      final EthProtocolManager ethProtocolManager,
+      final PivotBlockSelector pivotBlockSelector) {
+
+    DefaultSynchronizer sync =
+        (DefaultSynchronizer)
+            super.createSynchronizer(
+                protocolSchedule,
+                worldStateStorage,
+                protocolContext,
+                maybePruner,
+                ethContext,
+                syncState,
+                ethProtocolManager,
+                pivotBlockSelector);
+    final GenesisConfigOptions maybeForTTD = configOptionsSupplier.get();
+
+    if (maybeForTTD.getTerminalTotalDifficulty().isPresent()) {
+      LOG.info(
+          "TTD present, creating DefaultSynchronizer that stops propagating after finalization");
+      protocolContext.getConsensusContext(MergeContext.class).addNewForkchoiceMessageListener(sync);
+      Optional<Difficulty> currentTotal =
+          protocolContext
+              .getBlockchain()
+              .getTotalDifficultyByHash(protocolContext.getBlockchain().getChainHeadHash());
+      PandaPrinter.init(
+          currentTotal, Difficulty.of(maybeForTTD.getTerminalTotalDifficulty().get()));
+      sync.subscribeInSync(PandaPrinter.getInstance());
+      protocolContext.getBlockchain().observeBlockAdded(PandaPrinter.getInstance());
+      protocolContext
+          .getConsensusContext(MergeContext.class)
+          .addNewForkchoiceMessageListener(PandaPrinter.getInstance());
+    }
+
+    return sync;
+  }
+
   private void initTransitionWatcher(
       final ProtocolContext protocolContext, final TransitionCoordinator composedCoordinator) {
 
@@ -193,7 +250,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
 
             if (priorState.filter(prior -> !prior).isPresent()) {
               // only print pandas if we had a prior merge state, and it was false
-              PandaPrinter.printOnFirstCrossing();
+              PandaPrinter.getInstance().printOnFirstCrossing();
             }
 
           } else if (composedCoordinator.isMiningBeforeMerge()) {
@@ -219,7 +276,6 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
   @Override
   public BesuController build() {
     BesuController controller = super.build();
-    PandaPrinter.hasTTD();
     PostMergeContext.get().setSyncState(controller.getSyncState());
     return controller;
   }

--- a/besu/src/main/scripts/unixStartScript.txt
+++ b/besu/src/main/scripts/unixStartScript.txt
@@ -182,8 +182,19 @@ APP_ARGS=`save "\$@"`
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
 
-# limit malloc to 2 arenas, and use jemalloc if available
-export MALLOC_ARENA_MAX=2
-export LD_PRELOAD=libjemalloc.so
+unset BESU_USING_JEMALLOC
+if [ "\$darwin" = "false" -a "\$msys" = "false" ]; then
+  # check if jemalloc is available
+  TEST_JEMALLOC=\$(LD_PRELOAD=libjemalloc.so sh -c true 2>&1)
+
+  # if jemalloc is available the output is empty, otherwise the output has an error line
+  if [ -z "\$TEST_JEMALLOC" ]; then
+    export LD_PRELOAD=libjemalloc.so
+    export BESU_USING_JEMALLOC=true
+  else
+    # jemalloc not available, as fallback limit malloc to 2 arenas
+    export MALLOC_ARENA_MAX=2
+  fi
+fi
 
 exec "\$JAVACMD" "\$@"

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hyperledger.besu.cli.config.NetworkName.CLASSIC;
 import static org.hyperledger.besu.cli.config.NetworkName.DEV;
@@ -94,6 +95,7 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
+import org.hyperledger.besu.util.platform.PlatformDetector;
 
 import java.io.File;
 import java.io.IOException;
@@ -5317,5 +5319,21 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(pkiKeyStoreConfig.getTrustStorePath()).isEqualTo(Path.of("/tmp/truststore"));
     assertThat(pkiKeyStoreConfig.getTrustStorePassword()).isEqualTo("foo");
     assertThat(pkiKeyStoreConfig.getCrlFilePath()).hasValue(Path.of("/tmp/crl"));
+  }
+
+  @Test
+  public void logsUsingJemallocWhenEnvVarPresent() {
+    assumeThat(PlatformDetector.getOSType(), is("linux"));
+    setEnvironmentVariable("BESU_USING_JEMALLOC", "true");
+    parseCommand();
+    verify(mockLogger).info("Using jemalloc");
+  }
+
+  @Test
+  public void logsSuggestInstallingJemallocWhenEnvVarNotPresent() {
+    assumeThat(PlatformDetector.getOSType(), is("linux"));
+    parseCommand();
+    verify(mockLogger)
+        .info("jemalloc library not found, memory usage may be reduced by installing it");
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1707,8 +1707,68 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void checkValidDefaultFastSyncMinPeersOption() {
+    parseCommand("--sync-mode", "FAST");
+    verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
+
+    final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(5);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void checkValidDefaultFastSyncMinPeersPreMergeOption() {
+    parseCommand("--sync-mode", "FAST", "--network", "CLASSIC");
+    verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
+
+    final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(5);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void checkValidDefaultFastSyncMinPeersPostMergeOption() {
+    parseCommand("--sync-mode", "FAST", "--network", "GOERLI");
+    verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
+
+    final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(1);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
   public void parsesValidFastSyncMinPeersOption() {
     parseCommand("--sync-mode", "FAST", "--fast-sync-min-peers", "11");
+    verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
+
+    final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(11);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void parsesValidFastSyncMinPeersOptionPreMerge() {
+    parseCommand("--sync-mode", "FAST", "--network", "CLASSIC", "--fast-sync-min-peers", "11");
+    verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
+
+    final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
+    assertThat(syncConfig.getSyncMode()).isEqualTo(SyncMode.FAST);
+    assertThat(syncConfig.getFastSyncMinimumPeerCount()).isEqualTo(11);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void parsesValidFastSyncMinPeersOptionPostMerge() {
+    parseCommand("--sync-mode", "FAST", "--network", "GOERLI", "--fast-sync-min-peers", "11");
     verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
 
     final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();

--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -66,6 +66,7 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -144,7 +145,7 @@ public class BesuEventsImplTest {
             mockProtocolSchedule,
             mockProtocolContext,
             mockEthContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             new NoOpMetricsSystem(),
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -167,6 +167,7 @@ tx-pool-retention-hours=999
 tx-pool-price-bump=13
 tx-pool-max-size=1234
 tx-pool-hashes-max-size=10000
+tx-pool-future-max-by-account=50
 Xincoming-tx-messages-keep-alive-seconds=60
 rpc-tx-feecap=2000000000000000000
 strict-tx-replay-protection-enabled=true

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -47,7 +47,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -132,12 +132,10 @@ public class CliqueBlockCreatorTest {
             () -> Optional.of(10_000_000L),
             parent -> extraData,
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                5,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(5).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                blockchain::getChainHeadHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                blockchain::getChainHeadHeader),
             protocolContext,
             protocolSchedule,
             proposerNodeKey,
@@ -167,12 +165,10 @@ public class CliqueBlockCreatorTest {
             () -> Optional.of(10_000_000L),
             parent -> extraData,
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                5,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(5).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                blockchain::getChainHeadHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                blockchain::getChainHeadHeader),
             protocolContext,
             protocolSchedule,
             proposerNodeKey,
@@ -204,12 +200,10 @@ public class CliqueBlockCreatorTest {
             () -> Optional.of(10_000_000L),
             parent -> extraData,
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                5,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(5).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                blockchain::getChainHeadHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                blockchain::getChainHeadHeader),
             protocolContext,
             protocolSchedule,
             proposerNodeKey,

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -56,6 +56,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -133,7 +134,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -168,7 +169,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -205,7 +206,7 @@ public class CliqueBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 5,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -38,7 +38,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Util;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -95,12 +95,10 @@ public class CliqueMinerExecutorTest {
             CliqueProtocolSchedule.create(
                 GENESIS_CONFIG_OPTIONS, proposerNodeKey, false, EvmConfiguration.DEFAULT),
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                1,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                CliqueMinerExecutorTest::mockBlockHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                CliqueMinerExecutorTest::mockBlockHeader),
             proposerNodeKey,
             new MiningParameters.Builder()
                 .coinbase(AddressHelpers.ofValue(1))
@@ -139,12 +137,10 @@ public class CliqueMinerExecutorTest {
             CliqueProtocolSchedule.create(
                 GENESIS_CONFIG_OPTIONS, proposerNodeKey, false, EvmConfiguration.DEFAULT),
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                1,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                CliqueMinerExecutorTest::mockBlockHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                CliqueMinerExecutorTest::mockBlockHeader),
             proposerNodeKey,
             new MiningParameters.Builder()
                 .coinbase(AddressHelpers.ofValue(1))
@@ -183,12 +179,10 @@ public class CliqueMinerExecutorTest {
             CliqueProtocolSchedule.create(
                 GENESIS_CONFIG_OPTIONS, proposerNodeKey, false, EvmConfiguration.DEFAULT),
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                1,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                CliqueMinerExecutorTest::mockBlockHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                CliqueMinerExecutorTest::mockBlockHeader),
             proposerNodeKey,
             new MiningParameters.Builder()
                 .coinbase(AddressHelpers.ofValue(1))

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -96,7 +97,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -140,7 +141,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
@@ -184,7 +185,7 @@ public class CliqueMinerExecutorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 CliqueMinerExecutorTest::mockBlockHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -75,7 +75,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Util;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -332,12 +332,10 @@ public class TestContextBuilder {
 
     final GasPricePendingTransactionsSorter pendingTransactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             clock,
             metricsSystem,
-            blockChain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockChain::getChainHeadHeader);
 
     final Address localAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
     final BftBlockCreatorFactory<?> blockCreatorFactory =

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
@@ -52,6 +52,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -118,7 +119,7 @@ public class BftBlockCreatorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             blockchain::getChainHeadHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/blockcreation/BftBlockCreatorTest.java
@@ -41,7 +41,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
@@ -117,12 +117,10 @@ public class BftBlockCreatorTest {
 
     final GasPricePendingTransactionsSorter pendingTransactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
-            blockchain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockchain::getChainHeadHeader);
 
     final BftBlockCreator blockCreator =
         new BftBlockCreator(

--- a/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
@@ -106,12 +106,10 @@ public class BftBlockCreatorTest {
                         Bytes.wrap(new byte[32]), Lists.newArrayList(), null, initialValidatorList)
                     .encode(),
             new GasPricePendingTransactionsSorter(
-                TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-                1,
+                ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
                 TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
-                blockchain::getChainHeadHeader,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),
+                blockchain::getChainHeadHeader),
             protContext,
             protocolSchedule,
             nodeKeys,

--- a/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
+++ b/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/blockcreation/BftBlockCreatorTest.java
@@ -46,6 +46,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -107,7 +108,7 @@ public class BftBlockCreatorTest {
             new GasPricePendingTransactionsSorter(
                 TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
                 1,
-                TestClock.fixed(),
+                TestClock.system(ZoneId.systemDefault()),
                 metricsSystem,
                 blockchain::getChainHeadHeader,
                 TransactionPoolConfiguration.DEFAULT_PRICE_BUMP),

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PandaPrinter.java
@@ -17,6 +17,9 @@
 package org.hyperledger.besu.consensus.merge;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
+import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Synchronizer.InSyncListener;
 
@@ -31,18 +34,49 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PandaPrinter implements InSyncListener, ForkchoiceMessageListener, MergeStateHandler {
+public class PandaPrinter implements InSyncListener, ForkchoiceMessageListener, BlockAddedObserver {
+
+  private static PandaPrinter INSTANCE;
+
+  public static PandaPrinter init(final Optional<Difficulty> currentTotal, final Difficulty ttd) {
+    if (INSTANCE != null) {
+      LOG.debug("overwriting already initialized panda printer");
+    }
+
+    INSTANCE = new PandaPrinter(currentTotal, ttd);
+
+    return INSTANCE;
+  }
+
+  public static PandaPrinter getInstance() {
+    if (INSTANCE == null) {
+      throw new IllegalStateException("Uninitialized, unknown ttd");
+    }
+    return INSTANCE;
+  }
+
+  protected PandaPrinter(final Optional<Difficulty> currentTotal, final Difficulty ttd) {
+    this.ttd = ttd;
+    if (currentTotal.isPresent() && currentTotal.get().greaterOrEqualThan(ttd)) {
+      this.readyBeenDisplayed.set(true);
+      this.ttdBeenDisplayed.set(true);
+      this.finalizedBeenDisplayed.set(true);
+    }
+  }
 
   private static final Logger LOG = LoggerFactory.getLogger(PandaPrinter.class);
   private static final String readyBanner = PandaPrinter.loadBanner("/readyPanda.txt");
   private static final String ttdBanner = PandaPrinter.loadBanner("/ttdPanda.txt");
   private static final String finalizedBanner = PandaPrinter.loadBanner("/finalizedPanda.txt");
 
-  private static final AtomicBoolean hasTTD = new AtomicBoolean(false);
-  private static final AtomicBoolean inSync = new AtomicBoolean(false);
-  public static final AtomicBoolean readyBeenDisplayed = new AtomicBoolean();
-  public static final AtomicBoolean ttdBeenDisplayed = new AtomicBoolean();
-  public static final AtomicBoolean finalizedBeenDisplayed = new AtomicBoolean();
+  private final Difficulty ttd;
+  private final AtomicBoolean hasTTD = new AtomicBoolean(false);
+  private final AtomicBoolean inSync = new AtomicBoolean(false);
+  private final AtomicBoolean isPoS = new AtomicBoolean(false);
+
+  public final AtomicBoolean readyBeenDisplayed = new AtomicBoolean();
+  public final AtomicBoolean ttdBeenDisplayed = new AtomicBoolean();
+  public final AtomicBoolean finalizedBeenDisplayed = new AtomicBoolean();
 
   private static String loadBanner(final String filename) {
     Class<PandaPrinter> c = PandaPrinter.class;
@@ -55,55 +89,56 @@ public class PandaPrinter implements InSyncListener, ForkchoiceMessageListener, 
         resultStringBuilder.append(line).append("\n");
       }
     } catch (IOException e) {
-      LOG.error("Couldn't load hilarious panda banner");
+      LOG.error("Couldn't load hilarious panda banner at {} ", filename);
     }
     return resultStringBuilder.toString();
   }
 
-  public static void hasTTD() {
-    PandaPrinter.hasTTD.getAndSet(true);
-    if (hasTTD.get() && inSync.get()) {
-      printReadyToMerge();
-    }
+  public void hasTTD() {
+    this.hasTTD.getAndSet(true);
   }
 
-  public static void inSync() {
-    PandaPrinter.inSync.getAndSet(true);
-    if (inSync.get() && hasTTD.get()) {
-      printReadyToMerge();
-    }
+  public void inSync() {
+    this.inSync.getAndSet(true);
   }
 
-  public static void printOnFirstCrossing() {
+  public void printOnFirstCrossing() {
     if (!ttdBeenDisplayed.get()) {
+      LOG.info("Crossed TTD, merging underway!");
       LOG.info("\n" + ttdBanner);
+      ttdBeenDisplayed.compareAndSet(false, true);
     }
-    ttdBeenDisplayed.compareAndSet(false, true);
   }
 
-  static void resetForTesting() {
+  public void resetForTesting() {
     ttdBeenDisplayed.set(false);
     readyBeenDisplayed.set(false);
     finalizedBeenDisplayed.set(false);
+    hasTTD.set(false);
+    isPoS.set(false);
+    inSync.set(false);
   }
 
-  public static void printReadyToMerge() {
-    if (!readyBeenDisplayed.get()) {
+  public void printReadyToMerge() {
+    if (!readyBeenDisplayed.get() && !isPoS.get() && inSync.get()) {
+      LOG.info("Configured for TTD and in sync, still receiving PoW blocks. Ready to merge!");
       LOG.info("\n" + readyBanner);
+      readyBeenDisplayed.compareAndSet(false, true);
     }
-    readyBeenDisplayed.compareAndSet(false, true);
   }
 
-  public static void printFinalized() {
+  public void printFinalized() {
     if (!finalizedBeenDisplayed.get()) {
+      LOG.info("Beacon chain finalized, welcome to Proof of Stake Ethereum");
       LOG.info("\n" + finalizedBanner);
+      finalizedBeenDisplayed.compareAndSet(false, true);
     }
-    finalizedBeenDisplayed.compareAndSet(false, true);
   }
 
   @Override
   public void onInSyncStatusChange(final boolean newSyncStatus) {
-    if (newSyncStatus && hasTTD.get()) {
+    inSync.set(newSyncStatus);
+    if (newSyncStatus && hasTTD.get() && !isPoS.get()) {
       printReadyToMerge();
     }
   }
@@ -119,12 +154,22 @@ public class PandaPrinter implements InSyncListener, ForkchoiceMessageListener, 
   }
 
   @Override
-  public void mergeStateChanged(
-      final boolean isPoS,
-      final Optional<Boolean> priorState,
-      final Optional<Difficulty> difficultyStoppedAt) {
-    if (isPoS && priorState.isPresent() && !priorState.get()) { // just crossed from PoW to PoS
-      printOnFirstCrossing();
+  public void onBlockAdded(final BlockAddedEvent event) {
+    if (event.isNewCanonicalHead()) {
+      Block added = event.getBlock();
+      if (added.getHeader().getDifficulty().greaterOrEqualThan(this.ttd)) {
+        this.isPoS.set(true);
+        if (this.inSync.get()) {
+          this.printOnFirstCrossing();
+        }
+      } else {
+        this.isPoS.set(false);
+        if (this.inSync.get()) {
+          if (!readyBeenDisplayed.get()) {
+            this.printReadyToMerge();
+          }
+        }
+      }
     }
   }
 }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PandaPrinterTest.java
@@ -17,85 +17,121 @@
 package org.hyperledger.besu.consensus.merge;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PandaPrinterTest {
 
   final MergeStateHandler fauxTransitionHandler =
       (isPoS, priorState, ttd) -> {
         if (isPoS && priorState.filter(prior -> !prior).isPresent())
-          PandaPrinter.printOnFirstCrossing();
+          PandaPrinter.getInstance().printOnFirstCrossing();
       };
 
   @Test
   public void printsPanda() {
-    PandaPrinter.resetForTesting();
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    PandaPrinter.printOnFirstCrossing();
-    assertThat(PandaPrinter.ttdBeenDisplayed).isTrue();
-    assertThat(PandaPrinter.readyBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isFalse();
+    PandaPrinter p = new PandaPrinter(Optional.of(Difficulty.of(1)), Difficulty.of(BigInteger.TEN));
+    p.resetForTesting();
+    assertThat(p.ttdBeenDisplayed).isFalse();
+    p.printOnFirstCrossing();
+    assertThat(p.ttdBeenDisplayed).isTrue();
+    assertThat(p.readyBeenDisplayed).isFalse();
+    assertThat(p.finalizedBeenDisplayed).isFalse();
   }
 
   @Test
-  public void doesNotPrintAtInit() {
-    PandaPrinter.resetForTesting();
-    var mergeContext = new PostMergeContext(Difficulty.ONE);
+  public void doesNotPrintAtPreMergeInit() {
+    PandaPrinter p = new PandaPrinter(Optional.of(Difficulty.of(1)), Difficulty.of(BigInteger.TEN));
+
+    var mergeContext = new PostMergeContext(Difficulty.of(BigInteger.TEN));
     mergeContext.observeNewIsPostMergeState(fauxTransitionHandler);
 
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
+    assertThat(p.ttdBeenDisplayed).isFalse();
     mergeContext.setIsPostMerge(Difficulty.ONE);
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.readyBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isFalse();
+    assertThat(p.ttdBeenDisplayed).isFalse();
+    assertThat(p.readyBeenDisplayed).isFalse();
+    assertThat(p.finalizedBeenDisplayed).isFalse();
   }
 
   @Test
   public void printsWhenCrossingOnly() {
-    PandaPrinter.resetForTesting();
-    var mergeContext = new PostMergeContext(Difficulty.ONE);
-    mergeContext.observeNewIsPostMergeState(fauxTransitionHandler);
-
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    mergeContext.setIsPostMerge(Difficulty.ZERO);
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    mergeContext.setIsPostMerge(Difficulty.ONE);
-    assertThat(PandaPrinter.ttdBeenDisplayed).isTrue();
-    assertThat(PandaPrinter.readyBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isFalse();
+    PandaPrinter p = new PandaPrinter(Optional.of(Difficulty.of(1)), Difficulty.of(10));
+    p.inSync();
+    p.hasTTD();
+    assertThat(p.ttdBeenDisplayed).isFalse();
+    p.onBlockAdded(withDifficulty(Difficulty.of(11)));
+    assertThat(p.ttdBeenDisplayed).isTrue();
+    assertThat(p.readyBeenDisplayed).isFalse();
+    assertThat(p.finalizedBeenDisplayed).isFalse();
   }
 
   @Test
-  public void printsReadyOnStartupInSyncWithTTD() {
-    PandaPrinter.resetForTesting();
-    PandaPrinter.inSync();
-    PandaPrinter.hasTTD();
-    assertThat(PandaPrinter.readyBeenDisplayed).isTrue();
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isFalse();
+  public void printsReadyOnStartupInSyncWithPoWTTD() {
+    PandaPrinter p = new PandaPrinter(Optional.of(Difficulty.of(1)), Difficulty.of(10));
+    p.inSync();
+    p.hasTTD();
+    p.onBlockAdded(withDifficulty(Difficulty.of(2)));
+    assertThat(p.readyBeenDisplayed).isTrue();
+    assertThat(p.ttdBeenDisplayed).isFalse();
+    assertThat(p.finalizedBeenDisplayed).isFalse();
+  }
+
+  @Test
+  public void noPandasPostTTD() {
+    PandaPrinter p =
+        new PandaPrinter(Optional.of(Difficulty.of(11)), Difficulty.of(BigInteger.TEN));
+    p.inSync();
+    p.hasTTD();
+
+    assertThat(p.readyBeenDisplayed).isTrue();
+    assertThat(p.ttdBeenDisplayed).isTrue();
+    assertThat(p.finalizedBeenDisplayed).isTrue();
+    p.onBlockAdded(withDifficulty(Difficulty.of(11)));
+    assertThat(p.readyBeenDisplayed).isTrue();
+    assertThat(p.ttdBeenDisplayed).isTrue();
+    assertThat(p.finalizedBeenDisplayed).isTrue();
   }
 
   @Test
   public void printsFinalized() {
-    PandaPrinter.resetForTesting();
-    PandaPrinter pandaPrinter = new PandaPrinter();
+    PandaPrinter p = new PandaPrinter(Optional.of(Difficulty.of(9)), Difficulty.of(BigInteger.TEN));
+    assertThat(p.finalizedBeenDisplayed).isFalse();
     MergeContext mergeContext = new PostMergeContext(Difficulty.ZERO);
-    mergeContext.addNewForkchoiceMessageListener(pandaPrinter);
+    mergeContext.addNewForkchoiceMessageListener(p);
     mergeContext.fireNewUnverifiedForkchoiceMessageEvent(
         Hash.ZERO, Optional.of(Hash.ZERO), Hash.ZERO);
-    assertThat(PandaPrinter.readyBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
     mergeContext.fireNewUnverifiedForkchoiceMessageEvent(
         Hash.ZERO, Optional.of(Hash.fromHexStringLenient("0x1337")), Hash.ZERO);
-    assertThat(PandaPrinter.readyBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.ttdBeenDisplayed).isFalse();
-    assertThat(PandaPrinter.finalizedBeenDisplayed).isTrue();
+    assertThat(p.finalizedBeenDisplayed).isTrue();
+  }
+
+  private BlockAddedEvent withDifficulty(final Difficulty diff) {
+    BlockBody mockBody = mock(BlockBody.class);
+    when(mockBody.getTransactions()).thenReturn(new ArrayList<>());
+    BlockHeader mockHeader = mock(BlockHeader.class);
+    when(mockHeader.getDifficulty()).thenReturn(diff);
+    when(mockHeader.getParentHash()).thenReturn(Hash.ZERO);
+    Block mockBlock = mock(Block.class);
+    when(mockBlock.getHeader()).thenReturn(mockHeader);
+    when(mockBlock.getBody()).thenReturn(mockBody);
+    BlockAddedEvent powArrived =
+        BlockAddedEvent.createForHeadAdvancement(mockBlock, new ArrayList<>(), new ArrayList<>());
+    return powArrived;
   }
 }

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
@@ -89,7 +89,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.ProtocolScheduleFixture;
 import org.hyperledger.besu.ethereum.core.Util;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
@@ -437,12 +437,10 @@ public class TestContextBuilder {
 
     final GasPricePendingTransactionsSorter pendingTransactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             clock,
             metricsSystem,
-            blockChain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockChain::getChainHeadHeader);
 
     final Address localAddress = Util.publicKeyToAddress(nodeKey.getPublicKey());
     final BftBlockCreatorFactory<?> blockCreatorFactory =

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Wei.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Wei.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.datatypes;
 import org.hyperledger.besu.plugin.data.Quantity;
 
 import java.math.BigInteger;
+import java.util.Arrays;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.BaseUInt256Value;
@@ -97,5 +98,53 @@ public final class Wei extends BaseUInt256Value<Wei> implements Quantity {
 
   public static Wei fromQuantity(final Quantity quantity) {
     return Wei.wrap((Bytes) quantity);
+  }
+
+  public String toHumanReadableString() {
+    final BigInteger amount = toBigInteger();
+    final int numOfDigits = amount.toString().length();
+    final Unit preferredUnit = Unit.getPreferred(numOfDigits);
+    final double res = amount.doubleValue() / preferredUnit.divisor;
+    return String.format("%1." + preferredUnit.decimals + "f %s", res, preferredUnit);
+  }
+
+  enum Unit {
+    Wei(0, 0),
+    KWei(3),
+    MWei(6),
+    GWei(9),
+    Szabo(12),
+    Finney(15),
+    Ether(18),
+    KEther(21),
+    MEther(24),
+    GEther(27),
+    TEther(30);
+
+    final int pow;
+    final double divisor;
+    final int decimals;
+
+    Unit(final int pow) {
+      this(pow, 2);
+    }
+
+    Unit(final int pow, final int decimals) {
+      this.pow = pow;
+      this.decimals = decimals;
+      this.divisor = Math.pow(10, pow);
+    }
+
+    static Unit getPreferred(final int numOfDigits) {
+      return Arrays.stream(values())
+          .filter(u -> numOfDigits <= u.pow + 3)
+          .findFirst()
+          .orElse(TEther);
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
   }
 }

--- a/datatypes/src/test/java/org/hyperledger/besu/datatypes/WeiTest.java
+++ b/datatypes/src/test/java/org/hyperledger/besu/datatypes/WeiTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.datatypes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class WeiTest {
+
+  @Test
+  public void toHumanReadableString() {
+    assertThat(Wei.ZERO.toHumanReadableString()).isEqualTo("0 wei");
+    assertThat(Wei.ONE.toHumanReadableString()).isEqualTo("1 wei");
+
+    assertThat(Wei.of(999).toHumanReadableString()).isEqualTo("999 wei");
+    assertThat(Wei.of(1000).toHumanReadableString()).isEqualTo("1.00 kwei");
+
+    assertThat(Wei.of(1009).toHumanReadableString()).isEqualTo("1.01 kwei");
+    assertThat(Wei.of(1011).toHumanReadableString()).isEqualTo("1.01 kwei");
+
+    assertThat(Wei.of(new BigInteger("1000000000")).toHumanReadableString()).isEqualTo("1.00 gwei");
+
+    assertThat(Wei.of(new BigInteger("1000000000000000000")).toHumanReadableString())
+        .isEqualTo("1.00 ether");
+
+    final char[] manyZeros = new char[32];
+    Arrays.fill(manyZeros, '0');
+    assertThat(Wei.of(new BigInteger("1" + String.valueOf(manyZeros))).toHumanReadableString())
+        .isEqualTo("100.00 tether");
+  }
+}

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionBroadcaster;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
@@ -97,12 +98,10 @@ public class EthGetFilterChangesIntegrationTest {
     blockchain = executionContext.getBlockchain();
     transactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(MAX_TRANSACTIONS).build(),
             TestClock.fixed(),
             metricsSystem,
-            blockchain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockchain::getChainHeadHeader);
     final ProtocolContext protocolContext = executionContext.getProtocolContext();
 
     EthContext ethContext = mock(EthContext.class);

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionBroadcaster;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
@@ -97,12 +98,10 @@ public class EthGetFilterChangesIntegrationTest {
     blockchain = executionContext.getBlockchain();
     transactions =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(MAX_TRANSACTIONS).build(),
             TestClock.fixed(),
             metricsSystem,
-            blockchain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockchain::getChainHeadHeader);
     final ProtocolContext protocolContext = executionContext.getProtocolContext();
 
     EthContext ethContext = mock(EthContext.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TimedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TracedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.tls.TlsClientAuthConfiguration;
 import org.hyperledger.besu.ethereum.api.tls.TlsConfiguration;
@@ -298,7 +299,7 @@ public class JsonRpcHttpService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(checkAllowlistHostHeader());
-
+    router.errorHandler(403, new Logging403ErrorHandler());
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcService.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TimedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.TracedJsonRpcProcessor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketMessageHandler;
@@ -402,7 +403,7 @@ public class JsonRpcService {
 
     // Verify Host header to avoid rebind attack.
     router.route().handler(denyRouteToBlockedHost());
-
+    router.errorHandler(403, new Logging403ErrorHandler());
     router
         .route()
         .handler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception;
+
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Logging403ErrorHandler implements Handler<RoutingContext> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Logging403ErrorHandler.class);
+
+  @Override
+  public void handle(final RoutingContext event) {
+    LOG.error(event.failure().getMessage());
+    LOG.debug(event.failure().getMessage(), event.failure());
+    int statusCode = event.statusCode();
+
+    HttpServerResponse response = event.response();
+    response.setStatusCode(statusCode).end("Exception thrown handling RPC");
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
@@ -46,6 +48,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 
 import java.util.Collections;
 import java.util.List;
@@ -212,6 +215,15 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
       logImportedBlockInfo(block, (System.currentTimeMillis() - startTimeMs) / 1000.0);
       return respondWith(reqId, blockParam, newBlockHeader.getHash(), VALID);
     } else {
+      if (executionResult.cause.isPresent()) {
+        // TODO; would prefer to invert the logic so we rpc error on anything that isn't a
+        // consensus error
+        if (executionResult.cause.get() instanceof StorageException) {
+          JsonRpcError error = JsonRpcError.INTERNAL_ERROR;
+          JsonRpcErrorResponse response = new JsonRpcErrorResponse(reqId, error);
+          return response;
+        }
+      }
       LOG.debug("New payload is invalid: {}", executionResult.errorMessage.get());
       return respondWithInvalid(
           reqId, blockParam, latestValidAncestor.get(), executionResult.errorMessage.get());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineG
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayload;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,14 +39,19 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final Optional<MergeMiningCoordinator> mergeCoordinator;
   private final ProtocolContext protocolContext;
 
+  private final EthPeers ethPeers;
+
   ExecutionEngineJsonRpcMethods(
-      final MiningCoordinator miningCoordinator, final ProtocolContext protocolContext) {
+      final MiningCoordinator miningCoordinator,
+      final ProtocolContext protocolContext,
+      final EthPeers ethPeers) {
     this.mergeCoordinator =
         Optional.ofNullable(miningCoordinator)
             .filter(mc -> mc.isCompatibleWithEngineApi())
             .map(MergeMiningCoordinator.class::cast);
 
     this.protocolContext = protocolContext;
+    this.ethPeers = ethPeers;
   }
 
   @Override
@@ -59,7 +65,7 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
     if (mergeCoordinator.isPresent()) {
       return mapOf(
           new EngineGetPayload(syncVertx, protocolContext, blockResultFactory),
-          new EngineNewPayload(syncVertx, protocolContext, mergeCoordinator.get()),
+          new EngineNewPayload(syncVertx, protocolContext, mergeCoordinator.get(), ethPeers),
           new EngineForkchoiceUpdated(syncVertx, protocolContext, mergeCoordinator.get()),
           new EngineExchangeTransitionConfiguration(syncVertx, protocolContext));
     } else {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -94,7 +94,7 @@ public class JsonRpcMethodsFactory {
                   blockchainQueries, protocolSchedule, metricsSystem, transactionPool, dataDir),
               new EeaJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
-              new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext),
+              new ExecutionEngineJsonRpcMethods(miningCoordinator, protocolContext, ethPeers),
               new GoQuorumJsonRpcPrivacyMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
               new EthJsonRpcMethods(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.Streams.stream;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.DefaultAuthenticationService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.Logging403ErrorHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -222,7 +223,7 @@ public class WebSocketService {
           .produces(APPLICATION_JSON)
           .handler(DefaultAuthenticationService::handleDisabledLogin);
     }
-
+    router.errorHandler(403, new Logging403ErrorHandler());
     router.route().handler(WebSocketService::handleHttpNotSupported);
     return router;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 
 import java.util.Collections;
 import java.util.List;
@@ -77,11 +78,14 @@ public class EngineNewPayloadTest {
 
   @Mock private MutableBlockchain blockchain;
 
+  @Mock private EthPeers ethPeers;
+
   @Before
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
-    this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator);
+    when(ethPeers.peerCount()).thenReturn(1);
+    this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator, ethPeers);
   }
 
   @Test

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinator.java
@@ -95,11 +95,10 @@ public abstract class AbstractMiningCoordinator<
   @Override
   public void stop() {
     synchronized (this) {
-      if (state != State.RUNNING) {
-        return;
+      if (state == State.RUNNING) {
+        haltCurrentMiningOperation();
       }
       state = State.STOPPED;
-      haltCurrentMiningOperation();
       executor.shutDown();
     }
   }

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
@@ -60,6 +60,7 @@ import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -84,7 +85,7 @@ public class BlockTransactionSelectorTest {
       new GasPricePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           5,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           BlockTransactionSelectorTest::mockBlockHeader,
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -336,7 +337,7 @@ public class BlockTransactionSelectorTest {
         new BaseFeePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             5,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             () -> {
               final BlockHeader mockBlockHeader = mock(BlockHeader.class);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockTransactionSelectorTest.java
@@ -39,7 +39,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.difficulty.fixed.FixedDifficultyProtocolSchedule;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
@@ -83,12 +83,10 @@ public class BlockTransactionSelectorTest {
   private final Blockchain blockchain = new ReferenceTestBlockchain();
   private final GasPricePendingTransactionsSorter pendingTransactions =
       new GasPricePendingTransactionsSorter(
-          TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-          5,
+          ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(5).build(),
           TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
-          BlockTransactionSelectorTest::mockBlockHeader,
-          TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+          BlockTransactionSelectorTest::mockBlockHeader);
   private final MutableWorldState worldState =
       InMemoryKeyValueStorageProvider.createInMemoryWorldState();
   @Mock private MainnetTransactionProcessor transactionProcessor;
@@ -335,16 +333,14 @@ public class BlockTransactionSelectorTest {
     final Address miningBeneficiary = AddressHelpers.ofValue(1);
     final BaseFeePendingTransactionsSorter pendingTransactions1559 =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            5,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(5).build(),
             TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             () -> {
               final BlockHeader mockBlockHeader = mock(BlockHeader.class);
               when(mockBlockHeader.getBaseFee()).thenReturn(Optional.of(Wei.ONE));
               return mockBlockHeader;
-            },
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            });
     final BlockTransactionSelector selector =
         new BlockTransactionSelector(
             transactionProcessor,

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWBlockCreatorTest.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.EpochCalculator;
 import org.hyperledger.besu.ethereum.mainnet.PoWHasher;
@@ -94,12 +94,10 @@ public class PoWBlockCreatorTest {
 
     final BaseFeePendingTransactionsSorter pendingTransactions =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.fixed(),
             metricsSystem,
-            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader);
 
     final PoWBlockCreator blockCreator =
         new PoWBlockCreator(
@@ -155,12 +153,10 @@ public class PoWBlockCreatorTest {
 
     final BaseFeePendingTransactionsSorter pendingTransactions =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.fixed(),
             metricsSystem,
-            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader);
 
     final PoWBlockCreator blockCreator =
         new PoWBlockCreator(
@@ -211,12 +207,10 @@ public class PoWBlockCreatorTest {
 
     final BaseFeePendingTransactionsSorter pendingTransactions =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.fixed(),
             metricsSystem,
-            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader);
 
     final PoWBlockCreator blockCreator =
         new PoWBlockCreator(
@@ -283,12 +277,10 @@ public class PoWBlockCreatorTest {
 
     final BaseFeePendingTransactionsSorter pendingTransactions =
         new BaseFeePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.fixed(),
             metricsSystem,
-            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            executionContextTestFixture.getProtocolContext().getBlockchain()::getChainHeadHeader);
 
     final PoWBlockCreator blockCreator =
         new PoWBlockCreator(

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 import org.hyperledger.besu.util.Subscribers;
 
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class PoWMinerExecutorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             PoWMinerExecutorTest::mockBlockHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -74,7 +75,7 @@ public class PoWMinerExecutorTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             1,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             PoWMinerExecutorTest::mockBlockHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
-import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.EpochCalculator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -44,12 +44,10 @@ public class PoWMinerExecutorTest {
 
     final GasPricePendingTransactionsSorter pendingTransactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
-            PoWMinerExecutorTest::mockBlockHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            PoWMinerExecutorTest::mockBlockHeader);
 
     final PoWMinerExecutor executor =
         new PoWMinerExecutor(
@@ -73,12 +71,10 @@ public class PoWMinerExecutorTest {
 
     final GasPricePendingTransactionsSorter pendingTransactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            1,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(1).build(),
             TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
-            PoWMinerExecutorTest::mockBlockHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            PoWMinerExecutorTest::mockBlockHeader);
 
     final PoWMinerExecutor executor =
         new PoWMinerExecutor(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/BlockValidator.java
@@ -27,15 +27,24 @@ public interface BlockValidator {
   class Result {
     public final Optional<BlockProcessingOutputs> blockProcessingOutputs;
     public final Optional<String> errorMessage;
+    public final Optional<Throwable> cause;
 
     public Result(final BlockProcessingOutputs blockProcessingOutputs) {
       this.blockProcessingOutputs = Optional.of(blockProcessingOutputs);
       this.errorMessage = Optional.empty();
+      this.cause = Optional.empty();
     }
 
     public Result(final String errorMessage) {
       this.blockProcessingOutputs = Optional.empty();
       this.errorMessage = Optional.of(errorMessage);
+      this.cause = Optional.empty();
+    }
+
+    public Result(final String errorMessage, final Throwable cause) {
+      this.blockProcessingOutputs = Optional.empty();
+      this.errorMessage = Optional.of(errorMessage);
+      this.cause = Optional.of(cause);
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
@@ -14,9 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.bonsai;
 
+import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +35,15 @@ public class BonsaiInMemoryWorldStateKeyValueStorage extends BonsaiWorldStateKey
       final KeyValueStorage codeStorage,
       final KeyValueStorage storageStorage,
       final KeyValueStorage trieBranchStorage,
-      final KeyValueStorage trieLogStorage) {
-    super(accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
+      final KeyValueStorage trieLogStorage,
+      final Optional<PeerTrieNodeFinder> fallbackNodeFinder) {
+    super(
+        accountStorage,
+        codeStorage,
+        storageStorage,
+        trieBranchStorage,
+        trieLogStorage,
+        fallbackNodeFinder);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -259,14 +259,15 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   public MutableWorldState copy() {
     final BonsaiPersistedWorldState bonsaiPersistedWorldState =
         ((BonsaiPersistedWorldState) archive.getMutable());
-    return new BonsaiInMemoryWorldState(
-        archive,
+    BonsaiInMemoryWorldStateKeyValueStorage bonsaiInMemoryWorldStateKeyValueStorage =
         new BonsaiInMemoryWorldStateKeyValueStorage(
             bonsaiPersistedWorldState.getWorldStateStorage().accountStorage,
             bonsaiPersistedWorldState.getWorldStateStorage().codeStorage,
             bonsaiPersistedWorldState.getWorldStateStorage().storageStorage,
             bonsaiPersistedWorldState.getWorldStateStorage().trieBranchStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().trieLogStorage));
+            bonsaiPersistedWorldState.getWorldStateStorage().trieLogStorage,
+            bonsaiPersistedWorldState.getWorldStateStorage().getMaybeFallbackNodeFinder());
+    return new BonsaiInMemoryWorldState(archive, bonsaiInMemoryWorldStateKeyValueStorage);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -75,14 +75,16 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
   @Override
   public MutableWorldState copy() {
-    return new BonsaiInMemoryWorldState(
-        archive,
+    BonsaiInMemoryWorldStateKeyValueStorage bonsaiInMemoryWorldStateKeyValueStorage =
         new BonsaiInMemoryWorldStateKeyValueStorage(
             worldStateStorage.accountStorage,
             worldStateStorage.codeStorage,
             worldStateStorage.storageStorage,
             worldStateStorage.trieBranchStorage,
-            worldStateStorage.trieLogStorage));
+            worldStateStorage.trieLogStorage,
+            getWorldStateStorage().getMaybeFallbackNodeFinder());
+
+    return new BonsaiInMemoryWorldState(archive, bonsaiInMemoryWorldStateKeyValueStorage);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -16,6 +16,7 @@
 
 package org.hyperledger.besu.ethereum.bonsai;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hyperledger.besu.datatypes.Hash.fromPlugin;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -26,6 +27,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.proof.WorldStateProof;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
+import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.worldstate.WorldState;
 
@@ -242,5 +244,10 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
       final List<UInt256> accountStorageKeys) {
     // FIXME we can do proofs for layered tries and the persisted trie
     return Optional.empty();
+  }
+
+  public void useFallbackNodeFinder(final Optional<PeerTrieNodeFinder> fallbackNodeFinder) {
+    checkNotNull(fallbackNodeFinder);
+    worldStateStorage.useFallbackNodeFinder(fallbackNodeFinder);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -14,12 +14,15 @@
  */
 package org.hyperledger.besu.ethereum.bonsai;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.StoredNodeFactory;
+import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
@@ -46,16 +49,16 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
   protected final KeyValueStorage trieBranchStorage;
   protected final KeyValueStorage trieLogStorage;
 
+  private Optional<PeerTrieNodeFinder> maybeFallbackNodeFinder;
+
   public BonsaiWorldStateKeyValueStorage(final StorageProvider provider) {
-    accountStorage =
-        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE);
-    codeStorage = provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.CODE_STORAGE);
-    storageStorage =
-        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE);
-    trieBranchStorage =
-        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE);
-    trieLogStorage =
-        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
+    this(
+        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_INFO_STATE),
+        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.CODE_STORAGE),
+        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.ACCOUNT_STORAGE_STORAGE),
+        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE),
+        provider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE),
+        Optional.empty());
   }
 
   public BonsaiWorldStateKeyValueStorage(
@@ -64,11 +67,28 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
       final KeyValueStorage storageStorage,
       final KeyValueStorage trieBranchStorage,
       final KeyValueStorage trieLogStorage) {
+    this(
+        accountStorage,
+        codeStorage,
+        storageStorage,
+        trieBranchStorage,
+        trieLogStorage,
+        Optional.empty());
+  }
+
+  public BonsaiWorldStateKeyValueStorage(
+      final KeyValueStorage accountStorage,
+      final KeyValueStorage codeStorage,
+      final KeyValueStorage storageStorage,
+      final KeyValueStorage trieBranchStorage,
+      final KeyValueStorage trieLogStorage,
+      final Optional<PeerTrieNodeFinder> fallbackNodeFinder) {
     this.accountStorage = accountStorage;
     this.codeStorage = codeStorage;
     this.storageStorage = storageStorage;
     this.trieBranchStorage = trieBranchStorage;
     this.trieLogStorage = trieLogStorage;
+    this.maybeFallbackNodeFinder = fallbackNodeFinder;
   }
 
   @Override
@@ -104,7 +124,17 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
       return Optional.of(MerklePatriciaTrie.EMPTY_TRIE_NODE);
     } else {
-      return trieBranchStorage.get(location.toArrayUnsafe()).map(Bytes::wrap);
+      final Optional<Bytes> value =
+          trieBranchStorage.get(location.toArrayUnsafe()).map(Bytes::wrap);
+      if (value.isPresent()) {
+        return value
+            .filter(b -> Hash.hash(b).equals(nodeHash))
+            .or(
+                () ->
+                    maybeFallbackNodeFinder.flatMap(
+                        finder -> finder.getAccountStateTrieNode(location, nodeHash)));
+      }
+      return Optional.empty();
     }
   }
 
@@ -114,9 +144,20 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
       return Optional.of(MerklePatriciaTrie.EMPTY_TRIE_NODE);
     } else {
-      return trieBranchStorage
-          .get(Bytes.concatenate(accountHash, location).toArrayUnsafe())
-          .map(Bytes::wrap);
+      final Optional<Bytes> value =
+          trieBranchStorage
+              .get(Bytes.concatenate(accountHash, location).toArrayUnsafe())
+              .map(Bytes::wrap);
+      if (value.isPresent()) {
+        return value
+            .filter(b -> Hash.hash(b).equals(nodeHash))
+            .or(
+                () ->
+                    maybeFallbackNodeFinder.flatMap(
+                        finder ->
+                            finder.getAccountStorageTrieNode(accountHash, location, nodeHash)));
+      }
+      return Optional.empty();
     }
   }
 
@@ -216,6 +257,15 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
   @Override
   public void removeNodeAddedListener(final long id) {
     throw new RuntimeException("removeNodeAddedListener not available");
+  }
+
+  public Optional<PeerTrieNodeFinder> getMaybeFallbackNodeFinder() {
+    return maybeFallbackNodeFinder;
+  }
+
+  public void useFallbackNodeFinder(final Optional<PeerTrieNodeFinder> maybeFallbackNodeFinder) {
+    checkNotNull(maybeFallbackNodeFinder);
+    this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
   }
 
   public static class Updater implements WorldStateStorage.Updater {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 
 import java.util.List;
+import java.util.Optional;
 
 /** Processes a block. */
 public interface BlockProcessor {
@@ -59,6 +60,10 @@ public interface BlockProcessor {
 
     default boolean isFailed() {
       return !isSuccessful();
+    }
+
+    default Optional<Throwable> causedBy() {
+      return Optional.empty();
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/PeerTrieNodeFinder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/PeerTrieNodeFinder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.worldstate;
+
+import org.hyperledger.besu.datatypes.Hash;
+
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public interface PeerTrieNodeFinder {
+
+  Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash);
+
+  Optional<Bytes> getAccountStorageTrieNode(Hash accountHash, Bytes location, Bytes32 nodeHash);
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -203,7 +203,9 @@ public class EthPeers {
   }
 
   public Stream<EthPeer> streamAvailablePeers() {
-    return streamAllPeers().filter(EthPeer::readyForRequests);
+    return streamAllPeers()
+        .filter(EthPeer::readyForRequests)
+        .filter(peer -> !peer.isDisconnected());
   }
 
   public Stream<EthPeer> streamBestPeers() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -257,7 +257,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     } else if (!ethPeer.statusHasBeenReceived()) {
       // Peers are required to send status messages before any other message type
       LOG.debug(
-          "{} requires a Status ({}) message to be sent first.  Instead, received message {}.  Disconnecting from {}.",
+          "{} requires a Status ({}) message to be sent first.  Instead, received message {} (BREACH_OF_PROTOCOL).  Disconnecting from {}.",
           this.getClass().getSimpleName(),
           EthPV62.STATUS,
           code,
@@ -277,7 +277,9 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     final EthMessage ethMessage = new EthMessage(ethPeer, messageData);
 
     if (!ethPeer.validateReceivedMessage(ethMessage, getSupportedProtocol())) {
-      LOG.debug("Unsolicited message received, disconnecting from EthPeer: {}", ethPeer);
+      LOG.debug(
+          "Unsolicited message received (BREACH_OF_PROTOCOL), disconnecting from EthPeer: {}",
+          ethPeer);
       ethPeer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
       return;
     }
@@ -308,7 +310,10 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       }
     } catch (final RLPException e) {
       LOG.debug(
-          "Received malformed message {} , disconnecting: {}", messageData.getData(), ethPeer, e);
+          "Received malformed message {} (BREACH_OF_PROTOCOL), disconnecting: {}",
+          messageData.getData(),
+          ethPeer,
+          e);
 
       ethPeer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
@@ -29,7 +29,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class RequestManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestManager.class);
   private final AtomicLong requestIdCounter = new AtomicLong(0);
   private final Map<BigInteger, ResponseStream> responseStreams = new ConcurrentHashMap<>();
   private final EthPeer peer;
@@ -73,7 +78,10 @@ public class RequestManager {
           .ifPresentOrElse(
               responseStream -> responseStream.processMessage(requestIdAndEthMessage.getValue()),
               // disconnect on incorrect requestIds
-              () -> peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL));
+              () -> {
+                LOG.debug("Request ID incorrect (BREACH_OF_PROTOCOL), disconnecting peer {}", peer);
+                peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
+              });
     } else {
       // otherwise iterate through all of them
       streams.forEach(stream -> stream.processMessage(ethMessage.getData()));

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.manager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection.PeerNotConnected;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
+import org.hyperledger.besu.ethereum.rlp.RLPException;
 
 import java.math.BigInteger;
 import java.util.Collection;
@@ -70,22 +71,34 @@ public class RequestManager {
   public void dispatchResponse(final EthMessage ethMessage) {
     final Collection<ResponseStream> streams = List.copyOf(responseStreams.values());
     final int count = outstandingRequests.decrementAndGet();
-    if (supportsRequestId) {
-      // If there's a requestId, find the specific stream it belongs to
-      final Map.Entry<BigInteger, MessageData> requestIdAndEthMessage =
-          ethMessage.getData().unwrapMessageData();
-      Optional.ofNullable(responseStreams.get(requestIdAndEthMessage.getKey()))
-          .ifPresentOrElse(
-              responseStream -> responseStream.processMessage(requestIdAndEthMessage.getValue()),
-              // disconnect on incorrect requestIds
-              () -> {
-                LOG.debug("Request ID incorrect (BREACH_OF_PROTOCOL), disconnecting peer {}", peer);
-                peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
-              });
-    } else {
-      // otherwise iterate through all of them
-      streams.forEach(stream -> stream.processMessage(ethMessage.getData()));
+    try {
+      if (supportsRequestId) {
+        // If there's a requestId, find the specific stream it belongs to
+        final Map.Entry<BigInteger, MessageData> requestIdAndEthMessage =
+            ethMessage.getData().unwrapMessageData();
+        Optional.ofNullable(responseStreams.get(requestIdAndEthMessage.getKey()))
+            .ifPresentOrElse(
+                responseStream -> responseStream.processMessage(requestIdAndEthMessage.getValue()),
+                // disconnect on incorrect requestIds
+                () -> {
+                  LOG.debug(
+                      "Request ID incorrect (BREACH_OF_PROTOCOL), disconnecting peer {}", peer);
+                  peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
+                });
+      } else {
+        // otherwise iterate through all of them
+        streams.forEach(stream -> stream.processMessage(ethMessage.getData()));
+      }
+    } catch (final RLPException e) {
+      LOG.debug(
+          "Received malformed message {} (BREACH_OF_PROTOCOL), disconnecting: {}",
+          ethMessage.getData(),
+          peer,
+          e);
+
+      peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
     }
+
     if (count == 0) {
       // No possibility of any remaining outstanding messages
       closeOutstandingStreams(streams);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -109,7 +109,8 @@ public abstract class AbstractGetHeadersFromPeerTask
         final BlockHeader child = reverse ? prevBlockHeader : header;
         if (!parent.getHash().equals(child.getParentHash())) {
           LOG.debug(
-              "Sequential headers must form a chain through hashes, disconnecting peer: {}", peer);
+              "Sequential headers must form a chain through hashes (BREACH_OF_PROTOCOL), disconnecting peer: {}",
+              peer);
           peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
           return Optional.empty();
         }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingPeerTask.java
@@ -114,9 +114,9 @@ public abstract class AbstractRetryingPeerTask<T> extends AbstractEthTask<T> {
 
     if (cause instanceof NoAvailablePeersException) {
       LOG.debug(
-          "No useful peer found, checking remaining current peers for usefulness: {}",
+          "No useful peer found, wait max 5 seconds for new peer to connect: current peers {}",
           ethContext.getEthPeers().peerCount());
-      // Wait for new peer to connect
+
       final WaitForPeerTask waitTask = WaitForPeerTask.create(ethContext, metricsSystem);
       executeSubTask(
           () ->

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -131,7 +131,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
     return getEthContext()
         .getEthPeers()
         .streamBestPeers()
-        .filter(peer -> !peer.isDisconnected() && !triedPeers.contains(peer));
+        .filter(peer -> !triedPeers.contains(peer));
   }
 
   private void refreshPeers() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -325,7 +325,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       importOrSavePendingBlock(block, message.getPeer().nodeId());
     } catch (final RLPException e) {
       LOG.debug(
-          "Malformed NEW_BLOCK message received from peer, disconnecting: {}",
+          "Malformed NEW_BLOCK message received from peer (BREACH_OF_PROTOCOL), disconnecting: {}",
           message.getPeer(),
           e);
       message.getPeer().disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
@@ -388,7 +388,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       }
     } catch (final RLPException e) {
       LOG.debug(
-          "Malformed NEW_BLOCK_HASHES message received from peer, disconnecting: {}",
+          "Malformed NEW_BLOCK_HASHES message received from peer (BREACH_OF_PROTOCOL), disconnecting: {}",
           message.getPeer(),
           e);
       message.getPeer().disconnect(DisconnectReason.BREACH_OF_PROTOCOL);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync;
 
+import static org.hyperledger.besu.util.FutureUtils.exceptionallyCompose;
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.traceLambda;
 
 import org.hyperledger.besu.consensus.merge.ForkchoiceMessageListener;
@@ -23,6 +25,7 @@ import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent.EventType;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -46,6 +49,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.Di
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,8 +57,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -76,12 +82,9 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
   private final BlockBroadcaster blockBroadcaster;
 
   private final AtomicBoolean started = new AtomicBoolean(false);
-
-  private final Set<Hash> importingBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
-  private final Set<Hash> requestedBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
-  private final Set<Long> requestedNonAnnouncedBlocks =
-      Collections.newSetFromMap(new ConcurrentHashMap<>());
+  private final ProcessingBlocksManager processingBlocksManager;
   private final PendingBlocksManager pendingBlocksManager;
+  private final Duration getBlockTimeoutMillis;
   private Optional<Long> onBlockAddedSId = Optional.empty();
   private Optional<Long> newBlockSId;
   private Optional<Long> newBlockHashesSId;
@@ -95,6 +98,28 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       final PendingBlocksManager pendingBlocksManager,
       final MetricsSystem metricsSystem,
       final BlockBroadcaster blockBroadcaster) {
+    this(
+        config,
+        protocolSchedule,
+        protocolContext,
+        ethContext,
+        syncState,
+        pendingBlocksManager,
+        metricsSystem,
+        blockBroadcaster,
+        new ProcessingBlocksManager());
+  }
+
+  BlockPropagationManager(
+      final SynchronizerConfiguration config,
+      final ProtocolSchedule protocolSchedule,
+      final ProtocolContext protocolContext,
+      final EthContext ethContext,
+      final SyncState syncState,
+      final PendingBlocksManager pendingBlocksManager,
+      final MetricsSystem metricsSystem,
+      final BlockBroadcaster blockBroadcaster,
+      final ProcessingBlocksManager processingBlocksManager) {
     this.config = config;
     this.protocolSchedule = protocolSchedule;
     this.protocolContext = protocolContext;
@@ -104,6 +129,9 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
     this.syncState = syncState;
     this.pendingBlocksManager = pendingBlocksManager;
     this.syncState.subscribeTTDReached(this::reactToTTDReachedEvent);
+    this.getBlockTimeoutMillis =
+        Duration.ofMillis(config.getPropagationManagerGetBlockTimeoutMillis());
+    this.processingBlocksManager = processingBlocksManager;
   }
 
   public void start() {
@@ -156,6 +184,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
   private void onBlockAdded(final BlockAddedEvent blockAddedEvent) {
     // Check to see if any of our pending blocks are now ready for import
     final Block newBlock = blockAddedEvent.getBlock();
+
     traceLambda(
         LOG,
         "Block added event type {} for block {}. Current status {}",
@@ -247,7 +276,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
                 if (distance < config.getBlockPropagationRange().upperEndpoint()
                     && minAnnouncedBlockNumber > firstNonAnnouncedBlockNumber) {
 
-                  if (requestedNonAnnouncedBlocks.add(firstNonAnnouncedBlockNumber)) {
+                  if (processingBlocksManager.addNonAnnouncedBlocks(firstNonAnnouncedBlockNumber)) {
                     retrieveNonAnnouncedBlock(firstNonAnnouncedBlockNumber);
                   }
                 }
@@ -338,7 +367,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
           LOG.trace("New block hash from network {} is already pending", announcedBlock);
           continue;
         }
-        if (importingBlocks.contains(announcedBlock.hash())) {
+        if (processingBlocksManager.alreadyImporting(announcedBlock.hash())) {
           LOG.trace("New block hash from network {} is already importing", announcedBlock);
           continue;
         }
@@ -346,7 +375,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
           LOG.trace("New block hash from network {} was already imported", announcedBlock);
           continue;
         }
-        if (requestedBlocks.add(announcedBlock.hash())) {
+        if (processingBlocksManager.addRequestedBlock(announcedBlock.hash())) {
           newBlocks.add(announcedBlock);
         } else {
           LOG.trace("New block hash from network {} was already requested", announcedBlock);
@@ -379,7 +408,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
 
   private void requestParentBlock(final Block block) {
     final BlockHeader blockHeader = block.getHeader();
-    if (requestedBlocks.add(blockHeader.getParentHash())) {
+    if (processingBlocksManager.addRequestedBlock(blockHeader.getParentHash())) {
       retrieveParentBlock(blockHeader);
     } else {
       LOG.debug("Parent block with hash {} is already requested", blockHeader.getParentHash());
@@ -397,34 +426,115 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
   private CompletableFuture<Block> getBlockFromPeers(
       final Optional<EthPeer> preferredPeer,
       final long blockNumber,
-      final Optional<Hash> blockHash) {
+      final Optional<Hash> maybeBlockHash) {
+    return repeatableGetBlockFromPeer(preferredPeer, blockNumber, maybeBlockHash)
+        .whenComplete(
+            (block, throwable) -> {
+              if (block != null) {
+                debugLambda(LOG, "Successfully retrieved block {}", block::toLogString);
+                processingBlocksManager.registerReceivedBlock(block);
+              } else {
+                if (throwable != null) {
+                  LOG.warn(
+                      "Failed to retrieve block "
+                          + logBlockNumberMaybeHash(blockNumber, maybeBlockHash),
+                      throwable);
+                } else {
+                  // this could happen if we give up at some point since we find that it make no
+                  // sense to retry
+                  debugLambda(
+                      LOG,
+                      "Block {} not retrieved",
+                      () -> logBlockNumberMaybeHash(blockNumber, maybeBlockHash));
+                }
+                processingBlocksManager.registerFailedGetBlock(blockNumber, maybeBlockHash);
+              }
+            });
+  }
+
+  private CompletableFuture<Block> repeatableGetBlockFromPeer(
+      final Optional<EthPeer> preferredPeer,
+      final long blockNumber,
+      final Optional<Hash> maybeBlockHash) {
+    return exceptionallyCompose(
+            scheduleGetBlockFromPeers(preferredPeer, blockNumber, maybeBlockHash),
+            handleGetBlockErrors(blockNumber, maybeBlockHash))
+        .thenCompose(r -> maybeRepeatGetBlock(blockNumber, maybeBlockHash));
+  }
+
+  private Function<Throwable, CompletionStage<Block>> handleGetBlockErrors(
+      final long blockNumber, final Optional<Hash> maybeBlockHash) {
+    return throwable -> {
+      debugLambda(
+          LOG,
+          "Temporary failure retrieving block {} from peers with error {}",
+          () -> logBlockNumberMaybeHash(blockNumber, maybeBlockHash),
+          throwable::toString);
+      return CompletableFuture.completedFuture(null);
+    };
+  }
+
+  private CompletableFuture<Block> maybeRepeatGetBlock(
+      final long blockNumber, final Optional<Hash> maybeBlockHash) {
+    final MutableBlockchain blockchain = protocolContext.getBlockchain();
+    final Optional<Block> maybeBlock =
+        maybeBlockHash
+            .map(hash -> blockchain.getBlockByHash(hash))
+            .orElseGet(() -> blockchain.getBlockByNumber(blockNumber));
+
+    // check if we got this block by other means
+    if (maybeBlock.isPresent()) {
+      final Block block = maybeBlock.get();
+      debugLambda(
+          LOG, "No need to retry to get block {} since it is already present", block::toLogString);
+      return CompletableFuture.completedFuture(block);
+    }
+
+    final long localChainHeight = blockchain.getChainHeadBlockNumber();
+    final long bestChainHeight = syncState.bestChainHeight(localChainHeight);
+    if (!shouldImportBlockAtHeight(blockNumber, localChainHeight, bestChainHeight)) {
+      debugLambda(
+          LOG,
+          "Not retrying to get block {} since we are too far from local chain head {}",
+          () -> logBlockNumberMaybeHash(blockNumber, maybeBlockHash),
+          blockchain.getChainHead()::toLogString);
+      return CompletableFuture.completedFuture(null);
+    }
+
+    debugLambda(
+        LOG,
+        "Retrying to get block {}",
+        () -> logBlockNumberMaybeHash(blockNumber, maybeBlockHash));
+
+    return ethContext
+        .getScheduler()
+        .scheduleSyncWorkerTask(
+            () -> repeatableGetBlockFromPeer(Optional.empty(), blockNumber, maybeBlockHash));
+  }
+
+  private CompletableFuture<Block> scheduleGetBlockFromPeers(
+      final Optional<EthPeer> maybePreferredPeer,
+      final long blockNumber,
+      final Optional<Hash> maybeBlockHash) {
     final RetryingGetBlockFromPeersTask getBlockTask =
         RetryingGetBlockFromPeersTask.create(
             protocolSchedule,
             ethContext,
             metricsSystem,
-            ethContext.getEthPeers().getMaxPeers(),
-            blockHash,
+            Math.max(1, ethContext.getEthPeers().peerCount()),
+            maybeBlockHash,
             blockNumber);
-    preferredPeer.ifPresent(getBlockTask::assignPeer);
+    maybePreferredPeer.ifPresent(getBlockTask::assignPeer);
 
-    return ethContext
-        .getScheduler()
-        .scheduleSyncWorkerTask(getBlockTask::run)
-        .thenCompose(r -> importOrSavePendingBlock(r.getResult(), r.getPeer().nodeId()))
-        .whenComplete(
-            (r, t) -> {
-              requestedNonAnnouncedBlocks.remove(blockNumber);
-              blockHash.ifPresentOrElse(
-                  requestedBlocks::remove,
-                  () -> {
-                    if (r != null) {
-                      // in case we successfully retrieved only by block number, when can remove
-                      // the request by hash too
-                      requestedBlocks.remove(r.getHash());
-                    }
-                  });
-            });
+    var future =
+        ethContext
+            .getScheduler()
+            .scheduleSyncWorkerTask(getBlockTask::run)
+            .thenCompose(r -> importOrSavePendingBlock(r.getResult(), r.getPeer().nodeId()));
+
+    ethContext.getScheduler().failAfterTimeout(future, getBlockTimeoutMillis);
+
+    return future;
   }
 
   private void broadcastBlock(final Block block, final BlockHeader parent) {
@@ -453,14 +563,14 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       return CompletableFuture.completedFuture(block);
     }
 
-    if (!importingBlocks.add(block.getHash())) {
+    if (!processingBlocksManager.addImportingBlock(block.getHash())) {
       traceLambda(LOG, "We're already importing this block {}", block::toLogString);
       return CompletableFuture.completedFuture(block);
     }
 
     if (protocolContext.getBlockchain().contains(block.getHash())) {
       traceLambda(LOG, "We've already imported this block {}", block::toLogString);
-      importingBlocks.remove(block.getHash());
+      processingBlocksManager.registerBlockImportDone(block.getHash());
       return CompletableFuture.completedFuture(block);
     }
 
@@ -537,7 +647,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       ethContext.getScheduler().scheduleSyncWorkerTask(() -> broadcastBlock(block, parent));
       return runImportTask(block);
     } else {
-      importingBlocks.remove(block.getHash());
+      processingBlocksManager.registerBlockImportDone(block.getHash());
       badBlockManager.addBadBlock(block);
       LOG.warn("Failed to import announced block {}", block.toLogString());
       return CompletableFuture.completedFuture(block);
@@ -557,7 +667,7 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
         .run()
         .whenComplete(
             (result, throwable) -> {
-              importingBlocks.remove(block.getHash());
+              processingBlocksManager.registerBlockImportDone(block.getHash());
               if (throwable != null) {
                 LOG.warn("Failed to import announced block {}", block.toLogString());
               }
@@ -591,15 +701,15 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
   @Override
   public String toString() {
     return "BlockPropagationManager{"
-        + "requestedBlocks="
-        + requestedBlocks
-        + ", requestedNonAnnounceBlocks="
-        + requestedNonAnnouncedBlocks
-        + ", importingBlocks="
-        + importingBlocks
+        + processingBlocksManager
         + ", pendingBlocksManager="
         + pendingBlocksManager
         + '}';
+  }
+
+  private String logBlockNumberMaybeHash(
+      final long blockNumber, final Optional<Hash> maybeBlockHash) {
+    return blockNumber + maybeBlockHash.map(h -> " (" + h + ")").orElse("");
   }
 
   @Override
@@ -609,6 +719,56 @@ public class BlockPropagationManager implements ForkchoiceMessageListener {
       final Hash safeBlockHash) {
     if (maybeFinalizedBlockHash.isPresent() && !maybeFinalizedBlockHash.get().equals(Hash.ZERO)) {
       stop();
+    }
+  }
+
+  static class ProcessingBlocksManager {
+    private final Set<Hash> importingBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<Hash> requestedBlocks = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final Set<Long> requestedNonAnnouncedBlocks =
+        Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    boolean addRequestedBlock(final Hash hash) {
+      return requestedBlocks.add(hash);
+    }
+
+    public boolean addNonAnnouncedBlocks(final long blockNumber) {
+      return requestedNonAnnouncedBlocks.add(blockNumber);
+    }
+
+    public boolean alreadyImporting(final Hash hash) {
+      return importingBlocks.contains(hash);
+    }
+
+    public synchronized void registerReceivedBlock(final Block block) {
+      requestedBlocks.remove(block.getHash());
+      requestedNonAnnouncedBlocks.remove(block.getHeader().getNumber());
+    }
+
+    public synchronized void registerFailedGetBlock(
+        final long blockNumber, final Optional<Hash> maybeBlockHash) {
+      requestedNonAnnouncedBlocks.remove(blockNumber);
+      maybeBlockHash.ifPresent(requestedBlocks::remove);
+    }
+
+    public boolean addImportingBlock(final Hash hash) {
+      return importingBlocks.add(hash);
+    }
+
+    public void registerBlockImportDone(final Hash hash) {
+      importingBlocks.remove(hash);
+    }
+
+    @Override
+    public synchronized String toString() {
+      return "ProcessingBlocksManager{"
+          + "importingBlocks="
+          + importingBlocks
+          + ", requestedBlocks="
+          + requestedBlocks
+          + ", requestedNonAnnouncedBlocks="
+          + requestedNonAnnouncedBlocks
+          + '}';
     }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.hyperledger.besu.consensus.merge.ForkchoiceMessageListener;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateArchive;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.checkpointsync.CheckpointDownloaderFactory;
@@ -30,7 +32,9 @@ import org.hyperledger.besu.ethereum.eth.sync.fullsync.SyncTerminationCondition;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapDownloaderFactory;
 import org.hyperledger.besu.ethereum.eth.sync.state.PendingBlocksManager;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
+import org.hyperledger.besu.ethereum.eth.sync.worldstate.WorldStatePeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.Pruner;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -57,7 +61,10 @@ public class DefaultSynchronizer implements Synchronizer, ForkchoiceMessageListe
   private final Optional<BlockPropagationManager> blockPropagationManager;
   private final Optional<FastSyncDownloader<?>> fastSyncDownloader;
   private final Optional<FullSyncDownloader> fullSyncDownloader;
+  private final EthContext ethContext;
   private final ProtocolContext protocolContext;
+  private final WorldStateStorage worldStateStorage;
+  private final MetricsSystem metricsSystem;
   private final PivotBlockSelector pivotBlockSelector;
   private final SyncTerminationCondition terminationCondition;
 
@@ -78,7 +85,10 @@ public class DefaultSynchronizer implements Synchronizer, ForkchoiceMessageListe
     this.maybePruner = maybePruner;
     this.syncState = syncState;
     this.pivotBlockSelector = pivotBlockSelector;
+    this.ethContext = ethContext;
     this.protocolContext = protocolContext;
+    this.worldStateStorage = worldStateStorage;
+    this.metricsSystem = metricsSystem;
     this.terminationCondition = terminationCondition;
 
     ChainHeadTracker.trackChainHeadForPeers(
@@ -193,6 +203,7 @@ public class DefaultSynchronizer implements Synchronizer, ForkchoiceMessageListe
 
       } else {
         syncState.markInitialSyncPhaseAsDone();
+        enableFallbackNodeFinder();
         future = startFullSync();
       }
       return future.thenApply(this::finalizeSync);
@@ -241,11 +252,26 @@ public class DefaultSynchronizer implements Synchronizer, ForkchoiceMessageListe
     pivotBlockSelector.close();
     syncState.markInitialSyncPhaseAsDone();
 
+    enableFallbackNodeFinder();
+
     if (terminationCondition.shouldContinueDownload()) {
       return startFullSync();
     } else {
       syncState.setReachedTerminalDifficulty(true);
       return CompletableFuture.completedFuture(null);
+    }
+  }
+
+  private void enableFallbackNodeFinder() {
+    if (worldStateStorage instanceof BonsaiWorldStateKeyValueStorage) {
+      final Optional<PeerTrieNodeFinder> fallbackNodeFinder =
+          Optional.of(
+              new WorldStatePeerTrieNodeFinder(
+                  ethContext, protocolContext.getBlockchain(), metricsSystem));
+      ((BonsaiWorldStateArchive) protocolContext.getWorldStateArchive())
+          .useFallbackNodeFinder(fallbackNodeFinder);
+      ((BonsaiWorldStateKeyValueStorage) worldStateStorage)
+          .useFallbackNodeFinder(fallbackNodeFinder);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/PipelineChainDownloader.java
@@ -119,7 +119,7 @@ public class PipelineChainDownloader implements ChainDownloader {
     pipelineErrorCounter.inc();
     if (ExceptionUtils.rootCause(error) instanceof InvalidBlockException) {
       LOG.warn(
-          "Invalid block detected. Disconnecting from sync target. {}",
+          "Invalid block detected (BREACH_OF_PROTOCOL). Disconnecting from sync target. {}",
           ExceptionUtils.rootCause(error).getMessage());
       syncState.disconnectSyncTarget(DisconnectReason.BREACH_OF_PROTOCOL);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SynchronizerConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/SynchronizerConfiguration.java
@@ -47,6 +47,8 @@ public class SynchronizerConfiguration {
   public static final int DEFAULT_COMPUTATION_PARALLELISM = 2;
   public static final int DEFAULT_WORLD_STATE_TASK_CACHE_SIZE =
       CachingTaskCollection.DEFAULT_CACHE_SIZE;
+  public static final long DEFAULT_PROPAGATION_MANAGER_GET_BLOCK_TIMEOUT_MILLIS =
+      TimeUnit.SECONDS.toMillis(60);
 
   // Fast sync config
   private final int fastSyncPivotDistance;
@@ -77,6 +79,7 @@ public class SynchronizerConfiguration {
   private final int computationParallelism;
   private final int maxTrailingPeers;
   private final long worldStateMinMillisBeforeStalling;
+  private final long propagationManagerGetBlockTimeoutMillis;
 
   private SynchronizerConfiguration(
       final int fastSyncPivotDistance,
@@ -98,7 +101,8 @@ public class SynchronizerConfiguration {
       final int downloaderParallelism,
       final int transactionsParallelism,
       final int computationParallelism,
-      final int maxTrailingPeers) {
+      final int maxTrailingPeers,
+      final long propagationManagerGetBlockTimeoutMillis) {
     this.fastSyncPivotDistance = fastSyncPivotDistance;
     this.fastSyncFullValidationRate = fastSyncFullValidationRate;
     this.fastSyncMinimumPeerCount = fastSyncMinimumPeerCount;
@@ -119,6 +123,7 @@ public class SynchronizerConfiguration {
     this.transactionsParallelism = transactionsParallelism;
     this.computationParallelism = computationParallelism;
     this.maxTrailingPeers = maxTrailingPeers;
+    this.propagationManagerGetBlockTimeoutMillis = propagationManagerGetBlockTimeoutMillis;
   }
 
   public static Builder builder() {
@@ -234,6 +239,10 @@ public class SynchronizerConfiguration {
     return maxTrailingPeers;
   }
 
+  public long getPropagationManagerGetBlockTimeoutMillis() {
+    return propagationManagerGetBlockTimeoutMillis;
+  }
+
   public static class Builder {
     private SyncMode syncMode = SyncMode.FULL;
     private int fastSyncMinimumPeerCount = DEFAULT_FAST_SYNC_MINIMUM_PEERS;
@@ -259,6 +268,9 @@ public class SynchronizerConfiguration {
         DEFAULT_WORLD_STATE_MAX_REQUESTS_WITHOUT_PROGRESS;
     private long worldStateMinMillisBeforeStalling = DEFAULT_WORLD_STATE_MIN_MILLIS_BEFORE_STALLING;
     private int worldStateTaskCacheSize = DEFAULT_WORLD_STATE_TASK_CACHE_SIZE;
+
+    private long propagationManagerGetBlockTimeoutMillis =
+        DEFAULT_PROPAGATION_MANAGER_GET_BLOCK_TIMEOUT_MILLIS;
 
     public Builder fastSyncPivotDistance(final int distance) {
       fastSyncPivotDistance = distance;
@@ -371,6 +383,12 @@ public class SynchronizerConfiguration {
       return this;
     }
 
+    public Builder propagationManagerGetBlockTimeoutMillis(
+        final long propagationManagerGetBlockTimeoutMillis) {
+      this.propagationManagerGetBlockTimeoutMillis = propagationManagerGetBlockTimeoutMillis;
+      return this;
+    }
+
     public SynchronizerConfiguration build() {
       return new SynchronizerConfiguration(
           fastSyncPivotDistance,
@@ -392,7 +410,8 @@ public class SynchronizerConfiguration {
           downloaderParallelism,
           transactionsParallelism,
           computationParallelism,
-          maxTrailingPeers);
+          maxTrailingPeers,
+          propagationManagerGetBlockTimeoutMillis);
     }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -202,24 +202,24 @@ public class BackwardSyncContext {
             backwardSyncException -> {
               if (backwardSyncException.shouldRestart()) {
                 LOG.info(
-                    "Backward sync failed ({}). Current Peers: {}. Retrying in "
-                        + millisBetweenRetries
-                        + " milliseconds...",
-                    backwardSyncException.getMessage(),
-                    ethContext.getEthPeers().peerCount());
-                return;
+                    "Backward sync failed ({}). Current Peers: {}. Retrying in {} milliseconds...",
+                    throwable.getMessage(),
+                    ethContext.getEthPeers().peerCount(),
+                    millisBetweenRetries);
               } else {
                 debugLambda(
                     LOG, "Not recoverable backward sync exception {}", throwable::getMessage);
                 throw backwardSyncException;
               }
             },
-            () ->
-                LOG.warn(
-                    "There was an uncaught exception during Backwards Sync. Retrying in "
-                        + millisBetweenRetries
-                        + " milliseconds...",
-                    throwable));
+            () -> {
+              LOG.warn(
+                  "Backward sync failed ({}). Current Peers: {}. Retrying in {} milliseconds...",
+                  throwable.getMessage(),
+                  ethContext.getEthPeers().peerCount(),
+                  millisBetweenRetries);
+              LOG.debug("Exception details:", throwable);
+            });
   }
 
   private Optional<BackwardSyncException> extractBackwardSyncException(final Throwable throwable) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
@@ -156,7 +156,7 @@ public class SnapsyncMetricsManager {
   public void notifySnapSyncCompleted() {
     final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startSyncTime);
     LOG.info(
-        "Finished worldstate snapsync with nodes {} (healed={}) duration {}{}:{},{}. Sync block import still in progress...",
+        "Finished worldstate snapsync with nodes {} (healed={}) duration {}{}:{},{}. Sync block import may still be in progress...",
         nbNodesGenerated.addAndGet(nbNodesHealed.get()),
         nbNodesHealed,
         duration.toHoursPart() > 0 ? (duration.toHoursPart() + ":") : "",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapsyncMetricsManager.java
@@ -156,7 +156,7 @@ public class SnapsyncMetricsManager {
   public void notifySnapSyncCompleted() {
     final Duration duration = Duration.ofMillis(System.currentTimeMillis() - startSyncTime);
     LOG.info(
-        "Finished snapsync with nodes {} (healed={}) duration {}{}:{},{}",
+        "Finished worldstate snapsync with nodes {} (healed={}) duration {}{}:{},{}. Sync block import still in progress...",
         nbNodesGenerated.addAndGet(nbNodesHealed.get()),
         nbNodesHealed,
         duration.toHoursPart() > 0 ? (duration.toHoursPart() + ":") : "",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountTrieNodeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountTrieNodeDataRequest.java
@@ -65,8 +65,7 @@ public class AccountTrieNodeDataRequest extends TrieNodeDataRequest {
   public Optional<Bytes> getExistingData(final WorldStateStorage worldStateStorage) {
     return worldStateStorage
         .getAccountStateTrieNode(getLocation(), getNodeHash())
-        .filter(data -> !getLocation().isEmpty())
-        .filter(data -> Hash.hash(data).equals(getNodeHash()));
+        .filter(data -> !getLocation().isEmpty());
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageTrieNodeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageTrieNodeDataRequest.java
@@ -52,9 +52,8 @@ public class StorageTrieNodeDataRequest extends TrieNodeDataRequest {
 
   @Override
   public Optional<Bytes> getExistingData(final WorldStateStorage worldStateStorage) {
-    return worldStateStorage
-        .getAccountStorageTrieNode(getAccountHash(), getLocation(), getNodeHash())
-        .filter(data -> Hash.hash(data).equals(getNodeHash()));
+    return worldStateStorage.getAccountStorageTrieNode(
+        getAccountHash(), getLocation(), getNodeHash());
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
@@ -219,10 +219,10 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
                         if (error == null && blockPeerTaskResult.getResult() != null) {
                           badBlockManager.addBadBlock(blockPeerTaskResult.getResult());
                         }
-                        headersResult.getPeer().disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
                         LOG.debug(
-                            "Received invalid headers from peer, disconnecting from: {}",
+                            "Received invalid headers from peer (BREACH_OF_PROTOCOL), disconnecting from: {}",
                             headersResult.getPeer());
+                        headersResult.getPeer().disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
                         future.completeExceptionally(
                             new InvalidBlockException(
                                 "Header failed validation.",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinder.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinder.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.worldstate;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
+import org.hyperledger.besu.ethereum.eth.manager.snap.RetryingGetTrieNodeFromPeerTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
+import org.hyperledger.besu.ethereum.eth.manager.task.RetryingGetNodeDataFromPeerTask;
+import org.hyperledger.besu.ethereum.trie.CompactEncoding;
+import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This class is used to retrieve missing nodes in the trie by querying the peers */
+public class WorldStatePeerTrieNodeFinder implements PeerTrieNodeFinder {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WorldStatePeerTrieNodeFinder.class);
+
+  private final Cache<Bytes32, Bytes> foundNodes =
+      CacheBuilder.newBuilder().maximumSize(10_000).expireAfterWrite(5, TimeUnit.MINUTES).build();
+
+  private static final long TIMEOUT_SECONDS = 1;
+
+  final EthContext ethContext;
+  final Blockchain blockchain;
+  final MetricsSystem metricsSystem;
+
+  public WorldStatePeerTrieNodeFinder(
+      final EthContext ethContext, final Blockchain blockchain, final MetricsSystem metricsSystem) {
+    this.ethContext = ethContext;
+    this.blockchain = blockchain;
+    this.metricsSystem = metricsSystem;
+  }
+
+  @Override
+  public Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
+    Optional<Bytes> cachedValue = Optional.ofNullable(foundNodes.getIfPresent(nodeHash));
+    if (cachedValue.isPresent()) {
+      return cachedValue;
+    }
+    final Optional<Bytes> response =
+        findByGetNodeData(Hash.wrap(nodeHash))
+            .or(() -> findByGetTrieNodeData(Hash.wrap(nodeHash), Optional.empty(), location));
+    response.ifPresent(
+        bytes -> {
+          LOG.debug(
+              "Fixed missing account state trie node for location {} and hash {}",
+              location,
+              nodeHash);
+          foundNodes.put(nodeHash, bytes);
+        });
+    return response;
+  }
+
+  @Override
+  public Optional<Bytes> getAccountStorageTrieNode(
+      final Hash accountHash, final Bytes location, final Bytes32 nodeHash) {
+    Optional<Bytes> cachedValue = Optional.ofNullable(foundNodes.getIfPresent(nodeHash));
+    if (cachedValue.isPresent()) {
+      return cachedValue;
+    }
+    final Optional<Bytes> response =
+        findByGetNodeData(Hash.wrap(nodeHash))
+            .or(
+                () ->
+                    findByGetTrieNodeData(Hash.wrap(nodeHash), Optional.of(accountHash), location));
+    response.ifPresent(
+        bytes -> {
+          LOG.debug(
+              "Fixed missing storage state trie node for location {} and hash {}",
+              location,
+              nodeHash);
+          foundNodes.put(nodeHash, bytes);
+        });
+    return response;
+  }
+
+  public Optional<Bytes> findByGetNodeData(final Hash nodeHash) {
+    final BlockHeader chainHead = blockchain.getChainHeadHeader();
+    final RetryingGetNodeDataFromPeerTask retryingGetNodeDataFromPeerTask =
+        RetryingGetNodeDataFromPeerTask.forHashes(
+            ethContext, List.of(nodeHash), chainHead.getNumber(), metricsSystem);
+    try {
+      final Map<Hash, Bytes> response =
+          retryingGetNodeDataFromPeerTask.run().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      if (response.containsKey(nodeHash)) {
+        LOG.debug("Found node {} with getNodeData request", nodeHash);
+        return Optional.of(response.get(nodeHash));
+      } else {
+        LOG.debug("Found invalid node {} with getNodeData request", nodeHash);
+      }
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      LOG.debug("Error when trying to find node {} with getNodeData request", nodeHash);
+    }
+    return Optional.empty();
+  }
+
+  public Optional<Bytes> findByGetTrieNodeData(
+      final Hash nodeHash, final Optional<Bytes32> accountHash, final Bytes location) {
+    final BlockHeader chainHead = blockchain.getChainHeadHeader();
+    final Map<Bytes, List<Bytes>> request = new HashMap<>();
+    if (accountHash.isPresent()) {
+      request.put(accountHash.get(), List.of(CompactEncoding.encode(location)));
+    } else {
+      request.put(CompactEncoding.encode(location), new ArrayList<>());
+    }
+    final Bytes path = CompactEncoding.encode(location);
+    final EthTask<Map<Bytes, Bytes>> getTrieNodeFromPeerTask =
+        RetryingGetTrieNodeFromPeerTask.forTrieNodes(ethContext, request, chainHead, metricsSystem);
+    try {
+      final Map<Bytes, Bytes> response =
+          getTrieNodeFromPeerTask.run().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      final Bytes nodeValue =
+          response.get(Bytes.concatenate(accountHash.map(Bytes::wrap).orElse(Bytes.EMPTY), path));
+      if (nodeValue != null && Hash.hash(nodeValue).equals(nodeHash)) {
+        LOG.debug("Found node {} with getTrieNode request", nodeHash);
+        return Optional.of(nodeValue);
+      } else {
+        LOG.debug("Found invalid node {} with getTrieNode request", nodeHash);
+      }
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      LOG.debug("Error when trying to find node {} with getTrieNode request", nodeHash);
+    }
+    return Optional.empty();
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessor.java
@@ -133,7 +133,9 @@ public class NewPooledTransactionHashesMessageProcessor {
     } catch (final RLPException ex) {
       if (peer != null) {
         LOG.debug(
-            "Malformed pooled transaction hashes message received, disconnecting: {}", peer, ex);
+            "Malformed pooled transaction hashes message received (BREACH_OF_PROTOCOL), disconnecting: {}",
+            peer,
+            ex);
         peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
       }
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -26,7 +26,7 @@ import org.immutables.value.Value;
 public interface TransactionPoolConfiguration {
   int DEFAULT_TX_MSG_KEEP_ALIVE = 60;
   int MAX_PENDING_TRANSACTIONS = 4096;
-  int MAX_PENDING_TRANSACTIONS_HASHES = 4096;
+  int MAX_FUTURE_TRANSACTION_BY_ACCOUNT = 64;
   int DEFAULT_TX_RETENTION_HOURS = 13;
   boolean DEFAULT_STRICT_TX_REPLAY_PROTECTION_ENABLED = false;
   Percentage DEFAULT_PRICE_BUMP = Percentage.fromInt(10);
@@ -38,6 +38,11 @@ public interface TransactionPoolConfiguration {
   @Value.Default
   default int getTxPoolMaxSize() {
     return MAX_PENDING_TRANSACTIONS;
+  }
+
+  @Value.Default
+  default int getTxPoolMaxFutureTransactionByAccount() {
+    return MAX_FUTURE_TRANSACTION_BY_ACCOUNT;
   }
 
   @Value.Default

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -135,20 +135,16 @@ public class TransactionPoolFactory {
             .anyMatch(FeeMarket::implementsBaseFee);
     if (isFeeMarketImplementBaseFee) {
       return new BaseFeePendingTransactionsSorter(
-          transactionPoolConfiguration.getPendingTxRetentionPeriod(),
-          transactionPoolConfiguration.getTxPoolMaxSize(),
+          transactionPoolConfiguration,
           clock,
           metricsSystem,
-          protocolContext.getBlockchain()::getChainHeadHeader,
-          transactionPoolConfiguration.getPriceBump());
+          protocolContext.getBlockchain()::getChainHeadHeader);
     } else {
       return new GasPricePendingTransactionsSorter(
-          transactionPoolConfiguration.getPendingTxRetentionPeriod(),
-          transactionPoolConfiguration.getTxPoolMaxSize(),
+          transactionPoolConfiguration,
           clock,
           metricsSystem,
-          protocolContext.getBlockchain()::getChainHeadHeader,
-          transactionPoolConfiguration.getPriceBump());
+          protocolContext.getBlockchain()::getChainHeadHeader);
     }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
@@ -18,7 +18,9 @@ package org.hyperledger.besu.ethereum.eth.transactions;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter.TransactionInfo;
 
+import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -78,6 +80,10 @@ public class TransactionsForSenderInfo {
     } else {
       return nextGap.isEmpty() ? OptionalLong.of(transactionsInfos.lastKey() + 1) : nextGap;
     }
+  }
+
+  public Optional<TransactionInfo> maybeLastTx() {
+    return Optional.ofNullable(transactionsInfos.lastEntry()).map(Map.Entry::getValue);
   }
 
   public Stream<TransactionInfo> streamTransactionInfos() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsForSenderInfo.java
@@ -86,6 +86,10 @@ public class TransactionsForSenderInfo {
     return Optional.ofNullable(transactionsInfos.lastEntry()).map(Map.Entry::getValue);
   }
 
+  public int transactionCount() {
+    return transactionsInfos.size();
+  }
+
   public Stream<TransactionInfo> streamTransactionInfos() {
     return transactionsInfos.values().stream();
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageProcessor.java
@@ -112,7 +112,10 @@ class TransactionsMessageProcessor {
 
     } catch (final RLPException ex) {
       if (peer != null) {
-        LOG.debug("Malformed transaction message received, disconnecting: {}", peer, ex);
+        LOG.debug(
+            "Malformed transaction message received (BREACH_OF_PROTOCOL), disconnecting: {}",
+            peer,
+            ex);
         peer.disconnect(DisconnectReason.BREACH_OF_PROTOCOL);
       }
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -423,5 +424,17 @@ public abstract class AbstractPendingTransactionsSorter {
     public Optional<TransactionInvalidReason> getInvalidReason() {
       return invalidReason;
     }
+  }
+
+  Optional<TransactionInfo> lowestValueTxForRemovalBySender(NavigableSet<TransactionInfo> txSet) {
+    return txSet.descendingSet().stream()
+        .filter(
+            tx ->
+                transactionsBySender
+                    .get(tx.getSender())
+                    .maybeLastTx()
+                    .filter(tx::equals)
+                    .isPresent())
+        .findFirst();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -23,8 +23,8 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.util.number.Percentage;
 
 import java.time.Clock;
 import java.util.Comparator;
@@ -52,19 +52,11 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
   private Optional<Wei> baseFee;
 
   public BaseFeePendingTransactionsSorter(
-      final int maxTransactionRetentionHours,
-      final int maxPendingTransactions,
+      final TransactionPoolConfiguration poolConfig,
       final Clock clock,
       final MetricsSystem metricsSystem,
-      final Supplier<BlockHeader> chainHeadHeaderSupplier,
-      final Percentage priceBump) {
-    super(
-        maxTransactionRetentionHours,
-        maxPendingTransactions,
-        clock,
-        metricsSystem,
-        chainHeadHeaderSupplier,
-        priceBump);
+      final Supplier<BlockHeader> chainHeadHeaderSupplier) {
+    super(poolConfig, clock, metricsSystem, chainHeadHeaderSupplier);
     this.baseFee = chainHeadHeaderSupplier.get().getBaseFee();
   }
 
@@ -201,6 +193,7 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
       if (!transactionAddedStatus.equals(ADDED)) {
         return transactionAddedStatus;
       }
+
       // check if it's in static or dynamic range
       if (isInStaticRange(transaction, baseFee)) {
         prioritizedTransactionsStaticRange.add(transactionInfo);
@@ -210,29 +203,41 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
       LOG.trace("Adding {} to pending transactions", transactionInfo);
       pendingTransactions.put(transactionInfo.getHash(), transactionInfo);
 
-      if (pendingTransactions.size() > maxPendingTransactions) {
-        final Stream.Builder<TransactionInfo> removalCandidates = Stream.builder();
-        if (!prioritizedTransactionsDynamicRange.isEmpty())
-          lowestValueTxForRemovalBySender(prioritizedTransactionsDynamicRange)
-              .ifPresent(removalCandidates::add);
-        if (!prioritizedTransactionsStaticRange.isEmpty())
-          lowestValueTxForRemovalBySender(prioritizedTransactionsStaticRange)
-              .ifPresent(removalCandidates::add);
-
-        droppedTransaction =
-            removalCandidates
-                .build()
-                .min(
-                    Comparator.comparing(
-                        txInfo -> txInfo.getTransaction().getEffectivePriorityFeePerGas(baseFee)))
-                .map(TransactionInfo::getTransaction);
+      // check if this sender exceeds the transactions by sender limit:
+      var senderTxInfos = transactionsBySender.get(transactionInfo.getSender());
+      if (senderTxInfos.transactionCount() > poolConfig.getTxPoolMaxFutureTransactionByAccount()) {
+        droppedTransaction = senderTxInfos.maybeLastTx().map(TransactionInfo::getTransaction);
         droppedTransaction.ifPresent(
-            toRemove -> {
-              doRemoveTransaction(toRemove, false);
-              LOG.trace("Evicted {} due to transaction pool size", toRemove);
-            });
+            tx -> LOG.trace("Evicted {} due to too many transactions from sender", tx));
+
+      } else {
+        // else if we are over txpool limit, select the lowest value transaction to evict
+        if (pendingTransactions.size() > poolConfig.getTxPoolMaxSize()) {
+          final Stream.Builder<TransactionInfo> removalCandidates = Stream.builder();
+          if (!prioritizedTransactionsDynamicRange.isEmpty())
+            lowestValueTxForRemovalBySender(prioritizedTransactionsDynamicRange)
+                .ifPresent(removalCandidates::add);
+          if (!prioritizedTransactionsStaticRange.isEmpty())
+            lowestValueTxForRemovalBySender(prioritizedTransactionsStaticRange)
+                .ifPresent(removalCandidates::add);
+
+          droppedTransaction =
+              removalCandidates
+                  .build()
+                  .min(
+                      Comparator.comparing(
+                          txInfo -> txInfo.getTransaction().getEffectivePriorityFeePerGas(baseFee)))
+                  .map(TransactionInfo::getTransaction);
+        }
       }
+
+      droppedTransaction.ifPresent(
+          toRemove -> {
+            doRemoveTransaction(toRemove, false);
+            LOG.trace("Evicted {} due to transaction pool size", toRemove);
+          });
     }
+
     notifyTransactionAdded(transaction);
     droppedTransaction.ifPresent(this::notifyTransactionDropped);
     return ADDED;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
@@ -19,8 +19,8 @@ import static java.util.Comparator.comparing;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.util.number.Percentage;
 
 import java.time.Clock;
 import java.util.Iterator;
@@ -29,6 +29,9 @@ import java.util.Optional;
 import java.util.TreeSet;
 import java.util.function.Supplier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Holds the current set of pending transactions with the ability to iterate them based on priority
  * for mining or look-up by hash.
@@ -36,6 +39,8 @@ import java.util.function.Supplier;
  * <p>This class is safe for use across multiple threads.
  */
 public class GasPricePendingTransactionsSorter extends AbstractPendingTransactionsSorter {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GasPricePendingTransactionsSorter.class);
 
   private final NavigableSet<TransactionInfo> prioritizedTransactions =
       new TreeSet<>(
@@ -45,19 +50,11 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
               .reversed());
 
   public GasPricePendingTransactionsSorter(
-      final int maxTransactionRetentionHours,
-      final int maxPendingTransactions,
+      final TransactionPoolConfiguration poolConfig,
       final Clock clock,
       final MetricsSystem metricsSystem,
-      final Supplier<BlockHeader> chainHeadHeaderSupplier,
-      final Percentage priceBump) {
-    super(
-        maxTransactionRetentionHours,
-        maxPendingTransactions,
-        clock,
-        metricsSystem,
-        chainHeadHeaderSupplier,
-        priceBump);
+      final Supplier<BlockHeader> chainHeadHeaderSupplier) {
+    super(poolConfig, clock, metricsSystem, chainHeadHeaderSupplier);
   }
 
   @Override
@@ -100,12 +97,21 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       prioritizedTransactions.add(transactionInfo);
       pendingTransactions.put(transactionInfo.getHash(), transactionInfo);
 
-      if (pendingTransactions.size() > maxPendingTransactions) {
-        droppedTransaction =
-            lowestValueTxForRemovalBySender(prioritizedTransactions)
-                .map(TransactionInfo::getTransaction);
-        droppedTransaction.ifPresent(tx -> doRemoveTransaction(tx, false));
+      // check if this sender exceeds the transactions by sender limit:
+      var senderTxInfos = transactionsBySender.get(transactionInfo.getSender());
+      if (senderTxInfos.transactionCount() > poolConfig.getTxPoolMaxFutureTransactionByAccount()) {
+        droppedTransaction = senderTxInfos.maybeLastTx().map(TransactionInfo::getTransaction);
+        droppedTransaction.ifPresent(
+            tx -> LOG.trace("Evicted {} due to too many transactions from sender", tx));
+      } else {
+        // else if we are over txpool limit, select the lowest value transaction to evict
+        if (pendingTransactions.size() > poolConfig.getTxPoolMaxSize()) {
+          droppedTransaction =
+              lowestValueTxForRemovalBySender(prioritizedTransactions)
+                  .map(TransactionInfo::getTransaction);
+        }
       }
+      droppedTransaction.ifPresent(tx -> doRemoveTransaction(tx, false));
     }
     notifyTransactionAdded(transactionInfo.getTransaction());
     droppedTransaction.ifPresent(this::notifyTransactionDropped);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
@@ -41,7 +41,7 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       new TreeSet<>(
           comparing(TransactionInfo::isReceivedFromLocalSource)
               .thenComparing(TransactionInfo::getGasPrice)
-              .thenComparing(TransactionInfo::getSequence)
+              .thenComparing(TransactionInfo::getAddedToPoolAt)
               .reversed());
 
   public GasPricePendingTransactionsSorter(
@@ -101,9 +101,10 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
       pendingTransactions.put(transactionInfo.getHash(), transactionInfo);
 
       if (pendingTransactions.size() > maxPendingTransactions) {
-        final TransactionInfo toRemove = prioritizedTransactions.last();
-        doRemoveTransaction(toRemove.getTransaction(), false);
-        droppedTransaction = Optional.of(toRemove.getTransaction());
+        droppedTransaction =
+            lowestValueTxForRemovalBySender(prioritizedTransactions)
+                .map(TransactionInfo::getTransaction);
+        droppedTransaction.ifPresent(tx -> doRemoveTransaction(tx, false));
       }
     }
     notifyTransactionAdded(transactionInfo.getTransaction());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTest.java
@@ -73,6 +73,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1081,7 +1082,7 @@ public final class EthProtocolManagerTest {
           protocolSchedule,
           protocolContext,
           ethManager.ethContext(),
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           () -> true,
           new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -44,6 +44,7 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -104,7 +105,7 @@ public abstract class AbstractMessageTaskTest<T, R> {
             protocolSchedule,
             protocolContext,
             ethContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/SnapProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/SnapProtocolManagerTestUtil.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.manager.task;
+
+import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.snap.SnapProtocolManager;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+
+import java.util.Collections;
+
+public class SnapProtocolManagerTestUtil {
+
+  public static SnapProtocolManager create(final EthPeers ethPeers) {
+    return create(
+        BlockchainSetupUtil.forTesting(DataStorageFormat.FOREST).getWorldArchive(), ethPeers);
+  }
+
+  public static SnapProtocolManager create(
+      final WorldStateArchive worldStateArchive, final EthPeers ethPeers) {
+
+    EthMessages messages = new EthMessages();
+
+    return new SnapProtocolManager(Collections.emptyList(), ethPeers, messages, worldStateArchive);
+  }
+
+  public static SnapProtocolManager create(
+      final WorldStateArchive worldStateArchive,
+      final EthPeers ethPeers,
+      final EthMessages snapMessages) {
+    return new SnapProtocolManager(
+        Collections.emptyList(), ethPeers, snapMessages, worldStateArchive);
+  }
+
+  public static RespondingEthPeer createPeer(
+      final EthProtocolManager ethProtocolManager,
+      final SnapProtocolManager snapProtocolManager,
+      final long estimatedHeight) {
+    return RespondingEthPeer.builder()
+        .ethProtocolManager(ethProtocolManager)
+        .snapProtocolManager(snapProtocolManager)
+        .estimatedHeight(estimatedHeight)
+        .build();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskTest.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.exceptions.EthTaskException;
+import org.hyperledger.besu.ethereum.eth.manager.exceptions.EthTaskException.FailureReason;
 import org.hyperledger.besu.ethereum.eth.manager.task.EthTask;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
@@ -117,8 +118,7 @@ public class DetermineCommonAncestorTaskTest {
     assertThat(failure.get()).isNotNull();
     final Throwable error = ExceptionUtils.rootCause(failure.get());
     assertThat(error).isInstanceOf(EthTaskException.class);
-    assertThat(((EthTaskException) error).reason())
-        .isEqualTo(EthTaskException.FailureReason.PEER_DISCONNECTED);
+    assertThat(((EthTaskException) error).reason()).isEqualTo(FailureReason.NO_AVAILABLE_PEERS);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinderTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.worldstate;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
+import org.hyperledger.besu.ethereum.eth.manager.RequestManager;
+import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.manager.snap.SnapProtocolManager;
+import org.hyperledger.besu.ethereum.eth.manager.task.SnapProtocolManagerTestUtil;
+import org.hyperledger.besu.ethereum.eth.messages.EthPV63;
+import org.hyperledger.besu.ethereum.eth.messages.NodeDataMessage;
+import org.hyperledger.besu.ethereum.eth.messages.snap.SnapV1;
+import org.hyperledger.besu.ethereum.eth.messages.snap.TrieNodesMessage;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@SuppressWarnings({"FieldCanBeLocal", "unused"})
+@RunWith(MockitoJUnitRunner.class)
+public class WorldStatePeerTrieNodeFinderTest {
+
+  WorldStatePeerTrieNodeFinder worldStatePeerTrieNodeFinder;
+
+  private final BlockHeaderTestFixture blockHeaderBuilder = new BlockHeaderTestFixture();
+
+  @Mock private Blockchain blockchain;
+  private EthProtocolManager ethProtocolManager;
+  private SnapProtocolManager snapProtocolManager;
+  private EthPeers ethPeers;
+  private final PeerRequest peerRequest = mock(PeerRequest.class);
+  private final RequestManager.ResponseStream responseStream =
+      mock(RequestManager.ResponseStream.class);
+
+  @Before
+  public void setup() throws Exception {
+    ethProtocolManager = EthProtocolManagerTestUtil.create();
+    ethPeers = ethProtocolManager.ethContext().getEthPeers();
+    snapProtocolManager = SnapProtocolManagerTestUtil.create(ethPeers);
+    worldStatePeerTrieNodeFinder =
+        new WorldStatePeerTrieNodeFinder(
+            ethProtocolManager.ethContext(), blockchain, new NoOpMetricsSystem());
+  }
+
+  private RespondingEthPeer.Responder respondToGetNodeDataRequest(
+      final RespondingEthPeer peer, final Bytes32 nodeValue) {
+    return RespondingEthPeer.targetedResponder(
+        (cap, msg) -> {
+          if (msg.getCode() != EthPV63.GET_NODE_DATA) {
+            return false;
+          }
+          return true;
+        },
+        (cap, msg) -> NodeDataMessage.create(List.of(nodeValue)));
+  }
+
+  private RespondingEthPeer.Responder respondToGetTrieNodeRequest(
+      final RespondingEthPeer peer, final Bytes32 nodeValue) {
+    return RespondingEthPeer.targetedResponder(
+        (cap, msg) -> {
+          if (msg.getCode() != SnapV1.GET_TRIE_NODES) {
+            return false;
+          }
+          return true;
+        },
+        (cap, msg) -> TrieNodesMessage.create(Optional.of(BigInteger.ZERO), List.of(nodeValue)));
+  }
+
+  @Test
+  public void getAccountStateTrieNodeShouldReturnValueFromGetNodeDataRequest() {
+
+    BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    final RespondingEthPeer targetPeer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, blockHeader.getNumber());
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    new Thread(
+            () ->
+                targetPeer.respondWhileOtherThreadsWork(
+                    respondToGetNodeDataRequest(targetPeer, nodeValue),
+                    () -> response.accountStateTrieNode.isEmpty()))
+        .start();
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStateTrieNode(Bytes.EMPTY, nodeHash);
+
+    Assertions.assertThat(response.accountStateTrieNode).contains(nodeValue);
+  }
+
+  @Test
+  public void getAccountStateTrieNodeShouldReturnValueFromGetTrieNodeRequest() {
+
+    final BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    final RespondingEthPeer targetPeer =
+        SnapProtocolManagerTestUtil.createPeer(
+            ethProtocolManager, snapProtocolManager, blockHeader.getNumber());
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    new Thread(
+            () ->
+                targetPeer.respondWhileOtherThreadsWork(
+                    respondToGetTrieNodeRequest(targetPeer, nodeValue),
+                    () -> response.accountStateTrieNode.isEmpty()))
+        .start();
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStateTrieNode(Bytes.EMPTY, nodeHash);
+    Assertions.assertThat(response.accountStateTrieNode).contains(nodeValue);
+  }
+
+  @Test
+  public void getAccountStateTrieNodeShouldReturnEmptyWhenFoundNothing() {
+
+    final BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStateTrieNode(Bytes.EMPTY, nodeHash);
+    Assertions.assertThat(response.accountStateTrieNode).isEmpty();
+  }
+
+  @Test
+  public void getAccountStorageTrieNodeShouldReturnValueFromGetNodeDataRequest() {
+
+    BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Hash accountHash = Hash.wrap(Bytes32.random());
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    final RespondingEthPeer targetPeer =
+        EthProtocolManagerTestUtil.createPeer(ethProtocolManager, blockHeader.getNumber());
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    new Thread(
+            () ->
+                targetPeer.respondWhileOtherThreadsWork(
+                    respondToGetNodeDataRequest(targetPeer, nodeValue),
+                    () -> response.accountStateTrieNode.isEmpty()))
+        .start();
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStorageTrieNode(accountHash, Bytes.EMPTY, nodeHash);
+
+    Assertions.assertThat(response.accountStateTrieNode).contains(nodeValue);
+  }
+
+  @Test
+  public void getAccountStorageTrieNodeShouldReturnValueFromGetTrieNodeRequest() {
+
+    final BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Hash accountHash = Hash.wrap(Bytes32.random());
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    final RespondingEthPeer targetPeer =
+        SnapProtocolManagerTestUtil.createPeer(
+            ethProtocolManager, snapProtocolManager, blockHeader.getNumber());
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    new Thread(
+            () ->
+                targetPeer.respondWhileOtherThreadsWork(
+                    respondToGetTrieNodeRequest(targetPeer, nodeValue),
+                    () -> response.accountStateTrieNode.isEmpty()))
+        .start();
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStorageTrieNode(accountHash, Bytes.EMPTY, nodeHash);
+    Assertions.assertThat(response.accountStateTrieNode).contains(nodeValue);
+  }
+
+  @Test
+  public void getAccountStorageTrieNodeShouldReturnEmptyWhenFoundNothing() {
+
+    final BlockHeader blockHeader = blockHeaderBuilder.number(1000).buildHeader();
+    when(blockchain.getChainHeadHeader()).thenReturn(blockHeader);
+
+    final Hash accountHash = Hash.wrap(Bytes32.random());
+    final Bytes32 nodeValue = Bytes32.random();
+    final Bytes32 nodeHash = Hash.hash(nodeValue);
+
+    var response =
+        new Object() {
+          Optional<Bytes> accountStateTrieNode = Optional.empty();
+        };
+
+    response.accountStateTrieNode =
+        worldStatePeerTrieNodeFinder.getAccountStorageTrieNode(accountHash, Bytes.EMPTY, nodeHash);
+    Assertions.assertThat(response.accountStateTrieNode).isEmpty();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/BaseFeePendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/BaseFeePendingTransactionsTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTrans
 import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class BaseFeePendingTransactionsTest {
       new BaseFeePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           MAX_TRANSACTIONS,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           BaseFeePendingTransactionsTest::mockBlockHeader,
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -122,10 +123,13 @@ public class BaseFeePendingTransactionsTest {
 
   @Test
   public void shouldDropOldestTransactionWhenLimitExceeded() {
-    final Transaction oldestTransaction = createTransaction(0);
+    final Transaction oldestTransaction =
+        transactionWithNonceSenderAndGasPrice(0, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L);
     transactions.addRemoteTransaction(oldestTransaction);
     for (int i = 1; i < MAX_TRANSACTIONS; i++) {
-      transactions.addRemoteTransaction(createTransaction(i));
+      transactions.addRemoteTransaction(
+          transactionWithNonceSenderAndGasPrice(
+              i, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L));
     }
     assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
     assertThat(metricsSystem.getCounterValue(REMOVED_COUNTER, REMOTE, DROPPED)).isZero();
@@ -167,10 +171,13 @@ public class BaseFeePendingTransactionsTest {
   public void shouldPrioritizeGasPriceThenTimeAddedToPool() {
     final List<Transaction> lowGasPriceTransactions =
         IntStream.range(0, MAX_TRANSACTIONS)
-            .mapToObj(i -> transactionWithNonceSenderAndGasPrice(i + 1, KEYS1, 10))
+            .mapToObj(
+                i ->
+                    transactionWithNonceSenderAndGasPrice(
+                        i + 1, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10))
             .collect(Collectors.toUnmodifiableList());
 
-    // Fill the pool
+    // Fill the pool with transasctions from random senders
     lowGasPriceTransactions.forEach(transactions::addRemoteTransaction);
 
     // This should kick the oldest tx with the low gas price out, namely the first one we added
@@ -186,14 +193,14 @@ public class BaseFeePendingTransactionsTest {
 
   @Test
   public void shouldStartDroppingLocalTransactionsWhenPoolIsFullOfLocalTransactions() {
-    final Transaction firstLocalTransaction = createTransaction(0);
-    transactions.addLocalTransaction(firstLocalTransaction);
+    Transaction lastLocalTransactionForSender = null;
 
-    for (int i = 1; i <= MAX_TRANSACTIONS; i++) {
-      transactions.addLocalTransaction(createTransaction(i));
+    for (int i = 0; i <= MAX_TRANSACTIONS; i++) {
+      lastLocalTransactionForSender = createTransaction(i);
+      transactions.addLocalTransaction(lastLocalTransactionForSender);
     }
     assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
-    assertTransactionNotPending(firstLocalTransaction);
+    assertTransactionNotPending(lastLocalTransactionForSender);
   }
 
   @Test
@@ -687,9 +694,11 @@ public class BaseFeePendingTransactionsTest {
         .isPresent()
         .hasValue(6);
     addLocalTransactions(6, 10);
+
+    // assert that we drop future nonces first:
     assertThat(transactions.getNextNonceForSender(transaction1.getSender()))
         .isPresent()
-        .hasValue(7);
+        .hasValue(6);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/BaseFeePendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/BaseFeePendingTransactionsTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter.TransactionAddedStatus;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter.TransactionSelectionResult;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.BaseFeePendingTransactionsSorter;
@@ -54,6 +55,7 @@ import org.junit.Test;
 public class BaseFeePendingTransactionsTest {
 
   private static final int MAX_TRANSACTIONS = 5;
+  private static final int MAX_TRANSACTIONS_BY_SENDER = 4;
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance);
   private static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
@@ -68,12 +70,19 @@ public class BaseFeePendingTransactionsTest {
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final BaseFeePendingTransactionsSorter transactions =
       new BaseFeePendingTransactionsSorter(
-          TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-          MAX_TRANSACTIONS,
+          ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(MAX_TRANSACTIONS).build(),
           TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
-          BaseFeePendingTransactionsTest::mockBlockHeader,
-          TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+          BaseFeePendingTransactionsTest::mockBlockHeader);
+  private final BaseFeePendingTransactionsSorter senderLimitedTransactions =
+      new BaseFeePendingTransactionsSorter(
+          ImmutableTransactionPoolConfiguration.builder()
+              .txPoolMaxSize(MAX_TRANSACTIONS)
+              .txPoolMaxFutureTransactionByAccount(MAX_TRANSACTIONS_BY_SENDER)
+              .build(),
+          TestClock.system(ZoneId.systemDefault()),
+          metricsSystem,
+          BaseFeePendingTransactionsTest::mockBlockHeader);
   private final Transaction transaction1 = createTransaction(2);
   private final Transaction transaction2 = createTransaction(1);
 
@@ -125,19 +134,32 @@ public class BaseFeePendingTransactionsTest {
   public void shouldDropOldestTransactionWhenLimitExceeded() {
     final Transaction oldestTransaction =
         transactionWithNonceSenderAndGasPrice(0, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L);
-    transactions.addRemoteTransaction(oldestTransaction);
+    senderLimitedTransactions.addRemoteTransaction(oldestTransaction);
     for (int i = 1; i < MAX_TRANSACTIONS; i++) {
-      transactions.addRemoteTransaction(
+      senderLimitedTransactions.addRemoteTransaction(
           transactionWithNonceSenderAndGasPrice(
               i, SIGNATURE_ALGORITHM.get().generateKeyPair(), 10L));
     }
-    assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
+    assertThat(senderLimitedTransactions.size()).isEqualTo(MAX_TRANSACTIONS);
     assertThat(metricsSystem.getCounterValue(REMOVED_COUNTER, REMOTE, DROPPED)).isZero();
 
-    transactions.addRemoteTransaction(createTransaction(MAX_TRANSACTIONS + 1));
-    assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
+    senderLimitedTransactions.addRemoteTransaction(createTransaction(MAX_TRANSACTIONS + 1));
+    assertThat(senderLimitedTransactions.size()).isEqualTo(MAX_TRANSACTIONS);
     assertTransactionNotPending(oldestTransaction);
     assertThat(metricsSystem.getCounterValue(REMOVED_COUNTER, REMOTE, DROPPED)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldDropFutureTransactionWhenSenderLimitExceeded() {
+    Transaction furthestFutureTransaction = null;
+    for (int i = 0; i < MAX_TRANSACTIONS; i++) {
+      furthestFutureTransaction = transactionWithNonceSenderAndGasPrice(i, KEYS1, 10L);
+      senderLimitedTransactions.addRemoteTransaction(furthestFutureTransaction);
+    }
+    assertThat(senderLimitedTransactions.size()).isEqualTo(MAX_TRANSACTIONS_BY_SENDER);
+    assertThat(metricsSystem.getCounterValue(REMOVED_COUNTER, REMOTE, DROPPED)).isEqualTo(1L);
+    assertThat(senderLimitedTransactions.getTransactionByHash(furthestFutureTransaction.getHash()))
+        .isEmpty();
   }
 
   @Test
@@ -597,12 +619,13 @@ public class BaseFeePendingTransactionsTest {
     final int maxTransactionRetentionHours = 1;
     final BaseFeePendingTransactionsSorter transactions =
         new BaseFeePendingTransactionsSorter(
-            maxTransactionRetentionHours,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder()
+                .pendingTxRetentionPeriod(maxTransactionRetentionHours)
+                .txPoolMaxSize(MAX_TRANSACTIONS)
+                .build(),
             clock,
             metricsSystem,
-            BaseFeePendingTransactionsTest::mockBlockHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            BaseFeePendingTransactionsTest::mockBlockHeader);
 
     transactions.addRemoteTransaction(transaction1);
     assertThat(transactions.size()).isEqualTo(1);
@@ -620,12 +643,13 @@ public class BaseFeePendingTransactionsTest {
     final int maxTransactionRetentionHours = 1;
     final BaseFeePendingTransactionsSorter transactions =
         new BaseFeePendingTransactionsSorter(
-            maxTransactionRetentionHours,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder()
+                .pendingTxRetentionPeriod(maxTransactionRetentionHours)
+                .txPoolMaxSize(MAX_TRANSACTIONS)
+                .build(),
             clock,
             metricsSystem,
-            BaseFeePendingTransactionsTest::mockBlockHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            BaseFeePendingTransactionsTest::mockBlockHeader);
     transactions.addRemoteTransaction(transaction1);
     assertThat(transactions.size()).isEqualTo(1);
     clock.step(2L, ChronoUnit.HOURS);
@@ -639,12 +663,13 @@ public class BaseFeePendingTransactionsTest {
     final int maxTransactionRetentionHours = 2;
     final BaseFeePendingTransactionsSorter transactions =
         new BaseFeePendingTransactionsSorter(
-            maxTransactionRetentionHours,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder()
+                .pendingTxRetentionPeriod(maxTransactionRetentionHours)
+                .txPoolMaxSize(MAX_TRANSACTIONS)
+                .build(),
             clock,
             metricsSystem,
-            BaseFeePendingTransactionsTest::mockBlockHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            BaseFeePendingTransactionsTest::mockBlockHeader);
     transactions.addRemoteTransaction(transaction1);
     assertThat(transactions.size()).isEqualTo(1);
     clock.step(3L, ChronoUnit.HOURS);
@@ -702,6 +727,27 @@ public class BaseFeePendingTransactionsTest {
   }
 
   @Test
+  public void assertThatCorrectNonceIsReturnedForSenderLimitedPool() {
+    assertThat(senderLimitedTransactions.getNextNonceForSender(transaction1.getSender())).isEmpty();
+    addLocalTransactions(senderLimitedTransactions, 1, 2, 4, 5);
+    assertThat(senderLimitedTransactions.getNextNonceForSender(transaction1.getSender()))
+        .isPresent()
+        .hasValue(3);
+    addLocalTransactions(senderLimitedTransactions, 3);
+
+    // assert we have dropped previously added tx 5, and next nonce is now 5
+    assertThat(senderLimitedTransactions.getNextNonceForSender(transaction1.getSender()))
+        .isPresent()
+        .hasValue(5);
+    addLocalTransactions(senderLimitedTransactions, 6, 10);
+
+    // assert that we drop future nonces first:
+    assertThat(senderLimitedTransactions.getNextNonceForSender(transaction1.getSender()))
+        .isPresent()
+        .hasValue(5);
+  }
+
+  @Test
   public void assertThatCorrectNonceIsReturnedLargeGap() {
     assertThat(transactions.getNextNonceForSender(transaction1.getSender())).isEmpty();
     addLocalTransactions(1, 2, Long.MAX_VALUE);
@@ -722,8 +768,13 @@ public class BaseFeePendingTransactionsTest {
   }
 
   private void addLocalTransactions(final long... nonces) {
+    addLocalTransactions(transactions, nonces);
+  }
+
+  private void addLocalTransactions(
+      final AbstractPendingTransactionsSorter sorter, final long... nonces) {
     for (final long nonce : nonces) {
-      transactions.addLocalTransaction(createTransaction(nonce));
+      sorter.addLocalTransaction(createTransaction(nonce));
     }
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/GasPricePendingTransactionsTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTran
 import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -69,7 +70,7 @@ public class GasPricePendingTransactionsTest {
       new GasPricePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           MAX_TRANSACTIONS,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           GasPricePendingTransactionsTest::mockBlockHeader,
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -207,16 +208,14 @@ public class GasPricePendingTransactionsTest {
 
   @Test
   public void shouldStartDroppingLocalTransactionsWhenPoolIsFullOfLocalTransactions() {
+    Transaction lastLocalTransactionForSender = null;
 
-    final Transaction firstLocalTransaction = createTransaction(0);
-    transactions.addLocalTransaction(firstLocalTransaction);
-
-    for (int i = 1; i <= MAX_TRANSACTIONS; i++) {
-      transactions.addLocalTransaction(createTransaction(i));
+    for (int i = 0; i <= MAX_TRANSACTIONS; i++) {
+      lastLocalTransactionForSender = createTransaction(i);
+      transactions.addLocalTransaction(lastLocalTransactionForSender);
     }
-
     assertThat(transactions.size()).isEqualTo(MAX_TRANSACTIONS);
-    assertTransactionNotPending(firstLocalTransaction);
+    assertTransactionNotPending(lastLocalTransactionForSender);
   }
 
   @Test
@@ -710,9 +709,11 @@ public class GasPricePendingTransactionsTest {
         .isPresent()
         .hasValue(6);
     addLocalTransactions(6, 10);
+
+    // assert that transactions are pruned by account from latest future nonces first
     assertThat(transactions.getNextNonceForSender(transaction1.getSender()))
         .isPresent()
-        .hasValue(7);
+        .hasValue(6);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 public class PendingMultiTypesTransactionsTest {
 
   private static final int MAX_TRANSACTIONS = 5;
+  private static final int MAX_TRANSACTIONS_BY_SENDER = 4;
   private static final Supplier<SignatureAlgorithm> SIGNATURE_ALGORITHM =
       Suppliers.memoize(SignatureAlgorithmFactory::getInstance)::get;
   private static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
@@ -60,12 +61,13 @@ public class PendingMultiTypesTransactionsTest {
   private final StubMetricsSystem metricsSystem = new StubMetricsSystem();
   private final BaseFeePendingTransactionsSorter transactions =
       new BaseFeePendingTransactionsSorter(
-          TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-          MAX_TRANSACTIONS,
+          ImmutableTransactionPoolConfiguration.builder()
+              .txPoolMaxSize(MAX_TRANSACTIONS)
+              .txPoolMaxFutureTransactionByAccount(MAX_TRANSACTIONS_BY_SENDER)
+              .build(),
           TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
-          () -> mockBlockHeader(Wei.of(7L)),
-          TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+          () -> mockBlockHeader(Wei.of(7L)));
 
   @Test
   public void shouldReturnExclusivelyLocal1559TransactionsWhenAppropriate() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingMultiTypesTransactionsTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.testutil.TestClock;
 
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -47,6 +48,9 @@ public class PendingMultiTypesTransactionsTest {
   private static final KeyPair KEYS1 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final KeyPair KEYS2 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final KeyPair KEYS3 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS4 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS5 = SIGNATURE_ALGORITHM.get().generateKeyPair();
+  private static final KeyPair KEYS6 = SIGNATURE_ALGORITHM.get().generateKeyPair();
   private static final String ADDED_COUNTER = "transactions_added_total";
   private static final String REMOTE = "remote";
   private static final String LOCAL = "local";
@@ -58,7 +62,7 @@ public class PendingMultiTypesTransactionsTest {
       new BaseFeePendingTransactionsSorter(
           TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
           MAX_TRANSACTIONS,
-          TestClock.fixed(),
+          TestClock.system(ZoneId.systemDefault()),
           metricsSystem,
           () -> mockBlockHeader(Wei.of(7L)),
           TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
@@ -83,11 +87,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldReplaceTransactionWithLowestMaxFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = create1559Transaction(1, 190, 20, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 220, 20, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = create1559Transaction(0, 190, 20, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 220, 20, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -109,11 +113,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictTransactionWithLowestMaxFeePerGasAndLowestTip() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = create1559Transaction(1, 200, 19, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = create1559Transaction(0, 200, 19, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -133,11 +137,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictLegacyTransactionWithLowestEffectiveMaxPriorityFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = createLegacyTransaction(1, 25, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = createLegacyTransaction(0, 25, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);
@@ -156,11 +160,11 @@ public class PendingMultiTypesTransactionsTest {
   @Test
   public void shouldEvictEIP1559TransactionWithLowestEffectiveMaxPriorityFeePerGas() {
     final Transaction localTransaction0 = create1559Transaction(0, 200, 20, KEYS1);
-    final Transaction localTransaction1 = createLegacyTransaction(1, 26, KEYS1);
-    final Transaction localTransaction2 = create1559Transaction(2, 200, 18, KEYS1);
-    final Transaction localTransaction3 = create1559Transaction(3, 240, 20, KEYS1);
-    final Transaction localTransaction4 = create1559Transaction(4, 260, 20, KEYS1);
-    final Transaction localTransaction5 = create1559Transaction(5, 900, 20, KEYS1);
+    final Transaction localTransaction1 = createLegacyTransaction(0, 26, KEYS2);
+    final Transaction localTransaction2 = create1559Transaction(0, 200, 18, KEYS3);
+    final Transaction localTransaction3 = create1559Transaction(0, 240, 20, KEYS4);
+    final Transaction localTransaction4 = create1559Transaction(0, 260, 20, KEYS5);
+    final Transaction localTransaction5 = create1559Transaction(0, 900, 20, KEYS6);
     transactions.addLocalTransaction(localTransaction0);
     transactions.addLocalTransaction(localTransaction1);
     transactions.addLocalTransaction(localTransaction2);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -64,6 +64,7 @@ import org.hyperledger.besu.testutil.TestClock;
 import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -141,7 +142,7 @@ public class TestNode implements Closeable {
             protocolSchedule,
             protocolContext,
             ethContext,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             syncState::isInitialSyncPhaseDone,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
@@ -91,14 +91,11 @@ public class TransactionPoolFactoryTest {
             new NoOpMetricsSystem(),
             () -> true,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),
-            ImmutableTransactionPoolConfiguration.of(
-                1,
-                1,
-                1,
-                TransactionPoolConfiguration.DEFAULT_PRICE_BUMP,
-                TransactionPoolConfiguration.ETH65_TRX_ANNOUNCED_BUFFERING_PERIOD,
-                TransactionPoolConfiguration.DEFAULT_RPC_TX_FEE_CAP,
-                TransactionPoolConfiguration.DEFAULT_STRICT_TX_REPLAY_PROTECTION_ENABLED),
+            ImmutableTransactionPoolConfiguration.builder()
+                .txPoolMaxSize(1)
+                .txMessageKeepAliveSeconds(1)
+                .pendingTxRetentionPeriod(1)
+                .build(),
             pendingTransactions,
             peerTransactionTracker,
             transactionsMessageSender,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -134,12 +134,10 @@ public class TransactionPoolTest {
     blockchain = executionContext.getBlockchain();
     transactions =
         new GasPricePendingTransactionsSorter(
-            TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
-            MAX_TRANSACTIONS,
+            ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(MAX_TRANSACTIONS).build(),
             TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
-            blockchain::getChainHeadHeader,
-            TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);
+            blockchain::getChainHeadHeader);
     when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getTransactionValidator()).thenReturn(transactionValidator);
     when(protocolSpec.getFeeMarket()).thenReturn(FeeMarket.legacy());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -77,6 +77,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.math.BigInteger;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +136,7 @@ public class TransactionPoolTest {
         new GasPricePendingTransactionsSorter(
             TransactionPoolConfiguration.DEFAULT_TX_RETENTION_HOURS,
             MAX_TRANSACTIONS,
-            TestClock.fixed(),
+            TestClock.system(ZoneId.systemDefault()),
             metricsSystem,
             blockchain::getChainHeadHeader,
             TransactionPoolConfiguration.DEFAULT_PRICE_BUMP);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -554,7 +554,7 @@ public class RlpxAgent {
       }
     }
     // Otherwise, keep older connection
-    LOG.info("comparing timestamps " + a.getInitiatedAt() + " with " + b.getInitiatedAt());
+    LOG.debug("comparing timestamps " + a.getInitiatedAt() + " with " + b.getInitiatedAt());
     return Math.toIntExact(a.getInitiatedAt() - b.getInitiatedAt());
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramer.java
@@ -184,7 +184,7 @@ final class DeFramer extends ByteToMessageDecoder {
       } else {
         // Unexpected message - disconnect
         LOG.debug(
-            "Message received before HELLO's exchanged, disconnecting.  Peer: {}, Code: {}, Data: {}",
+            "Message received before HELLO's exchanged (BREACH_OF_PROTOCOL), disconnecting.  Peer: {}, Code: {}, Data: {}",
             expectedPeer.map(Peer::getEnodeURLString).orElse("unknown"),
             message.getCode(),
             message.getData().toString());
@@ -227,7 +227,7 @@ final class DeFramer extends ByteToMessageDecoder {
     if (cause instanceof FramingException
         || cause instanceof RLPException
         || cause instanceof IllegalArgumentException) {
-      LOG.debug("Invalid incoming message", throwable);
+      LOG.debug("Invalid incoming message (BREACH_OF_PROTOCOL)", throwable);
       if (connectFuture.isDone() && !connectFuture.isCompletedExceptionally()) {
         connectFuture.get().disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
         return;

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/WireMessagesSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/WireMessagesSedesTest.java
@@ -34,7 +34,7 @@ public class WireMessagesSedesTest {
                 + "b35761b0fe3f0de19cb96092be29a0d0c033a1629d3cf270345586679aba8bbda61069532e3ac7551fc3a9"
                 + "7766c30037184a5bed48a821861");
 
-    assertSedesWorks(rlp);
+    assertSedesWorks(rlp, true);
 
     rlp =
         decodeHexDump(
@@ -43,11 +43,21 @@ public class WireMessagesSedesTest {
                 + "dd83a6a6580b2559c3c2d87527b83ea8f232ddeed2fff3263949105761ab5d0fe3733046e0e75aaa83cada"
                 + "3b1e5d41");
 
-    assertSedesWorks(rlp);
+    assertSedesWorks(rlp, true);
+
+    rlp =
+        decodeHexDump(
+            "f8a305b74e65746865726d696e642f76312e31332e342d302d3365353937326332342d32303232303831312f5836342d4c696e75782f362e302e36e4c5836574683ec5836574683fc58365746840c58365746841c58365746842c5837769748082765db84005c95b2618ba1ca53f0f019d1750d12769267705e46b4dbfb77f73998b21d30973161542a2090bcaa5876e6aed99436009f3f646029bb723b8dff75feec27374");
+    // This test conatains a hello message from Nethermind. The Capability version of the wit
+    // capability is encoded as 0x80, which is an empty string
+    assertSedesWorks(rlp, false);
   }
 
-  private static void assertSedesWorks(final byte[] data) {
+  private static void assertSedesWorks(final byte[] data, final boolean encEqualsInput) {
+    // TODO: the boolean was added because we do encode the version number 0 as 0x00, not as 0x80
+    // Ticket #4284 to address the broader issue of encoding/decoding zero
     final Bytes input = Bytes.wrap(data);
+
     final PeerInfo peerInfo = PeerInfo.readFrom(RLP.input(input));
 
     assertThat(peerInfo.getClientId()).isNotBlank();
@@ -59,6 +69,8 @@ public class WireMessagesSedesTest {
     // Re-serialize and check that data matches
     final BytesValueRLPOutput out = new BytesValueRLPOutput();
     peerInfo.writeTo(out);
-    assertThat(out.encoded()).isEqualTo(input);
+    if (encEqualsInput) {
+      assertThat(out.encoded()).isEqualTo(input);
+    }
   }
 }

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
@@ -129,13 +129,13 @@ abstract class AbstractRLPInput implements RLPInput {
     // Sets the kind of the item, the offset at which his payload starts and the size of this
     // payload.
     try {
-      RLPDecodingHelpers.RLPElementMetadata elementMetadata =
+      final RLPDecodingHelpers.RLPElementMetadata elementMetadata =
           RLPDecodingHelpers.rlpElementMetadata(this::inputByte, size, currentItem);
       currentKind = elementMetadata.kind;
       currentPayloadOffset = elementMetadata.payloadStart;
       currentPayloadSize = elementMetadata.payloadSize;
-    } catch (RLPException exception) {
-      String message =
+    } catch (final RLPException exception) {
+      final String message =
           String.format(
               exception.getMessage() + getErrorMessageSuffix(), getErrorMessageSuffixParams());
       throw new RLPException(message, exception);
@@ -524,6 +524,11 @@ abstract class AbstractRLPInput implements RLPInput {
   @Override
   public boolean isEndOfCurrentList() {
     return depth > 0 && currentItem >= endOfListOffset[depth - 1];
+  }
+
+  @Override
+  public boolean isZeroLengthString() {
+    return currentKind == RLPDecodingHelpers.Kind.SHORT_ELEMENT && currentPayloadSize == 0;
   }
 
   @Override

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
@@ -221,6 +221,11 @@ public interface RLPInput {
    *     long.
    */
   default int readUnsignedByte() {
+    if (isZeroLengthString()) {
+      // Decode an empty string (0x80) as an unsigned byte with value 0
+      readBytes();
+      return 0;
+    }
     return readByte() & 0xFF;
   }
 
@@ -276,7 +281,7 @@ public interface RLPInput {
   Bytes32 readBytes32();
 
   /**
-   * Reads the next iterm of this input (assuming it is not a list) and transform it with the
+   * Reads the next item of this input (assuming it is not a list) and transforms it with the
    * provided mapping function.
    *
    * <p>Note that the only benefit of this method over calling the mapper function on the result of
@@ -310,6 +315,8 @@ public interface RLPInput {
    * @return The raw RLP.
    */
   Bytes raw();
+
+  boolean isZeroLengthString();
 
   /** Resets this RLP input to the start. */
   void reset();

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.7.1
+version=22.7.2-SNAPSHOT
 
 org.gradle.welcome=never
 org.gradle.jvmargs=-Xmx1g

--- a/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
+++ b/util/src/main/java/org/hyperledger/besu/util/Subscribers.java
@@ -112,7 +112,8 @@ public class Subscribers<T> {
                 action.accept(subscriber);
               } catch (final Exception e) {
                 if (suppressCallbackExceptions) {
-                  LOG.error("Error in callback: ", e);
+                  LOG.error("Error in callback: {}", e.getMessage());
+                  LOG.debug("Error in callback: ", e);
                 } else {
                   throw e;
                 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Cherry picks for 22.7.2, on top of post-22.7.1 release snapshot commit:

```
PR      commit     Description
4351    20fc1b7f2    snapsync logging tweaks
4312    c57dcd99d    Fix trie node from peers
4325    101f5efbd    Pandas
4352    93109ecc2    Returns INVALID on timeout exception
4353    d20f0a8f4    Miner shutdown
4337    296025865    quieten rlp decode error logging
4347    6e8a906df    snapsync logging for clearer sync status
4336    8ee253982    Future tx nonce limits by sender
4327    f3fd946ed    Txpool eviction by tail
4335    2e08c5c09    Better CORS errors
4334    86c308096    RLP Decoding should not log at ERROR
4311    b25779149    BWS logging fix
4310    c321a85ef    Post-Merge logging for block info
4271    af65c86e6    Retry mechanism in import
4269    b3b8e0aae    Peer filter for disconnected peers
4237    dcb951eb7    JEMalloc Logging changes
4283    e5e6a679d    interpret an empty string (0x80) as an unsigned byte of 0
4268    113bd54c6    logging for breach of protocol
4298    a44cb1cab    reduce post-merge fast sync min peers
4299    16922cac8    reduce logging
```
