### PR TITLE
alternate dco that can run on push to branch

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,19 +1,24 @@
-name: dco
+name: DCO
 on:
   pull_request:
-  workflow_dispatch:
-
+  push:
+    branches:
+      - main
+      - release*
+      - test-dco*
 jobs:
-  dco:
+  check:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - name: Get PR Commits
-        id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.2.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: DCO Check
-        uses: tim-actions/dco@v1.1.0
-        with:
-          commits: ${{ steps.get-pr-commits.outputs.commits }}
+      - uses: actions/checkout@v2
+        - name: Set up Python 3.x
+          uses: actions/setup-python@v1
+          with:
+            python-version: '3.x'
+        - name: Check DCO
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: |
+            pip3 install -U dco-check
+            dco-check

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
         - name: Set up Python 3.x


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Alternate DCO check action that can run on push (merge back into main) as well as pull_request action 

Uses this one https://github.com/christophebedard/dco-check

fixes #4837

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).