### PR TITLE
Less strict engine QoS timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Additions and Improvements
 - Allow free gas networks in the London fee market [#4061](https://github.com/hyperledger/besu/issues/4061)
 - Upgrade besu-native to 0.6.0 and use Blake2bf native implementation if available by default [#4264](https://github.com/hyperledger/besu/pull/4264)
+- Resets engine QoS timer with every call to the engine API instead of only when ExchangeTransitionConfiguration is called [#4411](https://github.com/hyperledger/besu/issues/4411)
+- ExchangeTransitionConfiguration mismatch will only submit a debug log not a warning anymore [#4411](https://github.com/hyperledger/besu/issues/4411)
 
 ### Bug Fixes
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineCallListener;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
@@ -45,12 +46,17 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
   protected final Optional<MergeContext> mergeContextOptional;
   protected final Supplier<MergeContext> mergeContext;
   protected final ProtocolContext protocolContext;
+  protected final EngineCallListener engineCallListener;
 
-  protected ExecutionEngineJsonRpcMethod(final Vertx vertx, final ProtocolContext protocolContext) {
+  protected ExecutionEngineJsonRpcMethod(
+      final Vertx vertx,
+      final ProtocolContext protocolContext,
+      final EngineCallListener engineCallListener) {
     this.syncVertx = vertx;
     this.protocolContext = protocolContext;
     this.mergeContextOptional = protocolContext.safeConsensusContext(MergeContext.class);
     this.mergeContext = mergeContextOptional::orElseThrow;
+    this.engineCallListener = engineCallListener;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineCallListener.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineCallListener.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+public interface EngineCallListener {
+  void executionEngineCalled();
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -50,8 +50,9 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
   public EngineForkchoiceUpdated(
       final Vertx vertx,
       final ProtocolContext protocolContext,
-      final MergeMiningCoordinator mergeCoordinator) {
-    super(vertx, protocolContext);
+      final MergeMiningCoordinator mergeCoordinator,
+      final EngineCallListener engineCallListener) {
+    super(vertx, protocolContext, engineCallListener);
     this.mergeCoordinator = mergeCoordinator;
   }
 
@@ -62,6 +63,8 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
 
   @Override
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
+    engineCallListener.executionEngineCalled();
+
     final Object requestId = requestContext.getRequest().getId();
 
     final EngineForkchoiceUpdatedParameter forkChoice =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayload.java
@@ -43,8 +43,9 @@ public class EngineGetPayload extends ExecutionEngineJsonRpcMethod {
   public EngineGetPayload(
       final Vertx vertx,
       final ProtocolContext protocolContext,
-      final BlockResultFactory blockResultFactory) {
-    super(vertx, protocolContext);
+      final BlockResultFactory blockResultFactory,
+      final EngineCallListener engineCallListener) {
+    super(vertx, protocolContext, engineCallListener);
     this.blockResultFactory = blockResultFactory;
   }
 
@@ -55,6 +56,8 @@ public class EngineGetPayload extends ExecutionEngineJsonRpcMethod {
 
   @Override
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext request) {
+    engineCallListener.executionEngineCalled();
+
     final PayloadIdentifier payloadId = request.getRequiredParameter(0, PayloadIdentifier.class);
 
     final Optional<Block> block = mergeContext.get().retrieveBlockById(payloadId);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -73,8 +73,9 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
       final Vertx vertx,
       final ProtocolContext protocolContext,
       final MergeMiningCoordinator mergeCoordinator,
-      final EthPeers ethPeers) {
-    super(vertx, protocolContext);
+      final EthPeers ethPeers,
+      final EngineCallListener engineCallListener) {
+    super(vertx, protocolContext, engineCallListener);
     this.mergeCoordinator = mergeCoordinator;
     this.ethPeers = ethPeers;
   }
@@ -86,6 +87,8 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
 
   @Override
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
+    engineCallListener.executionEngineCalled();
+
     final EnginePayloadParameter blockParam =
         requestContext.getRequiredParameter(0, EnginePayloadParameter.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.QosTimer;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EngineQosTimer implements EngineCallListener {
+  static final long QOS_TIMEOUT_MILLIS = 120000L;
+  private static final Logger LOG = LoggerFactory.getLogger(EngineQosTimer.class);
+
+  private final QosTimer qosTimer;
+
+  public EngineQosTimer(final Vertx vertx) {
+    qosTimer = new QosTimer(vertx, QOS_TIMEOUT_MILLIS, lastCall -> logTimeoutWarning());
+    qosTimer.resetTimer();
+  }
+
+  @Override
+  public void executionEngineCalled() {
+    getQosTimer().resetTimer();
+  }
+
+  public void logTimeoutWarning() {
+    LOG.warn(
+        "Execution engine not called in {} seconds, consensus client may not be connected",
+        QOS_TIMEOUT_MILLIS / 1000L);
+  }
+
+  @VisibleForTesting
+  public QosTimer getQosTimer() {
+    return qosTimer;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineE
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdated;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayload;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayload;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineQosTimer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -62,17 +63,26 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   @Override
   protected Map<String, JsonRpcMethod> create() {
+    final EngineQosTimer engineQosTimer = new EngineQosTimer(consensusEngineServer);
+
     if (mergeCoordinator.isPresent()) {
       return mapOf(
-          new EngineGetPayload(consensusEngineServer, protocolContext, blockResultFactory),
+          new EngineGetPayload(
+              consensusEngineServer, protocolContext, blockResultFactory, engineQosTimer),
           new EngineNewPayload(
-              consensusEngineServer, protocolContext, mergeCoordinator.get(), ethPeers),
+              consensusEngineServer,
+              protocolContext,
+              mergeCoordinator.get(),
+              ethPeers,
+              engineQosTimer),
           new EngineForkchoiceUpdated(
-              consensusEngineServer, protocolContext, mergeCoordinator.get()),
-          new EngineExchangeTransitionConfiguration(consensusEngineServer, protocolContext));
+              consensusEngineServer, protocolContext, mergeCoordinator.get(), engineQosTimer),
+          new EngineExchangeTransitionConfiguration(
+              consensusEngineServer, protocolContext, engineQosTimer));
     } else {
       return mapOf(
-          new EngineExchangeTransitionConfiguration(consensusEngineServer, protocolContext));
+          new EngineExchangeTransitionConfiguration(
+              consensusEngineServer, protocolContext, engineQosTimer));
     }
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Executi
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,11 +78,14 @@ public class EngineForkchoiceUpdatedTest {
 
   @Mock private MutableBlockchain blockchain;
 
+  @Mock private EngineCallListener engineCallListener;
+
   @Before
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
-    this.method = new EngineForkchoiceUpdated(vertx, protocolContext, mergeCoordinator);
+    this.method =
+        new EngineForkchoiceUpdated(vertx, protocolContext, mergeCoordinator, engineCallListener);
   }
 
   @Test
@@ -189,6 +193,7 @@ public class EngineForkchoiceUpdatedTest {
     assertThat(resp.getPayloadStatus().getLatestValidHash().get()).isEqualTo(parent.getBlockHash());
     assertThat(resp.getPayloadStatus().getError())
         .isEqualTo("new head timestamp not greater than parent");
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -255,6 +260,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -276,6 +282,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -300,6 +307,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -327,6 +335,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -351,6 +360,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -376,6 +386,7 @@ public class EngineForkchoiceUpdatedTest {
             Optional.empty());
 
     assertInvalidForkchoiceState(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -412,6 +423,8 @@ public class EngineForkchoiceUpdatedTest {
     assertThat(forkchoiceRes.getPayloadStatus().getLatestValidHashAsString())
         .isEqualTo(mockHeader.getHash().toHexString());
     assertThat(forkchoiceRes.getPayloadId()).isNull();
+    assertThat(forkchoiceRes.getPayloadId()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   private EngineUpdateForkchoiceResult assertSuccessWithPayloadForForkchoiceResult(
@@ -463,6 +476,8 @@ public class EngineForkchoiceUpdatedTest {
                 ? Optional.empty()
                 : Optional.of(fcuParam.getFinalizedBlockHash()),
             fcuParam.getSafeBlockHash());
+
+    verify(engineCallListener, times(1)).executionEngineCalled();
 
     return res;
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
@@ -15,6 +15,8 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
@@ -63,11 +65,13 @@ public class EngineGetPayloadTest {
 
   @Mock private MergeContext mergeContext;
 
+  @Mock private EngineCallListener engineCallListener;
+
   @Before
   public void before() {
     when(mergeContext.retrieveBlockById(mockPid)).thenReturn(Optional.of(mockBlock));
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
-    this.method = new EngineGetPayload(vertx, protocolContext, factory);
+    this.method = new EngineGetPayload(vertx, protocolContext, factory, engineCallListener);
   }
 
   @Test
@@ -90,12 +94,14 @@ public class EngineGetPayloadTest {
               assertThat(res.getPrevRandao())
                   .isEqualTo(mockHeader.getPrevRandao().map(Bytes32::toString).orElse(""));
             });
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
   public void shouldFailForUnknownPayloadId() {
     var resp = resp(PayloadIdentifier.forPayloadParams(Hash.ZERO, 0L));
     assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   private JsonRpcResponse resp(final PayloadIdentifier pid) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,12 +84,16 @@ public class EngineNewPayloadTest {
 
   @Mock private EthPeers ethPeers;
 
+  @Mock private EngineCallListener engineCallListener;
+
   @Before
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     when(ethPeers.peerCount()).thenReturn(1);
-    this.method = new EngineNewPayload(vertx, protocolContext, mergeCoordinator, ethPeers);
+    this.method =
+        new EngineNewPayload(
+            vertx, protocolContext, mergeCoordinator, ethPeers, engineCallListener);
   }
 
   @Test
@@ -116,6 +121,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash().get()).isEqualTo(mockHeader.getHash());
     assertThat(res.getStatusAsString()).isEqualTo(VALID.name());
     assertThat(res.getError()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -136,6 +142,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash().get()).isEqualTo(mockHash);
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
     assertThat(res.getError()).isEqualTo("error 42");
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -155,6 +162,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash()).isEmpty();
     assertThat(res.getStatusAsString()).isEqualTo(ACCEPTED.name());
     assertThat(res.getError()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -171,6 +179,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash().get()).isEqualTo(mockHeader.getHash());
     assertThat(res.getStatusAsString()).isEqualTo(VALID.name());
     assertThat(res.getError()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -188,6 +197,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash()).isEqualTo(Optional.of(Hash.ZERO));
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
     verify(mergeCoordinator, atLeastOnce()).addBadBlock(any());
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -205,6 +215,7 @@ public class EngineNewPayloadTest {
     EnginePayloadStatusResult res = fromSuccessResp(resp);
     assertThat(res.getLatestValidHash()).isEqualTo(Optional.of(latestValidHash));
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -223,6 +234,7 @@ public class EngineNewPayloadTest {
     var resp = resp(mockPayload(mockHeader, Collections.emptyList()));
 
     fromErrorResp(resp);
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -234,6 +246,7 @@ public class EngineNewPayloadTest {
     EnginePayloadStatusResult res = fromSuccessResp(resp);
     assertThat(res.getLatestValidHash()).isEmpty();
     assertThat(res.getStatusAsString()).isEqualTo(INVALID_BLOCK_HASH.name());
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -247,6 +260,7 @@ public class EngineNewPayloadTest {
     EnginePayloadStatusResult res = fromSuccessResp(resp);
     assertThat(res.getLatestValidHash()).isEmpty();
     assertThat(res.getStatusAsString()).isEqualTo(INVALID_BLOCK_HASH.name());
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -261,6 +275,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash().get()).isEqualTo(mockHash);
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
     assertThat(res.getError()).isEqualTo("Failed to decode transactions from block parameter");
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -282,6 +297,7 @@ public class EngineNewPayloadTest {
     var payloadStatusResult = (EnginePayloadStatusResult) res;
     assertThat(payloadStatusResult.getStatus()).isEqualTo(INVALID);
     assertThat(payloadStatusResult.getError()).isEqualTo("block timestamp not greater than parent");
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -297,6 +313,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getError()).isNull();
     assertThat(res.getStatusAsString()).isEqualTo(SYNCING.name());
     assertThat(res.getLatestValidHash()).isEmpty();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -310,6 +327,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash()).isEmpty();
     assertThat(res.getStatusAsString()).isEqualTo(SYNCING.name());
     assertThat(res.getError()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -331,6 +349,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash()).isEmpty();
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
     assertThat(res.getError()).isEqualTo("Field extraData must not be null");
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   @Test
@@ -344,6 +363,7 @@ public class EngineNewPayloadTest {
     assertThat(res.getLatestValidHash()).contains(Hash.ZERO);
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
     assertThat(res.getError()).isNull();
+    verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
   private JsonRpcResponse resp(final EnginePayloadParameter payload) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
@@ -26,6 +26,7 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,12 +34,17 @@ import org.junit.runner.RunWith;
 @RunWith(VertxUnitRunner.class)
 public class EngineQosTimerTest {
   private EngineQosTimer engineQosTimer;
-
-  private static final Vertx vertx = Vertx.vertx();
+  private Vertx vertx;
 
   @Before
   public void setUp() throws Exception {
+    vertx = Vertx.vertx();
     engineQosTimer = new EngineQosTimer(vertx);
+  }
+
+  @After
+  public void cleanUp() {
+    vertx.close();
   }
 
   @Test
@@ -60,12 +66,12 @@ public class EngineQosTimerTest {
           try {
             // once on construction, once on call:
             verify(spyTimer, times(2)).resetTimer();
+            // should not warn
+            verify(spyEngineQosTimer, never()).logTimeoutWarning();
+            async.complete();
           } catch (Exception ex) {
             ctx.fail(ex);
           }
-          // should not warn
-          verify(spyEngineQosTimer, never()).logTimeoutWarning();
-          async.complete();
         });
   }
 
@@ -85,12 +91,12 @@ public class EngineQosTimerTest {
           try {
             // once on construction:
             verify(spyTimer, times(1)).resetTimer();
+            // should warn
+            verify(spyEngineQosTimer, times(1)).logTimeoutWarning();
+            async.complete();
           } catch (Exception ex) {
             ctx.fail(ex);
           }
-          // should warn
-          verify(spyEngineQosTimer, times(1)).logTimeoutWarning();
-          async.complete();
         });
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
@@ -14,10 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -65,8 +65,7 @@ public class EngineQosTimerTest {
         100L,
         z -> {
           try {
-            // once on construction, once on call:
-            verify(spyTimer, times(2)).resetTimer();
+            verify(spyTimer, atLeast(2)).resetTimer();
             // should not warn
             verify(spyEngineQosTimer, never()).logTimeoutWarning();
             async.complete();
@@ -90,8 +89,7 @@ public class EngineQosTimerTest {
         100L,
         z -> {
           try {
-            // once on construction:
-            verify(spyTimer, times(1)).resetTimer();
+            verify(spyTimer, atLeastOnce()).resetTimer();
             // should warn
             verify(spyEngineQosTimer, atLeastOnce()).logTimeoutWarning();
             async.complete();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.QosTimer;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class EngineQosTimerTest {
+  private EngineQosTimer engineQosTimer;
+
+  private static final Vertx vertx = Vertx.vertx();
+
+  @Before
+  public void setUp() throws Exception {
+    engineQosTimer = new EngineQosTimer(vertx);
+  }
+
+  @Test
+  public void shouldNotWarnWhenCalledWithinTimeout(final TestContext ctx) {
+    final long TEST_QOS_TIMEOUT = 75L;
+    final Async async = ctx.async();
+    final var spyEngineQosTimer = spy(engineQosTimer);
+    final var spyTimer =
+        spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> spyEngineQosTimer.logTimeoutWarning()));
+    spyTimer.resetTimer();
+    when(spyEngineQosTimer.getQosTimer()).thenReturn(spyTimer);
+
+    // call executionEngineCalled() 50 milliseconds hence to reset our QoS timer
+    vertx.setTimer(50L, z -> spyEngineQosTimer.executionEngineCalled());
+
+    vertx.setTimer(
+        100L,
+        z -> {
+          try {
+            // once on construction, once on call:
+            verify(spyTimer, times(2)).resetTimer();
+          } catch (Exception ex) {
+            ctx.fail(ex);
+          }
+          // should not warn
+          verify(spyEngineQosTimer, never()).logTimeoutWarning();
+          async.complete();
+        });
+  }
+
+  @Test
+  public void shouldWarnWhenNotCalledWithinTimeout(final TestContext ctx) {
+    final long TEST_QOS_TIMEOUT = 75L;
+    final Async async = ctx.async();
+    final var spyEngineQosTimer = spy(engineQosTimer);
+    final var spyTimer =
+        spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> spyEngineQosTimer.logTimeoutWarning()));
+    spyTimer.resetTimer();
+    when(spyEngineQosTimer.getQosTimer()).thenReturn(spyTimer);
+
+    vertx.setTimer(
+        100L,
+        z -> {
+          try {
+            // once on construction:
+            verify(spyTimer, times(1)).resetTimer();
+          } catch (Exception ex) {
+            ctx.fail(ex);
+          }
+          // should warn
+          verify(spyEngineQosTimer, times(1)).logTimeoutWarning();
+          async.complete();
+        });
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -92,7 +93,7 @@ public class EngineQosTimerTest {
             // once on construction:
             verify(spyTimer, times(1)).resetTimer();
             // should warn
-            verify(spyEngineQosTimer, times(1)).logTimeoutWarning();
+            verify(spyEngineQosTimer, atLeastOnce()).logTimeoutWarning();
             async.complete();
           } catch (Exception ex) {
             ctx.fail(ex);


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Resets engine QoS timer with every call to the engine API instead of only when `ExchangeTransitionConfiguration` is called. `ExchangeTransitionConfiguration` mismatch will only submit a debug log not a warning anymore.

## Fixed Issue(s)
fixes #4404

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).