### PR TITLE
Fix some flaky tests

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/OpenTelemetryAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/OpenTelemetryAcceptanceTest.java
@@ -180,9 +180,9 @@ public class OpenTelemetryAcceptanceTest extends AcceptanceTestBase {
 
   @Test
   public void traceReporting() {
-
+    // longer timeout since at 30s this test is flaky
     WaitUtils.waitFor(
-        30,
+        60,
         () -> {
           // call the json RPC endpoint to generate a trace.
           net.netVersion().verify(metricsNode);
@@ -203,7 +203,7 @@ public class OpenTelemetryAcceptanceTest extends AcceptanceTestBase {
   public void traceReportingWithTraceId() {
     Duration timeout = Duration.ofSeconds(1);
     WaitUtils.waitFor(
-        30,
+        60,
         () -> {
           OpenTelemetry openTelemetry =
               OpenTelemetrySdk.builder()

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -3179,7 +3179,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             });
   }
 
-  private void checkIfRequiredPortsAreAvailable() {
+  protected void checkIfRequiredPortsAreAvailable() {
     final List<Integer> unavailablePorts = new ArrayList<>();
     getEffectivePorts().stream()
         .filter(Objects::nonNull)

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -477,6 +477,11 @@ public abstract class CommandTestAbstract {
       isGoQuorumCompatibilityMode = true;
     }
 
+    @Override
+    protected void checkIfRequiredPortsAreAvailable() {
+      // For testing, don't check for port conflicts
+    }
+
     public CommandSpec getSpec() {
       return spec;
     }


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

- increase timeout for OpenTelemetry trace test
- override port conflict check in BesuCommandTest

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).