### PR TITLE
Treat nonces as quantities

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
@@ -246,7 +246,7 @@ public class MessageWrapperTest {
         @JsonProperty("s") final String s,
         @JsonProperty("hash") final String __) {
       super(
-          Long.decode(nonce),
+          Bytes.fromHexStringLenient(nonce).toLong(),
           Wei.fromHexString(gasPrice),
           Long.decode(gasLimit),
           Address.fromHexString(to),
@@ -325,7 +325,7 @@ public class MessageWrapperTest {
           Bytes.fromHexString(extraData),
           null,
           Hash.fromHexString(mixHash),
-          Long.decode(nonce),
+          Bytes.fromHexStringLenient(nonce).toLong(),
           new MainnetBlockHeaderFunctions());
     }
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
@@ -308,7 +308,7 @@ public class MessageWrapperTest {
         @JsonProperty("extraData") final String extraData,
         @JsonProperty("mixHash") final String mixHash,
         @JsonProperty("nonce") final String nonce,
-        @JsonProperty("hash") final String hash) {
+        @JsonProperty("hash") final String __) {
       super(
           Hash.fromHexString(parentHash),
           Hash.fromHexString(uncleHash),
@@ -325,7 +325,7 @@ public class MessageWrapperTest {
           Bytes.fromHexString(extraData),
           null,
           Hash.fromHexString(mixHash),
-          Bytes.fromHexString(nonce).getLong(0),
+          Long.decode(nonce),
           new MainnetBlockHeaderFunctions());
     }
   }

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -174,7 +174,7 @@ public class BlockchainReferenceTestCaseSpec {
           Bytes.fromHexString(extraData), // extraData
           baseFee != null ? Wei.fromHexString(baseFee) : null, // baseFee
           Hash.fromHexString(mixHash), // mixHash
-          Long.decode(nonce),
+          Bytes.fromHexStringLenient(nonce).toLong(),
           new BlockHeaderFunctions() {
             @Override
             public Hash hash(final BlockHeader header) {

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -174,7 +174,7 @@ public class BlockchainReferenceTestCaseSpec {
           Bytes.fromHexString(extraData), // extraData
           baseFee != null ? Wei.fromHexString(baseFee) : null, // baseFee
           Hash.fromHexString(mixHash), // mixHash
-          Bytes.fromHexString(nonce).getLong(0),
+          Long.decode(nonce),
           new BlockHeaderFunctions() {
             @Override
             public Hash hash(final BlockHeader header) {
@@ -217,21 +217,21 @@ public class BlockchainReferenceTestCaseSpec {
         @JsonProperty("blockHeader") final Object blockHeader,
         @JsonProperty("transactions") final Object transactions,
         @JsonProperty("uncleHeaders") final Object uncleHeaders) {
-      boolean valid = true;
+      boolean blockVaid = true;
       // The BLOCK__WrongCharAtRLP_0 test has an invalid character in its rlp string.
       Bytes rlpAttempt = null;
       try {
         rlpAttempt = Bytes.fromHexString(rlp);
       } catch (final IllegalArgumentException e) {
-        valid = false;
+        blockVaid = false;
       }
       this.rlp = rlpAttempt;
 
       if (blockHeader == null && transactions == null && uncleHeaders == null) {
-        valid = false;
+        blockVaid = false;
       }
 
-      this.valid = valid;
+      this.valid = blockVaid;
     }
 
     public boolean isValid() {
@@ -250,7 +250,7 @@ public class BlockchainReferenceTestCaseSpec {
       final BlockBody body =
           new BlockBody(
               input.readList(Transaction::readFrom),
-              input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)));
+              input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions)));
       return new Block(header, body);
     }
   }

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
@@ -56,7 +56,7 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
         @JsonProperty("balance") final String balance,
         @JsonProperty("storage") final Map<String, String> storage,
         @JsonProperty("code") final String code) {
-      this.nonce = Long.parseUnsignedLong(nonce.startsWith("0x") ? nonce.substring(2) : nonce, 16);
+      this.nonce = Long.decode(nonce);
       this.balance = Wei.fromHexString(balance);
       this.code = Bytes.fromHexString(code);
       this.storage = parseStorage(storage);

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestWorldState.java
@@ -56,7 +56,7 @@ public class ReferenceTestWorldState extends DefaultMutableWorldState {
         @JsonProperty("balance") final String balance,
         @JsonProperty("storage") final Map<String, String> storage,
         @JsonProperty("code") final String code) {
-      this.nonce = Long.decode(nonce);
+      this.nonce = Bytes.fromHexStringLenient(nonce).toLong();
       this.balance = Wei.fromHexString(balance);
       this.code = Bytes.fromHexString(code);
       this.storage = parseStorage(storage);

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/StateTestVersionedTransaction.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/StateTestVersionedTransaction.java
@@ -100,7 +100,7 @@ public class StateTestVersionedTransaction {
       @JsonDeserialize(using = StateTestAccessListDeserializer.class) @JsonProperty("accessLists")
           final List<List<AccessListEntry>> maybeAccessLists) {
 
-    this.nonce = Bytes.fromHexString(nonce).toLong();
+    this.nonce = Long.decode(nonce);
     this.gasPrice = Optional.ofNullable(gasPrice).map(Wei::fromHexString).orElse(null);
     this.maxFeePerGas = Optional.ofNullable(maxFeePerGas).map(Wei::fromHexString).orElse(null);
     this.maxPriorityFeePerGas =


### PR DESCRIPTION

## PR description

Change nonce hex parsing to be treated as encoded longs, not trimmed byte arrays.

## Fixed Issue(s)

fixes #4719

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).