### PR TITLE
Peering - disconnect worst peer

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
@@ -48,7 +48,7 @@ public enum TransactionInvalidReason {
   PRIVATE_VALUE_NOT_ZERO,
   PRIVATE_UNIMPLEMENTED_TRANSACTION_TYPE,
   INTERNAL_ERROR,
-  // Quroum Compatibility Invalid Reasons
+  // Quorum Compatibility Invalid Reasons
   GAS_PRICE_MUST_BE_ZERO,
   ETHER_VALUE_NOT_SUPPORTED,
   UPFRONT_FEE_TOO_HIGH,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -14,9 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager;
 
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.infoLambda;
+
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer.DisconnectCallback;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.permissioning.NodeMessagePermissioningProvider;
@@ -244,6 +247,22 @@ public class EthPeers {
 
   public Comparator<EthPeer> getBestChainComparator() {
     return bestPeerComparator;
+  }
+
+  public void disconnectWorstUselessPeer() {
+    streamAvailablePeers()
+        .sorted(getBestChainComparator())
+        .findFirst()
+        .ifPresent(
+            peer -> {
+              infoLambda(
+                  LOG,
+                  "disconnecting peer {}. Waiting for better peers. Current {} of max {}",
+                  peer::toString,
+                  this::peerCount,
+                  this::getMaxPeers);
+              peer.disconnect(DisconnectMessage.DisconnectReason.USELESS_PEER);
+            });
   }
 
   @FunctionalInterface

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -136,7 +136,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
 
   private void refreshPeers() {
     final EthPeers peers = getEthContext().getEthPeers();
-    // If we are near max connections, then refresh peers disconnecting one of the failed peers,
+    // If we are at max connections, then refresh peers disconnecting one of the failed peers,
     // or the least useful
 
     if (peers.peerCount() >= peers.getMaxPeers()) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
@@ -91,7 +91,11 @@ public class GetHeadersFromPeerByHashTask extends AbstractGetHeadersFromPeerTask
   protected PendingPeerRequest sendRequest() {
     return sendRequestToPeer(
         peer -> {
-          LOG.debug("Requesting {} headers from peer {}.", count, peer);
+          LOG.debug(
+              "Requesting {} headers (hash {}...) from peer {}.",
+              count,
+              referenceHash.slice(0, 6),
+              peer);
           return peer.getHeadersByHash(referenceHash, count, skip, reverse);
         });
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByNumberTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByNumberTask.java
@@ -77,7 +77,8 @@ public class GetHeadersFromPeerByNumberTask extends AbstractGetHeadersFromPeerTa
   protected PendingPeerRequest sendRequest() {
     return sendRequestToPeer(
         peer -> {
-          LOG.debug("Requesting {} headers from peer {}.", count, peer);
+          LOG.debug(
+              "Requesting {} headers (blockNumber {}) from peer {}.", count, blockNumber, peer);
           return peer.getHeadersByNumber(blockNumber, count, skip, reverse);
         });
   }


### PR DESCRIPTION
Disconnect "worst" peer in two cases
* AbstractRetryingSwitchingPeerTask - when retrying task with multiple peers and all peers have been tried and found wanting
* FastSyncTargetManager - if best peer is behind the pivot block, disconnect worst peer 
Also add some extra context info to "Best peer" log message

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).