### PR TITLE
don't add to bad blocks manager on StorageException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Corrects emission of blockadded events when rewinding during a re-org. Fix for [#4495](https://github.com/hyperledger/besu/issues/4495)
 - Always return a transaction type for pending transactions [#4364](https://github.com/hyperledger/besu/pull/4364)
 - Avoid a cyclic reference while printing EngineExchangeTransitionConfigurationParameter [#4357](https://github.com/hyperledger/besu/pull/4357)
+- Corrects treating a block as bad on internal error [#4512](https://github.com/hyperledger/besu/issues/4512)
 
 ### Download Links
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -235,6 +235,8 @@ public class EngineNewPayloadTest {
 
     fromErrorResp(resp);
     verify(engineCallListener, times(1)).executionEngineCalled();
+    verify(mergeCoordinator, times(0)).addBadBlock(any());
+    // verify mainnetBlockValidator does not add to bad block manager
   }
 
   @Test
@@ -362,7 +364,7 @@ public class EngineNewPayloadTest {
     EnginePayloadStatusResult res = fromSuccessResp(resp);
     assertThat(res.getLatestValidHash()).contains(Hash.ZERO);
     assertThat(res.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(res.getError()).isNull();
+    assertThat(res.getError()).isEqualTo("Block already present in bad block manager.");
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -151,7 +151,9 @@ public class MainnetBlockValidator implements BlockValidator {
     if (result.causedBy().isPresent()) {
       LOG.info("{}. Block {}, caused by {}", reason, invalidBlock.toLogString(), result.causedBy());
       // TODO: if it's an internal error, don't add it
-      badBlockManager.addBadBlock(invalidBlock);
+      if (!result.internalError()) {
+        badBlockManager.addBadBlock(invalidBlock);
+      }
       return new Result(reason, result.causedBy().get());
     } else {
       LOG.info("{}. Block {}", reason, invalidBlock.toLogString());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -150,7 +150,6 @@ public class MainnetBlockValidator implements BlockValidator {
       final Block invalidBlock, final String reason, final BlockProcessor.Result result) {
     if (result.causedBy().isPresent()) {
       LOG.info("{}. Block {}, caused by {}", reason, invalidBlock.toLogString(), result.causedBy());
-      // TODO: if it's an internal error, don't add it
       if (!result.internalError()) {
         badBlockManager.addBadBlock(invalidBlock);
       }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 
 import java.util.List;
 import java.util.Optional;
@@ -64,6 +65,17 @@ public interface BlockProcessor {
 
     default Optional<Throwable> causedBy() {
       return Optional.empty();
+    }
+
+    default boolean internalError() {
+      if (causedBy().isPresent()) {
+        Throwable t = causedBy().get();
+        // As new "internal only" types of exception are discovered, add them here.
+        if (t instanceof StorageException) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Justin Florentine <justin+github@florentine.us>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fixes issue where Besu records a block that experienced a StorageException as a bad block, thus preventing it from being retried by the Consensus Layer. Also corrects some response handling which was hiding the issue.

## Fixed Issue(s)
fixes #4512 

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).