### PR TITLE
Update Security Policy contact info

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,13 +7,15 @@ hear from you. We will take all security bugs seriously and if confirmed upon in
 patch it within a reasonable amount of time and release a public security bulletin discussing the
 impact and credit the discoverer.
 
-There are two ways to report a security bug. The easiest is to email a description of the flaw and
-any related information (e.g. reproduction steps, version) to
-[security at hyperledger dot org](mailto:security@hyperledger.org).
-
-The other way is to file a confidential security bug in our
-[JIRA bug tracking system](https://jira.hyperledger.org). Be sure to set the “Security Level” to
-“Security issue”.
+When sending information to either of these emails please be sure to include a description of the
+flaw and any related information (e.g. reproduction steps, version, known active use). There are two
+email addresses where Hyperledger Besu accepts security bugs. The
+first, [security "dash" besu at lists dot hyperledger dot org](mailto:security-besu@lists.hyperledger.org)
+is limited to a subset of Hyperledger Besu maintainers and Hyperledger staff. For highly sensitive
+bugs this is a preferred address. The second email
+address [security at hyperledger dot org](mailto:security@hyperledger.org) is limited to a subset of
+maintainers and staff of all Hyperledger projects, and may be viewed by maintainers outside of
+Hyperledger Besu.
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in
 our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,15 +7,15 @@ hear from you. We will take all security bugs seriously and if confirmed upon in
 patch it within a reasonable amount of time and release a public security bulletin discussing the
 impact and credit the discoverer.
 
-When sending information to either of these emails please be sure to include a description of the
-flaw and any related information (e.g. reproduction steps, version, known active use). There are two
-email addresses where Hyperledger Besu accepts security bugs. The
+There are two email addresses where Hyperledger Besu accepts security bugs. The
 first, [security "dash" besu at lists dot hyperledger dot org](mailto:security-besu@lists.hyperledger.org)
 is limited to a subset of Hyperledger Besu maintainers and Hyperledger staff. For highly sensitive
 bugs this is a preferred address. The second email
 address [security at hyperledger dot org](mailto:security@hyperledger.org) is limited to a subset of
 maintainers and staff of all Hyperledger projects, and may be viewed by maintainers outside of
-Hyperledger Besu.
+Hyperledger Besu. When sending information to either of these emails please be sure to include a
+description of the flaw and any related information (e.g. reproduction steps, version, known active
+use).
 
 The process by which the Hyperledger Security Team handles security bugs is documented further in
 our [Defect Response page](https://wiki.hyperledger.org/display/SEC/Defect+Response) on our


### PR DESCRIPTION
## PR description

At the request of the EF, a besu-only security list was created, and is the first listed email.  The out-of-date Jira location is also removed.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).