### PR TITLE
Tune EthScheduler thread pools to avoid to recreate too many threads

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthScheduler.java
@@ -72,11 +72,12 @@ public class EthScheduler {
       final MetricsSystem metricsSystem) {
     this(
         MonitoredExecutors.newFixedThreadPool(
-            EthScheduler.class.getSimpleName() + "-Workers", syncWorkerCount, metricsSystem),
+            EthScheduler.class.getSimpleName() + "-Workers", 1, syncWorkerCount, metricsSystem),
         MonitoredExecutors.newScheduledThreadPool(
             EthScheduler.class.getSimpleName() + "-Timer", 1, metricsSystem),
         MonitoredExecutors.newBoundedThreadPool(
             EthScheduler.class.getSimpleName() + "-Transactions",
+            1,
             txWorkerCount,
             txWorkerQueueSize,
             metricsSystem),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
@@ -38,8 +38,12 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 public class MonitoredExecutors {
 
   public static ExecutorService newFixedThreadPool(
-      final String name, final int workerCount, final MetricsSystem metricsSystem) {
-    return newFixedThreadPool(name, 0, workerCount, new LinkedBlockingQueue<>(), metricsSystem);
+      final String name,
+      final int minWorkerCount,
+      final int workerCount,
+      final MetricsSystem metricsSystem) {
+    return newFixedThreadPool(
+        name, minWorkerCount, workerCount, new LinkedBlockingQueue<>(), metricsSystem);
   }
 
   public static ExecutorService newBoundedThreadPool(
@@ -47,7 +51,7 @@ public class MonitoredExecutors {
       final int workerCount,
       final int queueSize,
       final MetricsSystem metricsSystem) {
-    return newBoundedThreadPool(name, 0, workerCount, queueSize, metricsSystem);
+    return newBoundedThreadPool(name, 1, workerCount, queueSize, metricsSystem);
   }
 
   public static ExecutorService newBoundedThreadPool(
@@ -77,8 +81,8 @@ public class MonitoredExecutors {
             new ThreadPoolExecutor(
                 minWorkerCount,
                 maxWorkerCount,
-                0L,
-                TimeUnit.MILLISECONDS,
+                60L,
+                TimeUnit.SECONDS,
                 workingQueue,
                 threadFactory,
                 rejectedExecutionHandler));


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).