### PR TITLE
Fix TOML parsing of double and float values

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
@@ -69,15 +69,17 @@ public class TomlConfigFileDefaultProvider implements IDefaultValueProvider {
     } else if (optionSpec.isMultiValue() || isArray) {
       defaultValue = getListEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Integer.class) || optionSpec.type().equals(int.class)) {
-      defaultValue = getIntegerEntryAsString(optionSpec);
+      defaultValue = getNumericEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Long.class) || optionSpec.type().equals(long.class)) {
-      defaultValue = getIntegerEntryAsString(optionSpec);
+      defaultValue = getNumericEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Wei.class)) {
-      defaultValue = getIntegerEntryAsString(optionSpec);
+      defaultValue = getNumericEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(BigInteger.class)) {
-      defaultValue = getIntegerEntryAsString(optionSpec);
+      defaultValue = getNumericEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Double.class) || optionSpec.type().equals(double.class)) {
-      defaultValue = getDoubleEntryAsString(optionSpec);
+      defaultValue = getNumericEntryAsString(optionSpec);
+    } else if (optionSpec.type().equals(Float.class) || optionSpec.type().equals(float.class)) {
+      defaultValue = getNumericEntryAsString(optionSpec);
     } else { // else will be treated as String
       defaultValue = getEntryAsString(optionSpec);
     }
@@ -129,18 +131,11 @@ public class TomlConfigFileDefaultProvider implements IDefaultValueProvider {
     return getKeyName(spec).map(result::getBoolean).map(Object::toString).orElse(null);
   }
 
-  private String getIntegerEntryAsString(final OptionSpec spec) {
-    // return the string representation of the integer value corresponding to the option in toml
-    // file
+  private String getNumericEntryAsString(final OptionSpec spec) {
+    // return the string representation of the numeric value corresponding to the option in toml
+    // file - this works for integer, double, and float
     // or null if not present in the config
     return getKeyName(spec).map(result::get).map(String::valueOf).orElse(null);
-  }
-
-  private String getDoubleEntryAsString(final OptionSpec spec) {
-    // return the string representation of the double value corresponding to the option in toml
-    // file
-    // or null if not present in the config
-    return getKeyName(spec).map(result::getDouble).map(String::valueOf).orElse(null);
   }
 
   private void checkConfigurationValidity() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/TomlConfigFileDefaultProviderTest.java
@@ -120,6 +120,7 @@ public class TomlConfigFileDefaultProviderTest {
     validOptionsMap.put("--a-string-value-option", null);
     validOptionsMap.put("--a-nested-multi-value-option", null);
     validOptionsMap.put("--a-double-value-option", null);
+    validOptionsMap.put("--a-double-value-option-int", null);
 
     when(mockCommandSpec.optionsMap()).thenReturn(validOptionsMap);
 
@@ -149,6 +150,8 @@ public class TomlConfigFileDefaultProviderTest {
           "a-nested-multi-value-option=[ [\"value1\", \"value2\"], [\"value3\", \"value4\"] ]");
       fileWriter.newLine();
       fileWriter.write("a-double-value-option=0.01");
+      fileWriter.newLine();
+      fileWriter.write("a-double-value-option-int=1"); // should be able to parse int as double
       fileWriter.flush();
 
       final TomlConfigFileDefaultProvider providerUnderTest =
@@ -205,6 +208,11 @@ public class TomlConfigFileDefaultProviderTest {
               providerUnderTest.defaultValue(
                   OptionSpec.builder("a-double-value-option").type(Double.class).build()))
           .isEqualTo("0.01");
+
+      assertThat(
+              providerUnderTest.defaultValue(
+                  OptionSpec.builder("a-double-value-option-int").type(Double.class).build()))
+          .isEqualTo("1");
 
       assertThat(
               providerUnderTest.defaultValue(


### PR DESCRIPTION
Fix TOML parsing of double 
- no special processing required for double or float
- refactor getInteger to getNumeric since it works for all number types
- added a test to ensure we can parse an int value into double type
eg 
tx-pool-limit-by-account-percentage=1.0
should work the same as
tx-pool-limit-by-account-percentage=1

Ref #4899 which didn't quite work for me. 
@bl0up does this work for you? 

Fixes #4896 

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).