### PR TITLE
Docker release task for latest tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ jobs:
   dockerPromoteX64:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Login to DockerHub
         run: echo ${{ secrets.DOCKER_PASSWORD_RW }} | docker login -u ${{ secrets.DOCKER_USER_RW }} --password-stdin
-      - name: pull tagged image
-        run: docker pull ${{ secrets.DOCKER_ORG }}/besu:gitSha-${{ github.sha }}
-      - name: apply latest tag
-        run: docker tag ${{ secrets.DOCKER_ORG }}/besu:gitSha-${{ github.sha }} ${{ secrets.DOCKER_ORG }}/besu:latest
-      - name: push
-        run: docker push ${{ secrets.DOCKER_ORG }}/besu:latest
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Docker upload
+        run: ./gradlew "-Prelease.releaseVersion=${{ github.ref_name }}" "-PdockerOrgName=${{ secrets.DOCKER_ORG }}" dockerUploadRelease
+      - name: Docker manifest
+        run: ./gradlew "-Prelease.releaseVersion=${{ github.ref_name }}" "-PdockerOrgName=${{ secrets.DOCKER_ORG }}" manifestDockerRelease

--- a/build.gradle
+++ b/build.gradle
@@ -654,12 +654,6 @@ task distDocker {
       }
     }
 
-    def shaTag = "gitSha-${getCheckedOutGitCommitHash(40)}" //full length sha
-    exec {
-      executable "sh"
-      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${shaTag}'"
-    }
-
     // tag the "default" (which is the variant in the zero position)
     exec {
       executable "sh"
@@ -757,16 +751,34 @@ task dockerUpload {
       }
     }
 
-    def shaTag = "gitSha-${getCheckedOutGitCommitHash(40)}" //full length sha
-    exec {
-      executable "sh"
-      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${shaTag}' && docker push '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}'"
-    }
-
     exec {
       def archImage = "${image}-${architecture}"
       def cmd = "docker tag ${image} ${archImage} && docker push '${archImage}'"
       additionalTags.each { tag -> cmd += " && docker tag '${image}' '${dockerImageName}:${tag.trim()}-${architecture}' && docker push '${dockerImageName}:${tag.trim()}-${architecture}'" }
+      executable "sh"
+      args "-c", cmd
+    }
+  }
+}
+
+task dockerUploadRelease {
+  def architecture = System.getenv('architecture')
+  def image = "${dockerImageName}:${dockerBuildVersion}"
+
+  doLast {
+    for (def variant in dockerVariants) {
+      def variantImage = "${image}-${variant}"
+      exec {
+        def archVariantImage = "${variantImage}-${architecture}"
+        def cmd = "docker pull '${variantImage}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
+        executable "sh"
+        args "-c", cmd
+      }
+    }
+
+    exec {
+      def archImage = "${image}-${architecture}"
+      def cmd = "docker pull '${archImage}' && docker tag ${image} '${dockerImageName}:latest-${architecture}' && docker push '${dockerImageName}:latest-${architecture}'"
       executable "sh"
       args "-c", cmd
     }
@@ -801,12 +813,6 @@ task manifestDocker {
         }
       }
 
-      def shaTag = "gitSha-${getCheckedOutGitCommitHash(40)}" //full length sha
-      exec {
-        executable "sh"
-        args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${shaTag}' && docker manifest push '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}'"
-      }
-
       exec {
         def targets = ""
         archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
@@ -814,6 +820,33 @@ task manifestDocker {
         executable "sh"
         args "-c", cmd
       }
+    }
+  }
+}
+
+task manifestDockerRelease {
+  def archs = ["arm64", "amd64"]
+  def baseTag = "${dockerImageName}:latest";
+
+  doLast {
+    for (def variant in dockerVariants) {
+      def variantImage = "${baseTag}-${variant}"
+      def targets = ""
+      archs.forEach { arch -> targets += "'${variantImage}-${arch}' " }
+
+      exec {
+        def cmd = "docker manifest create '${variantImage}' ${targets} && docker manifest push '${variantImage}'"
+        executable "sh"
+        args "-c", cmd
+      }
+    }
+
+    exec {
+      def targets = ""
+      archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
+      def cmd = "docker manifest create '${baseTag}' ${targets} && docker manifest push '${baseTag}'"
+      executable "sh"
+      args "-c", cmd
     }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -769,10 +769,9 @@ task dockerUploadRelease {
   doLast {
     for (def architecture in archs) {
       for (def variant in dockerVariants) {
-
         def variantImage = "${image}-${variant}"
         exec {
-          def cmd = "docker pull '${variantImage}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
+          def cmd = "docker pull '${variantImage}-${architecture}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
           executable "sh"
           args "-c", cmd
         }

--- a/build.gradle
+++ b/build.gradle
@@ -768,7 +768,6 @@ task dockerUpload {
 }
 
 task manifestDocker {
-  dependsOn distDocker
 
   def image = "${dockerImageName}:${dockerBuildVersion}"
   def archs = ["arm64", "amd64"]

--- a/build.gradle
+++ b/build.gradle
@@ -762,31 +762,32 @@ task dockerUpload {
 }
 
 task dockerUploadRelease {
-  def architecture = System.getenv('architecture')
+  def archs = ["arm64", "amd64"]
   def image = "${dockerImageName}:${dockerBuildVersion}"
 
   doLast {
-    for (def variant in dockerVariants) {
-      def variantImage = "${image}-${variant}"
+    for (def architecture in archs) {
+      for (def variant in dockerVariants) {
+
+        def variantImage = "${image}-${variant}"
+        exec {
+          def cmd = "docker pull '${variantImage}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
+          executable "sh"
+          args "-c", cmd
+        }
+      }
+
       exec {
-        def archVariantImage = "${variantImage}-${architecture}"
-        def cmd = "docker pull '${variantImage}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
+        def archImage = "${image}-${architecture}"
+        def cmd = "docker pull '${archImage}' && docker tag ${image} '${dockerImageName}:latest-${architecture}' && docker push '${dockerImageName}:latest-${architecture}'"
         executable "sh"
         args "-c", cmd
       }
-    }
-
-    exec {
-      def archImage = "${image}-${architecture}"
-      def cmd = "docker pull '${archImage}' && docker tag ${image} '${dockerImageName}:latest-${architecture}' && docker push '${dockerImageName}:latest-${architecture}'"
-      executable "sh"
-      args "-c", cmd
     }
   }
 }
 
 task manifestDocker {
-
   def image = "${dockerImageName}:${dockerBuildVersion}"
   def archs = ["arm64", "amd64"]
   def tags = ["${image}"]

--- a/build.gradle
+++ b/build.gradle
@@ -762,8 +762,7 @@ task dockerUpload {
 }
 
 task dockerUploadRelease {
-  def archs = ["arm64"]
-  //def archs = ["arm64", "amd64"]
+  def archs = ["arm64", "amd64"]
   def image = "${dockerImageName}:${dockerBuildVersion}"
 
   doLast {
@@ -789,8 +788,7 @@ task dockerUploadRelease {
 
 task manifestDocker {
   def image = "${dockerImageName}:${dockerBuildVersion}"
-  def archs = ["arm64"]
-  //def archs = ["arm64", "amd64"]
+  def archs = ["arm64", "amd64"]
   def tags = ["${image}"]
 
   if (project.hasProperty('branch') && project.property('branch') == 'main') {
@@ -827,8 +825,7 @@ task manifestDocker {
 }
 
 task manifestDockerRelease {
-  def archs = ["arm64"]
-  //def archs = ["arm64", "amd64"]
+  def archs = ["arm64", "amd64"]
   def baseTag = "${dockerImageName}:latest";
 
   doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -757,6 +757,12 @@ task dockerUpload {
       }
     }
 
+    def shaTag = "gitSha-${getCheckedOutGitCommitHash(40)}" //full length sha
+    exec {
+      executable "sh"
+      args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${shaTag}' && docker push '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}'"
+    }
+
     exec {
       def archImage = "${image}-${architecture}"
       def cmd = "docker tag ${image} ${archImage} && docker push '${archImage}'"
@@ -793,6 +799,12 @@ task manifestDocker {
           executable "sh"
           args "-c", cmd
         }
+      }
+
+      def shaTag = "gitSha-${getCheckedOutGitCommitHash(40)}" //full length sha
+      exec {
+        executable "sh"
+        args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${shaTag}' && docker manifest push '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}'"
       }
 
       exec {

--- a/build.gradle
+++ b/build.gradle
@@ -771,7 +771,7 @@ task dockerUploadRelease {
       for (def variant in dockerVariants) {
         def variantImage = "${image}-${variant}"
         exec {
-          def cmd = "docker pull '${variantImage}-${architecture}' && docker tag '${variantImage}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
+          def cmd = "docker pull '${variantImage}-${architecture}' && docker tag '${variantImage}-${architecture}' '${dockerImageName}:latest-${variant}-${architecture}' && docker push '${dockerImageName}:latest-${variant}-${architecture}'"
           executable "sh"
           args "-c", cmd
         }
@@ -779,7 +779,7 @@ task dockerUploadRelease {
 
       exec {
         def archImage = "${image}-${architecture}"
-        def cmd = "docker pull '${archImage}' && docker tag ${image} '${dockerImageName}:latest-${architecture}' && docker push '${dockerImageName}:latest-${architecture}'"
+        def cmd = "docker pull '${archImage}' && docker tag ${archImage} '${dockerImageName}:latest-${architecture}' && docker push '${dockerImageName}:latest-${architecture}'"
         executable "sh"
         args "-c", cmd
       }

--- a/build.gradle
+++ b/build.gradle
@@ -762,7 +762,8 @@ task dockerUpload {
 }
 
 task dockerUploadRelease {
-  def archs = ["arm64", "amd64"]
+  def archs = ["arm64"]
+  //def archs = ["arm64", "amd64"]
   def image = "${dockerImageName}:${dockerBuildVersion}"
 
   doLast {
@@ -789,7 +790,8 @@ task dockerUploadRelease {
 
 task manifestDocker {
   def image = "${dockerImageName}:${dockerBuildVersion}"
-  def archs = ["arm64", "amd64"]
+  def archs = ["arm64"]
+  //def archs = ["arm64", "amd64"]
   def tags = ["${image}"]
 
   if (project.hasProperty('branch') && project.property('branch') == 'main') {
@@ -826,7 +828,8 @@ task manifestDocker {
 }
 
 task manifestDockerRelease {
-  def archs = ["arm64", "amd64"]
+  def archs = ["arm64"]
+  //def archs = ["arm64", "amd64"]
   def baseTag = "${dockerImageName}:latest";
 
   doLast {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.10.4-SNAPSHOT
+version=22.10.4
 
 org.gradle.welcome=never
 org.gradle.jvmargs=-Xmx1g

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.10.4
+version=22.10.4-SNAPSHOT
 
 org.gradle.welcome=never
 org.gradle.jvmargs=-Xmx1g


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Expands the github release workflow to support adding the latest tags for all the docker variants and architectures.

* Replace the use of git sha tags with existing release tags to avoid creating a lot of unneeded tags. When creating the latest tags for all the variants, arch and manifests 15 tags are needed in total
* Added latest tags for variants as was done for previous releases
* Added latest tags for all the architectures
* Added latest tags for multi-arch images

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).