### PR TITLE
Adjust tracing calls

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -114,7 +114,6 @@ public class EVM {
 
       OperationResult result;
       try {
-
         switch (opcode) {
             // case 0x00: // STOP
             //  result = StopOperation.staticOperation(frame);
@@ -292,12 +291,16 @@ public class EVM {
         LOG.trace("MessageFrame evaluation halted because of {}", haltReason);
         frame.setExceptionalHaltReason(Optional.of(haltReason));
         frame.setState(State.EXCEPTIONAL_HALT);
+      } else {
+        frame.decrementRemainingGas(result.getGasCost());
       }
-      frame.decrementRemainingGas(result.getGasCost());
       if (frame.getState() == State.CODE_EXECUTING) {
         final int currentPC = frame.getPC();
         final int opSize = result.getPcIncrement();
         frame.setPC(currentPC + opSize);
+      }
+      if (operationTracer != null) {
+        operationTracer.tracePostExecution(frame, result);
       }
     }
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -283,9 +283,6 @@ public class EVM {
       } catch (final UnderflowException ue) {
         result = UNDERFLOW_RESPONSE;
       }
-      if (operationTracer != null) {
-        operationTracer.tracePostExecution(frame, result);
-      }
       final ExceptionalHaltReason haltReason = result.getHaltReason();
       if (haltReason != null) {
         LOG.trace("MessageFrame evaluation halted because of {}", haltReason);


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Restore two tracing behaviors in the EVM introduced by the unrolled loop
* change gas only on successful operations
* send post execution call after gas and PC changes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).