### PR TITLE
Remove noop WithdrawalsProcessor

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -702,7 +702,7 @@ public abstract class MainnetProtocolSpecs {
                         TransactionType.EIP1559),
                     quorumCompatibilityMode,
                     SHANGHAI_INIT_CODE_SIZE_LIMIT))
-        .withdrawalsProcessor(new WithdrawalsProcessor.DefaultWithdrawalsProcessor())
+        .withdrawalsProcessor(new WithdrawalsProcessor())
         .withdrawalsValidator(new WithdrawalsValidator.AllowedWithdrawals())
         .name("Shanghai");
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessor.java
@@ -20,27 +20,14 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.List;
 
-public interface WithdrawalsProcessor {
+public class WithdrawalsProcessor {
 
-  void processWithdrawals(final List<Withdrawal> withdrawals, final WorldUpdater worldUpdater);
-
-  class NoOpWithdrawalsProcessor implements WithdrawalsProcessor {
-
-    @Override
-    public void processWithdrawals(
-        final List<Withdrawal> withdrawals, final WorldUpdater worldUpdater) {}
-  }
-
-  class DefaultWithdrawalsProcessor implements WithdrawalsProcessor {
-
-    @Override
-    public void processWithdrawals(
-        final List<Withdrawal> withdrawals, final WorldUpdater worldUpdater) {
-      for (final Withdrawal withdrawal : withdrawals) {
-        final EvmAccount account = worldUpdater.getOrCreate(withdrawal.getAddress());
-        account.getMutable().incrementBalance(withdrawal.getAmount());
-      }
-      worldUpdater.commit();
+  public void processWithdrawals(
+      final List<Withdrawal> withdrawals, final WorldUpdater worldUpdater) {
+    for (final Withdrawal withdrawal : withdrawals) {
+      final EvmAccount account = worldUpdater.getOrCreate(withdrawal.getAddress());
+      account.getMutable().incrementBalance(withdrawal.getAmount());
     }
+    worldUpdater.commit();
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
@@ -33,38 +33,6 @@ import org.junit.jupiter.api.Test;
 
 class WithdrawalsProcessorTest {
 
-  private final WithdrawalsProcessor.DefaultWithdrawalsProcessor defaultWithdrawalsProcessor =
-      new WithdrawalsProcessor.DefaultWithdrawalsProcessor();
-
-  @Test
-  void noopProcessor_shouldNotProcessWithdrawals() {
-    final MutableWorldState worldState =
-        createWorldStateWithAccounts(List.of(entry("0x1", 1), entry("0x2", 2), entry("0x3", 3)));
-    final MutableWorldState originalState = worldState.copy();
-    final WorldUpdater updater = worldState.updater();
-
-    final List<Withdrawal> withdrawals =
-        List.of(
-            new Withdrawal(
-                UInt64.valueOf(100),
-                UInt64.valueOf(1000),
-                Address.fromHexString("0x1"),
-                Wei.of(100)),
-            new Withdrawal(
-                UInt64.valueOf(200),
-                UInt64.valueOf(2000),
-                Address.fromHexString("0x2"),
-                Wei.of(200)));
-    final WithdrawalsProcessor noopWithdrawalsProcessor =
-        new WithdrawalsProcessor.NoOpWithdrawalsProcessor();
-    noopWithdrawalsProcessor.processWithdrawals(withdrawals, updater);
-
-    assertThat(worldState.get(Address.fromHexString("0x1")).getBalance()).isEqualTo(Wei.of(1));
-    assertThat(worldState.get(Address.fromHexString("0x2")).getBalance()).isEqualTo(Wei.of(2));
-    assertThat(worldState.get(Address.fromHexString("0x3")).getBalance()).isEqualTo(Wei.of(3));
-    assertThat(originalState).isEqualTo(worldState);
-  }
-
   @Test
   void defaultProcessor_shouldProcessEmptyWithdrawalsWithoutChangingWorldState() {
     final MutableWorldState worldState =
@@ -72,7 +40,8 @@ class WithdrawalsProcessorTest {
     final MutableWorldState originalState = worldState.copy();
     final WorldUpdater updater = worldState.updater();
 
-    defaultWithdrawalsProcessor.processWithdrawals(Collections.emptyList(), updater);
+    final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
+    withdrawalsProcessor.processWithdrawals(Collections.emptyList(), updater);
 
     assertThat(worldState.get(Address.fromHexString("0x1")).getBalance()).isEqualTo(Wei.of(1));
     assertThat(worldState.get(Address.fromHexString("0x2")).getBalance()).isEqualTo(Wei.of(2));
@@ -98,7 +67,8 @@ class WithdrawalsProcessorTest {
                 UInt64.valueOf(2000),
                 Address.fromHexString("0x2"),
                 Wei.of(200)));
-    defaultWithdrawalsProcessor.processWithdrawals(withdrawals, updater);
+    final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
+    withdrawalsProcessor.processWithdrawals(withdrawals, updater);
 
     assertThat(worldState.get(Address.fromHexString("0x1")).getBalance()).isEqualTo(Wei.of(101));
     assertThat(worldState.get(Address.fromHexString("0x2")).getBalance()).isEqualTo(Wei.of(202));
@@ -122,7 +92,8 @@ class WithdrawalsProcessorTest {
                 UInt64.valueOf(2000),
                 Address.fromHexString("0x2"),
                 Wei.of(200)));
-    defaultWithdrawalsProcessor.processWithdrawals(withdrawals, updater);
+    final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
+    withdrawalsProcessor.processWithdrawals(withdrawals, updater);
 
     assertThat(worldState.get(Address.fromHexString("0x1")).getBalance()).isEqualTo(Wei.of(100));
     assertThat(worldState.get(Address.fromHexString("0x2")).getBalance()).isEqualTo(Wei.of(200));


### PR DESCRIPTION
Signed-off-by: Jason Frame <jason.frame@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Some cleanup, the noop withdrawals processor is no longer needed since ProtocolSpec returns an Optional<WithdrawalsProcessor> instead.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).