### PR TITLE
rollback dco on push

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,7 +1,5 @@
 name: dco
 on:
-  push:
-    branches: [ main, release*, test-dco* ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

The action we're using here only supports pull_request events
https://github.com/tim-actions/get-pr-commits/blob/c64db31d359214d244884dd68f971a110b29ab83/index.js#L4

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).