### PR TITLE
Remove misleading fastSyncEnabled variable

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -375,8 +375,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     }
 
     final EthContext ethContext = new EthContext(ethPeers, ethMessages, snapMessages, scheduler);
-    final boolean fastSyncEnabled = !SyncMode.isFullSync(syncConfig.getSyncMode());
-    final SyncState syncState = new SyncState(blockchain, ethPeers, fastSyncEnabled, checkpoint);
+    final boolean fullSyncDisabled = !SyncMode.isFullSync(syncConfig.getSyncMode());
+    final SyncState syncState = new SyncState(blockchain, ethPeers, fullSyncDisabled, checkpoint);
 
     final TransactionPool transactionPool =
         TransactionPoolFactory.createTransactionPool(
@@ -394,7 +394,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final EthProtocolManager ethProtocolManager =
         createEthProtocolManager(
             protocolContext,
-            fastSyncEnabled,
+            syncConfig,
             transactionPool,
             ethereumWireProtocolConfiguration,
             ethPeers,
@@ -475,7 +475,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
       final EthProtocolManager ethProtocolManager,
       final PivotBlockSelector pivotBlockSelector) {
 
-    DefaultSynchronizer toUse =
+    final DefaultSynchronizer toUse =
         new DefaultSynchronizer(
             syncConfig,
             protocolSchedule,
@@ -583,7 +583,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
   protected EthProtocolManager createEthProtocolManager(
       final ProtocolContext protocolContext,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final TransactionPool transactionPool,
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
@@ -603,7 +603,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
         ethContext,
         peerValidators,
         mergePeerFilter,
-        fastSyncEnabled,
+        synchronizerConfiguration,
         scheduler,
         genesisConfig.getForks());
   }

--- a/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
@@ -226,7 +226,7 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
   @Override
   protected EthProtocolManager createEthProtocolManager(
       final ProtocolContext protocolContext,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final TransactionPool transactionPool,
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
@@ -239,7 +239,7 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
         .get(0L)
         .createEthProtocolManager(
             protocolContext,
-            fastSyncEnabled,
+            synchronizerConfiguration,
             transactionPool,
             ethereumWireProtocolConfiguration,
             ethPeers,

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftLegacyBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftLegacyBesuControllerBuilder.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.manager.MergePeerFilter;
 import org.hyperledger.besu.ethereum.eth.manager.snap.SnapProtocolManager;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -119,7 +120,7 @@ public class IbftLegacyBesuControllerBuilder extends BesuControllerBuilder {
   @Override
   protected EthProtocolManager createEthProtocolManager(
       final ProtocolContext protocolContext,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final TransactionPool transactionPool,
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
@@ -139,7 +140,7 @@ public class IbftLegacyBesuControllerBuilder extends BesuControllerBuilder {
         ethMessages,
         ethContext,
         peerValidators,
-        fastSyncEnabled,
+        synchronizerConfiguration,
         scheduler);
   }
 }

--- a/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/MergeBesuControllerBuilder.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.ethereum.eth.manager.MergePeerFilter;
 import org.hyperledger.besu.ethereum.eth.manager.MonitoredExecutors;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.eth.peervalidation.RequiredBlocksPeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardChain;
 import org.hyperledger.besu.ethereum.eth.sync.backwardsync.BackwardSyncContext;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
@@ -87,7 +88,7 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
   @Override
   protected EthProtocolManager createEthProtocolManager(
       final ProtocolContext protocolContext,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final TransactionPool transactionPool,
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
@@ -120,7 +121,7 @@ public class MergeBesuControllerBuilder extends BesuControllerBuilder {
     EthProtocolManager ethProtocolManager =
         super.createEthProtocolManager(
             protocolContext,
-            fastSyncEnabled,
+            synchronizerConfiguration,
             transactionPool,
             ethereumWireProtocolConfiguration,
             ethPeers,

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -141,7 +141,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
   @Override
   protected EthProtocolManager createEthProtocolManager(
       final ProtocolContext protocolContext,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final TransactionPool transactionPool,
       final EthProtocolConfiguration ethereumWireProtocolConfiguration,
       final EthPeers ethPeers,
@@ -152,7 +152,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
       final Optional<MergePeerFilter> mergePeerFilter) {
     return mergeBesuControllerBuilder.createEthProtocolManager(
         protocolContext,
-        fastSyncEnabled,
+        synchronizerConfiguration,
         transactionPool,
         ethereumWireProtocolConfiguration,
         ethPeers,

--- a/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/protocol/Istanbul99ProtocolManager.java
+++ b/consensus/ibftlegacy/src/main/java/org/hyperledger/besu/consensus/ibftlegacy/protocol/Istanbul99ProtocolManager.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -45,7 +46,7 @@ public class Istanbul99ProtocolManager extends EthProtocolManager {
       final EthMessages ethMessages,
       final EthContext ethContext,
       final List<PeerValidator> peerValidators,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final EthScheduler scheduler) {
     super(
         blockchain,
@@ -58,7 +59,7 @@ public class Istanbul99ProtocolManager extends EthProtocolManager {
         ethContext,
         peerValidators,
         Optional.empty(),
-        fastSyncEnabled,
+        synchronizerConfiguration,
         scheduler);
   }
 

--- a/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/protocol/Istanbul99ProtocolManagerTest.java
+++ b/consensus/ibftlegacy/src/test/java/org/hyperledger/besu/consensus/ibftlegacy/protocol/Istanbul99ProtocolManagerTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.consensus.ibftlegacy.protocol;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -34,6 +35,7 @@ import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
 import org.hyperledger.besu.ethereum.eth.messages.EthPV62;
 import org.hyperledger.besu.ethereum.eth.messages.GetBlockHeadersMessage;
 import org.hyperledger.besu.ethereum.eth.messages.StatusMessage;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
@@ -127,7 +129,7 @@ public class Istanbul99ProtocolManagerTest {
             messages,
             new EthContext(peers, messages, ethScheduler),
             Collections.emptyList(),
-            false,
+            mock(SynchronizerConfiguration.class),
             ethScheduler)) {
 
       final long startBlock = blockchain.getChainHeadBlockNumber() + 1;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -28,6 +28,8 @@ import org.hyperledger.besu.ethereum.eth.messages.StatusMessage;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidatorRunner;
 import org.hyperledger.besu.ethereum.eth.sync.BlockBroadcaster;
+import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.network.ProtocolManager;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
@@ -84,7 +86,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final EthContext ethContext,
       final List<PeerValidator> peerValidators,
       final Optional<MergePeerFilter> mergePeerFilter,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final EthScheduler scheduler,
       final ForkIdManager forkIdManager) {
     this.networkId = networkId;
@@ -103,7 +105,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
 
     this.blockBroadcaster = new BlockBroadcaster(ethContext);
 
-    supportedCapabilities = calculateCapabilities(fastSyncEnabled);
+    supportedCapabilities = calculateCapabilities(synchronizerConfiguration);
 
     // Run validators
     for (final PeerValidator peerValidator : this.peerValidators) {
@@ -131,7 +133,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final EthContext ethContext,
       final List<PeerValidator> peerValidators,
       final Optional<MergePeerFilter> mergePeerFilter,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final EthScheduler scheduler) {
     this(
         blockchain,
@@ -144,7 +146,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
         ethContext,
         peerValidators,
         mergePeerFilter,
-        fastSyncEnabled,
+        synchronizerConfiguration,
         scheduler,
         new ForkIdManager(
             blockchain,
@@ -163,7 +165,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final EthContext ethContext,
       final List<PeerValidator> peerValidators,
       final Optional<MergePeerFilter> mergePeerFilter,
-      final boolean fastSyncEnabled,
+      final SynchronizerConfiguration synchronizerConfiguration,
       final EthScheduler scheduler,
       final List<Long> forks) {
     this(
@@ -177,7 +179,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
         ethContext,
         peerValidators,
         mergePeerFilter,
-        fastSyncEnabled,
+        synchronizerConfiguration,
         scheduler,
         new ForkIdManager(
             blockchain, forks, ethereumWireProtocolConfiguration.isLegacyEth64ForkIdEnabled()));
@@ -196,9 +198,11 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     return EthProtocol.NAME;
   }
 
-  private List<Capability> calculateCapabilities(final boolean fastSyncEnabled) {
+  private List<Capability> calculateCapabilities(
+      final SynchronizerConfiguration synchronizerConfiguration) {
     final ImmutableList.Builder<Capability> capabilities = ImmutableList.builder();
-    if (!fastSyncEnabled) {
+
+    if (SyncMode.isFullSync(synchronizerConfiguration.getSyncMode())) {
       capabilities.add(EthProtocol.ETH62);
     }
     capabilities.add(EthProtocol.ETH63);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.manager.DeterministicEthScheduler.TimeoutPolicy;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.DefaultMessage;
@@ -88,7 +89,7 @@ public class EthProtocolManagerTestUtil {
         ethContext,
         Collections.emptyList(),
         mergePeerFilter,
-        false,
+        mock(SynchronizerConfiguration.class),
         ethScheduler,
         new ForkIdManager(blockchain, Collections.emptyList(), false));
   }
@@ -137,7 +138,7 @@ public class EthProtocolManagerTestUtil {
         ethContext,
         Collections.emptyList(),
         Optional.empty(),
-        false,
+        mock(SynchronizerConfiguration.class),
         ethScheduler,
         forkIdManager);
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduleBasedBlockHeaderFunctions;
@@ -122,6 +123,7 @@ public class TestNode implements Closeable {
         new ProtocolContext(blockchain, worldStateArchive, null);
 
     final SyncState syncState = mock(SyncState.class);
+    final SynchronizerConfiguration syncConfig = mock(SynchronizerConfiguration.class);
     when(syncState.isInSync(anyLong())).thenReturn(true);
     when(syncState.isInitialSyncPhaseDone()).thenReturn(true);
 
@@ -161,7 +163,7 @@ public class TestNode implements Closeable {
             ethContext,
             Collections.emptyList(),
             Optional.empty(),
-            false,
+            syncConfig,
             scheduler);
 
     final NetworkRunner networkRunner =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthProtocolManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.manager.ForkIdManager;
 import org.hyperledger.besu.ethereum.eth.manager.RespondingEthPeer;
+import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.sync.state.SyncState;
 import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -241,7 +242,7 @@ public class TransactionPoolFactoryTest {
             ethContext,
             Collections.emptyList(),
             Optional.empty(),
-            true,
+            mock(SynchronizerConfiguration.class),
             mock(EthScheduler.class),
             mock(ForkIdManager.class));
   }


### PR DESCRIPTION
Signed-off-by: Gabriel Trintinalia <gabriel.trintinalia@gmail.com>

## PR description

- Rename fastSyncEnabled to fullSyncDisabled as it can mislead someone into the assumption that the sync mode is FAST SYNC while it may be snap/checkout.
- Pass SynchronizerConfiguration object down to EthProtocolManager instead of Boolean fastSyncEnabled

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).