### PR TITLE
Change BlockBody to use an overloaded constructor with withdrawals

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -484,8 +484,7 @@ public class BesuEventsImplTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueBlockChoiceTests.java
@@ -37,7 +37,6 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -55,8 +54,7 @@ public class CliqueBlockChoiceTests {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, addresses);
-    return new Block(
-        header, new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
+    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/NodeCanProduceNextBlockTest.java
@@ -37,7 +37,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Util;
 
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.collect.Lists;
 import org.junit.Before;
@@ -60,8 +59,7 @@ public class NodeCanProduceNextBlockTest {
   private Block createEmptyBlock(final KeyPair blockSigner) {
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerBuilder, blockSigner, validatorList);
-    return new Block(
-        header, new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
+    return new Block(header, new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
   }
 
   @Before

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -115,7 +115,7 @@ public class CliqueBlockCreatorTest {
         new Block(
             TestHelpers.createCliqueSignedBlockHeader(
                 headerTestFixture, otherKeyPair, validatorList),
-            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
+            new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
     blockchain.appendBlock(emptyBlock, Lists.newArrayList());
   }
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
@@ -249,7 +249,6 @@ public class CliqueMiningCoordinatorTest {
     headerTestFixture.number(blockNumber).parentHash(parentHash);
     final BlockHeader header =
         TestHelpers.createCliqueSignedBlockHeader(headerTestFixture, signer, validators);
-    return new Block(
-        header, new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+    return new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
   }
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/validator/blockbased/VoteTallyCacheTestBase.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.util.Lists;
@@ -44,7 +43,7 @@ public class VoteTallyCacheTestBase {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
     return new Block(
         headerBuilder.buildHeader(),
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        new BlockBody(Collections.emptyList(), Collections.emptyList()));
   }
 
   protected MutableBlockchain blockChain;

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -280,8 +280,7 @@ public class TestContextBuilder {
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
     return new Block(
-        genesisHeader,
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
   }
 
   private static ControllerAndState createControllerAndFinalState(

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/tests/round/IbftRoundIntegrationTest.java
@@ -110,7 +110,7 @@ public class IbftRoundIntegrationTest {
     headerTestFixture.extraData(bftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftBlockHeightManagerTest.java
@@ -123,7 +123,7 @@ public class IbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(new IbftExtraDataCodec().encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
   }
 
   @Before

--- a/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
+++ b/consensus/ibft/src/test/java/org/hyperledger/besu/consensus/ibft/statemachine/IbftRoundTest.java
@@ -119,7 +119,7 @@ public class IbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/support/TestContextBuilder.java
@@ -361,8 +361,7 @@ public class TestContextBuilder {
 
     final BlockHeader genesisHeader = headerTestFixture.buildHeader();
     return new Block(
-        genesisHeader,
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        genesisHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
   }
 
   private GenesisState createGenesisBlock(final String genesisFile) throws IOException {

--- a/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
+++ b/consensus/qbft/src/integration-test/java/org/hyperledger/besu/consensus/qbft/test/round/QbftRoundIntegrationTest.java
@@ -55,7 +55,6 @@ import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleExcepti
 import org.hyperledger.besu.util.Subscribers;
 
 import java.math.BigInteger;
-import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -113,7 +112,7 @@ public class QbftRoundIntegrationTest {
     headerTestFixture.extraData(qbftExtraDataEncoder.encode(proposedExtraData));
     headerTestFixture.number(1);
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
 
     when(blockImporter.importBlock(any(), any(), any())).thenReturn(new BlockImportResult(true));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/blockcreation/PkiQbftBlockCreatorTest.java
@@ -40,7 +40,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.pki.cms.CmsCreator;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.Before;
@@ -122,7 +121,7 @@ public class PkiQbftBlockCreatorTest {
     final Block block =
         new Block(
             blockHeaderWithExtraData,
-            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+            new BlockBody(Collections.emptyList(), Collections.emptyList()));
     when(blockCreator.createBlock(eq(1L)))
         .thenReturn(new BlockCreationResult(block, new TransactionSelectionResults()));
 

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/ProposalTest.java
@@ -51,7 +51,7 @@ public class ProposalTest {
   private static final Block BLOCK =
       new Block(
           new BlockHeaderTestFixture().extraData(bftExtraDataCodec.encode(extraData)).buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList()));
 
   @Test
   public void canRoundTripProposalMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/messagewrappers/RoundChangeTest.java
@@ -51,7 +51,7 @@ public class RoundChangeTest {
           new BlockHeaderTestFixture()
               .extraData(new QbftExtraDataCodec().encode(extraData))
               .buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList()));
 
   @Test
   public void canRoundTripARoundChangeMessage() {

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -123,7 +123,7 @@ public class QbftBlockHeightManagerTest {
 
     headerTestFixture.extraData(bftExtraDataCodec.encode(extraData));
     final BlockHeader header = headerTestFixture.buildHeader();
-    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    createdBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
   }
 
   @Before

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRoundTest.java
@@ -127,7 +127,7 @@ public class QbftRoundTest {
     headerTestFixture.number(1);
 
     final BlockHeader header = headerTestFixture.buildHeader();
-    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    proposedBlock = new Block(header, new BlockBody(emptyList(), emptyList()));
 
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(new BlockCreationResult(proposedBlock, new TransactionSelectionResults()));

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ForkingValidatorProviderTest.java
@@ -92,8 +92,7 @@ public class ForkingValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(
-        headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
   }
 
   @Test

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/TransactionValidatorProviderTest.java
@@ -35,7 +35,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
@@ -78,8 +77,7 @@ public class TransactionValidatorProviderTest {
 
   private Block createEmptyBlock(final long blockNumber, final Hash parentHash) {
     headerBuilder.number(blockNumber).parentHash(parentHash).coinbase(AddressHelpers.ofValue(0));
-    return new Block(
-        headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList(), Optional.empty()));
+    return new Block(headerBuilder.buildHeader(), new BlockBody(emptyList(), emptyList()));
   }
 
   @Test

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList(), Optional.empty()));
+            new BlockBody(transactionList, emptyList()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -283,7 +283,7 @@ public class EthGetFilterChangesIntegrationTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList(), Optional.empty()));
+            new BlockBody(transactionList, emptyList()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Collections;
-import java.util.Optional;
 
 public class UncleBlockResult {
 
@@ -31,8 +30,7 @@ public class UncleBlockResult {
    * @return A BlockResult, generated from the header and empty body.
    */
   public static BlockResult build(final BlockHeader header) {
-    final BlockBody body =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
     final int size = new Block(header, body).calculateSize();
     return new BlockResult(
         header, Collections.emptyList(), Collections.emptyList(), Difficulty.ZERO, size);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -174,8 +174,7 @@ public class EthGasPriceTest {
                         Bytes.EMPTY,
                         Address.ZERO,
                         Optional.empty())),
-                List.of(),
-                Optional.empty())));
+                List.of())));
   }
 
   private Object createEmptyBlock(final Long height) {
@@ -199,7 +198,7 @@ public class EthGasPriceTest {
                 Hash.EMPTY,
                 0,
                 null),
-            new BlockBody(List.of(), List.of(), Optional.empty())));
+            new BlockBody(List.of(), List.of())));
   }
 
   private JsonRpcRequestContext requestWithParams(final Object... params) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -146,9 +146,7 @@ public class EthGetUncleByBlockHashAndIndexTest {
 
   private BlockResult blockResult(final BlockHeader header) {
     final Block block =
-        new Block(
-            header,
-            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -123,9 +123,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
 
   private BlockResult blockResult(final BlockHeader header) {
     final Block block =
-        new Block(
-            header,
-            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        new Block(header, new BlockBody(Collections.emptyList(), Collections.emptyList()));
     return new BlockResult(
         header,
         Collections.emptyList(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -76,9 +76,7 @@ public abstract class AbstractEngineGetPayloadTest {
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
   private static final Block mockBlock =
-      new Block(
-          mockHeader,
-          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+      new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
   private static final BlockWithReceipts mockBlockWithReceipts =
       new BlockWithReceipts(mockBlock, Collections.emptyList());
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -185,9 +185,7 @@ public abstract class AbstractEngineNewPayloadTest {
   public void shouldReturnSuccessOnAlreadyPresent() {
     BlockHeader mockHeader = new BlockHeaderTestFixture().baseFeePerGas(Wei.ONE).buildHeader();
     Block mockBlock =
-        new Block(
-            mockHeader,
-            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        new Block(mockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
 
     when(blockchain.getBlockByHash(any())).thenReturn(Optional.of(mockBlock));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -68,8 +68,7 @@ public class RewardTraceGeneratorTest {
 
   @Before
   public void setUp() {
-    final BlockBody blockBody =
-        new BlockBody(Collections.emptyList(), List.of(ommerHeader), Optional.empty());
+    final BlockBody blockBody = new BlockBody(Collections.emptyList(), List.of(ommerHeader));
     final BlockHeader blockHeader =
         gen.header(0x0A, blockBody, new BlockDataGenerator.BlockOptions());
     block = new Block(blockHeader, blockBody);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -112,8 +112,7 @@ public class BlockchainQueriesLogCacheTest {
             0,
             new MainnetBlockHeaderFunctions());
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testHash));
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/GoQuorumPrivateTxBloomBlockchainQueriesTest.java
@@ -95,8 +95,7 @@ public class GoQuorumPrivateTxBloomBlockchainQueriesTest {
             new MainnetBlockHeaderFunctions(),
             Optional.of(testLogsBloomFilter));
     testHash = fakeHeader.getHash();
-    final BlockBody fakeBody =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
     when(blockchain.getBlockHeader(any())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHeader(anyLong())).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/GoQuorumPrivateTransactionLogBloomCacherTest.java
@@ -107,8 +107,7 @@ public class GoQuorumPrivateTransactionLogBloomCacherTest {
   @Test
   public void shouldUpdateCacheWhenBlockAdded() throws IOException {
 
-    final BlockBody fakeBody =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody fakeBody = new BlockBody(Collections.emptyList(), Collections.emptyList());
     when(blockchain.getBlockHeader(testBlockHeaderHash)).thenReturn(Optional.of(fakeHeader));
     when(blockchain.getBlockHashByNumber(anyLong())).thenReturn(Optional.of(testBlockHeaderHash));
     when(blockchain.getTxReceipts(any())).thenReturn(Optional.of(Collections.emptyList()));

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -214,9 +214,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final BlockHeader blockHeader = createFinalBlockHeader(sealableBlockHeader);
 
       final Block block =
-          new Block(
-              blockHeader,
-              new BlockBody(transactionResults.getTransactions(), ommers, Optional.empty()));
+          new Block(blockHeader, new BlockBody(transactionResults.getTransactions(), ommers));
       return new BlockCreationResult(block, transactionResults);
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractMiningCoordinatorTest.java
@@ -42,7 +42,7 @@ public class AbstractMiningCoordinatorTest {
   private static final Block BLOCK =
       new Block(
           new BlockHeaderTestFixture().buildHeader(),
-          new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+          new BlockBody(Collections.emptyList(), Collections.emptyList()));
   private final Blockchain blockchain = mock(Blockchain.class);
   private final PoWMinerExecutor minerExecutor = mock(PoWMinerExecutor.class);
   private final SyncState syncState = mock(SyncState.class);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/BlockMinerTest.java
@@ -52,8 +52,7 @@ public class BlockMinerTest {
 
     final Block blockToCreate =
         new Block(
-            headerBuilder.buildHeader(),
-            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
+            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 
@@ -94,8 +93,7 @@ public class BlockMinerTest {
 
     final Block blockToCreate =
         new Block(
-            headerBuilder.buildHeader(),
-            new BlockBody(Lists.newArrayList(), Lists.newArrayList(), Optional.empty()));
+            headerBuilder.buildHeader(), new BlockBody(Lists.newArrayList(), Lists.newArrayList()));
 
     final ProtocolContext protocolContext = new ProtocolContext(null, null, null);
 

--- a/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
+++ b/ethereum/core/src/jmh/java/org/hyperledger/besu/ethereum/vm/operations/OperationBenchmarkHelper.java
@@ -34,7 +34,6 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.unsegmented.RocksDBK
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
@@ -77,7 +76,7 @@ public class OperationBenchmarkHelper {
                   .number(i)
                   .difficulty(Difficulty.ONE)
                   .buildHeader(),
-              new BlockBody(emptyList(), emptyList(), Optional.empty())),
+              new BlockBody(emptyList(), emptyList())),
           emptyList());
     }
     final MessageFrame messageFrame =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -54,7 +53,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 public final class GenesisState {
 
   private static final BlockBody BODY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+      new BlockBody(Collections.emptyList(), Collections.emptyList());
 
   private final Block block;
   private final List<GenesisAccount> genesisAccounts;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Block.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 
@@ -72,7 +71,7 @@ public class Block {
     final List<BlockHeader> ommers = in.readList(rlp -> BlockHeader.readFrom(rlp, hashFunction));
     in.leaveList();
 
-    return new Block(header, new BlockBody(transactions, ommers, Optional.empty()));
+    return new Block(header, new BlockBody(transactions, ommers));
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockBody.java
@@ -25,11 +25,17 @@ import java.util.Optional;
 public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
 
   private static final BlockBody EMPTY =
-      new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+      new BlockBody(Collections.emptyList(), Collections.emptyList());
 
   private final List<Transaction> transactions;
   private final List<BlockHeader> ommers;
   private final Optional<List<Withdrawal>> withdrawals;
+
+  public BlockBody(final List<Transaction> transactions, final List<BlockHeader> ommers) {
+    this.transactions = transactions;
+    this.ommers = ommers;
+    this.withdrawals = Optional.empty();
+  }
 
   public BlockBody(
       final List<Transaction> transactions,
@@ -90,8 +96,7 @@ public class BlockBody implements org.hyperledger.besu.plugin.data.BlockBody {
     final BlockBody body =
         new BlockBody(
             input.readList(Transaction::readFrom),
-            input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)),
-            Optional.empty());
+            input.readList(rlp -> BlockHeader.readFrom(rlp, blockHeaderFunctions)));
     input.leaveList();
     return body;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/util/RawBlockIterator.java
@@ -29,7 +29,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -102,8 +101,7 @@ public final class RawBlockIterator implements Iterator<Block>, Closeable {
       rlp.enterList();
       final BlockHeader header = headerReader.apply(rlp);
       final BlockBody body =
-          new BlockBody(
-              rlp.readList(Transaction::readFrom), rlp.readList(headerReader), Optional.empty());
+          new BlockBody(rlp.readList(Transaction::readFrom), rlp.readList(headerReader));
       next = new Block(header, body);
       readBuffer.position(length);
       readBuffer.compact();

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockDataGenerator.java
@@ -327,7 +327,7 @@ public class BlockDataGenerator {
       defaultTxs.add(transaction(options.getTransactionTypes()));
     }
 
-    return new BlockBody(options.getTransactions(defaultTxs), ommers, Optional.empty());
+    return new BlockBody(options.getTransactions(defaultTxs), ommers);
   }
 
   private BlockHeader ommer() {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
@@ -39,9 +39,7 @@ public class BlockValueCalculatorTest {
             .baseFeePerGas(Wei.of(baseFee))
             .buildHeader();
     final Block block =
-        new Block(
-            blockHeader,
-            new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty()));
+        new Block(blockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
     long blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(new BlockWithReceipts(block, Collections.emptyList()));
@@ -85,9 +83,7 @@ public class BlockValueCalculatorTest {
             .baseFeePerGas(Wei.of(baseFee))
             .buildHeader();
     final Block block =
-        new Block(
-            blockHeader,
-            new BlockBody(List.of(tx1, tx2, tx3), Collections.emptyList(), Optional.empty()));
+        new Block(blockHeader, new BlockBody(List.of(tx1, tx2, tx3), Collections.emptyList()));
     long blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/BaseFeeBlockBodyValidatorTest.java
@@ -76,8 +76,7 @@ public class BaseFeeBlockBodyValidatorTest {
                         .createTransaction(keyPair),
                     // frontier transaction
                     new TransactionTestFixture().gasPrice(Wei.of(10L)).createTransaction(keyPair)),
-                Collections.emptyList(),
-                Optional.empty()));
+                Collections.emptyList()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isTrue();
   }
@@ -91,8 +90,7 @@ public class BaseFeeBlockBodyValidatorTest {
                 List.of(
                     // underpriced frontier transaction
                     new TransactionTestFixture().gasPrice(Wei.of(9L)).createTransaction(keyPair)),
-                Collections.emptyList(),
-                Optional.empty()));
+                Collections.emptyList()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }
@@ -110,8 +108,7 @@ public class BaseFeeBlockBodyValidatorTest {
                         .maxPriorityFeePerGas(Optional.of(Wei.of(10L)))
                         .type(TransactionType.EIP1559)
                         .createTransaction(keyPair)),
-                Collections.emptyList(),
-                Optional.empty()));
+                Collections.emptyList()));
 
     assertThat(blockBodyValidator.validateTransactionGasPrice(block)).isFalse();
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/ValidationTestUtils.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
@@ -53,7 +52,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    return new BlockBody(transactions, ommers, Optional.empty());
+    return new BlockBody(transactions, ommers);
   }
 
   public static Block readBlock(final long num) throws IOException {
@@ -68,7 +67,7 @@ public final class ValidationTestUtils {
     final List<Transaction> transactions = input.readList(Transaction::readFrom);
     final List<BlockHeader> ommers =
         input.readList(rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()));
-    final BlockBody body = new BlockBody(transactions, ommers, Optional.empty());
+    final BlockBody body = new BlockBody(transactions, ommers);
     return new Block(header, body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/BlockBodiesMessageTest.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
@@ -61,8 +60,7 @@ public final class BlockBodiesMessageTest {
           new BlockBody(
               oneBlock.readList(Transaction::readFrom),
               oneBlock.readList(
-                  rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions())),
-              Optional.empty()));
+                  rlp -> BlockHeader.readFrom(rlp, new MainnetBlockHeaderFunctions()))));
     }
     final MessageData initialMessage = BlockBodiesMessage.create(bodies);
     final MessageData raw = new RawMessage(EthPV62.BLOCK_BODIES, initialMessage.getData());

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/MessageWrapperTest.java
@@ -285,8 +285,7 @@ public class MessageWrapperTest {
         @JsonProperty("Uncles") final List<TestBlockHeader> uncles) {
       super(
           transactions.stream().collect(toUnmodifiableList()),
-          uncles.stream().collect(toUnmodifiableList()),
-          Optional.empty());
+          uncles.stream().collect(toUnmodifiableList()));
     }
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/BlockBroadcasterTest.java
@@ -32,7 +32,6 @@ import org.hyperledger.besu.ethereum.eth.messages.NewBlockMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.Test;
@@ -83,8 +82,7 @@ public class BlockBroadcasterTest {
   }
 
   private Block generateBlock() {
-    final BlockBody body =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
     return new Block(new BlockHeaderTestFixture().buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/TrailingPeerLimiterTest.java
@@ -36,7 +36,6 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.Di
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -116,7 +115,7 @@ public class TrailingPeerLimiterTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList(), Optional.empty())),
+                new BlockBody(emptyList(), emptyList())),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);
@@ -134,7 +133,7 @@ public class TrailingPeerLimiterTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(599).buildHeader(),
-                new BlockBody(emptyList(), emptyList(), Optional.empty())),
+                new BlockBody(emptyList(), emptyList())),
             Collections.emptyList(),
             Collections.emptyList());
     trailingPeerLimiter.onBlockAdded(blockAddedEvent);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/ChainForTestCreator.java
@@ -94,14 +94,11 @@ public class ChainForTestCreator {
   }
 
   public static Block createEmptyBlock(final Long height) {
-    return new Block(
-        prepareEmptyHeader(height), new BlockBody(List.of(), List.of(), Optional.empty()));
+    return new Block(prepareEmptyHeader(height), new BlockBody(List.of(), List.of()));
   }
 
   private static Block createEmptyBlock(final Block parent) {
-    return new Block(
-        prepareEmptyHeader(parent.getHeader()),
-        new BlockBody(List.of(), List.of(), Optional.empty()));
+    return new Block(prepareEmptyHeader(parent.getHeader()), new BlockBody(List.of(), List.of()));
   }
 
   private static BlockHeader prepareEmptyHeader(final Long number) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/checkpointsync/CheckPointBlockImportStepTest.java
@@ -76,8 +76,7 @@ public class CheckPointBlockImportStepTest {
   }
 
   private Block generateBlock(final int blockNumber) {
-    final BlockBody body =
-        new BlockBody(Collections.emptyList(), Collections.emptyList(), Optional.empty());
+    final BlockBody body = new BlockBody(Collections.emptyList(), Collections.emptyList());
     return new Block(new BlockHeaderTestFixture().number(blockNumber).buildHeader(), body);
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/SnapWorldDownloadStateTest.java
@@ -329,7 +329,7 @@ public class SnapWorldDownloadStateTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList(), Optional.empty())),
+                new BlockBody(emptyList(), emptyList())),
             Collections.emptyList(),
             Collections.emptyList()));
 
@@ -355,7 +355,7 @@ public class SnapWorldDownloadStateTest {
         BlockAddedEvent.createForHeadAdvancement(
             new Block(
                 new BlockHeaderTestFixture().number(500).buildHeader(),
-                new BlockBody(emptyList(), emptyList(), Optional.empty())),
+                new BlockBody(emptyList(), emptyList())),
             Collections.emptyList(),
             Collections.emptyList()));
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLegacyTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLegacyTest.java
@@ -110,7 +110,7 @@ public class TransactionPoolLegacyTest extends AbstractTransactionPoolTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList(), Optional.empty()));
+            new BlockBody(transactionList, emptyList()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLondonTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolLondonTest.java
@@ -124,7 +124,7 @@ public class TransactionPoolLondonTest extends AbstractTransactionPoolTest {
                 .parentHash(executionContextTestFixture.getBlockchain().getChainHeadHash())
                 .number(executionContextTestFixture.getBlockchain().getChainHeadBlockNumber() + 1)
                 .buildHeader(),
-            new BlockBody(List.of(), List.of(), Optional.empty()));
+            new BlockBody(List.of(), List.of()));
     executionContextTestFixture.getBlockchain().appendBlock(block, List.of());
 
     return executionContextTestFixture;
@@ -150,7 +150,7 @@ public class TransactionPoolLondonTest extends AbstractTransactionPoolTest {
                 .parentHash(parentBlock.getHash())
                 .number(parentBlock.getNumber() + 1)
                 .buildHeader(),
-            new BlockBody(transactionList, emptyList(), Optional.empty()));
+            new BlockBody(transactionList, emptyList()));
     final List<TransactionReceipt> transactionReceipts =
         transactionList.stream()
             .map(transaction -> new TransactionReceipt(1, 1, emptyList(), Optional.empty()))

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -39,7 +39,6 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Map;
-import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -257,8 +256,7 @@ public class BlockchainReferenceTestCaseSpec {
       final BlockBody body =
           new BlockBody(
               input.readList(Transaction::readFrom),
-              input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions)),
-              Optional.empty());
+              input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions)));
       // input.readList(inputData -> BlockHeader.readFrom(inputData, blockHeaderFunctions),
       // input.isEndOfCurrentList()
       //         ? Optional.empty()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Change BlockBody to use an overloaded constructor with withdrawals instead having a mandatory `Optional<List<Withdrawals>>` as withdrawals are only required for ethereum mainnet.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).