### PR TITLE
Upgrade jackson-databind to 2.13.4.2 and other jackson deps to 2.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Version 22.10.0 will require Java 17 to build and run.
 
 ### Additions and Improvements
+- Updated jackson-databind library to version 2.13.4.2 addressing [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)
 
 ## 22.10.0-RC2
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -21,8 +21,8 @@ dependencyManagement {
       entry 'antlr4-runtime'
     }
 
-    dependencySet(group:'com.fasterxml.jackson.core', version:'2.13.3') {
-      entry 'jackson-databind'
+    dependency 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
+    dependencySet(group:'com.fasterxml.jackson.core', version:'2.13.4') {
       entry 'jackson-datatype'
       entry 'jackson-datatype-jdk8'
     }


### PR DESCRIPTION
## PR description

- Updated jackson-databind library to version 2.13.4.2 addressing [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)
- Also updated other jackson deps to 2.13.4

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).