### PR TITLE
Create a specific calculateRootHash method for BonsaiInMemoryWorldState to improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Upgrade RocksDB database version from 6.29.5 to 7.6.0 [#4517](https://github.com/hyperledger/besu/pull/4517)
 - Avoid connecting to self when using static-nodes [#4521](https://github.com/hyperledger/besu/pull/4521)
 - EVM performance has increased 20%-100% depending on the particulars of the contract. [#4540](https://github.com/hyperledger/besu/pull/4540)
+- Improve calculateRootHash method performance during Block processing [#4568](https://github.com/hyperledger/besu/pull/4568)
 
 ### Bug Fixes
 - Corrects emission of blockadded events when rewinding during a re-org. Fix for [#4495](https://github.com/hyperledger/besu/issues/4495)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -16,8 +16,16 @@
 
 package org.hyperledger.besu.ethereum.bonsai;
 
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
 
@@ -38,14 +46,98 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   }
 
   public Hash rootHash(final BonsaiWorldStateUpdater localUpdater) {
-    final BonsaiWorldStateKeyValueStorage.BonsaiUpdater updater = worldStateStorage.updater();
-    try {
-      final Hash calculatedRootHash = calculateRootHash(updater, localUpdater);
-      return Hash.wrap(calculatedRootHash);
-    } finally {
-      updater.rollback();
+    final Hash calculatedRootHash = calculateRootHash(localUpdater);
+    return Hash.wrap(calculatedRootHash);
+  }
+
+  protected Hash calculateRootHash(
+          final BonsaiWorldStateUpdater worldStateUpdater) {
+
+    // second update account storage state.  This must be done before updating the accounts so
+    // that we can get the storage state hash
+    CompletableFuture<?>[] updateStorageFutures =
+            worldStateUpdater.getStorageToUpdate().entrySet().stream()
+                    .map(
+                            storageAccountUpdate ->
+                                    CompletableFuture.runAsync(
+                                            () ->
+                                                    updateAccountStorage(worldStateUpdater, storageAccountUpdate)))
+                    .toArray(size -> new CompletableFuture<?>[size]);
+
+    CompletableFuture.allOf(updateStorageFutures).join();
+
+    // for manicured tries and composting, trim and compost here
+
+    // next walk the account trie
+    final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie =
+            new StoredMerklePatriciaTrie<>(
+                    this::getAccountStateTrieNode,
+                    worldStateRootHash,
+                    Function.identity(),
+                    Function.identity());
+
+    // for manicured tries and composting, collect branches here (not implemented)
+
+    // now add the accounts
+    for (final Map.Entry<Address, BonsaiValue<BonsaiAccount>> accountUpdate :
+            worldStateUpdater.getAccountsToUpdate().entrySet()) {
+      final Bytes accountKey = accountUpdate.getKey();
+      final BonsaiValue<BonsaiAccount> bonsaiValue = accountUpdate.getValue();
+      final BonsaiAccount updatedAccount = bonsaiValue.getUpdated();
+      if (updatedAccount == null) {
+        final Hash addressHash = Hash.hash(accountKey);
+        accountTrie.remove(addressHash);
+      } else {
+        final Hash addressHash = updatedAccount.getAddressHash();
+        final Bytes accountValue = updatedAccount.serializeAccount();
+        accountTrie.put(addressHash, accountValue);
+      }
+    }
+
+    // TODO write to a cache and then generate a layer update from that and the
+    // DB tx updates.  Right now it is just DB updates.
+    return Hash.wrap(accountTrie.getRootHash());
+  }
+
+  private void updateAccountStorage(
+          final BonsaiWorldStateUpdater worldStateUpdater,
+          final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate) {
+    final Address updatedAddress = storageAccountUpdate.getKey();
+    final Hash updatedAddressHash = Hash.hash(updatedAddress);
+    if (worldStateUpdater.getAccountsToUpdate().containsKey(updatedAddress)) {
+      final BonsaiValue<BonsaiAccount> accountValue =
+              worldStateUpdater.getAccountsToUpdate().get(updatedAddress);
+      final BonsaiAccount accountOriginal = accountValue.getPrior();
+      final Hash storageRoot =
+              (accountOriginal == null) ? Hash.EMPTY_TRIE_HASH : accountOriginal.getStorageRoot();
+      final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
+              new StoredMerklePatriciaTrie<>(
+                      (location, key) -> getStorageTrieNode(updatedAddressHash, location, key),
+                      storageRoot,
+                      Function.identity(),
+                      Function.identity());
+
+      // for manicured tries and composting, collect branches here (not implemented)
+
+      for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageUpdate :
+              storageAccountUpdate.getValue().entrySet()) {
+        final Hash keyHash = storageUpdate.getKey();
+        final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
+        if (updatedStorage == null || updatedStorage.equals(UInt256.ZERO)) {
+          storageTrie.remove(keyHash);
+        } else {
+          storageTrie.put(keyHash, BonsaiWorldView.encodeTrieValue(updatedStorage));
+        }
+      }
+
+      final BonsaiAccount accountUpdated = accountValue.getUpdated();
+      if (accountUpdated != null) {
+        final Hash newStorageRoot = Hash.wrap(storageTrie.getRootHash());
+        accountUpdated.setStorageRoot(newStorageRoot);
+      }
     }
   }
+
 
   @Override
   public void persist(final BlockHeader blockHeader) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -55,16 +55,11 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
 
     // second update account storage state.  This must be done before updating the accounts so
     // that we can get the storage state hash
-    CompletableFuture<?>[] updateStorageFutures =
-            worldStateUpdater.getStorageToUpdate().entrySet().stream()
-                    .map(
-                            storageAccountUpdate ->
-                                    CompletableFuture.runAsync(
-                                            () ->
-                                                    updateAccountStorage(worldStateUpdater, storageAccountUpdate)))
-                    .toArray(size -> new CompletableFuture<?>[size]);
 
-    CompletableFuture.allOf(updateStorageFutures).join();
+    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
+            worldStateUpdater.getStorageToUpdate().entrySet()) {
+      updateAccountStorage(worldStateUpdater, storageAccountUpdate);
+    }
 
     // for manicured tries and composting, trim and compost here
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -16,8 +16,6 @@
 
 package org.hyperledger.besu.ethereum.bonsai;
 
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -25,6 +23,9 @@ import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
 
 import java.util.Map;
 import java.util.function.Function;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
 
 public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
 
@@ -131,7 +132,6 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
       }
     }
   }
-
 
   @Override
   public void persist(final BlockHeader blockHeader) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -56,10 +56,10 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
     // second update account storage state.  This must be done before updating the accounts so
     // that we can get the storage state hash
 
-    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
-            worldStateUpdater.getStorageToUpdate().entrySet()) {
-      updateAccountStorage(worldStateUpdater, storageAccountUpdate);
-    }
+    worldStateUpdater.getStorageToUpdate().entrySet()
+            .parallelStream().forEach(addressMapEntry -> {
+              updateAccountStorage(worldStateUpdater, addressMapEntry);
+            });
 
     // for manicured tries and composting, trim and compost here
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -102,8 +102,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   protected Hash calculateRootHash(
-          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-          final BonsaiWorldStateUpdater worldStateUpdater) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+      final BonsaiWorldStateUpdater worldStateUpdater) {
     clearStorage(stateUpdater, worldStateUpdater);
 
     // This must be done before updating the accounts so
@@ -135,9 +135,9 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   private static void addTheAccounts(
-          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-          final BonsaiWorldStateUpdater worldStateUpdater,
-          final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+      final BonsaiWorldStateUpdater worldStateUpdater,
+      final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie) {
     for (final Map.Entry<Address, BonsaiValue<BonsaiAccount>> accountUpdate :
         worldStateUpdater.getAccountsToUpdate().entrySet()) {
       final Bytes accountKey = accountUpdate.getKey();
@@ -157,8 +157,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   private static void updateCode(
-          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-          final BonsaiWorldStateUpdater worldStateUpdater) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+      final BonsaiWorldStateUpdater worldStateUpdater) {
     for (final Map.Entry<Address, BonsaiValue<Bytes>> codeUpdate :
         worldStateUpdater.getCodeToUpdate().entrySet()) {
       final Bytes updatedCode = codeUpdate.getValue().getUpdated();
@@ -172,8 +172,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   private void updateAccountStorageState(
-          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-          final BonsaiWorldStateUpdater worldStateUpdater) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+      final BonsaiWorldStateUpdater worldStateUpdater) {
     for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
         worldStateUpdater.getStorageToUpdate().entrySet()) {
       final Address updatedAddress = storageAccountUpdate.getKey();
@@ -220,8 +220,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   private void clearStorage(
-          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-          final BonsaiWorldStateUpdater worldStateUpdater) {
+      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+      final BonsaiWorldStateUpdater worldStateUpdater) {
     for (final Address address : worldStateUpdater.getStorageToClear()) {
       // because we are clearing persisted values we need the account root as persisted
       final BonsaiAccount oldAccount =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -123,7 +123,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
                 storageAccountUpdate ->
                     CompletableFuture.runAsync(
                         () ->
-                            updateAcountStorage(
+                            updateAccountStorage(
                                 stateUpdater, worldStateUpdater, storageAccountUpdate)))
             .toArray(size -> new CompletableFuture<?>[size]);
 
@@ -153,7 +153,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
     // now add the accounts
     for (final Map.Entry<Address, BonsaiValue<BonsaiAccount>> accountUpdate :
-            worldStateUpdater.getAccountsToUpdate().entrySet()) {
+        worldStateUpdater.getAccountsToUpdate().entrySet()) {
       final Bytes accountKey = accountUpdate.getKey();
       final BonsaiValue<BonsaiAccount> bonsaiValue = accountUpdate.getValue();
       final BonsaiAccount updatedAccount = bonsaiValue.getUpdated();
@@ -190,7 +190,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     }
   }
 
-  private void updateAcountStorage(
+  private void updateAccountStorage(
       final BonsaiWorldStateKeyValueStorage.Updater stateUpdater,
       final BonsaiWorldStateUpdater worldStateUpdater,
       final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -381,7 +381,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
         .orElse(null);
   }
 
-  private Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
+  protected Optional<Bytes> getAccountStateTrieNode(final Bytes location, final Bytes32 nodeHash) {
     return worldStateStorage.getAccountStateTrieNode(location, nodeHash);
   }
 
@@ -390,7 +390,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     tx.put(location.toArrayUnsafe(), value.toArrayUnsafe());
   }
 
-  private Optional<Bytes> getStorageTrieNode(
+  protected Optional<Bytes> getStorageTrieNode(
       final Hash accountHash, final Bytes location, final Bytes32 nodeHash) {
     return worldStateStorage.getAccountStorageTrieNode(accountHash, location, nodeHash);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -103,80 +103,44 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   }
 
   protected Hash calculateRootHash(
-      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
-      final BonsaiWorldStateUpdater worldStateUpdater) {
-    // first clear storage
-    CompletableFuture<?>[] clearStorageFutures =
-        worldStateUpdater.getStorageToClear().stream()
-            .map(
-                address ->
-                    CompletableFuture.runAsync(() -> clearAccountStorage(stateUpdater, address)))
-            .toArray(size -> new CompletableFuture<?>[size]);
+          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+          final BonsaiWorldStateUpdater worldStateUpdater) {
+    clearStorage(stateUpdater, worldStateUpdater);
 
-    CompletableFuture.allOf(clearStorageFutures).join();
-
-    // second update account storage state.  This must be done before updating the accounts so
+    // This must be done before updating the accounts so
     // that we can get the storage state hash
-    CompletableFuture<?>[] updateStorageFutures =
-        worldStateUpdater.getStorageToUpdate().entrySet().stream()
-            .map(
-                storageAccountUpdate ->
-                    CompletableFuture.runAsync(
-                        () ->
-                            updateAccountStorage(
-                                stateUpdater, worldStateUpdater, storageAccountUpdate)))
-            .toArray(size -> new CompletableFuture<?>[size]);
-
-    CompletableFuture.allOf(updateStorageFutures).join();
-
-    // for manicured tries and composting, trim and compost here
+    updateAccountStorageState(stateUpdater, worldStateUpdater);
 
     // Third update the code.  This has the side effect of ensuring a code hash is calculated.
     updateCode(stateUpdater, worldStateUpdater);
 
     // next walk the account trie
     final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie =
-        new StoredMerklePatriciaTrie<>(
-            this::getAccountStateTrieNode,
-            worldStateRootHash,
-            Function.identity(),
-            Function.identity());
+            new StoredMerklePatriciaTrie<>(
+                    this::getAccountStateTrieNode,
+                    worldStateRootHash,
+                    Function.identity(),
+                    Function.identity());
 
     // for manicured tries and composting, collect branches here (not implemented)
 
-    // now add the accounts
     addTheAccounts(stateUpdater, worldStateUpdater, accountTrie);
 
     // TODO write to a cache and then generate a layer update from that and the
     // DB tx updates.  Right now it is just DB updates.
     accountTrie.commit(
-        (location, hash, value) ->
-            writeTrieNode(stateUpdater.getTrieBranchStorageTransaction(), location, value));
+            (location, hash, value) ->
+                    writeTrieNode(stateUpdater.getTrieBranchStorageTransaction(), location, value));
     final Bytes32 rootHash = accountTrie.getRootHash();
     return Hash.wrap(rootHash);
   }
 
-  private static void updateCode(
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater,
-      final BonsaiWorldStateUpdater worldStateUpdater) {
-    for (final Map.Entry<Address, BonsaiValue<Bytes>> codeUpdate :
-        worldStateUpdater.getCodeToUpdate().entrySet()) {
-      final Bytes updatedCode = codeUpdate.getValue().getUpdated();
-      final Hash accountHash = Hash.hash(codeUpdate.getKey());
-      if (updatedCode == null || updatedCode.size() == 0) {
-        stateUpdater.removeCode(accountHash);
-      } else {
-        stateUpdater.putCode(accountHash, null, updatedCode);
-      }
-    }
-  }
-
   private static void addTheAccounts(
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater,
-      final BonsaiWorldStateUpdater worldStateUpdater,
-      final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie) {
+          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+          final BonsaiWorldStateUpdater worldStateUpdater,
+          final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie) {
     for (final Map.Entry<Address, BonsaiValue<BonsaiAccount>> accountUpdate :
-        worldStateUpdater.getAccountsToUpdate().entrySet()) {
+            worldStateUpdater.getAccountsToUpdate().entrySet()) {
       final Bytes accountKey = accountUpdate.getKey();
       final BonsaiValue<BonsaiAccount> bonsaiValue = accountUpdate.getValue();
       final BonsaiAccount updatedAccount = bonsaiValue.getUpdated();
@@ -193,82 +157,103 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     }
   }
 
-  private void updateAccountStorage(
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater,
-      final BonsaiWorldStateUpdater worldStateUpdater,
-      final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate) {
-    final Address updatedAddress = storageAccountUpdate.getKey();
-    final Hash updatedAddressHash = Hash.hash(updatedAddress);
-    if (worldStateUpdater.getAccountsToUpdate().containsKey(updatedAddress)) {
-      final BonsaiValue<BonsaiAccount> accountValue =
-          worldStateUpdater.getAccountsToUpdate().get(updatedAddress);
-      final BonsaiAccount accountOriginal = accountValue.getPrior();
-      final Hash storageRoot =
-          (accountOriginal == null) ? Hash.EMPTY_TRIE_HASH : accountOriginal.getStorageRoot();
-      final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
-          new StoredMerklePatriciaTrie<>(
-              (location, key) -> getStorageTrieNode(updatedAddressHash, location, key),
-              storageRoot,
-              Function.identity(),
-              Function.identity());
-
-      // for manicured tries and composting, collect branches here (not implemented)
-
-      for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageUpdate :
-          storageAccountUpdate.getValue().entrySet()) {
-        final Hash keyHash = storageUpdate.getKey();
-        final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
-        if (updatedStorage == null || updatedStorage.equals(UInt256.ZERO)) {
-          stateUpdater.removeStorageValueBySlotHash(updatedAddressHash, keyHash);
-          storageTrie.remove(keyHash);
-        } else {
-          stateUpdater.putStorageValueBySlotHash(updatedAddressHash, keyHash, updatedStorage);
-          storageTrie.put(keyHash, BonsaiWorldView.encodeTrieValue(updatedStorage));
-        }
-      }
-
-      final BonsaiAccount accountUpdated = accountValue.getUpdated();
-      if (accountUpdated != null) {
-        storageTrie.commit(
-            (location, key, value) ->
-                writeStorageTrieNode(stateUpdater, updatedAddressHash, location, key, value));
-        final Hash newStorageRoot = Hash.wrap(storageTrie.getRootHash());
-        accountUpdated.setStorageRoot(newStorageRoot);
+  private static void updateCode(
+          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+          final BonsaiWorldStateUpdater worldStateUpdater) {
+    for (final Map.Entry<Address, BonsaiValue<Bytes>> codeUpdate :
+            worldStateUpdater.getCodeToUpdate().entrySet()) {
+      final Bytes updatedCode = codeUpdate.getValue().getUpdated();
+      final Hash accountHash = Hash.hash(codeUpdate.getKey());
+      if (updatedCode == null || updatedCode.size() == 0) {
+        stateUpdater.removeCode(accountHash);
+      } else {
+        stateUpdater.putCode(accountHash, null, updatedCode);
       }
     }
   }
 
-  private void clearAccountStorage(
-      final BonsaiWorldStateKeyValueStorage.Updater stateUpdater, final Address address) {
-    // because we are clearing persisted values we need the account root as persisted
-    final BonsaiAccount oldAccount =
-        worldStateStorage
-            .getAccount(Hash.hash(address))
-            .map(bytes -> fromRLP(BonsaiPersistedWorldState.this, address, bytes, true))
-            .orElse(null);
-    if (oldAccount == null) {
-      // This is when an account is both created and deleted within the scope of the same
-      // block.  A not-uncommon DeFi bot pattern.
-      return;
+  private void updateAccountStorageState(
+          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+          final BonsaiWorldStateUpdater worldStateUpdater) {
+    for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
+            worldStateUpdater.getStorageToUpdate().entrySet()) {
+      final Address updatedAddress = storageAccountUpdate.getKey();
+      final Hash updatedAddressHash = Hash.hash(updatedAddress);
+      if (worldStateUpdater.getAccountsToUpdate().containsKey(updatedAddress)) {
+        final BonsaiValue<BonsaiAccount> accountValue =
+                worldStateUpdater.getAccountsToUpdate().get(updatedAddress);
+        final BonsaiAccount accountOriginal = accountValue.getPrior();
+        final Hash storageRoot =
+                (accountOriginal == null) ? Hash.EMPTY_TRIE_HASH : accountOriginal.getStorageRoot();
+        final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
+                new StoredMerklePatriciaTrie<>(
+                        (location, key) -> getStorageTrieNode(updatedAddressHash, location, key),
+                        storageRoot,
+                        Function.identity(),
+                        Function.identity());
+
+        // for manicured tries and composting, collect branches here (not implemented)
+
+        for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageUpdate :
+                storageAccountUpdate.getValue().entrySet()) {
+          final Hash keyHash = storageUpdate.getKey();
+          final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
+          if (updatedStorage == null || updatedStorage.equals(UInt256.ZERO)) {
+            stateUpdater.removeStorageValueBySlotHash(updatedAddressHash, keyHash);
+            storageTrie.remove(keyHash);
+          } else {
+            stateUpdater.putStorageValueBySlotHash(updatedAddressHash, keyHash, updatedStorage);
+            storageTrie.put(keyHash, BonsaiWorldView.encodeTrieValue(updatedStorage));
+          }
+        }
+
+        final BonsaiAccount accountUpdated = accountValue.getUpdated();
+        if (accountUpdated != null) {
+          storageTrie.commit(
+                  (location, key, value) ->
+                          writeStorageTrieNode(stateUpdater, updatedAddressHash, location, key, value));
+          final Hash newStorageRoot = Hash.wrap(storageTrie.getRootHash());
+          accountUpdated.setStorageRoot(newStorageRoot);
+        }
+      }
+      // for manicured tries and composting, trim and compost here
     }
-    final Hash addressHash = Hash.hash(address);
-    final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
-        new StoredMerklePatriciaTrie<>(
-            (location, key) -> getStorageTrieNode(addressHash, location, key),
-            oldAccount.getStorageRoot(),
-            Function.identity(),
-            Function.identity());
-    Map<Bytes32, Bytes> entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
-    while (!entriesToDelete.isEmpty()) {
-      entriesToDelete
-          .keySet()
-          .forEach(
-              k -> stateUpdater.removeStorageValueBySlotHash(Hash.hash(address), Hash.wrap(k)));
-      if (entriesToDelete.size() == 256) {
+  }
+
+  private void clearStorage(
+          final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
+          final BonsaiWorldStateUpdater worldStateUpdater) {
+    for (final Address address : worldStateUpdater.getStorageToClear()) {
+      // because we are clearing persisted values we need the account root as persisted
+      final BonsaiAccount oldAccount =
+              worldStateStorage
+                      .getAccount(Hash.hash(address))
+                      .map(bytes -> fromRLP(BonsaiPersistedWorldState.this, address, bytes, true))
+                      .orElse(null);
+      if (oldAccount == null) {
+        // This is when an account is both created and deleted within the scope of the same
+        // block.  A not-uncommon DeFi bot pattern.
+        continue;
+      }
+      final Hash addressHash = Hash.hash(address);
+      final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
+              new StoredMerklePatriciaTrie<>(
+                      (location, key) -> getStorageTrieNode(addressHash, location, key),
+                      oldAccount.getStorageRoot(),
+                      Function.identity(),
+                      Function.identity());
+      Map<Bytes32, Bytes> entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
+      while (!entriesToDelete.isEmpty()) {
+        entriesToDelete
+                .keySet()
+                .forEach(
+                        k -> stateUpdater.removeStorageValueBySlotHash(Hash.hash(address), Hash.wrap(k)));
         entriesToDelete.keySet().forEach(storageTrie::remove);
-        entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
-      } else {
-        break;
+        if (entriesToDelete.size() == 256) {
+          entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
+        } else {
+          break;
+        }
       }
     }
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -34,7 +34,6 @@ import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -116,11 +115,11 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
     // next walk the account trie
     final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie =
-            new StoredMerklePatriciaTrie<>(
-                    this::getAccountStateTrieNode,
-                    worldStateRootHash,
-                    Function.identity(),
-                    Function.identity());
+        new StoredMerklePatriciaTrie<>(
+            this::getAccountStateTrieNode,
+            worldStateRootHash,
+            Function.identity(),
+            Function.identity());
 
     // for manicured tries and composting, collect branches here (not implemented)
 
@@ -129,8 +128,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     // TODO write to a cache and then generate a layer update from that and the
     // DB tx updates.  Right now it is just DB updates.
     accountTrie.commit(
-            (location, hash, value) ->
-                    writeTrieNode(stateUpdater.getTrieBranchStorageTransaction(), location, value));
+        (location, hash, value) ->
+            writeTrieNode(stateUpdater.getTrieBranchStorageTransaction(), location, value));
     final Bytes32 rootHash = accountTrie.getRootHash();
     return Hash.wrap(rootHash);
   }
@@ -140,7 +139,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
           final BonsaiWorldStateUpdater worldStateUpdater,
           final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie) {
     for (final Map.Entry<Address, BonsaiValue<BonsaiAccount>> accountUpdate :
-            worldStateUpdater.getAccountsToUpdate().entrySet()) {
+        worldStateUpdater.getAccountsToUpdate().entrySet()) {
       final Bytes accountKey = accountUpdate.getKey();
       final BonsaiValue<BonsaiAccount> bonsaiValue = accountUpdate.getValue();
       final BonsaiAccount updatedAccount = bonsaiValue.getUpdated();
@@ -161,7 +160,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
           final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
           final BonsaiWorldStateUpdater worldStateUpdater) {
     for (final Map.Entry<Address, BonsaiValue<Bytes>> codeUpdate :
-            worldStateUpdater.getCodeToUpdate().entrySet()) {
+        worldStateUpdater.getCodeToUpdate().entrySet()) {
       final Bytes updatedCode = codeUpdate.getValue().getUpdated();
       final Hash accountHash = Hash.hash(codeUpdate.getKey());
       if (updatedCode == null || updatedCode.size() == 0) {
@@ -176,26 +175,26 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
           final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater,
           final BonsaiWorldStateUpdater worldStateUpdater) {
     for (final Map.Entry<Address, Map<Hash, BonsaiValue<UInt256>>> storageAccountUpdate :
-            worldStateUpdater.getStorageToUpdate().entrySet()) {
+        worldStateUpdater.getStorageToUpdate().entrySet()) {
       final Address updatedAddress = storageAccountUpdate.getKey();
       final Hash updatedAddressHash = Hash.hash(updatedAddress);
       if (worldStateUpdater.getAccountsToUpdate().containsKey(updatedAddress)) {
         final BonsaiValue<BonsaiAccount> accountValue =
-                worldStateUpdater.getAccountsToUpdate().get(updatedAddress);
+            worldStateUpdater.getAccountsToUpdate().get(updatedAddress);
         final BonsaiAccount accountOriginal = accountValue.getPrior();
         final Hash storageRoot =
-                (accountOriginal == null) ? Hash.EMPTY_TRIE_HASH : accountOriginal.getStorageRoot();
+            (accountOriginal == null) ? Hash.EMPTY_TRIE_HASH : accountOriginal.getStorageRoot();
         final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
-                new StoredMerklePatriciaTrie<>(
-                        (location, key) -> getStorageTrieNode(updatedAddressHash, location, key),
-                        storageRoot,
-                        Function.identity(),
-                        Function.identity());
+            new StoredMerklePatriciaTrie<>(
+                (location, key) -> getStorageTrieNode(updatedAddressHash, location, key),
+                storageRoot,
+                Function.identity(),
+                Function.identity());
 
         // for manicured tries and composting, collect branches here (not implemented)
 
         for (final Map.Entry<Hash, BonsaiValue<UInt256>> storageUpdate :
-                storageAccountUpdate.getValue().entrySet()) {
+            storageAccountUpdate.getValue().entrySet()) {
           final Hash keyHash = storageUpdate.getKey();
           final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
           if (updatedStorage == null || updatedStorage.equals(UInt256.ZERO)) {
@@ -210,8 +209,8 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
         final BonsaiAccount accountUpdated = accountValue.getUpdated();
         if (accountUpdated != null) {
           storageTrie.commit(
-                  (location, key, value) ->
-                          writeStorageTrieNode(stateUpdater, updatedAddressHash, location, key, value));
+              (location, key, value) ->
+                  writeStorageTrieNode(stateUpdater, updatedAddressHash, location, key, value));
           final Hash newStorageRoot = Hash.wrap(storageTrie.getRootHash());
           accountUpdated.setStorageRoot(newStorageRoot);
         }
@@ -226,10 +225,10 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
     for (final Address address : worldStateUpdater.getStorageToClear()) {
       // because we are clearing persisted values we need the account root as persisted
       final BonsaiAccount oldAccount =
-              worldStateStorage
-                      .getAccount(Hash.hash(address))
-                      .map(bytes -> fromRLP(BonsaiPersistedWorldState.this, address, bytes, true))
-                      .orElse(null);
+          worldStateStorage
+              .getAccount(Hash.hash(address))
+              .map(bytes -> fromRLP(BonsaiPersistedWorldState.this, address, bytes, true))
+              .orElse(null);
       if (oldAccount == null) {
         // This is when an account is both created and deleted within the scope of the same
         // block.  A not-uncommon DeFi bot pattern.
@@ -237,17 +236,17 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
       }
       final Hash addressHash = Hash.hash(address);
       final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
-              new StoredMerklePatriciaTrie<>(
-                      (location, key) -> getStorageTrieNode(addressHash, location, key),
-                      oldAccount.getStorageRoot(),
-                      Function.identity(),
-                      Function.identity());
+          new StoredMerklePatriciaTrie<>(
+              (location, key) -> getStorageTrieNode(addressHash, location, key),
+              oldAccount.getStorageRoot(),
+              Function.identity(),
+              Function.identity());
       Map<Bytes32, Bytes> entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
       while (!entriesToDelete.isEmpty()) {
         entriesToDelete
-                .keySet()
-                .forEach(
-                        k -> stateUpdater.removeStorageValueBySlotHash(Hash.hash(address), Hash.wrap(k)));
+            .keySet()
+            .forEach(
+                k -> stateUpdater.removeStorageValueBySlotHash(Hash.hash(address), Hash.wrap(k)));
         entriesToDelete.keySet().forEach(storageTrie::remove);
         if (entriesToDelete.size() == 256) {
           entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -378,7 +378,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     }
 
     @Override
-    public BonsaiUpdater putStorageValueBySlotHash(
+    public synchronized BonsaiUpdater putStorageValueBySlotHash(
         final Hash accountHash, final Hash slotHash, final Bytes storage) {
       storageStorageTransaction.put(
           Bytes.concatenate(accountHash, slotHash).toArrayUnsafe(), storage.toArrayUnsafe());
@@ -386,7 +386,8 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
     }
 
     @Override
-    public void removeStorageValueBySlotHash(final Hash accountHash, final Hash slotHash) {
+    public synchronized void removeStorageValueBySlotHash(
+        final Hash accountHash, final Hash slotHash) {
       storageStorageTransaction.remove(Bytes.concatenate(accountHash, slotHash).toArrayUnsafe());
     }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
 import org.hyperledger.besu.evm.worldstate.WrappedEvmAccount;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -47,9 +48,9 @@ import org.apache.tuweni.units.bigints.UInt256;
 public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldView, BonsaiAccount>
     implements BonsaiWorldView {
 
-  private final Map<Address, BonsaiValue<BonsaiAccount>> accountsToUpdate = new HashMap<>();
-  private final Map<Address, BonsaiValue<Bytes>> codeToUpdate = new HashMap<>();
-  private final Set<Address> storageToClear = new HashSet<>();
+  private final Map<Address, BonsaiValue<BonsaiAccount>> accountsToUpdate = new ConcurrentHashMap<>();
+  private final Map<Address, BonsaiValue<Bytes>> codeToUpdate = new ConcurrentHashMap<>();
+  private final Set<Address> storageToClear = Collections.synchronizedSet(null);
 
   // storage sub mapped by _hashed_ key.  This is because in self_destruct calls we need to
   // enumerate the old storage and delete it.  Those are trie stored by hashed key by spec and the

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -50,7 +50,7 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
 
   private final Map<Address, BonsaiValue<BonsaiAccount>> accountsToUpdate = new ConcurrentHashMap<>();
   private final Map<Address, BonsaiValue<Bytes>> codeToUpdate = new ConcurrentHashMap<>();
-  private final Set<Address> storageToClear = Collections.synchronizedSet(null);
+  private final Set<Address> storageToClear = Collections.synchronizedSet(new HashSet<>());
 
   // storage sub mapped by _hashed_ key.  This is because in self_destruct calls we need to
   // enumerate the old storage and delete it.  Those are trie stored by hashed key by spec and the

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -48,7 +48,8 @@ import org.apache.tuweni.units.bigints.UInt256;
 public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldView, BonsaiAccount>
     implements BonsaiWorldView {
 
-  private final Map<Address, BonsaiValue<BonsaiAccount>> accountsToUpdate = new ConcurrentHashMap<>();
+  private final Map<Address, BonsaiValue<BonsaiAccount>> accountsToUpdate =
+      new ConcurrentHashMap<>();
   private final Map<Address, BonsaiValue<Bytes>> codeToUpdate = new ConcurrentHashMap<>();
   private final Set<Address> storageToClear = Collections.synchronizedSet(new HashSet<>());
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
@@ -21,11 +21,13 @@ import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * An abstract implementation of a {@link WorldUpdater} that buffers update over the {@link
@@ -38,8 +40,8 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
 
   private final W world;
 
-  protected Map<Address, UpdateTrackingAccount<A>> updatedAccounts = new HashMap<>();
-  protected Set<Address> deletedAccounts = new HashSet<>();
+  protected Map<Address, UpdateTrackingAccount<A>> updatedAccounts = new ConcurrentHashMap<>();
+  protected Set<Address> deletedAccounts = Collections.synchronizedSet(null);
 
   protected AbstractWorldUpdater(final W world) {
     this.world = world;

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.evm.account.MutableAccount;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -41,7 +40,7 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
   private final W world;
 
   protected Map<Address, UpdateTrackingAccount<A>> updatedAccounts = new ConcurrentHashMap<>();
-  protected Set<Address> deletedAccounts = Collections.synchronizedSet(null);
+  protected Set<Address> deletedAccounts = Collections.synchronizedSet(new HashSet<>());
 
   protected AbstractWorldUpdater(final W world) {
     this.world = world;

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -336,7 +336,7 @@ public class RocksDBColumnarKeyValueStorage
     }
 
     @Override
-    public void commit() throws StorageException {
+    public synchronized void commit() throws StorageException {
       try (final OperationTimer.TimingContext ignored = metrics.getCommitLatency().startTimer()) {
         innerTx.commit();
       } catch (final RocksDBException e) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Create a specific calculateRootHash for BonsaiInMemoryWorldState, avoid committing and rollbacking as it is not necessary. This PR parallelize also the accounts update storage in calculateRootHash method.

The yellow line below is the version with the modifications in this PR, the other node is used as a reference node (a baseline) regarding block size and the number of transactions per block. 

<img width="1666" alt="image" src="https://user-images.githubusercontent.com/5099602/198327521-150a9b36-6253-42e0-badd-c011f8054e89.png">

We have below engine_newPayloadV1 RPC call (Block processing) mean time comparaison between this PR, version 22.7.6 and version 22.7.7

<img width="1655" alt="image" src="https://user-images.githubusercontent.com/5099602/198872825-c2064635-21b7-409a-9a8d-7f0f835dbafa.png">


We can notice also that calculateRootHash method is consuming less (real) time on CPU because of the parallelization and the fact we removed commit and rollback method.

**Before this PR**
<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/198871604-cb840fb9-0089-4589-a2ae-499468e0d5c7.png">

**After this PR**
<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/198871660-6171dd5a-de14-40ba-95f1-aabb367f5126.png">

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Mitigate #4549

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).