### PR TITLE
Add post-run allocation output to EVMTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
-## 23.1
+## 23.1.0-beta
 
 ### Breaking Changes
 - GoQuorum-compatible privacy is deprecated and will be removed in 23.4
 - IBFT 1.0 is deprecated and will be removed in 23.4
+
+### Additions and Improvements
+- Added post-execution state logging option to EVM Tool [#4709](https://github.com/hyperledger/besu/pull/4709)
 
 ## 22.10.4
 
@@ -59,7 +62,7 @@ https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.2/besu-22.10.2
 - Support for ephemeral testnet Shandong, for EOF testing. [#4599](https://github.com/hyperledger/besu/pull/4599)
 - Improve performance of block processing by parallelizing some parts during the "commit" step [#4635](https://github.com/hyperledger/besu/pull/4635)
 - Upgrade RocksDB version from 7.6.0 to 7.7.3
-- Added new RPC endpoints `debug_setHead` & `debug_replayBlock  [4580](https://github.com/hyperledger/besu/pull/4580)
+- Added new RPC endpoints `debug_setHead` & `debug_replayBlock  [#4580](https://github.com/hyperledger/besu/pull/4580)
 - Upgrade OpenTelemetry to version 1.19.0 [#3675](https://github.com/hyperledger/besu/pull/3675)
 - Implement Eth/67 sub-protocol [#4596](https://github.com/hyperledger/besu/issues/4596)
 - Backward sync log UX improvements [#4655](https://github.com/hyperledger/besu/pull/4655)

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.services.BesuConfigurationImpl;
 
 import java.nio.file.Path;
 import javax.inject.Named;
+import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
@@ -71,6 +72,7 @@ public class EvmToolCommandOptionsModule {
   final Path dataPath = getDefaultBesuDataPath(this);
 
   @Provides
+  @Singleton
   BesuConfiguration provideBesuConfiguration() {
     return new BesuConfigurationImpl(dataPath, dataPath.resolve(BesuController.DATABASE_PATH));
   }
@@ -83,6 +85,7 @@ public class EvmToolCommandOptionsModule {
   private final BlockParameter blockParameter = BlockParameter.PENDING;
 
   @Provides
+  @Singleton
   BlockParameter provideBlockParameter() {
     return blockParameter;
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolComponent.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolComponent.java
@@ -16,6 +16,7 @@
 package org.hyperledger.besu.evmtool;
 
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
@@ -39,6 +40,8 @@ public interface EvmToolComponent {
   Function<Integer, ProtocolSpec> getProtocolSpec();
 
   WorldUpdater getWorldUpdater();
+
+  MutableWorldState getWorldState();
 
   Blockchain getBlockchain();
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/MetricsSystemModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/MetricsSystemModule.java
@@ -20,6 +20,8 @@ import org.hyperledger.besu.metrics.MetricsSystemFactory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -28,6 +30,7 @@ import dagger.Provides;
 public class MetricsSystemModule {
 
   @Provides
+  @Singleton
   MetricsSystem getMetricsSystem() {
     return MetricsSystemFactory.create(MetricsConfiguration.builder().build());
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/ProtocolModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/ProtocolModule.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
 import java.util.function.Function;
-
 import javax.inject.Singleton;
 
 import dagger.Module;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/ProtocolModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/ProtocolModule.java
@@ -20,6 +20,8 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
 import java.util.function.Function;
 
+import javax.inject.Singleton;
+
 import dagger.Module;
 import dagger.Provides;
 
@@ -28,6 +30,7 @@ import dagger.Provides;
 public class ProtocolModule {
 
   @Provides
+  @Singleton
   Function<Integer, ProtocolSpec> getProtocolSpec(final ProtocolSchedule protocolSchedule) {
     return protocolSchedule::getByBlockNumber;
   }


### PR DESCRIPTION
## PR description

Add a CLI flag --json-alloc that will output the post-execution state of the allocations the EVM Tool executed in. As well as post-execution state for state-tests.

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).