### PR TITLE
Calculate Transaction Size

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -926,6 +926,14 @@ public class Transaction
     return Optional.empty();
   }
 
+  private Bytes toRlp() {
+    return RLP.encode(this::writeTo);
+  }
+
+  public int calculateSize() {
+    return toRlp().size();
+  }
+
   public static class Builder {
 
     protected TransactionType transactionType;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/TransactionDecoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/TransactionDecoderTest.java
@@ -26,10 +26,13 @@ import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TransactionDecoderTest {
 
@@ -95,22 +98,24 @@ class TransactionDecoderTest {
     assertThat(transaction.getNonce()).isEqualTo(MAX_NONCE - 1);
   }
 
-  @Test
-  void shouldCalculateCorrectTransactionSize() {
-    for (final String rlp_tx :
-        List.of(
-            FRONTIER_TX_RLP,
-            EIP1559_TX_RLP,
-            GOQUORUM_PRIVATE_TX_RLP,
-            NONCE_64_BIT_MAX_MINUS_2_TX_RLP)) {
-      System.out.println(rlp_tx);
+  private static Collection<Object[]> dataTransactionSize() {
+    return Arrays.asList(
+        new Object[][] {
+          {FRONTIER_TX_RLP, "FRONTIER_TX_RLP"},
+          {EIP1559_TX_RLP, "EIP1559_TX_RLP"},
+          {GOQUORUM_PRIVATE_TX_RLP, "GOQUORUM_PRIVATE_TX_RLP"},
+          {NONCE_64_BIT_MAX_MINUS_2_TX_RLP, "NONCE_64_BIT_MAX_MINUS_2_TX_RLP"}
+        });
+  }
 
-      // Create bytes from String
-      final Bytes bytes = Bytes.fromHexString(rlp_tx);
-      // Decode bytes into a transaction
-      final Transaction transaction = TransactionDecoder.decodeForWire(RLP.input(bytes));
-      // Bytes size should be equal to transaction size
-      assertThat(transaction.calculateSize()).isEqualTo(bytes.size());
-    }
+  @ParameterizedTest(name = "[{index}] {1}")
+  @MethodSource("dataTransactionSize")
+  void shouldCalculateCorrectTransactionSize(final String rlp_tx, final String ignoredName) {
+    // Create bytes from String
+    final Bytes bytes = Bytes.fromHexString(rlp_tx);
+    // Decode bytes into a transaction
+    final Transaction transaction = TransactionDecoder.decodeForWire(RLP.input(bytes));
+    // Bytes size should be equal to transaction size
+    assertThat(transaction.calculateSize()).isEqualTo(bytes.size());
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/TransactionDecoderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/encoding/TransactionDecoderTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.math.BigInteger;
+import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -43,8 +44,8 @@ class TransactionDecoderTest {
 
   @Test
   void decodeGoQuorumPrivateTransactionRlp() {
-    boolean goQuorumCompatibilityMode = true;
-    RLPInput input = RLP.input(Bytes.fromHexString(GOQUORUM_PRIVATE_TX_RLP));
+    final boolean goQuorumCompatibilityMode = true;
+    final RLPInput input = RLP.input(Bytes.fromHexString(GOQUORUM_PRIVATE_TX_RLP));
 
     final Transaction transaction =
         TransactionDecoder.decodeForWire(input, goQuorumCompatibilityMode);
@@ -92,5 +93,24 @@ class TransactionDecoderTest {
             RLP.input(Bytes.fromHexString(NONCE_64_BIT_MAX_MINUS_2_TX_RLP)));
     assertThat(transaction).isNotNull();
     assertThat(transaction.getNonce()).isEqualTo(MAX_NONCE - 1);
+  }
+
+  @Test
+  void shouldCalculateCorrectTransactionSize() {
+    for (final String rlp_tx :
+        List.of(
+            FRONTIER_TX_RLP,
+            EIP1559_TX_RLP,
+            GOQUORUM_PRIVATE_TX_RLP,
+            NONCE_64_BIT_MAX_MINUS_2_TX_RLP)) {
+      System.out.println(rlp_tx);
+
+      // Create bytes from String
+      final Bytes bytes = Bytes.fromHexString(rlp_tx);
+      // Decode bytes into a transaction
+      final Transaction transaction = TransactionDecoder.decodeForWire(RLP.input(bytes));
+      // Bytes size should be equal to transaction size
+      assertThat(transaction.calculateSize()).isEqualTo(bytes.size());
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Gabriel Trintinalia <gabriel.trintinalia@gmail.com>

## PR description
The eth/68 protocol intends to pass the transaction size along with the transaction announcement.

## Fixed Issue(s)
fixes #4723

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).