### PR TITLE
[MINOR] add BftExtraData toString

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftExtraData.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftExtraData.java
@@ -67,4 +67,20 @@ public class BftExtraData implements ParsedExtraData {
   public int getRound() {
     return round;
   }
+
+  @Override
+  public String toString() {
+    return "BftExtraData{"
+        + "vanityData="
+        + vanityData
+        + ", seals="
+        + seals
+        + ", validators="
+        + validators
+        + ", vote="
+        + vote
+        + ", round="
+        + round
+        + '}';
+  }
 }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

To fix https://github.com/hyperledger/besu/security/code-scanning/654

In most cases, calling the default implementation of toString in java.lang.Object is not what is intended when a string representation of an object is required. The output of the default toString method consists of the class name of the object as well as the object's hashcode, which is usually not what was intended.


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).