### PR TITLE
Access fields/methods more directly

### DIFF
--- a/consensus/common/src/test-support/java/org/hyperledger/besu/consensus/common/bft/BftContextBuilder.java
+++ b/consensus/common/src/test-support/java/org/hyperledger/besu/consensus/common/bft/BftContextBuilder.java
@@ -37,7 +37,7 @@ public class BftContextBuilder {
     when(bftContext.getValidatorProvider()).thenReturn(mockValidatorProvider);
     when(mockValidatorProvider.getValidatorsAfterBlock(any())).thenReturn(validators);
     when(bftContext.getBlockInterface()).thenReturn(mockBftBlockInterface);
-    when(bftContext.as(Mockito.any())).thenReturn(bftContext);
+    when(bftContext.as(any())).thenReturn(bftContext);
     return bftContext;
   }
 
@@ -59,7 +59,7 @@ public class BftContextBuilder {
     when(mockValidatorProvider.getValidatorsAfterBlock(any())).thenReturn(validators);
     when(bftContext.getBlockInterface()).thenReturn(mockBftBlockInterface);
     when(mockBftBlockInterface.getExtraData(any())).thenReturn(bftExtraData);
-    when(bftContext.as(Mockito.any())).thenReturn(bftContext);
+    when(bftContext.as(any())).thenReturn(bftContext);
     return bftContext;
   }
 
@@ -78,7 +78,7 @@ public class BftContextBuilder {
     when(bftContext.getValidatorProvider()).thenReturn(mockValidatorProvider);
     when(mockValidatorProvider.getValidatorsAfterBlock(any())).thenReturn(validators);
     when(bftContext.getBlockInterface()).thenReturn(new BftBlockInterface(bftExtraDataCodec));
-    when(bftContext.as(Mockito.any())).thenReturn(bftContext);
+    when(bftContext.as(any())).thenReturn(bftContext);
 
     return bftContext;
   }

--- a/consensus/common/src/test-support/java/org/hyperledger/besu/consensus/common/bft/BftContextBuilder.java
+++ b/consensus/common/src/test-support/java/org/hyperledger/besu/consensus/common/bft/BftContextBuilder.java
@@ -24,8 +24,6 @@ import org.hyperledger.besu.datatypes.Address;
 
 import java.util.Collection;
 
-import org.mockito.Mockito;
-
 public class BftContextBuilder {
 
   public static BftContext setupContextWithValidators(final Collection<Address> validators) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.web3j.abi.DefaultFunctionReturnDecoder;
 import org.web3j.abi.FunctionEncoder;
+import org.web3j.abi.FunctionReturnDecoder;
 import org.web3j.abi.TypeReference;
 import org.web3j.abi.datatypes.DynamicArray;
 import org.web3j.abi.datatypes.Function;
@@ -81,7 +82,7 @@ public class ValidatorContractController {
       final TransactionSimulatorResult result, final Function function) {
     if (result.isSuccessful()) {
       final List<Type> decodedList =
-          DefaultFunctionReturnDecoder.decode(
+          FunctionReturnDecoder.decode(
               result.getResult().getOutput().toHexString(), function.getOutputParameters());
 
       if (decodedList.isEmpty()) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.web3j.abi.DefaultFunctionReturnDecoder;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.FunctionReturnDecoder;
 import org.web3j.abi.TypeReference;


### PR DESCRIPTION
## PR description

* `Mockito#any` is more directly accessible via `ArgumentMatchers#any`
* `DefaultFunctionReturnDecode#decode` is more directly accessible via `FunctionReturnDecoder#decode`

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).