### PR TITLE
Added 'result' field to eth_sendRawTransaction invalid transaction response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Additions and Improvements
 - Explain and improve price validation for London and local transactions during block proposal selection [#4602](https://github.com/hyperledger/besu/pull/4602)
 - Support for ephemeral testnet Shandong.  EIPs are still in flux, besu does not fully sync yet, and the network is subject to restarts. [#//FIXME](https://github.com/hyperledger/besu/pull///FIXME)
+- Added `result` field containing transaction hash to `eth_sendRawTransaction` invalid transaction response  [4650](https://github.com/hyperledger/besu/pull/4650)
 
 ### Bug Fixes
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -89,6 +89,6 @@ public class EthSendRawTransaction implements JsonRpcMethod {
                 : new JsonRpcErrorResponse(
                     requestContext.getRequest().getId(),
                     JsonRpcErrorConverter.convertTransactionInvalidReason(errorReason),
-                    Optional.ofNullable(transaction.getHash().toString())));
+                    transaction.getHash().toString()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
@@ -87,6 +88,7 @@ public class EthSendRawTransaction implements JsonRpcMethod {
                     requestContext.getRequest().getId(), Hash.EMPTY.toString())
                 : new JsonRpcErrorResponse(
                     requestContext.getRequest().getId(),
-                    JsonRpcErrorConverter.convertTransactionInvalidReason(errorReason)));
+                    JsonRpcErrorConverter.convertTransactionInvalidReason(errorReason),
+                    Optional.ofNullable(transaction.getHash().toString())));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -29,7 +29,6 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,10 +27,19 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
 
   private final Object id;
   private final JsonRpcError error;
+  private final Optional<Object> result;
 
   public JsonRpcErrorResponse(final Object id, final JsonRpcError error) {
     this.id = id;
     this.error = error;
+    this.result = Optional.empty();
+  }
+
+  public JsonRpcErrorResponse(
+      final Object id, final JsonRpcError error, final Optional<Object> result) {
+    this.id = id;
+    this.error = error;
+    this.result = result;
   }
 
   @JsonGetter("id")
@@ -40,6 +50,11 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
   @JsonGetter("error")
   public JsonRpcError getError() {
     return error;
+  }
+
+  @JsonGetter("result")
+  public Optional<Object> getResult() {
+    return result;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
@@ -15,10 +15,10 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.MoreObjects;
 
@@ -27,16 +27,15 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
 
   private final Object id;
   private final JsonRpcError error;
-  private final Optional<Object> result;
+  private final Object result;
 
   public JsonRpcErrorResponse(final Object id, final JsonRpcError error) {
     this.id = id;
     this.error = error;
-    this.result = Optional.empty();
+    this.result = null;
   }
 
-  public JsonRpcErrorResponse(
-      final Object id, final JsonRpcError error, final Optional<Object> result) {
+  public JsonRpcErrorResponse(final Object id, final JsonRpcError error, final Object result) {
     this.id = id;
     this.error = error;
     this.result = result;
@@ -52,8 +51,9 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
     return error;
   }
 
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter("result")
-  public Optional<Object> getResult() {
+  public Object getResult() {
     return result;
   }
 
@@ -72,16 +72,22 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
       return false;
     }
     final JsonRpcErrorResponse that = (JsonRpcErrorResponse) o;
-    return Objects.equals(id, that.id) && error == that.error;
+    return Objects.equals(id, that.id)
+        && error == that.error
+        && Objects.equals(result, that.result);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, error);
+    return Objects.hash(id, error, result);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("id", id).add("error", error).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("id", id)
+        .add("error", error)
+        .add("result", result)
+        .toString();
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
@@ -30,6 +30,9 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
+import java.util.Optional;
+
+import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -191,8 +194,13 @@ public class EthSendRawTransactionTest {
         new JsonRpcRequestContext(
             new JsonRpcRequest("2.0", "eth_sendRawTransaction", new String[] {VALID_TRANSACTION}));
 
+    final Transaction transaction = Transaction.readFrom(Bytes.fromHexString(VALID_TRANSACTION));
+
     final JsonRpcResponse expectedResponse =
-        new JsonRpcErrorResponse(request.getRequest().getId(), expectedError);
+        new JsonRpcErrorResponse(
+            request.getRequest().getId(),
+            expectedError,
+            Optional.ofNullable(transaction.getHash().toString()));
 
     final JsonRpcResponse actualResponse = method.response(request);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
@@ -30,8 +30,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
-import java.util.Optional;
-
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
 import org.junit.Test;
@@ -198,9 +196,7 @@ public class EthSendRawTransactionTest {
 
     final JsonRpcResponse expectedResponse =
         new JsonRpcErrorResponse(
-            request.getRequest().getId(),
-            expectedError,
-            Optional.ofNullable(transaction.getHash().toString()));
+            request.getRequest().getId(), expectedError, transaction.getHash().toString());
 
     final JsonRpcResponse actualResponse = method.response(request);
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Adds a `result` field (containing the transaction hash) to the response from `eth_sendRawTransaction` when the transaction is invalid. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).