### PR TITLE
Removing deprecated method

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
@@ -43,9 +43,9 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
     final List<String> fieldsToIgnore = getFieldsToIgnore();
     final String[] ignored = fieldsToIgnore.toArray(new String[0]);
     assertThat(domainObjectFromOptions)
-            .usingRecursiveComparison()
-            .ignoringFields(ignored)
-            .isEqualTo(domainObject);
+        .usingRecursiveComparison()
+        .ignoringFields(ignored)
+        .isEqualTo(domainObject);
   }
 
   @Test
@@ -82,10 +82,9 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
     // Check default values supplied by CLI match expected default values
     final String[] fieldsToIgnore = getFieldsWithComputedDefaults().toArray(new String[0]);
     assertThat(optionsFromCommand)
-            .usingRecursiveComparison()
-            .ignoringFields(fieldsToIgnore)
-            .isEqualTo(defaultOptions);
-
+        .usingRecursiveComparison()
+        .ignoringFields(fieldsToIgnore)
+        .isEqualTo(defaultOptions);
   }
 
   abstract D createDefaultDomainObject();

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/AbstractCLIOptionsTest.java
@@ -42,7 +42,10 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
 
     final List<String> fieldsToIgnore = getFieldsToIgnore();
     final String[] ignored = fieldsToIgnore.toArray(new String[0]);
-    assertThat(domainObjectFromOptions).isEqualToIgnoringGivenFields(domainObject, ignored);
+    assertThat(domainObjectFromOptions)
+            .usingRecursiveComparison()
+            .ignoringFields(ignored)
+            .isEqualTo(domainObject);
   }
 
   @Test
@@ -78,7 +81,11 @@ public abstract class AbstractCLIOptionsTest<D, T extends CLIOptions<D>>
 
     // Check default values supplied by CLI match expected default values
     final String[] fieldsToIgnore = getFieldsWithComputedDefaults().toArray(new String[0]);
-    assertThat(optionsFromCommand).isEqualToIgnoringGivenFields(defaultOptions, fieldsToIgnore);
+    assertThat(optionsFromCommand)
+            .usingRecursiveComparison()
+            .ignoringFields(fieldsToIgnore)
+            .isEqualTo(defaultOptions);
+
   }
 
   abstract D createDefaultDomainObject();

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
@@ -21,12 +21,12 @@ import static org.hyperledger.besu.cli.DefaultCommandValues.DEFAULT_P2P_PEER_LOW
 import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.util.Arrays;
-import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class NetworkingOptionsTest
@@ -217,7 +217,7 @@ public class NetworkingOptionsTest
   }
 
   @Override
-  protected List<String> getFieldsToIgnore(){
+  protected List<String> getFieldsToIgnore() {
     return Arrays.asList("rlpx.peerLowerBound");
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/NetworkingOptionsTest.java
@@ -25,6 +25,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Arrays;
+import java.util.List;
+
 @RunWith(MockitoJUnitRunner.class)
 public class NetworkingOptionsTest
     extends AbstractCLIOptionsTest<NetworkingConfiguration, NetworkingOptions> {
@@ -211,5 +214,10 @@ public class NetworkingOptionsTest
   @Override
   NetworkingOptions getOptionsFromBesuCommand(final TestBesuCommand besuCommand) {
     return besuCommand.getNetworkingOptions();
+  }
+
+  @Override
+  protected List<String> getFieldsToIgnore(){
+    return Arrays.asList("rlpx.peerLowerBound");
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Remove deprecated method isEqualToIgnoringGivenFields from the package org.assertj.core.api 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).