### PR TITLE
Create a new flag on RocksDB for high spec hardware to boost performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Resets engine QoS timer with every call to the engine API instead of only when ExchangeTransitionConfiguration is called [#4411](https://github.com/hyperledger/besu/issues/4411)
 - ExchangeTransitionConfiguration mismatch will only submit a debug log not a warning anymore [#4411](https://github.com/hyperledger/besu/issues/4411)
 - Upgrade besu-native to 0.6.1 and include linux arm64 build of bls12-381 [#4416](https://github.com/hyperledger/besu/pull/4416)
-
+- Create a new flag on RocksDB (_--Xplugin-rocksdb-high-spec-enabled_) for high spec hardware to boost performance
 ### Bug Fixes
 - Retry block creation if there is a transient error and we still have time, to mitigate empty block issue [#4407](https://github.com/hyperledger/besu/pull/4407)
 - Fix StacklessClosedChannelException in Besu and resulted timeout errors in CL clients ([#4398](https://github.com/hyperledger/besu/issues/4398), [#4400](https://github.com/hyperledger/besu/issues/4400))

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/privacy/PrivacyNode.java
@@ -15,6 +15,11 @@
 package org.hyperledger.besu.tests.acceptance.dsl.privacy;
 
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 
 import org.hyperledger.besu.crypto.KeyPairUtil;
 import org.hyperledger.besu.datatypes.Address;
@@ -65,10 +70,6 @@ import org.testcontainers.containers.Network;
 public class PrivacyNode implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyNode.class);
-  private static final int MAX_OPEN_FILES = 1024;
-  private static final long CACHE_CAPACITY = 8388608;
-  private static final int MAX_BACKGROUND_COMPACTIONS = 4;
-  private static final int BACKGROUND_THREAD_COUNT = 4;
 
   private final EnclaveTestHarness enclave;
   private final BesuNode besu;
@@ -275,10 +276,11 @@ public class PrivacyNode implements AutoCloseable {
                 new RocksDBKeyValueStorageFactory(
                     () ->
                         new RocksDBFactoryConfiguration(
-                            MAX_OPEN_FILES,
-                            MAX_BACKGROUND_COMPACTIONS,
-                            BACKGROUND_THREAD_COUNT,
-                            CACHE_CAPACITY),
+                            DEFAULT_MAX_OPEN_FILES,
+                            DEFAULT_MAX_BACKGROUND_COMPACTIONS,
+                            DEFAULT_BACKGROUND_THREAD_COUNT,
+                            DEFAULT_CACHE_CAPACITY,
+                            DEFAULT_IS_HIGH_SPEC),
                     Arrays.asList(KeyValueSegmentIdentifier.values()),
                     RocksDBMetricsFactory.PRIVATE_ROCKS_DB_METRICS)))
         .withCommonConfiguration(new BesuConfigurationImpl(dataLocation, dbLocation))

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -17,6 +17,11 @@ package org.hyperledger.besu;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.core.PrivacyParameters.DEFAULT_PRIVACY;
 import static org.hyperledger.besu.ethereum.core.PrivacyParameters.FLEXIBLE_PRIVACY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.controller.BesuController;
@@ -61,10 +66,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PrivacyTest {
 
-  private static final int MAX_OPEN_FILES = 1024;
-  private static final long CACHE_CAPACITY = 8388608;
-  private static final int MAX_BACKGROUND_COMPACTIONS = 4;
-  private static final int BACKGROUND_THREAD_COUNT = 4;
   private final Vertx vertx = Vertx.vertx();
 
   @Rule public final TemporaryFolder folder = new TemporaryFolder();
@@ -131,10 +132,11 @@ public class PrivacyTest {
                 new RocksDBKeyValueStorageFactory(
                     () ->
                         new RocksDBFactoryConfiguration(
-                            MAX_OPEN_FILES,
-                            MAX_BACKGROUND_COMPACTIONS,
-                            BACKGROUND_THREAD_COUNT,
-                            CACHE_CAPACITY),
+                            DEFAULT_MAX_OPEN_FILES,
+                            DEFAULT_MAX_BACKGROUND_COMPACTIONS,
+                            DEFAULT_BACKGROUND_THREAD_COUNT,
+                            DEFAULT_CACHE_CAPACITY,
+                            DEFAULT_IS_HIGH_SPEC),
                     Arrays.asList(KeyValueSegmentIdentifier.values()),
                     RocksDBMetricsFactory.PRIVATE_ROCKS_DB_METRICS)))
         .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -17,6 +17,11 @@ package org.hyperledger.besu;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.cli.config.NetworkName.DEV;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.config.GenesisConfigFile;
@@ -101,11 +106,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 /** Tests for {@link Runner}. */
 @RunWith(MockitoJUnitRunner.class)
 public final class RunnerTest {
-
-  private static final int MAX_OPEN_FILES = 1024;
-  private static final long CACHE_CAPACITY = 8388608;
-  private static final int MAX_BACKGROUND_COMPACTIONS = 4;
-  private static final int BACKGROUND_THREAD_COUNT = 4;
 
   private Vertx vertx;
 
@@ -415,10 +415,11 @@ public final class RunnerTest {
             new RocksDBKeyValueStorageFactory(
                 () ->
                     new RocksDBFactoryConfiguration(
-                        MAX_OPEN_FILES,
-                        MAX_BACKGROUND_COMPACTIONS,
-                        BACKGROUND_THREAD_COUNT,
-                        CACHE_CAPACITY),
+                        DEFAULT_MAX_OPEN_FILES,
+                        DEFAULT_MAX_BACKGROUND_COMPACTIONS,
+                        DEFAULT_BACKGROUND_THREAD_COUNT,
+                        DEFAULT_CACHE_CAPACITY,
+                        DEFAULT_IS_HIGH_SPEC),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
         .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))

--- a/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
+++ b/ethereum/eth/src/jmh/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStateDownloaderBenchmark.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.worldstate;
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryWorldStateArchive;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 
@@ -167,7 +168,8 @@ public class WorldStateDownloaderBenchmark {
                         DEFAULT_MAX_OPEN_FILES,
                         DEFAULT_MAX_BACKGROUND_COMPACTIONS,
                         DEFAULT_BACKGROUND_THREAD_COUNT,
-                        DEFAULT_CACHE_CAPACITY),
+                        DEFAULT_CACHE_CAPACITY,
+                        DEFAULT_IS_HIGH_SPEC),
                 Arrays.asList(KeyValueSegmentIdentifier.values()),
                 RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
         .withCommonConfiguration(new BesuConfigurationImpl(dataDir, dbDir))

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBCLIOptions.java
@@ -23,13 +23,15 @@ public class RocksDBCLIOptions {
   public static final long DEFAULT_CACHE_CAPACITY = 134217728;
   public static final int DEFAULT_MAX_BACKGROUND_COMPACTIONS = 4;
   public static final int DEFAULT_BACKGROUND_THREAD_COUNT = 4;
+  public static final boolean DEFAULT_IS_HIGH_SPEC = false;
 
-  private static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
-  private static final String CACHE_CAPACITY_FLAG = "--Xplugin-rocksdb-cache-capacity";
-  private static final String MAX_BACKGROUND_COMPACTIONS_FLAG =
+  public static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
+  public static final String CACHE_CAPACITY_FLAG = "--Xplugin-rocksdb-cache-capacity";
+  public static final String MAX_BACKGROUND_COMPACTIONS_FLAG =
       "--Xplugin-rocksdb-max-background-compactions";
-  private static final String BACKGROUND_THREAD_COUNT_FLAG =
+  public static final String BACKGROUND_THREAD_COUNT_FLAG =
       "--Xplugin-rocksdb-background-thread-count";
+  public static final String IS_HIGH_SPEC = "--Xplugin-rocksdb-high-spec-enabled";
 
   @CommandLine.Option(
       names = {MAX_OPEN_FILES_FLAG},
@@ -63,6 +65,15 @@ public class RocksDBCLIOptions {
       description = "Number of RocksDB background threads (default: ${DEFAULT-VALUE})")
   int backgroundThreadCount;
 
+  @CommandLine.Option(
+      names = {IS_HIGH_SPEC},
+      hidden = true,
+      paramLabel = "<BOOLEAN>",
+      description =
+          "Use this flag to boost Besu performance if you have a 16 GiB RAM hardware or more (default: ${DEFAULT-VALUE})",
+      arity = "0")
+  boolean isHighSpec;
+
   private RocksDBCLIOptions() {}
 
   public static RocksDBCLIOptions create() {
@@ -75,12 +86,13 @@ public class RocksDBCLIOptions {
     options.cacheCapacity = config.getCacheCapacity();
     options.maxBackgroundCompactions = config.getMaxBackgroundCompactions();
     options.backgroundThreadCount = config.getBackgroundThreadCount();
+    options.isHighSpec = config.isHighSpec();
     return options;
   }
 
   public RocksDBFactoryConfiguration toDomainObject() {
     return new RocksDBFactoryConfiguration(
-        maxOpenFiles, maxBackgroundCompactions, backgroundThreadCount, cacheCapacity);
+        maxOpenFiles, maxBackgroundCompactions, backgroundThreadCount, cacheCapacity, isHighSpec);
   }
 
   @Override
@@ -90,6 +102,7 @@ public class RocksDBCLIOptions {
         .add("cacheCapacity", cacheCapacity)
         .add("maxBackgroundCompactions", maxBackgroundCompactions)
         .add("backgroundThreadCount", backgroundThreadCount)
+        .add("isHighSpec", isHighSpec)
         .toString();
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfiguration.java
@@ -24,6 +24,7 @@ public class RocksDBConfiguration {
   private final int maxBackgroundCompactions;
   private final int backgroundThreadCount;
   private final long cacheCapacity;
+  private final boolean isHighSpec;
 
   public RocksDBConfiguration(
       final Path databaseDir,
@@ -31,13 +32,15 @@ public class RocksDBConfiguration {
       final int maxBackgroundCompactions,
       final int backgroundThreadCount,
       final long cacheCapacity,
-      final String label) {
+      final String label,
+      final boolean isHighSpec) {
     this.maxBackgroundCompactions = maxBackgroundCompactions;
     this.backgroundThreadCount = backgroundThreadCount;
     this.databaseDir = databaseDir;
     this.maxOpenFiles = maxOpenFiles;
     this.cacheCapacity = cacheCapacity;
     this.label = label;
+    this.isHighSpec = isHighSpec;
   }
 
   public Path getDatabaseDir() {
@@ -62,5 +65,9 @@ public class RocksDBConfiguration {
 
   public String getLabel() {
     return label;
+  }
+
+  public boolean isHighSpec() {
+    return isHighSpec;
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.plugin.services.storage.rocksdb.configuration;
 
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
 
@@ -29,6 +30,7 @@ public class RocksDBConfigurationBuilder {
   private long cacheCapacity = DEFAULT_CACHE_CAPACITY;
   private int maxBackgroundCompactions = DEFAULT_MAX_BACKGROUND_COMPACTIONS;
   private int backgroundThreadCount = DEFAULT_BACKGROUND_THREAD_COUNT;
+  private boolean isHighSpec = DEFAULT_IS_HIGH_SPEC;
 
   public RocksDBConfigurationBuilder databaseDir(final Path databaseDir) {
     this.databaseDir = databaseDir;
@@ -60,12 +62,18 @@ public class RocksDBConfigurationBuilder {
     return this;
   }
 
+  public RocksDBConfigurationBuilder isHighSpec(final boolean isHighSpec) {
+    this.isHighSpec = isHighSpec;
+    return this;
+  }
+
   public static RocksDBConfigurationBuilder from(final RocksDBFactoryConfiguration configuration) {
     return new RocksDBConfigurationBuilder()
         .backgroundThreadCount(configuration.getBackgroundThreadCount())
         .cacheCapacity(configuration.getCacheCapacity())
         .maxBackgroundCompactions(configuration.getMaxBackgroundCompactions())
-        .maxOpenFiles(configuration.getMaxOpenFiles());
+        .maxOpenFiles(configuration.getMaxOpenFiles())
+        .isHighSpec(configuration.isHighSpec());
   }
 
   public RocksDBConfiguration build() {
@@ -75,6 +83,7 @@ public class RocksDBConfigurationBuilder {
         maxBackgroundCompactions,
         backgroundThreadCount,
         cacheCapacity,
-        label);
+        label,
+        isHighSpec);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBFactoryConfiguration.java
@@ -20,16 +20,19 @@ public class RocksDBFactoryConfiguration {
   private final int maxBackgroundCompactions;
   private final int backgroundThreadCount;
   private final long cacheCapacity;
+  private final boolean isHighSpec;
 
   public RocksDBFactoryConfiguration(
       final int maxOpenFiles,
       final int maxBackgroundCompactions,
       final int backgroundThreadCount,
-      final long cacheCapacity) {
+      final long cacheCapacity,
+      final boolean isHighSpec) {
     this.maxBackgroundCompactions = maxBackgroundCompactions;
     this.backgroundThreadCount = backgroundThreadCount;
     this.maxOpenFiles = maxOpenFiles;
     this.cacheCapacity = cacheCapacity;
+    this.isHighSpec = isHighSpec;
   }
 
   public int getMaxOpenFiles() {
@@ -46,5 +49,9 @@ public class RocksDBFactoryConfiguration {
 
   public long getCacheCapacity() {
     return cacheCapacity;
+  }
+
+  public boolean isHighSpec() {
+    return isHighSpec;
   }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBCLIOptionsTest.java
@@ -15,10 +15,15 @@
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.CACHE_CAPACITY_FLAG;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_BACKGROUND_THREAD_COUNT;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_CACHE_CAPACITY;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_IS_HIGH_SPEC;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_BACKGROUND_COMPACTIONS;
 import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.DEFAULT_MAX_OPEN_FILES;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.IS_HIGH_SPEC;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_BACKGROUND_COMPACTIONS_FLAG;
+import static org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions.MAX_OPEN_FILES_FLAG;
 
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBCLIOptions;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
@@ -28,18 +33,11 @@ import picocli.CommandLine;
 
 public class RocksDBCLIOptionsTest {
 
-  private static final String MAX_OPEN_FILES_FLAG = "--Xplugin-rocksdb-max-open-files";
-  private static final String CACHE_CAPACITY_FLAG = "--Xplugin-rocksdb-cache-capacity";
-  private static final String MAX_BACKGROUND_COMPACTIONS_FLAG =
-      "--Xplugin-rocksdb-max-background-compactions";
-  private static final String BACKGROUND_THREAD_COUNT_FLAG =
-      "--Xplugin-rocksdb-background-thread-count";
-
   @Test
   public void defaultValues() {
     final RocksDBCLIOptions options = RocksDBCLIOptions.create();
 
-    new CommandLine(options).parse();
+    new CommandLine(options).parseArgs();
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
     assertThat(configuration).isNotNull();
@@ -48,6 +46,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getMaxBackgroundCompactions())
         .isEqualTo(DEFAULT_MAX_BACKGROUND_COMPACTIONS);
     assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 
   @Test
@@ -56,7 +55,8 @@ public class RocksDBCLIOptionsTest {
     final int expectedBackgroundThreadCount = 99;
 
     new CommandLine(options)
-        .parse(BACKGROUND_THREAD_COUNT_FLAG, "" + expectedBackgroundThreadCount);
+        .parseArgs(
+            RocksDBCLIOptions.BACKGROUND_THREAD_COUNT_FLAG, "" + expectedBackgroundThreadCount);
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
     assertThat(configuration).isNotNull();
@@ -65,6 +65,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getMaxBackgroundCompactions())
         .isEqualTo(DEFAULT_MAX_BACKGROUND_COMPACTIONS);
     assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 
   @Test
@@ -72,7 +73,7 @@ public class RocksDBCLIOptionsTest {
     final RocksDBCLIOptions options = RocksDBCLIOptions.create();
     final long expectedCacheCapacity = 400050006000L;
 
-    new CommandLine(options).parse(CACHE_CAPACITY_FLAG, "" + expectedCacheCapacity);
+    new CommandLine(options).parseArgs(CACHE_CAPACITY_FLAG, "" + expectedCacheCapacity);
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
     assertThat(configuration).isNotNull();
@@ -81,6 +82,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getMaxBackgroundCompactions())
         .isEqualTo(DEFAULT_MAX_BACKGROUND_COMPACTIONS);
     assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 
   @Test
@@ -89,7 +91,7 @@ public class RocksDBCLIOptionsTest {
     final int expectedMaxBackgroundCompactions = 223344;
 
     new CommandLine(options)
-        .parse(MAX_BACKGROUND_COMPACTIONS_FLAG, "" + expectedMaxBackgroundCompactions);
+        .parseArgs(MAX_BACKGROUND_COMPACTIONS_FLAG, "" + expectedMaxBackgroundCompactions);
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
     assertThat(configuration).isNotNull();
@@ -98,6 +100,7 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getMaxBackgroundCompactions())
         .isEqualTo(expectedMaxBackgroundCompactions);
     assertThat(configuration.getMaxOpenFiles()).isEqualTo(DEFAULT_MAX_OPEN_FILES);
+    assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
   }
 
   @Test
@@ -105,7 +108,7 @@ public class RocksDBCLIOptionsTest {
     final RocksDBCLIOptions options = RocksDBCLIOptions.create();
     final int expectedMaxOpenFiles = 65;
 
-    new CommandLine(options).parse(MAX_OPEN_FILES_FLAG, "" + expectedMaxOpenFiles);
+    new CommandLine(options).parseArgs(MAX_OPEN_FILES_FLAG, "" + expectedMaxOpenFiles);
 
     final RocksDBFactoryConfiguration configuration = options.toDomainObject();
     assertThat(configuration).isNotNull();
@@ -114,5 +117,21 @@ public class RocksDBCLIOptionsTest {
     assertThat(configuration.getMaxBackgroundCompactions())
         .isEqualTo(DEFAULT_MAX_BACKGROUND_COMPACTIONS);
     assertThat(configuration.getMaxOpenFiles()).isEqualTo(expectedMaxOpenFiles);
+    assertThat(configuration.isHighSpec()).isEqualTo(DEFAULT_IS_HIGH_SPEC);
+  }
+
+  @Test
+  public void customIsHighSpec() {
+    final RocksDBCLIOptions options = RocksDBCLIOptions.create();
+
+    new CommandLine(options).parseArgs(IS_HIGH_SPEC);
+
+    final RocksDBFactoryConfiguration configuration = options.toDomainObject();
+    assertThat(configuration).isNotNull();
+    assertThat(configuration.getBackgroundThreadCount()).isEqualTo(DEFAULT_BACKGROUND_THREAD_COUNT);
+    assertThat(configuration.getCacheCapacity()).isEqualTo(DEFAULT_CACHE_CAPACITY);
+    assertThat(configuration.getMaxBackgroundCompactions())
+        .isEqualTo(DEFAULT_MAX_BACKGROUND_COMPACTIONS);
+    assertThat(configuration.isHighSpec()).isEqualTo(Boolean.TRUE);
   }
 }


### PR DESCRIPTION
Signed-off-by: Ameziane H <ameziane.hamlat@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Create a new flag on RocksDB (_--Xplugin-rocksdb-high-spec-enabled_) for high spec hardware to boost performance. 
With this first version, the impact is on memory usage, as we're tuning RocksDB block cache and Memtables size. By high spec here, we mean a VM or machine with more than 16 GiB. Other modifications in future may include other resources' requirements but for now, the only requirement is on RAM.

The results are promising on a 32 GiB AWS VM, as this new flag reduces 95 percentile block processing time by 30%.
![image](https://user-images.githubusercontent.com/5099602/191719256-14a0b56d-9fa7-4164-aada-b472fcf8adf7.png)

Performance improvements may appear in a couple of hours because of cache warm up time, as we can notice with RocksDB block cache hit ratio and RocksDB get time :

![image](https://user-images.githubusercontent.com/5099602/191847101-1093cc5f-60e7-466f-b6de-7fed273c8a15.png)
![image](https://user-images.githubusercontent.com/5099602/191847138-0d4c95ac-122c-4c5c-b61c-ae71de3a5301.png)

 
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).