### PR TITLE
Fix circleCI snapshot segfaults

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -146,6 +147,13 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolated2.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
     assertThat(isolated2.get().rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
+
+    try {
+      isolated.get().close();
+      isolated2.get().close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close isolated worldstates");
+    }
   }
 
   @Test
@@ -176,6 +184,13 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(ws.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
     assertThat(ws.get().rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
+    try {
+      isolated.get().close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close isolated worldstates");
+    }
+
+
   }
 
   @Test
@@ -240,6 +255,14 @@ public class BonsaiSnapshotIsolationTests {
     var cloneForkTrieLog = archive.getTrieLogManager().getTrieLogLayer(cloneForkBlock.getHash());
     assertThat(cloneForkTrieLog.get().getAccount(testAddress)).isEmpty();
     assertThat(cloneForkTrieLog.get().getAccount(altTestAddress)).isNotEmpty();
+
+    try {
+      isolated.close();
+      isolatedClone.close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close isolated worldstates");
+    }
+
   }
 
   @Test
@@ -276,6 +299,13 @@ public class BonsaiSnapshotIsolationTests {
 
     // copy of closed isolated worldstate should still pass check
     checkIsolatedState.accept(isolatedClone);
+
+    try {
+      isolatedClone.close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close isolated worldstates");
+    }
+
   }
 
   @Test
@@ -320,6 +350,14 @@ public class BonsaiSnapshotIsolationTests {
     assertThat(isolatedRollBack.get().get(testAddress).getBalance())
         .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
     assertThat(isolatedRollBack.get().rootHash()).isEqualTo(block1.getHeader().getStateRoot());
+
+    try {
+      isolatedRollForward.get().close();
+      isolatedRollBack.get().close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close isolated worldstates");
+    }
+
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -71,7 +71,6 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -189,8 +188,6 @@ public class BonsaiSnapshotIsolationTests {
     } catch (Exception ex) {
       throw new RuntimeException("failed to close isolated worldstates");
     }
-
-
   }
 
   @Test
@@ -262,7 +259,6 @@ public class BonsaiSnapshotIsolationTests {
     } catch (Exception ex) {
       throw new RuntimeException("failed to close isolated worldstates");
     }
-
   }
 
   @Test
@@ -305,7 +301,6 @@ public class BonsaiSnapshotIsolationTests {
     } catch (Exception ex) {
       throw new RuntimeException("failed to close isolated worldstates");
     }
-
   }
 
   @Test
@@ -357,7 +352,6 @@ public class BonsaiSnapshotIsolationTests {
     } catch (Exception ex) {
       throw new RuntimeException("failed to close isolated worldstates");
     }
-
   }
 
   @Test


### PR DESCRIPTION
explicitly close snapshot worldstates and their copies to avoid a segfault on circle-ci when running BonsaiSnapshotIsolationTest