### PR TITLE
Fix: Hive engine api FCU regression

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -143,6 +143,10 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                         ws ->
                             ws.stream().map(WithdrawalParameter::toWithdrawal).collect(toList())));
 
+    ForkchoiceResult result =
+            mergeCoordinator.updateForkChoice(
+                    newHead, forkChoice.getFinalizedBlockHash(), forkChoice.getSafeBlockHash());
+
     if (maybePayloadAttributes.isPresent()
         && !isPayloadAttributesValid(maybePayloadAttributes.get(), withdrawals, newHead)) {
       warnLambda(
@@ -152,10 +156,6 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
               maybePayloadAttributes.map(EnginePayloadAttributesParameter::serialize).orElse(null));
       return new JsonRpcErrorResponse(requestId, JsonRpcError.INVALID_PAYLOAD_ATTRIBUTES);
     }
-
-    ForkchoiceResult result =
-        mergeCoordinator.updateForkChoice(
-            newHead, forkChoice.getFinalizedBlockHash(), forkChoice.getSafeBlockHash());
 
     if (!result.isValid()) {
       logForkchoiceUpdatedCall(INVALID, forkChoice);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -144,8 +144,8 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                             ws.stream().map(WithdrawalParameter::toWithdrawal).collect(toList())));
 
     ForkchoiceResult result =
-            mergeCoordinator.updateForkChoice(
-                    newHead, forkChoice.getFinalizedBlockHash(), forkChoice.getSafeBlockHash());
+        mergeCoordinator.updateForkChoice(
+            newHead, forkChoice.getFinalizedBlockHash(), forkChoice.getSafeBlockHash());
 
     if (maybePayloadAttributes.isPresent()
         && !isPayloadAttributesValid(maybePayloadAttributes.get(), withdrawals, newHead)) {


### PR DESCRIPTION
Swap lines order to ensure we commit FCU even if payload timestamp is before head timestamp

Signed-off-by: Gabriel Fukushima <gabrielfukushima@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR fixes the regression introduced recently.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Makes Besu compliant with ForkChoiceUpdate_V1 - item 7 of the Engine API specs for Paris. (https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).