### PR TITLE
Remove SHL, SHR and SAR from default EVM

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -43,9 +43,6 @@ import org.hyperledger.besu.evm.operation.PushOperation;
 import org.hyperledger.besu.evm.operation.SGtOperation;
 import org.hyperledger.besu.evm.operation.SLtOperation;
 import org.hyperledger.besu.evm.operation.SModOperation;
-import org.hyperledger.besu.evm.operation.SarOperation;
-import org.hyperledger.besu.evm.operation.ShlOperation;
-import org.hyperledger.besu.evm.operation.ShrOperation;
 import org.hyperledger.besu.evm.operation.SignExtendOperation;
 import org.hyperledger.besu.evm.operation.StopOperation;
 import org.hyperledger.besu.evm.operation.SwapOperation;
@@ -190,15 +187,6 @@ public class EVM {
             break;
           case 0x1a: // BYTE
             result = ByteOperation.staticOperation(frame);
-            break;
-          case 0x1b: // SHL
-            result = ShlOperation.staticOperation(frame);
-            break;
-          case 0x1c: // SHR
-            result = ShrOperation.staticOperation(frame);
-            break;
-          case 0x1d: // SAR
-            result = SarOperation.staticOperation(frame);
             break;
           case 0x50: // POP
             result = PopOperation.staticOperation(frame);


### PR DESCRIPTION
## PR description
This PR removes the opcodes `SHL`, `SHR` and `SAR` from the base EVM b/c those were added in [EIP-145](https://eips.ethereum.org/EIPS/eip-145) and shouldn't be available since Genesis.

## Fixed Issue(s)
Spotted by @winsvega during the execution of LegacyTests. E.g.
```shell
$ ./retesteth -t LegacyTests/Constantinople/BCGeneralStateTests/stShift -- --singletest shr11_d0g0v0 --clients besu --singlenet Byzantium --nodes 127.0.0.1:8545
```

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

Signed-off-by: Diego López León <dieguitoll@gmail.com>