### PR TITLE
Cherry pick burn-in release 22.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - fix for stale bonsai code storage leading to log rolling issues on contract recreates [#4906](https://github.com/hyperledger/besu/pull/4906)
 
 ### Download Links
+https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.4/besu-22.10.4.tar.gz / sha256: TBD
+https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.4/besu-22.10.4.zip / sha256: TBD
 
 
 ## 22.10.3
@@ -34,6 +36,9 @@
 - Fix storage key format for eth_getProof so that it follows the EIP-1474 spec [#4564](https://github.com/hyperledger/besu/pull/4564)
 
 ### Download Links
+https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.3/besu-22.10.3.tar.gz / sha256: 7213f9445a84a196e94ae1877c6fdb1e51d37bfb19615da02ef5121d4f40e38c
+https://hyperledger.jfrog.io/hyperledger/besu-binaries/besu/22.10.3/besu-22.10.3.zip / sha256: 0bf6bc98e01b0c1045f1b7d841a390c575bc5203c2a4e543d922fbc1ea0d3d5d
+
 
 ## 22.10.2
 This is a hotfix release to resolve a race condition that results in segfaults, introduced in 22.10.1 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+
+## 22.10.4
+
+### Breaking Changes
+
+### Additions and Improvements
+- Use safe block as snap sync pivot block [#4819](https://github.com/hyperledger/besu/pull/4912)
+- Disconnect worst peer when retrying p2p tasks fails [#4888](https://github.com/hyperledger/besu/pull/4888)
+
+### Bug Fixes
+- Fix for segmentation faults on worldstate truncation, snap-sync starts [#4786](https://github.com/hyperledger/besu/pull/4786)
+- Fix for worldstate mismatch on failed forkchoiceUpdate [#4862](https://github.com/hyperledger/besu/pull/4862)
+- Fix for cpu spikes on peer disconnect [#4867](https://github.com/hyperledger/besu/pull/4867)
+- Fix for performance regression in CachedMerkleTrieLoader [#4912](https://github.com/hyperledger/besu/pull/4912)
+- fix for stale bonsai code storage leading to log rolling issues on contract recreates [#4906](https://github.com/hyperledger/besu/pull/4906)
+
+### Download Links
+
+
 ## 22.10.3
 
 ### Breaking Changes

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -61,8 +61,8 @@ import org.hyperledger.besu.ethereum.eth.sync.DefaultSynchronizer;
 import org.hyperledger.besu.ethereum.eth.sync.PivotBlockSelector;
 import org.hyperledger.besu.ethereum.eth.sync.SyncMode;
 import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
-import org.hyperledger.besu.ethereum.eth.sync.fastsync.PivotSelectorFromFinalizedBlock;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.PivotSelectorFromPeers;
+import org.hyperledger.besu.ethereum.eth.sync.fastsync.PivotSelectorFromSafeBlock;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.checkpoint.Checkpoint;
 import org.hyperledger.besu.ethereum.eth.sync.fastsync.checkpoint.ImmutableCheckpoint;
 import org.hyperledger.besu.ethereum.eth.sync.fullsync.SyncTerminationCondition;
@@ -523,7 +523,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             LOG.info("Initial sync done, unsubscribe forkchoice supplier");
           };
 
-      return new PivotSelectorFromFinalizedBlock(
+      return new PivotSelectorFromSafeBlock(
           protocolContext,
           protocolSchedule,
           ethContext,

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -256,16 +256,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               if (ws.isPersistable()) {
                 return ws;
               } else {
-                var wsCopy = ws.copy();
-                try {
-                  ws.close();
-                } catch (Exception ex) {
-                  LOG.error(
-                      "unexpected error closing non-peristable worldstate + "
-                          + parentHeader.toLogString(),
-                      ex);
-                }
-                return wsCopy;
+                // non-persistable worldstates should return a copy which is persistable:
+                return ws.copy();
               }
             })
         .orElseThrow(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/AbstractTrieLogManager.java
@@ -18,7 +18,7 @@ package org.hyperledger.besu.ethereum.bonsai;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.ethereum.bonsai.TrieLogManager.CachedWorldState;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiUpdater;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
@@ -28,27 +28,29 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractTrieLogManager<T extends CachedWorldState> implements TrieLogManager {
+public abstract class AbstractTrieLogManager<T extends MutableWorldState>
+    implements TrieLogManager {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractTrieLogManager.class);
   public static final long RETAINED_LAYERS = 512; // at least 256 + typical rollbacks
 
   protected final Blockchain blockchain;
-  protected final BonsaiWorldStateKeyValueStorage worldStateStorage;
+  protected final BonsaiWorldStateKeyValueStorage rootWorldStateStorage;
 
-  protected final Map<Bytes32, T> cachedWorldStatesByHash;
+  protected final Map<Bytes32, CachedWorldState<T>> cachedWorldStatesByHash;
   protected final long maxLayersToLoad;
 
-  public AbstractTrieLogManager(
+  AbstractTrieLogManager(
       final Blockchain blockchain,
       final BonsaiWorldStateKeyValueStorage worldStateStorage,
       final long maxLayersToLoad,
-      final Map<Bytes32, T> cachedWorldStatesByHash) {
+      final Map<Bytes32, CachedWorldState<T>> cachedWorldStatesByHash) {
     this.blockchain = blockchain;
-    this.worldStateStorage = worldStateStorage;
+    this.rootWorldStateStorage = worldStateStorage;
     this.cachedWorldStatesByHash = cachedWorldStatesByHash;
     this.maxLayersToLoad = maxLayersToLoad;
   }
@@ -57,19 +59,24 @@ public abstract class AbstractTrieLogManager<T extends CachedWorldState> impleme
   public synchronized void saveTrieLog(
       final BonsaiWorldStateArchive worldStateArchive,
       final BonsaiWorldStateUpdater localUpdater,
-      final Hash worldStateRootHash,
-      final BlockHeader blockHeader) {
+      final Hash forWorldStateRootHash,
+      final BlockHeader forBlockHeader,
+      final BonsaiPersistedWorldState forWorldState) {
     // do not overwrite a trielog layer that already exists in the database.
     // if it's only in memory we need to save it
     // for example, in case of reorg we don't replace a trielog layer
-    if (worldStateStorage.getTrieLog(blockHeader.getHash()).isEmpty()) {
-      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater =
-          worldStateStorage.updater();
+    if (rootWorldStateStorage.getTrieLog(forBlockHeader.getHash()).isEmpty()) {
+      final BonsaiUpdater stateUpdater = forWorldState.getWorldStateStorage().updater();
       boolean success = false;
       try {
         final TrieLogLayer trieLog =
-            prepareTrieLog(blockHeader, worldStateRootHash, localUpdater, worldStateArchive);
-        persistTrieLog(blockHeader, worldStateRootHash, trieLog, stateUpdater);
+            prepareTrieLog(
+                forBlockHeader,
+                forWorldStateRootHash,
+                localUpdater,
+                worldStateArchive,
+                forWorldState);
+        persistTrieLog(forBlockHeader, forWorldStateRootHash, trieLog, stateUpdater);
         success = true;
       } finally {
         if (success) {
@@ -81,45 +88,57 @@ public abstract class AbstractTrieLogManager<T extends CachedWorldState> impleme
     }
   }
 
-  private TrieLogLayer prepareTrieLog(
+  protected abstract void addCachedLayer(
       final BlockHeader blockHeader,
-      final Hash currentWorldStateRootHash,
+      final Hash worldStateRootHash,
+      final TrieLogLayer trieLog,
+      final BonsaiWorldStateArchive worldStateArchive,
+      final BonsaiPersistedWorldState forWorldState);
+
+  @VisibleForTesting
+  TrieLogLayer prepareTrieLog(
+      final BlockHeader blockHeader,
+      final Hash worldStateRootHash,
       final BonsaiWorldStateUpdater localUpdater,
-      final BonsaiWorldStateArchive worldStateArchive) {
+      final BonsaiWorldStateArchive worldStateArchive,
+      final BonsaiPersistedWorldState forWorldState) {
     debugLambda(LOG, "Adding layered world state for {}", blockHeader::toLogString);
     final TrieLogLayer trieLog = localUpdater.generateTrieLog(blockHeader.getBlockHash());
     trieLog.freeze();
-    addCachedLayer(blockHeader, currentWorldStateRootHash, trieLog, worldStateArchive);
+    addCachedLayer(blockHeader, worldStateRootHash, trieLog, worldStateArchive, forWorldState);
     scrubCachedLayers(blockHeader.getNumber());
     return trieLog;
   }
 
   synchronized void scrubCachedLayers(final long newMaxHeight) {
-    final long waterline = newMaxHeight - RETAINED_LAYERS;
-    cachedWorldStatesByHash.values().stream()
-        .filter(layer -> layer.getHeight() < waterline)
-        .collect(Collectors.toList())
-        .stream()
-        .forEach(
-            layer -> {
-              cachedWorldStatesByHash.remove(layer.getTrieLog().getBlockHash());
-              Optional.ofNullable(layer.getMutableWorldState())
-                  .ifPresent(
-                      ws -> {
-                        try {
-                          ws.close();
-                        } catch (Exception e) {
-                          LOG.warn("Error closing bonsai worldstate layer", e);
-                        }
-                      });
-            });
+    if (cachedWorldStatesByHash.size() > RETAINED_LAYERS) {
+      final long waterline = newMaxHeight - RETAINED_LAYERS;
+      cachedWorldStatesByHash.values().stream()
+          .filter(layer -> layer.getHeight() < waterline)
+          .collect(Collectors.toList())
+          .stream()
+          .forEach(
+              layer -> {
+                cachedWorldStatesByHash.remove(layer.getTrieLog().getBlockHash());
+                layer.dispose();
+                Optional.ofNullable(layer.getMutableWorldState())
+                    .ifPresent(
+                        ws -> {
+                          try {
+                            ws.close();
+                          } catch (Exception e) {
+                            LOG.warn("Error closing bonsai worldstate layer", e);
+                          }
+                        });
+              });
+    }
   }
 
   private void persistTrieLog(
       final BlockHeader blockHeader,
       final Hash worldStateRootHash,
       final TrieLogLayer trieLog,
-      final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater) {
+      final BonsaiUpdater stateUpdater) {
     debugLambda(
         LOG,
         "Persisting trie log for block hash {} and world state root {}",
@@ -136,7 +155,7 @@ public abstract class AbstractTrieLogManager<T extends CachedWorldState> impleme
   public Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash) {
     if (cachedWorldStatesByHash.containsKey(blockHash)) {
       return Optional.ofNullable(cachedWorldStatesByHash.get(blockHash))
-          .map(T::getMutableWorldState);
+          .map(CachedWorldState::getMutableWorldState);
     }
     return Optional.empty();
   }
@@ -151,7 +170,7 @@ public abstract class AbstractTrieLogManager<T extends CachedWorldState> impleme
     if (cachedWorldStatesByHash.containsKey(blockHash)) {
       return Optional.of(cachedWorldStatesByHash.get(blockHash).getTrieLog());
     } else {
-      return worldStateStorage.getTrieLog(blockHash).map(TrieLogLayer::fromBytes);
+      return rootWorldStateStorage.getTrieLog(blockHash).map(TrieLogLayer::fromBytes);
     }
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
 import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldState;
@@ -261,14 +262,18 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   @MustBeClosed
   public MutableWorldState copy() {
     // return an in-memory worldstate that is based on a persisted snapshot for this blockhash.
-    return archive
-        .getMutableSnapshot(this.blockHash())
-        .map(BonsaiSnapshotWorldState.class::cast)
-        .map(snapshot -> new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage()))
-        .orElseThrow(
-            () ->
-                new StorageException(
-                    "Unable to copy Layered Worldstate for " + blockHash().toHexString()));
+    try (SnapshotMutableWorldState snapshot =
+        archive
+            .getMutableSnapshot(this.blockHash())
+            .map(SnapshotMutableWorldState.class::cast)
+            .orElseThrow(
+                () ->
+                    new StorageException(
+                        "Unable to copy Layered Worldstate for " + blockHash().toHexString()))) {
+      return new BonsaiInMemoryWorldState(archive, snapshot.getWorldStateStorage());
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiPersistedWorldState.java
@@ -72,11 +72,11 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
             (addr, value) ->
                 archive
                     .getCachedMerkleTrieLoader()
-                    .preLoadAccount(worldStateStorage, worldStateRootHash, addr),
+                    .preLoadAccount(getWorldStateStorage(), worldStateRootHash, addr),
             (addr, value) ->
                 archive
                     .getCachedMerkleTrieLoader()
-                    .preLoadStorageSlot(worldStateStorage, addr, value));
+                    .preLoadStorageSlot(getWorldStateStorage(), addr, value));
   }
 
   public BonsaiWorldStateArchive getArchive() {
@@ -282,6 +282,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
 
     final BonsaiWorldStateUpdater localUpdater = updater.copy();
     final BonsaiWorldStateKeyValueStorage.BonsaiUpdater stateUpdater = worldStateStorage.updater();
+    Runnable saveTrieLog = () -> {};
 
     try {
       final Hash newWorldStateRootHash = calculateRootHash(stateUpdater, localUpdater);
@@ -296,9 +297,12 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
                   + " calculated "
                   + newWorldStateRootHash.toHexString());
         }
-        archive
-            .getTrieLogManager()
-            .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader);
+        saveTrieLog =
+            () ->
+                archive
+                    .getTrieLogManager()
+                    .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader, this);
+
         stateUpdater
             .getTrieBranchStorageTransaction()
             .put(WORLD_BLOCK_HASH_KEY, blockHeader.getHash().toArrayUnsafe());
@@ -317,6 +321,7 @@ public class BonsaiPersistedWorldState implements MutableWorldState, BonsaiWorld
       if (success) {
         stateUpdater.commit();
         updater.reset();
+        saveTrieLog.run();
       } else {
         stateUpdater.rollback();
         updater.reset();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -102,7 +102,7 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
 
   @Override
   public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
-    if (shouldClose.get()) {
+    if (isClosed.get()) {
       throw new RuntimeException("Storage is marked to close or has already closed");
     }
     return super.subscribe(sub);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateKeyValueStorage.java
@@ -18,29 +18,37 @@ package org.hyperledger.besu.ethereum.bonsai;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.warnLambda;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.MerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
-import org.hyperledger.besu.util.Subscribers;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage {
+public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKeyValueStorage
+    implements BonsaiStorageSubscriber {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BonsaiSnapshotWorldStateKeyValueStorage.class);
 
+  private final AtomicReference<BonsaiWorldStateKeyValueStorage> parentStorage =
+      new AtomicReference<>();
+  private final AtomicLong parentStorageSubscriberId = new AtomicLong(Long.MAX_VALUE);
+  private final AtomicBoolean shouldClose = new AtomicBoolean(false);
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
-  private final Subscribers<Integer> subscribers = Subscribers.create();
 
   public BonsaiSnapshotWorldStateKeyValueStorage(final StorageProvider snappableStorageProvider) {
     this(
@@ -81,16 +89,28 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
   }
 
   @Override
-  public synchronized long subscribe() {
-    if (isClosed.get()) {
-      throw new RuntimeException("BonsaiSnapshotWorldStateKeyValueStorage already closed");
+  public void clear() {
+    // snapshot storage does not implement clear
+    throw new StorageException("Snapshot storage does not implement clear");
+  }
+
+  @Override
+  public void clearFlatDatabase() {
+    // snapshot storage does not implement clear
+    throw new StorageException("Snapshot storage does not implement clear");
+  }
+
+  @Override
+  public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
+    if (shouldClose.get()) {
+      throw new RuntimeException("Storage is marked to close or has already closed");
     }
-    return subscribers.subscribe(0);
+    return super.subscribe(sub);
   }
 
   @Override
   public synchronized void unSubscribe(final long id) {
-    subscribers.unsubscribe(id);
+    super.unSubscribe(id);
     try {
       tryClose();
     } catch (Exception e) {
@@ -98,18 +118,63 @@ public class BonsaiSnapshotWorldStateKeyValueStorage extends BonsaiWorldStateKey
     }
   }
 
+  void subscribeToParentStorage(final BonsaiWorldStateKeyValueStorage parentStorage) {
+    this.parentStorage.set(parentStorage);
+    parentStorageSubscriberId.set(parentStorage.subscribe(this));
+  }
+
+  @Override
+  public void onClearStorage() {
+    try {
+      // when the parent storage clears, close regardless of subscribers
+      doClose();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void onClearFlatDatabaseStorage() {
+    // when the parent storage clears, close regardless of subscribers
+    try {
+      doClose();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public synchronized void close() throws Exception {
-    isClosed.getAndSet(true);
+    // when the parent storage clears, close
+    shouldClose.set(true);
     tryClose();
   }
 
-  protected void tryClose() throws Exception {
-    if (isClosed.get() && subscribers.getSubscriberCount() < 1) {
+  protected synchronized void tryClose() throws Exception {
+    if (shouldClose.get() && subscribers.getSubscriberCount() < 1) {
+      // attempting to close already closed snapshots will segfault
+      doClose();
+    }
+  }
+
+  private void doClose() throws Exception {
+    if (!isClosed.get()) {
+      // alert any subscribers we are closing:
+      subscribers.forEach(BonsaiStorageSubscriber::onCloseStorage);
+
+      // unsubscribe from parent storage if we have subscribed
+      Optional.ofNullable(parentStorage.get())
+          .filter(__ -> parentStorageSubscriberId.get() != Long.MAX_VALUE)
+          .ifPresent(parent -> parent.unSubscribe(parentStorageSubscriberId.get()));
+
+      // close all of the SnappedKeyValueStorages:
       accountStorage.close();
       codeStorage.close();
       storageStorage.close();
       trieBranchStorage.close();
+
+      // set storage closed
+      isClosed.set(true);
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchive.java
@@ -115,7 +115,9 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
     this.blockchain = blockchain;
     this.worldStateStorage = worldStateStorage;
     this.persistedState = new BonsaiPersistedWorldState(this, worldStateStorage);
-    this.useSnapshots = useSnapshots;
+    // TODO: https://github.com/hyperledger/besu/issues/4641
+    // useSnapshots is disabled for now
+    this.useSnapshots = false;
     this.cachedMerkleTrieLoader = cachedMerkleTrieLoader;
     blockchain.observeBlockAdded(this::blockAddedHandler);
   }
@@ -276,11 +278,11 @@ public class BonsaiWorldStateArchive implements WorldStateArchive {
         } catch (final Exception e) {
           // if we fail we must clean up the updater
           bonsaiUpdater.reset();
-          LOG.debug("Archive rolling failed for block hash " + blockHash, e);
+          LOG.debug("State rolling failed for block hash " + blockHash, e);
           return Optional.empty();
         }
       } catch (final RuntimeException re) {
-        LOG.debug("Archive rolling failed for block hash " + blockHash, re);
+        LOG.error("Archive rolling failed for block hash " + blockHash, re);
         return Optional.empty();
       }
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -39,8 +39,9 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.rlp.RLP;
 
 public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoCloseable {
+  // 0x776f726c64526f6f74
   public static final byte[] WORLD_ROOT_HASH_KEY = "worldRoot".getBytes(StandardCharsets.UTF_8);
-
+  // 0x776f726c64426c6f636b48617368
   public static final byte[] WORLD_BLOCK_HASH_KEY =
       "worldBlockHash".getBytes(StandardCharsets.UTF_8);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateKeyValueStorage.java
@@ -27,10 +27,10 @@ import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
+import org.hyperledger.besu.util.Subscribers;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -49,6 +49,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
   protected final KeyValueStorage storageStorage;
   protected final KeyValueStorage trieBranchStorage;
   protected final KeyValueStorage trieLogStorage;
+  protected final Subscribers<BonsaiStorageSubscriber> subscribers = Subscribers.create();
 
   private Optional<PeerTrieNodeFinder> maybeFallbackNodeFinder;
 
@@ -221,6 +222,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clear() {
+    subscribers.forEach(BonsaiStorageSubscriber::onClearStorage);
     accountStorage.clear();
     codeStorage.clear();
     storageStorage.clear();
@@ -230,6 +232,7 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
 
   @Override
   public void clearFlatDatabase() {
+    subscribers.forEach(BonsaiStorageSubscriber::onClearFlatDatabaseStorage);
     accountStorage.clear();
     storageStorage.clear();
   }
@@ -268,24 +271,17 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
     this.maybeFallbackNodeFinder = maybeFallbackNodeFinder;
   }
 
-  public void safeExecute(final Consumer<KeyValueStorage> toExec) throws Exception {
-    final long id = subscribe();
-    toExec.accept((KeyValueStorage) this);
-    unSubscribe(id);
+  public synchronized long subscribe(final BonsaiStorageSubscriber sub) {
+    return subscribers.subscribe(sub);
   }
 
-  public long subscribe() {
-    // No op because close() is not implemented for BonsaiWorldStateKeyValueStorage
-    return 0;
-  }
-
-  public void unSubscribe(final long id) {
-    // No op because close() is not implemented for BonsaiWorldStateKeyValueStorage
+  public synchronized void unSubscribe(final long id) {
+    subscribers.unsubscribe(id);
   }
 
   @Override
   public void close() throws Exception {
-    // No need to close because BonsaiWorldStateKeyValueStorage is persistent
+    // No need to close or notify because BonsaiWorldStateKeyValueStorage is persistent
   }
 
   public interface BonsaiUpdater extends WorldStateStorage.Updater {
@@ -438,5 +434,13 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
       trieBranchStorageTransaction.rollback();
       trieLogStorageTransaction.rollback();
     }
+  }
+
+  interface BonsaiStorageSubscriber {
+    default void onClearStorage() {}
+
+    default void onClearFlatDatabaseStorage() {}
+
+    default void onCloseStorage() {}
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateUpdater.java
@@ -43,9 +43,12 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldView, BonsaiAccount>
     implements BonsaiWorldView {
+  private static final Logger LOG = LoggerFactory.getLogger(BonsaiWorldStateUpdater.class);
 
   private final AccountConsumingMap<BonsaiValue<BonsaiAccount>> accountsToUpdate;
   private final Consumer<BonsaiValue<BonsaiAccount>> accountPreloader;
@@ -591,10 +594,8 @@ public class BonsaiWorldStateUpdater extends AbstractWorldUpdater<BonsaiWorldVie
       if ((expectedCode == null || expectedCode.isEmpty())
           && existingCode != null
           && !existingCode.isEmpty()) {
-        throw new IllegalStateException(
-            String.format("Expected to create code, but the code exists.  Address=%s", address));
-      }
-      if (!Objects.equals(expectedCode, existingCode)) {
+        LOG.warn("At Address={}, expected to create code, but code exists. Overwriting.", address);
+      } else if (!Objects.equals(expectedCode, existingCode)) {
         throw new IllegalStateException(
             String.format(
                 "Old value of code does not match expected value.  Address=%s ExpectedHash=%s ActualHash=%s",

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/TrieLogManager.java
@@ -26,28 +26,25 @@ public interface TrieLogManager {
   void saveTrieLog(
       final BonsaiWorldStateArchive worldStateArchive,
       final BonsaiWorldStateUpdater localUpdater,
-      final Hash worldStateRootHash,
-      final BlockHeader blockHeader);
+      final Hash forWorldStateRootHash,
+      final BlockHeader forBlockHeader,
+      final BonsaiPersistedWorldState forWorldState);
 
   Optional<MutableWorldState> getBonsaiCachedWorldState(final Hash blockHash);
 
   long getMaxLayersToLoad();
 
-  void addCachedLayer(
-      final BlockHeader blockHeader,
-      final Hash worldStateRootHash,
-      final TrieLogLayer trieLog,
-      final BonsaiWorldStateArchive worldStateArchive);
-
   void updateCachedLayers(final Hash blockParentHash, final Hash blockHash);
 
   Optional<TrieLogLayer> getTrieLogLayer(final Hash blockHash);
 
-  interface CachedWorldState {
+  interface CachedWorldState<Z extends MutableWorldState> {
+    void dispose();
+
     long getHeight();
 
     TrieLogLayer getTrieLog();
 
-    MutableWorldState getMutableWorldState();
+    Z getMutableWorldState();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/SnapshotMutableWorldState.java
@@ -15,4 +15,8 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
-public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {}
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage;
+
+public interface SnapshotMutableWorldState extends MutableWorldState, AutoCloseable {
+  BonsaiWorldStateKeyValueStorage getWorldStateStorage();
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
@@ -48,7 +48,7 @@ public enum TransactionInvalidReason {
   PRIVATE_VALUE_NOT_ZERO,
   PRIVATE_UNIMPLEMENTED_TRANSACTION_TYPE,
   INTERNAL_ERROR,
-  // Quroum Compatibility Invalid Reasons
+  // Quorum Compatibility Invalid Reasons
   GAS_PRICE_MUST_BE_ZERO,
   ETHER_VALUE_NOT_SUPPORTED,
   UPFRONT_FEE_TOO_HIGH,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/AbstractIsolationTests.java
@@ -73,6 +73,7 @@ import org.junit.rules.TemporaryFolder;
 
 public abstract class AbstractIsolationTests {
   protected BonsaiWorldStateArchive archive;
+  protected BonsaiWorldStateKeyValueStorage bonsaiWorldStateStorage;
   protected ProtocolContext protocolContext;
   final Function<String, KeyPair> asKeyPair =
       key ->
@@ -107,11 +108,12 @@ public abstract class AbstractIsolationTests {
 
   @Before
   public void createStorage() {
-    //    final InMemoryKeyValueStorageProvider provider = new InMemoryKeyValueStorageProvider();
+    bonsaiWorldStateStorage =
+        (BonsaiWorldStateKeyValueStorage)
+            createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI);
     archive =
         new BonsaiWorldStateArchive(
-            (BonsaiWorldStateKeyValueStorage)
-                createKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI),
+            bonsaiWorldStateStorage,
             blockchain,
             Optional.of(16L),
             shouldUseSnapshots(),

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotIsolationTests.java
@@ -34,6 +34,21 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class BonsaiSnapshotIsolationTests extends AbstractIsolationTests {
 
   @Test
+  public void ensureTruncateDoesNotCauseSegfault() {
+
+    var preTruncatedWorldState = archive.getMutable(null, genesisState.getBlock().getHash(), false);
+    assertThat(preTruncatedWorldState)
+        .isPresent(); // really just assert that we have not segfaulted after truncating
+    bonsaiWorldStateStorage.clear();
+    var postTruncatedWorldState =
+        archive.getMutable(null, genesisState.getBlock().getHash(), false);
+    assertThat(postTruncatedWorldState).isEmpty();
+    // assert that trying to access pre-worldstate does not segfault after truncating
+    preTruncatedWorldState.get().get(Address.fromHexString(accounts.get(0).getAddress()));
+    assertThat(true).isTrue();
+  }
+
+  @Test
   public void testIsolatedFromHead_behindHead() {
     Address testAddress = Address.fromHexString("0xdeadbeef");
     // assert we can mutate head without mutating the isolated snapshot

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiSnapshotWorldStateArchiveTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.bonsai.SnapshotTrieLogManager.CachedSnapshotWorldState;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -123,20 +124,15 @@ public class BonsaiSnapshotWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, CachedSnapshotWorldState> worldStatesByHash = mock(HashMap.class);
-    when(worldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
-    when(worldStatesByHash.get(eq(blockHeaderChainA.getHash())))
-        .thenReturn(
-            new CachedSnapshotWorldState(
-                () -> mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
-                mock(TrieLogLayer.class),
-                2));
-    when(worldStatesByHash.get(eq(blockHeaderChainB.getHash())))
-        .thenReturn(
-            new CachedSnapshotWorldState(
-                () -> mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
-                mock(TrieLogLayer.class),
-                2));
+    final Map<Bytes32, CachedWorldState<BonsaiSnapshotWorldState>> worldStatesByHash =
+        new HashMap<>();
+    var mockCachedState =
+        new CachedSnapshotWorldState(
+            mock(BonsaiSnapshotWorldState.class, Answers.RETURNS_MOCKS),
+            mock(TrieLogLayer.class, Answers.RETURNS_MOCKS),
+            2);
+    worldStatesByHash.put(blockHeaderChainA.getHash(), mockCachedState);
+    worldStatesByHash.put(blockHeaderChainB.getHash(), mockCachedState);
     var worldStateStorage = new BonsaiWorldStateKeyValueStorage(storageProvider);
     bonsaiWorldStateArchive =
         spy(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateArchiveTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.bonsai.LayeredTrieLogManager.LayeredWorldStateCache;
+import org.hyperledger.besu.ethereum.bonsai.TrieLogManager.CachedWorldState;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -208,7 +209,8 @@ public class BonsaiWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, LayeredWorldStateCache> layeredWorldStatesByHash = mock(HashMap.class);
+    final Map<Bytes32, CachedWorldState<BonsaiLayeredWorldState>> layeredWorldStatesByHash =
+        mock(HashMap.class);
     when(layeredWorldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
     when(layeredWorldStatesByHash.get(eq(blockHeaderChainA.getHash())))
         .thenReturn(
@@ -262,7 +264,8 @@ public class BonsaiWorldStateArchiveTest {
     final BlockHeader blockHeaderChainB =
         blockBuilder.number(1).timestamp(2).parentHash(genesis.getHash()).buildHeader();
 
-    final Map<Bytes32, LayeredWorldStateCache> layeredWorldStatesByHash = mock(HashMap.class);
+    final Map<Bytes32, CachedWorldState<BonsaiLayeredWorldState>> layeredWorldStatesByHash =
+        mock(HashMap.class);
     when(layeredWorldStatesByHash.containsKey(any(Bytes32.class))).thenReturn(true);
     when(layeredWorldStatesByHash.get(eq(blockHeaderChainA.getHash())))
         .thenReturn(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/bonsai/LayeredWorldStateTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.ethereum.bonsai;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.SnapshotMutableWorldState;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LayeredWorldStateTests {
+
+  @Mock BonsaiWorldStateArchive archive;
+  @Mock Blockchain blockchain;
+
+  @Test
+  public void layeredWorldStateUsesCorrectPersistedWorldStateOnCopy() {
+    // when copying a layered worldstate we return mutable copy,
+    // ensure it is for the correct/corresponding worldstate:
+
+    Hash state1Hash = Hash.hash(Bytes.of("first_state".getBytes(StandardCharsets.UTF_8)));
+    Hash block1Hash = Hash.hash(Bytes.of("first_block".getBytes(StandardCharsets.UTF_8)));
+    var mockStorage = mock(BonsaiWorldStateKeyValueStorage.class);
+    when(mockStorage.getWorldStateBlockHash()).thenReturn(Optional.of(block1Hash));
+    when(mockStorage.getWorldStateRootHash()).thenReturn(Optional.of(state1Hash));
+    SnapshotMutableWorldState mockState =
+        when(mock(SnapshotMutableWorldState.class).getWorldStateStorage())
+            .thenReturn(mockStorage)
+            .getMock();
+
+    TrieLogLayer mockLayer =
+        when(mock(TrieLogLayer.class).getBlockHash()).thenReturn(Hash.ZERO).getMock();
+    BonsaiLayeredWorldState mockLayerWs =
+        new BonsaiLayeredWorldState(
+            blockchain,
+            archive,
+            Optional.of(mock(BonsaiLayeredWorldState.class)),
+            1L,
+            state1Hash,
+            mockLayer);
+
+    // mimic persisted state being at a different state:
+    when(archive.getMutableSnapshot(mockLayer.getBlockHash())).thenReturn(Optional.of(mockState));
+
+    try (var copyOfLayer1 = mockLayerWs.copy()) {
+      assertThat(copyOfLayer1.rootHash()).isEqualTo(state1Hash);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  @Test
+  public void saveTrieLogShouldUseCorrectPersistedWorldStateOnCopy() {
+    // when we save a snapshot based worldstate, ensure
+    // we used the passed in worldstate and roothash for calculating the trielog diff
+    Hash testStateRoot = Hash.fromHexStringLenient("0xdeadbeef");
+    BlockHeader testHeader = new BlockHeaderTestFixture().stateRoot(testStateRoot).buildHeader();
+
+    BonsaiWorldStateKeyValueStorage testStorage =
+        mock(BonsaiWorldStateKeyValueStorage.class, Answers.RETURNS_DEEP_STUBS);
+
+    BonsaiSnapshotWorldState testState = mock(BonsaiSnapshotWorldState.class);
+    when(testState.getWorldStateStorage()).thenReturn(testStorage);
+    when(testState.rootHash()).thenReturn(testStateRoot);
+    when(testState.blockHash()).thenReturn(testHeader.getBlockHash());
+
+    BonsaiWorldStateUpdater testUpdater = new BonsaiWorldStateUpdater(testState);
+    // mock kvstorage to mimic head being in a different state than testState
+    LayeredTrieLogManager manager =
+        spy(
+            new LayeredTrieLogManager(
+                blockchain, mock(BonsaiWorldStateKeyValueStorage.class), 10L, new HashMap<>()));
+
+    // assert we are using the target worldstate storage:
+    final AtomicBoolean calledPrepareTrieLog = new AtomicBoolean(false);
+    doAnswer(
+            prepareCallSpec -> {
+              Hash blockHash = prepareCallSpec.getArgument(0, BlockHeader.class).getHash();
+              Hash rootHash = prepareCallSpec.getArgument(1, Hash.class);
+              BonsaiPersistedWorldState ws =
+                  prepareCallSpec.getArgument(4, BonsaiPersistedWorldState.class);
+              assertThat(ws.rootHash()).isEqualTo(rootHash);
+              assertThat(ws.blockHash()).isEqualTo(blockHash);
+              calledPrepareTrieLog.set(true);
+              return mock(TrieLogLayer.class);
+            })
+        .when(manager)
+        .prepareTrieLog(
+            any(BlockHeader.class),
+            any(Hash.class),
+            any(BonsaiWorldStateUpdater.class),
+            any(BonsaiWorldStateArchive.class),
+            any(BonsaiPersistedWorldState.class));
+
+    manager.saveTrieLog(archive, testUpdater, testStateRoot, testHeader, testState);
+    assertThat(calledPrepareTrieLog.get()).isTrue();
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/consensus/merge/ForkchoiceEvent.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/consensus/merge/ForkchoiceEvent.java
@@ -33,6 +33,10 @@ public class ForkchoiceEvent {
     return !finalizedBlockHash.equals(Hash.ZERO);
   }
 
+  public boolean hasValidSafeBlockHash() {
+    return !safeBlockHash.equals(Hash.ZERO);
+  }
+
   public Hash getHeadBlockHash() {
     return headBlockHash;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -160,8 +160,8 @@ public class EthPeers {
 
   public void dispatchMessage(
       final EthPeer peer, final EthMessage ethMessage, final String protocolName) {
-    peer.dispatch(ethMessage, protocolName);
-    if (peer.hasAvailableRequestCapacity()) {
+    Optional<RequestManager> maybeRequestManager = peer.dispatch(ethMessage, protocolName);
+    if (maybeRequestManager.isPresent() && peer.hasAvailableRequestCapacity()) {
       reattemptPendingPeerRequests();
     }
   }
@@ -173,8 +173,9 @@ public class EthPeers {
   @VisibleForTesting
   void reattemptPendingPeerRequests() {
     synchronized (this) {
+      final List<EthPeer> peers = streamAvailablePeers().collect(Collectors.toList());
       final Iterator<PendingPeerRequest> iterator = pendingRequests.iterator();
-      while (iterator.hasNext()) {
+      while (iterator.hasNext() && peers.stream().anyMatch(EthPeer::hasAvailableRequestCapacity)) {
         final PendingPeerRequest request = iterator.next();
         if (request.attemptExecution()) {
           pendingRequests.remove(request);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -14,9 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.eth.manager;
 
+import static org.hyperledger.besu.util.Slf4jLambdaHelper.infoLambda;
+
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer.DisconnectCallback;
 import org.hyperledger.besu.ethereum.eth.peervalidation.PeerValidator;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.permissioning.NodeMessagePermissioningProvider;
@@ -244,6 +247,22 @@ public class EthPeers {
 
   public Comparator<EthPeer> getBestChainComparator() {
     return bestPeerComparator;
+  }
+
+  public void disconnectWorstUselessPeer() {
+    streamAvailablePeers()
+        .sorted(getBestChainComparator())
+        .findFirst()
+        .ifPresent(
+            peer -> {
+              infoLambda(
+                  LOG,
+                  "disconnecting peer {}. Waiting for better peers. Current {} of max {}",
+                  peer::toString,
+                  this::peerCount,
+                  this::getMaxPeers);
+              peer.disconnect(DisconnectMessage.DisconnectReason.USELESS_PEER);
+            });
   }
 
   @FunctionalInterface

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -66,7 +66,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
         assignedPeer
             .filter(u -> getRetryCount() == 1) // first try with the assigned peer if present
             .map(Optional::of)
-            .orElseGet(this::selectNextPeer); // otherwise select a new one from the pool
+            .orElseGet(this::selectNextPeer); // otherwise, select a new one from the pool
 
     if (maybePeer.isEmpty()) {
       traceLambda(
@@ -138,6 +138,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
     final EthPeers peers = getEthContext().getEthPeers();
     // If we are at max connections, then refresh peers disconnecting one of the failed peers,
     // or the least useful
+
     if (peers.peerCount() >= peers.getMaxPeers()) {
       failedPeers.stream()
           .filter(peer -> !peer.isDisconnected())
@@ -145,7 +146,12 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
           .or(() -> peers.streamAvailablePeers().sorted(peers.getBestChainComparator()).findFirst())
           .ifPresent(
               peer -> {
-                debugLambda(LOG, "Refresh peers disconnecting peer {}", peer::toString);
+                debugLambda(
+                    LOG,
+                    "Refresh peers disconnecting peer {}. Waiting for better peers. Current {} of max {}",
+                    peer::toString,
+                    peers::peerCount,
+                    peers::getMaxPeers);
                 peer.disconnect(DisconnectReason.USELESS_PEER);
               });
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Queue;
+import java.util.concurrent.ScheduledFuture;
 
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.Queues;
@@ -48,17 +49,20 @@ public class BufferedGetPooledTransactionsFromPeerFetcher {
   private final PeerTransactionTracker transactionTracker;
   private final EthContext ethContext;
   private final MetricsSystem metricsSystem;
+  private final ScheduledFuture<?> scheduledFuture;
   private final EthPeer peer;
   private final Queue<Hash> txAnnounces;
   private final Counter alreadySeenTransactionsCounter;
 
   public BufferedGetPooledTransactionsFromPeerFetcher(
       final EthContext ethContext,
+      final ScheduledFuture<?> scheduledFuture,
       final EthPeer peer,
       final TransactionPool transactionPool,
       final PeerTransactionTracker transactionTracker,
       final MetricsSystem metricsSystem) {
     this.ethContext = ethContext;
+    this.scheduledFuture = scheduledFuture;
     this.peer = peer;
     this.transactionPool = transactionPool;
     this.transactionTracker = transactionTracker;
@@ -73,6 +77,10 @@ public class BufferedGetPooledTransactionsFromPeerFetcher {
                 "Total number of received transactions already seen",
                 "source")
             .labels(HASHES);
+  }
+
+  public ScheduledFuture<?> getScheduledFuture() {
+    return scheduledFuture;
   }
 
   public void requestTransactions() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
@@ -91,7 +91,11 @@ public class GetHeadersFromPeerByHashTask extends AbstractGetHeadersFromPeerTask
   protected PendingPeerRequest sendRequest() {
     return sendRequestToPeer(
         peer -> {
-          LOG.debug("Requesting {} headers from peer {}.", count, peer);
+          LOG.debug(
+              "Requesting {} headers (hash {}...) from peer {}.",
+              count,
+              referenceHash.slice(0, 6),
+              peer);
           return peer.getHeadersByHash(referenceHash, count, skip, reverse);
         });
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByNumberTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByNumberTask.java
@@ -77,7 +77,8 @@ public class GetHeadersFromPeerByNumberTask extends AbstractGetHeadersFromPeerTa
   protected PendingPeerRequest sendRequest() {
     return sendRequestToPeer(
         peer -> {
-          LOG.debug("Requesting {} headers from peer {}.", count, peer);
+          LOG.debug(
+              "Requesting {} headers (blockNumber {}) from peer {}.", count, blockNumber, peer);
           return peer.getHeadersByNumber(blockNumber, count, skip, reverse);
         });
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromSafeBlock.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotSelectorFromSafeBlock.java
@@ -35,9 +35,9 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
+public class PivotSelectorFromSafeBlock implements PivotBlockSelector {
 
-  private static final Logger LOG = LoggerFactory.getLogger(PivotSelectorFromFinalizedBlock.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PivotSelectorFromSafeBlock.class);
   private final ProtocolContext protocolContext;
   private final ProtocolSchedule protocolSchedule;
   private final EthContext ethContext;
@@ -48,7 +48,7 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
 
   private volatile Optional<BlockHeader> maybeCachedHeadBlockHeader = Optional.empty();
 
-  public PivotSelectorFromFinalizedBlock(
+  public PivotSelectorFromSafeBlock(
       final ProtocolContext protocolContext,
       final ProtocolSchedule protocolSchedule,
       final EthContext ethContext,
@@ -68,9 +68,8 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
   @Override
   public Optional<FastSyncState> selectNewPivotBlock() {
     final Optional<ForkchoiceEvent> maybeForkchoice = forkchoiceStateSupplier.get();
-    if (maybeForkchoice.isPresent() && maybeForkchoice.get().hasValidFinalizedBlockHash()) {
-      return Optional.of(
-          selectLastFinalizedBlockAsPivot(maybeForkchoice.get().getFinalizedBlockHash()));
+    if (maybeForkchoice.isPresent() && maybeForkchoice.get().hasValidSafeBlockHash()) {
+      return Optional.of(selectLastSafeBlockAsPivot(maybeForkchoice.get().getSafeBlockHash()));
     }
     LOG.debug("No finalized block hash announced yet");
     return Optional.empty();
@@ -82,9 +81,9 @@ public class PivotSelectorFromFinalizedBlock implements PivotBlockSelector {
     return CompletableFuture.completedFuture(null);
   }
 
-  private FastSyncState selectLastFinalizedBlockAsPivot(final Hash finalizedHash) {
-    LOG.debug("Returning finalized block hash {} as pivot", finalizedHash);
-    return new FastSyncState(finalizedHash);
+  private FastSyncState selectLastSafeBlockAsPivot(final Hash safeHash) {
+    LOG.debug("Returning safe block hash {} as pivot", safeHash);
+    return new FastSyncState(safeHash);
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.eth.manager.task;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.netty.util.concurrent.ScheduledFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,10 +65,10 @@ public class BufferedGetPooledTransactionsFromPeerFetcherTest {
     metricsSystem = new StubMetricsSystem();
     transactionTracker = new PeerTransactionTracker();
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
-
+    ScheduledFuture<?> mock = mock(ScheduledFuture.class);
     fetcher =
         new BufferedGetPooledTransactionsFromPeerFetcher(
-            ethContext, ethPeer, transactionPool, transactionTracker, metricsSystem);
+            ethContext, mock, ethPeer, transactionPool, transactionTracker, metricsSystem);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncActionsTest.java
@@ -454,12 +454,16 @@ public class FastSyncActionsTest {
     when(genesisConfig.getTerminalBlockNumber()).thenReturn(OptionalLong.of(10L));
 
     final Optional<ForkchoiceEvent> finalizedEvent =
-        Optional.of(new ForkchoiceEvent(null, null, blockchain.getBlockHashByNumber(2L).get()));
+        Optional.of(
+            new ForkchoiceEvent(
+                null,
+                blockchain.getBlockHashByNumber(3L).get(),
+                blockchain.getBlockHashByNumber(2L).get()));
 
     fastSyncActions =
         createFastSyncActions(
             syncConfig,
-            new PivotSelectorFromFinalizedBlock(
+            new PivotSelectorFromSafeBlock(
                 blockchainSetupUtil.getProtocolContext(),
                 blockchainSetupUtil.getProtocolSchedule(),
                 ethContext,
@@ -471,13 +475,13 @@ public class FastSyncActionsTest {
     final RespondingEthPeer peer = EthProtocolManagerTestUtil.createPeer(ethProtocolManager, 1001);
     final CompletableFuture<FastSyncState> result =
         fastSyncActions.downloadPivotBlockHeader(
-            new FastSyncState(finalizedEvent.get().getFinalizedBlockHash()));
+            new FastSyncState(finalizedEvent.get().getSafeBlockHash()));
     assertThat(result).isNotCompleted();
 
     final RespondingEthPeer.Responder responder = RespondingEthPeer.blockchainResponder(blockchain);
     peer.respond(responder);
 
-    assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(2).get()));
+    assertThat(result).isCompletedWithValue(new FastSyncState(blockchain.getBlockHeader(3).get()));
   }
 
   private FastSyncActions createFastSyncActions(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageProcessorTest.java
@@ -170,7 +170,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
   }
 
   @Test
-  public void shouldScheduleGetPooledTransactionsTaskWhenNewTransactionAdded() {
+  public void
+      shouldScheduleGetPooledTransactionsTaskWhenNewTransactionAddedFromPeerForTheFirstTime() {
 
     final EthScheduler ethScheduler = mock(EthScheduler.class);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
@@ -183,7 +184,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         ofMinutes(1));
 
     verify(ethScheduler, times(1))
-        .scheduleFutureTask(any(FetcherCreatorTask.class), any(Duration.class));
+        .scheduleFutureTaskWithFixedDelay(
+            any(FetcherCreatorTask.class), any(Duration.class), any(Duration.class));
   }
 
   @Test
@@ -204,7 +206,8 @@ public class NewPooledTransactionHashesMessageProcessorTest {
         ofMinutes(1));
 
     verify(ethScheduler, times(1))
-        .scheduleFutureTask(any(FetcherCreatorTask.class), any(Duration.class));
+        .scheduleFutureTaskWithFixedDelay(
+            any(FetcherCreatorTask.class), any(Duration.class), any(Duration.class));
   }
 
   @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=22.10.4-SNAPSHOT
+version=22.10.4
 
 org.gradle.welcome=never
 org.gradle.jvmargs=-Xmx1g

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshot.java
@@ -36,12 +36,12 @@ class RocksDBSnapshot {
     this.dbSnapshot = db.getSnapshot();
   }
 
-  Snapshot markAndUseSnapshot() {
+  synchronized Snapshot markAndUseSnapshot() {
     usages.incrementAndGet();
     return dbSnapshot;
   }
 
-  void unMarkSnapshot() {
+  synchronized void unMarkSnapshot() {
     if (usages.decrementAndGet() < 1) {
       db.releaseSnapshot(dbSnapshot);
       dbSnapshot.close();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Cherry picks include:

* b4e2cdb82 2022-12-21 | Use safe block as pivot block suring snapsync (#4819) [matkt]
* 418d392fa 2022-12-22 | Bugfix snapshot transaction segfaults after storage truncation (#4786) [garyschulte]
* adb76c597 2022-12-23 | Bugfix potential chain head and worldstate inconsistency (#4862) [garyschulte]
* 33ee2bba6 2023-01-08 | Peering - disconnect worst peer (#4888) [Sally MacFarlane]
* b4d5e9d27 2023-01-11 | Attempt to fix CPU spikes issue (#4867) [ahamlat]
* bc4f9e7a7 2023-01-12 | not block subscribe when the worldstate storage is open (#4912) [matkt]
* a5e3ed4f4 2023-01-13 | Address bonsai self-destruct stale code present  (#4906) (HEAD -> cherry-pick-22.10.4, 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).