### PR TITLE
Migrate storage APIs to Bytes32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## 22.10.0
 ### Breaking Changes
 - Version 22.10.0 will require Java 17 to build and run.
+- Internal and interface APIs relating to storage have migrated from `UInt256` to `Bytes32` [#4562](https://github.com/hyperledger/besu/pull/4562)
 
 ### Additions and Improvements
 - Updated jackson-databind library to version 2.13.4.2 addressing [CVE-2022-42003](https://nvd.nist.gov/vuln/detail/CVE-2022-42003)

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyGroupGenesisProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyGroupGenesisProvider.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class TestPrivacyGroupGenesisProvider implements PrivacyGroupGenesisProvider {
   private boolean genesisEnabled = false;
@@ -50,7 +50,7 @@ public class TestPrivacyGroupGenesisProvider implements PrivacyGroupGenesisProvi
               }
 
               @Override
-              public Map<UInt256, UInt256> getStorage() {
+              public Map<Bytes32, Bytes32> getStorage() {
                 return Collections.emptyMap();
               }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/MultiTenancyAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/multitenancy/MultiTenancyAcceptanceTest.java
@@ -212,7 +212,7 @@ public class MultiTenancyAcceptanceTest extends AcceptanceTestBase {
   public void privDistributeRawTransactionSuccessShouldReturnEnclaveKey()
       throws JsonProcessingException {
     final String enclaveResponseKeyBytes =
-        Bytes.wrap(Bytes.fromBase64String(PARTICIPANT_ENCLAVE_KEY1)).toString();
+        Bytes.fromBase64String(PARTICIPANT_ENCLAVE_KEY1).toString();
 
     retrievePrivacyGroupEnclaveStub();
     sendEnclaveStub(PARTICIPANT_ENCLAVE_KEY1);

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
@@ -218,7 +218,7 @@ public class RestoreState implements Runnable {
             throw new RuntimeException("Unexpected storage trie entry length " + len);
           }
           final Bytes32 storageTrieKey = Bytes32.wrap(trieInput.readBytes());
-          final Bytes storageTrieValue = Bytes.wrap(trieInput.readBytes());
+          final Bytes storageTrieValue = trieInput.readBytes();
           final RestoreVisitor<Bytes> storageTrieWriteVisitor =
               new RestoreVisitor<>(t -> t, storageTrieValue, storagePersistVisitor);
           storageRoot = storageRoot.accept(storageTrieWriteVisitor, bytesToPath(storageTrieKey));

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -75,7 +75,6 @@ import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -251,7 +250,6 @@ public class PrivacyReorgTest {
   }
 
   @Test
-  @Ignore("//FIXME")
   public void reorgToChainAtEqualHeight() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();
@@ -285,7 +283,6 @@ public class PrivacyReorgTest {
   }
 
   @Test
-  @Ignore("//FIXME")
   public void reorgToShorterChain() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();
@@ -339,7 +336,6 @@ public class PrivacyReorgTest {
   }
 
   @Test
-  @Ignore("//FIXME")
   public void reorgToLongerChain() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -75,6 +75,7 @@ import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -250,6 +251,7 @@ public class PrivacyReorgTest {
   }
 
   @Test
+  @Ignore("//FIXME")
   public void reorgToChainAtEqualHeight() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();
@@ -283,6 +285,7 @@ public class PrivacyReorgTest {
   }
 
   @Test
+  @Ignore("//FIXME")
   public void reorgToShorterChain() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();
@@ -336,6 +339,7 @@ public class PrivacyReorgTest {
   }
 
   @Test
+  @Ignore("//FIXME")
   public void reorgToLongerChain() {
     // Setup an initial blockchain with one private transaction
     final ProtocolContext protocolContext = besuController.getProtocolContext();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class EthGetProof extends AbstractBlockParameterOrBlockHashMethod {
   public EthGetProof(final BlockchainQueries blockchain) {
@@ -56,7 +56,7 @@ public class EthGetProof extends AbstractBlockParameterOrBlockHashMethod {
       final JsonRpcRequestContext requestContext, final Hash blockHash) {
 
     final Address address = requestContext.getRequiredParameter(0, Address.class);
-    final List<UInt256> storageKeys = getStorageKeys(requestContext);
+    final List<Bytes32> storageKeys = getStorageKeys(requestContext);
 
     final Optional<WorldState> worldState = getBlockchainQueries().getWorldState(blockHash);
 
@@ -86,9 +86,9 @@ public class EthGetProof extends AbstractBlockParameterOrBlockHashMethod {
     return (JsonRpcResponse) handleParamTypes(requestContext);
   }
 
-  private List<UInt256> getStorageKeys(final JsonRpcRequestContext request) {
+  private List<Bytes32> getStorageKeys(final JsonRpcRequestContext request) {
     return Arrays.stream(request.getRequiredParameter(1, String[].class))
-        .map(UInt256::fromHexString)
+        .map(Bytes32::fromHexString)
         .collect(Collectors.toList());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UInt256Parameter;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class EthGetStorageAt extends AbstractBlockParameterOrBlockHashMethod {
   public EthGetStorageAt(final BlockchainQueries blockchainQueries) {
@@ -43,11 +43,11 @@ public class EthGetStorageAt extends AbstractBlockParameterOrBlockHashMethod {
   @Override
   protected String resultByBlockHash(final JsonRpcRequestContext request, final Hash blockHash) {
     final Address address = request.getRequiredParameter(0, Address.class);
-    final UInt256 position = request.getRequiredParameter(1, UInt256Parameter.class).getValue();
+    final Bytes32 position = request.getRequiredParameter(1, UInt256Parameter.class).getValue();
     return blockchainQueries
         .get()
         .storageAt(address, position, blockHash)
-        .map(UInt256::toHexString)
+        .map(Bytes32::toHexString)
         .orElse(null);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class DebugStorageRangeAtResult implements JsonRpcResult {
 
@@ -88,17 +87,17 @@ public class DebugStorageRangeAtResult implements JsonRpcResult {
 
     public StorageEntry(final AccountStorageEntry entry, final boolean shortValues) {
       if (shortValues) {
-        this.value = entry.getValue().toMinimalBytes().toHexString();
+        this.value = entry.getValue().trimLeadingZeros().toHexString();
         this.key =
             entry
                 .getKey()
-                .map(UInt256::toMinimalBytes)
+                .map(Bytes32::trimLeadingZeros)
                 .map(Bytes::toHexString)
                 .map(s -> "0x".equals(s) ? "0x00" : s)
                 .orElse(null);
       } else {
         this.value = entry.getValue().toHexString();
-        this.key = entry.getKey().map(UInt256::toHexString).orElse(null);
+        this.key = entry.getKey().map(Bytes32::toHexString).orElse(null);
       }
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 @JsonPropertyOrder({"pc", "op", "gas", "gasCost", "depth", "stack", "memory", "storage"})
 public class StructLog {
@@ -59,7 +59,7 @@ public class StructLog {
     reason = traceFrame.getRevertReason().map(Bytes::toShortHexString).orElse(null);
   }
 
-  private static Map<String, String> formatStorage(final Map<UInt256, UInt256> storage) {
+  private static Map<String, String> formatStorage(final Map<Bytes32, Bytes32> storage) {
     final Map<String, String> formattedStorage = new TreeMap<>();
     storage.forEach(
         (key, value) ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/StorageEntryProof.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/StorageEntryProof.java
@@ -21,17 +21,17 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class StorageEntryProof {
 
-  private final UInt256 key;
+  private final Bytes32 key;
 
-  private final UInt256 value;
+  private final Bytes32 value;
 
   private final List<Bytes> storageProof;
 
-  public StorageEntryProof(final UInt256 key, final UInt256 value, final List<Bytes> storageProof) {
+  public StorageEntryProof(final Bytes32 key, final Bytes32 value, final List<Bytes> storageProof) {
     this.key = key;
     this.value = value;
     this.storageProof = storageProof;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class StateDiffGenerator {
 
@@ -59,18 +59,18 @@ public class StateDiffGenerator {
 
       // calculate storage diff
       final Map<String, DiffNode> storageDiff = new TreeMap<>();
-      for (final Map.Entry<UInt256, UInt256> entry :
+      for (final Map.Entry<Bytes32, Bytes32> entry :
           ((UpdateTrackingAccount<?>) updatedAccount)
               .getUpdatedStorage()
               .entrySet()) { // FIXME cast
-        final UInt256 newValue = entry.getValue();
+        final Bytes32 newValue = entry.getValue();
         if (rootAccount == null) {
-          if (!UInt256.ZERO.equals(newValue)) {
+          if (!Bytes32.ZERO.equals(newValue)) {
             storageDiff.put(
                 entry.getKey().toHexString(), new DiffNode(null, newValue.toHexString()));
           }
         } else {
-          final UInt256 originalValue = rootAccount.getStorageValue(entry.getKey());
+          final Bytes32 originalValue = rootAccount.getStorageValue(entry.getKey());
           if (!originalValue.equals(newValue)) {
             storageDiff.put(
                 entry.getKey().toHexString(),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTraceGenerator.java
@@ -256,7 +256,7 @@ public class VmTraceGenerator {
           .ifPresent(
               stack ->
                   IntStream.range(0, currentTraceFrame.getStackItemsProduced())
-                      .mapToObj(i -> Bytes.wrap(stack[stack.length - i - 1]).trimLeadingZeros())
+                      .mapToObj(i -> stack[stack.length - i - 1].trimLeadingZeros())
                       .map(value -> Quantity.create(UInt256.fromHexString(value.toHexString())))
                       .forEach(report::addPush));
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -56,7 +56,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,8 +167,8 @@ public class BlockchainQueries {
    * @param blockNumber The blockNumber that is being queried.
    * @return The value at the storage index being queried.
    */
-  public Optional<UInt256> storageAt(
-      final Address address, final UInt256 storageIndex, final long blockNumber) {
+  public Optional<Bytes32> storageAt(
+      final Address address, final Bytes32 storageIndex, final long blockNumber) {
     final Hash blockHash =
         getBlockHeaderByNumber(blockNumber).map(BlockHeader::getHash).orElse(Hash.EMPTY);
 
@@ -183,10 +183,10 @@ public class BlockchainQueries {
    * @param blockHash The blockHash that is being queried.
    * @return The value at the storage index being queried.
    */
-  public Optional<UInt256> storageAt(
-      final Address address, final UInt256 storageIndex, final Hash blockHash) {
+  public Optional<Bytes32> storageAt(
+      final Address address, final Bytes32 storageIndex, final Hash blockHash) {
     return fromAccount(
-        address, blockHash, account -> account.getStorageValue(storageIndex), UInt256.ZERO);
+        address, blockHash, account -> account.getStorageValue(storageIndex), Bytes32.ZERO);
   }
 
   /**

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
@@ -103,7 +103,7 @@ public class EthSubmitWorkTest {
     final JsonRpcRequestContext request =
         requestWithParams(
             Bytes.ofUnsignedLong(expectedFirstOutput.getNonce()).trimLeadingZeros().toHexString(),
-            Bytes.wrap(expectedFirstOutput.getPowHash()).toHexString(),
+            expectedFirstOutput.getPowHash().toHexString(),
             expectedFirstOutput.getMixHash().toHexString());
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -199,7 +199,7 @@ public class BlockchainQueriesTest {
   @Test
   public void getAccountStorageBlockNumber() {
     final List<Address> addresses = Arrays.asList(gen.address(), gen.address(), gen.address());
-    final List<UInt256> storageKeys =
+    final List<Bytes32> storageKeys =
         Arrays.asList(gen.storageKey(), gen.storageKey(), gen.storageKey());
     final BlockchainWithData data = setupBlockchain(3, addresses, storageKeys);
     final BlockchainQueries queries = data.blockchainQueries;
@@ -213,7 +213,7 @@ public class BlockchainQueriesTest {
             storageKeys.forEach(
                 storageKey -> {
                   final Account actualAccount0 = worldState0.get(address);
-                  final Optional<UInt256> result = queries.storageAt(address, storageKey, 2L);
+                  final Optional<Bytes32> result = queries.storageAt(address, storageKey, 2L);
                   assertThat(result).contains(actualAccount0.getStorageValue(storageKey));
                 }));
 
@@ -226,7 +226,7 @@ public class BlockchainQueriesTest {
             storageKeys.forEach(
                 storageKey -> {
                   final Account actualAccount1 = worldState1.get(address);
-                  final Optional<UInt256> result = queries.storageAt(address, storageKey, 1L);
+                  final Optional<Bytes32> result = queries.storageAt(address, storageKey, 1L);
                   assertThat(result).contains(actualAccount1.getStorageValue(storageKey));
                 }));
   }
@@ -540,7 +540,7 @@ public class BlockchainQueriesTest {
   }
 
   private BlockchainWithData setupBlockchain(
-      final int blocksToAdd, final List<Address> accountsToSetup, final List<UInt256> storageKeys) {
+      final int blocksToAdd, final List<Address> accountsToSetup, final List<Bytes32> storageKeys) {
     checkArgument(blocksToAdd >= 1, "Must add at least one block to the queries");
 
     final WorldStateArchive worldStateArchive = createInMemoryWorldStateArchive();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiAccount.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class BonsaiAccount implements MutableAccount, EvmAccount {
   private final BonsaiWorldView context;
@@ -51,7 +50,7 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
   private Hash storageRoot;
   private Bytes code;
 
-  private final Map<UInt256, UInt256> updatedStorage = new HashMap<>();
+  private final Map<Bytes32, Bytes32> updatedStorage = new HashMap<>();
 
   BonsaiAccount(
       final BonsaiWorldView context,
@@ -204,12 +203,12 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
   }
 
   @Override
-  public UInt256 getStorageValue(final UInt256 key) {
+  public Bytes32 getStorageValue(final Bytes32 key) {
     return context.getStorageValue(address, key);
   }
 
   @Override
-  public UInt256 getOriginalStorageValue(final UInt256 key) {
+  public Bytes32 getOriginalStorageValue(final Bytes32 key) {
     return context.getPriorStorageValue(address, key);
   }
 
@@ -233,7 +232,7 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
   }
 
   @Override
-  public void setStorageValue(final UInt256 key, final UInt256 value) {
+  public void setStorageValue(final Bytes32 key, final Bytes32 value) {
     if (!mutable) {
       throw new UnsupportedOperationException("Account is immutable");
     }
@@ -246,7 +245,7 @@ public class BonsaiAccount implements MutableAccount, EvmAccount {
   }
 
   @Override
-  public Map<UInt256, UInt256> getUpdatedStorage() {
+  public Map<Bytes32, Bytes32> getUpdatedStorage() {
     return updatedStorage;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -33,7 +33,6 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /** A World State backed first by trie log layer and then by another world state. */
 public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldView, WorldState {
@@ -125,19 +124,19 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   }
 
   @Override
-  public UInt256 getStorageValue(final Address address, final UInt256 key) {
-    return getStorageValueBySlotHash(address, Hash.hash(key)).orElse(UInt256.ZERO);
+  public Bytes32 getStorageValue(final Address address, final Bytes32 key) {
+    return getStorageValueBySlotHash(address, Hash.hash(key)).orElse(Bytes32.ZERO);
   }
 
   @Override
-  public Optional<UInt256> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
+  public Optional<Bytes32> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
     // this must be iterative and lambda light because the stack may blow up
     // mainly because we don't have tail calls.
     BonsaiLayeredWorldState currentLayer = this;
     while (currentLayer != null) {
-      final Optional<UInt256> maybeValue =
+      final Optional<Bytes32> maybeValue =
           currentLayer.trieLog.getStorageBySlotHash(address, slotHash);
-      final Optional<UInt256> maybePriorValue =
+      final Optional<Bytes32> maybePriorValue =
           currentLayer.trieLog.getPriorStorageBySlotHash(address, slotHash);
       if (currentLayer == this && maybeValue.isPresent()) {
         return maybeValue;
@@ -158,7 +157,7 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   }
 
   @Override
-  public UInt256 getPriorStorageValue(final Address address, final UInt256 key) {
+  public Bytes32 getPriorStorageValue(final Address address, final Bytes32 key) {
     // This is the base layer for a block, all values are original.
     return getStorageValue(address, key);
   }
@@ -177,7 +176,7 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
             .forEach(
                 entry -> {
                   if (!results.containsKey(entry.getKey())) {
-                    final UInt256 value = entry.getValue().getUpdated();
+                    final Bytes32 value = entry.getValue().getUpdated();
                     // yes, store the nulls.  If it was deleted it should stay deleted
                     results.put(entry.getKey(), value);
                   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -40,7 +40,6 @@ import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,7 +141,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
     // second update account storage state.  This must be done before updating the accounts so
     // that we can get the storage state hash
-    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
+    for (final Map.Entry<Address, Map<Hash, BonsaiValue<Bytes32>>> storageAccountUpdate :
         worldStateUpdater.getStorageToUpdate().entrySet()) {
       final Address updatedAddress = storageAccountUpdate.getKey();
       final Hash updatedAddressHash = Hash.hash(updatedAddress);
@@ -161,11 +160,11 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
         // for manicured tries and composting, collect branches here (not implemented)
 
-        for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageUpdate :
+        for (final Map.Entry<Hash, BonsaiValue<Bytes32>> storageUpdate :
             storageAccountUpdate.getValue().entrySet()) {
           final Hash keyHash = storageUpdate.getKey();
-          final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
-          if (updatedStorage == null || updatedStorage.equals(UInt256.ZERO)) {
+          final Bytes32 updatedStorage = storageUpdate.getValue().getUpdated();
+          if (updatedStorage == null || updatedStorage.equals(Bytes32.ZERO)) {
             stateUpdater.removeStorageValueBySlotHash(updatedAddressHash, keyHash);
             storageTrie.remove(keyHash);
           } else {
@@ -372,19 +371,19 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   @Override
-  public UInt256 getStorageValue(final Address address, final UInt256 storageKey) {
-    return getStorageValueBySlotHash(address, Hash.hash(storageKey)).orElse(UInt256.ZERO);
+  public Bytes32 getStorageValue(final Address address, final Bytes32 storageKey) {
+    return getStorageValueBySlotHash(address, Hash.hash(storageKey)).orElse(Bytes32.ZERO);
   }
 
   @Override
-  public Optional<UInt256> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
+  public Optional<Bytes32> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
     return worldStateStorage
         .getStorageValueBySlotHash(Hash.hash(address), slotHash)
-        .map(UInt256::fromBytes);
+        .map(Bytes32::leftPad);
   }
 
   @Override
-  public UInt256 getPriorStorageValue(final Address address, final UInt256 storageKey) {
+  public Bytes32 getPriorStorageValue(final Address address, final Bytes32 storageKey) {
     return getStorageValue(address, storageKey);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -263,7 +263,7 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
   public Optional<WorldStateProof> getAccountProof(
       final Hash worldStateRoot,
       final Address accountAddress,
-      final List<UInt256> accountStorageKeys) {
+      final List<Bytes32> accountStorageKeys) {
     // FIXME we can do proofs for layered tries and the persisted trie
     return Optional.empty();
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -28,7 +28,6 @@ import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
 import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -38,11 +37,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldView, BonsaiAccount>
     implements BonsaiWorldView {
@@ -54,7 +51,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
   // storage sub mapped by _hashed_ key.  This is because in self_destruct calls we need to
   // enumerate the old storage and delete it.  Those are trie stored by hashed key by spec and the
   // alternative was to keep a giant pre-image cache of the entire trie.
-  private Map<Address, Map<Hash, BonsaiValue<UInt256>>> storageToUpdate = new ConcurrentHashMap<>();
+  private Map<Address, Map<Hash, BonsaiValue<Bytes32>>> storageToUpdate = new ConcurrentHashMap<>();
 
   BonsaiWorldStateUpdater(final BonsaiWorldView world) {
     super(world);
@@ -69,22 +66,6 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
     copy.updatedAccounts = new HashMap<>(updatedAccounts);
     copy.deletedAccounts = new HashSet<>(deletedAccounts);
     return copy;
-  }
-
-  @Override
-  public Account get(final Address address) {
-    return super.get(address);
-  }
-
-  @Override
-  protected UpdateTrackingAccount<BonsaiAccount> track(
-      final UpdateTrackingAccount<BonsaiAccount> account) {
-    return super.track(account);
-  }
-
-  @Override
-  public EvmAccount getAccount(final Address address) {
-    return super.getAccount(address);
   }
 
   @Override
@@ -122,7 +103,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
     return storageToClear;
   }
 
-  Map<Address, Map<Hash, BonsaiValue<UInt256>>> getStorageToUpdate() {
+  Map<Address, Map<Hash, BonsaiValue<Bytes32>>> getStorageToUpdate() {
     return storageToUpdate;
   }
 
@@ -178,13 +159,13 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
       }
 
       // mark all updated storage as to be cleared
-      final Map<Hash, BonsaiValue<UInt256>> deletedStorageUpdates =
+      final Map<Hash, BonsaiValue<Bytes32>> deletedStorageUpdates =
           storageToUpdate.computeIfAbsent(deletedAddress, k -> new HashMap<>());
-      final Iterator<Map.Entry<Hash, BonsaiValue<UInt256>>> iter =
+      final Iterator<Map.Entry<Hash, BonsaiValue<Bytes32>>> iter =
           deletedStorageUpdates.entrySet().iterator();
       while (iter.hasNext()) {
-        final Map.Entry<Hash, BonsaiValue<UInt256>> updateEntry = iter.next();
-        final BonsaiValue<UInt256> updatedSlot = updateEntry.getValue();
+        final Map.Entry<Hash, BonsaiValue<Bytes32>> updateEntry = iter.next();
+        final BonsaiValue<Bytes32> updatedSlot = updateEntry.getValue();
         if (updatedSlot.getPrior() == null || updatedSlot.getPrior().isZero()) {
           iter.remove();
         } else {
@@ -201,7 +182,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                 (keyHash, entryValue) -> {
                   final Hash slotHash = Hash.wrap(keyHash);
                   if (!deletedStorageUpdates.containsKey(slotHash)) {
-                    final UInt256 value = UInt256.fromBytes(RLP.decodeOne(entryValue));
+                    final Bytes32 value = Bytes32.leftPad(Bytes.wrap(RLP.decodeOne(entryValue)));
                     deletedStorageUpdates.put(slotHash, new BonsaiValue<>(value, null, true));
                   }
                 });
@@ -245,24 +226,22 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
         pendingCode.setUpdated(updatedAccount.getCode());
       }
 
-      final Map<Hash, BonsaiValue<UInt256>> pendingStorageUpdates =
+      final Map<Hash, BonsaiValue<Bytes32>> pendingStorageUpdates =
           storageToUpdate.computeIfAbsent(updatedAddress, __ -> new HashMap<>());
       if (tracked.getStorageWasCleared()) {
         storageToClear.add(updatedAddress);
         pendingStorageUpdates.clear();
       }
 
-      final TreeSet<Map.Entry<UInt256, UInt256>> entries =
-          new TreeSet<>(
-              Comparator.comparing(
-                  (Function<Map.Entry<UInt256, UInt256>, UInt256>) Map.Entry::getKey));
+      final TreeSet<Map.Entry<Bytes32, Bytes32>> entries =
+          new TreeSet<>(Map.Entry.comparingByKey());
       entries.addAll(updatedAccount.getUpdatedStorage().entrySet());
 
-      for (final Map.Entry<UInt256, UInt256> storageUpdate : entries) {
-        final UInt256 keyUInt = storageUpdate.getKey();
+      for (final Map.Entry<Bytes32, Bytes32> storageUpdate : entries) {
+        final Bytes32 keyUInt = storageUpdate.getKey();
         final Hash slotHash = Hash.hash(keyUInt);
-        final UInt256 value = storageUpdate.getValue();
-        final BonsaiValue<UInt256> pendingValue = pendingStorageUpdates.get(slotHash);
+        final Bytes32 value = storageUpdate.getValue();
+        final BonsaiValue<Bytes32> pendingValue = pendingStorageUpdates.get(slotHash);
         if (pendingValue == null) {
           pendingStorageUpdates.put(
               slotHash, new BonsaiValue<>(updatedAccount.getOriginalStorageValue(keyUInt), value));
@@ -301,22 +280,22 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
   }
 
   @Override
-  public UInt256 getStorageValue(final Address address, final UInt256 storageKey) {
+  public Bytes32 getStorageValue(final Address address, final Bytes32 storageKey) {
     // TODO maybe log the read into the trie layer?
     final Hash slotHashBytes = Hash.hash(storageKey);
-    return getStorageValueBySlotHash(address, slotHashBytes).orElse(UInt256.ZERO);
+    return getStorageValueBySlotHash(address, slotHashBytes).orElse(Bytes32.ZERO);
   }
 
   @Override
-  public Optional<UInt256> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
-    final Map<Hash, BonsaiValue<UInt256>> localAccountStorage = storageToUpdate.get(address);
+  public Optional<Bytes32> getStorageValueBySlotHash(final Address address, final Hash slotHash) {
+    final Map<Hash, BonsaiValue<Bytes32>> localAccountStorage = storageToUpdate.get(address);
     if (localAccountStorage != null) {
-      final BonsaiValue<UInt256> value = localAccountStorage.get(slotHash);
+      final BonsaiValue<Bytes32> value = localAccountStorage.get(slotHash);
       if (value != null) {
         return Optional.ofNullable(value.getUpdated());
       }
     }
-    final Optional<UInt256> valueUInt =
+    final Optional<Bytes32> valueUInt =
         wrappedWorldView().getStorageValueBySlotHash(address, slotHash);
     valueUInt.ifPresent(
         v ->
@@ -327,28 +306,28 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
   }
 
   @Override
-  public UInt256 getPriorStorageValue(final Address address, final UInt256 storageKey) {
+  public Bytes32 getPriorStorageValue(final Address address, final Bytes32 storageKey) {
     // TODO maybe log the read into the trie layer?
-    final Map<Hash, BonsaiValue<UInt256>> localAccountStorage = storageToUpdate.get(address);
+    final Map<Hash, BonsaiValue<Bytes32>> localAccountStorage = storageToUpdate.get(address);
     final Hash slotHash = Hash.hash(storageKey);
     if (localAccountStorage != null) {
-      final BonsaiValue<UInt256> value = localAccountStorage.get(slotHash);
+      final BonsaiValue<Bytes32> value = localAccountStorage.get(slotHash);
       if (value != null) {
         if (value.isCleared()) {
-          return UInt256.ZERO;
+          return Bytes32.ZERO;
         }
-        final UInt256 updated = value.getUpdated();
+        final Bytes32 updated = value.getUpdated();
         if (updated != null) {
           return updated;
         }
-        final UInt256 original = value.getPrior();
+        final Bytes32 original = value.getPrior();
         if (original != null) {
           return original;
         }
       }
     }
     if (storageToClear.contains(address)) {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     }
     return getStorageValue(address, storageKey);
   }
@@ -400,10 +379,10 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
           blockHash);
     }
 
-    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> updatesStorage :
+    for (final Map.Entry<Address, Map<Hash, BonsaiValue<Bytes32>>> updatesStorage :
         storageToUpdate.entrySet()) {
       final Address address = updatesStorage.getKey();
-      for (final Map.Entry<Hash, BonsaiValue<UInt256>> slotUpdate :
+      for (final Map.Entry<Hash, BonsaiValue<Bytes32>> slotUpdate :
           updatesStorage.getValue().entrySet()) {
         layer.addStorageChange(
             address,
@@ -573,10 +552,10 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
     }
   }
 
-  private Map<Hash, BonsaiValue<UInt256>> maybeCreateStorageMap(
-      final Map<Hash, BonsaiValue<UInt256>> storageMap, final Address address) {
+  private Map<Hash, BonsaiValue<Bytes32>> maybeCreateStorageMap(
+      final Map<Hash, BonsaiValue<Bytes32>> storageMap, final Address address) {
     if (storageMap == null) {
-      final Map<Hash, BonsaiValue<UInt256>> newMap = new HashMap<>();
+      final Map<Hash, BonsaiValue<Bytes32>> newMap = new HashMap<>();
       storageToUpdate.put(address, newMap);
       return newMap;
     } else {
@@ -587,8 +566,8 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
   private void rollStorageChange(
       final Address address,
       final Hash slotHash,
-      final UInt256 expectedValue,
-      final UInt256 replacementValue) {
+      final Bytes32 expectedValue,
+      final Bytes32 replacementValue) {
     if (Objects.equals(expectedValue, replacementValue)) {
       // non-change, a cached read.
       return;
@@ -597,10 +576,10 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
       // corner case on deletes, non-change
       return;
     }
-    final Map<Hash, BonsaiValue<UInt256>> storageMap = storageToUpdate.get(address);
-    BonsaiValue<UInt256> slotValue = storageMap == null ? null : storageMap.get(slotHash);
+    final Map<Hash, BonsaiValue<Bytes32>> storageMap = storageToUpdate.get(address);
+    BonsaiValue<Bytes32> slotValue = storageMap == null ? null : storageMap.get(slotHash);
     if (slotValue == null) {
-      final Optional<UInt256> storageValue =
+      final Optional<Bytes32> storageValue =
           wrappedWorldView().getStorageValueBySlotHash(address, slotHash);
       if (storageValue.isPresent()) {
         slotValue = new BonsaiValue<>(storageValue.get(), storageValue.get());
@@ -618,7 +597,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                 address, slotHash));
       }
     } else {
-      final UInt256 existingSlotValue = slotValue.getUpdated();
+      final Bytes32 existingSlotValue = slotValue.getUpdated();
       if ((expectedValue == null || expectedValue.isZero())
           && existingSlotValue != null
           && !existingSlotValue.isZero()) {
@@ -637,7 +616,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                 existingSlotValue == null ? "null" : existingSlotValue.toShortHexString()));
       }
       if (replacementValue == null && slotValue.getPrior() == null) {
-        final Map<Hash, BonsaiValue<UInt256>> thisStorageUpdate =
+        final Map<Hash, BonsaiValue<Bytes32>> thisStorageUpdate =
             maybeCreateStorageMap(storageMap, address);
         thisStorageUpdate.remove(slotHash);
         if (thisStorageUpdate.isEmpty()) {
@@ -649,10 +628,10 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
     }
   }
 
-  private boolean isSlotEquals(final UInt256 expectedValue, final UInt256 existingSlotValue) {
-    final UInt256 sanitizedExpectedValue = (expectedValue == null) ? UInt256.ZERO : expectedValue;
-    final UInt256 sanitizedExistingSlotValue =
-        (existingSlotValue == null) ? UInt256.ZERO : existingSlotValue;
+  private boolean isSlotEquals(final Bytes32 expectedValue, final Bytes32 existingSlotValue) {
+    final Bytes32 sanitizedExpectedValue = (expectedValue == null) ? Bytes32.ZERO : expectedValue;
+    final Bytes32 sanitizedExistingSlotValue =
+        (existingSlotValue == null) ? Bytes32.ZERO : existingSlotValue;
     return Objects.equals(sanitizedExpectedValue, sanitizedExistingSlotValue);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -182,7 +182,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
                 (keyHash, entryValue) -> {
                   final Hash slotHash = Hash.wrap(keyHash);
                   if (!deletedStorageUpdates.containsKey(slotHash)) {
-                    final Bytes32 value = Bytes32.leftPad(Bytes.wrap(RLP.decodeOne(entryValue)));
+                    final Bytes32 value = Bytes32.leftPad(RLP.decodeOne(entryValue));
                     deletedStorageUpdates.put(slotHash, new BonsaiValue<>(value, null, true));
                   }
                 });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldView.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldView.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public interface BonsaiWorldView extends WorldView {
 
@@ -34,11 +33,11 @@ public interface BonsaiWorldView extends WorldView {
 
   Optional<Bytes> getStateTrieNode(Bytes location);
 
-  UInt256 getStorageValue(Address address, UInt256 key);
+  Bytes32 getStorageValue(Address address, Bytes32 key);
 
-  Optional<UInt256> getStorageValueBySlotHash(Address address, Hash slotHash);
+  Optional<Bytes32> getStorageValueBySlotHash(Address address, Hash slotHash);
 
-  UInt256 getPriorStorageValue(Address address, UInt256 key);
+  Bytes32 getPriorStorageValue(Address address, Bytes32 key);
 
   /**
    * Retrieve all the storage values of a account.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogLayer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogLayer.java
@@ -141,8 +141,8 @@ public class TrieLogLayer {
         while (!input.isEndOfCurrentList()) {
           input.enterList();
           final Hash slotHash = Hash.wrap(input.readBytes32());
-          final Bytes32 oldValue = nullOrValue(input, RLPInput::readUInt256Scalar);
-          final Bytes32 newValue = nullOrValue(input, RLPInput::readUInt256Scalar);
+          final Bytes32 oldValue = nullOrValue(input, RLPInput::readBytes32Scalar);
+          final Bytes32 newValue = nullOrValue(input, RLPInput::readBytes32Scalar);
           storageChanges.put(slotHash, new BonsaiValue<>(oldValue, newValue));
           input.leaveList();
         }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogLayer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogLayer.java
@@ -36,7 +36,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 /**
  * This class encapsulates the changes that are done to transition one block to the next. This
@@ -50,7 +50,7 @@ public class TrieLogLayer {
   private Hash blockHash;
   private final Map<Address, BonsaiValue<StateTrieAccountValue>> accounts;
   private final Map<Address, BonsaiValue<Bytes>> code;
-  private final Map<Address, Map<Hash, BonsaiValue<UInt256>>> storage;
+  private final Map<Address, Map<Hash, BonsaiValue<Bytes32>>> storage;
   private boolean frozen = false;
 
   TrieLogLayer() {
@@ -92,7 +92,7 @@ public class TrieLogLayer {
   }
 
   void addStorageChange(
-      final Address address, final Hash slotHash, final UInt256 oldValue, final UInt256 newValue) {
+      final Address address, final Hash slotHash, final Bytes32 oldValue, final Bytes32 newValue) {
     checkState(!frozen, "Layer is Frozen");
     storage
         .computeIfAbsent(address, a -> new TreeMap<>())
@@ -136,13 +136,13 @@ public class TrieLogLayer {
       if (input.nextIsNull()) {
         input.skipNext();
       } else {
-        final Map<Hash, BonsaiValue<UInt256>> storageChanges = new TreeMap<>();
+        final Map<Hash, BonsaiValue<Bytes32>> storageChanges = new TreeMap<>();
         input.enterList();
         while (!input.isEndOfCurrentList()) {
           input.enterList();
           final Hash slotHash = Hash.wrap(input.readBytes32());
-          final UInt256 oldValue = nullOrValue(input, RLPInput::readUInt256Scalar);
-          final UInt256 newValue = nullOrValue(input, RLPInput::readUInt256Scalar);
+          final Bytes32 oldValue = nullOrValue(input, RLPInput::readUInt256Scalar);
+          final Bytes32 newValue = nullOrValue(input, RLPInput::readUInt256Scalar);
           storageChanges.put(slotHash, new BonsaiValue<>(oldValue, newValue));
           input.leaveList();
         }
@@ -190,16 +190,16 @@ public class TrieLogLayer {
         codeChange.writeRlp(output, RLPOutput::writeBytes);
       }
 
-      final Map<Hash, BonsaiValue<UInt256>> storageChanges = storage.get(address);
+      final Map<Hash, BonsaiValue<Bytes32>> storageChanges = storage.get(address);
       if (storageChanges == null) {
         output.writeNull();
       } else {
         output.startList();
-        for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageChangeEntry :
+        for (final Map.Entry<Hash, BonsaiValue<Bytes32>> storageChangeEntry :
             storageChanges.entrySet()) {
           output.startList();
           output.writeBytes(storageChangeEntry.getKey());
-          storageChangeEntry.getValue().writeInnerRlp(output, RLPOutput::writeUInt256Scalar);
+          storageChangeEntry.getValue().writeInnerRlp(output, RLPOutput::writeBytesScalar);
           output.endList();
         }
         output.endList();
@@ -220,7 +220,7 @@ public class TrieLogLayer {
     return code.entrySet().stream();
   }
 
-  public Stream<Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>>> streamStorageChanges() {
+  public Stream<Map.Entry<Address, Map<Hash, BonsaiValue<Bytes32>>>> streamStorageChanges() {
     return storage.entrySet().stream();
   }
 
@@ -228,7 +228,7 @@ public class TrieLogLayer {
     return storage.containsKey(address);
   }
 
-  public Stream<Map.Entry<Hash, BonsaiValue<UInt256>>> streamStorageChanges(final Address address) {
+  public Stream<Map.Entry<Hash, BonsaiValue<Bytes32>>> streamStorageChanges(final Address address) {
     return storage.getOrDefault(address, Map.of()).entrySet().stream();
   }
 
@@ -249,13 +249,13 @@ public class TrieLogLayer {
     return Optional.ofNullable(code.get(address)).map(BonsaiValue::getUpdated);
   }
 
-  Optional<UInt256> getPriorStorageBySlotHash(final Address address, final Hash slotHash) {
+  Optional<Bytes32> getPriorStorageBySlotHash(final Address address, final Hash slotHash) {
     return Optional.ofNullable(storage.get(address))
         .map(i -> i.get(slotHash))
         .map(BonsaiValue::getPrior);
   }
 
-  Optional<UInt256> getStorageBySlotHash(final Address address, final Hash slotHash) {
+  Optional<Bytes32> getStorageBySlotHash(final Address address, final Hash slotHash) {
     return Optional.ofNullable(storage.get(address))
         .map(i -> i.get(slotHash))
         .map(BonsaiValue::getUpdated);
@@ -294,11 +294,11 @@ public class TrieLogLayer {
       }
     }
     sb.append("Storage").append("\n");
-    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storage : storage.entrySet()) {
+    for (final Map.Entry<Address, Map<Hash, BonsaiValue<Bytes32>>> storage : storage.entrySet()) {
       sb.append(" : ").append(storage.getKey()).append("\n");
-      for (final Map.Entry<Hash, BonsaiValue<UInt256>> slot : storage.getValue().entrySet()) {
-        final UInt256 originalValue = slot.getValue().getPrior();
-        final UInt256 updatedValue = slot.getValue().getUpdated();
+      for (final Map.Entry<Hash, BonsaiValue<Bytes32>> slot : storage.getValue().entrySet()) {
+        final Bytes32 originalValue = slot.getValue().getPrior();
+        final Bytes32 updatedValue = slot.getValue().getUpdated();
         sb.append("   : ").append(slot.getKey()).append("\n");
         if (Objects.equals(originalValue, updatedValue)) {
           sb.append("     = ")

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/debug/TraceFrame.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/debug/TraceFrame.java
@@ -29,7 +29,6 @@ import java.util.OptionalLong;
 import com.google.common.base.MoreObjects;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class TraceFrame {
 
@@ -46,7 +45,7 @@ public class TraceFrame {
   private final Bytes outputData;
   private final Optional<Bytes32[]> stack;
   private final Optional<Bytes[]> memory;
-  private final Optional<Map<UInt256, UInt256>> storage;
+  private final Optional<Map<Bytes32, Bytes32>> storage;
   private final WorldUpdater worldUpdater;
   private final Optional<Bytes> revertReason;
   private final Optional<Map<Address, Wei>> maybeRefunds;
@@ -74,7 +73,7 @@ public class TraceFrame {
       final Bytes outputData,
       final Optional<Bytes32[]> stack,
       final Optional<Bytes[]> memory,
-      final Optional<Map<UInt256, UInt256>> storage,
+      final Optional<Map<Bytes32, Bytes32>> storage,
       final WorldUpdater worldUpdater,
       final Optional<Bytes> revertReason,
       final Optional<Map<Address, Wei>> maybeRefunds,
@@ -166,7 +165,7 @@ public class TraceFrame {
     return memory;
   }
 
-  public Optional<Map<UInt256, UInt256>> getStorage() {
+  public Optional<Map<Bytes32, Bytes32>> getStorage() {
     return storage;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProof.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProof.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 import java.util.SortedMap;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class WorldStateProof {
 
@@ -33,12 +33,12 @@ public class WorldStateProof {
 
   private final Proof<Bytes> accountProof;
 
-  private final Map<UInt256, Proof<Bytes>> storageProofs;
+  private final Map<Bytes32, Proof<Bytes>> storageProofs;
 
   public WorldStateProof(
       final StateTrieAccountValue stateTrieAccountValue,
       final Proof<Bytes> accountProof,
-      final SortedMap<UInt256, Proof<Bytes>> storageProofs) {
+      final SortedMap<Bytes32, Proof<Bytes>> storageProofs) {
     this.stateTrieAccountValue = stateTrieAccountValue;
     this.accountProof = accountProof;
     this.storageProofs = storageProofs;
@@ -52,20 +52,20 @@ public class WorldStateProof {
     return accountProof.getProofRelatedNodes();
   }
 
-  public List<UInt256> getStorageKeys() {
+  public List<Bytes32> getStorageKeys() {
     return new ArrayList<>(storageProofs.keySet());
   }
 
-  public UInt256 getStorageValue(final UInt256 key) {
+  public Bytes32 getStorageValue(final Bytes32 key) {
     Optional<Bytes> value = storageProofs.get(key).getValue();
     if (value.isEmpty()) {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     } else {
-      return RLP.input(value.get()).readUInt256Scalar();
+      return RLP.input(value.get()).readBytes32Scalar();
     }
   }
 
-  public List<Bytes> getStorageProof(final UInt256 key) {
+  public List<Bytes> getStorageProof(final Bytes32 key) {
     return storageProofs.get(key).getProofRelatedNodes();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
@@ -40,7 +40,6 @@ import java.util.function.Function;
 import com.google.common.collect.Ordering;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class WorldStateProofProvider {
 
@@ -53,7 +52,7 @@ public class WorldStateProofProvider {
   public Optional<WorldStateProof> getAccountProof(
       final Hash worldStateRoot,
       final Address accountAddress,
-      final List<UInt256> accountStorageKeys) {
+      final List<Bytes32> accountStorageKeys) {
 
     if (!worldStateStorage.isWorldStateAvailable(worldStateRoot, null)) {
       return Optional.empty();
@@ -68,20 +67,20 @@ public class WorldStateProofProvider {
           .map(StateTrieAccountValue::readFrom)
           .map(
               account -> {
-                final SortedMap<UInt256, Proof<Bytes>> storageProofs =
+                final SortedMap<Bytes32, Proof<Bytes>> storageProofs =
                     getStorageProofs(accountHash, account, accountStorageKeys);
                 return new WorldStateProof(account, accountProof, storageProofs);
               });
     }
   }
 
-  private SortedMap<UInt256, Proof<Bytes>> getStorageProofs(
+  private SortedMap<Bytes32, Proof<Bytes>> getStorageProofs(
       final Hash accountHash,
       final StateTrieAccountValue account,
-      final List<UInt256> accountStorageKeys) {
+      final List<Bytes32> accountStorageKeys) {
     final MerklePatriciaTrie<Bytes32, Bytes> storageTrie =
         newAccountStorageTrie(accountHash, account.getStorageRoot());
-    final NavigableMap<UInt256, Proof<Bytes>> storageProofs = new TreeMap<>();
+    final NavigableMap<Bytes32, Proof<Bytes>> storageProofs = new TreeMap<>();
     accountStorageKeys.forEach(
         key -> storageProofs.put(key, storageTrie.getValueWithProof(Hash.hash(key))));
     return storageProofs;
@@ -114,7 +113,7 @@ public class WorldStateProofProvider {
       final Bytes32 endKeyHash,
       final Bytes32 rootHash,
       final List<Bytes> proofs,
-      final TreeMap<Bytes32, Bytes> keys) {
+      final NavigableMap<Bytes32, Bytes> keys) {
 
     // check if it's monotonic increasing
     if (!Ordering.natural().isOrdered(keys.keySet())) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/WorldStatePreimageKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/WorldStatePreimageKeyValueStorage.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class WorldStatePreimageKeyValueStorage implements WorldStatePreimageStorage {
   private final KeyValueStorage keyValueStorage;
@@ -33,12 +32,11 @@ public class WorldStatePreimageKeyValueStorage implements WorldStatePreimageStor
   }
 
   @Override
-  public Optional<UInt256> getStorageTrieKeyPreimage(final Bytes32 trieKey) {
+  public Optional<Bytes32> getStorageTrieKeyPreimage(final Bytes32 trieKey) {
     return keyValueStorage
         .get(trieKey.toArrayUnsafe())
         .filter(val -> val.length == Bytes32.SIZE)
-        .map(Bytes32::wrap)
-        .map(UInt256::fromBytes);
+        .map(Bytes32::wrap);
   }
 
   @Override
@@ -63,7 +61,7 @@ public class WorldStatePreimageKeyValueStorage implements WorldStatePreimageStor
 
     @Override
     public WorldStatePreimageStorage.Updater putStorageTrieKeyPreimage(
-        final Bytes32 trieKey, final UInt256 preimage) {
+        final Bytes32 trieKey, final Bytes32 preimage) {
       transaction.put(trieKey.toArrayUnsafe(), preimage.toArrayUnsafe());
       return this;
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -37,7 +37,6 @@ import java.util.TreeMap;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class DebugOperationTracer implements OperationTracer {
 
@@ -75,7 +74,7 @@ public class DebugOperationTracer implements OperationTracer {
     if (lastFrame != null) {
       lastFrame.setGasRemainingPostExecution(gasRemaining);
     }
-    final Optional<Map<UInt256, UInt256>> storage = captureStorage(frame);
+    final Optional<Map<Bytes32, Bytes32>> storage = captureStorage(frame);
     final Optional<Map<Address, Wei>> maybeRefunds =
         frame.getRefunds().isEmpty() ? Optional.empty() : Optional.of(frame.getRefunds());
     lastFrame =
@@ -189,12 +188,12 @@ public class DebugOperationTracer implements OperationTracer {
         });
   }
 
-  private Optional<Map<UInt256, UInt256>> captureStorage(final MessageFrame frame) {
+  private Optional<Map<Bytes32, Bytes32>> captureStorage(final MessageFrame frame) {
     if (!options.isStorageEnabled()) {
       return Optional.empty();
     }
     try {
-      final Map<UInt256, UInt256> storageContents =
+      final Map<Bytes32, Bytes32> storageContents =
           new TreeMap<>(
               frame
                   .getWorldUpdater()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultMutableWorldState.java
@@ -46,7 +46,6 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class DefaultMutableWorldState implements MutableWorldState {
 
@@ -57,7 +56,7 @@ public class DefaultMutableWorldState implements MutableWorldState {
   private final Map<Address, MerklePatriciaTrie<Bytes32, Bytes>> updatedStorageTries =
       new HashMap<>();
   private final Map<Address, Bytes> updatedAccountCode = new HashMap<>();
-  private final Map<Bytes32, UInt256> newStorageKeyPreimages = new HashMap<>();
+  private final Map<Bytes32, Bytes32> newStorageKeyPreimages = new HashMap<>();
   private final Map<Bytes32, Address> newAccountKeyPreimages = new HashMap<>();
 
   public DefaultMutableWorldState(
@@ -203,16 +202,16 @@ public class DefaultMutableWorldState implements MutableWorldState {
     stateUpdater.commit();
   }
 
-  private Optional<UInt256> getStorageTrieKeyPreimage(final Bytes32 trieKey) {
+  private Optional<Bytes32> getStorageTrieKeyPreimage(final Bytes32 trieKey) {
     return Optional.ofNullable(newStorageKeyPreimages.get(trieKey))
         .or(() -> preimageStorage.getStorageTrieKeyPreimage(trieKey));
   }
 
-  private static UInt256 convertToUInt256(final Bytes value) {
+  private static Bytes32 convertToBytes32(final Bytes value) {
     // TODO: we could probably have an optimized method to decode a single scalar since it's used
     // pretty often.
     final RLPInput in = RLP.input(value);
-    return in.readUInt256Scalar();
+    return Bytes32.leftPad(in.readBytes());
   }
 
   private Optional<Address> getAccountTrieKeyPreimage(final Bytes32 trieKey) {
@@ -299,15 +298,15 @@ public class DefaultMutableWorldState implements MutableWorldState {
     }
 
     @Override
-    public UInt256 getStorageValue(final UInt256 key) {
+    public Bytes32 getStorageValue(final Bytes32 key) {
       return storageTrie()
           .get(Hash.hash(key))
-          .map(DefaultMutableWorldState::convertToUInt256)
-          .orElse(UInt256.ZERO);
+          .map(DefaultMutableWorldState::convertToBytes32)
+          .orElse(Bytes32.ZERO);
     }
 
     @Override
-    public UInt256 getOriginalStorageValue(final UInt256 key) {
+    public Bytes32 getOriginalStorageValue(final Bytes32 key) {
       return getStorageValue(key);
     }
 
@@ -321,7 +320,7 @@ public class DefaultMutableWorldState implements MutableWorldState {
               (key, value) -> {
                 final AccountStorageEntry entry =
                     AccountStorageEntry.create(
-                        convertToUInt256(value), key, getStorageTrieKeyPreimage(key));
+                        convertToBytes32(value), key, getStorageTrieKeyPreimage(key));
                 storageEntries.put(key, entry);
               });
       return storageEntries;
@@ -400,7 +399,7 @@ public class DefaultMutableWorldState implements MutableWorldState {
         if (freshState) {
           wrapped.updatedStorageTries.remove(updated.getAddress());
         }
-        final Map<UInt256, UInt256> updatedStorage = updated.getUpdatedStorage();
+        final Map<Bytes32, Bytes32> updatedStorage = updated.getUpdatedStorage();
         if (!updatedStorage.isEmpty()) {
           // Apply any storage updates
           final MerklePatriciaTrie<Bytes32, Bytes> storageTrie =
@@ -408,21 +407,21 @@ public class DefaultMutableWorldState implements MutableWorldState {
                   ? wrapped.newAccountStorageTrie(Hash.EMPTY_TRIE_HASH)
                   : origin.storageTrie();
           wrapped.updatedStorageTries.put(updated.getAddress(), storageTrie);
-          final TreeSet<Map.Entry<UInt256, UInt256>> entries =
+          final TreeSet<Map.Entry<Bytes32, Bytes32>> entries =
               new TreeSet<>(
                   Comparator.comparing(
-                      (Function<Map.Entry<UInt256, UInt256>, UInt256>) Map.Entry::getKey));
+                      (Function<Map.Entry<Bytes32, Bytes32>, Bytes32>) Map.Entry::getKey));
           entries.addAll(updatedStorage.entrySet());
 
-          for (final Map.Entry<UInt256, UInt256> entry : entries) {
-            final UInt256 value = entry.getValue();
+          for (final Map.Entry<Bytes32, Bytes32> entry : entries) {
+            final Bytes32 value = entry.getValue();
             final Hash keyHash = Hash.hash(entry.getKey());
             if (value.isZero()) {
               storageTrie.remove(keyHash);
             } else {
               wrapped.newStorageKeyPreimages.put(keyHash, entry.getKey());
               storageTrie.put(
-                  keyHash, RLP.encode(out -> out.writeBytes(entry.getValue().toMinimalBytes())));
+                  keyHash, RLP.encode(out -> out.writeBytes(entry.getValue().trimLeadingZeros())));
             }
           }
           storageRoot = Hash.wrap(storageTrie.getRootHash());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DefaultWorldStateArchive.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class DefaultWorldStateArchive implements WorldStateArchive {
   private final WorldStateStorage worldStateStorage;
@@ -99,7 +99,7 @@ public class DefaultWorldStateArchive implements WorldStateArchive {
   public Optional<WorldStateProof> getAccountProof(
       final Hash worldStateRoot,
       final Address accountAddress,
-      final List<UInt256> accountStorageKeys) {
+      final List<Bytes32> accountStorageKeys) {
     return worldStateProof.getAccountProof(worldStateRoot, accountAddress, accountStorageKeys);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public interface WorldStateArchive {
   Hash EMPTY_ROOT_HASH = Hash.wrap(MerklePatriciaTrie.EMPTY_TRIE_NODE_HASH);
@@ -49,5 +49,5 @@ public interface WorldStateArchive {
   Optional<Bytes> getNodeData(Hash hash);
 
   Optional<WorldStateProof> getAccountProof(
-      Hash worldStateRoot, Address accountAddress, List<UInt256> accountStorageKeys);
+      Hash worldStateRoot, Address accountAddress, List<Bytes32> accountStorageKeys);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStatePreimageStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStatePreimageStorage.java
@@ -19,11 +19,10 @@ import org.hyperledger.besu.datatypes.Address;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public interface WorldStatePreimageStorage {
 
-  Optional<UInt256> getStorageTrieKeyPreimage(Bytes32 trieKey);
+  Optional<Bytes32> getStorageTrieKeyPreimage(Bytes32 trieKey);
 
   Optional<Address> getAccountTrieKeyPreimage(Bytes32 trieKey);
 
@@ -31,7 +30,7 @@ public interface WorldStatePreimageStorage {
 
   interface Updater {
 
-    Updater putStorageTrieKeyPreimage(Bytes32 trieKey, UInt256 preimage);
+    Updater putStorageTrieKeyPreimage(Bytes32 trieKey, Bytes32 preimage);
 
     Updater putAccountTrieKeyPreimage(Bytes32 trieKey, Address preimage);
 

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -122,7 +122,7 @@ public class BlockDataGenerator {
       final Hash parent,
       final WorldStateArchive worldStateArchive,
       final List<Address> accountsToSetup,
-      final List<UInt256> storageKeys) {
+      final List<Bytes32> storageKeys) {
     final List<Block> seq = new ArrayList<>(count);
 
     final MutableWorldState worldState = worldStateArchive.getMutable();
@@ -224,7 +224,7 @@ public class BlockDataGenerator {
       final int count,
       final WorldStateArchive worldStateArchive,
       final List<Address> accountsToSetup,
-      final List<UInt256> storageKeys) {
+      final List<Bytes32> storageKeys) {
     final long blockNumber = BlockHeader.GENESIS_BLOCK_NUMBER;
     final Hash parentHash = Hash.ZERO;
     return blockSequence(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
@@ -147,7 +147,7 @@ public class PrivateStateGenesisAllocatorTest {
     Account managementProxy = worldState.get(FLEXIBLE_PRIVACY_PROXY);
     assertThat(managementProxy.getCode()).isEqualTo(PROXY_RUNTIME_BYTECODE);
     assertThat(managementProxy.getStorageValue(Bytes32.ZERO))
-        .isEqualTo(Bytes32.leftPad(Bytes.wrap(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT)));
+        .isEqualTo(Bytes32.leftPad(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT));
 
     Account managementContract = worldState.get(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT);
     assertThat(managementContract.getCode()).isEqualTo(DEFAULT_GROUP_MANAGEMENT_RUNTIME_BYTECODE);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/privacy/PrivateStateGenesisAllocatorTest.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Test;
 
 public class PrivateStateGenesisAllocatorTest {
@@ -61,7 +61,7 @@ public class PrivateStateGenesisAllocatorTest {
                 }
 
                 @Override
-                public Map<UInt256, UInt256> getStorage() {
+                public Map<Bytes32, Bytes32> getStorage() {
                   return Collections.emptyMap();
                 }
 
@@ -146,8 +146,8 @@ public class PrivateStateGenesisAllocatorTest {
   private void assertManagementContractApplied() {
     Account managementProxy = worldState.get(FLEXIBLE_PRIVACY_PROXY);
     assertThat(managementProxy.getCode()).isEqualTo(PROXY_RUNTIME_BYTECODE);
-    assertThat(managementProxy.getStorageValue(UInt256.ZERO))
-        .isEqualTo(UInt256.fromBytes(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT));
+    assertThat(managementProxy.getStorageValue(Bytes32.ZERO))
+        .isEqualTo(Bytes32.leftPad(Bytes.wrap(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT)));
 
     Account managementContract = worldState.get(DEFAULT_FLEXIBLE_PRIVACY_MANAGEMENT);
     assertThat(managementContract.getCode()).isEqualTo(DEFAULT_GROUP_MANAGEMENT_RUNTIME_BYTECODE);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -38,8 +38,8 @@ import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -98,9 +98,9 @@ public class DebugOperationTracerTest {
   @Test
   public void shouldRecordStackWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
-    final UInt256 stackItem1 = UInt256.fromHexString("0x01");
-    final UInt256 stackItem2 = UInt256.fromHexString("0x02");
-    final UInt256 stackItem3 = UInt256.fromHexString("0x03");
+    final Bytes32 stackItem1 = Bytes32.fromHexStringLenient("0x01");
+    final Bytes32 stackItem2 = Bytes32.fromHexString("0x02");
+    final Bytes32 stackItem3 = Bytes32.fromHexString("0x03");
     frame.pushStackItem(stackItem1);
     frame.pushStackItem(stackItem2);
     frame.pushStackItem(stackItem3);
@@ -140,7 +140,7 @@ public class DebugOperationTracerTest {
   @Test
   public void shouldRecordStorageWhenEnabled() {
     final MessageFrame frame = validMessageFrame();
-    final Map<UInt256, UInt256> updatedStorage = setupStorageForCapture(frame);
+    final Map<Bytes32, Bytes32> updatedStorage = setupStorageForCapture(frame);
     final TraceFrame traceFrame = traceFrame(frame, new TraceOptions(true, false, false));
     assertThat(traceFrame.getStorage()).isPresent();
     assertThat(traceFrame.getStorage()).contains(updatedStorage);
@@ -156,7 +156,7 @@ public class DebugOperationTracerTest {
   @Test
   public void shouldCaptureFrameWhenExceptionalHaltOccurs() {
     final MessageFrame frame = validMessageFrame();
-    final Map<UInt256, UInt256> updatedStorage = setupStorageForCapture(frame);
+    final Map<Bytes32, Bytes32> updatedStorage = setupStorageForCapture(frame);
 
     final DebugOperationTracer tracer =
         new DebugOperationTracer(new TraceOptions(true, true, true));
@@ -205,15 +205,16 @@ public class DebugOperationTracerTest {
         .depth(DEPTH);
   }
 
-  private Map<UInt256, UInt256> setupStorageForCapture(final MessageFrame frame) {
+  private Map<Bytes32, Bytes32> setupStorageForCapture(final MessageFrame frame) {
     final WrappedEvmAccount account = mock(WrappedEvmAccount.class);
     final MutableAccount mutableAccount = mock(MutableAccount.class);
     when(account.getMutable()).thenReturn(mutableAccount);
     when(worldUpdater.getAccount(frame.getRecipientAddress())).thenReturn(account);
 
-    final Map<UInt256, UInt256> updatedStorage = new TreeMap<>();
-    updatedStorage.put(UInt256.ZERO, UInt256.valueOf(233));
-    updatedStorage.put(UInt256.ONE, UInt256.valueOf(2424));
+    final Map<Bytes32, Bytes32> updatedStorage = new TreeMap<>();
+    updatedStorage.put(Bytes32.ZERO, Bytes32.leftPad(Bytes.ofUnsignedInt(233)));
+    updatedStorage.put(
+        Bytes32.leftPad(Bytes.ofUnsignedInt(1)), Bytes32.leftPad(Bytes.ofUnsignedInt(2424)));
     when(mutableAccount.getUpdatedStorage()).thenReturn(updatedStorage);
     final Bytes32 word1 = Bytes32.fromHexString("0x01");
     final Bytes32 word2 = Bytes32.fromHexString("0x02");

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinder.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/worldstate/WorldStatePeerTrieNodeFinder.java
@@ -126,7 +126,7 @@ public class WorldStatePeerTrieNodeFinder implements PeerTrieNodeFinder {
   }
 
   public Optional<Bytes> findByGetTrieNodeData(
-      final Hash nodeHash, final Optional<Bytes32> accountHash, final Bytes location) {
+      final Hash nodeHash, final Optional<Bytes> accountHash, final Bytes location) {
     final BlockHeader chainHead = blockchain.getChainHeadHeader();
     final Map<Bytes, List<Bytes>> request = new HashMap<>();
     if (accountHash.isPresent()) {
@@ -141,7 +141,7 @@ public class WorldStatePeerTrieNodeFinder implements PeerTrieNodeFinder {
       final Map<Bytes, Bytes> response =
           getTrieNodeFromPeerTask.run().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       final Bytes nodeValue =
-          response.get(Bytes.concatenate(accountHash.map(Bytes::wrap).orElse(Bytes.EMPTY), path));
+          response.get(Bytes.concatenate(accountHash.orElse(Bytes.EMPTY), path));
       if (nodeValue != null && Hash.hash(nodeValue).equals(nodeHash)) {
         LOG.debug("Found node {} with getTrieNode request", nodeHash);
         return Optional.of(nodeValue);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManagerTest.java
@@ -131,7 +131,7 @@ public final class RangeManagerTest {
             accountStateTrie.getRootHash(), proofs, accounts, RangeManager.MAX_RANGE);
 
     Assertions.assertThat(newBeginElementInRange)
-        .contains(Bytes32.leftPad(Bytes.wrap(Bytes.ofUnsignedShort(0x0b))));
+        .contains(Bytes32.leftPad(Bytes.ofUnsignedShort(0x0b)));
   }
 
   @Test

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
@@ -324,7 +324,8 @@ abstract class AbstractRLPInput implements RLPInput {
     return res;
   }
 
-  private Bytes32 readBytes32Scalar() {
+  @Override
+  public Bytes32 readBytes32Scalar() {
     checkScalar("32-bytes scalar", 32);
     final MutableBytes32 res = MutableBytes32.create();
     payloadSlice().copyTo(res, res.size() - currentPayloadSize);

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
@@ -166,6 +166,16 @@ public interface RLPInput {
   BigInteger readBigIntegerScalar();
 
   /**
+   * Reads a scalar from the input and return is as a {@link Bytes32}.
+   *
+   * @return The next scalar item of this input as a {@link Bytes32}.
+   * @throws RLPException if the next item to read is a list, the input is at the end of its current
+   *     list (and {@link #leaveList()} hasn't been called) or if the next item is either too big to
+   *     fit a {@link Bytes32} or has leading zeros.
+   */
+  Bytes32 readBytes32Scalar();
+
+  /**
    * Reads a scalar from the input and return is as a {@link UInt256}.
    *
    * @return The next scalar item of this input as a {@link UInt256}.

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPOutput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPOutput.java
@@ -80,6 +80,10 @@ public interface RLPOutput {
     writeBytes(v.trimLeadingZeros());
   }
 
+  default void writeBytesScalar(final Bytes v) {
+    writeBytes(v.trimLeadingZeros());
+  }
+
   /**
    * Writes a RLP "null", that is an empty value.
    *

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
@@ -626,6 +626,7 @@ public class BytesValueRLPInputTest {
             RLPInput::readBigIntegerScalar,
             RLPInput::readIntScalar,
             RLPInput::readLongScalar,
+            RLPInput::readBytes32Scalar,
             RLPInput::readUInt256Scalar);
 
     for (Function<RLPInput, Object> decoder : invalidDecoders) {

--- a/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
+++ b/ethereum/stratum/src/main/java/org/hyperledger/besu/ethereum/stratum/Stratum1Protocol.java
@@ -146,7 +146,7 @@ public class Stratum1Protocol implements StratumProtocol {
     Object[] params =
         new Object[] {
           jobIdSupplier.get(),
-          Bytes.wrap(currentInput.getPrePowHash()).toHexString(),
+          currentInput.getPrePowHash().toHexString(),
           Bytes.wrap(dagSeed).toHexString(),
           currentInput.getTarget().toHexString(),
           true

--- a/evm/src/main/java/org/hyperledger/besu/evm/account/AccountState.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/account/AccountState.java
@@ -21,7 +21,6 @@ import java.util.NavigableMap;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /**
  * An account state.
@@ -100,7 +99,7 @@ public interface AccountState {
    * @return the value associated to {@code key} in the account storage. Note that this is never
    *     {@code null}, but 0 acts as a default value.
    */
-  UInt256 getStorageValue(UInt256 key);
+  Bytes32 getStorageValue(Bytes32 key);
 
   /**
    * Retrieves the original value from before the current transaction in the account storage given
@@ -110,7 +109,7 @@ public interface AccountState {
    * @return the original value associated to {@code key} in the account storage. Note that this is
    *     never {@code null}, but 0 acts as a default value.
    */
-  UInt256 getOriginalStorageValue(UInt256 key);
+  Bytes32 getOriginalStorageValue(Bytes32 key);
 
   /**
    * Whether the account is "empty".

--- a/evm/src/main/java/org/hyperledger/besu/evm/account/AccountStorageEntry.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/account/AccountStorageEntry.java
@@ -20,32 +20,31 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class AccountStorageEntry {
 
-  private final UInt256 value;
-  private final Optional<UInt256> key;
+  private final Bytes32 value;
+  private final Optional<Bytes32> key;
   private final Bytes32 keyHash;
 
   private AccountStorageEntry(
-      final UInt256 value, final Bytes32 keyHash, final Optional<UInt256> key) {
+      final Bytes32 value, final Bytes32 keyHash, final Optional<Bytes32> key) {
     this.key = key;
     this.keyHash = keyHash;
     this.value = value;
   }
 
   public static AccountStorageEntry create(
-      final UInt256 value, final Bytes32 keyHash, final UInt256 key) {
+      final Bytes32 value, final Bytes32 keyHash, final Bytes32 key) {
     return create(value, keyHash, Optional.ofNullable(key));
   }
 
   public static AccountStorageEntry create(
-      final UInt256 value, final Bytes32 keyHash, final Optional<UInt256> key) {
+      final Bytes32 value, final Bytes32 keyHash, final Optional<Bytes32> key) {
     return new AccountStorageEntry(value, keyHash, key);
   }
 
-  public static AccountStorageEntry forKeyAndValue(final UInt256 key, final UInt256 value) {
+  public static AccountStorageEntry forKeyAndValue(final Bytes32 key, final Bytes32 value) {
     return create(value, Hash.hash(key), key);
   }
 
@@ -56,7 +55,7 @@ public class AccountStorageEntry {
    *
    * @return If available, returns the original key corresponding to this storage entry.
    */
-  public Optional<UInt256> getKey() {
+  public Optional<Bytes32> getKey() {
     return key;
   }
 
@@ -71,7 +70,7 @@ public class AccountStorageEntry {
     return keyHash;
   }
 
-  public UInt256 getValue() {
+  public Bytes32 getValue() {
     return value;
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/account/MutableAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/account/MutableAccount.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import java.util.Map;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 /** A mutable world state account. */
 public interface MutableAccount extends Account {
@@ -94,7 +94,7 @@ public interface MutableAccount extends Account {
    * @param key the key to set.
    * @param value the value to set {@code key} to.
    */
-  void setStorageValue(UInt256 key, UInt256 value);
+  void setStorageValue(Bytes32 key, Bytes32 value);
 
   /** Clears out an account's storage. */
   void clearStorage();
@@ -104,5 +104,5 @@ public interface MutableAccount extends Account {
    *
    * @return a map of storage that has been modified.
    */
-  Map<UInt256, UInt256> getUpdatedStorage();
+  Map<Bytes32, Bytes32> getUpdatedStorage();
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/fluent/SimpleAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/fluent/SimpleAccount.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class SimpleAccount implements EvmAccount, MutableAccount {
 
@@ -46,7 +45,7 @@ public class SimpleAccount implements EvmAccount, MutableAccount {
   private Bytes code;
   private Supplier<Hash> codeHash =
       Suppliers.memoize(() -> code == null ? Hash.EMPTY : Hash.hash(code));
-  private final Map<UInt256, UInt256> storage = new HashMap<>();
+  private final Map<Bytes32, Bytes32> storage = new HashMap<>();
 
   public SimpleAccount(final Address address, final long nonce, final Wei balance) {
     this(null, address, nonce, balance, Bytes.EMPTY);
@@ -96,7 +95,7 @@ public class SimpleAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public UInt256 getStorageValue(final UInt256 key) {
+  public Bytes32 getStorageValue(final Bytes32 key) {
     if (storage.containsKey(key)) {
       return storage.get(key);
     } else {
@@ -105,11 +104,11 @@ public class SimpleAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public UInt256 getOriginalStorageValue(final UInt256 key) {
+  public Bytes32 getOriginalStorageValue(final Bytes32 key) {
     if (parent != null) {
       return parent.getStorageValue(key);
     } else {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     }
   }
 
@@ -142,7 +141,7 @@ public class SimpleAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public void setStorageValue(final UInt256 key, final UInt256 value) {
+  public void setStorageValue(final Bytes32 key, final Bytes32 value) {
     storage.put(key, value);
   }
 
@@ -152,7 +151,7 @@ public class SimpleAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public Map<UInt256, UInt256> getUpdatedStorage() {
+  public Map<Bytes32, Bytes32> getUpdatedStorage() {
     return storage;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -45,7 +45,6 @@ import com.google.common.collect.Multimap;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /**
  * A container object for all the states associated with a message.
@@ -320,7 +319,7 @@ public class MessageFrame {
                             .get(address)
                             .forEach(
                                 storageKeyBytes ->
-                                    account.getStorageValue(UInt256.fromBytes(storageKeyBytes)))));
+                                    account.getStorageValue(Bytes32.leftPad(storageKeyBytes)))));
   }
 
   /**
@@ -719,7 +718,7 @@ public class MessageFrame {
     maybeUpdatedMemory = Optional.of(new MemoryEntry(offset, value));
   }
 
-  public void storageWasUpdated(final UInt256 storageAddress, final Bytes value) {
+  public void storageWasUpdated(final Bytes32 storageAddress, final Bytes value) {
     maybeUpdatedStorage = Optional.of(new StorageEntry(storageAddress, value));
   }
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/BerlinGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/BerlinGasCalculator.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.evm.precompile.BigIntegerModularExponentiationPrecom
 import java.math.BigInteger;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class BerlinGasCalculator extends IstanbulGasCalculator {
 
@@ -160,13 +160,13 @@ public class BerlinGasCalculator extends IstanbulGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public long calculateStorageCost(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return SLOAD_GAS;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         return originalValue.isZero() ? SSTORE_SET_GAS : SSTORE_RESET_GAS;
       } else {
@@ -179,13 +179,13 @@ public class BerlinGasCalculator extends IstanbulGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return 0L;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         if (originalValue.isZero()) {
           return 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/ConstantinopleGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/ConstantinopleGasCalculator.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class ConstantinopleGasCalculator extends ByzantiumGasCalculator {
 
@@ -48,13 +47,13 @@ public class ConstantinopleGasCalculator extends ByzantiumGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-1283
   public long calculateStorageCost(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return SSTORE_NO_OP_COST;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         return originalValue.isZero()
             ? SSTORE_FIRST_DIRTY_NEW_STORAGE_COST
@@ -68,13 +67,13 @@ public class ConstantinopleGasCalculator extends ByzantiumGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-1283
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return 0L;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         if (originalValue.isZero()) {
           return 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/FrontierGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/FrontierGasCalculator.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.operation.ExpOperation;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class FrontierGasCalculator implements GasCalculator {
 
@@ -417,7 +417,7 @@ public class FrontierGasCalculator implements GasCalculator {
 
   @Override
   public long calculateStorageCost(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
     return !newValue.isZero() && account.getStorageValue(key).isZero()
         ? STORAGE_SET_GAS_COST
         : STORAGE_RESET_GAS_COST;
@@ -425,7 +425,7 @@ public class FrontierGasCalculator implements GasCalculator {
 
   @Override
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
     return newValue.isZero() && !account.getStorageValue(key).isZero()
         ? STORAGE_RESET_REFUND_AMOUNT
         : 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -42,7 +42,7 @@ import org.hyperledger.besu.evm.processor.AbstractMessageProcessor;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 /**
  * Provides various gas cost lookups and calculations used during block processing.
@@ -353,7 +353,7 @@ public interface GasCalculator {
    * @param newValue the new value to be stored
    * @return the gas cost for the SSTORE operation
    */
-  long calculateStorageCost(Account account, UInt256 key, UInt256 newValue);
+  long calculateStorageCost(Account account, Bytes32 key, Bytes32 newValue);
 
   /**
    * Returns the refund amount for an SSTORE operation.
@@ -363,7 +363,7 @@ public interface GasCalculator {
    * @param newValue the new value to be stored
    * @return the gas refund for the SSTORE operation
    */
-  long calculateStorageRefundAmount(Account account, UInt256 key, UInt256 newValue);
+  long calculateStorageRefundAmount(Account account, Bytes32 key, Bytes32 newValue);
 
   /**
    * Returns the refund amount for deleting an account in a {@link SelfDestructOperation}.

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/IstanbulGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/IstanbulGasCalculator.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.evm.gascalculator;
 import org.hyperledger.besu.evm.account.Account;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class IstanbulGasCalculator extends PetersburgGasCalculator {
 
@@ -56,13 +56,13 @@ public class IstanbulGasCalculator extends PetersburgGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public long calculateStorageCost(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return SLOAD_GAS;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         return originalValue.isZero() ? SSTORE_SET_GAS : SSTORE_RESET_GAS;
       } else {
@@ -74,13 +74,13 @@ public class IstanbulGasCalculator extends PetersburgGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-2200
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
 
-    final UInt256 currentValue = account.getStorageValue(key);
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return 0L;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         if (originalValue.isZero()) {
           return 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/LondonGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/LondonGasCalculator.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.evm.gascalculator;
 
 import org.hyperledger.besu.evm.account.Account;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class LondonGasCalculator extends BerlinGasCalculator {
 
@@ -40,12 +40,12 @@ public class LondonGasCalculator extends BerlinGasCalculator {
   @Override
   // As per https://eips.ethereum.org/EIPS/eip-3529
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
-    final UInt256 currentValue = account.getStorageValue(key);
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
+    final Bytes32 currentValue = account.getStorageValue(key);
     if (currentValue.equals(newValue)) {
       return 0L;
     } else {
-      final UInt256 originalValue = account.getOriginalStorageValue(key);
+      final Bytes32 originalValue = account.getOriginalStorageValue(key);
       if (originalValue.equals(currentValue)) {
         if (originalValue.isZero()) {
           return 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/PetersburgGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/PetersburgGasCalculator.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.evm.gascalculator;
 
 import org.hyperledger.besu.evm.account.Account;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 /**
  * Gas Calculator for Petersberg Hard Fork. Rollback EIP-1283.
@@ -33,24 +33,21 @@ public class PetersburgGasCalculator extends ConstantinopleGasCalculator {
   /** Same as {#link {@link FrontierGasCalculator#STORAGE_RESET_REFUND_AMOUNT} */
   private static final long STORAGE_RESET_REFUND_AMOUNT = 15_000L;
 
-  /**
-   * Same as {#link {@link FrontierGasCalculator#calculateStorageCost(Account, UInt256, UInt256)}
-   */
+  /** Same as {#link {@link GasCalculator#calculateStorageCost(Account, Bytes32, Bytes32)} */
   @Override
   public long calculateStorageCost(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
     return !newValue.isZero() && account.getStorageValue(key).isZero()
         ? STORAGE_SET_GAS_COST
         : STORAGE_RESET_GAS_COST;
   }
 
   /**
-   * Same as {#link {@link FrontierGasCalculator#calculateStorageRefundAmount(Account, UInt256,
-   * UInt256)}
+   * Same as {#link {@link GasCalculator#calculateStorageRefundAmount(Account, Bytes32, Bytes32)}
    */
   @Override
   public long calculateStorageRefundAmount(
-      final Account account, final UInt256 key, final UInt256 newValue) {
+      final Account account, final Bytes32 key, final Bytes32 newValue) {
     return newValue.isZero() && !account.getStorageValue(key).isZero()
         ? STORAGE_RESET_REFUND_AMOUNT
         : 0L;

--- a/evm/src/main/java/org/hyperledger/besu/evm/internal/StorageEntry.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/internal/StorageEntry.java
@@ -16,18 +16,18 @@
 package org.hyperledger.besu.evm.internal;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class StorageEntry {
-  private final UInt256 offset;
+  private final Bytes32 offset;
   private final Bytes value;
 
-  public StorageEntry(final UInt256 offset, final Bytes value) {
+  public StorageEntry(final Bytes32 offset, final Bytes value) {
     this.offset = offset;
     this.value = value;
   }
 
-  public UInt256 getOffset() {
+  public Bytes32 getOffset() {
     return offset;
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SLoadOperation.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.evm.internal.FixedStack.OverflowException;
 import org.hyperledger.besu.evm.internal.FixedStack.UnderflowException;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class SLoadOperation extends AbstractOperation {
 
@@ -49,13 +48,13 @@ public class SLoadOperation extends AbstractOperation {
     try {
       final Account account = frame.getWorldUpdater().get(frame.getRecipientAddress());
       final Address address = account.getAddress();
-      final Bytes32 key = UInt256.fromBytes(frame.popStackItem());
+      final Bytes32 key = Bytes32.leftPad(frame.popStackItem());
       final boolean slotIsWarm = frame.warmUpStorage(address, key);
       final long cost = slotIsWarm ? warmCost : coldCost;
       if (frame.getRemainingGas() < cost) {
         return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
       } else {
-        frame.pushStackItem(account.getStorageValue(UInt256.fromBytes(key)));
+        frame.pushStackItem(account.getStorageValue(key));
 
         return slotIsWarm ? warmSuccess : coldSuccess;
       }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public class SStoreOperation extends AbstractOperation {
 
@@ -45,8 +45,8 @@ public class SStoreOperation extends AbstractOperation {
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
 
-    final UInt256 key = UInt256.fromBytes(frame.popStackItem());
-    final UInt256 value = UInt256.fromBytes(frame.popStackItem());
+    final Bytes32 key = Bytes32.leftPad(frame.popStackItem());
+    final Bytes32 value = Bytes32.leftPad(frame.popStackItem());
 
     final MutableAccount account =
         frame.getWorldUpdater().getAccount(frame.getRecipientAddress()).getMutable();

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
@@ -34,7 +34,6 @@ import javax.annotation.Nullable;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /**
  * A implementation of {@link MutableAccount} that tracks updates made to the account since the
@@ -57,9 +56,9 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
   @Nullable private Bytes updatedCode; // Null if the underlying code has not been updated.
   @Nullable private Hash updatedCodeHash;
 
-  // Only contains updated storage entries, but may contains entry with a value of 0 to signify
+  // Only contains updated storage entries, but may contain entry with a value of 0 to signify
   // deletion.
-  private final NavigableMap<UInt256, UInt256> updatedStorage;
+  private final NavigableMap<Bytes32, Bytes32> updatedStorage;
   private boolean storageWasCleared = false;
   private boolean transactionBoundary = false;
 
@@ -127,7 +126,7 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
    *     with a value of 0 to signify deletion.
    */
   @Override
-  public Map<UInt256, UInt256> getUpdatedStorage() {
+  public Map<Bytes32, Bytes32> getUpdatedStorage() {
     return updatedStorage;
   }
 
@@ -199,26 +198,26 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
   }
 
   @Override
-  public UInt256 getStorageValue(final UInt256 key) {
-    final UInt256 value = updatedStorage.get(key);
+  public Bytes32 getStorageValue(final Bytes32 key) {
+    final Bytes32 value = updatedStorage.get(key);
     if (value != null) {
       return value;
     }
     if (storageWasCleared) {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     }
 
     // We haven't updated the key-value yet, so either it's a new account and it doesn't have the
     // key, or we should query the underlying storage for its existing value (which might be 0).
-    return account == null ? UInt256.ZERO : account.getStorageValue(key);
+    return account == null ? Bytes32.ZERO : account.getStorageValue(key);
   }
 
   @Override
-  public UInt256 getOriginalStorageValue(final UInt256 key) {
+  public Bytes32 getOriginalStorageValue(final Bytes32 key) {
     if (transactionBoundary) {
       return getStorageValue(key);
     } else if (storageWasCleared || account == null) {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     } else {
       return account.getOriginalStorageValue(key);
     }
@@ -246,7 +245,7 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount,
   }
 
   @Override
-  public void setStorageValue(final UInt256 key, final UInt256 value) {
+  public void setStorageValue(final Bytes32 key, final Bytes32 value) {
     updatedStorage.put(key, value);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldState.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldState.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 /**
  * A specific state of the world.
@@ -101,12 +100,12 @@ public interface WorldState extends WorldView {
     }
 
     @Override
-    public UInt256 getStorageValue(final UInt256 key) {
+    public Bytes32 getStorageValue(final Bytes32 key) {
       return accountState.getStorageValue(key);
     }
 
     @Override
-    public UInt256 getOriginalStorageValue(final UInt256 key) {
+    public Bytes32 getOriginalStorageValue(final Bytes32 key) {
       return accountState.getOriginalStorageValue(key);
     }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WrappedEvmAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WrappedEvmAccount.java
@@ -26,7 +26,6 @@ import java.util.NavigableMap;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class WrappedEvmAccount implements EvmAccount {
   private final MutableAccount mutableAccount;
@@ -86,12 +85,12 @@ public class WrappedEvmAccount implements EvmAccount {
   }
 
   @Override
-  public UInt256 getStorageValue(final UInt256 key) {
+  public Bytes32 getStorageValue(final Bytes32 key) {
     return mutableAccount.getStorageValue(key);
   }
 
   @Override
-  public UInt256 getOriginalStorageValue(final UInt256 key) {
+  public Bytes32 getOriginalStorageValue(final Bytes32 key) {
     return mutableAccount.getOriginalStorageValue(key);
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyAccount.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyAccount.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.apache.tuweni.units.bigints.UInt256;
 
 public class ToyAccount implements EvmAccount, MutableAccount {
 
@@ -46,7 +45,7 @@ public class ToyAccount implements EvmAccount, MutableAccount {
   private Bytes code;
   private Supplier<Hash> codeHash =
       Suppliers.memoize(() -> code == null ? Hash.EMPTY : Hash.hash(code));
-  private final Map<UInt256, UInt256> storage = new HashMap<>();
+  private final Map<Bytes32, Bytes32> storage = new HashMap<>();
 
   public ToyAccount(final Address address, final long nonce, final Wei balance) {
     this(null, address, nonce, balance, Bytes.EMPTY);
@@ -96,7 +95,7 @@ public class ToyAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public UInt256 getStorageValue(final UInt256 key) {
+  public Bytes32 getStorageValue(final Bytes32 key) {
     if (storage.containsKey(key)) {
       return storage.get(key);
     } else {
@@ -105,11 +104,11 @@ public class ToyAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public UInt256 getOriginalStorageValue(final UInt256 key) {
+  public Bytes32 getOriginalStorageValue(final Bytes32 key) {
     if (parent != null) {
       return parent.getStorageValue(key);
     } else {
-      return UInt256.ZERO;
+      return Bytes32.ZERO;
     }
   }
 
@@ -141,7 +140,7 @@ public class ToyAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public void setStorageValue(final UInt256 key, final UInt256 value) {
+  public void setStorageValue(final Bytes32 key, final Bytes32 value) {
     storage.put(key, value);
   }
 
@@ -151,7 +150,7 @@ public class ToyAccount implements EvmAccount, MutableAccount {
   }
 
   @Override
-  public Map<UInt256, UInt256> getUpdatedStorage() {
+  public Map<Bytes32, Bytes32> getUpdatedStorage() {
     return storage;
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -65,7 +65,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 't1ECxSKuhCHrMq9uKYC9datxfFqqTpCPc6GFmUfC8Pg='
+  knownHash = 'aHn61uLvuWqM5e2JReOs5wVCRSQXSqo0U39+pAIPGFE='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/PrivacyGenesisAccount.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/PrivacyGenesisAccount.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.plugin.data;
 import java.util.Map;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.bytes.Bytes32;
 
 public interface PrivacyGenesisAccount {
   /**
@@ -32,7 +32,7 @@ public interface PrivacyGenesisAccount {
    *
    * @return account storage
    */
-  Map<UInt256, UInt256> getStorage();
+  Map<Bytes32, Bytes32> getStorage();
 
   /**
    * The initial nonce assigned to the account.


### PR DESCRIPTION

## PR description

The current internal storage APIs implement UInt256 rather than Bytes32, which is an accident of prior EVM design.  This migrates all internal handling of storage addresses and values to Bytes32.

The main performance gain is that UInt256 stores the data as an array of ints, whereas Bytes32 keeps a sliced or wrapped array of bytes.  Since database APIs are all byte array based this should remove unneeded conversions when going to/from the DB.

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).