### PR TITLE
Bugfix concurrent legacy transaction eviction in BaseFee txpool

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
-import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.time.Clock;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
+import org.hyperledger.besu.plugin.data.TransactionType;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.time.Clock;
@@ -72,8 +73,8 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
                       transactionInfo
                           .getTransaction()
                           .getMaxPriorityFeePerGas()
-                          // safe to .get() here because only 1559 txs can be in the static range
-                          .get()
+                          // just in case we attempt to compare non-1559 transaction
+                          .orElse(Wei.ZERO)
                           .getAsBigInteger()
                           .longValue())
               .thenComparing(TransactionInfo::getAddedToPoolAt)
@@ -104,7 +105,10 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
           pendingTransactions.remove(transaction.getHash());
       if (removedTransactionInfo != null) {
         if (!prioritizedTransactionsDynamicRange.remove(removedTransactionInfo))
-          prioritizedTransactionsStaticRange.remove(removedTransactionInfo);
+          removedTransactionInfo
+              .getTransaction()
+              .getMaxPriorityFeePerGas()
+              .ifPresent(__ -> prioritizedTransactionsStaticRange.remove(removedTransactionInfo));
         removeTransactionTrackedBySenderAndNonce(transaction);
         incrementTransactionRemovedCounter(
             removedTransactionInfo.isReceivedFromLocalSource(), addedToBlock);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Address a concurrency problem with transaction eviction, where we try to evict a transaction that has been concurrently removed from the dynamic transaction pool set.
* make the static transaction pool comparator (base-fee-only transactions) safe for non-1559 transactions, in case we attempt to remove a non-1559 transaction.
* check to see if removed transaction has a basefee before attempting to remove it from the static (base-fee only) transaction set.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #4343


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).