### PR TITLE
check for self in one more spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Additions and Improvements
 - Improved RLP processing of zero-length string as 0x80 [#4283](https://github.com/hyperledger/besu/pull/4283) [#4388](https://github.com/hyperledger/besu/issues/4388)
 - Increased level of detail in JSON-RPC parameter error log messages [#4510](https://github.com/hyperledger/besu/pull/4510)
+- Avoid connecting to self when using static-nodes [#4521](https://github.com/hyperledger/besu/pull/4521) 
 
 ### Bug Fixes
 - Corrects emission of blockadded events when rewinding during a re-org. Fix for [#4495](https://github.com/hyperledger/besu/issues/4495)

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -359,8 +359,10 @@ public class DefaultP2PNetwork implements P2PNetwork {
     if (!localNode.isReady()) {
       return;
     }
+    final EnodeURL localEnodeURL = localNode.getPeer().getEnodeURL();
     maintainedPeers
         .streamPeers()
+        .filter(peer -> !peer.getEnodeURL().getNodeId().equals(localEnodeURL.getNodeId()))
         .filter(p -> !rlpxAgent.getPeerConnection(p).isPresent())
         .forEach(rlpxAgent::connect);
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -52,6 +52,7 @@ import org.hyperledger.besu.nat.NatMethod;
 import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.nat.core.domain.NetworkProtocol;
 import org.hyperledger.besu.nat.upnp.UpnpNatManager;
+import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -164,6 +165,21 @@ public final class DefaultP2PNetworkTest {
     assertThat(maintainedPeers.contains(peer)).isFalse();
     verify(rlpxAgent, times(1)).disconnect(peer.getId(), DisconnectReason.REQUESTED);
     verify(discoveryAgent, times(1)).dropPeer(peer);
+  }
+
+  @Test
+  public void checkMaintainedConnectionPeers_doesNotConnectToSelf() {
+    final DefaultP2PNetwork network = network();
+    network.start();
+
+    final Optional<EnodeURL> maybeSelfEnode = network.getLocalEnode();
+    final Peer selfPeer = PeerTestHelper.createPeer(maybeSelfEnode.get());
+    maintainedPeers.add(selfPeer);
+
+    verify(rlpxAgent, times(0)).connect(selfPeer);
+
+    network.checkMaintainedConnectionPeers();
+    verify(rlpxAgent, times(0)).connect(selfPeer);
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTestHelper.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTestHelper.java
@@ -27,6 +27,10 @@ public class PeerTestHelper {
     return DefaultPeer.fromEnodeURL(enode());
   }
 
+  public static Peer createPeer(final EnodeURL enodeURL) {
+    return DefaultPeer.fromEnodeURL(enodeURL);
+  }
+
   public static Peer createPeer(final Bytes nodeId) {
     return DefaultPeer.fromEnodeURL(enodeBuilder().nodeId(nodeId).build());
   }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

When regularly checking connections to maintained peers (static nodes), ensure connection to self is not initiated.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).