### PR TITLE
Fix banning (static peers) because of late response in eth/66

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/RequestManager.java
@@ -79,12 +79,12 @@ public class RequestManager {
         Optional.ofNullable(responseStreams.get(requestIdAndEthMessage.getKey()))
             .ifPresentOrElse(
                 responseStream -> responseStream.processMessage(requestIdAndEthMessage.getValue()),
-                // disconnect on incorrect requestIds
+                // Consider incorrect requestIds to be a useless response; too
+                // many of these and we will disconnect.
                 () -> {
-                  LOG.debug(
-                      "Request ID incorrect (BREACH_OF_PROTOCOL), disconnecting peer {}", peer);
-                  peer.disconnect(DisconnectMessage.DisconnectReason.BREACH_OF_PROTOCOL);
+                  peer.recordUselessResponse("Request ID incorrect");
                 });
+
       } else {
         // otherwise iterate through all of them
         streams.forEach(stream -> stream.processMessage(ethMessage.getData()));

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -494,7 +494,8 @@ public class DefaultP2PNetwork implements P2PNetwork {
       // Set up permissions
       // Fold peer reputation into permissions
       final PeerPermissionsDenylist misbehavingPeers = PeerPermissionsDenylist.create(500);
-      final PeerDenylistManager reputationManager = new PeerDenylistManager(misbehavingPeers);
+      final PeerDenylistManager reputationManager =
+          new PeerDenylistManager(misbehavingPeers, maintainedPeers);
       peerPermissions = PeerPermissions.combine(peerPermissions, misbehavingPeers);
 
       final MutableLocalNode localNode =

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
+import org.hyperledger.besu.ethereum.p2p.peers.MaintainedPeers;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions;
 import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissionsDenylist;
@@ -34,10 +35,11 @@ public class PeerDenylistManagerTest {
   private final Peer localNode = generatePeer();
   private final PeerDenylistManager peerDenylistManager;
   private final PeerPermissionsDenylist denylist;
+  private final MaintainedPeers maintainedPeers = new MaintainedPeers();
 
   public PeerDenylistManagerTest() {
     denylist = PeerPermissionsDenylist.create();
-    peerDenylistManager = new PeerDenylistManager(denylist);
+    peerDenylistManager = new PeerDenylistManager(denylist, maintainedPeers);
   }
 
   @Test
@@ -66,6 +68,16 @@ public class PeerDenylistManagerTest {
 
     checkPermissions(denylist, peer.getPeer(), true);
     peerDenylistManager.onDisconnect(peer, DisconnectReason.BREACH_OF_PROTOCOL, true);
+    checkPermissions(denylist, peer.getPeer(), true);
+  }
+
+  @Test
+  public void doesNotDenylistMaintainedPeer() {
+    final PeerConnection peer = generatePeerConnection();
+    maintainedPeers.add(peer.getPeer());
+
+    checkPermissions(denylist, peer.getPeer(), true);
+    peerDenylistManager.onDisconnect(peer, DisconnectReason.BREACH_OF_PROTOCOL, false);
     checkPermissions(denylist, peer.getPeer(), true);
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

- The RequestManager commit that lessens the penalty should be somewhat straightforward. A late response is typically already punished with a timeout before (too many of which and we disconnect). Instead of immediately considering a late response a breach of protocol, we just consider it useless (again, too many of which and we disconnect).

- The not banning of maintained/static peers was a bit more difficult. I'm not sure if this is the right^TM way to do it, but a Peer object has no notion of it being static/maintained. And static nodes are also not instantiated in a single call, they are combined with bootnodes. So adding a `isStatic` field to EthPeer also seemed more trouble than it was worth. Therefore I settled on this solution, but there might be a better/simpler/more elegant one.

Feedback more than welcome!

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #4320
Related to #4294

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

## TODO before merging
- [x] Elaborate RequestManager commit message
- [x] Elaborate in PeerDenylistManager commit message
- [x] Fix test cases PeerDenylistManager 
- [x] Add test case (with maintained/static peer) for PeerDenylistManager 
- [x] run spotlessApply to fix formatting issues