### PR TITLE
Ensure snapshots released before gc

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
@@ -26,6 +26,7 @@ import org.rocksdb.Snapshot;
  * use.
  */
 class RocksDBSnapshot {
+
   private final OptimisticTransactionDB db;
   private final Snapshot dbSnapshot;
   private final AtomicInteger usages = new AtomicInteger(0);
@@ -42,8 +43,17 @@ class RocksDBSnapshot {
 
   void unMarkSnapshot() {
     if (usages.decrementAndGet() < 1) {
-      dbSnapshot.close();
       db.releaseSnapshot(dbSnapshot);
+      dbSnapshot.close();
+    }
+  }
+
+  // TODO:  this is a stopgap measure, revisit with https://github.com/hyperledger/besu/issues/4641
+  @Override
+  protected void finalize() {
+    if (usages.decrementAndGet() > 0) {
+      db.releaseSnapshot(dbSnapshot);
+      dbSnapshot.close();
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Short term fix to ensure snapshot transactions are closed and snapshots released before their respective objects are GC'd.

This is a stop-gap measure until a subsequent PR addresses #4641 and can use static analysis to ensure all worldstates are closed at the end of their lifecycle.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes  #4643 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).