### PR TITLE
Add withdrawals details to eth_getBlock methods

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
@@ -56,7 +56,8 @@ public class BlockResultFactory {
         ommers,
         blockWithMetadata.getTotalDifficulty(),
         blockWithMetadata.getSize(),
-        includeCoinbase);
+        includeCoinbase,
+        blockWithMetadata.getWithdrawals());
   }
 
   public BlockResult transactionComplete(final Block block) {
@@ -135,6 +136,7 @@ public class BlockResultFactory {
         ommers,
         blockWithMetadata.getTotalDifficulty(),
         blockWithMetadata.getSize(),
-        includeCoinbase);
+        includeCoinbase,
+        blockWithMetadata.getWithdrawals());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockWithMetadata.java
@@ -16,8 +16,10 @@ package org.hyperledger.besu.ethereum.api.query;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.Withdrawal;
 
 import java.util.List;
+import java.util.Optional;
 
 public class BlockWithMetadata<T, O> {
 
@@ -26,6 +28,7 @@ public class BlockWithMetadata<T, O> {
   private final List<O> ommers;
   private final Difficulty totalDifficulty;
   private final int size;
+  private final Optional<List<Withdrawal>> withdrawals;
 
   /**
    * @param header The block header
@@ -40,11 +43,22 @@ public class BlockWithMetadata<T, O> {
       final List<O> ommers,
       final Difficulty totalDifficulty,
       final int size) {
+    this(header, transactions, ommers, totalDifficulty, size, Optional.empty());
+  }
+
+  public BlockWithMetadata(
+      final BlockHeader header,
+      final List<T> transactions,
+      final List<O> ommers,
+      final Difficulty totalDifficulty,
+      final int size,
+      final Optional<List<Withdrawal>> withdrawals) {
     this.header = header;
     this.transactions = transactions;
     this.ommers = ommers;
     this.totalDifficulty = totalDifficulty;
     this.size = size;
+    this.withdrawals = withdrawals;
   }
 
   public BlockHeader getHeader() {
@@ -65,5 +79,9 @@ public class BlockWithMetadata<T, O> {
 
   public int getSize() {
     return size;
+  }
+
+  public Optional<List<Withdrawal>> getWithdrawals() {
+    return withdrawals;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -414,7 +414,12 @@ public class BlockchainQueries {
                                               .collect(Collectors.toList());
                                       final int size = new Block(header, body).calculateSize();
                                       return new BlockWithMetadata<>(
-                                          header, formattedTxs, ommers, td, size);
+                                          header,
+                                          formattedTxs,
+                                          ommers,
+                                          td,
+                                          size,
+                                          body.getWithdrawals());
                                     })));
   }
 
@@ -468,7 +473,8 @@ public class BlockchainQueries {
                                               .map(BlockHeader::getHash)
                                               .collect(Collectors.toList());
                                       final int size = new Block(header, body).calculateSize();
-                                      return new BlockWithMetadata<>(header, txs, ommers, td, size);
+                                      return new BlockWithMetadata<>(
+                                          header, txs, ommers, td, size, body.getWithdrawals());
                                     })));
   }
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This is the critical piece that will allow Withdrawals interop to work.

Integration tests and any other RPCs that return a block will be added in a subsequent PR.

Signed-off-by: Simon Dudley <simon.dudley@consensys.net>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Critical piece of #4808
