### PR TITLE
bugfix: BlockValidator should pass shouldPersist flag when getting worldstate

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -97,7 +97,7 @@ public class MainnetBlockValidator implements BlockValidator {
     final Optional<MutableWorldState> maybeWorldState =
         context
             .getWorldStateArchive()
-            .getMutable(parentHeader.getStateRoot(), parentHeader.getHash());
+            .getMutable(parentHeader.getStateRoot(), parentHeader.getHash(), shouldPersist);
 
     if (maybeWorldState.isEmpty()) {
       return handleAndReportFailure(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -83,10 +84,8 @@ public class MainnetBlockValidatorTest {
         protocolContext,
         badBlock,
         HeaderValidationMode.DETACHED_ONLY,
-        HeaderValidationMode.DETACHED_ONLY,
-        false);
+        HeaderValidationMode.DETACHED_ONLY);
     assertThat(badBlockManager.getBadBlocks().size()).isEqualTo(1);
-    verify(worldStateArchive, times(1)).getMutable(any(Hash.class), any(Hash.class), eq(false));
   }
 
   @Test
@@ -223,7 +222,7 @@ public class MainnetBlockValidatorTest {
             eq(protocolContext),
             eq(HeaderValidationMode.DETACHED_ONLY)))
         .thenReturn(true);
-    when(worldStateArchive.getMutable(any(Hash.class), any(Hash.class)))
+    when(worldStateArchive.getMutable(any(Hash.class), any(Hash.class), anyBoolean()))
         .thenReturn(Optional.of(mock(MutableWorldState.class)));
     when(blockProcessor.processBlock(eq(blockchain), any(MutableWorldState.class), eq(badBlock)))
         .thenReturn(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
@@ -83,7 +83,8 @@ public class MainnetBlockValidatorTest {
         protocolContext,
         badBlock,
         HeaderValidationMode.DETACHED_ONLY,
-        HeaderValidationMode.DETACHED_ONLY, false);
+        HeaderValidationMode.DETACHED_ONLY,
+        false);
     assertThat(badBlockManager.getBadBlocks().size()).isEqualTo(1);
     verify(worldStateArchive, times(1)).getMutable(any(Hash.class), any(Hash.class), eq(false));
   }
@@ -284,10 +285,10 @@ public class MainnetBlockValidatorTest {
     when(blockchain.getBlockHeader(any(Hash.class)))
         .thenReturn(Optional.of(new BlockHeaderTestFixture().buildHeader()));
     when(blockHeaderValidator.validateHeader(
-        any(BlockHeader.class),
-        any(BlockHeader.class),
-        eq(protocolContext),
-        eq(HeaderValidationMode.DETACHED_ONLY)))
+            any(BlockHeader.class),
+            any(BlockHeader.class),
+            eq(protocolContext),
+            eq(HeaderValidationMode.DETACHED_ONLY)))
         .thenReturn(true);
 
     mainnetBlockValidator.validateAndProcessBlock(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
The 'remember block' and 'prepare payload' functions in MergeCoordinator uses a mutable worldstate to validate and process blocks, and should not mutate the current head worldstate during these operations.  This PR fixes a bug where we did not plumb the shouldPersist parameter through into the block validator.

The net result is that a preparePayload call could mutate the worldstate concurrenctly / incorrectly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4372

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).