### PR TITLE
Logging change to FCU if syncing for clarity.

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdated.java
@@ -278,12 +278,20 @@ public class EngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
     // cheaply limit the noise of fcU during consensus client syncing to once a minute:
     if (lastFcuInfoLog + ENGINE_API_LOGGING_THRESHOLD < System.currentTimeMillis()) {
       lastFcuInfoLog = System.currentTimeMillis();
+      if (status.name() == "SYNCING") {
+        LOG.info(
+          "Besu is still syncing. Consensus layer providing a fork-choice-update: head: {}, finalized: {}, safeBlockHash: {}",
+          forkChoice.getHeadBlockHash(),
+          forkChoice.getFinalizedBlockHash(),
+          forkChoice.getSafeBlockHash());
+      } else {
       LOG.info(
           "{} for fork-choice-update: head: {}, finalized: {}, safeBlockHash: {}",
           status.name(),
           forkChoice.getHeadBlockHash(),
           forkChoice.getFinalizedBlockHash(),
           forkChoice.getSafeBlockHash());
+      }
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Matt Nelson <matt.nelson@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Changes logging behavior if besu is still syncing with a CL attached. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).