### PR TITLE
Retry mechanism for block creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
 
 ### Bug Fixes
-
+- Retry block creation if there is a transient error and we still have time, to mitigate empty block issue [#4407](https://github.com/hyperledger/besu/pull/4407)
 
 ## 22.7.2
 ### Besu 22.7.2 is a recommended release for the Merge and Mainnet users. 22.7.1 remains Merge-ready. This release provides additional robustness before the Merge with some fixes and improvements in sync, peering, and logging.

--- a/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -66,6 +66,7 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
     return createTransitionMiningCoordinator(
         protocolSchedule,
         protocolContext,
+        ethProtocolManager.ethContext(),
         transactionPool,
         miningParameters,
         syncState,
@@ -131,6 +132,7 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
   protected MiningCoordinator createTransitionMiningCoordinator(
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
+      final EthContext ethContext,
       final TransactionPool transactionPool,
       final MiningParameters miningParameters,
       final SyncState syncState,
@@ -141,6 +143,7 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
     return new MergeCoordinator(
         protocolContext,
         protocolSchedule,
+        ethContext,
         transactionPool.getPendingTransactions(),
         miningParameters,
         backwardSyncContext);

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -131,6 +131,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
             mergeBesuControllerBuilder.createTransitionMiningCoordinator(
                 transitionProtocolSchedule,
                 protocolContext,
+                ethProtocolManager.ethContext(),
                 transactionPool,
                 transitionMiningParameters,
                 syncState,

--- a/consensus/merge/build.gradle
+++ b/consensus/merge/build.gradle
@@ -48,8 +48,11 @@ dependencies {
   implementation 'org.apache.tuweni:tuweni-units'
 
   testImplementation project(path: ':consensus:common', configuration: 'testArtifacts')
+  testImplementation project(':crypto')
   testImplementation project(path: ':crypto', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:core', configuration: 'testSupportArtifacts')
+  testImplementation project(':metrics:core')
+  testImplementation project(path: ':metrics:core', configuration: 'testSupportArtifacts')
   testImplementation project(':testutil')
 
   testImplementation 'junit:junit'

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -19,6 +19,7 @@ import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoor
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.INVALID_PAYLOAD_ATTRIBUTES;
 import static org.hyperledger.besu.util.FutureUtils.exceptionallyCompose;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.infoLambda;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.datatypes.Address;
@@ -219,12 +220,11 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
               final var resultBest = validateBlock(bestBlock);
               if (resultBest.blockProcessingOutputs.isPresent()) {
                 mergeContext.putPayloadById(payloadIdentifier, bestBlock);
-                debugLambda(
-                    LOG,
+                LOG.info(
                     "Block proposal {} with {} transactions, ready in {}ms",
-                    bestBlock::toLogString,
-                    bestBlock.getBody().getTransactions()::size,
-                    () -> System.currentTimeMillis() - startedAt);
+                    bestBlock.toLogString(),
+                    bestBlock.getBody().getTransactions().size(),
+                    System.currentTimeMillis() - startedAt);
               } else {
                 LOG.warn(
                     "Failed to execute block proposal {}, reason {}",

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.consensus.merge.blockcreation;
 import static org.hyperledger.besu.consensus.merge.TransitionUtils.isTerminalProofOfWorkBlock;
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.INVALID;
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.INVALID_PAYLOAD_ATTRIBUTES;
+import static org.hyperledger.besu.util.FutureUtils.exceptionallyCompose;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
@@ -33,6 +34,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BadChainListener;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
@@ -40,13 +42,17 @@ import org.hyperledger.besu.ethereum.mainnet.AbstractGasLimitSpecification;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -64,17 +70,20 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   protected final AtomicReference<BlockHeader> latestDescendsFromTerminal = new AtomicReference<>();
   protected final MergeContext mergeContext;
   protected final ProtocolContext protocolContext;
+  protected final EthContext ethContext;
   protected final BackwardSyncContext backwardSyncContext;
   protected final ProtocolSchedule protocolSchedule;
 
   public MergeCoordinator(
       final ProtocolContext protocolContext,
       final ProtocolSchedule protocolSchedule,
+      final EthContext ethContext,
       final AbstractPendingTransactionsSorter pendingTransactions,
       final MiningParameters miningParams,
       final BackwardSyncContext backwardSyncContext) {
     this.protocolContext = protocolContext;
     this.protocolSchedule = protocolSchedule;
+    this.ethContext = ethContext;
     this.mergeContext = protocolContext.getConsensusContext(MergeContext.class);
     this.miningParameters = miningParams;
     this.backwardSyncContext = backwardSyncContext;
@@ -188,28 +197,86 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
           result.errorMessage);
     }
 
-    // start working on a full block and update the payload value and candidate when it's ready
-    CompletableFuture.supplyAsync(
-            () -> mergeBlockCreator.createBlock(Optional.empty(), random, timestamp))
-        .orTimeout(12, TimeUnit.SECONDS)
-        .whenComplete(
-            (bestBlock, throwable) -> {
-              if (throwable != null) {
-                LOG.debug("something went wrong creating block", throwable);
-              } else {
-                final var resultBest = validateBlock(bestBlock);
-                if (resultBest.blockProcessingOutputs.isPresent()) {
-                  mergeContext.putPayloadById(payloadIdentifier, bestBlock);
-                } else {
-                  LOG.warn(
-                      "failed to execute block proposal {}, reason {}",
-                      bestBlock.getHash(),
-                      resultBest.errorMessage);
-                }
-              }
-            });
+    tryToBuildBetterBlock(timestamp, random, payloadIdentifier, mergeBlockCreator);
 
     return payloadIdentifier;
+  }
+
+  private void tryToBuildBetterBlock(
+      final Long timestamp,
+      final Bytes32 random,
+      final PayloadIdentifier payloadIdentifier,
+      final MergeBlockCreator mergeBlockCreator) {
+
+    long remainingTime = miningParameters.getPosBlockCreationTimeout();
+    final Supplier<Block> blockCreator =
+        () -> mergeBlockCreator.createBlock(Optional.empty(), random, timestamp);
+    // start working on a full block and update the payload value and candidate when it's ready
+    final long startedAt = System.currentTimeMillis();
+    retryBlockCreation(payloadIdentifier, blockCreator, remainingTime)
+        .thenAccept(
+            bestBlock -> {
+              final var resultBest = validateBlock(bestBlock);
+              if (resultBest.blockProcessingOutputs.isPresent()) {
+                mergeContext.putPayloadById(payloadIdentifier, bestBlock);
+                debugLambda(
+                    LOG,
+                    "Block proposal {} with {} transactions, ready in {}ms",
+                    bestBlock::toLogString,
+                    bestBlock.getBody().getTransactions()::size,
+                    () -> System.currentTimeMillis() - startedAt);
+              } else {
+                LOG.warn(
+                    "Failed to execute block proposal {}, reason {}",
+                    bestBlock.getHash(),
+                    resultBest.errorMessage);
+              }
+            });
+  }
+
+  private CompletableFuture<Block> retryBlockCreation(
+      final PayloadIdentifier payloadIdentifier,
+      final Supplier<Block> blockCreator,
+      final long remainingTime) {
+    final long startedAt = System.currentTimeMillis();
+
+    debugLambda(
+        LOG,
+        "Block creation started for payload id {}, remaining time is {}ms",
+        payloadIdentifier::toShortHexString,
+        () -> remainingTime);
+
+    return exceptionallyCompose(
+        ethContext
+            .getScheduler()
+            .scheduleComputationTask(blockCreator)
+            .orTimeout(remainingTime, TimeUnit.MILLISECONDS),
+        throwable -> {
+          if (canRetryBlockCreation(throwable)) {
+            final long newRemainingTime = remainingTime - (System.currentTimeMillis() - startedAt);
+            debugLambda(
+                LOG,
+                "Retrying block creation for payload id {}, remaining time is {}ms, last error {}",
+                payloadIdentifier::toShortHexString,
+                () -> newRemainingTime,
+                () -> logException(throwable));
+            return retryBlockCreation(payloadIdentifier, blockCreator, newRemainingTime);
+          } else {
+            debugLambda(
+                LOG,
+                "Something went wrong creating block for payload id {}, error {}",
+                payloadIdentifier::toShortHexString,
+                () -> logException(throwable));
+          }
+          return CompletableFuture.failedFuture(throwable);
+        });
+  }
+
+  private boolean canRetryBlockCreation(final Throwable throwable) {
+    if (throwable instanceof TimeoutException) {
+      return false;
+    }
+    return true;
   }
 
   @Override
@@ -632,5 +699,13 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
   private boolean isPoSHeader(final BlockHeader header) {
     return header.getDifficulty().equals(Difficulty.ZERO);
+  }
+
+  private String logException(final Throwable throwable) {
+    final StringWriter sw = new StringWriter();
+    final PrintWriter pw = new PrintWriter(sw);
+    throwable.printStackTrace(pw);
+    pw.flush();
+    return sw.toString();
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -19,7 +19,6 @@ import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoor
 import static org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator.ForkchoiceResult.Status.INVALID_PAYLOAD_ATTRIBUTES;
 import static org.hyperledger.besu.util.FutureUtils.exceptionallyCompose;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
-import static org.hyperledger.besu.util.Slf4jLambdaHelper.infoLambda;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.datatypes.Address;
@@ -221,14 +220,16 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
               if (resultBest.blockProcessingOutputs.isPresent()) {
                 mergeContext.putPayloadById(payloadIdentifier, bestBlock);
                 LOG.info(
-                    "Block proposal {} with {} transactions, ready in {}ms",
+                    "Successfully built block {} for proposal identified by {}, with {} transactions, in {}ms",
                     bestBlock.toLogString(),
+                    payloadIdentifier.toHexString(),
                     bestBlock.getBody().getTransactions().size(),
                     System.currentTimeMillis() - startedAt);
               } else {
                 LOG.warn(
-                    "Failed to execute block proposal {}, reason {}",
+                    "Block {} built for proposal identified by {}, is not valid reason {}",
                     bestBlock.getHash(),
+                    payloadIdentifier.toHexString(),
                     resultBest.errorMessage);
               }
             });

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -41,6 +41,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTran
 import org.hyperledger.besu.ethereum.mainnet.AbstractGasLimitSpecification;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -49,7 +50,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -273,10 +273,10 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   }
 
   private boolean canRetryBlockCreation(final Throwable throwable) {
-    if (throwable instanceof TimeoutException) {
-      return false;
+    if (throwable instanceof StorageException) {
+      return true;
     }
-    return true;
+    return false;
   }
 
   @Override

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.BlockHeaderValidator;
@@ -86,6 +87,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
         new MergeCoordinator(
             protocolContext,
             mockProtocolSchedule,
+            mock(EthContext.class),
             mockSorter,
             new MiningParameters.Builder().coinbase(coinbase).build(),
             mock(BackwardSyncContext.class));

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -40,6 +40,7 @@ import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
 import java.math.BigInteger;
@@ -205,6 +206,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);
     } catch (final CancellationException ex) {
+      throw ex;
+    } catch (final StorageException ex) {
       throw ex;
     } catch (final Exception ex) {
       // TODO(tmm): How are we going to know this has exploded, and thus restart it?

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningParameters.java
@@ -34,6 +34,8 @@ public class MiningParameters {
 
   public static final int DEFAULT_MAX_OMMERS_DEPTH = 8;
 
+  public static final long DEFAULT_POS_BLOCK_CREATION_TIMEOUT_MS = Duration.ofSeconds(7).toMillis();
+
   private final Optional<Address> coinbase;
   private final Optional<AtomicLong> targetGasLimit;
   private final Wei minTransactionGasPrice;
@@ -49,6 +51,7 @@ public class MiningParameters {
   private final long remoteSealersTimeToLive;
   private final long powJobTimeToLive;
   private final int maxOmmerDepth;
+  private final long posBlockCreationTimeout;
 
   private MiningParameters(
       final Address coinbase,
@@ -65,7 +68,8 @@ public class MiningParameters {
       final int remoteSealersLimit,
       final long remoteSealersTimeToLive,
       final long powJobTimeToLive,
-      final int maxOmmerDepth) {
+      final int maxOmmerDepth,
+      final long posBlockCreationTimeout) {
     this.coinbase = Optional.ofNullable(coinbase);
     this.targetGasLimit = Optional.ofNullable(targetGasLimit).map(AtomicLong::new);
     this.minTransactionGasPrice = minTransactionGasPrice;
@@ -81,6 +85,7 @@ public class MiningParameters {
     this.remoteSealersTimeToLive = remoteSealersTimeToLive;
     this.powJobTimeToLive = powJobTimeToLive;
     this.maxOmmerDepth = maxOmmerDepth;
+    this.posBlockCreationTimeout = posBlockCreationTimeout;
   }
 
   public Optional<Address> getCoinbase() {
@@ -143,6 +148,10 @@ public class MiningParameters {
     return maxOmmerDepth;
   }
 
+  public long getPosBlockCreationTimeout() {
+    return posBlockCreationTimeout;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
@@ -160,7 +169,8 @@ public class MiningParameters {
         && Objects.equals(minBlockOccupancyRatio, that.minBlockOccupancyRatio)
         && remoteSealersTimeToLive == that.remoteSealersTimeToLive
         && remoteSealersLimit == that.remoteSealersLimit
-        && powJobTimeToLive == that.powJobTimeToLive;
+        && powJobTimeToLive == that.powJobTimeToLive
+        && posBlockCreationTimeout == that.posBlockCreationTimeout;
   }
 
   @Override
@@ -178,7 +188,8 @@ public class MiningParameters {
         minBlockOccupancyRatio,
         remoteSealersLimit,
         remoteSealersTimeToLive,
-        powJobTimeToLive);
+        powJobTimeToLive,
+        posBlockCreationTimeout);
   }
 
   @Override
@@ -214,6 +225,8 @@ public class MiningParameters {
         + remoteSealersTimeToLive
         + ", powJobTimeToLive="
         + powJobTimeToLive
+        + ", posBlockCreationTimeout="
+        + posBlockCreationTimeout
         + '}';
   }
 
@@ -234,6 +247,8 @@ public class MiningParameters {
     private long remoteSealersTimeToLive = DEFAULT_REMOTE_SEALERS_TTL;
     private long powJobTimeToLive = DEFAULT_POW_JOB_TTL;
     private int maxOmmerDepth = DEFAULT_MAX_OMMERS_DEPTH;
+
+    private long posBlockCreationTimeout = DEFAULT_POS_BLOCK_CREATION_TIMEOUT_MS;
 
     public Builder() {
       // zero arg
@@ -258,6 +273,7 @@ public class MiningParameters {
       this.remoteSealersTimeToLive = existing.getRemoteSealersTimeToLive();
       this.powJobTimeToLive = existing.getPowJobTimeToLive();
       this.maxOmmerDepth = existing.getMaxOmmerDepth();
+      this.posBlockCreationTimeout = existing.getPosBlockCreationTimeout();
     }
 
     public Builder coinbase(final Address address) {
@@ -335,6 +351,11 @@ public class MiningParameters {
       return this;
     }
 
+    public Builder posBlockCreationTimeout(final long posBlockCreationTimeoutMillis) {
+      this.posBlockCreationTimeout = posBlockCreationTimeoutMillis;
+      return this;
+    }
+
     public MiningParameters build() {
       return new MiningParameters(
           coinbase,
@@ -351,7 +372,8 @@ public class MiningParameters {
           remoteSealersLimit,
           remoteSealersTimeToLive,
           powJobTimeToLive,
-          maxOmmerDepth);
+          maxOmmerDepth,
+          posBlockCreationTimeout);
     }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
@@ -82,8 +82,9 @@ public class EthScheduler {
             metricsSystem),
         MonitoredExecutors.newCachedThreadPool(
             EthScheduler.class.getSimpleName() + "-Services", metricsSystem),
-        MonitoredExecutors.newFixedThreadPool(
+        MonitoredExecutors.newBoundedThreadPool(
             EthScheduler.class.getSimpleName() + "-Computation",
+            1,
             computationWorkerCount,
             metricsSystem));
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
@@ -39,7 +39,7 @@ public class MonitoredExecutors {
 
   public static ExecutorService newFixedThreadPool(
       final String name, final int workerCount, final MetricsSystem metricsSystem) {
-    return newFixedThreadPool(name, workerCount, new LinkedBlockingQueue<>(), metricsSystem);
+    return newFixedThreadPool(name, 0, workerCount, new LinkedBlockingQueue<>(), metricsSystem);
   }
 
   public static ExecutorService newBoundedThreadPool(
@@ -47,16 +47,27 @@ public class MonitoredExecutors {
       final int workerCount,
       final int queueSize,
       final MetricsSystem metricsSystem) {
+    return newBoundedThreadPool(name, 0, workerCount, queueSize, metricsSystem);
+  }
+
+  public static ExecutorService newBoundedThreadPool(
+      final String name,
+      final int minWorkerCount,
+      final int maxWorkerCount,
+      final int queueSize,
+      final MetricsSystem metricsSystem) {
     return newFixedThreadPool(
         name,
-        workerCount,
+        minWorkerCount,
+        maxWorkerCount,
         new BoundedQueue(queueSize, toMetricName(name), metricsSystem),
         metricsSystem);
   }
 
-  public static ExecutorService newFixedThreadPool(
+  private static ExecutorService newFixedThreadPool(
       final String name,
-      final int workerCount,
+      final int minWorkerCount,
+      final int maxWorkerCount,
       final BlockingQueue<Runnable> workingQueue,
       final MetricsSystem metricsSystem) {
     return newMonitoredExecutor(
@@ -64,8 +75,8 @@ public class MonitoredExecutors {
         metricsSystem,
         (rejectedExecutionHandler, threadFactory) ->
             new ThreadPoolExecutor(
-                workerCount,
-                workerCount,
+                minWorkerCount,
+                maxWorkerCount,
                 0L,
                 TimeUnit.MILLISECONDS,
                 workingQueue,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -173,7 +173,8 @@ public class RocksDBColumnarKeyValueStorage
     throwIfClosed();
 
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
-      return Optional.ofNullable(db.get(segment.get(), key));
+      // return Optional.ofNullable(db.get(segment.get(), key));
+      throw new RocksDBException(new Status(Code.TimedOut, SubCode.LockTimeout, "failure"));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }
@@ -258,6 +259,7 @@ public class RocksDBColumnarKeyValueStorage
     public void put(final RocksDbSegmentIdentifier segment, final byte[] key, final byte[] value) {
       try (final OperationTimer.TimingContext ignored = metrics.getWriteLatency().startTimer()) {
         innerTx.put(segment.get(), key, value);
+        throw new RocksDBException(new Status(Code.TimedOut, SubCode.LockTimeout, "failure"));
       } catch (final RocksDBException e) {
         if (e.getMessage().contains(NO_SPACE_LEFT_ON_DEVICE)) {
           LOG.error(e.getMessage());

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -173,8 +173,7 @@ public class RocksDBColumnarKeyValueStorage
     throwIfClosed();
 
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
-      // return Optional.ofNullable(db.get(segment.get(), key));
-      throw new RocksDBException(new Status(Code.TimedOut, SubCode.LockTimeout, "failure"));
+      return Optional.ofNullable(db.get(segment.get(), key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }
@@ -259,7 +258,6 @@ public class RocksDBColumnarKeyValueStorage
     public void put(final RocksDbSegmentIdentifier segment, final byte[] key, final byte[] value) {
       try (final OperationTimer.TimingContext ignored = metrics.getWriteLatency().startTimer()) {
         innerTx.put(segment.get(), key, value);
-        throw new RocksDBException(new Status(Code.TimedOut, SubCode.LockTimeout, "failure"));
       } catch (final RocksDBException e) {
         if (e.getMessage().contains(NO_SPACE_LEFT_ON_DEVICE)) {
           LOG.error(e.getMessage());


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Retry block creation if there is a transient error and we still have time, to mitigate empty block issue, as describe here
https://github.com/hyperledger/besu/issues/4401#issuecomment-1249340589

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

mitigates #4401 when there is a `org.rocksdb.RocksDBException: TimedOut(LockTimeout)`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).