### PR TITLE
Bonsai snapshot worldstate 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Increased level of detail in JSON-RPC parameter error log messages [#4510](https://github.com/hyperledger/besu/pull/4510)
 - New unstable configuration options to set the maximum time, in milliseconds, a PoS block creation jobs is allowed to run [#4519](https://github.com/hyperledger/besu/pull/4519)
 - Tune EthScheduler thread pools to avoid to recreate too many threads [#4529](https://github.com/hyperledger/besu/pull/4529)
+- RocksDB snapshot based worldstate and plugin-api addition of Snapshot interfaces [#4409](https://github.com/hyperledger/besu/pull/4409)
 
 ### Bug Fixes
 - Corrects emission of blockadded events when rewinding during a re-org. Fix for [#4495](https://github.com/hyperledger/besu/issues/4495)
@@ -88,6 +89,7 @@ https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.7.5/besu-22.7.5.t
 ### Additions and Improvements
 - Allow free gas networks in the London fee market [#4061](https://github.com/hyperledger/besu/issues/4061)
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
+<<<<<<< HEAD
 - Resets engine QoS timer with every call to the engine API instead of only when ExchangeTransitionConfiguration is called [#4411](https://github.com/hyperledger/besu/issues/4411)
 - ExchangeTransitionConfiguration mismatch will only submit a debug log not a warning anymore [#4411](https://github.com/hyperledger/besu/issues/4411)
 - Upgrade besu-native to 0.6.1 and include linux arm64 build of bls12-381 [#4416](https://github.com/hyperledger/besu/pull/4416)

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisAllocation.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisAllocation.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -30,6 +31,10 @@ public class GenesisAllocation {
 
   public String getAddress() {
     return address;
+  }
+
+  public Optional<String> getPrivateKey() {
+    return Optional.ofNullable(JsonUtil.getString(data, "privatekey", null));
   }
 
   public String getBalance() {

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -61,8 +61,13 @@ dependencies {
 
   testImplementation project(path: ':config', configuration: 'testSupportArtifacts')
   testImplementation project(path: ':ethereum:api')
+  testImplementation project(path: ':ethereum:blockcreation')
   testImplementation project(path: ':ethereum:referencetests')
+  testImplementation project(path: ':ethereum:eth')
   testImplementation project(':testutil')
+  // TESTING HACK HACK HACK
+  testImplementation project(path: ':plugins:rocksdb')
+
 
   testImplementation 'junit:junit'
   testImplementation 'org.apache.logging.log4j:log4j-core'

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -65,7 +65,6 @@ dependencies {
   testImplementation project(path: ':ethereum:referencetests')
   testImplementation project(path: ':ethereum:eth')
   testImplementation project(':testutil')
-  // TESTING HACK HACK HACK
   testImplementation project(path: ':plugins:rocksdb')
 
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -38,7 +38,7 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   }
 
   public Hash rootHash(final BonsaiWorldStateUpdater localUpdater) {
-    final BonsaiWorldStateKeyValueStorage.Updater updater = worldStateStorage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = worldStateStorage.updater();
     try {
       final Hash calculatedRootHash = calculateRootHash(updater, localUpdater);
       return Hash.wrap(calculatedRootHash);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.util.Optional;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldStateKeyValueStorage.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
-import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.util.Optional;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -102,7 +102,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   protected Hash calculateRootHash(
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater,
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
       final BonsaiWorldStateUpdater worldStateUpdater) {
     // first clear storage
     for (final Address address : worldStateUpdater.getStorageToClear()) {
@@ -241,7 +241,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     boolean success = false;
 
     final BonsaiWorldStateUpdater localUpdater = updater.copy();
-    final BonsaiWorldStateKeyValueStorage.Updater stateUpdater = worldStateStorage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater = worldStateStorage.updater();
 
     try {
       final Hash newWorldStateRootHash = calculateRootHash(stateUpdater, localUpdater);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -75,6 +75,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
   @Override
   public MutableWorldState copy() {
+    // TODO: consider returning a snapshot rather than a copy here.
     BonsaiInMemoryWorldStateKeyValueStorage bonsaiInMemoryWorldStateKeyValueStorage =
         new BonsaiInMemoryWorldStateKeyValueStorage(
             worldStateStorage.accountStorage,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -4,9 +4,10 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 /**
- * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is not
- * able to commit or persist however. This is useful for async blockchain opperations like block
- * creation and/or point-in-time queries.
+ * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is able
+ * to commit/perist as a trielog layer only. This is useful for async blockchain opperations like block
+ * creation and/or point-in-time queries since the snapshot worldstate is fully isolated from the main
+ * BonsaiPersistedWorldState.
  */
 public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
   //  private static final Logger LOG = LoggerFactory.getLogger(BonsaiSnapshotWorldState.class);
@@ -32,8 +33,8 @@ public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
 
   @Override
   public MutableWorldState copy() {
-    // TODO: we are transaction based, so perhaps we return a new transaction based worldstate...
-    //       for now lets just return ourselves
+    // TODO: find out if we can stack transaction based snapshots, so perhaps we return a new transaction based
+    //  worldstate.  For now we just return ourself rather than a copy.
     return this;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -27,7 +27,7 @@ public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
             ((SnappableKeyValueStorage) parentWorldStateStorage.codeStorage).takeSnapshot(),
             ((SnappableKeyValueStorage) parentWorldStateStorage.storageStorage).takeSnapshot(),
             ((SnappableKeyValueStorage) parentWorldStateStorage.trieBranchStorage).takeSnapshot(),
-            ((SnappableKeyValueStorage) parentWorldStateStorage.trieLogStorage).takeSnapshot()));
+            parentWorldStateStorage.trieLogStorage));
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -15,19 +15,19 @@ public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
       final BonsaiWorldStateArchive archive,
       final BonsaiWorldStateKeyValueStorage snapshotWorldStateStorage) {
     super(archive, snapshotWorldStateStorage);
-    }
+  }
 
   public static BonsaiSnapshotWorldState create(
       final BonsaiWorldStateArchive archive,
       final BonsaiWorldStateKeyValueStorage parentWorldStateStorage) {
     return new BonsaiSnapshotWorldState(
         archive,
-        new BonsaiWorldStateKeyValueStorage(
+        new BonsaiSnapshotWorldStateKeyValueStorage(
             ((SnappableKeyValueStorage) parentWorldStateStorage.accountStorage).takeSnapshot(),
             ((SnappableKeyValueStorage) parentWorldStateStorage.codeStorage).takeSnapshot(),
             ((SnappableKeyValueStorage) parentWorldStateStorage.storageStorage).takeSnapshot(),
             ((SnappableKeyValueStorage) parentWorldStateStorage.trieBranchStorage).takeSnapshot(),
-            parentWorldStateStorage.trieLogStorage));
+            ((SnappableKeyValueStorage) parentWorldStateStorage.trieLogStorage).takeSnapshot()));
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -1,224 +1,39 @@
 package org.hyperledger.besu.ethereum.bonsai;
 
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.trie.StoredNodeFactory;
-import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
-import org.hyperledger.besu.evm.account.Account;
-import org.hyperledger.besu.evm.account.EvmAccount;
-import org.hyperledger.besu.evm.worldstate.MutableWorldView;
-import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
-import org.hyperledger.besu.evm.worldstate.WorldUpdater;
-import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import static org.hyperledger.besu.ethereum.bonsai.BonsaiAccount.fromRLP;
 
 /**
  * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is not
  * able to commit or persist however. This is useful for async blockchain opperations like block
  * creation and/or point-in-time queries.
  */
-public class BonsaiSnapshotWorldState implements MutableWorldState, MutableWorldView {
+public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
   //  private static final Logger LOG = LoggerFactory.getLogger(BonsaiSnapshotWorldState.class);
-  final KeyValueStorage accountStorage;
-  final KeyValueStorage codeStorage;
-  final KeyValueStorage storageStorage;
-  final KeyValueStorage trieBranchStorage;
-  final KeyValueStorage trieLogStorage;
-  final WorldUpdater txUpdter;
 
-  //TODO: we may or may not persist trie logs in the archive trielog layer.  this might just be a callback instead
-  final BonsaiWorldStateArchive archive;
-
-  public BonsaiSnapshotWorldState(
+  private BonsaiSnapshotWorldState(
       final BonsaiWorldStateArchive archive,
-      final KeyValueStorage accountStorage,
-      final KeyValueStorage codeStorage,
-      final KeyValueStorage storageStorage,
-      final KeyValueStorage trieBranchStorage,
-      final KeyValueStorage trieLogStorage
-      ) {
-    this.accountStorage = accountStorage;
-    this.codeStorage = codeStorage;
-    this.storageStorage = storageStorage;
-    this.trieBranchStorage = trieBranchStorage;
-    this.trieLogStorage = trieLogStorage;
-    this.archive = archive;
-
-    // TODO: revisit updater.  In memory or transaction based?
-    this.txUpdter = new SnapshotTransactionUpdater<EvmAccount>();
-  }
+      final BonsaiWorldStateKeyValueStorage snapshotWorldStateStorage) {
+    super(archive, snapshotWorldStateStorage);
+    }
 
   public static BonsaiSnapshotWorldState create(
       final BonsaiWorldStateArchive archive,
       final BonsaiWorldStateKeyValueStorage parentWorldStateStorage) {
     return new BonsaiSnapshotWorldState(
         archive,
-        ((SnappableKeyValueStorage) parentWorldStateStorage.accountStorage).takeSnapshot(),
-        ((SnappableKeyValueStorage) parentWorldStateStorage.codeStorage).takeSnapshot(),
-        ((SnappableKeyValueStorage) parentWorldStateStorage.storageStorage).takeSnapshot(),
-        ((SnappableKeyValueStorage) parentWorldStateStorage.trieBranchStorage).takeSnapshot(),
-        parentWorldStateStorage.trieLogStorage);
+        new BonsaiWorldStateKeyValueStorage(
+            ((SnappableKeyValueStorage) parentWorldStateStorage.accountStorage).takeSnapshot(),
+            ((SnappableKeyValueStorage) parentWorldStateStorage.codeStorage).takeSnapshot(),
+            ((SnappableKeyValueStorage) parentWorldStateStorage.storageStorage).takeSnapshot(),
+            ((SnappableKeyValueStorage) parentWorldStateStorage.trieBranchStorage).takeSnapshot(),
+            parentWorldStateStorage.trieLogStorage));
   }
+
   @Override
   public MutableWorldState copy() {
     // TODO: we are transaction based, so perhaps we return a new transaction based worldstate...
     //       for now lets just return ourselves
     return this;
   }
-
-  @Override
-  public void persist(final BlockHeader blockHeader) {
-    // snapshots are mutable but not persistable
-//    throw new UnsupportedOperationException(
-//        "BonsaiSnapshotWorldState does not support persisting changes to database");
-    // TODO: for testing we are using persist to indicate we can release the snapshot
-  try {
-    trieBranchStorage.close();
-    accountStorage.close();
-    codeStorage.close();
-    storageStorage.close();
-    } catch (IOException ex) {
-    System.err.println("unexpected ioexception closing snapshot: " + ex);
-  }
-
-  }
-
-  @Override
-  public WorldUpdater updater() {
-    return txUpdter;
-  }
-
-  @Override
-  public Hash rootHash() {
-    return null;
-  }
-
-  @Override
-  public Hash frontierRootHash() {
-    return null;
-  }
-
-  @Override
-  public Stream<StreamableAccount> streamAccounts(final Bytes32 startKeyHash, final int limit) {
-    return null;
-  }
-
-  @Override
-  public Account get(final Address address) {
-    //TODO: this should be moved to shared abstract BonsaiWorldStateKVStorage
-    //TODO: need to add context for code lookup
-    final var accountHash = Hash.hash(address).toArrayUnsafe();
-    return accountStorage
-      .get(accountHash)
-        .map(Bytes::wrap)
-        .map(Optional::of)
-      .orElseGet(() -> getWorldStateRootHash()
-        .map(stateRootHash -> new StoredMerklePatriciaTrie<>(
-                    new StoredNodeFactory<>(
-                        this::getAccountStateTrieNode, Function.identity(), Function.identity()),
-                    Bytes32.wrap(stateRootHash)))
-          .flatMap(mpt -> mpt.get(Bytes.of(accountHash))))
-        .map(bytes -> fromRLP(null, address, bytes, true))
-        .orElse(null);
-  }
-
-  //TODO: this is a WorldStateStorage method, refactor
-  Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
-    if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
-      return Optional.of(MerklePatriciaTrie.EMPTY_TRIE_NODE);
-    } else {
-      return trieBranchStorage.get(location.toArrayUnsafe()).map(Bytes::wrap);
-    }
-  }
-  //TODO: also ripped off from WorldStateStorage
-  static final byte[] WORLD_ROOT_HASH_KEY = "worldRoot".getBytes(StandardCharsets.UTF_8);
-  Optional<Bytes> getWorldStateRootHash() {
-    return trieBranchStorage.get(WORLD_ROOT_HASH_KEY).map(Bytes::wrap);
-  }
-
-
-  static class SnapshotTransactionUpdater<A extends Account> implements WorldUpdater {
-
-    protected Map<Address, UpdateTrackingAccount<A>> updatedAccounts = new HashMap<>();
-    protected Set<Address> deletedAccounts = new HashSet<>();
-
-    SnapshotTransactionUpdater() {
-      // TODO: writeme
-    }
-
-    //    private UpdateTrackingAccount<A> track(final UpdateTrackingAccount<A> account) {
-    //      final Address address = account.getAddress();
-    //      updatedAccounts.put(address, account);
-    //      deletedAccounts.remove(address);
-    //      return account;
-    //    }
-
-    @Override
-    public WorldUpdater updater() {
-      return null;
-    }
-
-    @Override
-    public EvmAccount createAccount(final Address address, final long nonce, final Wei balance) {
-      return null;
-    }
-
-    @Override
-    public EvmAccount getAccount(final Address address) {
-      return null;
-    }
-
-    @Override
-    public void deleteAccount(final Address address) {}
-
-    @Override
-    public Collection<? extends Account> getTouchedAccounts() {
-      return null;
-    }
-
-    @Override
-    public Collection<Address> getDeletedAccountAddresses() {
-      return null;
-    }
-
-    @Override
-    public void revert() {}
-
-    @Override
-    public void commit() {
-      // we explicitly do not implement commit for the transaction-based snapshot updater
-    }
-
-    @Override
-    public Optional<WorldUpdater> parentUpdater() {
-      return Optional.empty();
-    }
-
-    @Override
-    public Account get(final Address address) {
-      return null;
-    }
-  }
-
-
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -1,0 +1,224 @@
+package org.hyperledger.besu.ethereum.bonsai;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
+import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
+import org.hyperledger.besu.ethereum.trie.StoredNodeFactory;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.account.EvmAccount;
+import org.hyperledger.besu.evm.worldstate.MutableWorldView;
+import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
+import org.hyperledger.besu.evm.worldstate.WorldUpdater;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.hyperledger.besu.ethereum.bonsai.BonsaiAccount.fromRLP;
+
+/**
+ * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is not
+ * able to commit or persist however. This is useful for async blockchain opperations like block
+ * creation and/or point-in-time queries.
+ */
+public class BonsaiSnapshotWorldState implements MutableWorldState, MutableWorldView {
+  //  private static final Logger LOG = LoggerFactory.getLogger(BonsaiSnapshotWorldState.class);
+  final KeyValueStorage accountStorage;
+  final KeyValueStorage codeStorage;
+  final KeyValueStorage storageStorage;
+  final KeyValueStorage trieBranchStorage;
+  final KeyValueStorage trieLogStorage;
+  final WorldUpdater txUpdter;
+
+  //TODO: we may or may not persist trie logs in the archive trielog layer.  this might just be a callback instead
+  final BonsaiWorldStateArchive archive;
+
+  public BonsaiSnapshotWorldState(
+      final BonsaiWorldStateArchive archive,
+      final KeyValueStorage accountStorage,
+      final KeyValueStorage codeStorage,
+      final KeyValueStorage storageStorage,
+      final KeyValueStorage trieBranchStorage,
+      final KeyValueStorage trieLogStorage
+      ) {
+    this.accountStorage = accountStorage;
+    this.codeStorage = codeStorage;
+    this.storageStorage = storageStorage;
+    this.trieBranchStorage = trieBranchStorage;
+    this.trieLogStorage = trieLogStorage;
+    this.archive = archive;
+
+    // TODO: revisit updater.  In memory or transaction based?
+    this.txUpdter = new SnapshotTransactionUpdater<EvmAccount>();
+  }
+
+  public static BonsaiSnapshotWorldState create(
+      final BonsaiWorldStateArchive archive,
+      final BonsaiWorldStateKeyValueStorage parentWorldStateStorage) {
+    return new BonsaiSnapshotWorldState(
+        archive,
+        ((SnappableKeyValueStorage) parentWorldStateStorage.accountStorage).takeSnapshot(),
+        ((SnappableKeyValueStorage) parentWorldStateStorage.codeStorage).takeSnapshot(),
+        ((SnappableKeyValueStorage) parentWorldStateStorage.storageStorage).takeSnapshot(),
+        ((SnappableKeyValueStorage) parentWorldStateStorage.trieBranchStorage).takeSnapshot(),
+        parentWorldStateStorage.trieLogStorage);
+  }
+  @Override
+  public MutableWorldState copy() {
+    // TODO: we are transaction based, so perhaps we return a new transaction based worldstate...
+    //       for now lets just return ourselves
+    return this;
+  }
+
+  @Override
+  public void persist(final BlockHeader blockHeader) {
+    // snapshots are mutable but not persistable
+//    throw new UnsupportedOperationException(
+//        "BonsaiSnapshotWorldState does not support persisting changes to database");
+    // TODO: for testing we are using persist to indicate we can release the snapshot
+  try {
+    trieBranchStorage.close();
+    accountStorage.close();
+    codeStorage.close();
+    storageStorage.close();
+    } catch (IOException ex) {
+    System.err.println("unexpected ioexception closing snapshot: " + ex);
+  }
+
+  }
+
+  @Override
+  public WorldUpdater updater() {
+    return txUpdter;
+  }
+
+  @Override
+  public Hash rootHash() {
+    return null;
+  }
+
+  @Override
+  public Hash frontierRootHash() {
+    return null;
+  }
+
+  @Override
+  public Stream<StreamableAccount> streamAccounts(final Bytes32 startKeyHash, final int limit) {
+    return null;
+  }
+
+  @Override
+  public Account get(final Address address) {
+    //TODO: this should be moved to shared abstract BonsaiWorldStateKVStorage
+    //TODO: need to add context for code lookup
+    final var accountHash = Hash.hash(address).toArrayUnsafe();
+    return accountStorage
+      .get(accountHash)
+        .map(Bytes::wrap)
+        .map(Optional::of)
+      .orElseGet(() -> getWorldStateRootHash()
+        .map(stateRootHash -> new StoredMerklePatriciaTrie<>(
+                    new StoredNodeFactory<>(
+                        this::getAccountStateTrieNode, Function.identity(), Function.identity()),
+                    Bytes32.wrap(stateRootHash)))
+          .flatMap(mpt -> mpt.get(Bytes.of(accountHash))))
+        .map(bytes -> fromRLP(null, address, bytes, true))
+        .orElse(null);
+  }
+
+  //TODO: this is a WorldStateStorage method, refactor
+  Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
+    if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
+      return Optional.of(MerklePatriciaTrie.EMPTY_TRIE_NODE);
+    } else {
+      return trieBranchStorage.get(location.toArrayUnsafe()).map(Bytes::wrap);
+    }
+  }
+  //TODO: also ripped off from WorldStateStorage
+  static final byte[] WORLD_ROOT_HASH_KEY = "worldRoot".getBytes(StandardCharsets.UTF_8);
+  Optional<Bytes> getWorldStateRootHash() {
+    return trieBranchStorage.get(WORLD_ROOT_HASH_KEY).map(Bytes::wrap);
+  }
+
+
+  static class SnapshotTransactionUpdater<A extends Account> implements WorldUpdater {
+
+    protected Map<Address, UpdateTrackingAccount<A>> updatedAccounts = new HashMap<>();
+    protected Set<Address> deletedAccounts = new HashSet<>();
+
+    SnapshotTransactionUpdater() {
+      // TODO: writeme
+    }
+
+    //    private UpdateTrackingAccount<A> track(final UpdateTrackingAccount<A> account) {
+    //      final Address address = account.getAddress();
+    //      updatedAccounts.put(address, account);
+    //      deletedAccounts.remove(address);
+    //      return account;
+    //    }
+
+    @Override
+    public WorldUpdater updater() {
+      return null;
+    }
+
+    @Override
+    public EvmAccount createAccount(final Address address, final long nonce, final Wei balance) {
+      return null;
+    }
+
+    @Override
+    public EvmAccount getAccount(final Address address) {
+      return null;
+    }
+
+    @Override
+    public void deleteAccount(final Address address) {}
+
+    @Override
+    public Collection<? extends Account> getTouchedAccounts() {
+      return null;
+    }
+
+    @Override
+    public Collection<Address> getDeletedAccountAddresses() {
+      return null;
+    }
+
+    @Override
+    public void revert() {}
+
+    @Override
+    public void commit() {
+      // we explicitly do not implement commit for the transaction-based snapshot updater
+    }
+
+    @Override
+    public Optional<WorldUpdater> parentUpdater() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Account get(final Address address) {
+      return null;
+    }
+  }
+
+
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -1,21 +1,33 @@
 package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 
 /**
- * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is able
- * to commit/perist as a trielog layer only. This is useful for async blockchain opperations like block
- * creation and/or point-in-time queries since the snapshot worldstate is fully isolated from the main
- * BonsaiPersistedWorldState.
+ * This class takes a snapshot of the worldstate as the basis of a mutable worldstate. It is able to
+ * commit/perist as a trielog layer only. This is useful for async blockchain opperations like block
+ * creation and/or point-in-time queries since the snapshot worldstate is fully isolated from the
+ * main BonsaiPersistedWorldState.
  */
-public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
+public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState
+    implements SnapshotMutableWorldState {
   //  private static final Logger LOG = LoggerFactory.getLogger(BonsaiSnapshotWorldState.class);
+
+  private final SnappedKeyValueStorage accountSnap;
+  private final SnappedKeyValueStorage codeSnap;
+  private final SnappedKeyValueStorage storageSnap;
+  private final SnappedKeyValueStorage trieBranchSnap;
 
   private BonsaiSnapshotWorldState(
       final BonsaiWorldStateArchive archive,
-      final BonsaiWorldStateKeyValueStorage snapshotWorldStateStorage) {
+      final BonsaiSnapshotWorldStateKeyValueStorage snapshotWorldStateStorage) {
     super(archive, snapshotWorldStateStorage);
+    this.accountSnap = (SnappedKeyValueStorage) snapshotWorldStateStorage.accountStorage;
+    this.codeSnap = (SnappedKeyValueStorage) snapshotWorldStateStorage.codeStorage;
+    this.storageSnap = (SnappedKeyValueStorage) snapshotWorldStateStorage.storageStorage;
+    this.trieBranchSnap = (SnappedKeyValueStorage) snapshotWorldStateStorage.trieBranchStorage;
   }
 
   public static BonsaiSnapshotWorldState create(
@@ -33,8 +45,18 @@ public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState {
 
   @Override
   public MutableWorldState copy() {
-    // TODO: find out if we can stack transaction based snapshots, so perhaps we return a new transaction based
+    // TODO: find out if we can stack transaction based snapshots, so perhaps we return a new
+    // transaction based
     //  worldstate.  For now we just return ourself rather than a copy.
     return this;
+  }
+
+  @Override
+  public void close() throws Exception {
+    // TODO: close and free snapshot transactions
+    this.accountSnap.getSnapshotTransaction().rollback();
+    this.codeSnap.getSnapshotTransaction().rollback();
+    this.storageSnap.getSnapshotTransaction().rollback();
+    this.trieBranchSnap.getSnapshotTransaction().rollback();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
@@ -45,9 +60,9 @@ public class BonsaiSnapshotWorldState extends BonsaiInMemoryWorldState
 
   @Override
   public MutableWorldState copy() {
-    // TODO: find out if we can stack transaction based snapshots, so perhaps we return a new
-    // transaction based
-    //  worldstate.  For now we just return ourself rather than a copy.
+    // The copy method interface doesn't make much sense in this context since
+    // this class is a snapshot based copy of the worldstate and *is* an
+    // independent/isolated version of the worldstate, so just return ourselves.
     return this;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -31,11 +31,14 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
   }
 
   public static class SnapshotUpdater implements BonsaiWorldStateKeyValueStorage.BonsaiUpdater {
+    //    private static final Logger LOG =
+    // LoggerFactory.getLogger(BonsaiSnapshotWorldStateKeyValueStorage.class);
+
     private final SnappedKeyValueStorage accountStorage;
     private final SnappedKeyValueStorage codeStorage;
     private final SnappedKeyValueStorage storageStorage;
     private final SnappedKeyValueStorage trieBranchStorage;
-    private final KeyValueStorageTransaction trieLogStorage;
+    private final KeyValueStorageTransaction trieLogStorageTransaction;
 
     public SnapshotUpdater(
         final SnappedKeyValueStorage accountStorage,
@@ -47,7 +50,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
       this.codeStorage = codeStorage;
       this.storageStorage = storageStorage;
       this.trieBranchStorage = trieBranchStorage;
-      this.trieLogStorage = trieLogStorage.startTransaction();
+      this.trieLogStorageTransaction = trieLogStorage.startTransaction();
     }
 
     @Override
@@ -108,7 +111,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
     @Override
     public KeyValueStorageTransaction getTrieLogStorageTransaction() {
-      return trieLogStorage;
+      return trieLogStorageTransaction;
     }
 
     @Override
@@ -159,12 +162,13 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
     @Override
     public void commit() {
-      // no-op, do not commit snapshot transactions
+      // only commit the trielog layer transaction, leave the snapshot transactions open:
+      trieLogStorageTransaction.commit();
     }
 
     @Override
     public void rollback() {
-      // no-op, do not commit snapshot transactions
+      // no-op
     }
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -1,0 +1,169 @@
+package org.hyperledger.besu.ethereum.bonsai;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage {
+  private final SnapshotUpdater updater;
+
+  public BonsaiSnapshotWorldStateKeyValueStorage(
+      final SnappedKeyValueStorage accountStorage,
+      final SnappedKeyValueStorage codeStorage,
+      final SnappedKeyValueStorage storageStorage,
+      final SnappedKeyValueStorage trieBranchStorage,
+      final SnappedKeyValueStorage trieLogStorage) {
+    super(accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
+    this.updater =
+        new SnapshotUpdater(
+            accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
+  }
+
+  @Override
+  public BonsaiUpdater updater() {
+    return updater;
+  }
+
+  public static class SnapshotUpdater implements BonsaiWorldStateKeyValueStorage.BonsaiUpdater {
+    private final SnappedKeyValueStorage accountStorage;
+    private final SnappedKeyValueStorage codeStorage;
+    private final SnappedKeyValueStorage storageStorage;
+    private final SnappedKeyValueStorage trieBranchStorage;
+    private final SnappedKeyValueStorage trieLogStorage;
+
+    public SnapshotUpdater(
+        final SnappedKeyValueStorage accountStorage,
+        final SnappedKeyValueStorage codeStorage,
+        final SnappedKeyValueStorage storageStorage,
+        final SnappedKeyValueStorage trieBranchStorage,
+        final SnappedKeyValueStorage trieLogStorage) {
+      this.accountStorage = accountStorage;
+      this.codeStorage = codeStorage;
+      this.storageStorage = storageStorage;
+      this.trieBranchStorage = trieBranchStorage;
+      this.trieLogStorage = trieLogStorage;
+    }
+
+    @Override
+    public BonsaiUpdater removeCode(final Hash accountHash) {
+      codeStorage.getSnapshotTransaction().remove(accountHash.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public WorldStateStorage.Updater putCode(
+        final Hash accountHash, final Bytes32 nodeHash, final Bytes code) {
+      if (code.size() == 0) {
+        // Don't save empty values
+        return this;
+      }
+      codeStorage.getSnapshotTransaction().put(accountHash.toArrayUnsafe(), code.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public BonsaiUpdater removeAccountInfoState(final Hash accountHash) {
+      accountStorage.getSnapshotTransaction().remove(accountHash.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public BonsaiUpdater putAccountInfoState(final Hash accountHash, final Bytes accountValue) {
+      if (accountValue.size() == 0) {
+        // Don't save empty values
+        return this;
+      }
+      accountStorage
+          .getSnapshotTransaction()
+          .put(accountHash.toArrayUnsafe(), accountValue.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public BonsaiUpdater putStorageValueBySlotHash(
+        final Hash accountHash, final Hash slotHash, final Bytes storage) {
+      storageStorage
+          .getSnapshotTransaction()
+          .put(Bytes.concatenate(accountHash, slotHash).toArrayUnsafe(), storage.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public void removeStorageValueBySlotHash(final Hash accountHash, final Hash slotHash) {
+      storageStorage
+          .getSnapshotTransaction()
+          .remove(Bytes.concatenate(accountHash, slotHash).toArrayUnsafe());
+    }
+
+    @Override
+    public KeyValueStorageTransaction getTrieBranchStorageTransaction() {
+      return trieBranchStorage.getSnapshotTransaction();
+    }
+
+    @Override
+    public KeyValueStorageTransaction getTrieLogStorageTransaction() {
+      return trieLogStorage.getSnapshotTransaction();
+    }
+
+    @Override
+    public WorldStateStorage.Updater saveWorldState(
+        final Bytes blockHash, final Bytes32 nodeHash, final Bytes node) {
+      trieBranchStorage
+          .getSnapshotTransaction()
+          .put(Bytes.EMPTY.toArrayUnsafe(), node.toArrayUnsafe());
+      trieBranchStorage.getSnapshotTransaction().put(WORLD_ROOT_HASH_KEY, nodeHash.toArrayUnsafe());
+      trieBranchStorage
+          .getSnapshotTransaction()
+          .put(WORLD_BLOCK_HASH_KEY, blockHash.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public WorldStateStorage.Updater putAccountStateTrieNode(
+        final Bytes location, final Bytes32 nodeHash, final Bytes node) {
+      if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
+        // Don't save empty nodes
+        return this;
+      }
+      trieBranchStorage
+          .getSnapshotTransaction()
+          .put(location.toArrayUnsafe(), node.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public WorldStateStorage.Updater removeAccountStateTrieNode(
+        final Bytes location, final Bytes32 nodeHash) {
+      trieBranchStorage.getSnapshotTransaction().remove(location.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public WorldStateStorage.Updater putAccountStorageTrieNode(
+        final Hash accountHash, final Bytes location, final Bytes32 nodeHash, final Bytes node) {
+      if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
+        // Don't save empty nodes
+        return this;
+      }
+      trieBranchStorage
+          .getSnapshotTransaction()
+          .put(Bytes.concatenate(accountHash, location).toArrayUnsafe(), node.toArrayUnsafe());
+      return this;
+    }
+
+    @Override
+    public void commit() {
+      // no-op, do not commit snapshot transactions
+    }
+
+    @Override
+    public void rollback() {
+      // no-op, do not commit snapshot transactions
+    }
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -3,6 +3,7 @@ package org.hyperledger.besu.ethereum.bonsai;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 
@@ -17,7 +18,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
       final SnappedKeyValueStorage codeStorage,
       final SnappedKeyValueStorage storageStorage,
       final SnappedKeyValueStorage trieBranchStorage,
-      final SnappedKeyValueStorage trieLogStorage) {
+      final KeyValueStorage trieLogStorage) {
     super(accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
     this.updater =
         new SnapshotUpdater(
@@ -34,19 +35,19 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
     private final SnappedKeyValueStorage codeStorage;
     private final SnappedKeyValueStorage storageStorage;
     private final SnappedKeyValueStorage trieBranchStorage;
-    private final SnappedKeyValueStorage trieLogStorage;
+    private final KeyValueStorageTransaction trieLogStorage;
 
     public SnapshotUpdater(
         final SnappedKeyValueStorage accountStorage,
         final SnappedKeyValueStorage codeStorage,
         final SnappedKeyValueStorage storageStorage,
         final SnappedKeyValueStorage trieBranchStorage,
-        final SnappedKeyValueStorage trieLogStorage) {
+        final KeyValueStorage trieLogStorage) {
       this.accountStorage = accountStorage;
       this.codeStorage = codeStorage;
       this.storageStorage = storageStorage;
       this.trieBranchStorage = trieBranchStorage;
-      this.trieLogStorage = trieLogStorage;
+      this.trieLogStorage = trieLogStorage.startTransaction();
     }
 
     @Override
@@ -107,7 +108,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
     @Override
     public KeyValueStorageTransaction getTrieLogStorageTransaction() {
-      return trieLogStorage.getSnapshotTransaction();
+      return trieLogStorage;
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -26,7 +26,6 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
 public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage {
-  private final SnapshotUpdater updater;
 
   public BonsaiSnapshotWorldStateKeyValueStorage(
       final SnappedKeyValueStorage accountStorage,
@@ -35,14 +34,16 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
       final SnappedKeyValueStorage trieBranchStorage,
       final KeyValueStorage trieLogStorage) {
     super(accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
-    this.updater =
-        new SnapshotUpdater(
-            accountStorage, codeStorage, storageStorage, trieBranchStorage, trieLogStorage);
   }
 
   @Override
   public BonsaiUpdater updater() {
-    return updater;
+    return new SnapshotUpdater(
+        (SnappedKeyValueStorage) accountStorage,
+        (SnappedKeyValueStorage) codeStorage,
+        (SnappedKeyValueStorage) storageStorage,
+        (SnappedKeyValueStorage) trieBranchStorage,
+        trieLogStorage);
   }
 
   public static class SnapshotUpdater implements BonsaiWorldStateKeyValueStorage.BonsaiUpdater {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.datatypes.Hash;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiValue.java
@@ -46,13 +46,15 @@ public class BonsaiValue<T> {
     return updated;
   }
 
-  public void setPrior(final T prior) {
+  public BonsaiValue<T> setPrior(final T prior) {
     this.prior = prior;
+    return this;
   }
 
-  public void setUpdated(final T updated) {
+  public BonsaiValue<T> setUpdated(final T updated) {
     this.cleared = updated == null;
     this.updated = updated;
+    return this;
   }
 
   void writeRlp(final RLPOutput output, final BiConsumer<RLPOutput, T> writer) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -99,8 +99,8 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
   }
 
   public Optional<MutableWorldState> getMutableSnapshot(final Hash blockHash) {
-    return rollMutableStateToBlockHash(BonsaiSnapshotWorldState.create(this, worldStateStorage),
-        blockHash);
+    return rollMutableStateToBlockHash(
+        BonsaiSnapshotWorldState.create(this, worldStateStorage), blockHash);
   }
 
   @Override
@@ -204,7 +204,7 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
         }
 
         // attempt the state rolling
-        final BonsaiWorldStateUpdater bonsaiUpdater = getUpdater();
+        final BonsaiWorldStateUpdater bonsaiUpdater = getUpdaterFromPersistedState(mutableState);
         try {
           for (final TrieLogLayer rollBack : rollBacks) {
             LOG.debug("Attempting Rollback of {}", rollBack.getBlockHash());
@@ -232,8 +232,9 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
     }
   }
 
-  BonsaiWorldStateUpdater getUpdater() {
-    return (BonsaiWorldStateUpdater) persistedState.updater();
+  BonsaiWorldStateUpdater getUpdaterFromPersistedState(
+      final BonsaiPersistedWorldState mutableState) {
+    return (BonsaiWorldStateUpdater) mutableState.updater();
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -99,7 +99,8 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
   }
 
   public Optional<MutableWorldState> getMutableSnapshot(final Hash blockHash) {
-    return getWorldstateFor(BonsaiSnapshotWorldState.create(this, worldStateStorage), blockHash);
+    return rollMutableStateToBlockHash(BonsaiSnapshotWorldState.create(this, worldStateStorage),
+        blockHash);
   }
 
   @Override
@@ -150,10 +151,10 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
 
   @Override
   public Optional<MutableWorldState> getMutable(final Hash rootHash, final Hash blockHash) {
-    return getWorldstateFor(persistedState, blockHash);
+    return rollMutableStateToBlockHash(persistedState, blockHash);
   }
 
-  private Optional<MutableWorldState> getWorldstateFor(
+  private Optional<MutableWorldState> rollMutableStateToBlockHash(
       final BonsaiPersistedWorldState mutableState, final Hash blockHash) {
     if (blockHash.equals(mutableState.blockHash())) {
       return Optional.of(mutableState);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 import org.hyperledger.besu.ethereum.proof.WorldStateProof;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.worldstate.PeerTrieNodeFinder;
@@ -98,9 +99,10 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
         || worldStateStorage.isWorldStateAvailable(rootHash, blockHash);
   }
 
-  public Optional<MutableWorldState> getMutableSnapshot(final Hash blockHash) {
+  public Optional<SnapshotMutableWorldState> getMutableSnapshot(final Hash blockHash) {
     return rollMutableStateToBlockHash(
-        BonsaiSnapshotWorldState.create(this, worldStateStorage), blockHash);
+            BonsaiSnapshotWorldState.create(this, worldStateStorage), blockHash)
+        .map(SnapshotMutableWorldState.class::cast);
   }
 
   @Override
@@ -154,8 +156,9 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
     return rollMutableStateToBlockHash(persistedState, blockHash);
   }
 
-  private Optional<MutableWorldState> rollMutableStateToBlockHash(
-      final BonsaiPersistedWorldState mutableState, final Hash blockHash) {
+  private <T extends BonsaiPersistedWorldState>
+      Optional<MutableWorldState> rollMutableStateToBlockHash(
+          final T mutableState, final Hash blockHash) {
     if (blockHash.equals(mutableState.blockHash())) {
       return Optional.of(mutableState);
     } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -153,12 +153,12 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
 
   @Override
   public Optional<MutableWorldState> getMutable(final Hash rootHash, final Hash blockHash) {
-    return rollMutableStateToBlockHash(persistedState, blockHash);
+    return rollMutableStateToBlockHash(persistedState, blockHash)
+        .map(MutableWorldState.class::cast);
   }
 
-  private <T extends BonsaiPersistedWorldState>
-      Optional<MutableWorldState> rollMutableStateToBlockHash(
-          final T mutableState, final Hash blockHash) {
+  private <T extends BonsaiPersistedWorldState> Optional<T> rollMutableStateToBlockHash(
+      final T mutableState, final Hash blockHash) {
     if (blockHash.equals(mutableState.blockHash())) {
       return Optional.of(mutableState);
     } else {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
-import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -236,7 +235,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
   }
 
   @Override
-  public Updater updater() {
+  public BonsaiUpdater updater() {
     return new Updater(
         accountStorage.startTransaction(),
         codeStorage.startTransaction(),
@@ -269,7 +268,24 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
   }
 
-  public static class Updater implements WorldStateStorage.Updater {
+  public interface BonsaiUpdater extends WorldStateStorage.Updater {
+    BonsaiUpdater removeCode(final Hash accountHash);
+
+    BonsaiUpdater removeAccountInfoState(final Hash accountHash);
+
+    BonsaiUpdater putAccountInfoState(final Hash accountHash, final Bytes accountValue);
+
+    BonsaiUpdater putStorageValueBySlotHash(
+        final Hash accountHash, final Hash slotHash, final Bytes storage);
+
+    void removeStorageValueBySlotHash(final Hash accountHash, final Hash slotHash);
+
+    KeyValueStorageTransaction getTrieBranchStorageTransaction();
+
+    KeyValueStorageTransaction getTrieLogStorageTransaction();
+  }
+
+  public static class Updater implements BonsaiUpdater {
 
     private final KeyValueStorageTransaction accountStorageTransaction;
     private final KeyValueStorageTransaction codeStorageTransaction;
@@ -291,13 +307,14 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
       this.trieLogStorageTransaction = trieLogStorageTransaction;
     }
 
-    public Updater removeCode(final Hash accountHash) {
+    @Override
+    public BonsaiUpdater removeCode(final Hash accountHash) {
       codeStorageTransaction.remove(accountHash.toArrayUnsafe());
       return this;
     }
 
     @Override
-    public Updater putCode(final Hash accountHash, final Bytes32 codeHash, final Bytes code) {
+    public BonsaiUpdater putCode(final Hash accountHash, final Bytes32 codeHash, final Bytes code) {
       if (code.size() == 0) {
         // Don't save empty values
         return this;
@@ -306,12 +323,14 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
       return this;
     }
 
-    public Updater removeAccountInfoState(final Hash accountHash) {
+    @Override
+    public BonsaiUpdater removeAccountInfoState(final Hash accountHash) {
       accountStorageTransaction.remove(accountHash.toArrayUnsafe());
       return this;
     }
 
-    public Updater putAccountInfoState(final Hash accountHash, final Bytes accountValue) {
+    @Override
+    public BonsaiUpdater putAccountInfoState(final Hash accountHash, final Bytes accountValue) {
       if (accountValue.size() == 0) {
         // Don't save empty values
         return this;
@@ -330,7 +349,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     }
 
     @Override
-    public Updater putAccountStateTrieNode(
+    public BonsaiUpdater putAccountStateTrieNode(
         final Bytes location, final Bytes32 nodeHash, final Bytes node) {
       if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
         // Don't save empty nodes
@@ -341,13 +360,13 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     }
 
     @Override
-    public Updater removeAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
+    public BonsaiUpdater removeAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
       trieBranchStorageTransaction.remove(location.toArrayUnsafe());
       return this;
     }
 
     @Override
-    public Updater putAccountStorageTrieNode(
+    public BonsaiUpdater putAccountStorageTrieNode(
         final Hash accountHash, final Bytes location, final Bytes32 nodeHash, final Bytes node) {
       if (nodeHash.equals(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH)) {
         // Don't save empty nodes
@@ -358,21 +377,25 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
       return this;
     }
 
-    public Updater putStorageValueBySlotHash(
+    @Override
+    public BonsaiUpdater putStorageValueBySlotHash(
         final Hash accountHash, final Hash slotHash, final Bytes storage) {
       storageStorageTransaction.put(
           Bytes.concatenate(accountHash, slotHash).toArrayUnsafe(), storage.toArrayUnsafe());
       return this;
     }
 
+    @Override
     public void removeStorageValueBySlotHash(final Hash accountHash, final Hash slotHash) {
       storageStorageTransaction.remove(Bytes.concatenate(accountHash, slotHash).toArrayUnsafe());
     }
 
+    @Override
     public KeyValueStorageTransaction getTrieBranchStorageTransaction() {
       return trieBranchStorageTransaction;
     }
 
+    @Override
     public KeyValueStorageTransaction getTrieLogStorageTransaction() {
       return trieLogStorageTransaction;
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -74,7 +74,8 @@ public class TrieLogManager {
     // if it's only in memory we need to save it
     // for example, like that in case of reorg we don't replace a trielog layer
     if (worldStateStorage.getTrieLog(blockHeader.getHash()).isEmpty()) {
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater = worldStateStorage.updater();
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater =
+          worldStateStorage.updater();
       boolean success = false;
       try {
         final TrieLogLayer trieLog =
@@ -167,7 +168,7 @@ public class TrieLogManager {
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater) {
     debugLambda(
         LOG,
         "Persisting trie log for block hash {} and world state root {}",

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
@@ -1,0 +1,3 @@
+package org.hyperledger.besu.ethereum.core;
+
+public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.ethereum.core;
 
 public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/StorageProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/StorageProvider.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStatePreimageStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.io.Closeable;
 
@@ -34,6 +35,8 @@ public interface StorageProvider extends Closeable {
   WorldStatePreimageStorage createWorldStatePreimageStorage();
 
   KeyValueStorage getStorageBySegmentIdentifier(SegmentIdentifier segment);
+
+  SnappableKeyValueStorage getSnappableStorageBySegmentIdentifier(SegmentIdentifier segment);
 
   WorldStateStorage createPrivateWorldStateStorage();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStatePreimageStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -86,6 +87,14 @@ public class KeyValueStorageProvider implements StorageProvider {
   @Override
   public KeyValueStorage getStorageBySegmentIdentifier(final SegmentIdentifier segment) {
     return storageInstances.computeIfAbsent(segment, storageCreator);
+  }
+
+  @Override
+  public SnappableKeyValueStorage getSnappableStorageBySegmentIdentifier(
+      final SegmentIdentifier segment) {
+    // TODO: this is an expedient cast for now, we should add some safety and/or fix the storage
+    // hierarchy
+    return (SnappableKeyValueStorage) storageInstances.computeIfAbsent(segment, storageCreator);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStorageProvider.java
@@ -92,8 +92,6 @@ public class KeyValueStorageProvider implements StorageProvider {
   @Override
   public SnappableKeyValueStorage getSnappableStorageBySegmentIdentifier(
       final SegmentIdentifier segment) {
-    // TODO: this is an expedient cast for now, we should add some safety and/or fix the storage
-    // hierarchy
     return (SnappableKeyValueStorage) storageInstances.computeIfAbsent(segment, storageCreator);
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
+
+import org.hyperledger.besu.config.GenesisAllocation;
+import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECPPrivateKey;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator;
+import org.hyperledger.besu.ethereum.chain.GenesisState;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SealableBlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.mainnet.BlockProcessor;
+import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.storage.StorageProvider;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.Unstable;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValueStorageFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
+import org.hyperledger.besu.util.number.Percentage;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BonsaiSnapshotIsolationTests {
+
+  private BonsaiWorldStateArchive archive;
+  private ProtocolContext protocolContext;
+  final Function<String, KeyPair> asKeyPair =
+      key ->
+          SignatureAlgorithmFactory.getInstance()
+              .createKeyPair(SECPPrivateKey.create(Bytes32.fromHexString(key), "ECDSA"));
+  final Function<GenesisAllocation, Address> extractAddress =
+      ga -> Address.fromHexString(ga.getAddress());
+
+  private final ProtocolSchedule protocolSchedule =
+      MainnetProtocolSchedule.fromConfig(GenesisConfigFile.development().getConfigOptions());
+  private final GenesisState genesisState =
+      GenesisState.fromConfig(GenesisConfigFile.development(), protocolSchedule);
+  private final MutableBlockchain blockchain = createInMemoryBlockchain(genesisState.getBlock());
+  private final AbstractPendingTransactionsSorter sorter =
+      new GasPricePendingTransactionsSorter(
+          ImmutableTransactionPoolConfiguration.builder()
+              .txPoolMaxSize(100)
+              .build(),
+          Clock.systemUTC(),
+          new NoOpMetricsSystem(),
+          blockchain::getChainHeadHeader);
+
+  private final List<GenesisAllocation> accounts =
+      GenesisConfigFile.development()
+          .streamAllocations()
+          .filter(ga -> ga.getPrivateKey().isPresent())
+          .collect(Collectors.toList());
+
+  KeyPair sender1 = asKeyPair.apply(accounts.get(0).getPrivateKey().get());
+
+  @Rule
+  public final TemporaryFolder tempData = new TemporaryFolder();
+
+  @Before
+  public void createStorage() {
+//    final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
+    archive = new BonsaiWorldStateArchive(createKeyValueStorageProvider(), blockchain);
+    var ws = archive.getMutable();
+    genesisState.writeStateTo(ws);
+    ws.persist(blockchain.getChainHeadHeader());
+    protocolContext = new ProtocolContext(blockchain, archive, null);
+  }
+
+  @Test
+  public void testIsolatedFromHead_behindHead() {
+    Address testAddress = Address.fromHexString("0xdeadbeef");
+    // assert we can find the correct path if we are some number of blocks behind head
+    var isolated = archive.getMutableSnapshot(genesisState.getBlock().getHash());
+
+    var firstBlock = forTransactions(List.of(burnTransaction(sender1, 0L, testAddress)));
+    var res = executeBlock(archive.getMutable(), firstBlock);
+
+    var isolated2 = archive.getMutableSnapshot(firstBlock.getHash());
+    var res2 =
+        executeBlock(
+            archive.getMutable(),
+            forTransactions(List.of(burnTransaction(sender1, 1L, testAddress))));
+    assertThat(res.isSuccessful()).isTrue();
+    assertThat(res2.isSuccessful()).isTrue();
+
+    assertThat(archive.getMutable().get(testAddress)).isNotNull();
+    assertThat(archive.getMutable().get(testAddress).getBalance())
+      .isEqualTo(Wei.of(2_000_000_000_000_000_000L));
+    assertThat(isolated.get().get(testAddress)).isNull();
+    assertThat(isolated2.get().get(testAddress)).isNotNull();
+    assertThat(isolated2.get().get(testAddress).getBalance())
+        .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+
+    // hacky snapshot release using persist
+    isolated.get().persist(null);
+    isolated2.get().persist(null);
+  }
+
+  @Test
+  public void testIsolatedFromHead_pastHead() {
+    // assert we can find the correct path if our state is n blocks ahead of head
+    Address testAddress = Address.fromHexString("0xdeadbeef");
+
+    var res =
+        executeBlock(
+            archive.getMutable(),
+            forTransactions(List.of(burnTransaction(sender1, 0L, testAddress))));
+
+    var block2 = forTransactions(List.of(burnTransaction(sender1, 1L, testAddress)));
+    var res2 = executeBlock(archive.getMutable(), block2);
+    var isolated2 = archive.getMutableSnapshot(block2.getHash());
+
+    var block3 = forTransactions(List.of(burnTransaction(sender1, 2L, testAddress)));
+    var res3 = executeBlock(archive.getMutable(), block3);
+    var isolated3 = archive.getMutableSnapshot(block3.getHash());
+
+    assertThat(res.isSuccessful()).isTrue();
+    assertThat(res2.isSuccessful()).isTrue();
+    assertThat(res3.isSuccessful()).isTrue();
+
+    blockchain.rewindToBlock(1L);
+
+    // we should be 1 blocks ahead of head
+    assertThat(isolated2.get().get(testAddress)).isNotNull();
+    assertThat(isolated2.get().get(testAddress).getBalance())
+        .isEqualTo(Wei.of(2_000_000_000_000_000_000L));
+
+    // we should be 2 blocks ahead of head
+    assertThat(isolated3.get().get(testAddress)).isNotNull();
+    assertThat(isolated3.get().get(testAddress).getBalance())
+        .isEqualTo(Wei.of(3_000_000_000_000_000_000L));
+
+    // hacky close using persist
+    isolated2.get().persist(null);
+    isolated3.get().persist(null);
+  }
+
+  /**
+   * this is an initial negative test case. we should expect this to fail with a mutable and
+   * non-persisting copy of the persisted state.
+   */
+  @Test
+  @Ignore("this is expected to fail without getting an isolated mutable copy")
+  public void testCopyNonIsolation() {
+    var tx1 = burnTransaction(sender1, 0L, Address.ZERO);
+    Block oneTx = forTransactions(List.of(tx1));
+
+    MutableWorldState firstWorldState = archive.getMutable();
+    var res = executeBlock(firstWorldState, oneTx);
+
+    assertThat(res.isSuccessful()).isTrue();
+    // get a copy of this worldstate after it has persisted, then save the account val
+    var isolated = archive.getMutable(oneTx.getHeader().getStateRoot(), oneTx.getHash(), false);
+    Address beforeAddress = extractAddress.apply(accounts.get(1));
+    var before = isolated.get().get(beforeAddress);
+
+    // build and execute another block
+    var tx2 = burnTransaction(sender1, 1L, beforeAddress);
+
+    Block oneMoreTx = forTransactions(List.of(tx2));
+
+    var res2 =
+        executeBlock(archive.getMutable(oneTx.getHeader().getNumber(), true).get(), oneMoreTx);
+    assertThat(res2.isSuccessful()).isTrue();
+
+    // compare the cached account value to the current account value from the mutable worldstate
+    var after = isolated.get().get(beforeAddress);
+    assertThat(after.getBalance()).isNotEqualTo(before.getBalance());
+  }
+
+  private Transaction burnTransaction(final KeyPair sender, final Long nonce, final Address to) {
+    return new TransactionTestFixture()
+        .sender(Address.extract(Hash.hash(sender.getPublicKey().getEncodedBytes())))
+        .to(Optional.of(to))
+        .value(Wei.of(1_000_000_000_000_000_000L))
+        .gasLimit(21_000L)
+        .nonce(nonce)
+        .createTransaction(sender);
+  }
+
+  private Block forTransactions(final List<Transaction> transactions) {
+    return TestBlockCreator.forHeader(
+            blockchain.getChainHeadHeader(), protocolContext, protocolSchedule, sorter)
+        .createBlock(transactions, Collections.emptyList(), System.currentTimeMillis());
+  }
+
+  private BlockProcessor.Result executeBlock(final MutableWorldState ws, final Block block) {
+    var res =
+        protocolSchedule
+            .getByBlockNumber(0)
+            .getBlockProcessor()
+            .processBlock(blockchain, ws, block);
+    blockchain.appendBlock(block, res.getReceipts());
+    return res;
+  }
+
+  static class TestBlockCreator extends AbstractBlockCreator {
+    private TestBlockCreator(
+        final Address coinbase,
+        final MiningBeneficiaryCalculator miningBeneficiaryCalculator,
+        final Supplier<Optional<Long>> targetGasLimitSupplier,
+        final ExtraDataCalculator extraDataCalculator,
+        final AbstractPendingTransactionsSorter pendingTransactions,
+        final ProtocolContext protocolContext,
+        final ProtocolSchedule protocolSchedule,
+        final Wei minTransactionGasPrice,
+        final Double minBlockOccupancyRatio,
+        final BlockHeader parentHeader) {
+      super(
+          coinbase,
+          miningBeneficiaryCalculator,
+          targetGasLimitSupplier,
+          extraDataCalculator,
+          pendingTransactions,
+          protocolContext,
+          protocolSchedule,
+          minTransactionGasPrice,
+          minBlockOccupancyRatio,
+          parentHeader);
+    }
+
+    static TestBlockCreator forHeader(
+        final BlockHeader parentHeader,
+        final ProtocolContext protocolContext,
+        final ProtocolSchedule protocolSchedule,
+        final AbstractPendingTransactionsSorter sorter) {
+      return new TestBlockCreator(
+          Address.ZERO,
+          __ -> Address.ZERO,
+          () -> Optional.of(30_000_000L),
+          __ -> Bytes.fromHexString("deadbeef"),
+          sorter,
+          protocolContext,
+          protocolSchedule,
+          Wei.of(1L),
+          0d,
+          parentHeader);
+    }
+
+    @Override
+    protected BlockHeader createFinalBlockHeader(final SealableBlockHeader sealableBlockHeader) {
+      return BlockHeaderBuilder.create()
+          .difficulty(Difficulty.ZERO)
+          .mixHash(Hash.ZERO)
+          .populateFrom(sealableBlockHeader)
+          .nonce(0L)
+          .blockHeaderFunctions(blockHeaderFunctions)
+          .buildBlockHeader();
+    }
+  }
+
+  // storage provider which uses a temporary directory based rocksdb
+  private StorageProvider createKeyValueStorageProvider() {
+    try {
+      tempData.create();
+      return new KeyValueStorageProviderBuilder()
+          .withStorageFactory(
+              new RocksDBKeyValueStorageFactory(
+                  () ->
+                      new RocksDBFactoryConfiguration(
+                          1024 /* MAX_OPEN_FILES*/,
+                          4 /*MAX_BACKGROUND_COMPACTIONS*/,
+                          4 /*BACKGROUND_THREAD_COUNT*/,
+                          8388608 /*CACHE_CAPACITY*/),
+                  Arrays.asList(KeyValueSegmentIdentifier.values()),
+                  2,
+                  RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
+          .withCommonConfiguration(
+              new BesuConfiguration() {
+
+                @Override
+                public Path getStoragePath() {
+                  return new File(tempData.getRoot().toString() + File.pathSeparator + "database").toPath();
+                }
+
+                @Override
+                public Path getDataPath() {
+                  return tempData.getRoot().toPath();
+                }
+
+                @Override
+                public int getDatabaseVersion() {
+                  return 2;
+                }
+              })
+          .withMetricsSystem(new NoOpMetricsSystem())
+          .build();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -138,10 +138,9 @@ public class BonsaiSnapshotIsolationTests {
     var res = executeBlock(archive.getMutable(), firstBlock);
 
     var isolated2 = archive.getMutableSnapshot(firstBlock.getHash());
-    var res2 =
-        executeBlock(
-            archive.getMutable(),
-            forTransactions(List.of(burnTransaction(sender1, 1L, testAddress))));
+    var secondBlock = forTransactions(List.of(burnTransaction(sender1, 1L, testAddress)));
+    var res2 = executeBlock(archive.getMutable(), secondBlock);
+
     assertThat(res.isSuccessful()).isTrue();
     assertThat(res2.isSuccessful()).isTrue();
 
@@ -153,9 +152,11 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolated2.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
 
-    // hacky snapshot release using persist
-    isolated.get().persist(null);
-    isolated2.get().persist(null);
+    // persist trielogs
+    isolated.get().persist(firstBlock.getHeader());
+    isolated2.get().persist(secondBlock.getHeader());
+
+    //todo: check trielog layer for correctness
   }
 
   @Test
@@ -192,9 +193,11 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolated3.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(3_000_000_000_000_000_000L));
 
-    // hacky close using persist
-    isolated2.get().persist(null);
-    isolated3.get().persist(null);
+    // persist trielog layer:
+    isolated2.get().persist(block2.getHeader());
+    isolated3.get().persist(block3.getHeader());
+
+    //todo: check trieloglayer for correctness
   }
 
   /**

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -163,7 +163,7 @@ public class BonsaiSnapshotIsolationTests {
     // persist the isolated worldstate as trielog only:
     isolated.get().persist(firstBlock.getHeader());
 
-    //assert we have not modified the head worldstate:
+    // assert we have not modified the head worldstate:
     assertThat(archive.getMutable().get(testAddress)).isNull();
 
     // roll the persisted world state to the new trie log from the persisted snapshot
@@ -180,8 +180,7 @@ public class BonsaiSnapshotIsolationTests {
     Address testAddress = Address.fromHexString("0xdeadbeef");
 
     var block1 = forTransactions(List.of(burnTransaction(sender1, 0L, testAddress)));
-    var res =
-        executeBlock(archive.getMutable(), block1);
+    var res = executeBlock(archive.getMutable(), block1);
 
     var block2 = forTransactions(List.of(burnTransaction(sender1, 1L, testAddress)));
     var res2 = executeBlock(archive.getMutable(), block2);
@@ -215,13 +214,6 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolatedRollBack.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
   }
-
-  @Test
-  public void assertCanPersistTrieLogFromMutableSnapshot() {
-    //TODO: assert we can roll the peristed state to a trie log saved from a mutatble snapshot
-  }
-
-
 
   /**
    * this is an initial negative test case. we should expect this to fail with a mutable and

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -222,39 +221,6 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolatedRollBack.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
     assertThat(isolatedRollBack.get().rootHash()).isEqualTo(block1.getHeader().getStateRoot());
-  }
-
-  /**
-   * this is an initial negative test case. we should expect this to fail with a mutable and
-   * non-persisting copy of the persisted state.
-   */
-  @Test
-  @Ignore("this is expected to fail without getting an isolated mutable copy")
-  public void testCopyNonIsolation() {
-    var tx1 = burnTransaction(sender1, 0L, Address.ZERO);
-    Block oneTx = forTransactions(List.of(tx1));
-
-    MutableWorldState firstWorldState = archive.getMutable();
-    var res = executeBlock(firstWorldState, oneTx);
-
-    assertThat(res.isSuccessful()).isTrue();
-    // get a copy of this worldstate after it has persisted, then save the account val
-    var isolated = archive.getMutable(oneTx.getHeader().getStateRoot(), oneTx.getHash(), false);
-    Address beforeAddress = extractAddress.apply(accounts.get(1));
-    var before = isolated.get().get(beforeAddress);
-
-    // build and execute another block
-    var tx2 = burnTransaction(sender1, 1L, beforeAddress);
-
-    Block oneMoreTx = forTransactions(List.of(tx2));
-
-    var res2 =
-        executeBlock(archive.getMutable(oneTx.getHeader().getNumber(), true).get(), oneMoreTx);
-    assertThat(res2.isSuccessful()).isTrue();
-
-    // compare the cached account value to the current account value from the mutable worldstate
-    var after = isolated.get().get(beforeAddress);
-    assertThat(after.getBalance()).isNotEqualTo(before.getBalance());
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -141,9 +141,13 @@ public class BonsaiSnapshotIsolationTests {
         .isEqualTo(Wei.of(2_000_000_000_000_000_000L));
 
     assertThat(isolated.get().get(testAddress)).isNull();
+    assertThat(isolated.get().rootHash())
+        .isEqualTo(genesisState.getBlock().getHeader().getStateRoot());
+
     assertThat(isolated2.get().get(testAddress)).isNotNull();
     assertThat(isolated2.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+    assertThat(isolated2.get().rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
   }
 
   @Test
@@ -159,6 +163,7 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolated.get().get(testAddress)).isNotNull();
     assertThat(isolated.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+    assertThat(isolated.get().rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
 
     // persist the isolated worldstate as trielog only:
     isolated.get().persist(firstBlock.getHeader());
@@ -172,6 +177,7 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(ws.get().get(testAddress)).isNotNull();
     assertThat(ws.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+    assertThat(ws.get().rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
   }
 
   @Test
@@ -200,6 +206,7 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(block1State.get().get(testAddress)).isNotNull();
     assertThat(block1State.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(2_000_000_000_000_000_000L));
+    assertThat(block1State.get().rootHash()).isEqualTo(block2.getHeader().getStateRoot());
 
     var isolatedRollForward = archive.getMutableSnapshot(block3.getHash());
 
@@ -207,12 +214,14 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolatedRollForward.get().get(testAddress)).isNotNull();
     assertThat(isolatedRollForward.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(3_000_000_000_000_000_000L));
+    assertThat(isolatedRollForward.get().rootHash()).isEqualTo(block3.getHeader().getStateRoot());
 
     // we should be at block 1, one block behind BonsaiPersistatedWorldState
     var isolatedRollBack = archive.getMutableSnapshot(block1.getHash());
     assertThat(isolatedRollBack.get().get(testAddress)).isNotNull();
     assertThat(isolatedRollBack.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+    assertThat(isolatedRollBack.get().rootHash()).isEqualTo(block1.getHeader().getStateRoot());
   }
 
   /**

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -342,7 +342,8 @@ public class BonsaiSnapshotIsolationTests {
                           1024 /* MAX_OPEN_FILES*/,
                           4 /*MAX_BACKGROUND_COMPACTIONS*/,
                           4 /*BACKGROUND_THREAD_COUNT*/,
-                          8388608 /*CACHE_CAPACITY*/),
+                          8388608 /*CACHE_CAPACITY*/,
+                          false),
                   Arrays.asList(KeyValueSegmentIdentifier.values()),
                   2,
                   RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -173,8 +173,12 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater = spy(bonsaiWorldStateArchive.getUpdater());
-    when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
+    var updater =
+        spy(
+            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
+                any(BonsaiSnapshotWorldState.class)));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
+        .thenReturn(updater);
 
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
 
@@ -217,8 +221,12 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater = spy(bonsaiWorldStateArchive.getUpdater());
-    when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
+    var updater =
+        spy(
+            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
+                any(BonsaiSnapshotWorldState.class)));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
+        .thenReturn(updater);
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));
@@ -268,8 +276,12 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater = spy(bonsaiWorldStateArchive.getUpdater());
-    when(bonsaiWorldStateArchive.getUpdater()).thenReturn(updater);
+    var updater =
+        spy(
+            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
+                any(BonsaiSnapshotWorldState.class)));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
+        .thenReturn(updater);
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -173,12 +173,10 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater =
-        spy(
-            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
-                any(BonsaiSnapshotWorldState.class)));
-    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
-        .thenReturn(updater);
+
+    var worldState = (BonsaiPersistedWorldState) bonsaiWorldStateArchive.getMutable();
+    var updater = spy(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState)).thenReturn(updater);
 
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
 
@@ -221,12 +219,9 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater =
-        spy(
-            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
-                any(BonsaiSnapshotWorldState.class)));
-    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
-        .thenReturn(updater);
+    var worldState = (BonsaiPersistedWorldState) bonsaiWorldStateArchive.getMutable();
+    var updater = spy(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState)).thenReturn(updater);
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));
@@ -276,12 +271,9 @@ public class BonsaiWorldStateArchiveTest {
                     layeredWorldStatesByHash),
                 storageProvider,
                 blockchain));
-    var updater =
-        spy(
-            bonsaiWorldStateArchive.getUpdaterFromPersistedState(
-                any(BonsaiSnapshotWorldState.class)));
-    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(any(BonsaiSnapshotWorldState.class)))
-        .thenReturn(updater);
+    var worldState = (BonsaiPersistedWorldState) bonsaiWorldStateArchive.getMutable();
+    var updater = spy(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState));
+    when(bonsaiWorldStateArchive.getUpdaterFromPersistedState(worldState)).thenReturn(updater);
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(eq(Hash.ZERO))).thenReturn(Optional.of(blockHeaderChainA));

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorageTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorageTest.java
@@ -174,7 +174,7 @@ public class BonsaiWorldStateKeyValueStorageTest {
             trie.entriesFrom(root -> StorageEntriesCollector.collectEntries(root, Hash.ZERO, 1));
 
     // save world state root hash
-    final BonsaiWorldStateKeyValueStorage.Updater updater = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = storage.updater();
     updater
         .getTrieBranchStorageTransaction()
         .put(WORLD_ROOT_HASH_KEY, trie.getRootHash().toArrayUnsafe());
@@ -214,7 +214,7 @@ public class BonsaiWorldStateKeyValueStorageTest {
                 root -> StorageEntriesCollector.collectEntries(root, Hash.ZERO, 1));
 
     // save world state root hash
-    final BonsaiWorldStateKeyValueStorage.Updater updater = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = storage.updater();
     updater
         .getTrieBranchStorageTransaction()
         .put(WORLD_ROOT_HASH_KEY, trie.getRootHash().toArrayUnsafe());
@@ -244,8 +244,8 @@ public class BonsaiWorldStateKeyValueStorageTest {
     final Bytes bytesC = Bytes.fromHexString("0x123456");
 
     final BonsaiWorldStateKeyValueStorage storage = emptyStorage();
-    final BonsaiWorldStateKeyValueStorage.Updater updaterA = storage.updater();
-    final BonsaiWorldStateKeyValueStorage.Updater updaterB = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updaterA = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updaterB = storage.updater();
 
     updaterA.putCode(accountHashA, bytesA);
     updaterB.putCode(accountHashB, bytesA);
@@ -269,7 +269,7 @@ public class BonsaiWorldStateKeyValueStorageTest {
   public void isWorldStateAvailable_StateAvailableByRootHash() {
 
     final BonsaiWorldStateKeyValueStorage storage = emptyStorage();
-    final BonsaiWorldStateKeyValueStorage.Updater updater = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = storage.updater();
     final Bytes rootHashKey = Bytes32.fromHexString("0x01");
     updater.getTrieBranchStorageTransaction().put(WORLD_ROOT_HASH_KEY, rootHashKey.toArrayUnsafe());
     updater.commit();
@@ -281,7 +281,7 @@ public class BonsaiWorldStateKeyValueStorageTest {
   public void isWorldStateAvailable_afterCallingSaveWorldstate() {
 
     final BonsaiWorldStateKeyValueStorage storage = emptyStorage();
-    final BonsaiWorldStateKeyValueStorage.Updater updater = storage.updater();
+    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = storage.updater();
 
     final Bytes blockHash = Bytes32.fromHexString("0x01");
     final Bytes32 nodeHashKey = Bytes32.fromHexString("0x02");

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -65,7 +65,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '04i5t63zL2UxFKrdlfGMMt099SejaywYvtkgpn9jUE0='
+  knownHash = 'XC8yUiSOLc+dKdIFk8l9aEsc6w3EqedptcH53kvfag4='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -65,7 +65,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'XC8yUiSOLc+dKdIFk8l9aEsc6w3EqedptcH53kvfag4='
+  knownHash = 't1ECxSKuhCHrMq9uKYC9datxfFqqTpCPc6GFmUfC8Pg='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
@@ -1,0 +1,6 @@
+package org.hyperledger.besu.plugin.services.storage;
+
+public interface SnappableKeyValueStorage extends KeyValueStorage {
+
+  KeyValueStorage takeSnapshot();
+}

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
@@ -2,5 +2,5 @@ package org.hyperledger.besu.plugin.services.storage;
 
 public interface SnappableKeyValueStorage extends KeyValueStorage {
 
-  KeyValueStorage takeSnapshot();
+  SnappedKeyValueStorage takeSnapshot();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappableKeyValueStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.plugin.services.storage;
 
 public interface SnappableKeyValueStorage extends KeyValueStorage {

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
@@ -1,0 +1,6 @@
+package org.hyperledger.besu.plugin.services.storage;
+
+public interface SnappedKeyValueStorage extends KeyValueStorage {
+
+  KeyValueStorageTransaction getSnapshotTransaction();
+}

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
@@ -18,4 +18,6 @@ package org.hyperledger.besu.plugin.services.storage;
 public interface SnappedKeyValueStorage extends KeyValueStorage {
 
   KeyValueStorageTransaction getSnapshotTransaction();
+
+  SnappedKeyValueStorage cloneFromSnapshot();
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/SnappedKeyValueStorage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.plugin.services.storage;
 
 public interface SnappedKeyValueStorage extends KeyValueStorage {

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
@@ -22,10 +22,9 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration;
-
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;
-import org.rocksdb.TransactionDB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,7 @@ public class RocksDBMetricsFactory {
   public RocksDBMetrics create(
       final MetricsSystem metricsSystem,
       final RocksDBConfiguration rocksDbConfiguration,
-      final TransactionDB db,
+      final OptimisticTransactionDB db,
       final Statistics stats) {
     final OperationTimer readLatency =
         metricsSystem

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBConfiguration;
+
 import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.Statistics;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
@@ -21,16 +21,17 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.TransactionDB;
 
 public class RocksDbSegmentIdentifier {
 
-  private final TransactionDB db;
+  private final OptimisticTransactionDB db;
   private final AtomicReference<ColumnFamilyHandle> reference;
 
   public RocksDbSegmentIdentifier(
-      final TransactionDB db, final ColumnFamilyHandle columnFamilyHandle) {
+      final OptimisticTransactionDB db, final ColumnFamilyHandle columnFamilyHandle) {
     this.db = db;
     this.reference = new AtomicReference<>(columnFamilyHandle);
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDbSegmentIdentifier.java
@@ -23,7 +23,6 @@ import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
-import org.rocksdb.TransactionDB;
 
 public class RocksDbSegmentIdentifier {
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -14,14 +14,15 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.TransactionDB;
 
 public class RocksDBColumnarKeyValueSnapshot implements KeyValueStorage {
-  final TransactionDB db;
+  final OptimisticTransactionDB db;
   final RocksDBSnapshotTransaction snapTx;
 
   RocksDBColumnarKeyValueSnapshot(
-      final TransactionDB db,
+      final OptimisticTransactionDB db,
       final RocksDbSegmentIdentifier segment,
       final RocksDBMetrics metrics) {
     this.db = db;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -1,0 +1,73 @@
+package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+import org.hyperledger.besu.plugin.services.exception.StorageException;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetrics;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbSegmentIdentifier;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.rocksdb.TransactionDB;
+
+public class RocksDBColumnarKeyValueSnapshot implements KeyValueStorage {
+  final TransactionDB db;
+  final RocksDBSnapshotTransaction snapTx;
+
+  RocksDBColumnarKeyValueSnapshot(
+      final TransactionDB db,
+      final RocksDbSegmentIdentifier segment,
+      final RocksDBMetrics metrics) {
+    this.db = db;
+    this.snapTx = new RocksDBSnapshotTransaction(db, segment.get(), metrics);
+  }
+
+  @Override
+  public Optional<byte[]> get(final byte[] key) throws StorageException {
+    return snapTx.get(key);
+  }
+
+  @Override
+  public Stream<byte[]> streamKeys() {
+    return snapTx.streamKeys();
+  }
+
+  @Override
+  public boolean tryDelete(final byte[] key) throws StorageException {
+    snapTx.remove(key);
+    return true;
+  }
+
+  @Override
+  public Set<byte[]> getAllKeysThat(final Predicate<byte[]> returnCondition) {
+    return streamKeys().filter(returnCondition).collect(toUnmodifiableSet());
+  }
+
+  @Override
+  public KeyValueStorageTransaction startTransaction() throws StorageException {
+    // TODO: we should probably return a wrapped transaction
+    return snapTx;
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException(
+        "RocksDBColumnarKeyValueSnapshot does not support clear");
+  }
+
+  @Override
+  public boolean containsKey(final byte[] key) throws StorageException {
+    return snapTx.get(key).isPresent();
+  }
+
+  @Override
+  public void close() throws IOException {
+    snapTx.close();
+  }
+}

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -3,8 +3,8 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import org.hyperledger.besu.plugin.services.exception.StorageException;
-import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetrics;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbSegmentIdentifier;
 
@@ -15,9 +15,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.rocksdb.OptimisticTransactionDB;
-import org.rocksdb.TransactionDB;
 
-public class RocksDBColumnarKeyValueSnapshot implements KeyValueStorage {
+public class RocksDBColumnarKeyValueSnapshot implements SnappedKeyValueStorage {
   final OptimisticTransactionDB db;
   final RocksDBSnapshotTransaction snapTx;
 
@@ -70,5 +69,10 @@ public class RocksDBColumnarKeyValueSnapshot implements KeyValueStorage {
   @Override
   public void close() throws IOException {
     snapTx.close();
+  }
+
+  @Override
+  public KeyValueStorageTransaction getSnapshotTransaction() {
+    return snapTx;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -43,6 +43,12 @@ public class RocksDBColumnarKeyValueSnapshot implements SnappedKeyValueStorage {
     this.snapTx = new RocksDBSnapshotTransaction(db, segment.get(), metrics);
   }
 
+  private RocksDBColumnarKeyValueSnapshot(
+      final OptimisticTransactionDB db, final RocksDBSnapshotTransaction snapTx) {
+    this.db = db;
+    this.snapTx = snapTx;
+  }
+
   @Override
   public Optional<byte[]> get(final byte[] key) throws StorageException {
     return snapTx.get(key);
@@ -90,5 +96,10 @@ public class RocksDBColumnarKeyValueSnapshot implements SnappedKeyValueStorage {
   @Override
   public KeyValueStorageTransaction getSnapshotTransaction() {
     return snapTx;
+  }
+
+  @Override
+  public SnappedKeyValueStorage cloneFromSnapshot() {
+    return new RocksDBColumnarKeyValueSnapshot(db, snapTx.copy());
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
@@ -51,7 +66,8 @@ public class RocksDBColumnarKeyValueSnapshot implements SnappedKeyValueStorage {
 
   @Override
   public KeyValueStorageTransaction startTransaction() throws StorageException {
-    // TODO: we should probably return a wrapped transaction
+    // The use of a transaction on a transaction based key value store is dubious
+    // at best.  return our snapshot transaction instead.
     return snapTx;
   }
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -256,7 +256,7 @@ public class RocksDBColumnarKeyValueStorage
     columnHandlesByName.values().stream()
         .filter(e -> e.equals(segmentHandle))
         .findAny()
-        .ifPresent(segmentIdentifier -> segmentIdentifier.reset());
+        .ifPresent(RocksDbSegmentIdentifier::reset);
   }
 
   @Override

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -51,6 +51,7 @@ import org.rocksdb.CompressionType;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
@@ -78,7 +79,7 @@ public class RocksDBColumnarKeyValueStorage
 
   private final DBOptions options;
   private final TransactionDBOptions txOptions;
-  private final TransactionDB db;
+  private final OptimisticTransactionDB db;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final Map<String, RocksDbSegmentIdentifier> columnHandlesByName;
   private final RocksDBMetrics metrics;
@@ -141,9 +142,8 @@ public class RocksDBColumnarKeyValueStorage
       txOptions = new TransactionDBOptions();
       final List<ColumnFamilyHandle> columnHandles = new ArrayList<>(columnDescriptors.size());
       db =
-          TransactionDB.open(
+          OptimisticTransactionDB.open(
               options,
-              txOptions,
               configuration.getDatabaseDir().toString(),
               columnDescriptors,
               columnHandles);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -212,6 +212,12 @@ public class RocksDBColumnarKeyValueStorage
     }
   }
 
+  public RocksDBColumnarKeyValueSnapshot takeSnapshot(final RocksDbSegmentIdentifier segment)
+      throws StorageException {
+    throwIfClosed();
+    return new RocksDBColumnarKeyValueSnapshot(db, segment, metrics);
+  }
+
   @Override
   public Transaction<RocksDbSegmentIdentifier> startTransaction() throws StorageException {
     throwIfClosed();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -56,7 +56,6 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.Status;
-import org.rocksdb.TransactionDB;
 import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
@@ -143,10 +142,7 @@ public class RocksDBColumnarKeyValueStorage
       final List<ColumnFamilyHandle> columnHandles = new ArrayList<>(columnDescriptors.size());
       db =
           OptimisticTransactionDB.open(
-              options,
-              configuration.getDatabaseDir().toString(),
-              columnDescriptors,
-              columnHandles);
+              options, configuration.getDatabaseDir().toString(), columnDescriptors, columnHandles);
       metrics = rocksDBMetricsFactory.create(metricsSystem, configuration, db, stats);
       final Map<Bytes, String> segmentsById =
           segments.stream()

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -25,7 +26,7 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
   private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
 
   private final RocksDBMetrics metrics;
-  private final TransactionDB db;
+  private final OptimisticTransactionDB db;
   private final ColumnFamilyHandle columnFamilyHandle;
   private final Transaction snapTx;
   private final Snapshot snapshot;
@@ -33,7 +34,7 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
   private final ReadOptions readOptions;
 
   RocksDBSnapshotTransaction(
-      final TransactionDB db,
+      final OptimisticTransactionDB db,
       final ColumnFamilyHandle columnFamilyHandle,
       final RocksDBMetrics metrics) {
     this.metrics = metrics;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -1,0 +1,116 @@
+package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
+
+import org.hyperledger.besu.plugin.services.exception.StorageException;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
+import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetrics;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbKeyIterator;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.Snapshot;
+import org.rocksdb.Transaction;
+import org.rocksdb.TransactionDB;
+import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
+  private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotTransaction.class);
+  private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
+
+  private final RocksDBMetrics metrics;
+  private final TransactionDB db;
+  private final ColumnFamilyHandle columnFamilyHandle;
+  private final Transaction snapTx;
+  private final Snapshot snapshot;
+  private final WriteOptions writeOptions;
+  private final ReadOptions readOptions;
+
+  RocksDBSnapshotTransaction(
+      final TransactionDB db,
+      final ColumnFamilyHandle columnFamilyHandle,
+      final RocksDBMetrics metrics) {
+    this.metrics = metrics;
+    this.db = db;
+    this.columnFamilyHandle = columnFamilyHandle;
+    this.snapshot = db.getSnapshot();
+    this.writeOptions = new WriteOptions();
+    this.snapTx = db.beginTransaction(writeOptions);
+    this.readOptions = new ReadOptions().setSnapshot(snapshot);
+  }
+
+  public Optional<byte[]> get(final byte[] key) {
+    try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
+      return Optional.ofNullable(snapTx.getForUpdate(readOptions, columnFamilyHandle, key, false));
+    } catch (final RocksDBException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  @Override
+  public void put(final byte[] key, final byte[] value) {
+    try (final OperationTimer.TimingContext ignored = metrics.getWriteLatency().startTimer()) {
+      snapTx.put(columnFamilyHandle, key, value);
+    } catch (final RocksDBException e) {
+      if (e.getMessage().contains(NO_SPACE_LEFT_ON_DEVICE)) {
+        LOG.error(e.getMessage());
+        System.exit(0);
+      }
+      throw new StorageException(e);
+    }
+  }
+
+  @Override
+  public void remove(final byte[] key) {
+    try (final OperationTimer.TimingContext ignored = metrics.getRemoveLatency().startTimer()) {
+      snapTx.delete(columnFamilyHandle, key);
+    } catch (final RocksDBException e) {
+      if (e.getMessage().contains(NO_SPACE_LEFT_ON_DEVICE)) {
+        LOG.error(e.getMessage());
+        System.exit(0);
+      }
+      throw new StorageException(e);
+    }
+  }
+
+  public Stream<byte[]> streamKeys() {
+    final RocksIterator rocksIterator = db.newIterator(columnFamilyHandle, readOptions);
+    rocksIterator.seekToFirst();
+    return RocksDbKeyIterator.create(rocksIterator).toStream();
+  }
+
+  @Override
+  public void commit() throws StorageException {
+    // no-op or throw?
+    throw new UnsupportedOperationException("RocksDBSnapshotTransaction does not support commit");
+  }
+
+  @Override
+  public void rollback() {
+    try {
+      snapTx.rollback();
+      metrics.getRollbackCount().inc();
+    } catch (final RocksDBException e) {
+      if (e.getMessage().contains(NO_SPACE_LEFT_ON_DEVICE)) {
+        LOG.error(e.getMessage());
+        System.exit(0);
+      }
+      throw new StorageException(e);
+    } finally {
+      close();
+    }
+  }
+
+  void close() {
+    snapshot.close();
+    snapTx.close();
+    writeOptions.close();
+    readOptions.close();
+  }
+}

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -16,7 +16,6 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Snapshot;
 import org.rocksdb.Transaction;
-import org.rocksdb.TransactionDB;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +47,7 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
 
   public Optional<byte[]> get(final byte[] key) {
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
-      return Optional.ofNullable(snapTx.getForUpdate(readOptions, columnFamilyHandle, key, false));
+      return Optional.ofNullable(snapTx.get(columnFamilyHandle, readOptions, key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.plugin.services.storage.rocksdb.segmented;
 
 import org.hyperledger.besu.plugin.services.exception.StorageException;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -138,14 +138,15 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
 
   public RocksDBSnapshotTransaction copy() {
     // TODO: if we use snapshot as the basis of a cloned state, we need to ensure close() of this
-    // Transaction
-    // does not release and close the snapshot in use by the cloned state.
+    // transaction does not release and close the snapshot in use by the cloned state.
     return new RocksDBSnapshotTransaction(db, columnFamilyHandle, metrics, snapshot);
   }
 
   @Override
   public void close() {
+    // TODO: this is unsafe since another transaction might be using this snapshot
     db.releaseSnapshot(snapshot);
+
     snapshot.close();
     snapTx.close();
     writeOptions.close();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -20,7 +20,7 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
+public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBSnapshotTransaction.class);
   private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
 
@@ -107,7 +107,8 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction {
     }
   }
 
-  void close() {
+  @Override
+  public void close() {
     snapshot.close();
     snapTx.close();
     writeOptions.close();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -42,8 +42,6 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
 import org.rocksdb.Status;
-import org.rocksdb.TransactionDB;
-import org.rocksdb.TransactionDBOptions;
 import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,9 +77,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
               .setStatistics(stats);
       options.getEnv().setBackgroundThreads(configuration.getBackgroundThreadCount());
 
-      db =
-          OptimisticTransactionDB.open(
-              options, configuration.getDatabaseDir().toString());
+      db = OptimisticTransactionDB.open(options, configuration.getDatabaseDir().toString());
       rocksDBMetrics = rocksDBMetricsFactory.create(metricsSystem, configuration, db, stats);
     } catch (final RocksDBException e) {
       throw new StorageException(e);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.LRUCache;
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -56,7 +57,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   private static final Logger LOG = LoggerFactory.getLogger(RocksDBKeyValueStorage.class);
 
   private final Options options;
-  private final TransactionDB db;
+  private final OptimisticTransactionDB db;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final RocksDBMetrics rocksDBMetrics;
   private final WriteOptions tryDeleteOptions =
@@ -79,8 +80,8 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
       options.getEnv().setBackgroundThreads(configuration.getBackgroundThreadCount());
 
       db =
-          TransactionDB.open(
-              options, new TransactionDBOptions(), configuration.getDatabaseDir().toString());
+          OptimisticTransactionDB.open(
+              options, configuration.getDatabaseDir().toString());
       rocksDBMetrics = rocksDBMetricsFactory.create(metricsSystem, configuration, db, stats);
     } catch (final RocksDBException e) {
       throw new StorageException(e);

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsTest.java
@@ -39,8 +39,8 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Statistics;
-import org.rocksdb.TransactionDB;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RocksDBMetricsTest {
@@ -49,7 +49,7 @@ public class RocksDBMetricsTest {
   @Mock private LabelledMetric<OperationTimer> labelledMetricOperationTimerMock;
   @Mock private LabelledMetric<Counter> labelledMetricCounterMock;
   @Mock private OperationTimer operationTimerMock;
-  @Mock private TransactionDB db;
+  @Mock private OptimisticTransactionDB db;
   @Mock private Statistics stats;
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
@@ -19,7 +19,6 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
-import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.io.PrintStream;
 import java.util.HashMap;

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
@@ -19,6 +19,7 @@ import static java.util.stream.Collectors.toUnmodifiableSet;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 
 import java.io.PrintStream;
 import java.util.HashMap;

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
@@ -15,10 +15,10 @@
 package org.hyperledger.besu.services.kvstore;
 
 import org.hyperledger.besu.plugin.services.exception.StorageException;
-import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.storage.SegmentIdentifier;
 import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
+import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 public class SegmentedKeyValueStorageAdapter<S> implements SnappableKeyValueStorage {
   private final S segmentHandle;
   private final SegmentedKeyValueStorage<S> storage;
-  private final Supplier<? extends KeyValueStorage> snapshotSupplier;
+  private final Supplier<SnappedKeyValueStorage> snapshotSupplier;
 
   public SegmentedKeyValueStorageAdapter(
       final SegmentIdentifier segment, final SegmentedKeyValueStorage<S> storage) {
@@ -45,7 +45,7 @@ public class SegmentedKeyValueStorageAdapter<S> implements SnappableKeyValueStor
   public SegmentedKeyValueStorageAdapter(
       final SegmentIdentifier segment,
       final SegmentedKeyValueStorage<S> storage,
-      final Supplier<? extends KeyValueStorage> snapshotSupplier) {
+      final Supplier<SnappedKeyValueStorage> snapshotSupplier) {
     segmentHandle = storage.getSegmentIdentifierByName(segment);
     this.storage = storage;
     this.snapshotSupplier = snapshotSupplier;
@@ -114,7 +114,7 @@ public class SegmentedKeyValueStorageAdapter<S> implements SnappableKeyValueStor
   }
 
   @Override
-  public KeyValueStorage takeSnapshot() {
+  public SnappedKeyValueStorage takeSnapshot() {
     return snapshotSupplier.get();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR adds support for using rocksdb snapshot transactions as the basis for a bonsai worldstate.  This gives us the ability to have an isolated copy of the world state for concurrent operations like block production, block validation, transaction validation, historical state queries, etc.

The notion is to merge this capability into main, and start replacing the uses of BonsaiLayeredWorldState and direct uses of BonsaiInMemoryWorldState when we need isolated and/or concurrent operations on the worldstate.

This is a strictly additive PR and does not change existing implementations.  Uses of snapshot worldstates will be useful to resolve issues such as #4372 #4250 #4199 #4151 and other bonsai concurrency issues.

Changes in support of snapshot worldstate include:
* moving (back) to OptimisticTransactionDB, so we can mutate the snapshot transactions
* creating `BonsaiWorldStateKeyValueStorage.BonsaiUpdater` interface extending `WorldStateStorage.Updater`, so we can have a snapshot specific Updater implementation
* Addition of SnappableStorage, SnappedStorage to plugin-api in order to support/expose the snapshot behavior 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
relates to #4402 
relates to #4403 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).