### PR TITLE
Improve get protocol schedule (only get header and not the entire block)

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.consensus.merge;
 import static org.hyperledger.besu.util.Slf4jLambdaHelper.debugLambda;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
-import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 import org.hyperledger.besu.ethereum.core.TransactionFilter;
@@ -117,8 +116,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
 
     return Optional.ofNullable(protocolContext)
         .map(ProtocolContext::getBlockchain)
-        .flatMap(blockchain -> blockchain.getBlockByNumber(number))
-        .map(Block::getHeader)
+        .flatMap(blockchain -> blockchain.getBlockHeader(number))
         .map(timestampSchedule::getByBlockHeader)
         .orElseGet(
             () ->

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionProtocolScheduleTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionProtocolScheduleTest.java
@@ -162,8 +162,7 @@ public class TransitionProtocolScheduleTest {
 
   @Test
   public void getByBlockNumber_returnsTimestampScheduleIfPresent() {
-    final Block block = new Block(blockHeader, BlockBody.empty());
-    when(blockchain.getBlockByNumber(BLOCK_NUMBER)).thenReturn(Optional.of(block));
+    when(blockchain.getBlockHeader(BLOCK_NUMBER)).thenReturn(Optional.of(blockHeader));
     when(timestampSchedule.getByBlockHeader(blockHeader)).thenReturn(mock(ProtocolSpec.class));
 
     assertThat(transitionProtocolSchedule.getByBlockNumber(BLOCK_NUMBER)).isNotNull();

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionProtocolScheduleTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/TransitionProtocolScheduleTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
-import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -173,7 +171,7 @@ public class TransitionProtocolScheduleTest {
 
   @Test
   public void getByBlockNumber_delegatesToPreMergeScheduleWhenBlockNotFound() {
-    when(blockchain.getBlockByNumber(BLOCK_NUMBER)).thenReturn(Optional.empty());
+    when(blockchain.getBlockHeader(BLOCK_NUMBER)).thenReturn(Optional.empty());
     when(mergeContext.isPostMerge()).thenReturn(false);
 
     transitionProtocolSchedule.getByBlockNumber(BLOCK_NUMBER);
@@ -183,7 +181,7 @@ public class TransitionProtocolScheduleTest {
 
   @Test
   public void getByBlockNumber_delegatesToPostMergeScheduleWhenBlockNotFound() {
-    when(blockchain.getBlockByNumber(BLOCK_NUMBER)).thenReturn(Optional.empty());
+    when(blockchain.getBlockHeader(BLOCK_NUMBER)).thenReturn(Optional.empty());
     when(mergeContext.isPostMerge()).thenReturn(true);
 
     transitionProtocolSchedule.getByBlockNumber(BLOCK_NUMBER);
@@ -193,8 +191,6 @@ public class TransitionProtocolScheduleTest {
 
   @Test
   public void getByBlockNumber_delegatesToPostMergeScheduleWhenTimestampScheduleDoesNotExist() {
-    final Block block = new Block(blockHeader, BlockBody.empty());
-    when(blockchain.getBlockByNumber(BLOCK_NUMBER)).thenReturn(Optional.of(block));
     when(mergeContext.isPostMerge()).thenReturn(true);
 
     transitionProtocolSchedule.getByBlockNumber(BLOCK_NUMBER);


### PR DESCRIPTION
Signed-off-by: Karim TAAM [karim.t2am@gmail.com](mailto:karim.t2am@gmail.com)
Co-authored-by: Ameziane H [ameziane.hamlat@consensys.net](mailto:ameziane.hamlat@consensys.net)

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
There is a performance regression in the RC version 23.1.0-RC1 compared to 22.10.3 in both engine_getPayloadV1 and engine_forkchoiceUpdatedV1 calls. This regression is related to recent changes in the way we get the protocol specifications. We get the whole block by decoding each single transaction to use only the block header.
```
return Optional.ofNullable(protocolContext)
        .map(ProtocolContext::getBlockchain)
        .flatMap(blockchain -> blockchain.getBlockByNumber(number))
        .map(Block::getHeader)
        .map(timestampSchedule::getByBlockHeader)
        .orElseGet(
            () ->
                transitionUtils.dispatchFunctionAccordingToMergeState(
                    protocolSchedule -> protocolSchedule.getByBlockNumber(number)));
```

![image](https://user-images.githubusercontent.com/5099602/212659020-cd0c50d1-894c-423d-831c-ae8ff2b0784b.png)

The fix here is to use         
```.flatMap(blockchain -> blockchain.getBlockHeader(number))```

instead of
```  
.flatMap(blockchain -> blockchain.getBlockByNumber(number))
        .map(Block::getHeader)
```

Profiling on version 23.1.0-RC1 (with the regression)
![Screenshot 2023-01-16 at 11 18 31](https://user-images.githubusercontent.com/5099602/212657155-adbd67c8-a5e7-4b44-b23d-8fbd187096ee.png)


Profiling on version 22.10.3 (without the performance regression)

![image](https://user-images.githubusercontent.com/5099602/212658097-9db79cc5-5de7-41c4-a65c-aa6cd629ace5.png)

Block processing and FCU time

![image](https://user-images.githubusercontent.com/5099602/212666583-7b8c9704-87d9-4e60-803f-9564ff3dd89d.png)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).