### PR TITLE
Change JSON RPC Error-32602 (Invalid Params) to return with http status code 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+- Changed JsonRpc http service to return the error -32602 (Invalid params) with a 200 http status code
+
 ### Additions and Improvements
 - Added option to evm CLI tool to allow code execution at specific forks [#4913](https://github.com/hyperledger/besu/pull/4913)
 - Improve get account performance by using the world state updater cache [#4897](https://github.com/hyperledger/besu/pull/4897)

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -141,7 +141,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
   }
 
   @Test
-  public void mustNotSucceedWithWronglyEncodedFunction() {
+  public void mustNotSucceedWithWronglyEncodedFunction() throws IOException {
 
     final String privacyGroupId =
         minerNode.execute(createPrivacyGroup("myGroupName", "my group description", minerNode));
@@ -162,9 +162,8 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
 
     final Request<Object, EthCall> priv_call = privCall(privacyGroupId, eventEmitter, true, false);
 
-    assertThatExceptionOfType(ClientConnectionException.class)
-        .isThrownBy(() -> priv_call.send())
-        .withMessageContaining("Invalid params");
+    final String errorMessage = priv_call.send().getError().getMessage();
+    assertThat(errorMessage).isEqualTo("Invalid params");
   }
 
   @Test

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.tests.acceptance.privacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.web3j.utils.Restriction.UNRESTRICTED;
 
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.ParameterizedEnclaveTestBase;
@@ -43,7 +42,6 @@ import org.web3j.protocol.core.Request;
 import org.web3j.protocol.core.methods.request.Transaction;
 import org.web3j.protocol.core.methods.response.EthCall;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
-import org.web3j.protocol.exceptions.ClientConnectionException;
 import org.web3j.protocol.http.HttpService;
 import org.web3j.tx.Contract;
 import org.web3j.utils.Restriction;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
@@ -177,7 +177,6 @@ public class JsonRpcExecutorHandler {
   private static HttpResponseStatus statusCodeFromError(final JsonRpcError error) {
     switch (error) {
       case INVALID_REQUEST:
-      case INVALID_PARAMS:
       case PARSE_ERROR:
         return HttpResponseStatus.BAD_REQUEST;
       default:

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -759,7 +759,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
         .thenReturn(Optional.empty());
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -783,7 +783,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -806,7 +806,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -829,7 +829,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -853,7 +853,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -873,7 +873,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -893,7 +893,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;
@@ -978,7 +978,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final String respBody = resp.body().string();
       final JsonObject json = new JsonObject(respBody);
@@ -2035,7 +2035,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
             JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {
-      assertThat(resp.code()).isEqualTo(400);
+      assertThat(resp.code()).isEqualTo(200);
       // Check general format of result
       final JsonObject json = new JsonObject(resp.body().string());
       final JsonRpcError expectedError = JsonRpcError.INVALID_PARAMS;

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_callParamsMissing_block_8.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_callParamsMissing_block_8.json
@@ -15,5 +15,5 @@
       "message":"Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_invalidBlockhash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_invalidBlockhash.json
@@ -20,5 +20,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_illegalRangeLessThan.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_illegalRangeLessThan.json
@@ -16,5 +16,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_invalidBlockHash.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBalance_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBlockTransactionCountByHash_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBlockTransactionCountByHash_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBlockTransactionCountByNumber_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getBlockTransactionCountByNumber_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_illegalRangeLessThan.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_illegalRangeLessThan.json
@@ -16,5 +16,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_invalidBlockHash.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getCode_invalidParams.json
@@ -13,5 +13,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getLogs_invalidInput.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getLogs_invalidInput.json
@@ -19,7 +19,7 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }
 
 

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getNewFilter_invalidFilter.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getNewFilter_invalidFilter.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_illegalRangeLessThan.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_illegalRangeLessThan.json
@@ -17,5 +17,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_invalidBlockHash.json
@@ -17,5 +17,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getProof_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_illegalRangeLessThan.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_illegalRangeLessThan.json
@@ -17,5 +17,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_invalidBlockHash.json
@@ -17,5 +17,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getStorageAt_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_intOverflow.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_intOverflow.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParam_00.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParam_00.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParam_01.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParam_01.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_missingParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_wrongParamType.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockHashAndIndex_wrongParamType.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockNumberAndIndex_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByBlockNumberAndIndex_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_invalidHashAndIndex.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_invalidHashAndIndex.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_invalidParams.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_invalidParams.json
@@ -13,5 +13,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_typeMismatch.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionByHash_typeMismatch.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_invalidBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_invalidBlockHash.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_invalidBlockNumber.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_invalidBlockNumber.json
@@ -16,5 +16,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_missingArgument.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getTransactionCount_missingArgument.json
@@ -13,5 +13,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_invalidByteValueHex.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_invalidByteValueHex.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_invalidRawTransaction.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_invalidRawTransaction.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_unsignedTransaction.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_sendRawTransaction_unsignedTransaction.json
@@ -15,5 +15,5 @@
       "message" : "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/flat/trace_replayBlockTransactions_invalidBlockParam.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/flat/trace_replayBlockTransactions_invalidBlockParam.json
@@ -16,5 +16,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/flat/trace_replayBlockTransactions_invalidTraceOptions.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/flat/trace_replayBlockTransactions_invalidTraceOptions.json
@@ -16,5 +16,5 @@
       "message": "Invalid params"
     }
   },
-  "statusCode": 400
+  "statusCode": 200
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR changes the JsonRpc http service to return the error -32602 (Invalid params) with a 200 http status code.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).