### PR TITLE
[MINOR] Correct order of args to RequestBody.create

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/login/LoginRequestFactory.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/login/LoginRequestFactory.java
@@ -74,7 +74,7 @@ public class LoginRequestFactory {
   private Request loginRequest(final String username, final String password) {
     final RequestBody requestBody =
         RequestBody.create(
-            JSON, String.format("{\"username\":\"%s\",\"password\":\"%s\"}", username, password));
+            String.format("{\"username\":\"%s\",\"password\":\"%s\"}", username, password), JSON);
     return new Request.Builder().post(requestBody).url(loginUri()).build();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -146,7 +146,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
   }
 
   private int doRequest(final String hostname) throws IOException {
-    final RequestBody body = RequestBody.create(GRAPHQL, "{maxPriorityFeePerGas}");
+    final RequestBody body = RequestBody.create("{maxPriorityFeePerGas}", GRAPHQL);
 
     final Request build =
         new Request.Builder()

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -123,7 +123,7 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
     final ObjectNode specNode = (ObjectNode) objectMapper.readTree(json);
     final String rawRequestBody = specNode.get("request").toString();
 
-    final RequestBody requestBody = RequestBody.create(JSON, rawRequestBody);
+    final RequestBody requestBody = RequestBody.create(rawRequestBody, JSON);
     final Request request = new Request.Builder().post(requestBody).url(baseUrl).build();
 
     try (final Response resp = client.newCall(request).execute()) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -105,8 +105,8 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"admin_peers\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"admin_peers\"}",
+            JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl).build();
     LOG.info("Request: " + request);
     try (final Response resp = client.newCall(request).execute()) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
@@ -189,8 +189,8 @@ public class JsonRpcHttpServiceHostAllowlistTest {
   private int doRequest(final String hostname) throws IOException {
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode("123") + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode("123") + ",\"method\":\"net_version\"}",
+            JSON);
 
     final Request build =
         new Request.Builder().post(body).url(baseUrl).addHeader("Host", hostname).build();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -202,7 +202,7 @@ public class JsonRpcHttpServiceLoginTest {
   @Test
   public void loginWithBadCredentials() throws IOException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"badpass\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"badpass\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(401);
@@ -213,7 +213,7 @@ public class JsonRpcHttpServiceLoginTest {
   @Test
   public void loginWithGoodCredentials() throws IOException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -247,7 +247,7 @@ public class JsonRpcHttpServiceLoginTest {
   @Test
   public void loginWithGoodCredentialsAndPermissions() throws IOException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -288,7 +288,7 @@ public class JsonRpcHttpServiceLoginTest {
   public void loginDoesntPopulateJWTPayloadWithPassword()
       throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -315,7 +315,7 @@ public class JsonRpcHttpServiceLoginTest {
   public void loginPopulatesJWTPayloadWithRequiredValues()
       throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -348,7 +348,7 @@ public class JsonRpcHttpServiceLoginTest {
   private String login(final String username, final String password) throws IOException {
     final RequestBody loginBody =
         RequestBody.create(
-            JSON, "{\"username\":\"" + username + "\",\"password\":\"" + password + "\"}");
+            "{\"username\":\"" + username + "\",\"password\":\"" + password + "\"}", JSON);
     final Request loginRequest =
         new Request.Builder().post(loginBody).url(baseUrl + "/login").build();
     final String token;
@@ -372,7 +372,7 @@ public class JsonRpcHttpServiceLoginTest {
   @Test
   public void checkJsonRpcMethodsAvailableWithGoodCredentialsAndPermissions() throws IOException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -441,7 +441,7 @@ public class JsonRpcHttpServiceLoginTest {
   public void checkJsonRpcMethodsAvailableWithGoodCredentialsAndAllPermissions()
       throws IOException {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"adminuser\",\"password\":\"pegasys\"}");
+        RequestBody.create("{\"username\":\"adminuser\",\"password\":\"pegasys\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -524,10 +524,10 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(401);
@@ -540,10 +540,10 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body, "badtoken")).execute()) {
       assertThat(resp.code()).isEqualTo(401);
@@ -558,10 +558,10 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "123";
     final RequestBody web3ClientVersionBody =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response web3ClientVersionResp =
         client.newCall(buildPostRequest(web3ClientVersionBody, token)).execute()) {
@@ -582,8 +582,8 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "123";
     final RequestBody requestBody =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}",
+            JSON);
 
     try (final Response response = client.newCall(buildPostRequest(requestBody, token)).execute()) {
       assertThat(response.code()).isEqualTo(200);
@@ -597,8 +597,8 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "123";
     final RequestBody requestBody =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}",
+            JSON);
 
     try (final Response response = client.newCall(buildPostRequest(requestBody)).execute()) {
       assertThat(response.code()).isEqualTo(200);
@@ -614,8 +614,8 @@ public class JsonRpcHttpServiceLoginTest {
     final String id = "007";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body, token)).execute()) {
       assertThat(resp.code()).isEqualTo(401);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceParameterizedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceParameterizedTest.java
@@ -57,7 +57,7 @@ public class JsonRpcHttpServiceParameterizedTest extends JsonRpcHttpServiceTestB
 
   @Test
   public void invalidJsonShouldReturnParseError() throws Exception {
-    final RequestBody body = RequestBody.create(JSON, requestJson);
+    final RequestBody body = RequestBody.create(requestJson, JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -120,8 +120,8 @@ public class JsonRpcHttpServiceRpcApisTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -134,8 +134,8 @@ public class JsonRpcHttpServiceRpcApisTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -149,8 +149,8 @@ public class JsonRpcHttpServiceRpcApisTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -168,8 +168,8 @@ public class JsonRpcHttpServiceRpcApisTest {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -413,7 +413,7 @@ public class JsonRpcHttpServiceRpcApisTest {
   public RequestBody createNetServicesRequestBody() {
     final String id = "123";
     return RequestBody.create(
-        JSON, "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}");
+        "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_services\"}", JSON);
   }
 
   public JsonRpcHttpService getJsonRpcHttpService(final boolean[] enabledNetServices)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -86,7 +86,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   @Test
   public void handleLoginRequestWithAuthDisabled() throws Exception {
     final RequestBody body =
-        RequestBody.create(JSON, "{\"username\":\"user\",\"password\":\"pass\"}");
+        RequestBody.create("{\"username\":\"user\",\"password\":\"pass\"}", JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl + "/login").build();
     try (final Response resp = client.newCall(request).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -122,10 +122,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     // Create a request with an extra "beta" param
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"net_version\", \"beta\":true}");
+                + ",\"method\":\"net_version\", \"beta\":true}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -177,10 +177,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.header("Content-Type")).isEqualTo("application/json");
@@ -192,10 +192,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -213,8 +213,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_version\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -232,8 +232,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_accounts\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_accounts\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -253,8 +253,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_peerCount\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_peerCount\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -277,12 +277,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"" + blockHash + "\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockHash\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockHash\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -305,12 +305,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"" + blockHash + "\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockHash\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockHash\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -334,12 +334,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"" + number + "\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -362,12 +362,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"" + number + "\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -389,12 +389,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"earliest\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -417,12 +417,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"latest\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -445,12 +445,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"pending\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -468,12 +468,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String params = "\"params\": [\"pending\"]";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ","
                 + params
-                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}");
+                + ",\"method\":\"eth_getUncleCountByBlockNumber\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -493,8 +493,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_peerCount\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"net_peerCount\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -522,12 +522,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBalance\", \"params\": [\""
                 + address
-                + "\",\"latest\"]}");
+                + "\",\"latest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -556,12 +556,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBalance\", \"params\": [\""
                 + address
-                + "\",\"latest\"]}");
+                + "\",\"latest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -589,12 +589,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBalance\", \"params\": [\""
                 + address
-                + "\",\"earliest\"]}");
+                + "\",\"earliest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -624,14 +624,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBalance\", \"params\": [\""
                 + address
                 + "\",\"0x"
                 + Long.toString(blockNumber, 16)
-                + "\"]}");
+                + "\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -653,12 +653,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final Hash blockHash = Hash.fromHexString(blockHashString);
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHashString
-                + "\",true]}");
+                + "\",true]}",
+            JSON);
 
     // Setup mocks
     when(blockchainQueries.blockByHash(eq(blockHash))).thenReturn(Optional.empty());
@@ -688,12 +688,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHash
-                + "\",true]}");
+                + "\",true]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -720,12 +720,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHash
-                + "\",false]}");
+                + "\",false]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -744,10 +744,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByHash\", \"params\": [true]}");
+                + ",\"method\":\"eth_getBlockByHash\", \"params\": [true]}",
+            JSON);
 
     // Setup mocks
     when(blockchainQueries.blockByHash(ArgumentMatchers.isA(Hash.class)))
@@ -770,12 +770,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273321";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHashString
-                + "\"]}");
+                + "\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -793,12 +793,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String blockHashString = "0xe";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHashString
-                + "\",true]}");
+                + "\",true]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -816,12 +816,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String blockHashString = "0xe670";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHashString
-                + "\",true]}");
+                + "\",true]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -840,12 +840,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
         "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d15273321";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByHash\", \"params\": [\""
                 + blockHashString
-                + "\",{}]}");
+                + "\",{}]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -862,10 +862,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByHash\", \"params\": []}");
+                + ",\"method\":\"eth_getBlockByHash\", \"params\": []}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -882,10 +882,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByHash\"}");
+                + ",\"method\":\"eth_getBlockByHash\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -910,12 +910,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"0x"
                 + Long.toString(number, 16)
-                + "\",true]}");
+                + "\",true]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -942,12 +942,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"0x"
                 + Long.toString(number, 16)
-                + "\",false]}");
+                + "\",false]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -967,10 +967,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"bla\",false]}");
+                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"bla\",false]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -996,10 +996,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"earliest\",true]}");
+                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"earliest\",true]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1018,10 +1018,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"0x0\",true]}");
+                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"0x0\",true]}",
+            JSON);
 
     // Setup mocks to return a block
     final BlockDataGenerator gen = new BlockDataGenerator();
@@ -1047,10 +1047,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"latest\",true]}");
+                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"latest\",true]}",
+            JSON);
 
     // Setup mocks to return a block
     final BlockDataGenerator gen = new BlockDataGenerator();
@@ -1083,10 +1083,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"pending\",true]}");
+                + ",\"method\":\"eth_getBlockByNumber\", \"params\": [\"pending\",true]}",
+            JSON);
     // Setup mocks to return a block
     final BlockDataGenerator gen = new BlockDataGenerator();
     final Block block = gen.genesisBlock();
@@ -1118,10 +1118,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "123";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\", \"params\": [1,2,3]}");
+                + ",\"method\":\"web3_clientVersion\", \"params\": [1,2,3]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1139,7 +1139,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "456";
     final RequestBody body =
         RequestBody.create(
-            JSON, "{\"id\":" + Json.encode(id) + ",\"method\":\"web3_clientVersion\"}");
+            "{\"id\":" + Json.encode(id) + ",\"method\":\"web3_clientVersion\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1154,7 +1154,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   public void notification() throws Exception {
     // No id field is present - marking this as a notification
     final RequestBody body =
-        RequestBody.create(JSON, "{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\"}");
+        RequestBody.create("{\"jsonrpc\":\"2.0\",\"method\":\"web3_clientVersion\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       // Notifications return an empty response
@@ -1169,7 +1169,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     // Be lenient - allow explicit null id fields
     final RequestBody body =
         RequestBody.create(
-            JSON, "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"web3_clientVersion\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":null,\"method\":\"web3_clientVersion\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1187,10 +1187,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       // An empty string is still a string, so should be a valid id
@@ -1209,10 +1209,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final int id = -1;
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1233,10 +1233,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1259,10 +1259,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1280,10 +1280,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final double id = 1.5;
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1300,7 +1300,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   public void objectId() throws Exception {
     final RequestBody body =
         RequestBody.create(
-            JSON, "{\"jsonrpc\":\"2.0\",\"id\":{},\"method\":\"web3_clientVersion\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":{},\"method\":\"web3_clientVersion\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -1315,7 +1315,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   public void arrayId() throws Exception {
     final RequestBody body =
         RequestBody.create(
-            JSON, "{\"jsonrpc\":\"2.0\",\"id\":[],\"method\":\"web3_clientVersion\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":[],\"method\":\"web3_clientVersion\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -1330,7 +1330,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   public void missingMethodField() throws Exception {
     final Integer id = 2;
     final RequestBody body =
-        RequestBody.create(JSON, "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + "}");
+        RequestBody.create("{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + "}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -1346,10 +1346,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "234";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"1.0\",\"id\":"
                 + Json.encode(id)
-                + ",\"method\":\"web3_clientVersion\"}");
+                + ",\"method\":\"web3_clientVersion\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1365,7 +1365,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "234";
     final RequestBody body =
         RequestBody.create(
-            JSON, "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"bla\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"bla\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1383,12 +1383,12 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "234";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\""
                 + methodName
-                + "\"}");
+                + "\"}",
+            JSON);
 
     when(rpcMethods.get(any(String.class))).thenReturn(null);
     when(rpcMethods.containsKey(any(String.class))).thenReturn(false);
@@ -1416,7 +1416,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     doReturn(jsonRpcMethod).when(rpcMethods).get("foo");
 
     final RequestBody body =
-        RequestBody.create(JSON, "{\"jsonrpc\":\"2.0\",\"id\":\"666\",\"method\":\"foo\"}");
+        RequestBody.create("{\"jsonrpc\":\"2.0\",\"id\":\"666\",\"method\":\"foo\"}", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1436,10 +1436,10 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "[{\"jsonrpc\":\"2.0\",\"id\":\"000\",\"method\":\"web3_clientVersion\"},"
                 + "{\"jsonrpc\":\"2.0\",\"id\":\"111\",\"method\":\"foo\"},"
-                + "{\"jsonrpc\":\"2.0\",\"id\":\"222\",\"method\":\"net_version\"}]");
+                + "{\"jsonrpc\":\"2.0\",\"id\":\"222\",\"method\":\"net_version\"}]",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1459,7 +1459,6 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final int netVersionRequestId = 4;
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "[{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(clientVersionRequestId)
                 + ",\"method\":\"web3_clientVersion\"},"
@@ -1468,7 +1467,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
                 + ",\"method\":\"bla\"},"
                 + "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(netVersionRequestId)
-                + ",\"method\":\"net_version\"}]");
+                + ",\"method\":\"net_version\"}]",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1516,7 +1516,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             + Json.encode(netVersionRequestId)
             + ",\"method\":\"net_version\"}";
     final String batchRequest = "[" + String.join(", ", reqs) + "]";
-    final RequestBody body = RequestBody.create(JSON, batchRequest);
+    final RequestBody body = RequestBody.create(batchRequest, JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1563,7 +1563,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             + "  {\"jsonrpc\": \"2.0\", \"method\"\n"
             + "]";
 
-    final RequestBody body = RequestBody.create(JSON, req);
+    final RequestBody body = RequestBody.create(req, JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -1580,14 +1580,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final int netVersionRequestId = 3;
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "[{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(clientVersionRequestId)
                 + ",\"method\":\"web3_clientVersion\"},"
                 + "{\"jsonrpc\":\"2.0\", \"method\":\"web3_clientVersion\"},"
                 + "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(netVersionRequestId)
-                + ",\"method\":\"net_version\"}]");
+                + ",\"method\":\"net_version\"}]",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1620,7 +1620,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
    */
   @Test
   public void emptyBatchRequest() throws Exception {
-    final RequestBody body = RequestBody.create(JSON, "[]");
+    final RequestBody body = RequestBody.create("[]", JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);
@@ -1759,8 +1759,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "007";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}",
+            JSON);
     when(synchronizer.getSyncStatus()).thenReturn(Optional.empty());
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
@@ -1781,8 +1781,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "999";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       final String respBody = resp.body().string();
@@ -1805,8 +1805,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "999";
     final RequestBody body =
         RequestBody.create(
-            JSON,
-            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}");
+            "{\"jsonrpc\":\"2.0\",\"id\":" + Json.encode(id) + ",\"method\":\"eth_syncing\"}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       final String respBody = resp.body().string();
@@ -1873,14 +1873,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "88";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getStorageAt\", \"params\": [\""
                 + address
                 + "\",\""
                 + UInt256.ZERO
-                + "\",\"latest\"]}");
+                + "\",\"latest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1910,14 +1910,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "88";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getStorageAt\", \"params\": [\""
                 + address
                 + "\",\""
                 + UInt256.ONE
-                + "\",\"latest\"]}");
+                + "\",\"latest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1946,14 +1946,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "88";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getStorageAt\", \"params\": [\""
                 + address
                 + "\",\""
                 + UInt256.ONE
-                + "\",\"earliest\"]}");
+                + "\",\"earliest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -1982,7 +1982,6 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "999";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getStorageAt\", \"params\": [\""
@@ -1991,7 +1990,8 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
                 + UInt256.ZERO
                 + "\",\""
                 + 0L
-                + "\"]}");
+                + "\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(200);
@@ -2016,14 +2016,14 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     final String id = "88";
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"method\":\"eth_getStorageAt\", \"params\": [\""
                 + address
                 + "\",\""
                 + "blah"
-                + "\",\"latest\"]}");
+                + "\",\"latest\"]}",
+            JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
       assertThat(resp.code()).isEqualTo(400);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/EthJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/EthJsonRpcHttpServiceTest.java
@@ -125,14 +125,14 @@ public class EthJsonRpcHttpServiceTest extends AbstractJsonRpcHttpServiceTest {
       throws Exception {
     final RequestBody body =
         RequestBody.create(
-            JSON,
             "{\"jsonrpc\":\"2.0\",\"id\":"
                 + Json.encode(id)
                 + ",\"params\": "
                 + params
                 + ",\"method\":\""
                 + method
-                + "\"}");
+                + "\"}",
+            JSON);
     final Request request = new Request.Builder().post(body).url(baseUrl).build();
     return client.newCall(request).execute();
   }


### PR DESCRIPTION
Content type moved to second arg where needed to avoid deprecation warning

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).