### PR TITLE
List.of like utility class for BlockBodies

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -35,7 +35,7 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -213,7 +213,7 @@ public class MergeBesuControllerBuilderTest {
             .gasLimit(genesisState.getBlock().getHeader().getGasLimit())
             .stateRoot(genesisState.getBlock().getHeader().getStateRoot())
             .buildHeader();
-    blockchain.appendBlock(new Block(parent, BlockBody.empty()), Collections.emptyList());
+    blockchain.appendBlock(new Block(parent, BlockBodies.empty()), Collections.emptyList());
 
     BlockHeader terminal =
         headerGenerator
@@ -224,7 +224,7 @@ public class MergeBesuControllerBuilderTest {
             .stateRoot(parent.getStateRoot())
             .buildHeader();
 
-    blockchain.appendBlock(new Block(terminal, BlockBody.empty()), Collections.emptyList());
+    blockchain.appendBlock(new Block(terminal, BlockBodies.empty()), Collections.emptyList());
     assertThat(mergeContext.isPostMerge()).isTrue();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -68,7 +69,6 @@ import org.hyperledger.besu.testutil.TestClock;
 import java.math.BigInteger;
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -479,7 +479,7 @@ public class BesuEventsImplTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body = BlockBodies.empty();
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,7 +53,7 @@ public class CliqueBlockChoiceTests {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, addresses);
-    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    return new Block(header, BlockBodies.empty());
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
@@ -31,7 +31,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -59,7 +59,7 @@ public class NodeCanProduceNextBlockTest {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, validatorList);
-    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    return new Block(header, BlockBodies.empty());
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -44,7 +44,7 @@ import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
@@ -115,7 +115,7 @@ public class CliqueBlockCreatorTest {
         new Block(
             TestHelpers.createCliqueSignedBlockHeader(
                 headerTestFixture, otherKeyPair, validatorList),
-            new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+            BlockBodies.empty());
     blockchain.appendBlock(emptyBlock, Lists.newArrayList());
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
@@ -36,7 +36,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
@@ -249,6 +249,6 @@ public class CliqueMiningCoordinatorTest {
     headerTestFixture.number(blockNumber).parentHash(parentHash);
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerTestFixture, signer, validators);
-    return new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    return new Block(header, BlockBodies.empty());
   }
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
@@ -25,7 +25,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collections;
@@ -41,9 +41,7 @@ public class VoteTallyCacheTestBase {
 
   protected Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(
-        headerBuilder.buildHeader(),
-        new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    return new Block(headerBuilder.buildHeader(), BlockBodies.empty());
   }
 
   protected MutableBlockchain blockChain;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -69,7 +69,7 @@ import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -279,8 +279,7 @@ public class TestContextBuilder {
     headerTestFixture.coinbase(coinbase);
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
-    return new Block(
-        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    return new Block(genesisHeader, BlockBodies.empty());
   }
 
   private static ControllerAndState createControllerAndFinalState(

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
@@ -43,7 +43,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -110,7 +110,7 @@ public class IbftRoundIntegrationTest {
     headerTestFixture.extraData(bftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, BlockBodies.empty());
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -61,7 +61,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator.BlockCreationResult;
 import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -123,7 +123,7 @@ public class IbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(new IbftExtraDataCodec().encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    createdBlock = new Block(header, BlockBodies.empty());
   }
 
   @Before

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -50,7 +50,7 @@ import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.Tran
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -119,7 +119,7 @@ public class IbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, BlockBodies.empty());
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -50,7 +50,7 @@ import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -408,14 +408,14 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void childTimestampExceedsParentsFails() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader parentHeader = nextBlockHeader(terminalHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
+    Block parent = new Block(parentHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(parent, Optional.empty(), terminalHeader.getHash());
 
     BlockHeader childHeader = nextBlockHeader(parentHeader, parentHeader.getTimestamp());
-    Block child = new Block(childHeader, BlockBody.empty());
+    Block child = new Block(childHeader, BlockBodies.empty());
     coordinator.rememberBlock(child);
 
     ForkchoiceResult result =
@@ -440,10 +440,10 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void latestValidAncestorDescendsFromTerminal() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader parentHeader = nextBlockHeader(terminalHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
+    Block parent = new Block(parentHeader, BlockBodies.empty());
 
     // if latest valid ancestor is PoW, then latest valid hash should be Hash.ZERO
     var lvh = this.coordinator.getLatestValidAncestor(parentHeader);
@@ -452,7 +452,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
 
     sendNewPayloadAndForkchoiceUpdate(parent, Optional.empty(), terminalHeader.getHash());
     BlockHeader childHeader = nextBlockHeader(parentHeader);
-    Block child = new Block(childHeader, BlockBody.empty());
+    Block child = new Block(childHeader, BlockBodies.empty());
     coordinator.validateBlock(child);
     assertThat(this.coordinator.latestValidAncestorDescendsFromTerminal(child.getHeader()))
         .isTrue();
@@ -465,10 +465,10 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void latestValidAncestorDescendsFromFinalizedBlock() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader grandParentHeader = nextBlockHeader(terminalHeader);
-    Block grandParent = new Block(grandParentHeader, BlockBody.empty());
+    Block grandParent = new Block(grandParentHeader, BlockBodies.empty());
 
     // if latest valid ancestor is PoW, then latest valid hash should be Hash.ZERO
     var lvh = this.coordinator.getLatestValidAncestor(grandParentHeader);
@@ -477,12 +477,12 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
 
     sendNewPayloadAndForkchoiceUpdate(grandParent, Optional.empty(), terminalHeader.getHash());
     BlockHeader parentHeader = nextBlockHeader(grandParentHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
+    Block parent = new Block(parentHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         parent, Optional.of(grandParentHeader), grandParentHeader.getHash());
 
     BlockHeader childHeader = nextBlockHeader(parentHeader);
-    Block child = new Block(childHeader, BlockBody.empty());
+    Block child = new Block(childHeader, BlockBodies.empty());
     coordinator.validateBlock(child);
 
     assertThat(this.coordinator.latestValidAncestorDescendsFromTerminal(child.getHeader()))
@@ -499,15 +499,15 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void updateForkChoiceShouldPersistFirstFinalizedBlockHash() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader firstFinalizedHeader = nextBlockHeader(terminalHeader);
-    Block firstFinalizedBlock = new Block(firstFinalizedHeader, BlockBody.empty());
+    Block firstFinalizedBlock = new Block(firstFinalizedHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         firstFinalizedBlock, Optional.empty(), terminalHeader.getHash());
 
     BlockHeader headBlockHeader = nextBlockHeader(firstFinalizedHeader);
-    Block headBlock = new Block(headBlockHeader, BlockBody.empty());
+    Block headBlock = new Block(headBlockHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         headBlock, Optional.of(firstFinalizedHeader), firstFinalizedHeader.getHash());
 
@@ -535,7 +535,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
       BlockHeader nextBlock =
           nextBlockHeader(
               prevParent, genesisState.getBlock().getHeader().getTimestamp() + i * 1000);
-      coordinator.rememberBlock(new Block(nextBlock, BlockBody.empty()));
+      coordinator.rememberBlock(new Block(nextBlock, BlockBodies.empty()));
       prevParent = nextBlock;
     }
 
@@ -553,7 +553,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
       BlockHeader nextPrime =
           nextBlockHeader(
               prevParent, genesisState.getBlock().getHeader().getTimestamp() + i * 1001);
-      coordinator.rememberBlock(new Block(nextPrime, BlockBody.empty()));
+      coordinator.rememberBlock(new Block(nextPrime, BlockBodies.empty()));
       prevParent = nextPrime;
     }
     coordinator.updateForkChoice(
@@ -570,20 +570,20 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void updateForkChoiceShouldPersistLastFinalizedBlockHash() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader prevFinalizedHeader = nextBlockHeader(terminalHeader);
-    Block prevFinalizedBlock = new Block(prevFinalizedHeader, BlockBody.empty());
+    Block prevFinalizedBlock = new Block(prevFinalizedHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         prevFinalizedBlock, Optional.empty(), terminalHeader.getHash());
 
     BlockHeader lastFinalizedHeader = nextBlockHeader(prevFinalizedHeader);
-    Block lastFinalizedBlock = new Block(lastFinalizedHeader, BlockBody.empty());
+    Block lastFinalizedBlock = new Block(lastFinalizedHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         lastFinalizedBlock, Optional.of(prevFinalizedHeader), prevFinalizedHeader.getHash());
 
     BlockHeader headBlockHeader = nextBlockHeader(lastFinalizedHeader);
-    Block headBlock = new Block(headBlockHeader, BlockBody.empty());
+    Block headBlock = new Block(headBlockHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         headBlock, Optional.of(lastFinalizedHeader), lastFinalizedHeader.getHash());
 
@@ -763,21 +763,21 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void invalidPayloadShouldReturnErrorAndUpdateForkchoiceState() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader prevFinalizedHeader = nextBlockHeader(terminalHeader);
-    Block prevFinalizedBlock = new Block(prevFinalizedHeader, BlockBody.empty());
+    Block prevFinalizedBlock = new Block(prevFinalizedHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(
         prevFinalizedBlock, Optional.empty(), terminalHeader.getHash());
 
     BlockHeader lastFinalizedHeader = nextBlockHeader(prevFinalizedHeader);
-    Block lastFinalizedBlock = new Block(lastFinalizedHeader, BlockBody.empty());
+    Block lastFinalizedBlock = new Block(lastFinalizedHeader, BlockBodies.empty());
 
     sendNewPayloadAndForkchoiceUpdate(
         lastFinalizedBlock, Optional.of(prevFinalizedHeader), prevFinalizedHeader.getHash());
 
     BlockHeader headBlockHeader = nextBlockHeader(lastFinalizedHeader);
-    Block headBlock = new Block(headBlockHeader, BlockBody.empty());
+    Block headBlock = new Block(headBlockHeader, BlockBodies.empty());
     assertThat(coordinator.rememberBlock(headBlock).blockProcessingOutputs).isPresent();
 
     var res =
@@ -802,14 +802,14 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public void forkchoiceUpdateShouldIgnoreAncestorOfChainHead() {
     BlockHeader terminalHeader = terminalPowBlock();
     sendNewPayloadAndForkchoiceUpdate(
-        new Block(terminalHeader, BlockBody.empty()), Optional.empty(), Hash.ZERO);
+        new Block(terminalHeader, BlockBodies.empty()), Optional.empty(), Hash.ZERO);
 
     BlockHeader parentHeader = nextBlockHeader(terminalHeader);
-    Block parent = new Block(parentHeader, BlockBody.empty());
+    Block parent = new Block(parentHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(parent, Optional.empty(), terminalHeader.getHash());
 
     BlockHeader childHeader = nextBlockHeader(parentHeader);
-    Block child = new Block(childHeader, BlockBody.empty());
+    Block child = new Block(childHeader, BlockBodies.empty());
     sendNewPayloadAndForkchoiceUpdate(child, Optional.empty(), parent.getHash());
 
     ForkchoiceResult res =

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -115,7 +115,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
     assertThat(blockchain.getChainHead().getHeight()).isEqualTo(10L);
     BlockHeader tddPenultimate = this.blockchain.getChainHeadHeader();
     // Add TTD block A to chain as child of N.
-    Block ttdA = new Block(terminalPowBlock(tddPenultimate, Difficulty.ONE), BlockBody.empty());
+    Block ttdA = new Block(terminalPowBlock(tddPenultimate, Difficulty.ONE), BlockBodies.empty());
     appendBlock(ttdA);
     assertThat(blockchain.getChainHead().getHeight()).isEqualTo(11L);
     assertThat(blockchain.getTotalDifficultyByHash(ttdA.getHash())).isPresent();
@@ -134,7 +134,8 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
     assertThat(blockchain.getChainHead().getHash())
         .isEqualTo(builtOnTTDA.get(builtOnTTDA.size() - 1).getHash());
 
-    Block ttdB = new Block(terminalPowBlock(tddPenultimate, Difficulty.of(2L)), BlockBody.empty());
+    Block ttdB =
+        new Block(terminalPowBlock(tddPenultimate, Difficulty.of(2L)), BlockBodies.empty());
     appendBlock(ttdB);
     List<Block> builtOnTTDB = subChain(ttdB.getHeader(), 10, Difficulty.of(0L));
     builtOnTTDB.stream().forEach(this::appendBlock);
@@ -177,7 +178,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
         headerGenerator.difficulty(each);
       }
       BlockHeader h = headerGenerator.buildHeader();
-      retval.add(new Block(h, BlockBody.empty()));
+      retval.add(new Block(h, BlockBodies.empty()));
       newParent = h;
     }
     return retval;

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
@@ -82,7 +82,7 @@ import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -360,8 +360,7 @@ public class TestContextBuilder {
     headerTestFixture.coinbase(coinbase);
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
-    return new Block(
-        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    return new Block(genesisHeader, BlockBodies.empty());
   }
 
   private GenesisState createGenesisBlock(final String genesisFile) throws IOException {

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -45,7 +45,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -112,7 +112,7 @@ public class QbftRoundIntegrationTest {
     headerTestFixture.extraData(qbftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, BlockBodies.empty());
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -34,12 +34,10 @@ import org.hyperledger.besu.ethereum.blockcreation.BlockCreator;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator.BlockCreationResult;
 import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.pki.cms.CmsCreator;
-
-import java.util.Collections;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
@@ -118,10 +116,7 @@ public class PkiQbftBlockCreatorTest {
         createExtraData(blockHeaderBuilder.buildHeader(), extraDataCodec);
     final BlockHeader blockHeaderWithExtraData =
         blockHeaderBuilder.extraData(extraDataCodec.encode(originalExtraData)).buildHeader();
-    final Block block =
-        new Block(
-            blockHeaderWithExtraData,
-            new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    final Block block = new Block(blockHeaderWithExtraData, BlockBodies.empty());
     when(blockCreator.createBlock(eq(1L)))
         .thenReturn(new BlockCreationResult(block, new TransactionSelectionResults()));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
@@ -51,7 +51,7 @@ public class ProposalTest {
   private static final Block BLOCK =
       new Block(
           new BlockHeaderTestFixture().extraData(bftExtraDataCodec.encode(extraData)).buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+          BlockBodies.empty());
 
   @Test
   public void canRoundTripProposalMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.crypto.NodeKey;
 import org.hyperledger.besu.crypto.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
@@ -51,7 +51,7 @@ public class RoundChangeTest {
           new BlockHeaderTestFixture()
               .extraData(new QbftExtraDataCodec().encode(extraData))
               .buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+          BlockBodies.empty());
 
   @Test
   public void canRoundTripARoundChangeMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -61,7 +61,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.BlockCreator.BlockCreationResult;
 import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -123,7 +123,7 @@ public class QbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(bftExtraDataCodec.encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    createdBlock = new Block(header, BlockBodies.empty());
   }
 
   @Before

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -54,7 +54,7 @@ import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.Tran
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -127,7 +127,7 @@ public class QbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, BlockBodies.empty());
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
@@ -92,7 +92,7 @@ public class ForkingValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
+    return new Block(headerBuilder.buildHeader(), BlockBodies.empty());
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
@@ -30,7 +30,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collection;
@@ -77,7 +77,7 @@ public class TransactionValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
+    return new Block(headerBuilder.buildHeader(), BlockBodies.empty());
   }
 
   @Test

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -38,7 +38,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            BlockBodies.ofTransactions(transactionList));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -38,7 +38,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            BlockBodies.ofTransactions(transactionList));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayload.java
@@ -37,7 +37,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -49,7 +49,6 @@ import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -178,8 +177,7 @@ public class EngineNewPayload extends ExecutionEngineJsonRpcMethod {
           "block timestamp not greater than parent");
     }
 
-    final var block =
-        new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
+    final var block = new Block(newBlockHeader, BlockBodies.ofTransactions(transactions));
     final String warningMessage = "Sync to block " + block.toLogString() + " failed";
 
     if (mergeContext.get().isSyncing() || parentHeader.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -30,7 +31,7 @@ public class UncleBlockResult {
    * @return A BlockResult, generated from the header and empty body.
    */
   public static BlockResult build(final BlockHeader header) {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body = BlockBodies.empty();
     final int size = new Block(header, body).calculateSize();
     return new BlockResult(
         header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, size);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -32,13 +32,12 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -162,19 +161,17 @@ public class EthGasPriceTest {
                 Hash.EMPTY,
                 0,
                 null),
-            new BlockBody(
-                List.of(
-                    new Transaction(
-                        0,
-                        Wei.of(height * 1000000L),
-                        0,
-                        Optional.empty(),
-                        Wei.ZERO,
-                        null,
-                        Bytes.EMPTY,
-                        Address.ZERO,
-                        Optional.empty())),
-                List.of())));
+            BlockBodies.of(
+                new Transaction(
+                    0,
+                    Wei.of(height * 1000000L),
+                    0,
+                    Optional.empty(),
+                    Wei.ZERO,
+                    null,
+                    Bytes.EMPTY,
+                    Address.ZERO,
+                    Optional.empty()))));
   }
 
   private Object createEmptyBlock(final Long height) {
@@ -198,7 +195,7 @@ public class EthGasPriceTest {
                 Hash.EMPTY,
                 0,
                 null),
-            new BlockBody(List.of(), List.of())));
+            BlockBodies.empty()));
   }
 
   private JsonRpcRequestContext requestWithParams(final Object... params) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -32,7 +32,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -145,8 +145,7 @@ public class EthGetUncleByBlockHashAndIndexTest {
   }
 
   private BlockResult blockResult(final BlockHeader header) {
-    final Block block =
-        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    final Block block = new Block(header, BlockBodies.empty());
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -33,7 +33,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -122,8 +122,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
   }
 
   private BlockResult blockResult(final BlockHeader header) {
-    final Block block =
-        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    final Block block = new Block(header, BlockBodies.empty());
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadTest.java
@@ -34,11 +34,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineGetPayloadResult;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
@@ -61,8 +60,7 @@ public class EngineGetPayloadTest {
           Hash.ZERO, 1337L, Bytes32.random(), Address.fromHexString("0x42"));
   private static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
-  private static final Block mockBlock =
-      new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+  private static final Block mockBlock = new Block(mockHeader, BlockBodies.empty());
 
   @Mock private ProtocolContext protocolContext;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadTest.java
@@ -48,7 +48,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
@@ -168,8 +168,7 @@ public class EngineNewPayloadTest {
   @Test
   public void shouldReturnSuccessOnAlreadyPresent() {
     BlockHeader mockHeader = new BlockHeaderTestFixture().baseFeePerGas(Wei.ONE).buildHeader();
-    Block mockBlock =
-        new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    Block mockBlock = new Block(mockHeader, BlockBodies.empty());
 
     when(blockchain.getBlockByHash(any())).thenReturn(Optional.of(mockBlock));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.Trace;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -33,7 +34,6 @@ import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
@@ -68,7 +68,7 @@ public class RewardTraceGeneratorTest {
 
   @Before
   public void setUp() {
-    final BlockBody blockBody = new BlockBody(Collections.emptyList(), List.of(ommerHeader));
+    final BlockBody blockBody = BlockBodies.of(ommerHeader);
     final BlockHeader blockHeader =
         gen.header(0x0A, blockBody, new BlockDataGenerator.BlockOptions());
     block = new Block(blockHeader, blockBody);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -112,7 +113,7 @@ public class BlockchainQueriesLogCacheTest {
             0,
             new MainnetBlockHeaderFunctions());
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody = BlockBodies.empty();
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testHash));
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -95,7 +96,7 @@ public class GoQuorumPrivateTxBloomBlockchainQueriesTest {
             new MainnetBlockHeaderFunctions(),
             Optional.of(testLogsBloomFilter));
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody = BlockBodies.empty();
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -107,7 +108,7 @@ public class GoQuorumPrivateTransactionLogBloomCacherTest {
   @Test
   public void shouldUpdateCacheWhenBlockAdded() throws IOException {
 
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody = BlockBodies.empty();
     when(blockchain.getBlockHeader(testBlockHeaderHash)).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testBlockHeaderHash));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
@@ -203,7 +203,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final BlockHeader blockHeader = createFinalBlockHeader(sealableBlockHeader);
 
       final Block block =
-          new Block(blockHeader, new BlockBody(transactionResults.getTransactions(), ommers));
+          new Block(blockHeader, BlockBodies.of(transactionResults.getTransactions(), ommers));
       return new BlockCreationResult(block, transactionResults);
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -40,9 +40,7 @@ import org.junit.Test;
 public class AbstractMiningCoordinatorTest {
 
   private static final Block BLOCK =
-      new Block(
-          new BlockHeaderTestFixture().buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+      new Block(new BlockHeaderTestFixture().buildHeader(), BlockBodies.empty());
   private final Blockchain blockchain = mock(Blockchain.class);
   private final PoWMinerExecutor minerExecutor = mock(PoWMinerExecutor.class);
   private final SyncState syncState = mock(SyncState.class);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.blockcreation.BlockCreator.BlockCreationRes
 import org.hyperledger.besu.ethereum.blockcreation.BlockTransactionSelector.TransactionSelectionResults;
 import org.hyperledger.besu.ethereum.chain.MinedBlockObserver;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
@@ -41,7 +41,6 @@ import java.math.BigInteger;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
 public class BlockMinerTest {
@@ -50,9 +49,7 @@ public class BlockMinerTest {
   public void blockCreatedIsAddedToBlockChain() throws InterruptedException {
     final BlockHeaderTestFixture headerBuilder = new BlockHeaderTestFixture();
 
-    final Block blockToCreate =
-        new Block(
-            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    final Block blockToCreate = new Block(headerBuilder.buildHeader(), BlockBodies.empty());
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 
@@ -91,9 +88,7 @@ public class BlockMinerTest {
   public void failureToImportDoesNotTriggerObservers() throws InterruptedException {
     final BlockHeaderTestFixture headerBuilder = new BlockHeaderTestFixture();
 
-    final Block blockToCreate =
-        new Block(
-            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    final Block blockToCreate = new Block(headerBuilder.buildHeader(), BlockBodies.empty());
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
@@ -19,7 +19,7 @@ import static java.util.Collections.emptyList;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
@@ -76,7 +76,7 @@ public class OperationBenchmarkHelper {
                   .number(i)
                   .difficulty(Difficulty.ONE)
                   .buildHeader(),
-              new BlockBody(emptyList(), emptyList())),
+              BlockBodies.empty()),
           emptyList());
     }
     final MessageFrame messageFrame =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
@@ -36,7 +37,6 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
 import java.math.BigInteger;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -51,8 +51,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public final class GenesisState {
 
-  private static final BlockBody BODY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList());
+  private static final BlockBody BODY = BlockBodies.empty();
 
   private final Block block;
   private final List<GenesisAccount> genesisAccounts;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
@@ -71,7 +71,7 @@ public class Block {
     final List<BlockHeader> ommers = in.readList(rlp -> BlockHeader.readFrom(rlp, hashFunction));
     in.leaveList();
 
-    return new Block(header, new BlockBody(transactions, ommers));
+    return new Block(header, BlockBodies.of(transactions, ommers));
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBodies.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBodies.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  * Copyright Hyperledger Besu Contributors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ *  * the License. You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ *  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ *  * specific language governing permissions and limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+package org.hyperledger.besu.ethereum.core;
+
+import java.util.Collections;
+import java.util.List;
+
+public class BlockBodies {
+
+  private BlockBodies() {}
+
+  public static BlockBody empty() {
+    return new BlockBody(Collections.emptyList(), Collections.emptyList());
+  }
+
+  public static BlockBody of(
+      final List<Transaction> transactions, final List<BlockHeader> ommerHeaders) {
+    return new BlockBody(transactions, ommerHeaders);
+  }
+
+  public static BlockBody ofTransactions(final List<Transaction> transactionList) {
+    return new BlockBody(transactionList, Collections.emptyList());
+  }
+
+  public static BlockBody of(final Transaction transaction) {
+    return ofTransactions(Collections.singletonList(transaction));
+  }
+
+  public static BlockBody of(final Transaction transaction, final Transaction transaction1) {
+    return ofTransactions(List.of(transaction, transaction1));
+  }
+
+  public static BlockBody ofOmmers(final List<BlockHeader> ommerHeaders) {
+    return new BlockBody(Collections.emptyList(), ommerHeaders);
+  }
+
+  public static BlockBody of(final BlockHeader ommerHeader) {
+    return ofOmmers(Collections.singletonList(ommerHeader));
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
@@ -17,14 +17,10 @@ package org.hyperledger.besu.ethereum.core;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
-
-  private static final BlockBody EMPTY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList());
 
   private final List<Transaction> transactions;
   private final List<BlockHeader> ommers;
@@ -33,11 +29,6 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     this.transactions = transactions;
     this.ommers = ommers;
   }
-
-  public static BlockBody empty() {
-    return EMPTY;
-  }
-
   /** @return The list of transactions of the block. */
   @Override
   public List<Transaction> getTransactions() {
@@ -69,7 +60,7 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     input.enterList();
     // TODO: Support multiple hard fork transaction formats.
     final BlockBody body =
-        new BlockBody(
+        BlockBodies.of(
             input.readList(Transaction::readFrom),
             input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)));
     input.leaveList();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.util;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -101,7 +102,7 @@ public final class RawBlockIterator implements Iterator<Block>, Closeable {
       rlp.enterList();
       final BlockHeader header = headerReader.apply(rlp);
       final BlockBody body =
-          new BlockBody(rlp.readList(Transaction::readFrom), rlp.readList(headerReader));
+          BlockBodies.of(rlp.readList(Transaction::readFrom), rlp.readList(headerReader));
       next = new Block(header, body);
       readBuffer.position(length);
       readBuffer.compact();

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -246,7 +246,7 @@ public class BlockDataGenerator {
   public Block block(final BlockOptions options) {
     final long blockNumber = options.getBlockNumber(positiveLong());
     final BlockBody body =
-        blockNumber == BlockHeader.GENESIS_BLOCK_NUMBER ? BlockBody.empty() : body(options);
+        blockNumber == BlockHeader.GENESIS_BLOCK_NUMBER ? BlockBodies.empty() : body(options);
     final BlockHeader header = header(blockNumber, body, options);
     return new Block(header, body);
   }
@@ -327,7 +327,7 @@ public class BlockDataGenerator {
       defaultTxs.add(transaction(options.getTransactionTypes()));
     }
 
-    return new BlockBody(options.getTransactions(defaultTxs), ommers);
+    return BlockBodies.of(options.getTransactions(defaultTxs), ommers);
   }
 
   private BlockHeader ommer() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
@@ -22,14 +22,12 @@ import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.plugin.data.TransactionType;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -66,17 +64,15 @@ public class BaseFeeBlockBodyValidatorTest {
     when(blockHeader.getBaseFee()).thenReturn(Optional.of(Wei.of(10L)));
     when(block.getBody())
         .thenReturn(
-            new BlockBody(
-                List.of(
-                    // eip1559 transaction
-                    new TransactionTestFixture()
-                        .maxFeePerGas(Optional.of(Wei.of(10L)))
-                        .maxPriorityFeePerGas(Optional.of(Wei.of(1L)))
-                        .type(TransactionType.EIP1559)
-                        .createTransaction(keyPair),
-                    // frontier transaction
-                    new TransactionTestFixture().gasPrice(Wei.of(10L)).createTransaction(keyPair)),
-                Collections.emptyList()));
+            BlockBodies.of(
+                // eip1559 transaction
+                new TransactionTestFixture()
+                    .maxFeePerGas(Optional.of(Wei.of(10L)))
+                    .maxPriorityFeePerGas(Optional.of(Wei.of(1L)))
+                    .type(TransactionType.EIP1559)
+                    .createTransaction(keyPair),
+                // frontier transaction
+                new TransactionTestFixture().gasPrice(Wei.of(10L)).createTransaction(keyPair)));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isTrue();
   }
@@ -86,11 +82,9 @@ public class BaseFeeBlockBodyValidatorTest {
     when(blockHeader.getBaseFee()).thenReturn(Optional.of(Wei.of(10L)));
     when(block.getBody())
         .thenReturn(
-            new BlockBody(
-                List.of(
-                    // underpriced frontier transaction
-                    new TransactionTestFixture().gasPrice(Wei.of(9L)).createTransaction(keyPair)),
-                Collections.emptyList()));
+            BlockBodies.of(
+                // underpriced frontier transaction
+                new TransactionTestFixture().gasPrice(Wei.of(9L)).createTransaction(keyPair)));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }
@@ -100,15 +94,13 @@ public class BaseFeeBlockBodyValidatorTest {
     when(blockHeader.getBaseFee()).thenReturn(Optional.of(Wei.of(10L)));
     when(block.getBody())
         .thenReturn(
-            new BlockBody(
-                List.of(
-                    // underpriced eip1559 transaction
-                    new TransactionTestFixture()
-                        .maxFeePerGas(Optional.of(Wei.of(1L)))
-                        .maxPriorityFeePerGas(Optional.of(Wei.of(10L)))
-                        .type(TransactionType.EIP1559)
-                        .createTransaction(keyPair)),
-                Collections.emptyList()));
+            BlockBodies.of(
+                // underpriced eip1559 transaction
+                new TransactionTestFixture()
+                    .maxFeePerGas(Optional.of(Wei.of(1L)))
+                    .maxPriorityFeePerGas(Optional.of(Wei.of(10L)))
+                    .type(TransactionType.EIP1559)
+                    .createTransaction(keyPair)));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.mainnet;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -52,7 +53,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    return new BlockBody(transactions, ommers);
+    return BlockBodies.of(transactions, ommers);
   }
 
   public static Block readBlock(final long num) throws IOException {
@@ -67,7 +68,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    final BlockBody body = new BlockBody(transactions, ommers);
+    final BlockBody body = BlockBodies.of(transactions, ommers);
     return new Block(header, body);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTask.java
@@ -21,7 +21,7 @@ import static java.util.stream.Collectors.toMap;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
@@ -74,7 +74,8 @@ public class CompleteBlocksTask extends AbstractRetryingPeerTask<List<Block>> {
     this.blocks =
         headers.stream()
             .filter(this::hasEmptyBody)
-            .collect(toMap(BlockHeader::getNumber, header -> new Block(header, BlockBody.empty())));
+            .collect(
+                toMap(BlockHeader::getNumber, header -> new Block(header, BlockBodies.empty())));
   }
 
   private boolean hasEmptyBody(final BlockHeader header) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.messages;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -57,7 +58,7 @@ public final class BlockBodiesMessageTest {
       oneBlock.skipNext();
       bodies.add(
           // We know the test data to only contain Frontier blocks
-          new BlockBody(
+          BlockBodies.of(
               oneBlock.readList(Transaction::readFrom),
               oneBlock.readList(
                   rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()))));

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
@@ -31,7 +32,6 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.messages.NewBlockMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 
-import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.junit.Test;
@@ -82,7 +82,7 @@ public class BlockBroadcasterTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body = BlockBodies.empty();
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.eth.sync;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -25,7 +24,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.eth.manager.ChainState;
@@ -113,9 +112,7 @@ public class TrailingPeerLimiterTest {
 
     final BlockAddedEvent blockAddedEvent =
         BlockAddedEvent.createForHeadAdvancement(
-            new Block(
-                new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+            new Block(new BlockHeaderTestFixture().number(500).buildHeader(), BlockBodies.empty()),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);
@@ -131,9 +128,7 @@ public class TrailingPeerLimiterTest {
 
     final BlockAddedEvent blockAddedEvent =
         BlockAddedEvent.createForHeadAdvancement(
-            new Block(
-                new BlockHeaderTestFixture().number(599).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+            new Block(new BlockHeaderTestFixture().number(599).buildHeader(), BlockBodies.empty()),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
@@ -94,11 +94,11 @@ public class ChainForTestCreator {
   }
 
   public static Block createEmptyBlock(final Long height) {
-    return new Block(prepareEmptyHeader(height), new BlockBody(List.of(), List.of()));
+    return new Block(prepareEmptyHeader(height), BlockBodies.empty());
   }
 
   private static Block createEmptyBlock(final Block parent) {
-    return new Block(prepareEmptyHeader(parent.getHeader()), new BlockBody(List.of(), List.of()));
+    return new Block(prepareEmptyHeader(parent.getHeader()), BlockBodies.empty());
   }
 
   private static BlockHeader prepareEmptyHeader(final Long number) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockWithReceipts;
@@ -31,7 +32,6 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -76,7 +76,7 @@ public class CheckPointBlockImportStepTest {
   }
 
   private Block generateBlock(final int blockNumber) {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body = BlockBodies.empty();
     return new Block(new BlockHeaderTestFixture().number(blockNumber).buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.eth.sync.snapsync;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -30,7 +29,7 @@ import org.hyperledger.besu.ethereum.chain.BlockAddedEvent;
 import org.hyperledger.besu.ethereum.chain.BlockAddedObserver;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider;
@@ -325,9 +324,7 @@ public class SnapWorldDownloadStateTest {
     final BlockAddedObserver blockAddedListener = downloadState.getBlockAddedListener();
     blockAddedListener.onBlockAdded(
         BlockAddedEvent.createForHeadAdvancement(
-            new Block(
-                new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+            new Block(new BlockHeaderTestFixture().number(500).buildHeader(), BlockBodies.empty()),
             Collections.emptyList(),
             Collections.emptyList()));
 
@@ -351,9 +348,7 @@ public class SnapWorldDownloadStateTest {
     final BlockAddedObserver blockAddedListener = downloadState.getBlockAddedListener();
     blockAddedListener.onBlockAdded(
         BlockAddedEvent.createForHeadAdvancement(
-            new Block(
-                new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+            new Block(new BlockHeaderTestFixture().number(500).buildHeader(), BlockBodies.empty()),
             Collections.emptyList(),
             Collections.emptyList()));
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/CompleteBlocksTaskTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -70,9 +71,9 @@ public class CompleteBlocksTaskTest extends RetryingMessageTaskTest<List<Block>>
     final BlockHeader header2 = new BlockHeaderTestFixture().number(2).buildHeader();
     final BlockHeader header3 = new BlockHeaderTestFixture().number(3).buildHeader();
 
-    final Block block1 = new Block(header1, BlockBody.empty());
-    final Block block2 = new Block(header2, BlockBody.empty());
-    final Block block3 = new Block(header3, BlockBody.empty());
+    final Block block1 = new Block(header1, BlockBodies.empty());
+    final Block block2 = new Block(header2, BlockBodies.empty());
+    final Block block3 = new Block(header3, BlockBodies.empty());
 
     final List<Block> blocks = asList(block1, block2, block3);
     final EthTask<List<Block>> task = createTask(blocks);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolTest.java
@@ -43,7 +43,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -1048,7 +1048,7 @@ public class TransactionPoolTest {
             .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
             .parentHash(blockchain.getChainHeadHash())
             .buildBlockHeader();
-    blockchain.appendBlock(new Block(header, BlockBody.empty()), emptyList());
+    blockchain.appendBlock(new Block(header, BlockBodies.empty()), emptyList());
   }
 
   @Test
@@ -1105,7 +1105,7 @@ public class TransactionPoolTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            BlockBodies.ofTransactions(transactionList));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBodies;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
@@ -82,7 +83,7 @@ public class BlockchainReferenceTestCaseSpec {
   }
 
   private static MutableBlockchain buildBlockchain(final BlockHeader genesisBlockHeader) {
-    final Block genesisBlock = new Block(genesisBlockHeader, BlockBody.empty());
+    final Block genesisBlock = new Block(genesisBlockHeader, BlockBodies.empty());
     return InMemoryKeyValueStorageProvider.createInMemoryBlockchain(genesisBlock);
   }
 
@@ -248,7 +249,7 @@ public class BlockchainReferenceTestCaseSpec {
       final MainnetBlockHeaderFunctions blockHeaderFunctions = new MainnetBlockHeaderFunctions();
       final BlockHeader header = BlockHeader.readFrom(input, blockHeaderFunctions);
       final BlockBody body =
-          new BlockBody(
+          BlockBodies.of(
               input.readList(Transaction::readFrom),
               input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)));
       return new Block(header, body);


### PR DESCRIPTION
This is a QoL refactor that should not have an effect of behaviour. 

When working on Withdrawals I noticed code similar to some of these:
```
  new BlockBody(emptyList(),emptyList());
  new BlockBody(List.of(transaction1),emptyList());
  new BlockBody(emptyList(),List.of(ommerHeader));
```

This PR adds a utility class BlockBodies that should work similarly to List.of(...) there is a BlockBodies.empty()
there is a utility method for BlockBodies.of(transaction) there is a utility method for BlockBodies.of(ommerHeader)

And there will be probably similar one when you will need a Block body only with a withdrawal.

The BlockBody.empty() was moved into this utility class as well...

Signed-off-by: Jiri Peinlich <jiri.peinlich@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->