### PR TITLE
Add optional list of withdrawals to block body

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -484,7 +484,8 @@ public class BesuEventsImplTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -54,7 +55,8 @@ public class CliqueBlockChoiceTests {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, addresses);
-    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    return new Block(
+        header, new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
@@ -59,7 +60,8 @@ public class NodeCanProduceNextBlockTest {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, validatorList);
-    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+    return new Block(
+        header, new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -115,7 +115,7 @@ public class CliqueBlockCreatorTest {
         new Block(
             TestHelpers.createCliqueSignedBlockHeader(
                 headerTestFixture, otherKeyPair, validatorList),
-            new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
     blockchain.appendBlock(emptyBlock, Lists.newArrayList());
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
@@ -249,6 +249,7 @@ public class CliqueMiningCoordinatorTest {
     headerTestFixture.number(blockNumber).parentHash(parentHash);
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerTestFixture, signer, validators);
-    return new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+    return new Block(
+        header, new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   }
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.util.Lists;
@@ -43,7 +44,7 @@ public class VoteTallyCacheTestBase {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
     return new Block(
         headerBuilder.buildHeader(),
-        new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   }
 
   protected MutableBlockchain blockChain;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -280,7 +280,8 @@ public class TestContextBuilder {
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
     return new Block(
-        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        genesisHeader,
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   }
 
   private static ControllerAndState createControllerAndFinalState(

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
@@ -110,7 +110,7 @@ public class IbftRoundIntegrationTest {
     headerTestFixture.extraData(bftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -123,7 +123,7 @@ public class IbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(new IbftExtraDataCodec().encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
   }
 
   @Before

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -119,7 +119,7 @@ public class IbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
@@ -361,7 +361,8 @@ public class TestContextBuilder {
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
     return new Block(
-        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        genesisHeader,
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   }
 
   private GenesisState createGenesisBlock(final String genesisFile) throws IOException {

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -55,6 +55,7 @@ import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleExcepti
 import org.hyperledger.besu.util.Subscribers;
 
 import java.math.BigInteger;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,7 +113,7 @@ public class QbftRoundIntegrationTest {
     headerTestFixture.extraData(qbftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -40,6 +40,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.pki.cms.CmsCreator;
 
 import java.util.Collections;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
@@ -121,7 +122,7 @@ public class PkiQbftBlockCreatorTest {
     final Block block =
         new Block(
             blockHeaderWithExtraData,
-            new BlockBody(Collections.emptyList(), Collections.emptyList()));
+            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
     when(blockCreator.createBlock(eq(1L)))
         .thenReturn(new BlockCreationResult(block, new TransactionSelectionResults()));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -51,7 +51,7 @@ public class ProposalTest {
   private static final Block BLOCK =
       new Block(
           new BlockHeaderTestFixture().extraData(bftExtraDataCodec.encode(extraData)).buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
 
   @Test
   public void canRoundTripProposalMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -51,7 +51,7 @@ public class RoundChangeTest {
           new BlockHeaderTestFixture()
               .extraData(new QbftExtraDataCodec().encode(extraData))
               .buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
 
   @Test
   public void canRoundTripARoundChangeMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -123,7 +123,7 @@ public class QbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(bftExtraDataCodec.encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
   }
 
   @Before

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -127,7 +127,7 @@ public class QbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
@@ -92,7 +92,8 @@ public class ForkingValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
+    return new Block(
+        headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList(), Optional.empty()));
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
@@ -77,7 +78,8 @@ public class TransactionValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
+    return new Block(
+        headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList(), Optional.empty()));
   }
 
   @Test

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            new BlockBody(transactionList, emptyList(), Optional.empty()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            new BlockBody(transactionList, emptyList(), Optional.empty()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -179,7 +179,8 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
 
     final var block =
-        new Block(newBlockHeader, new BlockBody(transactions, Collections.emptyList()));
+        new Block(
+            newBlockHeader, new BlockBody(transactions, Collections.emptyList(), Optional.empty()));
 
     if (parentHeader.isEmpty()) {
       debugLambda(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Collections;
+import java.util.Optional;
 
 public class UncleBlockResult {
 
@@ -30,7 +31,8 @@ public class UncleBlockResult {
    * @return A BlockResult, generated from the header and empty body.
    */
   public static BlockResult build(final BlockHeader header) {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     final int size = new Block(header, body).calculateSize();
     return new BlockResult(
         header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, size);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -174,7 +174,8 @@ public class EthGasPriceTest {
                         Bytes.EMPTY,
                         Address.ZERO,
                         Optional.empty())),
-                List.of())));
+                List.of(),
+                Optional.empty())));
   }
 
   private Object createEmptyBlock(final Long height) {
@@ -198,7 +199,7 @@ public class EthGasPriceTest {
                 Hash.EMPTY,
                 0,
                 null),
-            new BlockBody(List.of(), List.of())));
+            new BlockBody(List.of(), List.of(), Optional.empty())));
   }
 
   private JsonRpcRequestContext requestWithParams(final Object... params) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -146,7 +146,9 @@ public class EthGetUncleByBlockHashAndIndexTest {
 
   private BlockResult blockResult(final BlockHeader header) {
     final Block block =
-        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        new Block(
+            header,
+            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -123,7 +123,9 @@ public class EthGetUncleByBlockNumberAndIndexTest {
 
   private BlockResult blockResult(final BlockHeader header) {
     final Block block =
-        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        new Block(
+            header,
+            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -76,7 +76,9 @@ public abstract class AbstractEngineGetPayloadTest {
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
   private static final Block mockBlock =
-      new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+      new Block(
+          mockHeader,
+          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   private static final BlockWithReceipts mockBlockWithReceipts =
       new BlockWithReceipts(mockBlock, Collections.emptyList());
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -186,7 +186,9 @@ public abstract class AbstractEngineNewPayloadTest {
   public void shouldReturnSuccessOnAlreadyPresent() {
     BlockHeader mockHeader = new BlockHeaderTestFixture().baseFeePerGas(Wei.ONE).buildHeader();
     Block mockBlock =
-        new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        new Block(
+            mockHeader,
+            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
 
     when(blockchain.getBlockByHash(any())).thenReturn(Optional.of(mockBlock));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -68,7 +68,8 @@ public class RewardTraceGeneratorTest {
 
   @Before
   public void setUp() {
-    final BlockBody blockBody = new BlockBody(Collections.emptyList(), List.of(ommerHeader));
+    final BlockBody blockBody =
+        new BlockBody(Collections.emptyList(), List.of(ommerHeader), Optional.empty());
     final BlockHeader blockHeader =
         gen.header(0x0A, blockBody, new BlockDataGenerator.BlockOptions());
     block = new Block(blockHeader, blockBody);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -112,7 +112,8 @@ public class BlockchainQueriesLogCacheTest {
             0,
             new MainnetBlockHeaderFunctions());
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testHash));
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
@@ -95,7 +95,8 @@ public class GoQuorumPrivateTxBloomBlockchainQueriesTest {
             new MainnetBlockHeaderFunctions(),
             Optional.of(testLogsBloomFilter));
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
@@ -107,7 +107,8 @@ public class GoQuorumPrivateTransactionLogBloomCacherTest {
   @Test
   public void shouldUpdateCacheWhenBlockAdded() throws IOException {
 
-    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody fakeBody =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     when(blockchain.getBlockHeader(testBlockHeaderHash)).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testBlockHeaderHash));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -214,7 +214,9 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final BlockHeader blockHeader = createFinalBlockHeader(sealableBlockHeader);
 
       final Block block =
-          new Block(blockHeader, new BlockBody(transactionResults.getTransactions(), ommers));
+          new Block(
+              blockHeader,
+              new BlockBody(transactionResults.getTransactions(), ommers, Optional.empty()));
       return new BlockCreationResult(block, transactionResults);
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
@@ -42,7 +42,7 @@ public class AbstractMiningCoordinatorTest {
   private static final Block BLOCK =
       new Block(
           new BlockHeaderTestFixture().buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
   private final Blockchain blockchain = mock(Blockchain.class);
   private final PoWMinerExecutor minerExecutor = mock(PoWMinerExecutor.class);
   private final SyncState syncState = mock(SyncState.class);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
@@ -52,7 +52,8 @@ public class BlockMinerTest {
 
     final Block blockToCreate =
         new Block(
-            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+            headerBuilder.buildHeader(),
+            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 
@@ -93,7 +94,8 @@ public class BlockMinerTest {
 
     final Block blockToCreate =
         new Block(
-            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
+            headerBuilder.buildHeader(),
+            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.unsegmented.RocksDBK
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -76,7 +77,7 @@ public class OperationBenchmarkHelper {
                   .number(i)
                   .difficulty(Difficulty.ONE)
                   .buildHeader(),
-              new BlockBody(emptyList(), emptyList())),
+              new BlockBody(emptyList(), emptyList(), Optional.empty())),
           emptyList());
     }
     final MessageFrame messageFrame =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -53,7 +54,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 public final class GenesisState {
 
   private static final BlockBody BODY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList());
+      new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
 
   private final Block block;
   private final List<GenesisAccount> genesisAccounts;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -71,7 +72,7 @@ public class Block {
     final List<BlockHeader> ommers = in.readList(rlp -> BlockHeader.readFrom(rlp, hashFunction));
     in.leaveList();
 
-    return new Block(header, new BlockBody(transactions, ommers));
+    return new Block(header, new BlockBody(transactions, ommers, Optional.empty()));
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
@@ -60,9 +60,7 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     return ommers;
   }
 
-  /**
-   * @return The list of transactions of the block.
-   */
+  /** Returns the list of withdrawals of the block. */
   public Optional<List<Withdrawal>> getWithdrawals() {
     return withdrawals;
   }
@@ -95,7 +93,7 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     BlockBody blockBody = (BlockBody) o;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
@@ -20,18 +20,24 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
 
   private static final BlockBody EMPTY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList());
+      new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
 
   private final List<Transaction> transactions;
   private final List<BlockHeader> ommers;
+  private final Optional<List<Withdrawal>> withdrawals;
 
-  public BlockBody(final List<Transaction> transactions, final List<BlockHeader> ommers) {
+  public BlockBody(
+      final List<Transaction> transactions,
+      final List<BlockHeader> ommers,
+      final Optional<List<Withdrawal>> withdrawals) {
     this.transactions = transactions;
     this.ommers = ommers;
+    this.withdrawals = withdrawals;
   }
 
   public static BlockBody empty() {
@@ -55,6 +61,13 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
   }
 
   /**
+   * @return The list of transactions of the block.
+   */
+  public Optional<List<Withdrawal>> getWithdrawals() {
+    return withdrawals;
+  }
+
+  /**
    * Writes Block to {@link RLPOutput}.
    *
    * @param output Output to write to
@@ -75,34 +88,36 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     final BlockBody body =
         new BlockBody(
             input.readList(Transaction::readFrom),
-            input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)));
+            input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)),
+            Optional.empty());
     input.leaveList();
     return body;
   }
 
   @Override
-  public boolean equals(final Object obj) {
-    if (obj == this) {
-      return true;
-    }
-    if (!(obj instanceof BlockBody)) {
-      return false;
-    }
-    final BlockBody other = (BlockBody) obj;
-    return transactions.equals(other.transactions) && ommers.equals(other.ommers);
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    BlockBody blockBody = (BlockBody) o;
+    return Objects.equals(transactions, blockBody.transactions)
+        && Objects.equals(ommers, blockBody.ommers)
+        && Objects.equals(withdrawals, blockBody.withdrawals);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(transactions, ommers);
+    return Objects.hash(transactions, ommers, withdrawals);
   }
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append("BlockBody{");
-    sb.append("transactions=").append(transactions).append(", ");
-    sb.append("ommers=").append(ommers);
-    return sb.append("}").toString();
+    return "BlockBody{"
+        + "transactions="
+        + transactions
+        + ", ommers="
+        + ommers
+        + ", withdrawals="
+        + withdrawals
+        + '}';
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
@@ -60,7 +60,11 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     return ommers;
   }
 
-  /** Returns the list of withdrawals of the block. */
+  /**
+   * Returns the withdrawals of the block.
+   *
+   * @return The optional list of withdrawals included in the block.
+   */
   public Optional<List<Withdrawal>> getWithdrawals() {
     return withdrawals;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
@@ -29,6 +29,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -101,7 +102,8 @@ public final class RawBlockIterator implements Iterator<Block>, Closeable {
       rlp.enterList();
       final BlockHeader header = headerReader.apply(rlp);
       final BlockBody body =
-          new BlockBody(rlp.readList(Transaction::readFrom), rlp.readList(headerReader));
+          new BlockBody(
+              rlp.readList(Transaction::readFrom), rlp.readList(headerReader), Optional.empty());
       next = new Block(header, body);
       readBuffer.position(length);
       readBuffer.compact();

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -327,7 +327,7 @@ public class BlockDataGenerator {
       defaultTxs.add(transaction(options.getTransactionTypes()));
     }
 
-    return new BlockBody(options.getTransactions(defaultTxs), ommers);
+    return new BlockBody(options.getTransactions(defaultTxs), ommers, Optional.empty());
   }
 
   private BlockHeader ommer() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
@@ -39,7 +39,9 @@ public class BlockValueCalculatorTest {
             .baseFeePerGas(Wei.of(baseFee))
             .buildHeader();
     final Block block =
-        new Block(blockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
+        new Block(
+            blockHeader,
+            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
     long blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(new BlockWithReceipts(block, Collections.emptyList()));
@@ -83,7 +85,9 @@ public class BlockValueCalculatorTest {
             .baseFeePerGas(Wei.of(baseFee))
             .buildHeader();
     final Block block =
-        new Block(blockHeader, new BlockBody(List.of(tx1, tx2, tx3), Collections.emptyList()));
+        new Block(
+            blockHeader,
+            new BlockBody(List.of(tx1, tx2, tx3), Collections.emptyList(), Optional.empty()));
     long blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
@@ -76,7 +76,8 @@ public class BaseFeeBlockBodyValidatorTest {
                         .createTransaction(keyPair),
                     // frontier transaction
                     new TransactionTestFixture().gasPrice(Wei.of(10L)).createTransaction(keyPair)),
-                Collections.emptyList()));
+                Collections.emptyList(),
+                Optional.empty()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isTrue();
   }
@@ -90,7 +91,8 @@ public class BaseFeeBlockBodyValidatorTest {
                 List.of(
                     // underpriced frontier transaction
                     new TransactionTestFixture().gasPrice(Wei.of(9L)).createTransaction(keyPair)),
-                Collections.emptyList()));
+                Collections.emptyList(),
+                Optional.empty()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }
@@ -108,7 +110,8 @@ public class BaseFeeBlockBodyValidatorTest {
                         .maxPriorityFeePerGas(Optional.of(Wei.of(10L)))
                         .type(TransactionType.EIP1559)
                         .createTransaction(keyPair)),
-                Collections.emptyList()));
+                Collections.emptyList(),
+                Optional.empty()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
@@ -52,7 +53,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    return new BlockBody(transactions, ommers);
+    return new BlockBody(transactions, ommers, Optional.empty());
   }
 
   public static Block readBlock(final long num) throws IOException {
@@ -67,7 +68,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    final BlockBody body = new BlockBody(transactions, ommers);
+    final BlockBody body = new BlockBody(transactions, ommers, Optional.empty());
     return new Block(header, body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
@@ -60,7 +61,8 @@ public final class BlockBodiesMessageTest {
           new BlockBody(
               oneBlock.readList(Transaction::readFrom),
               oneBlock.readList(
-                  rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()))));
+                  rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions())),
+              Optional.empty()));
     }
     final MessageData initialMessage = BlockBodiesMessage.create(bodies);
     final MessageData raw = new RawMessage(EthPV62.BLOCK_BODIES, initialMessage.getData());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
@@ -285,7 +285,8 @@ public class MessageWrapperTest {
         @JsonProperty("Uncles") final List<TestBlockHeader> uncles) {
       super(
           transactions.stream().collect(toUnmodifiableList()),
-          uncles.stream().collect(toUnmodifiableList()));
+          uncles.stream().collect(toUnmodifiableList()),
+          Optional.empty());
     }
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.ethereum.eth.messages.NewBlockMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 
 import java.util.Collections;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.Test;
@@ -82,7 +83,8 @@ public class BlockBroadcasterTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.Di
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -115,7 +116,7 @@ public class TrailingPeerLimiterTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+                new BlockBody(emptyList(), emptyList(), Optional.empty())),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);
@@ -133,7 +134,7 @@ public class TrailingPeerLimiterTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(599).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+                new BlockBody(emptyList(), emptyList(), Optional.empty())),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
@@ -94,11 +94,14 @@ public class ChainForTestCreator {
   }
 
   public static Block createEmptyBlock(final Long height) {
-    return new Block(prepareEmptyHeader(height), new BlockBody(List.of(), List.of()));
+    return new Block(
+        prepareEmptyHeader(height), new BlockBody(List.of(), List.of(), Optional.empty()));
   }
 
   private static Block createEmptyBlock(final Block parent) {
-    return new Block(prepareEmptyHeader(parent.getHeader()), new BlockBody(List.of(), List.of()));
+    return new Block(
+        prepareEmptyHeader(parent.getHeader()),
+        new BlockBody(List.of(), List.of(), Optional.empty()));
   }
 
   private static BlockHeader prepareEmptyHeader(final Long number) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
@@ -76,7 +76,8 @@ public class CheckPointBlockImportStepTest {
   }
 
   private Block generateBlock(final int blockNumber) {
-    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
+    final BlockBody body =
+        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
     return new Block(new BlockHeaderTestFixture().number(blockNumber).buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -329,7 +329,7 @@ public class SnapWorldDownloadStateTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+                new BlockBody(emptyList(), emptyList(), Optional.empty())),
             Collections.emptyList(),
             Collections.emptyList()));
 
@@ -355,7 +355,7 @@ public class SnapWorldDownloadStateTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList())),
+                new BlockBody(emptyList(), emptyList(), Optional.empty())),
             Collections.emptyList(),
             Collections.emptyList()));
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLegacyTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLegacyTest.java
@@ -111,7 +111,7 @@ public class TransactionPoolLegacyTest extends AbstractTransactionPoolTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            new BlockBody(transactionList, emptyList(), Optional.empty()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLondonTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLondonTest.java
@@ -126,7 +126,7 @@ public class TransactionPoolLondonTest extends AbstractTransactionPoolTest {
                 .parentHash(executionContextTestFixture.getBlockchain().getChainHeadHash())
                 .number(executionContextTestFixture.getBlockchain().getChainHeadBlockNumber() + 1)
                 .buildHeader(),
-            new BlockBody(List.of(), List.of()));
+            new BlockBody(List.of(), List.of(), Optional.empty()));
     executionContextTestFixture.getBlockchain().appendBlock(block, List.of());
 
     return executionContextTestFixture;
@@ -152,7 +152,7 @@ public class TransactionPoolLondonTest extends AbstractTransactionPoolTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList()));
+            new BlockBody(transactionList, emptyList(), Optional.empty()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Map;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -256,7 +257,8 @@ public class BlockchainReferenceTestCaseSpec {
       final BlockBody body =
           new BlockBody(
               input.readList(Transaction::readFrom),
-              input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions)));
+              input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions)),
+              Optional.empty());
       // input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions),
       // input.isEndOfCurrentList()
       //         ? Optional.empty()


### PR DESCRIPTION
Signed-off-by: Jason Frame <jason.frame@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Add optional list of withdrawals to block body. Also update the equals, hashcode methods. This does not wire withdrawals into the block body it's just to reduce the noise as many uses especially tests will use Optional.empty for withdrawals. Changes to wire in the list of withdrawals will be done in a subsequent PR.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).