### PR TITLE
P2P: Don't add peer to maintained connections if local node is not ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add Mainnet to merged networks [#4463](https://github.com/hyperledger/besu/pull/4463)
 
 ### Bug Fixes
+- Do not add static node to maintained connection list if local node is not yet ready.
+
 ### Download Links
 
 ## 22.7.4

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -259,6 +259,9 @@ public class DefaultP2PNetwork implements P2PNetwork {
     peerBondedObserverId =
         OptionalLong.of(peerDiscoveryAgent.observePeerBondedEvents(this::handlePeerBondedEvent));
 
+    // Call checkMaintainedConnectionPeers() now that the local node is up, for immediate peer additions
+    checkMaintainedConnectionPeers();
+
     // Periodically check maintained connections
     final int checkMaintainedConnectionsSec = config.getCheckMaintainedConnectionsFrequencySec();
     peerConnectionScheduler.scheduleWithFixedDelay(
@@ -307,10 +310,12 @@ public class DefaultP2PNetwork implements P2PNetwork {
 
   @Override
   public boolean addMaintainedConnectionPeer(final Peer peer) {
-    if (localNode.isReady()
-        && localNode.getPeer() != null
-        && localNode.getPeer().getEnodeURL() != null
-        && peer.getEnodeURL().getNodeId().equals(localNode.getPeer().getEnodeURL().getNodeId())) {
+    final boolean localNodeIsReady =
+        localNode.isReady()
+            && localNode.getPeer() != null
+            && localNode.getPeer().getEnodeURL() != null;
+    if (!localNodeIsReady
+        || peer.getEnodeURL().getNodeId().equals(localNode.getPeer().getEnodeURL().getNodeId())) {
       return false;
     }
     final boolean wasAdded = maintainedPeers.add(peer);


### PR DESCRIPTION
## PR description

* Fixes an issue due to which multiple peer connections are setup over time to the local node if it is present in the static nodes list. The code was not handling the case where local node is not yet ready (encountered at startup). https://github.com/hyperledger/besu/pull/1703 added logic to skip adding local node to the set of maintained peer connections. However, the check fails to take into account the case where the local node is not marked ready (occurs at startup since [sanitizePeers](https://github.com/hyperledger/besu/blob/main/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java#L573) is called _before_ the call is made to setup the [networkRunner](https://github.com/hyperledger/besu/blob/main/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java#L844-L846) at which time the local node is setup and marked ready.

* Also adds a one time call to initiate connection to nodes in static nodes list after local node is ready. In the absence of this call, the connection attempt is made after the configured interval (default 60 seconds) to check maintained connections. This is to make sure the node doesn't have to wait for almost a minute before it can start interacting with peers (and sync blocks etc.).



## Fixed Issue(s)

Fixes https://github.com/hyperledger/besu/issues/1702

## Documentation

- [ ] ~I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).~

No doc updates necessary.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).