### PR TITLE
Worldstate-only resync behavior

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -34,6 +34,7 @@ public enum RpcMethod {
   CLIQUE_GET_SIGNER_METRICS("clique_getSignerMetrics"),
   DEBUG_ACCOUNT_AT("debug_accountAt"),
   DEBUG_METRICS("debug_metrics"),
+  DEBUG_RESYNC_WORLDSTATE("debug_resyncWorldState"),
   DEBUG_SET_HEAD("debug_setHead"),
   DEBUG_REPLAY_BLOCK("debug_replayBlock"),
   DEBUG_STORAGE_RANGE_AT("debug_storageRangeAt"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
@@ -20,7 +20,7 @@ public class DebugResyncWorldstate implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
-      return new JsonRpcSuccessResponse(request.getRequest().getId(), synchronizer.resyncWorldState());
+    return new JsonRpcSuccessResponse(
+        request.getRequest().getId(), synchronizer.resyncWorldState());
   }
-
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
@@ -1,0 +1,26 @@
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
+
+public class DebugResyncWorldstate implements JsonRpcMethod {
+  private final Synchronizer synchronizer;
+
+  public DebugResyncWorldstate(final Synchronizer synchronizer) {
+    this.synchronizer = synchronizer;
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.DEBUG_RESYNC_WORLDSTATE.getMethodName();
+  }
+
+  @Override
+  public JsonRpcResponse response(final JsonRpcRequestContext request) {
+      return new JsonRpcSuccessResponse(request.getRequest().getId(), synchronizer.resyncWorldState());
+  }
+
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
@@ -1,16 +1,39 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 public class DebugResyncWorldstate implements JsonRpcMethod {
   private final Synchronizer synchronizer;
+  private final ProtocolSchedule protocolSchedule;
+  private final Blockchain blockchain;
 
-  public DebugResyncWorldstate(final Synchronizer synchronizer) {
+  public DebugResyncWorldstate(
+      final ProtocolSchedule protocolSchedule,
+      final Blockchain blockchain,
+      final Synchronizer synchronizer) {
     this.synchronizer = synchronizer;
+    this.protocolSchedule = protocolSchedule;
+    this.blockchain = blockchain;
   }
 
   @Override
@@ -20,6 +43,10 @@ public class DebugResyncWorldstate implements JsonRpcMethod {
 
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
+    protocolSchedule
+        .getByBlockNumber(blockchain.getChainHeadBlockNumber())
+        .getBadBlocksManager()
+        .reset();
     return new JsonRpcSuccessResponse(
         request.getRequest().getId(), synchronizer.resyncWorldState());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugAccountRa
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugBatchSendRawTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugGetBadBlocks;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugMetrics;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugResyncWorldstate;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugSetHead;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugStandardTraceBadBlockToFile;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.DebugStandardTraceBlockToFile;
@@ -36,6 +37,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduleBasedBlockHeaderFunctions;
@@ -53,6 +55,7 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ProtocolSchedule protocolSchedule;
   private final ObservableMetricsSystem metricsSystem;
   private final TransactionPool transactionPool;
+  private final Synchronizer synchronizer;
   private final Path dataDir;
 
   DebugJsonRpcMethods(
@@ -61,12 +64,14 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
       final ProtocolSchedule protocolSchedule,
       final ObservableMetricsSystem metricsSystem,
       final TransactionPool transactionPool,
+      final Synchronizer synchronizer,
       final Path dataDir) {
     this.blockchainQueries = blockchainQueries;
     this.protocolContext = protocolContext;
     this.protocolSchedule = protocolSchedule;
     this.metricsSystem = metricsSystem;
     this.transactionPool = transactionPool;
+    this.synchronizer = synchronizer;
     this.dataDir = dataDir;
   }
 
@@ -88,6 +93,7 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new DebugAccountRange(blockchainQueries),
         new DebugStorageRangeAt(blockchainQueries, blockReplay),
         new DebugMetrics(metricsSystem),
+        new DebugResyncWorldstate(synchronizer),
         new DebugTraceBlock(
             () -> new BlockTracer(blockReplay),
             ScheduleBasedBlockHeaderFunctions.create(protocolSchedule),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -93,7 +93,7 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new DebugAccountRange(blockchainQueries),
         new DebugStorageRangeAt(blockchainQueries, blockReplay),
         new DebugMetrics(metricsSystem),
-        new DebugResyncWorldstate(synchronizer),
+        new DebugResyncWorldstate(protocolSchedule, protocolContext.getBlockchain(), synchronizer),
         new DebugTraceBlock(
             () -> new BlockTracer(blockReplay),
             ScheduleBasedBlockHeaderFunctions.create(protocolSchedule),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -100,6 +100,7 @@ public class JsonRpcMethodsFactory {
                   protocolSchedule,
                   metricsSystem,
                   transactionPool,
+                  synchronizer,
                   dataDir),
               new EeaJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockManager.java
@@ -49,6 +49,12 @@ public class BadBlockManager {
     }
   }
 
+  public void reset() {
+    this.badBlocks.invalidateAll();
+    this.badHeaders.invalidateAll();
+    this.latestValidHashes.invalidateAll();
+  }
+
   /**
    * Return all invalid blocks
    *

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Synchronizer.java
@@ -40,6 +40,8 @@ public interface Synchronizer {
    */
   Optional<SyncStatus> getSyncStatus();
 
+  boolean resyncWorldState();
+
   long subscribeSyncStatus(final BesuEvents.SyncStatusListener listener);
 
   boolean unsubscribeSyncStatus(long observerId);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -50,6 +50,7 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,8 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
   private final SyncState syncState;
   private final AtomicBoolean running = new AtomicBoolean(false);
   private final Optional<BlockPropagationManager> blockPropagationManager;
-  private final Optional<FastSyncDownloader<?>> fastSyncDownloader;
+  private final Function<Boolean, Optional<FastSyncDownloader<?>>> fastSyncFactory;
+  private Optional<FastSyncDownloader<?>> fastSyncDownloader;
   private final Optional<FullSyncDownloader> fullSyncDownloader;
   private final EthContext ethContext;
   private final ProtocolContext protocolContext;
@@ -133,47 +135,56 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
                     terminationCondition));
 
     if (SyncMode.FAST.equals(syncConfig.getSyncMode())) {
-      this.fastSyncDownloader =
-          FastDownloaderFactory.create(
-              pivotBlockSelector,
-              syncConfig,
-              dataDirectory,
-              protocolSchedule,
-              protocolContext,
-              metricsSystem,
-              ethContext,
-              worldStateStorage,
-              syncState,
-              clock);
+      this.fastSyncFactory =
+          (isResync) ->
+              FastDownloaderFactory.create(
+                  pivotBlockSelector,
+                  syncConfig,
+                  dataDirectory,
+                  protocolSchedule,
+                  protocolContext,
+                  metricsSystem,
+                  ethContext,
+                  worldStateStorage,
+                  syncState,
+                  clock,
+                  isResync);
     } else if (SyncMode.X_CHECKPOINT.equals(syncConfig.getSyncMode())) {
-      this.fastSyncDownloader =
-          CheckpointDownloaderFactory.createCheckpointDownloader(
-              new SnapPersistedContext(storageProvider),
-              pivotBlockSelector,
-              syncConfig,
-              dataDirectory,
-              protocolSchedule,
-              protocolContext,
-              metricsSystem,
-              ethContext,
-              worldStateStorage,
-              syncState,
-              clock);
+      this.fastSyncFactory =
+          (isResync) ->
+              CheckpointDownloaderFactory.createCheckpointDownloader(
+                  new SnapPersistedContext(storageProvider),
+                  pivotBlockSelector,
+                  syncConfig,
+                  dataDirectory,
+                  protocolSchedule,
+                  protocolContext,
+                  metricsSystem,
+                  ethContext,
+                  worldStateStorage,
+                  syncState,
+                  clock,
+                  isResync);
     } else {
-      this.fastSyncDownloader =
-          SnapDownloaderFactory.createSnapDownloader(
-              new SnapPersistedContext(storageProvider),
-              pivotBlockSelector,
-              syncConfig,
-              dataDirectory,
-              protocolSchedule,
-              protocolContext,
-              metricsSystem,
-              ethContext,
-              worldStateStorage,
-              syncState,
-              clock);
+      this.fastSyncFactory =
+          (isResync) ->
+              SnapDownloaderFactory.createSnapDownloader(
+                  new SnapPersistedContext(storageProvider),
+                  pivotBlockSelector,
+                  syncConfig,
+                  dataDirectory,
+                  protocolSchedule,
+                  protocolContext,
+                  metricsSystem,
+                  ethContext,
+                  worldStateStorage,
+                  syncState,
+                  clock,
+                  isResync);
     }
+
+    // create a non-resync fast sync downloader:
+    this.fastSyncDownloader = this.fastSyncFactory.apply(false);
 
     metricsSystem.createLongGauge(
         BesuMetricCategory.ETHEREUM,
@@ -209,7 +220,6 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
       CompletableFuture<Void> future;
       if (fastSyncDownloader.isPresent()) {
         future = fastSyncDownloader.get().start().thenCompose(this::handleSyncResult);
-
       } else {
         syncState.markInitialSyncPhaseAsDone();
         enableFallbackNodeFinder();
@@ -303,6 +313,25 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
       return Optional.empty();
     }
     return syncState.syncStatus();
+  }
+
+  @Override
+  public boolean resyncWorldState() {
+    // if we do not have a fast sync mode configured, return false
+    if (!fastSyncDownloader.isPresent()) {
+      return false;
+    }
+
+    // if sync is running currently, stop it and delete the fast sync state
+    if (running.get()) {
+      stop();
+      fastSyncDownloader.get().deleteFastSyncState();
+    }
+
+    // recreate fast sync with resync and start
+    this.fastSyncDownloader = this.fastSyncFactory.apply(true);
+    start();
+    return true;
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/DefaultSynchronizer.java
@@ -317,18 +317,14 @@ public class DefaultSynchronizer implements Synchronizer, UnverifiedForkchoiceLi
 
   @Override
   public boolean resyncWorldState() {
-    // if we do not have a fast sync mode configured, return false
-    if (!fastSyncDownloader.isPresent()) {
-      return false;
-    }
-
     // if sync is running currently, stop it and delete the fast sync state
-    if (running.get()) {
+    if (fastSyncDownloader.isPresent() && running.get()) {
       stop();
       fastSyncDownloader.get().deleteFastSyncState();
     }
 
     // recreate fast sync with resync and start
+    this.syncState.markInitialSyncRestart();
     this.fastSyncDownloader = this.fastSyncFactory.apply(true);
     start();
     return true;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncAlgorithm.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardsSyncAlgorithm.java
@@ -24,21 +24,25 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.eth.manager.task.WaitForPeersTask;
+import org.hyperledger.besu.plugin.services.BesuEvents;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 
-public class BackwardsSyncAlgorithm {
+public class BackwardsSyncAlgorithm implements BesuEvents.InitialSyncCompletionListener {
   private static final Logger LOG = getLogger(BackwardsSyncAlgorithm.class);
 
   private final BackwardSyncContext context;
   private final FinalBlockConfirmation finalBlockConfirmation;
+  private final AtomicReference<CountDownLatch> latch =
+      new AtomicReference<>(new CountDownLatch(1));
   private volatile boolean finished = false;
 
   public BackwardsSyncAlgorithm(
@@ -125,19 +129,16 @@ public class BackwardsSyncAlgorithm {
 
   @VisibleForTesting
   protected CompletableFuture<Void> waitForReady() {
-    final CountDownLatch latch = new CountDownLatch(1);
-    final long idTTD =
-        context.getSyncState().subscribeTTDReached(reached -> countDownIfReady(latch));
-    final long idIS =
-        context.getSyncState().subscribeCompletionReached(() -> countDownIfReady(latch));
-    return CompletableFuture.runAsync(() -> checkReadiness(latch, idTTD, idIS));
+    final long idTTD = context.getSyncState().subscribeTTDReached(reached -> countDownIfReady());
+    final long idIS = context.getSyncState().subscribeCompletionReached(this);
+    return CompletableFuture.runAsync(() -> checkReadiness(idTTD, idIS));
   }
 
-  private void checkReadiness(final CountDownLatch latch, final long idTTD, final long idIS) {
+  private void checkReadiness(final long idTTD, final long idIS) {
     try {
       if (!context.isReady()) {
         LOG.debug("Waiting for preconditions...");
-        final boolean await = latch.await(2, TimeUnit.MINUTES);
+        final boolean await = latch.get().await(2, TimeUnit.MINUTES);
         if (await) {
           LOG.debug("Preconditions meet, ensure at least one peer is connected");
           waitForPeers(1).get();
@@ -156,9 +157,9 @@ public class BackwardsSyncAlgorithm {
     }
   }
 
-  private void countDownIfReady(final CountDownLatch latch) {
+  private void countDownIfReady() {
     if (context.isReady()) {
-      latch.countDown();
+      latch.get().countDown();
     }
   }
 
@@ -166,5 +167,15 @@ public class BackwardsSyncAlgorithm {
     final WaitForPeersTask waitForPeersTask =
         WaitForPeersTask.create(context.getEthContext(), count, context.getMetricsSystem());
     return waitForPeersTask.run();
+  }
+
+  @Override
+  public void onInitialSyncCompleted() {
+    countDownIfReady();
+  }
+
+  @Override
+  public void onInitialSyncRestart() {
+    latch.set(new CountDownLatch(1));
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
@@ -83,6 +83,7 @@ public class CheckpointDownloaderFactory extends SnapDownloaderFactory {
     final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
     if (shouldResync) {
       snapContext.clear();
+      worldStateStorage.clear();
     }
 
     if (!shouldResync

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
@@ -60,7 +60,8 @@ public class CheckpointDownloaderFactory extends SnapDownloaderFactory {
       final EthContext ethContext,
       final WorldStateStorage worldStateStorage,
       final SyncState syncState,
-      final Clock clock) {
+      final Clock clock,
+      final boolean isResync) {
 
     final Path fastSyncDataDirectory = dataDirectory.resolve(FAST_SYNC_FOLDER);
     final FastSyncStateStorage fastSyncStateStorage =
@@ -80,13 +81,12 @@ public class CheckpointDownloaderFactory extends SnapDownloaderFactory {
     final FastSyncState fastSyncState =
         fastSyncStateStorage.loadState(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule));
 
-    final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
-    if (shouldResync) {
+    if (isResync) {
       snapContext.clear();
       worldStateStorage.clear();
     }
 
-    if (!shouldResync
+    if (!isResync
         && fastSyncState.getPivotBlockHeader().isEmpty()
         && protocolContext.getBlockchain().getChainHeadBlockNumber()
             != BlockHeader.GENESIS_BLOCK_NUMBER) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckpointDownloaderFactory.java
@@ -79,7 +79,14 @@ public class CheckpointDownloaderFactory extends SnapDownloaderFactory {
 
     final FastSyncState fastSyncState =
         fastSyncStateStorage.loadState(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule));
-    if (fastSyncState.getPivotBlockHeader().isEmpty()
+
+    final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
+    if (shouldResync) {
+      snapContext.clear();
+    }
+
+    if (!shouldResync
+        && fastSyncState.getPivotBlockHeader().isEmpty()
         && protocolContext.getBlockchain().getChainHeadBlockNumber()
             != BlockHeader.GENESIS_BLOCK_NUMBER) {
       LOG.info(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -85,14 +85,16 @@ public class FastDownloaderFactory {
 
     final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
 
-    if (!shouldResync
-        && fastSyncState.getPivotBlockHeader().isEmpty()
+    if (shouldResync) {
+      worldStateStorage.clear();
+    } else if (fastSyncState.getPivotBlockHeader().isEmpty()
         && protocolContext.getBlockchain().getChainHeadBlockNumber()
             != BlockHeader.GENESIS_BLOCK_NUMBER) {
       LOG.info(
           "Fast sync was requested, but cannot be enabled because the local blockchain is not empty.");
       return Optional.empty();
     }
+
     if (worldStateStorage instanceof BonsaiWorldStateKeyValueStorage) {
       worldStateStorage.clearFlatDatabase();
     } else {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
 public class FastDownloaderFactory {
 
   protected static final String FAST_SYNC_FOLDER = "fastsync";
-  protected static final String FAST_SYNC_RESYNC = "resync";
+  protected static final String FAST_SYNC_RESYNC = FAST_SYNC_FOLDER + "/resync";
 
   private static final Logger LOG = LoggerFactory.getLogger(FastDownloaderFactory.class);
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastDownloaderFactory.java
@@ -40,7 +40,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -79,6 +79,7 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
     final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
     if (shouldResync) {
       snapContext.clear();
+      worldStateStorage.clear();
     }
 
     if (!shouldResync

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -75,7 +75,14 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
 
     final FastSyncState fastSyncState =
         fastSyncStateStorage.loadState(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule));
-    if (fastSyncState.getPivotBlockHeader().isEmpty()
+
+    final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
+    if (shouldResync) {
+      snapContext.clear();
+    }
+
+    if (!shouldResync
+        && fastSyncState.getPivotBlockHeader().isEmpty()
         && protocolContext.getBlockchain().getChainHeadBlockNumber()
             != BlockHeader.GENESIS_BLOCK_NUMBER) {
       LOG.info(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapDownloaderFactory.java
@@ -56,7 +56,8 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
       final EthContext ethContext,
       final WorldStateStorage worldStateStorage,
       final SyncState syncState,
-      final Clock clock) {
+      final Clock clock,
+      final boolean isResync) {
 
     final Path fastSyncDataDirectory = dataDirectory.resolve(FAST_SYNC_FOLDER);
     final FastSyncStateStorage fastSyncStateStorage =
@@ -76,13 +77,12 @@ public class SnapDownloaderFactory extends FastDownloaderFactory {
     final FastSyncState fastSyncState =
         fastSyncStateStorage.loadState(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule));
 
-    final boolean shouldResync = shouldResyncWorldstate(dataDirectory.resolve(FAST_SYNC_RESYNC));
-    if (shouldResync) {
+    if (isResync) {
       snapContext.clear();
       worldStateStorage.clear();
     }
 
-    if (!shouldResync
+    if (!isResync
         && fastSyncState.getPivotBlockHeader().isEmpty()
         && protocolContext.getBlockchain().getChainHeadBlockNumber()
             != BlockHeader.GENESIS_BLOCK_NUMBER) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/state/SyncState.java
@@ -319,4 +319,9 @@ public class SyncState {
   public boolean isInitialSyncPhaseDone() {
     return isInitialSyncPhaseDone;
   }
+
+  public void markInitialSyncRestart() {
+    isInitialSyncPhaseDone = false;
+    completionListenerSubscribers.forEach(InitialSyncCompletionListener::onInitialSyncRestart);
+  }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
@@ -25,12 +25,14 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class NewPooledTransactionHashesMessageHandler implements EthMessages.MessageCallback {
 
   private final NewPooledTransactionHashesMessageProcessor transactionsMessageProcessor;
   private final EthScheduler scheduler;
   private final Duration txMsgKeepAlive;
+  private final AtomicBoolean isEnabled = new AtomicBoolean(true);
 
   public NewPooledTransactionHashesMessageHandler(
       final EthScheduler scheduler,
@@ -47,9 +49,19 @@ class NewPooledTransactionHashesMessageHandler implements EthMessages.MessageCal
     final NewPooledTransactionHashesMessage transactionsMessage =
         NewPooledTransactionHashesMessage.readFrom(message.getData(), capability);
     final Instant startedAt = now();
-    scheduler.scheduleTxWorkerTask(
-        () ->
-            transactionsMessageProcessor.processNewPooledTransactionHashesMessage(
-                message.getPeer(), transactionsMessage, startedAt, txMsgKeepAlive));
+    if (isEnabled.get()) {
+      scheduler.scheduleTxWorkerTask(
+          () ->
+              transactionsMessageProcessor.processNewPooledTransactionHashesMessage(
+                  message.getPeer(), transactionsMessage, startedAt, txMsgKeepAlive));
+    }
+  }
+
+  public void enable() {
+    isEnabled.set(true);
+  }
+
+  public void disable() {
+    isEnabled.set(false);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
@@ -57,11 +57,15 @@ class NewPooledTransactionHashesMessageHandler implements EthMessages.MessageCal
     }
   }
 
-  public void enable() {
+  public void setEnabled() {
     isEnabled.set(true);
   }
 
-  public void disable() {
+  public void setDisabled() {
     isEnabled.set(false);
+  }
+
+  public boolean isEnabled() {
+    return isEnabled.get();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -33,6 +33,11 @@ public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
   private final Map<EthPeer, Set<Hash>> seenTransactions = new ConcurrentHashMap<>();
   private final Map<EthPeer, Set<Transaction>> transactionsToSend = new ConcurrentHashMap<>();
 
+  public void reset() {
+    seenTransactions.clear();
+    transactionsToSend.clear();
+  }
+
   public synchronized void markTransactionsAsSeen(
       final EthPeer peer, final Collection<Transaction> transactions) {
     markTransactionHashesAsSeen(peer, toHashList(transactions));

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -431,15 +431,19 @@ public class TransactionPool implements BlockAddedObserver {
     }
   }
 
-  public void enable() {
+  public void setEnabled() {
     isPoolEnabled.set(true);
   }
 
-  public void disable() {
+  public void setDisabled() {
     //    should disable:
     //    block added listener / behavior
     //    transactionsMessageHandler
     //    pooledTransactionsMessageHandler
     isPoolEnabled.set(false);
+  }
+
+  public boolean isEnabled() {
+    return isPoolEnabled.get();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -436,10 +436,6 @@ public class TransactionPool implements BlockAddedObserver {
   }
 
   public void setDisabled() {
-    //    should disable:
-    //    block added listener / behavior
-    //    transactionsMessageHandler
-    //    pooledTransactionsMessageHandler
     isPoolEnabled.set(false);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -79,6 +80,7 @@ public class TransactionPool implements BlockAddedObserver {
   private final MiningParameters miningParameters;
   private final LabelledMetric<Counter> duplicateTransactionCounter;
   private final TransactionPoolConfiguration configuration;
+  private final AtomicBoolean isPoolEnabled = new AtomicBoolean(true);
 
   public TransactionPool(
       final AbstractPendingTransactionsSorter pendingTransactions,
@@ -222,9 +224,11 @@ public class TransactionPool implements BlockAddedObserver {
   @Override
   public void onBlockAdded(final BlockAddedEvent event) {
     LOG.trace("Block added event {}", event);
-    event.getAddedTransactions().forEach(pendingTransactions::transactionAddedToBlock);
-    pendingTransactions.manageBlockAdded(event.getBlock());
-    reAddTransactions(event.getRemovedTransactions());
+    if (isPoolEnabled.get()) {
+      event.getAddedTransactions().forEach(pendingTransactions::transactionAddedToBlock);
+      pendingTransactions.manageBlockAdded(event.getBlock());
+      reAddTransactions(event.getRemovedTransactions());
+    }
   }
 
   private void reAddTransactions(final List<Transaction> reAddTransactions) {
@@ -425,5 +429,17 @@ public class TransactionPool implements BlockAddedObserver {
     static ValidationResultAndAccount invalid(final TransactionInvalidReason reason) {
       return new ValidationResultAndAccount(ValidationResult.invalid(reason));
     }
+  }
+
+  public void enable() {
+    isPoolEnabled.set(true);
+  }
+
+  public void disable() {
+    //    should disable:
+    //    block added listener / behavior
+    //    transactionsMessageHandler
+    //    pooledTransactionsMessageHandler
+    isPoolEnabled.set(false);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -112,6 +112,10 @@ public class TransactionPool implements BlockAddedObserver {
     transactionBroadcaster.relayTransactionPoolTo(peer);
   }
 
+  public void reset() {
+    pendingTransactions.reset();
+  }
+
   public ValidationResult<TransactionInvalidReason> addLocalTransaction(
       final Transaction transaction) {
     final ValidationResultAndAccount validationResult = validateLocalTransaction(transaction);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -137,6 +137,8 @@ public class TransactionPoolFactory {
           @Override
           public void onInitialSyncCompleted() {
             LOG.info("Enabling transaction handling following initial sync");
+            transactionPool.reset();
+            transactionTracker.reset();
             transactionPool.setEnabled();
             transactionsMessageHandler.setEnabled();
             pooledTransactionsMessageHandler.setEnabled();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -127,9 +127,9 @@ public class TransactionPoolFactory {
 
     if (!syncState.isInitialSyncPhaseDone()) {
       LOG.info("Disabling transaction handling during initial sync");
-      pooledTransactionsMessageHandler.disable();
-      transactionsMessageHandler.disable();
-      transactionPool.disable();
+      pooledTransactionsMessageHandler.setDisabled();
+      transactionsMessageHandler.setDisabled();
+      transactionPool.setDisabled();
     }
 
     syncState.subscribeCompletionReached(
@@ -137,17 +137,17 @@ public class TransactionPoolFactory {
           @Override
           public void onInitialSyncCompleted() {
             LOG.info("Enabling transaction handling following initial sync");
-            transactionPool.enable();
-            transactionsMessageHandler.enable();
-            pooledTransactionsMessageHandler.enable();
+            transactionPool.setEnabled();
+            transactionsMessageHandler.setEnabled();
+            pooledTransactionsMessageHandler.setEnabled();
           }
 
           @Override
           public void onInitialSyncRestart() {
             LOG.info("Disabling transaction handling during re-sync");
-            pooledTransactionsMessageHandler.disable();
-            transactionsMessageHandler.disable();
-            transactionPool.disable();
+            pooledTransactionsMessageHandler.setDisabled();
+            transactionsMessageHandler.setDisabled();
+            transactionPool.setDisabled();
           }
         });
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
@@ -23,12 +23,14 @@ import org.hyperledger.besu.ethereum.eth.messages.TransactionsMessage;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class TransactionsMessageHandler implements EthMessages.MessageCallback {
 
   private final TransactionsMessageProcessor transactionsMessageProcessor;
   private final EthScheduler scheduler;
   private final Duration txMsgKeepAlive;
+  private final AtomicBoolean isEnabled = new AtomicBoolean(true);
 
   public TransactionsMessageHandler(
       final EthScheduler scheduler,
@@ -43,9 +45,19 @@ class TransactionsMessageHandler implements EthMessages.MessageCallback {
   public void exec(final EthMessage message) {
     final TransactionsMessage transactionsMessage = TransactionsMessage.readFrom(message.getData());
     final Instant startedAt = now();
-    scheduler.scheduleTxWorkerTask(
-        () ->
-            transactionsMessageProcessor.processTransactionsMessage(
-                message.getPeer(), transactionsMessage, startedAt, txMsgKeepAlive));
+    if (isEnabled.get()) {
+      scheduler.scheduleTxWorkerTask(
+          () ->
+              transactionsMessageProcessor.processTransactionsMessage(
+                  message.getPeer(), transactionsMessage, startedAt, txMsgKeepAlive));
+    }
+  }
+
+  public void disable() {
+    isEnabled.set(false);
+  }
+
+  public void enable() {
+    isEnabled.set(true);
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
@@ -53,11 +53,15 @@ class TransactionsMessageHandler implements EthMessages.MessageCallback {
     }
   }
 
-  public void disable() {
+  public void setDisabled() {
     isEnabled.set(false);
   }
 
-  public void enable() {
+  public void setEnabled() {
     isEnabled.set(true);
+  }
+
+  public boolean isEnabled() {
+    return isEnabled.get();
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -134,6 +134,12 @@ public abstract class AbstractPendingTransactionsSorter {
         pendingTransactions::size);
   }
 
+  public void reset() {
+    pendingTransactions.clear();
+    transactionsBySender.clear();
+    lowestInvalidKnownNonceCache.reset();
+  }
+
   public void evictOldTransactions() {
     final Instant removeTransactionsBefore =
         clock.instant().minus(poolConfig.getPendingTxRetentionPeriod(), ChronoUnit.HOURS);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/BaseFeePendingTransactionsSorter.java
@@ -94,6 +94,13 @@ public class BaseFeePendingTransactionsSorter extends AbstractPendingTransaction
               .reversed());
 
   @Override
+  public void reset() {
+    super.reset();
+    prioritizedTransactionsStaticRange.clear();
+    prioritizedTransactionsDynamicRange.clear();
+  }
+
+  @Override
   public void manageBlockAdded(final Block block) {
     block.getHeader().getBaseFee().ifPresent(this::updateBaseFee);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/GasPricePendingTransactionsSorter.java
@@ -53,6 +53,12 @@ public class GasPricePendingTransactionsSorter extends AbstractPendingTransactio
   }
 
   @Override
+  public void reset() {
+    super.reset();
+    prioritizedTransactions.clear();
+  }
+
+  @Override
   public void manageBlockAdded(final Block block) {
     // nothing to do
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/LowestInvalidNonceCache.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/LowestInvalidNonceCache.java
@@ -126,6 +126,11 @@ class LowestInvalidNonceCache {
         + '}';
   }
 
+  public void reset() {
+    lowestInvalidKnownNonceBySender.clear();
+    evictionOrder.clear();
+  }
+
   private static class InvalidNonceStatus implements Comparable<InvalidNonceStatus> {
 
     final Address address;

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastDownloaderFactoryTest.java
@@ -80,7 +80,8 @@ public class FastDownloaderFactoryTest {
                     ethContext,
                     worldStateStorage,
                     syncState,
-                    clock))
+                    clock,
+                    false))
         .isInstanceOf(IllegalStateException.class);
   }
 
@@ -101,7 +102,8 @@ public class FastDownloaderFactoryTest {
             ethContext,
             worldStateStorage,
             syncState,
-            clock);
+            clock,
+            false);
     assertThat(result).isEmpty();
   }
 
@@ -125,7 +127,8 @@ public class FastDownloaderFactoryTest {
         ethContext,
         worldStateStorage,
         syncState,
-        clock);
+        clock,
+        false);
 
     verify(mutableBlockchain).getChainHeadBlockNumber();
   }
@@ -155,7 +158,8 @@ public class FastDownloaderFactoryTest {
         ethContext,
         worldStateStorage,
         syncState,
-        clock);
+        clock,
+        false);
 
     verify(worldStateStorage).clear();
     assertThat(Files.exists(stateQueueDir)).isFalse();
@@ -187,7 +191,8 @@ public class FastDownloaderFactoryTest {
                     ethContext,
                     worldStateStorage,
                     syncState,
-                    clock))
+                    clock,
+                    false))
         .isInstanceOf(IllegalStateException.class);
   }
 

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/DummySynchronizer.java
@@ -45,6 +45,11 @@ public class DummySynchronizer implements Synchronizer {
   }
 
   @Override
+  public boolean resyncWorldState() {
+    return false;
+  }
+
+  @Override
   public long subscribeSyncStatus(final BesuEvents.SyncStatusListener listener) {
     return 0;
   }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -66,7 +66,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'nBDCEeFH318uhGZEBmuTGOfYLI1+9tLDyjn/RDe5saI='
+  knownHash = 'vFf6OIL506w5+DvYxs7btZcCnVpkuRw5WjzWUkrPeu4='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuEvents.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BesuEvents.java
@@ -253,5 +253,8 @@ public interface BesuEvents extends BesuService {
 
     /** Emitted when initial sync finishes */
     void onInitialSyncCompleted();
+
+    /** Emitted when initial sync restarts */
+    void onInitialSyncRestart();
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Implements a  debug rpc endpoint and a behavior to resync just the worldstate.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).