### PR TITLE
always return a transaction type for pending transactions

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
@@ -79,10 +79,7 @@ public class TransactionCompleteResult implements TransactionResult {
   private final String raw;
   private final String to;
   private final String transactionIndex;
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String type;
-
   private final String value;
   private final String v;
   private final String r;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
@@ -68,10 +68,7 @@ public class TransactionPendingResult implements TransactionResult {
   private final String publicKey;
   private final String raw;
   private final String to;
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String type;
-
   private final String value;
   private final String v;
   private final String r;
@@ -97,7 +94,7 @@ public class TransactionPendingResult implements TransactionResult {
     this.to = transaction.getTo().map(Address::toHexString).orElse(null);
     this.type =
         transactionType.equals(TransactionType.FRONTIER)
-            ? null
+            ? Quantity.create(0)
             : Quantity.create(transactionType.getSerializedType());
     this.value = Quantity.create(transaction.getValue());
     this.v = Quantity.create(transaction.getV());


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

## PR description

This PR ensures that a pending transaction with transaction type 0 always returns its type when being serializes to JSON.

## Fixed Issue(s)
fixes #4248

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).