### PR TITLE
Re-enable integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -344,6 +344,7 @@ subprojects {
       testClassesDirs = sourceSets.integrationTest.output.classesDirs
       classpath = sourceSets.integrationTest.runtimeClasspath
       outputs.upToDateWhen { false }
+      useJUnitPlatform {}
     }
   }
 

--- a/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
+++ b/enclave/src/integration-test/java/org/hyperledger/besu/enclave/EnclaveTest.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import org.hyperledger.besu.enclave.types.PrivacyGroup;
 import org.hyperledger.besu.enclave.types.ReceiveResponse;
 import org.hyperledger.besu.enclave.types.SendResponse;
+
+import org.hyperledger.enclave.testutil.EnclaveEncryptorType;
 import org.hyperledger.enclave.testutil.EnclaveKeyConfiguration;
 import org.hyperledger.enclave.testutil.TesseraTestHarness;
 import org.hyperledger.enclave.testutil.TesseraTestHarnessFactory;
@@ -47,11 +49,11 @@ public class EnclaveTest {
 
   private static final String PAYLOAD = "a wonderful transaction";
   private static final String MOCK_KEY = "iOCzoGo5kwtZU0J41Z9xnGXHN6ZNukIa9MspvHtu3Jk=";
-  private static Enclave enclave;
+  private Enclave enclave;
   private Vertx vertx;
   private EnclaveFactory factory;
 
-  private static TesseraTestHarness testHarness;
+  private TesseraTestHarness testHarness;
 
   @BeforeEach
   public void setUp() throws Exception {
@@ -62,7 +64,10 @@ public class EnclaveTest {
         TesseraTestHarnessFactory.create(
             "enclave",
             Files.createTempDirectory(folder, "enclave"),
-            new EnclaveKeyConfiguration("enclave_key_0.pub", "enclave_key_0.key"),
+            new EnclaveKeyConfiguration(
+                new String[] {"enclave_key_0.pub"},
+                new String[] {"enclave_key_0.key"},
+                EnclaveEncryptorType.NOOP),
             Optional.empty());
 
     testHarness.start();


### PR DESCRIPTION

## PR description

When Integration tests were migrated to JUnit 5 the gradle configuration
was not added.  Also, fix an NPE.

## Fixed Issue(s)

Fixes #4852 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).