### PR TITLE
Bring standard tracer closer to EIP standards

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
@@ -33,8 +33,13 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class StandardJsonTracer implements OperationTracer {
 
+  private static final Joiner commaJoiner = Joiner.on(',');
   private final PrintStream out;
   private final boolean showMemory;
+  private int pc;
+  private List<String> stack;
+  private String gas;
+  private Bytes memory;
 
   public StandardJsonTracer(final PrintStream out, final boolean showMemory) {
     this.out = out;
@@ -53,61 +58,7 @@ public class StandardJsonTracer implements OperationTracer {
     return bytes.isZero() ? "0x0" : bytes.toShortHexString();
   }
 
-  final Joiner commaJoiner = Joiner.on(',');
-
-  private List<String> preExecuteStack;
-
-  @Override
-  public void tracePreExecution(final MessageFrame messageFrame) {
-    preExecuteStack = new ArrayList<>(messageFrame.stackSize());
-    for (int i = messageFrame.stackSize() - 1; i >= 0; i--) {
-      preExecuteStack.add("\"" + shortBytes(messageFrame.getStackItem(i)) + "\"");
-    }
-  }
-
-  @Override
-  public void tracePostExecution(
-      final MessageFrame messageFrame, final Operation.OperationResult executeResult) {
-    final Operation currentOp = messageFrame.getCurrentOperation();
-    final int pc = messageFrame.getPC();
-    final int opcode = currentOp.getOpcode();
-    final String remainingGas = shortNumber(messageFrame.getRemainingGas());
-    final Bytes returnData = messageFrame.getReturnData();
-    final int depth = messageFrame.getMessageStackDepth() + 1;
-
-    final StringBuilder sb = new StringBuilder(1024);
-    sb.append("{");
-    sb.append("\"pc\":").append(pc).append(",");
-    sb.append("\"op\":").append(opcode).append(",");
-    sb.append("\"gas\":\"").append(remainingGas).append("\",");
-    sb.append("\"gasCost\":\"")
-        .append(executeResult.getGasCost() != 0 ? shortNumber(executeResult.getGasCost()) : "")
-        .append("\",");
-    if (showMemory) {
-      final Bytes memory = messageFrame.readMemory(0, messageFrame.memoryWordSize() * 32L);
-      sb.append("\"memory\":\"").append(memory.toHexString()).append("\",");
-      sb.append("\"memSize\":").append(memory.size()).append(",");
-    } else {
-      sb.append("\"memory\":\"0x\",");
-      sb.append("\"memSize\":").append(messageFrame.memoryByteSize()).append(",");
-    }
-    sb.append("\"stack\":[").append(commaJoiner.join(preExecuteStack)).append("],");
-    sb.append("\"returnData\":")
-        .append(returnData.size() > 0 ? '"' + returnData.toHexString() + '"' : "null")
-        .append(",");
-    sb.append("\"depth\":").append(depth).append(",");
-    sb.append("\"refund\":").append(messageFrame.getGasRefund()).append(",");
-    sb.append("\"opName\":\"").append(currentOp.getName()).append("\",");
-    sb.append("\"error\":\"")
-        .append(
-            executeResult.getHaltReason() == null
-                ? (quoteEscape(messageFrame.getRevertReason().orElse(Bytes.EMPTY)))
-                : executeResult.getHaltReason().getDescription())
-        .append("\"}");
-    out.println(sb);
-  }
-
-  static String quoteEscape(final Bytes bytes) {
+  private static String quoteEscape(final Bytes bytes) {
     final StringBuilder result = new StringBuilder(bytes.size());
     for (final byte b : bytes.toArrayUnsafe()) {
       final int c = Byte.toUnsignedInt(b);
@@ -136,6 +87,54 @@ public class StandardJsonTracer implements OperationTracer {
       }
     }
     return result.toString();
+  }
+
+  @Override
+  public void tracePreExecution(final MessageFrame messageFrame) {
+    stack = new ArrayList<>(messageFrame.stackSize());
+    for (int i = messageFrame.stackSize() - 1; i >= 0; i--) {
+      stack.add("\"" + shortBytes(messageFrame.getStackItem(i)) + "\"");
+    }
+    pc = messageFrame.getPC();
+    gas = shortNumber(messageFrame.getRemainingGas());
+    memory = messageFrame.readMemory(0, messageFrame.memoryWordSize() * 32L);
+  }
+
+  @Override
+  public void tracePostExecution(
+      final MessageFrame messageFrame, final Operation.OperationResult executeResult) {
+    final Operation currentOp = messageFrame.getCurrentOperation();
+    final int opcode = currentOp.getOpcode();
+    final Bytes returnData = messageFrame.getReturnData();
+    final int depth = messageFrame.getMessageStackDepth() + 1;
+
+    final StringBuilder sb = new StringBuilder(1024);
+    sb.append("{");
+    sb.append("\"pc\":").append(pc).append(",");
+    sb.append("\"op\":").append(opcode).append(",");
+    sb.append("\"gas\":\"").append(gas).append("\",");
+    sb.append("\"gasCost\":\"").append(shortNumber(executeResult.getGasCost())).append("\",");
+    if (showMemory) {
+      sb.append("\"memory\":\"").append(memory.toHexString()).append("\",");
+      sb.append("\"memSize\":").append(memory.size()).append(",");
+    } else {
+      sb.append("\"memory\":\"0x\",");
+      sb.append("\"memSize\":").append(messageFrame.memoryByteSize()).append(",");
+    }
+    sb.append("\"stack\":[").append(commaJoiner.join(stack)).append("],");
+    sb.append("\"returnData\":")
+        .append(returnData.size() > 0 ? '"' + returnData.toHexString() + '"' : "\"0x\"")
+        .append(",");
+    sb.append("\"depth\":").append(depth).append(",");
+    sb.append("\"refund\":").append(messageFrame.getGasRefund()).append(",");
+    sb.append("\"opName\":\"").append(currentOp.getName()).append("\",");
+    sb.append("\"error\":\"")
+        .append(
+            executeResult.getHaltReason() == null
+                ? (quoteEscape(messageFrame.getRevertReason().orElse(Bytes.EMPTY)))
+                : executeResult.getHaltReason().getDescription())
+        .append("\"}");
+    out.println(sb);
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
@@ -58,37 +58,6 @@ public class StandardJsonTracer implements OperationTracer {
     return bytes.isZero() ? "0x0" : bytes.toShortHexString();
   }
 
-  private static String quoteEscape(final Bytes bytes) {
-    final StringBuilder result = new StringBuilder(bytes.size());
-    for (final byte b : bytes.toArrayUnsafe()) {
-      final int c = Byte.toUnsignedInt(b);
-      // list from RFC-4627 section 2
-      if (c == '"') {
-        result.append("\\\"");
-      } else if (c == '\\') {
-        result.append("\\\\");
-      } else if (c == '/') {
-        result.append("\\/");
-      } else if (c == '\b') {
-        result.append("\\b");
-      } else if (c == '\f') {
-        result.append("\\f");
-      } else if (c == '\n') {
-        result.append("\\n");
-      } else if (c == '\r') {
-        result.append("\\r");
-      } else if (c == '\t') {
-        result.append("\\t");
-      } else if (c <= 0x1F) {
-        result.append("\\u");
-        result.append(padStart(Integer.toHexString(c), 4, '0'));
-      } else {
-        result.append((char) b);
-      }
-    }
-    return result.toString();
-  }
-
   @Override
   public void tracePreExecution(final MessageFrame messageFrame) {
     stack = new ArrayList<>(messageFrame.stackSize());
@@ -135,6 +104,37 @@ public class StandardJsonTracer implements OperationTracer {
                 : executeResult.getHaltReason().getDescription())
         .append("\"}");
     out.println(sb);
+  }
+
+  private static String quoteEscape(final Bytes bytes) {
+    final StringBuilder result = new StringBuilder(bytes.size());
+    for (final byte b : bytes.toArrayUnsafe()) {
+      final int c = Byte.toUnsignedInt(b);
+      // list from RFC-4627 section 2
+      if (c == '"') {
+        result.append("\\\"");
+      } else if (c == '\\') {
+        result.append("\\\\");
+      } else if (c == '/') {
+        result.append("\\/");
+      } else if (c == '\b') {
+        result.append("\\b");
+      } else if (c == '\f') {
+        result.append("\\f");
+      } else if (c == '\n') {
+        result.append("\\n");
+      } else if (c == '\r') {
+        result.append("\\r");
+      } else if (c == '\t') {
+        result.append("\\t");
+      } else if (c <= 0x1F) {
+        result.append("\\u");
+        result.append(padStart(Integer.toHexString(c), 4, '0'));
+      } else {
+        result.append((char) b);
+      }
+    }
+    return result.toString();
   }
 
   @Override

--- a/evm/src/test/java/org/hyperledger/besu/evm/StandardJsonTracerTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/StandardJsonTracerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
 package org.hyperledger.besu.evm;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/evm/src/test/java/org/hyperledger/besu/evm/StandardJsonTracerTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/StandardJsonTracerTest.java
@@ -1,0 +1,57 @@
+package org.hyperledger.besu.evm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.fluent.EVMExecutor;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.evm.tracing.StandardJsonTracer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+class StandardJsonTracerTest {
+
+  @Test
+  void eip3155TestCase() {
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(baos);
+    var executor = EVMExecutor.istanbul(EvmConfiguration.DEFAULT);
+    StandardJsonTracer tracer = new StandardJsonTracer(out, true);
+    executor.tracer(tracer);
+    executor.gas(10_000_000_000L);
+
+    var codeBytes = Bytes.fromHexString("0x604080536040604055604060006040600060025afa6040f3");
+    executor.execute(codeBytes, Bytes.EMPTY, Wei.ZERO, Address.ZERO);
+
+    // differences from the EIP-3155 test case
+    //  (a) the test case was written when EIP-2315 was part of the pending hard fork, so
+    //      returnStack was a valid field.  It no longer appears in any traces.
+    //  (b) the summary line is omitted
+    //  (c) pc:3 is in error, the size of the memory before the first MSTORE8 is zero.
+    //  (d) we don't report call requested gas in CALL series operations as a gas cost, just the EVM
+    //      consumed gas
+    assertThat(baos)
+        .hasToString(
+            "{\"pc\":0,\"op\":96,\"gas\":\"0x2540be400\",\"gasCost\":\"0x3\",\"memory\":\"0x\",\"memSize\":0,\"stack\":[],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":2,\"op\":128,\"gas\":\"0x2540be3fd\",\"gasCost\":\"0x3\",\"memory\":\"0x\",\"memSize\":0,\"stack\":[\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"DUP1\",\"error\":\"\"}\n"
+                + "{\"pc\":3,\"op\":83,\"gas\":\"0x2540be3fa\",\"gasCost\":\"0xc\",\"memory\":\"0x\",\"memSize\":0,\"stack\":[\"0x40\",\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"MSTORE8\",\"error\":\"\"}\n"
+                + "{\"pc\":4,\"op\":96,\"gas\":\"0x2540be3ee\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":6,\"op\":96,\"gas\":\"0x2540be3eb\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":8,\"op\":85,\"gas\":\"0x2540be3e8\",\"gasCost\":\"0x4e20\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"SSTORE\",\"error\":\"\"}\n"
+                + "{\"pc\":9,\"op\":96,\"gas\":\"0x2540b95c8\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":11,\"op\":96,\"gas\":\"0x2540b95c5\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":13,\"op\":96,\"gas\":\"0x2540b95c2\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x0\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":15,\"op\":96,\"gas\":\"0x2540b95bf\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x0\",\"0x40\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":17,\"op\":96,\"gas\":\"0x2540b95bc\",\"gasCost\":\"0x3\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x0\",\"0x40\",\"0x0\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":19,\"op\":90,\"gas\":\"0x2540b95b9\",\"gasCost\":\"0x2\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x0\",\"0x40\",\"0x0\",\"0x2\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"GAS\",\"error\":\"\"}\n"
+                + "{\"pc\":20,\"op\":250,\"gas\":\"0x2540b95b7\",\"gasCost\":\"0x2bc\",\"memory\":\"0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x40\",\"0x0\",\"0x40\",\"0x0\",\"0x2\",\"0x2540b95b7\"],\"returnData\":\"0x\",\"depth\":1,\"refund\":0,\"opName\":\"STATICCALL\",\"error\":\"\"}\n"
+                + "{\"pc\":21,\"op\":96,\"gas\":\"0x2540b92a7\",\"gasCost\":\"0x3\",\"memory\":\"0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x1\"],\"returnData\":\"0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b\",\"depth\":1,\"refund\":0,\"opName\":\"PUSH1\",\"error\":\"\"}\n"
+                + "{\"pc\":23,\"op\":243,\"gas\":\"0x2540b92a4\",\"gasCost\":\"0x0\",\"memory\":\"0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b00000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000\",\"memSize\":96,\"stack\":[\"0x1\",\"0x40\"],\"returnData\":\"0xf5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a92759fb4b\",\"depth\":1,\"refund\":0,\"opName\":\"RETURN\",\"error\":\"\"}\n");
+  }
+}


### PR DESCRIPTION
## PR description

The EVM refactor introduced a couple of EVM trace changes that are outside the EIP-3115 standards.
* pc, gasRemaining, and memory were all post-execution values
* some places null should be "0x0" or "0x"

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).