### PR TITLE
Do not apply final arguments ErrorProne to generated code

### DIFF
--- a/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinal.java
+++ b/errorprone-checks/src/main/java/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinal.java
@@ -25,6 +25,7 @@ import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.bugpatterns.BugChecker.MethodTreeMatcher;
 import com.google.errorprone.matchers.Description;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
@@ -39,6 +40,7 @@ public class MethodInputParametersMustBeFinal extends BugChecker
     implements MethodTreeMatcher, ClassTreeMatcher {
 
   private boolean isAbstraction = false;
+  private boolean isGenerated = false;
 
   @Override
   public Description matchClass(final ClassTree tree, final VisitorState state) {
@@ -46,11 +48,16 @@ public class MethodInputParametersMustBeFinal extends BugChecker
         isInterface(tree.getModifiers())
             || isAnonymousClassInAbstraction(tree)
             || isEnumInAbstraction(tree);
+    isGenerated = ASTHelpers.hasDirectAnnotationWithSimpleName(tree, "Generated");
     return Description.NO_MATCH;
   }
 
   @Override
   public Description matchMethod(final MethodTree tree, final VisitorState state) {
+    if (isGenerated) {
+      return Description.NO_MATCH;
+    }
+
     final ModifiersTree mods = tree.getModifiers();
 
     if (isAbstraction) {
@@ -106,5 +113,19 @@ public class MethodInputParametersMustBeFinal extends BugChecker
   @SuppressWarnings("TreeToString")
   private boolean isEnum(final ClassTree tree) {
     return tree.toString().contains("enum");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    // isAbstract and isGenerated are transient calculations, not relevant to equality checks
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    return super.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    // isAbstract and isGenerated are transient calculations, not relevant to equality checks
+    return super.hashCode();
   }
 }

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinalNegativeCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinalNegativeCases.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.errorpronechecks;
 
+import javax.annotation.processing.Generated;
+
 public class MethodInputParametersMustBeFinalNegativeCases {
 
   public void noInputParameters() {}
@@ -27,4 +29,31 @@ public class MethodInputParametersMustBeFinalNegativeCases {
   public interface allInterfacesAreValid {
     void parameterCannotBeFinal(int value);
   }
+}
+
+@Generated(value="test", comments="Every method is buggy, but ignored because the class has been tagged generated")
+class MethodInputParametersMustBeFinalPositiveCasesBugGenerated1 {
+
+  public void primativeInputMethod(int value) {}
+
+  public void objectInputMethod(Object value) {}
+
+  public void mixedInputMethod(Object value, int anotherValue) {}
+
+  @Generated(value="test", comments="Every method is buggy, but ignored because the class has been tagged generated")
+  public abstract class abstractClassDefinition {
+    public void concreteMethodsAreIncluded(int value) {}
+  }
+
+  public void varArgsInputMethod(String... value) {}
+}
+
+@Generated(
+    value = "test",
+    comments = "Every method is buggy, but ignored because the class has been tagged generated")
+class MethodInputParametersMustBeFinalPositiveCasesBugGenerated2 {
+
+  public void mixedInputMethodFirstFinal(final Object value, int anotherValue) {}
+
+  public void mixedInputMethodSecondFinal(Object value, final int anotherValue) {}
 }

--- a/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinalNegativeCases.java
+++ b/errorprone-checks/src/test/resources/org/hyperledger/errorpronechecks/MethodInputParametersMustBeFinalNegativeCases.java
@@ -31,7 +31,9 @@ public class MethodInputParametersMustBeFinalNegativeCases {
   }
 }
 
-@Generated(value="test", comments="Every method is buggy, but ignored because the class has been tagged generated")
+@Generated(
+    value = "test",
+    comments = "Every method is buggy, but ignored because the class has been tagged generated")
 class MethodInputParametersMustBeFinalPositiveCasesBugGenerated1 {
 
   public void primativeInputMethod(int value) {}
@@ -40,7 +42,9 @@ class MethodInputParametersMustBeFinalPositiveCasesBugGenerated1 {
 
   public void mixedInputMethod(Object value, int anotherValue) {}
 
-  @Generated(value="test", comments="Every method is buggy, but ignored because the class has been tagged generated")
+  @Generated(
+      value = "test",
+      comments = "Every method is buggy, but ignored because the class has been tagged generated")
   public abstract class abstractClassDefinition {
     public void concreteMethodsAreIncluded(int value) {}
   }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Custom ErrorProne checks should not be validating generated code we cannot change, hence the "method params must be final" ErrorProne check will not fire in classes with a "generated" annotation.  This covers Dagger generated code.

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [X] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).