### PR TITLE
Use snapshots for in-memory copies of layered worldstate

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
@@ -103,11 +103,15 @@ public abstract class AbstractTrieLogManager<T extends CachedWorldState> impleme
         .forEach(
             layer -> {
               cachedWorldStatesByHash.remove(layer.getTrieLog().getBlockHash());
-              try {
-                layer.getMutableWorldState().close();
-              } catch (Exception e) {
-                LOG.warn("Error closing bonsai worldstate layer", e);
-              }
+              Optional.ofNullable(layer.getMutableWorldState())
+                  .ifPresent(
+                      ws -> {
+                        try {
+                          ws.close();
+                        } catch (Exception e) {
+                          LOG.warn("Error closing bonsai worldstate layer", e);
+                        }
+                      });
             });
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -144,4 +144,10 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
     worldStateBlockHash = blockHeader.getBlockHash();
     isPersisted = true;
   }
+
+  @Override
+  public void close() throws Exception {
+    // if storage is snapshot-based we need to close:
+    worldStateStorage.close();
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -264,16 +264,7 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
     return archive
         .getMutableSnapshot(this.blockHash())
         .map(BonsaiSnapshotWorldState.class::cast)
-        .map(
-            snapshot ->
-                new BonsaiInMemoryWorldStateKeyValueStorage(
-                    snapshot.getWorldStateStorage().accountStorage,
-                    snapshot.getWorldStateStorage().codeStorage,
-                    snapshot.getWorldStateStorage().storageStorage,
-                    snapshot.getWorldStateStorage().trieBranchStorage,
-                    snapshot.getWorldStateStorage().trieLogStorage,
-                    snapshot.getWorldStateStorage().getMaybeFallbackNodeFinder()))
-        .map(kvStorage -> new BonsaiInMemoryWorldState(archive, kvStorage))
+        .map(snapshot -> new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage()))
         .orElseThrow(
             () ->
                 new StorageException(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -257,26 +258,22 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   }
 
   @Override
+  @MustBeClosed
   public MutableWorldState copy() {
-    // TODO: this is unsafe because the underlying persisted worldstate will likely have mutated if
-    // this
-    //  layer is not the current head
-    //  revisit with https://github.com/hyperledger/besu/issues/4641
-    final BonsaiPersistedWorldState bonsaiPersistedWorldState =
-        ((BonsaiPersistedWorldState) archive.getMutable());
-    BonsaiInMemoryWorldStateKeyValueStorage bonsaiInMemoryWorldStateKeyValueStorage =
-        new BonsaiInMemoryWorldStateKeyValueStorage(
-            bonsaiPersistedWorldState.getWorldStateStorage().accountStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().codeStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().storageStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().trieBranchStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().trieLogStorage,
-            bonsaiPersistedWorldState.getWorldStateStorage().getMaybeFallbackNodeFinder());
-
+    // return an in-memory worldstate that is based on a persisted snapshot for this blockhash.
     return archive
-        .rollMutableStateToBlockHash(
-            new BonsaiInMemoryWorldState(archive, bonsaiInMemoryWorldStateKeyValueStorage),
-            this.blockHash())
+        .getMutableSnapshot(this.blockHash())
+        .map(BonsaiSnapshotWorldState.class::cast)
+        .map(
+            snapshot ->
+                new BonsaiInMemoryWorldStateKeyValueStorage(
+                    snapshot.getWorldStateStorage().accountStorage,
+                    snapshot.getWorldStateStorage().codeStorage,
+                    snapshot.getWorldStateStorage().storageStorage,
+                    snapshot.getWorldStateStorage().trieBranchStorage,
+                    snapshot.getWorldStateStorage().trieLogStorage,
+                    snapshot.getWorldStateStorage().getMaybeFallbackNodeFinder()))
+        .map(kvStorage -> new BonsaiInMemoryWorldState(archive, kvStorage))
         .orElseThrow(
             () ->
                 new StorageException(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -67,6 +67,14 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
         trieLogStorage);
   }
 
+  @Override
+  public void close() throws Exception {
+    accountStorage.close();
+    codeStorage.close();
+    storageStorage.close();
+    trieBranchStorage.close();
+  }
+
   public static class SnapshotUpdater implements BonsaiWorldStateKeyValueStorage.BonsaiUpdater {
 
     private final SnappedKeyValueStorage accountStorage;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -37,7 +37,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.rlp.RLP;
 
-public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
+public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoCloseable {
   public static final byte[] WORLD_ROOT_HASH_KEY = "worldRoot".getBytes(StandardCharsets.UTF_8);
 
   public static final byte[] WORLD_BLOCK_HASH_KEY =
@@ -266,6 +266,11 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage {
   public void useFallbackNodeFinder(final Optional<PeerTrieNodeFinder> maybeFallbackNodeFinder) {
     checkNotNull(maybeFallbackNodeFinder);
     this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
+  }
+
+  @Override
+  public void close() throws Exception {
+    // no-op
   }
 
   public interface BonsaiUpdater extends WorldStateStorage.Updater {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -78,7 +78,8 @@ public class SnapshotTrieLogManager
   @Override
   public Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash) {
     if (cachedWorldStatesByHash.containsKey(blockHash)) {
-      return Optional.ofNullable(cachedWorldStatesByHash.get(blockHash).getMutableWorldState())
+      return Optional.ofNullable(cachedWorldStatesByHash.get(blockHash))
+          .map(CachedSnapshotWorldState::getMutableWorldState)
           .map(MutableWorldState::copy);
     }
     return Optional.empty();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
+
+import org.hyperledger.besu.config.GenesisAllocation;
+import org.hyperledger.besu.config.GenesisConfigFile;
+import org.hyperledger.besu.crypto.KeyPair;
+import org.hyperledger.besu.crypto.SECPPrivateKey;
+import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.BlockProcessingResult;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.blockcreation.AbstractBlockCreator;
+import org.hyperledger.besu.ethereum.chain.GenesisState;
+import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
+import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SealableBlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
+import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolConfiguration;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.AbstractPendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.eth.transactions.sorter.GasPricePendingTransactionsSorter;
+import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.storage.StorageProvider;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.plugin.services.BesuConfiguration;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBKeyValueStorageFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetricsFactory;
+import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public abstract class AbstractIsolationTests {
+  protected BonsaiWorldStateArchive archive;
+  protected ProtocolContext protocolContext;
+  final Function<String, KeyPair> asKeyPair =
+      key ->
+          SignatureAlgorithmFactory.getInstance()
+              .createKeyPair(SECPPrivateKey.create(Bytes32.fromHexString(key), "ECDSA"));
+  protected final ProtocolSchedule protocolSchedule =
+      MainnetProtocolSchedule.fromConfig(GenesisConfigFile.development().getConfigOptions());
+  protected final GenesisState genesisState =
+      GenesisState.fromConfig(GenesisConfigFile.development(), protocolSchedule);
+  protected final MutableBlockchain blockchain = createInMemoryBlockchain(genesisState.getBlock());
+  protected final AbstractPendingTransactionsSorter sorter =
+      new GasPricePendingTransactionsSorter(
+          ImmutableTransactionPoolConfiguration.builder().txPoolMaxSize(100).build(),
+          Clock.systemUTC(),
+          new NoOpMetricsSystem(),
+          blockchain::getChainHeadHeader);
+
+  protected final List<GenesisAllocation> accounts =
+      GenesisConfigFile.development()
+          .streamAllocations()
+          .filter(ga -> ga.getPrivateKey().isPresent())
+          .collect(Collectors.toList());
+
+  KeyPair sender1 = asKeyPair.apply(accounts.get(0).getPrivateKey().get());
+
+  @Rule public final TemporaryFolder tempData = new TemporaryFolder();
+
+  protected boolean shouldUseSnapshots() {
+    // override for layered worldstate
+    return true;
+  }
+
+  @Before
+  public void createStorage() {
+    //    final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
+    archive =
+        new BonsaiWorldStateArchive(
+            (BonsaiWorldStateKeyValueStorage)
+                createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI),
+            blockchain,
+            Optional.of(16L),
+            shouldUseSnapshots());
+    var ws = archive.getMutable();
+    genesisState.writeStateTo(ws);
+    ws.persist(blockchain.getChainHeadHeader());
+    protocolContext = new ProtocolContext(blockchain, archive, null);
+  }
+
+  // storage provider which uses a temporary directory based rocksdb
+  protected StorageProvider createKeyValueStorageProvider() {
+    try {
+      tempData.create();
+      return new KeyValueStorageProviderBuilder()
+          .withStorageFactory(
+              new RocksDBKeyValueStorageFactory(
+                  () ->
+                      new RocksDBFactoryConfiguration(
+                          1024 /* MAX_OPEN_FILES*/,
+                          4 /*MAX_BACKGROUND_COMPACTIONS*/,
+                          4 /*BACKGROUND_THREAD_COUNT*/,
+                          8388608 /*CACHE_CAPACITY*/,
+                          false),
+                  Arrays.asList(KeyValueSegmentIdentifier.values()),
+                  2,
+                  RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS))
+          .withCommonConfiguration(
+              new BesuConfiguration() {
+
+                @Override
+                public Path getStoragePath() {
+                  return new File(tempData.getRoot().toString() + File.pathSeparator + "database")
+                      .toPath();
+                }
+
+                @Override
+                public Path getDataPath() {
+                  return tempData.getRoot().toPath();
+                }
+
+                @Override
+                public int getDatabaseVersion() {
+                  return 2;
+                }
+              })
+          .withMetricsSystem(new NoOpMetricsSystem())
+          .build();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static class TestBlockCreator extends AbstractBlockCreator {
+    private TestBlockCreator(
+        final Address coinbase,
+        final MiningBeneficiaryCalculator miningBeneficiaryCalculator,
+        final Supplier<Optional<Long>> targetGasLimitSupplier,
+        final ExtraDataCalculator extraDataCalculator,
+        final AbstractPendingTransactionsSorter pendingTransactions,
+        final ProtocolContext protocolContext,
+        final ProtocolSchedule protocolSchedule,
+        final Wei minTransactionGasPrice,
+        final Double minBlockOccupancyRatio,
+        final BlockHeader parentHeader) {
+      super(
+          coinbase,
+          miningBeneficiaryCalculator,
+          targetGasLimitSupplier,
+          extraDataCalculator,
+          pendingTransactions,
+          protocolContext,
+          protocolSchedule,
+          minTransactionGasPrice,
+          minBlockOccupancyRatio,
+          parentHeader);
+    }
+
+    static TestBlockCreator forHeader(
+        final BlockHeader parentHeader,
+        final ProtocolContext protocolContext,
+        final ProtocolSchedule protocolSchedule,
+        final AbstractPendingTransactionsSorter sorter) {
+      return new TestBlockCreator(
+          Address.ZERO,
+          __ -> Address.ZERO,
+          () -> Optional.of(30_000_000L),
+          __ -> Bytes.fromHexString("deadbeef"),
+          sorter,
+          protocolContext,
+          protocolSchedule,
+          Wei.of(1L),
+          0d,
+          parentHeader);
+    }
+
+    @Override
+    protected BlockHeader createFinalBlockHeader(final SealableBlockHeader sealableBlockHeader) {
+      return BlockHeaderBuilder.create()
+          .difficulty(Difficulty.ZERO)
+          .mixHash(Hash.ZERO)
+          .populateFrom(sealableBlockHeader)
+          .nonce(0L)
+          .blockHeaderFunctions(blockHeaderFunctions)
+          .buildBlockHeader();
+    }
+  }
+
+  protected Transaction burnTransaction(final KeyPair sender, final Long nonce, final Address to) {
+    return new TransactionTestFixture()
+        .sender(Address.extract(Hash.hash(sender.getPublicKey().getEncodedBytes())))
+        .to(Optional.of(to))
+        .value(Wei.of(1_000_000_000_000_000_000L))
+        .gasLimit(21_000L)
+        .nonce(nonce)
+        .createTransaction(sender);
+  }
+
+  protected Block forTransactions(final List<Transaction> transactions) {
+    return forTransactions(transactions, blockchain.getChainHeadHeader());
+  }
+
+  protected Block forTransactions(
+      final List<Transaction> transactions, final BlockHeader forHeader) {
+    return TestBlockCreator.forHeader(forHeader, protocolContext, protocolSchedule, sorter)
+        .createBlock(transactions, Collections.emptyList(), System.currentTimeMillis())
+        .getBlock();
+  }
+
+  protected BlockProcessingResult executeBlock(final MutableWorldState ws, final Block block) {
+    var res =
+        protocolSchedule
+            .getByBlockNumber(0)
+            .getBlockProcessor()
+            .processBlock(blockchain, ws, block);
+    blockchain.appendBlock(block, res.getReceipts());
+    return res;
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryIsolationTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BonsaiInMemoryIsolationTests extends AbstractIsolationTests {
+
+  @Override
+  protected boolean shouldUseSnapshots() {
+    // override for layered worldstate
+    return false;
+  }
+
+  @Test
+  public void testInMemoryWorldStateConsistentAfterMutatingPersistedState() {
+    Address testAddress = Address.fromHexString("0xdeadbeef");
+    var persisted = archive.getMutable();
+
+    var genesisBlock = genesisState.getBlock();
+
+    var layered =
+        archive
+            .getMutable(genesisBlock.getHeader().getStateRoot(), genesisBlock.getHash(), false)
+            .orElse(null);
+    var inMemoryBeforeMutation = layered.copy();
+
+    var firstBlock = forTransactions(List.of(burnTransaction(sender1, 0L, testAddress)));
+    var res = executeBlock(persisted, firstBlock);
+    assertThat(res.isSuccessful()).isTrue();
+
+    assertThat(archive.getTrieLogManager().getBonsaiCachedWorldState(firstBlock.getHash()))
+        .isNotEmpty();
+
+    assertThat(res.isSuccessful()).isTrue();
+    assertThat(persisted.get(testAddress)).isNotNull();
+    assertThat(persisted.get(testAddress).getBalance())
+        .isEqualTo(Wei.of(1_000_000_000_000_000_000L));
+    assertThat(persisted.rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
+
+    var layered2 =
+        archive
+            .getMutable(genesisBlock.getHeader().getStateRoot(), genesisBlock.getHash(), false)
+            .orElse(null);
+
+    // assert layered before and after the block is what and where we expect it to be:
+    assertThat(layered2).isInstanceOf(BonsaiLayeredWorldState.class);
+    assertThat(layered2.rootHash()).isEqualTo(genesisBlock.getHeader().getStateRoot());
+    assertThat(layered2.get(testAddress)).isNull();
+    assertThat(layered).isInstanceOf(BonsaiLayeredWorldState.class);
+    assertThat(layered.rootHash()).isEqualTo(genesisBlock.getHeader().getStateRoot());
+    assertThat(layered.get(testAddress)).isNull();
+
+    var inMemoryAfterMutation = layered2.copy();
+
+    // assert we have not modified the head worldstate:
+    assertThat(persisted.rootHash()).isEqualTo(firstBlock.getHeader().getStateRoot());
+
+    // assert the inMemory copy of worldstate 0 from [before mutating persisted state to 1] is
+    // consistent
+    assertThat(inMemoryBeforeMutation).isInstanceOf(BonsaiInMemoryWorldState.class);
+    assertThat(inMemoryBeforeMutation.rootHash())
+        .isEqualTo(genesisBlock.getHeader().getStateRoot());
+    assertThat(inMemoryBeforeMutation.get(testAddress)).isNull();
+
+    // assert the inMemory copy of worldstate 0 from [after mutating persisted state to 1] is
+    // consistent
+    assertThat(inMemoryAfterMutation).isInstanceOf(BonsaiInMemoryWorldState.class);
+    assertThat(inMemoryAfterMutation.rootHash()).isEqualTo(genesisBlock.getHeader().getStateRoot());
+    assertThat(inMemoryAfterMutation.get(testAddress)).isNull();
+
+    try {
+      layered.close();
+      layered2.close();
+      inMemoryBeforeMutation.close();
+      inMemoryAfterMutation.close();
+    } catch (Exception ex) {
+      throw new RuntimeException("failed to close worldstates");
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

In `BonsaiLayeredWorldState.copy()`, use a snapshot worldstate as the basis for a BonsaiInMemoryWorldstate copy

Prevents stateroot mismatches that arise from the persisted worldstate being different than the worldstate assoicated with a given layered worldstate.

Also moves isolation test setup into an abstract class, and adds a new BonsaiInMemoryIsolationTest

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).