### PR TITLE
Remove redundant evmBuilder override

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -23,11 +23,9 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecAdapters;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
-import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.math.BigInteger;
-import java.util.Optional;
 
 public class MergeProtocolSchedule {
 
@@ -46,11 +44,7 @@ public class MergeProtocolSchedule {
     return new ProtocolScheduleBuilder(
             config,
             DEFAULT_CHAIN_ID,
-            ProtocolSpecAdapters.create(
-                0,
-                (specBuilder) ->
-                    MergeProtocolSchedule.applyMergeSpecificModifications(
-                        specBuilder, config.getChainId())),
+            ProtocolSpecAdapters.create(0, MergeProtocolSchedule::applyMergeSpecificModifications),
             privacyParameters,
             isRevertReasonEnabled,
             config.isQuorum(),
@@ -59,13 +53,9 @@ public class MergeProtocolSchedule {
   }
 
   private static ProtocolSpecBuilder applyMergeSpecificModifications(
-      final ProtocolSpecBuilder specBuilder, final Optional<BigInteger> chainId) {
+      final ProtocolSpecBuilder specBuilder) {
 
     return specBuilder
-        .evmBuilder(
-            (gasCalculator, jdCacheConfig) ->
-                MainnetEVMs.paris(
-                    gasCalculator, chainId.orElse(BigInteger.ZERO), EvmConfiguration.DEFAULT))
         .blockProcessorBuilder(MergeBlockProcessor::new)
         .blockHeaderValidatorBuilder(MergeProtocolSchedule::getBlockHeaderValidator)
         .blockReward(Wei.ZERO)


### PR DESCRIPTION
## PR description
This PR removes forcing the evmBuilder for post merge networks

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

Signed-off-by: Diego López León <dieguitoll@gmail.com>