### PR TITLE
add engine_preparePayload_debug endpoint

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -58,7 +58,7 @@ public enum RpcMethod {
   ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1("engine_getPayloadBodiesByHashV1"),
   ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1("engine_getPayloadBodiesByRangeV1"),
   ENGINE_EXCHANGE_CAPABILITIES("engine_exchangeCapabilities"),
-
+  ENGINE_PREPARE_PAYLOAD_DEBUG("engine_preparePayload_debug"),
   PRIV_CALL("priv_call"),
   PRIV_GET_PRIVATE_TRANSACTION("priv_getPrivateTransaction"),
   PRIV_GET_TRANSACTION_COUNT("priv_getTransactionCount"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.ENGINE_EXCHANGE_CAPABILITIES;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod.ENGINE_PREPARE_PAYLOAD_DEBUG;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -61,6 +62,7 @@ public class EngineExchangeCapabilities extends ExecutionEngineJsonRpcMethod {
         Stream.of(RpcMethod.values())
             .filter(e -> e.getMethodName().startsWith("engine_"))
             .filter(e -> !e.equals(ENGINE_EXCHANGE_CAPABILITIES))
+            .filter(e -> !e.equals(ENGINE_PREPARE_PAYLOAD_DEBUG))
             .map(RpcMethod::getMethodName)
             .collect(Collectors.toList());
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Hyperledger Besu
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,19 +14,23 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
+import static java.util.stream.Collectors.toList;
+
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePreparePayloadParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.WithdrawalParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePreparePayloadResult;
+import org.hyperledger.besu.ethereum.core.Withdrawal;
 
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
@@ -54,6 +58,10 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
         requestContext.getRequiredParameter(0, EnginePreparePayloadParameter.class);
 
     // TODO: respond with error if we're syncing
+    final List<Withdrawal> withdrawals =
+        enginePreparePayloadParameter.getWithdrawals().stream()
+            .map(WithdrawalParameter::toWithdrawal)
+            .collect(toList());
 
     return enginePreparePayloadParameter
         .getParentHash()
@@ -71,7 +79,7 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
                                 .orElse(parentHeader.getTimestamp() + 1L),
                             enginePreparePayloadParameter.getPrevRandao(),
                             enginePreparePayloadParameter.getFeeRecipient(),
-                            Optional.of(Collections.emptyList())))))
+                            Optional.of(withdrawals)))))
         .orElseGet(
             () ->
                 new JsonRpcErrorResponse(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -59,7 +59,15 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
   @Override
   public JsonRpcResponse syncResponse(final JsonRpcRequestContext requestContext) {
     final EnginePreparePayloadParameter enginePreparePayloadParameter =
-        requestContext.getRequiredParameter(0, EnginePreparePayloadParameter.class);
+        requestContext
+            .getOptionalParameter(0, EnginePreparePayloadParameter.class)
+            .orElse(
+                new EnginePreparePayloadParameter(
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()));
 
     final var requestId = requestContext.getRequest().getId();
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,15 +35,15 @@ public class EnginePreparePayloadParameter {
   @JsonCreator
   public EnginePreparePayloadParameter(
       @JsonProperty("parentHash") final Optional<Hash> parentHash,
-      @JsonProperty("feeRecipient") final Address feeRecipient,
+      @JsonProperty("feeRecipient") final Optional<Address> feeRecipient,
       @JsonProperty("timestamp") final Optional<UnsignedLongParameter> timestamp,
-      @JsonProperty("prevRandao") final String prevRandao,
-      @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals) {
+      @JsonProperty("prevRandao") final Optional<String> prevRandao,
+      @JsonProperty("withdrawals") final Optional<List<WithdrawalParameter>> withdrawals) {
     this.parentHash = parentHash;
-    this.feeRecipient = feeRecipient;
+    this.feeRecipient = feeRecipient.orElse(Address.ZERO);
     this.timestamp = timestamp.map(UnsignedLongParameter::getValue);
-    this.prevRandao = Bytes32.fromHexStringLenient(prevRandao);
-    this.withdrawals = withdrawals;
+    this.prevRandao = Bytes32.fromHexStringLenient(prevRandao.orElse("deadbeef"));
+    this.withdrawals = withdrawals.orElse(Collections.emptyList());
   }
 
   public Optional<Hash> getParentHash() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.tuweni.bytes.Bytes32;
+
+public class EnginePreparePayloadParameter {
+  private final Optional<Hash> parentHash;
+  private final Address feeRecipient;
+  private final Bytes32 prevRandao;
+  private final Optional<Long> timestamp;
+
+  @JsonCreator
+  public EnginePreparePayloadParameter(
+      @JsonProperty("parentHash") final Optional<Hash> parentHash,
+      @JsonProperty("feeRecipient") final Address feeRecipient,
+      @JsonProperty("timestamp") final Optional<UnsignedLongParameter> timestamp,
+      @JsonProperty("prevRandao") final String prevRandao) {
+    this.parentHash = parentHash;
+    this.feeRecipient = feeRecipient;
+    this.timestamp = timestamp.map(UnsignedLongParameter::getValue);
+    this.prevRandao = Bytes32.fromHexStringLenient(prevRandao);
+  }
+
+  public Optional<Hash> getParentHash() {
+    return parentHash;
+  }
+
+  public Address getFeeRecipient() {
+    return feeRecipient;
+  }
+
+  public Optional<Long> getTimestamp() {
+    return timestamp;
+  }
+
+  public Bytes32 getPrevRandao() {
+    return prevRandao;
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Hyperledger Besu
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,17 +29,20 @@ public class EnginePreparePayloadParameter {
   private final Address feeRecipient;
   private final Bytes32 prevRandao;
   private final Optional<Long> timestamp;
+  final List<WithdrawalParameter> withdrawals;
 
   @JsonCreator
   public EnginePreparePayloadParameter(
       @JsonProperty("parentHash") final Optional<Hash> parentHash,
       @JsonProperty("feeRecipient") final Address feeRecipient,
       @JsonProperty("timestamp") final Optional<UnsignedLongParameter> timestamp,
-      @JsonProperty("prevRandao") final String prevRandao) {
+      @JsonProperty("prevRandao") final String prevRandao,
+      @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals) {
     this.parentHash = parentHash;
     this.feeRecipient = feeRecipient;
     this.timestamp = timestamp.map(UnsignedLongParameter::getValue);
     this.prevRandao = Bytes32.fromHexStringLenient(prevRandao);
+    this.withdrawals = withdrawals;
   }
 
   public Optional<Hash> getParentHash() {
@@ -55,5 +59,9 @@ public class EnginePreparePayloadParameter {
 
   public Bytes32 getPrevRandao() {
     return prevRandao;
+  }
+
+  public List<WithdrawalParameter> getWithdrawals() {
+    return withdrawals;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Hyperledger Besu
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
@@ -15,20 +15,30 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus;
+
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-@JsonPropertyOrder({"payloadId"})
+@JsonPropertyOrder({"status", "payloadId"})
 public class EnginePreparePayloadResult {
+  private final EngineStatus status;
   private final PayloadIdentifier payloadId;
 
-  public EnginePreparePayloadResult(final PayloadIdentifier payloadId) {
+  public EnginePreparePayloadResult(final EngineStatus status, final PayloadIdentifier payloadId) {
+    this.status = status;
     this.payloadId = payloadId;
   }
 
+  @JsonGetter(value = "status")
+  public String getStatus() {
+    return status.name();
+  }
+
   @JsonGetter(value = "payloadId")
-  public String getNumber() {
-    return payloadId.toShortHexString();
+  public String getPayloadId() {
+    return Optional.ofNullable(payloadId).map(PayloadIdentifier::toShortHexString).orElse("");
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
+
+import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"payloadId"})
+public class EnginePreparePayloadResult {
+  private final PayloadIdentifier payloadId;
+
+  public EnginePreparePayloadResult(final PayloadIdentifier payloadId) {
+    this.payloadId = payloadId;
+  }
+
+  @JsonGetter(value = "payloadId")
+  public String getNumber() {
+    return payloadId.toShortHexString();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineG
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadV2;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayloadV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineNewPayloadV2;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EnginePreparePayloadDebug;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineQosTimer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -120,7 +121,9 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
               consensusEngineServer, protocolContext, blockResultFactory, engineQosTimer),
           new EngineGetPayloadBodiesByRangeV1(
               consensusEngineServer, protocolContext, blockResultFactory, engineQosTimer),
-          new EngineExchangeCapabilities(consensusEngineServer, protocolContext, engineQosTimer));
+          new EngineExchangeCapabilities(consensusEngineServer, protocolContext, engineQosTimer),
+          new EnginePreparePayloadDebug(
+              consensusEngineServer, protocolContext, engineQosTimer, mergeCoordinator.get()));
     } else {
       return mapOf(
           new EngineExchangeTransitionConfiguration(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
@@ -1,0 +1,80 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.SYNCING;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod.EngineStatus.VALID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
+import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePreparePayloadParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePreparePayloadResult;
+
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EnginePreparePayloadDebugTest {
+  private static final Vertx vertx = Vertx.vertx();
+  EnginePreparePayloadDebug method;
+  @Mock private ProtocolContext protocolContext;
+  @Mock private EngineCallListener engineCallListener;
+  @Mock private MergeMiningCoordinator mergeCoordinator;
+  @Mock private MergeContext mergeContext;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JsonRpcRequestContext requestContext;
+
+  @Mock private EnginePreparePayloadParameter param;
+
+  @Before
+  public void setUp() {
+    when(protocolContext.safeConsensusContext(MergeContext.class))
+        .thenReturn(Optional.of(mergeContext));
+    when(requestContext.getRequiredParameter(0, EnginePreparePayloadParameter.class))
+        .thenReturn(param);
+    method =
+        spy(
+            new EnginePreparePayloadDebug(
+                vertx, protocolContext, engineCallListener, mergeCoordinator));
+  }
+
+  @Test
+  public void shouldReturnSyncing() {
+    when(mergeContext.isSyncing()).thenReturn(true);
+    var resp = method.syncResponse(requestContext);
+    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+    var result = ((JsonRpcSuccessResponse) resp).getResult();
+    assertThat(result).isInstanceOf(EnginePreparePayloadResult.class);
+    var payloadResult = (EnginePreparePayloadResult) result;
+    assertThat(payloadResult.getStatus()).isEqualTo(SYNCING.name());
+  }
+
+  @Test
+  public void shouldReturnPayloadId() {
+    doAnswer(__ -> Optional.of(new PayloadIdentifier(0xdeadbeefL)))
+        .when(method)
+        .generatePayload(any());
+    var resp = method.syncResponse(requestContext);
+    assertThat(resp).isInstanceOf(JsonRpcSuccessResponse.class);
+    var result = ((JsonRpcSuccessResponse) resp).getResult();
+    assertThat(result).isInstanceOf(EnginePreparePayloadResult.class);
+    var payloadResult = (EnginePreparePayloadResult) result;
+    assertThat(payloadResult.getStatus()).isEqualTo(VALID.name());
+    assertThat(payloadResult.getPayloadId()).isEqualTo("0xdeadbeef");
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
@@ -45,8 +45,8 @@ public class EnginePreparePayloadDebugTest {
   public void setUp() {
     when(protocolContext.safeConsensusContext(MergeContext.class))
         .thenReturn(Optional.of(mergeContext));
-    when(requestContext.getRequiredParameter(0, EnginePreparePayloadParameter.class))
-        .thenReturn(param);
+    when(requestContext.getOptionalParameter(0, EnginePreparePayloadParameter.class))
+        .thenReturn(Optional.of(param));
     method =
         spy(
             new EnginePreparePayloadDebug(
@@ -66,6 +66,17 @@ public class EnginePreparePayloadDebugTest {
 
   @Test
   public void shouldReturnPayloadId() {
+    checkForPayloadId();
+  }
+
+  @Test
+  public void shouldReturnPayloadIdWhenNoParams() {
+    when(requestContext.getOptionalParameter(0, EnginePreparePayloadParameter.class))
+        .thenReturn(Optional.empty());
+    checkForPayloadId();
+  }
+
+  private void checkForPayloadId() {
     doAnswer(__ -> Optional.of(new PayloadIdentifier(0xdeadbeefL)))
         .when(method)
         .generatePayload(any());


### PR DESCRIPTION
## PR description

PR to enable debugging block proposals by re-adding an updated version of the deprecated 
`engine_preparePayload` endpoint

*be sure to use the current or a recent parent blockhash or you will DoS bonsai db*

All fields in the parameter are optional, including the parameter itself

example usage:
```
curl --location --request POST 'http://localhost:8551' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NTkwNDEzMzZ9.4PDdSaG9hFOFR4Th7rEgaKKECsXfz6IPckFRcfSP13o' \
--data-raw '{
    "jsonrpc":"2.0",
    "method":"engine_preparePayload_debug",
    "params":
    [
        {
            "parentHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
            "feeRecipient": "0x0000000000000000000000000000000000000000",
            "timestamp": "0x0",
            "prevRandao": "0x0",
            "withdrawals": []
        }
    ],
    "id":1
}'
```

OR, this usage will use fee recipient 0x00..00, current timestamp, current chain head, "deadbeef" prevrandao, and empty withdrawals:
```
curl --location --request POST 'http://localhost:8551' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2NTkwNDEzMzZ9.4PDdSaG9hFOFR4Th7rEgaKKECsXfz6IPckFRcfSP13o' \
--data-raw '{
    "jsonrpc":"2.0",
    "method":"engine_preparePayload_debug",
    "params":
    [],
    "id":1
}'
```


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).