### PR TITLE
The block variable was keeping too much memory while waiting for future to finish

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -176,6 +176,7 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
 
     final var block =
         new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
+    final String warningMessage = "Sync to block " + block.toLogString() + " failed";
 
     if (mergeContext.get().isSyncing() || parentHeader.isEmpty()) {
       LOG.debug(
@@ -187,8 +188,7 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
           .appendNewPayloadToSync(block)
           .exceptionally(
               exception -> {
-                LOG.warn(
-                    "Sync to block " + block.toLogString() + " failed", exception.getMessage());
+                LOG.warn(warningMessage, exception.getMessage());
                 return null;
               });
       return respondWith(reqId, blockParam, null, SYNCING);


### PR DESCRIPTION

The `exceptionally` was holding a pointer to a block and was not released for potentially long time. 

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>
