### PR TITLE
Bugfix snapshot transaction segfaults after storage truncation

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -256,16 +256,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               if (ws.isPersistable()) {
                 return ws;
               } else {
-                var wsCopy = ws.copy();
-                try {
-                  ws.close();
-                } catch (Exception ex) {
-                  LOG.error(
-                      "unexpected error closing non-peristable worldstate + "
-                          + parentHeader.toLogString(),
-                      ex);
-                }
-                return wsCopy;
+                // non-persistable worldstates should return a copy which is persistable:
+                return ws.copy();
               }
             })
         .orElseThrow(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
@@ -118,6 +118,7 @@ public abstract class AbstractTrieLogManager<T extends MutableWorldState>
           .forEach(
               layer -> {
                 cachedWorldStatesByHash.remove(layer.getTrieLog().getBlockHash());
+                layer.dispose();
                 Optional.ofNullable(layer.getMutableWorldState())
                     .ifPresent(
                         ws -> {
@@ -169,13 +170,5 @@ public abstract class AbstractTrieLogManager<T extends MutableWorldState>
     } else {
       return worldStateStorage.getTrieLog(blockHash).map(TrieLogLayer::fromBytes);
     }
-  }
-
-  interface CachedWorldState<Z extends MutableWorldState> {
-    long getHeight();
-
-    TrieLogLayer getTrieLog();
-
-    Z getMutableWorldState();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -18,6 +18,7 @@ package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
 
@@ -27,14 +28,17 @@ import java.util.function.Function;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
-public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
+public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState
+    implements BonsaiStorageSubscriber {
 
   private boolean isPersisted = false;
+  private final Long worldstateSubcriberId;
 
   public BonsaiInMemoryWorldState(
       final BonsaiWorldStateArchive archive,
       final BonsaiWorldStateKeyValueStorage worldStateStorage) {
     super(archive, worldStateStorage);
+    worldstateSubcriberId = worldStateStorage.subscribe(this);
   }
 
   @Override
@@ -155,6 +159,7 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
   @Override
   public void close() throws Exception {
     // if storage is snapshot-based we need to close:
+    worldStateStorage.unSubscribe(worldstateSubcriberId);
     worldStateStorage.close();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -146,7 +146,7 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState {
     final Hash newWorldStateRootHash = rootHash(localUpdater);
     archive
         .getTrieLogManager()
-        .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader);
+        .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader, this);
     worldStateRootHash = newWorldStateRootHash;
     worldStateBlockHash = blockHeader.getBlockHash();
     isPersisted = true;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -261,14 +261,18 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   @MustBeClosed
   public MutableWorldState copy() {
     // return an in-memory worldstate that is based on a persisted snapshot for this blockhash.
-    return archive
-        .getMutableSnapshot(this.blockHash())
-        .map(BonsaiSnapshotWorldState.class::cast)
-        .map(snapshot -> new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage()))
-        .orElseThrow(
-            () ->
-                new StorageException(
-                    "Unable to copy Layered Worldstate for " + blockHash().toHexString()));
+    try (BonsaiSnapshotWorldState snapshot =
+        archive
+            .getMutableSnapshot(this.blockHash())
+            .map(BonsaiSnapshotWorldState.class::cast)
+            .orElseThrow(
+                () ->
+                    new StorageException(
+                        "Unable to copy Layered Worldstate for " + blockHash().toHexString()))) {
+      return new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage());
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldState;
@@ -261,10 +262,10 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   @MustBeClosed
   public MutableWorldState copy() {
     // return an in-memory worldstate that is based on a persisted snapshot for this blockhash.
-    try (BonsaiSnapshotWorldState snapshot =
+    try (SnapshotMutableWorldState snapshot =
         archive
             .getMutableSnapshot(this.blockHash())
-            .map(BonsaiSnapshotWorldState.class::cast)
+            .map(SnapshotMutableWorldState.class::cast)
             .orElseThrow(
                 () ->
                     new StorageException(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
-import org.hyperledger.besu.util.Subscribers;
 
 import java.util.Map;
 import java.util.Optional;
@@ -57,8 +56,6 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
   protected Hash worldStateRootHash;
   protected Hash worldStateBlockHash;
 
-  protected final Subscribers<BonsaiWorldStateSubscriber> subscribers = Subscribers.create();
-
   public BonsaiPersistedWorldState(
       final BonsaiWorldStateArchive archive,
       final BonsaiWorldStateKeyValueStorage worldStateStorage) {
@@ -73,21 +70,17 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
         new BonsaiWorldStateUpdater(
             this,
             (addr, value) ->
-                archive.getCachedMerkleTrieLoader().preLoadAccount(this, worldStateRootHash, addr),
+                archive
+                    .getCachedMerkleTrieLoader()
+                    .preLoadAccount(getWorldStateStorage(), worldStateRootHash, addr),
             (addr, value) ->
-                archive.getCachedMerkleTrieLoader().preLoadStorageSlot(this, addr, value));
+                archive
+                    .getCachedMerkleTrieLoader()
+                    .preLoadStorageSlot(getWorldStateStorage(), addr, value));
   }
 
   public BonsaiWorldStateArchive getArchive() {
     return archive;
-  }
-
-  public synchronized long subscribe(final BonsaiWorldStateSubscriber sub) {
-    return subscribers.subscribe(sub);
-  }
-
-  public synchronized void unSubscribe(final long id) {
-    subscribers.unsubscribe(id);
   }
 
   @Override
@@ -448,10 +441,5 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
             Function.identity(),
             Function.identity());
     return storageTrie.entriesFrom(Bytes32.ZERO, Integer.MAX_VALUE);
-  }
-
-  interface BonsaiWorldStateSubscriber {
-
-    default void onCloseWorldState() {}
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -301,7 +301,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
             () ->
                 archive
                     .getTrieLogManager()
-                    .saveTrieLog(archive, localUpdater, worldStateRootHash, blockHeader);
+                    .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader);
 
         stateUpdater
             .getTrieBranchStorageTransaction()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -297,9 +297,11 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
                   + " calculated "
                   + newWorldStateRootHash.toHexString());
         }
-        saveTrieLog = () -> archive
-            .getTrieLogManager()
-            .saveTrieLog(archive, localUpdater, worldStateRootHash, blockHeader);
+        saveTrieLog =
+            () ->
+                archive
+                    .getTrieLogManager()
+                    .saveTrieLog(archive, localUpdater, worldStateRootHash, blockHeader);
 
         stateUpdater
             .getTrieBranchStorageTransaction()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -16,6 +16,7 @@
 package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
@@ -27,7 +28,7 @@ import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
  * non-persisting mutable world state rather than writing worldstate changes directly.
  */
 public class BonsaiSnapshotWorldState extends BonsaiPersistedWorldState
-    implements SnapshotMutableWorldState {
+    implements SnapshotMutableWorldState, BonsaiStorageSubscriber {
 
   private final SnappedKeyValueStorage accountSnap;
   private final SnappedKeyValueStorage codeSnap;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldState.java
@@ -68,7 +68,7 @@ public class BonsaiSnapshotWorldState extends BonsaiPersistedWorldState
   }
 
   protected BonsaiSnapshotWorldState subscribeToParent() {
-   parentWorldStateSubscriberId.set(parentWorldStateStorage.subscribe(this));
+    parentWorldStateSubscriberId.set(parentWorldStateStorage.subscribe(this));
     return this;
   }
 
@@ -84,15 +84,15 @@ public class BonsaiSnapshotWorldState extends BonsaiPersistedWorldState
   public MutableWorldState copy() {
     // return a clone-based copy of worldstate storage
     return new BonsaiSnapshotWorldState(
-        archive,
-        new BonsaiSnapshotWorldStateKeyValueStorage(
-            accountSnap.cloneFromSnapshot(),
-            codeSnap.cloneFromSnapshot(),
-            storageSnap.cloneFromSnapshot(),
-            trieBranchSnap.cloneFromSnapshot(),
-            worldStateStorage.trieLogStorage),
-        parentWorldStateStorage)
-            .subscribeToParent();
+            archive,
+            new BonsaiSnapshotWorldStateKeyValueStorage(
+                accountSnap.cloneFromSnapshot(),
+                codeSnap.cloneFromSnapshot(),
+                storageSnap.cloneFromSnapshot(),
+                trieBranchSnap.cloneFromSnapshot(),
+                worldStateStorage.trieLogStorage),
+            parentWorldStateStorage)
+        .subscribeToParent();
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -85,7 +85,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
   }
 
   @Override
-  public synchronized long subscribe(BonsaiStorageSubscriber sub) {
+  public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
     if (isClosed.get()) {
       throw new RuntimeException("BonsaiSnapshotWorldStateKeyValueStorage already closed");
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -114,7 +114,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
   protected void tryClose() throws Exception {
     if (isClosed.get() && subscribers.getSubscriberCount() < 1) {
-      subscribers.forEach(BonsaiStorageSubscriber::onClose);
+      subscribers.forEach(BonsaiStorageSubscriber::onCloseStorage);
       accountStorage.close();
       codeStorage.close();
       storageStorage.close();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -18,26 +18,36 @@ package org.hyperledger.besu.ethereum.bonsai;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.warnLambda;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage {
+public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage
+    implements BonsaiStorageSubscriber {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BonsaiSnapshotWorldStateKeyValueStorage.class);
 
+  private final AtomicReference<BonsaiWorldStateKeyValueStorage> parentStorage =
+      new AtomicReference<>();
+  private final AtomicLong parentStorageSubscriberId = new AtomicLong(Long.MAX_VALUE);
+  private final AtomicBoolean shouldClose = new AtomicBoolean(false);
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
   public BonsaiSnapshotWorldStateKeyValueStorage(final StorageProvider snappableStorageProvider) {
@@ -57,16 +67,6 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
             .takeSnapshot(),
         snappableStorageProvider.getStorageBySegmentIdentifier(
             KeyValueSegmentIdentifier.TRIE_LOG_STORAGE));
-  }
-
-  @Override
-  public void clear() {
-    // not implemented
-  }
-
-  @Override
-  public void clearFlatDatabase() {
-    // not implemented
   }
 
   public BonsaiSnapshotWorldStateKeyValueStorage(
@@ -89,9 +89,21 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
   }
 
   @Override
+  public void clear() {
+    // snapshot storage does not implement clear
+    throw new StorageException("Snapshot storage does not implement clear");
+  }
+
+  @Override
+  public void clearFlatDatabase() {
+    // snapshot storage does not implement clear
+    throw new StorageException("Snapshot storage does not implement clear");
+  }
+
+  @Override
   public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
-    if (isClosed.get()) {
-      throw new RuntimeException("BonsaiSnapshotWorldStateKeyValueStorage already closed");
+    if (shouldClose.get()) {
+      throw new RuntimeException("Storage is marked to close or has already closed");
     }
     return super.subscribe(sub);
   }
@@ -106,19 +118,63 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
     }
   }
 
+  void subscribeToParentStorage(final BonsaiWorldStateKeyValueStorage parentStorage) {
+    this.parentStorage.set(parentStorage);
+    parentStorageSubscriberId.set(parentStorage.subscribe(this));
+  }
+
+  @Override
+  public void onClearStorage() {
+    try {
+      // when the parent storage clears, close regardless of subscribers
+      doClose();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onClearFlatDatabaseStorage() {
+    // when the parent storage clears, close regardless of subscribers
+    try {
+      doClose();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public synchronized void close() throws Exception {
-    isClosed.getAndSet(true);
+    // when the parent storage clears, close
+    shouldClose.set(true);
     tryClose();
   }
 
-  protected void tryClose() throws Exception {
-    if (isClosed.get() && subscribers.getSubscriberCount() < 1) {
+  protected synchronized void tryClose() throws Exception {
+    if (shouldClose.get() && subscribers.getSubscriberCount() < 1) {
+      // attempting to close already closed snapshots will segfault
+      doClose();
+    }
+  }
+
+  private void doClose() throws Exception {
+    if (!isClosed.get()) {
+      // alert any subscribers we are closing:
       subscribers.forEach(BonsaiStorageSubscriber::onCloseStorage);
+
+      // unsubscribe from parent storage if we have subscribed
+      Optional.ofNullable(parentStorage.get())
+          .filter(__ -> parentStorageSubscriberId.get() != Long.MAX_VALUE)
+          .ifPresent(parent -> parent.unSubscribe(parentStorageSubscriberId.get()));
+
+      // close all of the SnappedKeyValueStorages:
       accountStorage.close();
       codeStorage.close();
       storageStorage.close();
       trieBranchStorage.close();
+
+      // set storage closed
+      isClosed.set(true);
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -60,9 +60,13 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
   }
 
   @Override
+  public void clear() {
+    // not implemented
+  }
+
+    @Override
   public void clearFlatDatabase() {
-    accountStorage.clear();
-    storageStorage.clear();
+    // not implemented
   }
 
   public BonsaiSnapshotWorldStateKeyValueStorage(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -64,7 +64,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
     // not implemented
   }
 
-    @Override
+  @Override
   public void clearFlatDatabase() {
     // not implemented
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -115,7 +115,9 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
     this.blockchain = blockchain;
     this.worldStateStorage = worldStateStorage;
     this.persistedState = new BonsaiPersistedWorldState(this, worldStateStorage);
-    this.useSnapshots = useSnapshots;
+    // TODO: https://github.com/hyperledger/besu/issues/4641
+    // useSnapshots is disabled for now
+    this.useSnapshots = false;
     this.cachedMerkleTrieLoader = cachedMerkleTrieLoader;
     blockchain.observeBlockAdded(this::blockAddedHandler);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -276,11 +276,11 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
         } catch (final Exception e) {
           // if we fail we must clean up the updater
           bonsaiUpdater.reset();
-          LOG.debug("Archive rolling failed for block hash " + blockHash, e);
+          LOG.debug("State rolling failed for block hash " + blockHash, e);
           return Optional.empty();
         }
       } catch (final RuntimeException re) {
-        LOG.debug("Archive rolling failed for block hash " + blockHash, re);
+        LOG.error("Archive rolling failed for block hash " + blockHash, re);
         return Optional.empty();
       }
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -438,12 +438,9 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   interface BonsaiStorageSubscriber {
     default void onClear() {}
-    ;
 
     default void onClearFlatDatabase() {}
-    ;
 
     default void onClose() {}
-    ;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -271,7 +271,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
     this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
   }
 
-  public synchronized long subscribe(BonsaiStorageSubscriber sub) {
+  public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
     return subscribers.subscribe(sub);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -27,10 +27,10 @@ import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.util.Subscribers;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -49,6 +49,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
   protected final KeyValueStorage storageStorage;
   protected final KeyValueStorage trieBranchStorage;
   protected final KeyValueStorage trieLogStorage;
+  protected final Subscribers<BonsaiStorageSubscriber> subscribers = Subscribers.create();
 
   private Optional<PeerTrieNodeFinder> maybeFallbackNodeFinder;
 
@@ -221,6 +222,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clear() {
+    subscribers.forEach(BonsaiStorageSubscriber::onClear);
     accountStorage.clear();
     codeStorage.clear();
     storageStorage.clear();
@@ -230,6 +232,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clearFlatDatabase() {
+    subscribers.forEach(BonsaiStorageSubscriber::onClearFlatDatabase);
     accountStorage.clear();
     storageStorage.clear();
   }
@@ -268,24 +271,17 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
     this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
   }
 
-  public void safeExecute(final Consumer<KeyValueStorage> toExec) throws Exception {
-    final long id = subscribe();
-    toExec.accept((KeyValueStorage) this);
-    unSubscribe(id);
+  public synchronized long subscribe(BonsaiStorageSubscriber sub) {
+    return subscribers.subscribe(sub);
   }
 
-  public long subscribe() {
-    // No op because close() is not implemented for BonsaiWorldStateKeyValueStorage
-    return 0;
-  }
-
-  public void unSubscribe(final long id) {
-    // No op because close() is not implemented for BonsaiWorldStateKeyValueStorage
+  public synchronized void unSubscribe(final long id) {
+    subscribers.unsubscribe(id);
   }
 
   @Override
   public void close() throws Exception {
-    // No need to close because BonsaiWorldStateKeyValueStorage is persistent
+    // No need to close or notify because BonsaiWorldStateKeyValueStorage is persistent
   }
 
   public interface BonsaiUpdater extends WorldStateStorage.Updater {
@@ -438,5 +434,16 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
       trieBranchStorageTransaction.rollback();
       trieLogStorageTransaction.rollback();
     }
+  }
+
+  interface BonsaiStorageSubscriber {
+    default void onClear() {}
+    ;
+
+    default void onClearFlatDatabase() {}
+    ;
+
+    default void onClose() {}
+    ;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -222,7 +222,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clear() {
-    subscribers.forEach(BonsaiStorageSubscriber::onClear);
+    subscribers.forEach(BonsaiStorageSubscriber::onClearStorage);
     accountStorage.clear();
     codeStorage.clear();
     storageStorage.clear();
@@ -232,7 +232,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clearFlatDatabase() {
-    subscribers.forEach(BonsaiStorageSubscriber::onClearFlatDatabase);
+    subscribers.forEach(BonsaiStorageSubscriber::onClearFlatDatabaseStorage);
     accountStorage.clear();
     storageStorage.clear();
   }
@@ -437,10 +437,10 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
   }
 
   interface BonsaiStorageSubscriber {
-    default void onClear() {}
+    default void onClearStorage() {}
 
-    default void onClearFlatDatabase() {}
+    default void onClearFlatDatabaseStorage() {}
 
-    default void onClose() {}
+    default void onCloseStorage() {}
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/CachedMerkleTrieLoader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/CachedMerkleTrieLoader.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.StoredMerklePatriciaTrie;
@@ -35,7 +36,7 @@ import io.prometheus.client.guava.cache.CacheMetricsCollector;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
-public class CachedMerkleTrieLoader {
+public class CachedMerkleTrieLoader implements BonsaiStorageSubscriber {
 
   private static final int ACCOUNT_CACHE_SIZE = 100_000;
   private static final int STORAGE_CACHE_SIZE = 200_000;
@@ -67,7 +68,7 @@ public class CachedMerkleTrieLoader {
       final BonsaiWorldStateKeyValueStorage worldStateStorage,
       final Hash worldStateRootHash,
       final Address account) {
-    final long worldStateSubscriberId = worldStateStorage.subscribe();
+    final long worldStateSubscriberId = worldStateStorage.subscribe(this);
     try {
       final StoredMerklePatriciaTrie<Bytes, Bytes> accountTrie =
           new StoredMerklePatriciaTrie<>(
@@ -100,7 +101,7 @@ public class CachedMerkleTrieLoader {
       final Address account,
       final Hash slotHash) {
     final Hash accountHash = Hash.hash(account);
-    final long worldStateSubscriberId = worldStateStorage.subscribe();
+    final long worldStateSubscriberId = worldStateStorage.subscribe(this);
     try {
       worldStateStorage
           .getStateTrieNode(Bytes.concatenate(accountHash, Bytes.EMPTY))

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
@@ -49,7 +49,7 @@ public class LayeredTrieLogManager extends AbstractTrieLogManager<BonsaiLayeredW
   @Override
   public synchronized void addCachedLayer(
       final BlockHeader blockHeader,
-      final BonsaiLayeredWorldState cachedState,
+      final Hash worldStateRootHash,
       final TrieLogLayer trieLog,
       final BonsaiWorldStateArchive worldStateArchive) {
 
@@ -59,13 +59,13 @@ public class LayeredTrieLogManager extends AbstractTrieLogManager<BonsaiLayeredW
             worldStateArchive,
             Optional.of((BonsaiPersistedWorldState) worldStateArchive.getMutable()),
             blockHeader.getNumber(),
-            cachedState.rootHash(),
+            worldStateRootHash,
             trieLog);
     debugLambda(
         LOG,
         "adding layered world state for block {}, state root hash {}",
         blockHeader::toLogString,
-        () -> cachedState.rootHash().toShortHexString());
+        worldStateRootHash::toShortHexString);
     cachedWorldStatesByHash.put(
         blockHeader.getHash(), new LayeredWorldStateCache(bonsaiLayeredWorldState));
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
@@ -51,13 +51,14 @@ public class LayeredTrieLogManager extends AbstractTrieLogManager<BonsaiLayeredW
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,
-      final BonsaiWorldStateArchive worldStateArchive) {
+      final BonsaiWorldStateArchive worldStateArchive,
+      final BonsaiPersistedWorldState forWorldState) {
 
     final BonsaiLayeredWorldState bonsaiLayeredWorldState =
         new BonsaiLayeredWorldState(
             blockchain,
             worldStateArchive,
-            Optional.of((BonsaiPersistedWorldState) worldStateArchive.getMutable()),
+            Optional.of(forWorldState),
             blockHeader.getNumber(),
             worldStateRootHash,
             trieLog);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
@@ -95,6 +95,11 @@ public class LayeredTrieLogManager extends AbstractTrieLogManager<BonsaiLayeredW
     }
 
     @Override
+    public void dispose() {
+      // no-op
+    }
+
+    @Override
     public long getHeight() {
       return layeredWorldState.getHeight();
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/LayeredTrieLogManager.java
@@ -32,7 +32,7 @@ public class LayeredTrieLogManager
     extends AbstractTrieLogManager<LayeredTrieLogManager.LayeredWorldStateCache> {
   private static final Logger LOG = LoggerFactory.getLogger(LayeredTrieLogManager.class);
 
-  public LayeredTrieLogManager(
+  LayeredTrieLogManager(
       final Blockchain blockchain,
       final BonsaiWorldStateKeyValueStorage worldStateStorage,
       final long maxLayersToLoad,
@@ -45,11 +45,6 @@ public class LayeredTrieLogManager
       final BonsaiWorldStateKeyValueStorage worldStateStorage,
       final long maxLayersToLoad) {
     this(blockchain, worldStateStorage, maxLayersToLoad, new HashMap<>());
-  }
-
-  public LayeredTrieLogManager(
-      final Blockchain blockchain, final BonsaiWorldStateKeyValueStorage worldStateStorage) {
-    this(blockchain, worldStateStorage, RETAINED_LAYERS, new HashMap<>());
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -71,7 +71,8 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
     if (worldState instanceof BonsaiSnapshotWorldState) {
       snapshotWorldState = (BonsaiSnapshotWorldState) worldState;
     } else {
-      snapshotWorldState = BonsaiSnapshotWorldState.create(worldStateArchive, worldStateStorage);
+      snapshotWorldState =
+          BonsaiSnapshotWorldState.create(worldStateArchive, rootWorldStateStorage);
     }
 
     cachedWorldStatesByHash.put(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -53,7 +53,7 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
   }
 
   @Override
-  protected synchronized void addCachedLayer(
+  protected void addCachedLayer(
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,
@@ -101,7 +101,7 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
   private void dropArchive() {
     // drop all cached snapshot worldstates, they are unsafe when the db has been truncated
     LOG.info("Key-value storage truncated, dropping cached worldstates");
-    cachedWorldStatesByHash.keySet().forEach(cachedWorldStatesByHash::remove);
+    cachedWorldStatesByHash.clear();
   }
 
   public static class CachedSnapshotWorldState

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -115,7 +115,7 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
 
     public CachedSnapshotWorldState(
         final BonsaiSnapshotWorldState snapshot, final TrieLogLayer trieLog, final long height) {
-      this.worldStateSubscriberId = snapshot.worldStateStorage.subscribe(this);
+      this.worldStateSubscriberId = snapshot.getWorldStateStorage().subscribe(this);
       this.snapshot = snapshot;
       this.trieLog = trieLog;
       this.height = height;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -43,7 +43,7 @@ public class SnapshotTrieLogManager
     this(blockchain, worldStateStorage, maxLayersToLoad, new HashMap<>());
   }
 
-  public SnapshotTrieLogManager(
+  SnapshotTrieLogManager(
       final Blockchain blockchain,
       final BonsaiWorldStateKeyValueStorage worldStateStorage,
       final long maxLayersToLoad,
@@ -52,7 +52,7 @@ public class SnapshotTrieLogManager
   }
 
   @Override
-  public void addCachedLayer(
+  public synchronized void addCachedLayer(
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -95,7 +95,7 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
 
   @Override
   public synchronized void onClearFlatDatabase() {
-    dropArchive();;
+    dropArchive();
   }
 
   private void dropArchive() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/SnapshotTrieLogManager.java
@@ -133,16 +133,6 @@ public class SnapshotTrieLogManager extends AbstractTrieLogManager<BonsaiSnapsho
     }
 
     @Override
-    public synchronized void onClear() {
-      setClosed();
-    }
-
-    @Override
-    public synchronized void onClearFlatDatabase() {
-      setClosed();
-    }
-
-    @Override
     public long getHeight() {
       return height;
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -26,8 +26,9 @@ public interface TrieLogManager {
   void saveTrieLog(
       final BonsaiWorldStateArchive worldStateArchive,
       final BonsaiWorldStateUpdater localUpdater,
-      final Hash worldStateRootHash,
-      final BlockHeader blockHeader);
+      final Hash forWorldStateRootHash,
+      final BlockHeader forBlockHeader,
+      final BonsaiPersistedWorldState forWorldState);
 
   Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -21,21 +21,21 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 
 import java.util.Optional;
 
-public interface TrieLogManager {
+public interface TrieLogManager<I extends MutableWorldState> {
 
   void saveTrieLog(
       final BonsaiWorldStateArchive worldStateArchive,
       final BonsaiWorldStateUpdater localUpdater,
-      final Hash worldStateRootHash,
+      final I cachedState,
       final BlockHeader blockHeader);
 
-  Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
+  Optional<? extends MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
 
   long getMaxLayersToLoad();
 
   void addCachedLayer(
       final BlockHeader blockHeader,
-      final Hash worldStateRootHash,
+      final I cachedState,
       final TrieLogLayer trieLog,
       final BonsaiWorldStateArchive worldStateArchive);
 
@@ -43,11 +43,12 @@ public interface TrieLogManager {
 
   Optional<TrieLogLayer> getTrieLogLayer(final Hash blockHash);
 
-  interface CachedWorldState {
+  interface CachedWorldState<Z extends MutableWorldState>
+      extends BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber {
     long getHeight();
 
     TrieLogLayer getTrieLog();
 
-    MutableWorldState getMutableWorldState();
+    Z getMutableWorldState();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -38,8 +38,9 @@ public interface TrieLogManager {
 
   Optional<TrieLogLayer> getTrieLogLayer(final Hash blockHash);
 
-  interface CachedWorldState<Z extends MutableWorldState>
-      extends BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber {
+  interface CachedWorldState<Z extends MutableWorldState> {
+    void dispose();
+
     long getHeight();
 
     TrieLogLayer getTrieLog();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -21,23 +21,17 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 
 import java.util.Optional;
 
-public interface TrieLogManager<I extends MutableWorldState> {
+public interface TrieLogManager {
 
   void saveTrieLog(
       final BonsaiWorldStateArchive worldStateArchive,
       final BonsaiWorldStateUpdater localUpdater,
-      final I cachedState,
+      final Hash worldStateRootHash,
       final BlockHeader blockHeader);
 
-  Optional<? extends MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
+  Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
 
   long getMaxLayersToLoad();
-
-  void addCachedLayer(
-      final BlockHeader blockHeader,
-      final I cachedState,
-      final TrieLogLayer trieLog,
-      final BonsaiWorldStateArchive worldStateArchive);
 
   void updateCachedLayers(final Hash blockParentHash, final Hash blockHash);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
@@ -15,4 +15,8 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
-public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {}
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+
+public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {
+  BonsaiWorldStateKeyValueStorage getWorldStateStorage();
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
@@ -73,6 +73,7 @@ import org.junit.rules.TemporaryFolder;
 
 public abstract class AbstractIsolationTests {
   protected BonsaiWorldStateArchive archive;
+  protected BonsaiWorldStateKeyValueStorage bonsaiWorldStateStorage;
   protected ProtocolContext protocolContext;
   final Function<String, KeyPair> asKeyPair =
       key ->
@@ -100,6 +101,7 @@ public abstract class AbstractIsolationTests {
 
   @Rule public final TemporaryFolder tempData = new TemporaryFolder();
 
+
   protected boolean shouldUseSnapshots() {
     // override for layered worldstate
     return true;
@@ -107,11 +109,11 @@ public abstract class AbstractIsolationTests {
 
   @Before
   public void createStorage() {
-    //    final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
+    bonsaiWorldStateStorage =(BonsaiWorldStateKeyValueStorage)
+            createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI);
     archive =
         new BonsaiWorldStateArchive(
-            (BonsaiWorldStateKeyValueStorage)
-                createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI),
+            bonsaiWorldStateStorage,
             blockchain,
             Optional.of(16L),
             shouldUseSnapshots(),

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
@@ -101,7 +101,6 @@ public abstract class AbstractIsolationTests {
 
   @Rule public final TemporaryFolder tempData = new TemporaryFolder();
 
-
   protected boolean shouldUseSnapshots() {
     // override for layered worldstate
     return true;
@@ -109,7 +108,8 @@ public abstract class AbstractIsolationTests {
 
   @Before
   public void createStorage() {
-    bonsaiWorldStateStorage =(BonsaiWorldStateKeyValueStorage)
+    bonsaiWorldStateStorage =
+        (BonsaiWorldStateKeyValueStorage)
             createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI);
     archive =
         new BonsaiWorldStateArchive(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -16,18 +16,19 @@
 
 package org.hyperledger.besu.ethereum.bonsai;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BonsaiSnapshotIsolationTests extends AbstractIsolationTests {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
@@ -185,8 +185,6 @@ public class BonsaiSnapshotWorldStateArchiveTest {
     when(worldStateStorage.updater()).thenReturn(bonsaiUpdater);
     var snapshotTrieLogManager = new SnapshotTrieLogManager(blockchain, worldStateStorage, 12L);
     var mockArchive = mock(BonsaiWorldStateArchive.class);
-    when(mockArchive.getMutableSnapshot(any()))
-        .thenReturn(Optional.of(mock(BonsaiSnapshotWorldState.class)));
     BonsaiWorldStateUpdater mockUpdater = mock(BonsaiWorldStateUpdater.class);
 
     doAnswer(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.AbstractTrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.bonsai.SnapshotTrieLogManager.CachedSnapshotWorldState;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.AbstractTrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiUpdater;
 import org.hyperledger.besu.ethereum.bonsai.SnapshotTrieLogManager.CachedSnapshotWorldState;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -125,18 +126,19 @@ public class BonsaiSnapshotWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, CachedSnapshotWorldState> worldStatesByHash = mock(HashMap.class);
+    final Map<Bytes32, CachedWorldState<BonsaiSnapshotWorldState>> worldStatesByHash =
+        mock(HashMap.class);
     when(worldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
     when(worldStatesByHash.get(eq(blockHeaderChainA.getHash())))
         .thenReturn(
             new CachedSnapshotWorldState(
-                () -> mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
+                mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
                 mock(TrieLogLayer.class),
                 2));
     when(worldStatesByHash.get(eq(blockHeaderChainB.getHash())))
         .thenReturn(
             new CachedSnapshotWorldState(
-                () -> mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
+                mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
                 mock(TrieLogLayer.class),
                 2));
     var worldStateStorage = new BonsaiWorldStateKeyValueStorage(storageProvider);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.AbstractTrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.bonsai.LayeredTrieLogManager.LayeredWorldStateCache;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -208,7 +209,8 @@ public class BonsaiWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, LayeredWorldStateCache> layeredWorldStatesByHash = mock(HashMap.class);
+    final Map<Bytes32, CachedWorldState<BonsaiLayeredWorldState>> layeredWorldStatesByHash =
+        mock(HashMap.class);
     when(layeredWorldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
     when(layeredWorldStatesByHash.get(eq(blockHeaderChainA.getHash())))
         .thenReturn(
@@ -262,7 +264,8 @@ public class BonsaiWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, LayeredWorldStateCache> layeredWorldStatesByHash = mock(HashMap.class);
+    final Map<Bytes32, CachedWorldState<BonsaiLayeredWorldState>> layeredWorldStatesByHash =
+        mock(HashMap.class);
     when(layeredWorldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
     when(layeredWorldStatesByHash.get(eq(blockHeaderChainA.getHash())))
         .thenReturn(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -28,8 +28,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.AbstractTrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.bonsai.LayeredTrieLogManager.LayeredWorldStateCache;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LayeredWorldStateTests {
+
+  @Mock BonsaiWorldStateArchive archive;
+  @Mock Blockchain blockchain;
+
+  @Test
+  public void layeredWorldStateUsesCorrectPersistedWorldStateOnCopy() {
+    // when copying a layered worldstate we return mutable copy,
+    // ensure it is for the correct/corresponding worldstate:
+
+    Hash state1Hash = Hash.hash(Bytes.of("first_state".getBytes(StandardCharsets.UTF_8)));
+    Hash block1Hash = Hash.hash(Bytes.of("first_block".getBytes(StandardCharsets.UTF_8)));
+    var mockStorage = mock(BonsaiWorldStateKeyValueStorage.class);
+    when(mockStorage.getWorldStateBlockHash()).thenReturn(Optional.of(block1Hash));
+    when(mockStorage.getWorldStateRootHash()).thenReturn(Optional.of(state1Hash));
+    SnapshotMutableWorldState mockState =
+        when(mock(SnapshotMutableWorldState.class).getWorldStateStorage())
+            .thenReturn(mockStorage)
+            .getMock();
+
+    TrieLogLayer mockLayer =
+        when(mock(TrieLogLayer.class).getBlockHash()).thenReturn(Hash.ZERO).getMock();
+    BonsaiLayeredWorldState mockLayerWs =
+        new BonsaiLayeredWorldState(
+            blockchain,
+            archive,
+            Optional.of(mock(BonsaiLayeredWorldState.class)),
+            1L,
+            state1Hash,
+            mockLayer);
+
+    // mimic persisted state being at a different state:
+    when(archive.getMutable()).thenReturn(mock(MutableWorldState.class));
+    when(archive.getMutableSnapshot(mockLayer.getBlockHash())).thenReturn(Optional.of(mockState));
+
+    try (var copyOfLayer1 = mockLayerWs.copy()) {
+      assertThat(copyOfLayer1.rootHash()).isEqualTo(state1Hash);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Test
+  public void saveTrieLogShouldUseCorrectPersistedWorldStateOnCopy() {
+    // when we save a snapshot based worldstate, ensure
+    // we used the passed in worldstate and roothash for calculating the trielog diff
+    Hash testStateRoot = Hash.fromHexStringLenient("0xdeadbeef");
+    BlockHeader testHeader = new BlockHeaderTestFixture().stateRoot(testStateRoot).buildHeader();
+
+    BonsaiWorldStateKeyValueStorage testStorage =
+        when(mock(BonsaiWorldStateKeyValueStorage.class, Answers.RETURNS_DEEP_STUBS)
+                .getWorldStateRootHash())
+            .thenReturn(Optional.of(testStateRoot))
+            .getMock();
+
+    BonsaiSnapshotWorldState testState = mock(BonsaiSnapshotWorldState.class);
+    when(testState.getWorldStateStorage()).thenReturn(testStorage);
+    when(testState.rootHash()).thenReturn(testStateRoot);
+    when(testState.blockHash()).thenReturn(testHeader.getBlockHash());
+
+    BonsaiWorldStateUpdater testUpdater =
+        when(spy(new BonsaiWorldStateUpdater(testState)).generateTrieLog(any(Hash.class)))
+            .thenReturn(mock(TrieLogLayer.class))
+            .getMock();
+
+    // mock kvstorage to mimic head being in a different state than testState
+    LayeredTrieLogManager manager =
+        spy(
+            new LayeredTrieLogManager(
+                blockchain, mock(BonsaiWorldStateKeyValueStorage.class), 10L, new HashMap<>()));
+
+    // assert we are using the target worldstate storage:
+    final AtomicBoolean calledPrepareTrieLog = new AtomicBoolean(false);
+    doAnswer(
+            prepareCallSpec -> {
+              Hash blockHash = prepareCallSpec.getArgument(0, BlockHeader.class).getHash();
+              Hash rootHash = prepareCallSpec.getArgument(1, Hash.class);
+              BonsaiPersistedWorldState ws =
+                  prepareCallSpec.getArgument(4, BonsaiPersistedWorldState.class);
+              assertThat(ws.rootHash()).isEqualTo(rootHash);
+              assertThat(ws.blockHash()).isEqualTo(blockHash);
+              calledPrepareTrieLog.set(true);
+              return mock(TrieLogLayer.class);
+            })
+        .when(manager)
+        .prepareTrieLog(
+            any(BlockHeader.class),
+            any(Hash.class),
+            any(BonsaiWorldStateUpdater.class),
+            any(BonsaiWorldStateArchive.class),
+            any(BonsaiPersistedWorldState.class));
+
+    manager.saveTrieLog(archive, testUpdater, testStateRoot, testHeader, testState);
+    assertThat(calledPrepareTrieLog.get()).isTrue();
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
-import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 
 import java.nio.charset.StandardCharsets;
@@ -74,7 +73,6 @@ public class LayeredWorldStateTests {
             mockLayer);
 
     // mimic persisted state being at a different state:
-    when(archive.getMutable()).thenReturn(mock(MutableWorldState.class));
     when(archive.getMutableSnapshot(mockLayer.getBlockHash())).thenReturn(Optional.of(mockState));
 
     try (var copyOfLayer1 = mockLayerWs.copy()) {
@@ -92,21 +90,14 @@ public class LayeredWorldStateTests {
     BlockHeader testHeader = new BlockHeaderTestFixture().stateRoot(testStateRoot).buildHeader();
 
     BonsaiWorldStateKeyValueStorage testStorage =
-        when(mock(BonsaiWorldStateKeyValueStorage.class, Answers.RETURNS_DEEP_STUBS)
-                .getWorldStateRootHash())
-            .thenReturn(Optional.of(testStateRoot))
-            .getMock();
+        mock(BonsaiWorldStateKeyValueStorage.class, Answers.RETURNS_DEEP_STUBS);
 
     BonsaiSnapshotWorldState testState = mock(BonsaiSnapshotWorldState.class);
     when(testState.getWorldStateStorage()).thenReturn(testStorage);
     when(testState.rootHash()).thenReturn(testStateRoot);
     when(testState.blockHash()).thenReturn(testHeader.getBlockHash());
 
-    BonsaiWorldStateUpdater testUpdater =
-        when(spy(new BonsaiWorldStateUpdater(testState)).generateTrieLog(any(Hash.class)))
-            .thenReturn(mock(TrieLogLayer.class))
-            .getMock();
-
+    BonsaiWorldStateUpdater testUpdater = new BonsaiWorldStateUpdater(testState);
     // mock kvstorage to mimic head being in a different state than testState
     LayeredTrieLogManager manager =
         spy(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
@@ -167,6 +167,7 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
             SnapDataRequest.createAccountTrieNodeDataRequest(
                 stateRoot, Bytes.EMPTY, snapContext.getInconsistentAccounts()));
       } else { // start from scratch
+        LOG.info("CLEARING WORLDSTATE STORAGE!");
         worldStateStorage.clear();
         ranges.forEach(
             (key, value) ->

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldStateDownloader.java
@@ -167,7 +167,6 @@ public class SnapWorldStateDownloader implements WorldStateDownloader {
             SnapDataRequest.createAccountTrieNodeDataRequest(
                 stateRoot, Bytes.EMPTY, snapContext.getInconsistentAccounts()));
       } else { // start from scratch
-        LOG.info("CLEARING WORLDSTATE STORAGE!");
         worldStateStorage.clear();
         ranges.forEach(
             (key, value) ->

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
@@ -36,12 +36,12 @@ class RocksDBSnapshot {
     this.dbSnapshot = db.getSnapshot();
   }
 
-  Snapshot markAndUseSnapshot() {
+  synchronized Snapshot markAndUseSnapshot() {
     usages.incrementAndGet();
     return dbSnapshot;
   }
 
-  void unMarkSnapshot() {
+  synchronized void unMarkSnapshot() {
     if (usages.decrementAndGet() < 1) {
       db.releaseSnapshot(dbSnapshot);
       dbSnapshot.close();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -161,6 +161,9 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
   }
 
   public RocksDBSnapshotTransaction copy() {
+    if (isClosed.get()) {
+      throw new StorageException("Snapshot already closed");
+    }
     try {
       var copyReadOptions = new ReadOptions().setSnapshot(snapshot.markAndUseSnapshot());
       var copySnapTx = db.beginTransaction(writeOptions);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDBMetrics;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.RocksDbIterator;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -46,6 +47,7 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
   private final RocksDBSnapshot snapshot;
   private final WriteOptions writeOptions;
   private final ReadOptions readOptions;
+  private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
   RocksDBSnapshotTransaction(
       final OptimisticTransactionDB db,
@@ -77,6 +79,11 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
   }
 
   public Optional<byte[]> get(final byte[] key) {
+    if (isClosed.get()) {
+      LOG.debug("Attempted to access closed snapshot");
+      return Optional.empty();
+    }
+
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
       return Optional.ofNullable(snapTx.get(columnFamilyHandle, readOptions, key));
     } catch (final RocksDBException e) {
@@ -86,6 +93,11 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
 
   @Override
   public void put(final byte[] key, final byte[] value) {
+    if (isClosed.get()) {
+      LOG.debug("Attempted to access closed snapshot");
+      return;
+    }
+
     try (final OperationTimer.TimingContext ignored = metrics.getWriteLatency().startTimer()) {
       snapTx.put(columnFamilyHandle, key, value);
     } catch (final RocksDBException e) {
@@ -99,6 +111,10 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
 
   @Override
   public void remove(final byte[] key) {
+    if (isClosed.get()) {
+      LOG.debug("Attempted to access closed snapshot");
+      return;
+    }
     try (final OperationTimer.TimingContext ignored = metrics.getRemoveLatency().startTimer()) {
       snapTx.delete(columnFamilyHandle, key);
     } catch (final RocksDBException e) {
@@ -164,5 +180,6 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
     writeOptions.close();
     readOptions.close();
     snapshot.unMarkSnapshot();
+    isClosed.set(true);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR addresses a race where snap and checkpoint syncs can cause a segfault when starting a worldstate download.  The segfault occurs when rocksdb snapshot transactions are read/written after a storage truncation.  To prevent this and to ensure future uses of clear() and clearFlatDatabase() cannot cause segfaults, this PR:

* adds BonsaiStorageSubscriber type to handle storage events
* removes addCachedLayer from TrieLogManager, moves to AbstractTrieLogManager
* TrieLogManager takes a snapshot immediately in addCachedLayer rather than deferring it 
* notifies subscribers on events that can affect the worldstate, specifically:
  * clear (truncate)
  * clearFlatDatabase (truncating a subset of storage)
  * close (closing the worldstate storage)

Additionally, only drop cached layers by distance from head when the worldstate archive has more than the configured number of retained layers.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
addresses #4765 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).