### PR TITLE
Increase cache performance post snapshot fix

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -102,7 +102,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
   @Override
   public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
-    if (shouldClose.get()) {
+    if (isClosed.get()) {
       throw new RuntimeException("Storage is marked to close or has already closed");
     }
     return super.subscribe(sub);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

We detected a regression in the cache after the fix of the snapshot segfault issue. This is due to the fact that the cache tried to use a worldstate storage that was unavailable too soon (not subscribe because shouldClose is true). The cache did not have time to preload enough node and so the calculate root hash is less efficient

the issue is 

- In the validateAndProcessBlock we are doing a copy of the worldState
```java
      try (final var worldState =
        context
            .getWorldStateArchive()
            .getMutable(parentHeader.getStateRoot(), parentHeader.getBlockHash(), shouldPersist)
            .map(
                ws -> {
                  if (!ws.isPersistable()) {
                    return ws.copy();
                  }
                  return ws;
                })
            .orElse(null)) {
```

In our case it was BonsaiLayeredWorldstate

```java
public MutableWorldState copy() {
    // return an in-memory worldstate that is based on a persisted snapshot for this blockhash.
    try (SnapshotMutableWorldState snapshot =
        archive
            .getMutableSnapshot(this.blockHash())
            .map(SnapshotMutableWorldState.class::cast)
            .orElseThrow(
                () ->
                    new StorageException(
                        "Unable to copy Layered Worldstate for " + blockHash().toHexString()))) {
      return new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage());
    } catch (Exception ex) {
      throw new RuntimeException(ex);
    }
  }
```

In this code we can see that we are getting a snapshot and passing the worldstate storage of this snapshot to the BonsaiInMemoryWorldState class. It is a try -with-resources statement so the snapshot will be close at the end of the copy

The close of the snapshot will call the close method of the worldstate storage but this one will not be close because BonsaiInMemoryWorldState subscribed to it . The close snapshot will not close the storage but will set the shouldClose to true. And this is the problem.

when the cache try to subscribe to worldstate storage an exception is raised because this shouldClose is true even if the worldstate is still open 

```java
public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
    if (shouldClose.get()) {
      throw new RuntimeException("Storage is marked to close or has already closed");
    }
    return super.subscribe(sub);
  }
```

The idea is to use isClosed instead of shouldClose during the subscribe 

Here come CPU profiling flame graphs that show the difference before and after the regression 
**Before**

- Calculate Root Hash (Pink part)

<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/212098966-c6b11e66-9e1d-4b4c-a8a9-e9772a9a4746.png">

- Cache Preload

<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/212096887-9a97ae9e-026e-46c9-a9c3-e0040786bd0e.png">

**After**

- Calculate Root Hash (Pink part)

<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/212100089-93f9a402-f3e0-407c-9369-8770dd53ff9b.png">

- Cache Preload
![image](https://user-images.githubusercontent.com/5099602/212104122-77e42da9-2e3c-40b8-a8fb-87ddc326ae84.png)

Zoom on the code snippet that triggers the runtime exception
<img width="1718" alt="image" src="https://user-images.githubusercontent.com/5099602/212097985-f4e5a740-dfc9-495a-953a-77a75794daa4.png">


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).