### PR TITLE
Upgrade Apache Commons Text to 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Avoid a cyclic reference while printing EngineExchangeTransitionConfigurationParameter [#4357](https://github.com/hyperledger/besu/pull/4357)
 - Corrects treating a block as bad on internal error [#4512](https://github.com/hyperledger/besu/issues/4512)
 - In GraphQL update scalar parsing to be variable friendly [#4522](https://github.com/hyperledger/besu/pull/4522)
+- update appache-commons-text to 1.10.0 to address CVE-2022-42889 [#4542](https://github.com/hyperledger/besu/pull/4542) 
 
 ### Download Links
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -122,7 +122,7 @@ dependencyManagement {
 
     dependency 'org.apache.commons:commons-compress:1.21'
     dependency 'org.apache.commons:commons-lang3:3.12.0'
-    dependency 'org.apache.commons:commons-text:1.9'
+    dependency 'org.apache.commons:commons-text:1.10.0'
 
     dependency 'org.apache.logging.log4j:log4j-api:2.17.2'
     dependency 'org.apache.logging.log4j:log4j-core:2.17.2'


### PR DESCRIPTION
Signed-off-by: Daniel Lehrner <daniel.lehrner@consensys.net>

Upgrades Apache Commons Text to 1.10.0 to fix [CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).