### PR TITLE
Deprecation notice for GoQuorum-compatible privacy and IBFT 1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,6 @@ executors:
     working_directory: ~/project
     environment:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
-      
-  quorum_ats_executor:
-    docker:
-      - image: cimg/openjdk:11.0
-    resource_class: xlarge
-    working_directory: ~/project
-    environment:
-      GRADLE_OPTS: -Dorg.gradle.daemon=false
 
   xl_machine_executor:
     machine:
@@ -251,25 +243,6 @@ jobs:
       - capture_test_results
       - capture_test_logs
 
-  acceptanceTestsQuorum:
-    parallelism: 1
-    executor: quorum_ats_executor
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - setup_remote_docker:
-          version: 20.10.14
-          docker_layer_caching: true
-      - run:
-          name: Quorum Acceptance Tests
-          no_output_timeout: 5m
-          command: ./gradlew --no-daemon acceptanceTestsQuorum
-      - store_artifacts:
-          path: build/quorum-at
-          destination: quorum-at-artifacts
-      - store_test_results:
-          path: build/quorum-at/openjdk-latest/reports/xml-report
-
   buildDocker:
     executor: besu_executor_med
     steps:
@@ -469,7 +442,4 @@ workflows:
                 - main
     jobs:
       - assemble
-      - acceptanceTestsQuorum:
-          requires:
-            - assemble
       - dockerScan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 23.1
+
+### Breaking Changes
+- GoQuorum-compatible privacy is deprecated and will be removed in 23.4
+- IBFT 1.0 is deprecated and will be removed in 23.4
+
 ## 22.10.4
 
 ### Additions and Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.3/besu-22.10.3
 This is a hotfix release to resolve a race condition that results in segfaults, introduced in 22.10.1 release.
 
 ### Bug Fixes
-- bugfix for async operations on Snashot worldstates [#4767](https://github.com/hyperledger/besu/pull/4767)
+- bugfix for async operations on Snapshot worldstates [#4767](https://github.com/hyperledger/besu/pull/4767)
 
 ### Download Links
 https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.2/besu-22.10.2.tar.gz  / sha256: cdb36141e3cba6379d35016e0a2de2edba579d4786124b5f7257b1e4a68867a2

--- a/build.gradle
+++ b/build.gradle
@@ -687,41 +687,6 @@ task testDocker {
   }
 }
 
-task acceptanceTestsQuorum {
-  /**
-   * Tags Description
-   *
-   * Basic tests for private and public tx: basic
-   * Start a Besu/EthSigner/Tessera network with IBFT2: networks/typical-besu::ibft2
-   *
-   * Filter only for spam tests supported by Besu: (spam && raw)
-   * Not available features in Besu: privacy-enhancements-disabled, extension, mps
-   * Not available RPC methods in Besu: async, storage-root, personal-api-signed
-   *
-   * Ignored for now (privacy-polishing): eth-api-signed, nosupport
-   *
-   * LOGGING_LEVEL_COM_QUORUM_GAUGE=DEBUG -- enables HTTP JSON-RPC logging
-   */
-  def tags = "(basic && !nosupport && !mps && !(spam && !raw) && !eth-api-signed && !privacy-enhancements-disabled && !async && !extension && !storage-root && !personal-api-signed) || networks/typical-besu::ibft2"
-
-  doLast {
-    exec {
-      def variant = "openjdk-latest"
-      def variantDirectory = "${buildDir}/quorum-at/${variant}"
-      def dataDirectory = "${variantDirectory}/data"
-      def reportsDirectory = "${variantDirectory}/reports"
-      new File(dataDirectory).mkdirs()
-      new File(reportsDirectory).mkdirs()
-
-      def image = project.hasProperty('release.releaseVersion') ? "${dockerImageName}:" + project.property('release.releaseVersion') : "${dockerImageName}:${project.version}"
-      def dockerEnv = "--env LOGGING_LEVEL_COM_QUORUM_GAUGE=DEBUG --env TF_VAR_besu_docker_image='{name=\"${image}-${variant}\",local=true}'"
-      def dockerVolumes = "-v ${reportsDirectory}:/workspace/target/gauge/reports/ -v /var/run/docker.sock:/var/run/docker.sock -v ${dataDirectory}:${dataDirectory}"
-      executable "sh"
-      args "-c", "docker run ${dockerEnv} --rm --network host ${dockerVolumes} quorumengineering/acctests:latest test -PgaugeFailSafe -Pauto -Dtags=\"${tags}\" -Dauto.outputDir=${dataDirectory} -Dnetwork.forceDestroy=true -Dauto.jobid=${variant}"
-    }
-  }
-}
-
 task dockerUpload {
   dependsOn distDocker
   def architecture = System.getenv('architecture')


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Besu currently has 3 privacy modes. The privacy mode that provides compatibility with GoQuorum privacy is intertwined with mainnet code at the transaction and block processing level. We also have not seen demand for this privacy mode within the Besu community.
We plan to deprecate the GoQuorum-compatible privacy feature, along with IBFT 1.0, in the coming quarterly release 23.1, and then remove it in the following quarterly release 23.4.
Removing the code associated with this feature will reduce the complexity of the transaction and block processing code, reducing friction for mainnet-focused development.

This will not affect the remaining 2 privacy modes (EEA privacy and flexible privacy groups).
This will not affect IBFT 2.0 or QBFT.

Reach out to us on Discord with any questions.

Also remove quorum ATs nightly task - this nightly task is currently consistently failing. Since we are deprecating the GoQuorum-compatible privacy feature in 23.1 so we won't be investing time fixing these tests.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).