### PR TITLE
Rework log of imported block to support also ProcessKnownAncestorsStep

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -47,7 +47,7 @@ public class BackwardSyncContext {
   private static final Logger LOG = LoggerFactory.getLogger(BackwardSyncContext.class);
   public static final int BATCH_SIZE = 200;
   private static final int DEFAULT_MAX_RETRIES = 20;
-
+  private static final long MILLIS_DELAY_BETWEEN_PROGRESS_LOG = 10_000L;
   private static final long DEFAULT_MILLIS_BETWEEN_RETRIES = 5000;
 
   protected final ProtocolContext protocolContext;
@@ -122,41 +122,51 @@ public class BackwardSyncContext {
   }
 
   public synchronized CompletableFuture<Void> syncBackwardsUntil(final Hash newBlockHash) {
-    Optional<CompletableFuture<Void>> maybeFuture =
-        Optional.ofNullable(this.currentBackwardSyncStatus.get())
-            .map(status -> status.currentFuture);
+    Optional<Status> maybeCurrentStatus = Optional.ofNullable(this.currentBackwardSyncStatus.get());
     if (isTrusted(newBlockHash)) {
-      return maybeFuture.orElseGet(() -> CompletableFuture.completedFuture(null));
+      return maybeCurrentStatus
+          .map(
+              status -> {
+                backwardChain
+                    .getBlock(newBlockHash)
+                    .ifPresent(block -> status.updateTargetHeight(block.getHeader().getNumber()));
+                return status.currentFuture;
+              })
+          .orElseGet(() -> CompletableFuture.completedFuture(null));
     }
     backwardChain.addNewHash(newBlockHash);
-    return maybeFuture.orElseGet(
-        () -> {
-          LOG.info("Starting a new backward sync session");
-          Status status = new Status(prepareBackwardSyncFutureWithRetry());
-          this.currentBackwardSyncStatus.set(status);
-          return status.currentFuture;
-        });
+    return maybeCurrentStatus
+        .map(Status::getCurrentFuture)
+        .orElseGet(
+            () -> {
+              LOG.info("Starting a new backward sync session");
+              Status status = new Status(prepareBackwardSyncFutureWithRetry());
+              this.currentBackwardSyncStatus.set(status);
+              return status.currentFuture;
+            });
   }
 
   public synchronized CompletableFuture<Void> syncBackwardsUntil(final Block newPivot) {
-    Optional<CompletableFuture<Void>> maybeFuture =
-        Optional.ofNullable(this.currentBackwardSyncStatus.get())
-            .map(status -> status.currentFuture);
+    Optional<Status> maybeCurrentStatus = Optional.ofNullable(this.currentBackwardSyncStatus.get());
     if (isTrusted(newPivot.getHash())) {
-      return maybeFuture.orElseGet(() -> CompletableFuture.completedFuture(null));
+      return maybeCurrentStatus
+          .map(Status::getCurrentFuture)
+          .orElseGet(() -> CompletableFuture.completedFuture(null));
     }
     backwardChain.appendTrustedBlock(newPivot);
-    return maybeFuture.orElseGet(
-        () -> {
-          LOG.info("Starting a new backward sync session");
-          LOG.info("Backward sync target block is {}", newPivot.toLogString());
-          Status status = new Status(prepareBackwardSyncFutureWithRetry());
-          status.setSyncRange(
-              protocolContext.getBlockchain().getChainHeadBlockNumber(),
-              newPivot.getHeader().getNumber());
-          this.currentBackwardSyncStatus.set(status);
-          return status.currentFuture;
-        });
+    return maybeCurrentStatus
+        .map(Status::getCurrentFuture)
+        .orElseGet(
+            () -> {
+              LOG.info("Starting a new backward sync session");
+              LOG.info("Backward sync target block is {}", newPivot.toLogString());
+              Status status = new Status(prepareBackwardSyncFutureWithRetry());
+              status.setSyncRange(
+                  getProtocolContext().getBlockchain().getChainHeadBlockNumber(),
+                  newPivot.getHeader().getNumber());
+              this.currentBackwardSyncStatus.set(status);
+              return status.currentFuture;
+            });
   }
 
   private boolean isTrusted(final Hash hash) {
@@ -319,6 +329,7 @@ public class BackwardSyncContext {
           .getBlockchain()
           .appendBlock(block, optResult.getYield().get().getReceipts());
       possiblyMoveHead(block);
+      logBlockImportProgress(block.getHeader().getNumber());
     } else {
       emitBadChainEvent(block);
       throw new BackwardSyncException(
@@ -393,10 +404,41 @@ public class BackwardSyncContext {
         listener -> listener.onBadChain(badBlock, badBlockDescendants, badBlockHeaderDescendants));
   }
 
+  private void logBlockImportProgress(final long currImportedHeight) {
+    final Status currentStatus = getStatus();
+    final long targetHeight = currentStatus.getTargetChainHeight();
+    final long initialHeight = currentStatus.getInitialChainHeight();
+    final long estimatedTotal = targetHeight - initialHeight;
+    final long imported = currImportedHeight - initialHeight;
+
+    final float completedPercentage = 100.0f * imported / estimatedTotal;
+
+    if (completedPercentage < 100.0f) {
+      if (currentStatus.couldLogProgress()) {
+        LOG.info(
+            String.format(
+                "Backward sync phase 2 of 2, %.2f%% completed, imported %d blocks of at least %d (current head %d, target head %d). Peers: %d",
+                completedPercentage,
+                imported,
+                estimatedTotal,
+                currImportedHeight,
+                currentStatus.getTargetChainHeight(),
+                getEthContext().getEthPeers().peerCount()));
+      }
+    } else {
+      LOG.info(
+          String.format(
+              "Backward sync phase 2 of 2 completed, imported a total of %d blocks. Peers: %d",
+              imported, getEthContext().getEthPeers().peerCount()));
+    }
+  }
+
   static class Status {
     private final CompletableFuture<Void> currentFuture;
     private long targetChainHeight;
     private long initialChainHeight;
+
+    private static long lastLogAt = 0;
 
     public Status(final CompletableFuture<Void> currentFuture) {
       this.currentFuture = currentFuture;
@@ -405,6 +447,23 @@ public class BackwardSyncContext {
     public void setSyncRange(final long initialHeight, final long targetHeight) {
       initialChainHeight = initialHeight;
       targetChainHeight = targetHeight;
+    }
+
+    public void updateTargetHeight(final long newTargetHeight) {
+      targetChainHeight = newTargetHeight;
+    }
+
+    public boolean couldLogProgress() {
+      final long now = System.currentTimeMillis();
+      if (now - lastLogAt > MILLIS_DELAY_BETWEEN_PROGRESS_LOG) {
+        lastLogAt = now;
+        return true;
+      }
+      return false;
+    }
+
+    public CompletableFuture<Void> getCurrentFuture() {
+      return currentFuture;
     }
 
     public long getTargetChainHeight() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncStep.java
@@ -30,8 +30,6 @@ import org.slf4j.LoggerFactory;
 
 public class BackwardSyncStep {
   private static final Logger LOG = LoggerFactory.getLogger(BackwardSyncStep.class);
-  private static final long MILLIS_DELAY_BETWEEN_PROGRESS_LOG = 10_000L;
-  private static long lastLogAt = 0;
   private final BackwardSyncContext context;
   private final BackwardChain backwardChain;
 
@@ -114,8 +112,7 @@ public class BackwardSyncStep {
     final float completedPercentage = 100.0f * downloaded / estimatedTotal;
 
     if (completedPercentage < 100.0f) {
-      final long now = System.currentTimeMillis();
-      if (now - lastLogAt > MILLIS_DELAY_BETWEEN_PROGRESS_LOG) {
+      if (context.getStatus().couldLogProgress()) {
         LOG.info(
             String.format(
                 "Backward sync phase 1 of 2, %.2f%% completed, downloaded %d headers of at least %d. Peers: %d",
@@ -123,7 +120,6 @@ public class BackwardSyncStep {
                 downloaded,
                 estimatedTotal,
                 context.getEthContext().getEthPeers().peerCount()));
-        lastLogAt = now;
       }
     } else {
       LOG.info(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ForwardSyncStep.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 public class ForwardSyncStep {
 
   private static final Logger LOG = LoggerFactory.getLogger(ForwardSyncStep.class);
-  private static final long MILLIS_DELAY_BETWEEN_PROGRESS_LOG = 10_000L;
-  private static long lastLogAt = 0;
   private final BackwardSyncContext context;
   private final BackwardChain backwardChain;
 
@@ -94,9 +92,6 @@ public class ForwardSyncStep {
       return null;
     }
 
-    long lastImportedHeight =
-        context.getProtocolContext().getBlockchain().getChainHeadBlockNumber();
-
     for (Block block : blocks) {
       final Optional<Block> parent =
           context
@@ -112,45 +107,13 @@ public class ForwardSyncStep {
             block.getHeader().getParentHash()::toString,
             block::toLogString,
             context::getBatchSize);
-        logProgress(lastImportedHeight);
         return null;
       } else {
         context.saveBlock(block);
-        lastImportedHeight = block.getHeader().getNumber();
       }
     }
-
-    logProgress(lastImportedHeight);
 
     context.resetBatchSize();
     return null;
-  }
-
-  private void logProgress(final long currImportedHeight) {
-    final long targetHeight = context.getStatus().getTargetChainHeight();
-    final long initialHeight = context.getStatus().getInitialChainHeight();
-    final long estimatedTotal = targetHeight - initialHeight;
-    final long imported = currImportedHeight - initialHeight;
-
-    final float completedPercentage = 100.0f * imported / estimatedTotal;
-
-    if (completedPercentage < 100.0f) {
-      final long now = System.currentTimeMillis();
-      if (now - lastLogAt > MILLIS_DELAY_BETWEEN_PROGRESS_LOG) {
-        LOG.info(
-            String.format(
-                "Backward sync phase 2 of 2, %.2f%% completed, imported %d blocks of at least %d. Peers: %d",
-                completedPercentage,
-                imported,
-                estimatedTotal,
-                context.getEthContext().getEthPeers().peerCount()));
-        lastLogAt = now;
-      }
-    } else {
-      LOG.info(
-          String.format(
-              "Backward sync phase 2 of 2 completed, imported a total of %d blocks. Peers: %d",
-              imported, context.getEthContext().getEthPeers().peerCount()));
-    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Porting from #4655 the update to the block import progess log to also include blocks imported during the final ProcessKnownAncestorsStep since that part could take some time if the backward sync was long.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).