### PR TITLE
Upgrade RocksDB from version 7.6.0 to 7.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Explain and improve price validation for London and local transactions during block proposal selection [#4602](https://github.com/hyperledger/besu/pull/4602)
 - Support for ephemeral testnet Shandong.  EIPs are still in flux, besu does not fully sync yet, and the network is subject to restarts. [#//FIXME](https://github.com/hyperledger/besu/pull///FIXME)
 - Improve performance of block processing by parallelizing some parts during the "commit" step [#4635](https://github.com/hyperledger/besu/pull/4635)
+- Upgrade RocksDB version from 7.6.0 to 7.7.3
 
 ### Bug Fixes
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -185,7 +185,7 @@ dependencyManagement {
     dependency 'org.openjdk.jmh:jmh-core:1.34'
     dependency 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
 
-    dependency 'org.rocksdb:rocksdbjni:7.6.0'
+    dependency 'org.rocksdb:rocksdbjni:7.7.3'
 
     dependency 'org.slf4j:slf4j-api:1.7.36'
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
The new version of RocksDB JNI library was published in maven on Oct 25, 2022, this PR will upgrade rocksdb JNI library from 7.6.0 to 7.7.3.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).