### PR TITLE
Keep the best block built until now instead of the last one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 22.7.5
 
-
 ### Additions and Improvements
+- When building a new proposal, keep the best block built until now instead of the last one [#4455](https://github.com/hyperledger/besu/pull/4455)
+
 ### Bug Fixes
 ### Download Links
 

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/test-cases/01_prepare_payload.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/test-cases/01_prepare_payload.json
@@ -25,7 +25,7 @@
         "latestValidHash": "0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a",
         "validationError": null
       },
-      "payloadId": "0x0000000021f32cc1"
+      "payloadId": "0x0065bd195a9b3bfb"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/test-cases/02_get_payload.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/test-cases/02_get_payload.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV1",
     "params": [
-      "0x0000000021f32cc1"
+      "0x0065bd195a9b3bfb"
     ],
     "id": 67
   },

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -224,7 +224,6 @@ public class PostMergeContext implements MergeContext {
                 .get();
 
         if (currBestBlock.getHash().equals(block.getHash())) {
-          debugLambda(LOG, "");
           prevBlockTuples.forEach(blocksInProgress::remove);
           blocksInProgress.add(new PayloadTuple(payloadId, block));
         }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -175,17 +175,18 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   public PayloadIdentifier preparePayload(
       final BlockHeader parentHeader,
       final Long timestamp,
-      final Bytes32 random,
+      final Bytes32 prevRandao,
       final Address feeRecipient) {
 
     final PayloadIdentifier payloadIdentifier =
-        PayloadIdentifier.forPayloadParams(parentHeader.getBlockHash(), timestamp);
+        PayloadIdentifier.forPayloadParams(
+            parentHeader.getBlockHash(), timestamp, prevRandao, feeRecipient);
     final MergeBlockCreator mergeBlockCreator =
         this.mergeBlockCreator.forParams(parentHeader, Optional.ofNullable(feeRecipient));
 
     // put the empty block in first
     final Block emptyBlock =
-        mergeBlockCreator.createBlock(Optional.of(Collections.emptyList()), random, timestamp);
+        mergeBlockCreator.createBlock(Optional.of(Collections.emptyList()), prevRandao, timestamp);
 
     Result result = validateBlock(emptyBlock);
     if (result.blockProcessingOutputs.isPresent()) {
@@ -202,7 +203,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
           result.errorMessage);
     }
 
-    tryToBuildBetterBlock(timestamp, random, payloadIdentifier, mergeBlockCreator);
+    tryToBuildBetterBlock(timestamp, prevRandao, payloadIdentifier, mergeBlockCreator);
 
     return payloadIdentifier;
   }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -33,7 +33,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
   PayloadIdentifier preparePayload(
       final BlockHeader parentHeader,
       final Long timestamp,
-      final Bytes32 random,
+      final Bytes32 prevRandao,
       final Address feeRecipient);
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.consensus.merge.blockcreation;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.plugin.data.Quantity;
 
@@ -21,6 +22,7 @@ import java.math.BigInteger;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
 
 public class PayloadIdentifier implements Quantity {
@@ -36,8 +38,16 @@ public class PayloadIdentifier implements Quantity {
     this.val = UInt64.valueOf(Math.abs(payloadId));
   }
 
-  public static PayloadIdentifier forPayloadParams(final Hash parentHash, final Long timestamp) {
-    return new PayloadIdentifier(((long) parentHash.toHexString().hashCode()) ^ timestamp);
+  public static PayloadIdentifier forPayloadParams(
+      final Hash parentHash,
+      final Long timestamp,
+      final Bytes32 prevRandao,
+      final Address feeRecipient) {
+    return new PayloadIdentifier(
+        timestamp
+            ^ ((long) parentHash.toHexString().hashCode()) << 8
+            ^ ((long) prevRandao.toHexString().hashCode()) << 16
+            ^ ((long) feeRecipient.toHexString().hashCode()) << 24);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -127,9 +127,9 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
   public PayloadIdentifier preparePayload(
       final BlockHeader parentHeader,
       final Long timestamp,
-      final Bytes32 random,
+      final Bytes32 prevRandao,
       final Address feeRecipient) {
-    return mergeCoordinator.preparePayload(parentHeader, timestamp, random, feeRecipient);
+    return mergeCoordinator.preparePayload(parentHeader, timestamp, prevRandao, feeRecipient);
   }
 
   @Override

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/PostMergeContextTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -146,12 +145,10 @@ public class PostMergeContextTest {
     Block zeroTxBlock = mock(Block.class);
     when(zeroTxBlock.getHeader()).thenReturn(zeroTxBlockHeader);
 
-    Hash betterBlockHash = Hash.fromHexStringLenient("0xBE51");
     BlockHeader betterBlockHeader = mock(BlockHeader.class);
     when(betterBlockHeader.getGasUsed()).thenReturn(11L);
     Block betterBlock = mock(Block.class);
     when(betterBlock.getHeader()).thenReturn(betterBlockHeader);
-    when(betterBlock.getHash()).thenReturn(betterBlockHash);
 
     PayloadIdentifier payloadId = new PayloadIdentifier(1L);
     postMergeContext.putPayloadById(payloadId, zeroTxBlock);
@@ -167,19 +164,15 @@ public class PostMergeContextTest {
     Block zeroTxBlock = mock(Block.class);
     when(zeroTxBlock.getHeader()).thenReturn(zeroTxBlockHeader);
 
-    Hash betterBlockHash = Hash.fromHexStringLenient("0xBE51");
     BlockHeader betterBlockHeader = mock(BlockHeader.class);
     when(betterBlockHeader.getGasUsed()).thenReturn(11L);
     Block betterBlock = mock(Block.class);
     when(betterBlock.getHeader()).thenReturn(betterBlockHeader);
-    when(betterBlock.getHash()).thenReturn(betterBlockHash);
 
-    Hash smallBlockHash = Hash.fromHexStringLenient("0x5011");
     BlockHeader smallBlockHeader = mock(BlockHeader.class);
     when(smallBlockHeader.getGasUsed()).thenReturn(5L);
     Block smallBlock = mock(Block.class);
     when(smallBlock.getHeader()).thenReturn(smallBlockHeader);
-    when(smallBlock.getHash()).thenReturn(smallBlockHash);
 
     PayloadIdentifier payloadId = new PayloadIdentifier(1L);
     postMergeContext.putPayloadById(payloadId, zeroTxBlock);

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -16,10 +16,12 @@ package org.hyperledger.besu.consensus.merge.blockcreation;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 
 import java.util.List;
 
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class PayloadIdentifierTest {
@@ -39,7 +41,9 @@ public class PayloadIdentifierTest {
 
   @Test
   public void conversionCoverage() {
-    var idTest = PayloadIdentifier.forPayloadParams(Hash.ZERO, 1337L);
+    var idTest =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO, 1337L, Bytes32.random(), Address.fromHexString("0x42"));
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -72,6 +72,8 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
     final Optional<EnginePayloadAttributesParameter> maybePayloadAttributes =
         requestContext.getOptionalParameter(1, EnginePayloadAttributesParameter.class);
 
+    LOG.debug("Forkchoice parameters {}", forkChoice);
+
     Optional<Hash> maybeFinalizedHash =
         Optional.ofNullable(forkChoice.getFinalizedBlockHash())
             .filter(finalized -> !finalized.isZero());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineForkchoiceUpdatedParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineForkchoiceUpdatedParameter.java
@@ -47,4 +47,14 @@ public class EngineForkchoiceUpdatedParameter {
     this.headBlockHash = headBlockHash;
     this.safeBlockHash = safeBlockHash;
   }
+
+  @Override
+  public String toString() {
+    return "headBlockHash="
+        + headBlockHash
+        + ", safeBlockHash="
+        + safeBlockHash
+        + ", finalizedBlockHash="
+        + finalizedBlockHash;
+  }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedTest.java
@@ -227,7 +227,11 @@ public class EngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString());
     var mockPayloadId =
-        PayloadIdentifier.forPayloadParams(mockHeader.getHash(), payloadParams.getTimestamp());
+        PayloadIdentifier.forPayloadParams(
+            mockHeader.getHash(),
+            payloadParams.getTimestamp(),
+            payloadParams.getPrevRandao(),
+            payloadParams.getSuggestedFeeRecipient());
 
     when(mergeCoordinator.preparePayload(
             mockHeader, payloadParams.getTimestamp(), payloadParams.getPrevRandao(), Address.ECREC))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.blockcreation.PayloadIdentifier;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
@@ -55,7 +56,8 @@ public class EngineGetPayloadTest {
   private static final Vertx vertx = Vertx.vertx();
   private static final BlockResultFactory factory = new BlockResultFactory();
   private static final PayloadIdentifier mockPid =
-      PayloadIdentifier.forPayloadParams(Hash.ZERO, 1337L);
+      PayloadIdentifier.forPayloadParams(
+          Hash.ZERO, 1337L, Bytes32.random(), Address.fromHexString("0x42"));
   private static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
   private static final Block mockBlock =
@@ -99,7 +101,10 @@ public class EngineGetPayloadTest {
 
   @Test
   public void shouldFailForUnknownPayloadId() {
-    var resp = resp(PayloadIdentifier.forPayloadParams(Hash.ZERO, 0L));
+    var resp =
+        resp(
+            PayloadIdentifier.forPayloadParams(
+                Hash.ZERO, 0L, Bytes32.random(), Address.fromHexString("0x42")));
     assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);
     verify(engineCallListener, times(1)).executionEngineCalled();
   }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

If the consensus layer client, send more than once the same forkchoice update with payload attributes, we build more blocks with the same payload id, but the current implementation just keep the latest one built, no matter if it is better or not than the existing ones.
This PR improve that, comparing the blocks with the same payload id, and keeping the best according to the amount of gas used, this could be improved in a next iteration, comparing the actual fee reward of the block.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).