### PR TITLE
Fix OpenTelemetry disabling in MetricsSystemFactory

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsSystemFactory.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsSystemFactory.java
@@ -22,6 +22,8 @@ import org.hyperledger.besu.metrics.opentelemetry.OpenTelemetrySystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import org.slf4j.Logger;
@@ -31,11 +33,14 @@ import org.slf4j.LoggerFactory;
 public class MetricsSystemFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsSystemFactory.class);
+  private static final AtomicBoolean globalOpenTelemetryDisabled = new AtomicBoolean(false);
 
   private MetricsSystemFactory() {}
 
   private static void disableGlobalOpenTelemetry() {
-    GlobalOpenTelemetry.set(OpenTelemetry.noop());
+    if (!globalOpenTelemetryDisabled.compareAndExchange(false, true)) {
+      GlobalOpenTelemetry.set(OpenTelemetry.noop());
+    }
   }
 
   /**


### PR DESCRIPTION

Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Prevent trying to re-disable OpenTelemetry global if it has already been disabled previously.  Otherwise `evmtool` was failing to start with this error:
```
java.lang.IllegalStateException: GlobalOpenTelemetry.set has already been called. GlobalOpenTelemetry.set must be called only once before any calls to GlobalOpenTelemetry.get. If you are using the OpenTelemetrySdk, use OpenTelemetrySdkBuilder.buildAndRegisterGlobal instead. Previous invocation set to cause of this exception.
        at io.opentelemetry.api.GlobalOpenTelemetry.set(GlobalOpenTelemetry.java:99)
        at org.hyperledger.besu.metrics.MetricsSystemFactory.disableGlobalOpenTelemetry(MetricsSystemFactory.java:38)
 ...
 ```


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).