### PR TITLE
Don't cache protocol spec in block creator

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -110,7 +110,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
           protocolContext
               .getBlockchain()
               .getTotalDifficultyByHash(blockHeader.getParentHash())
-              .orElseThrow();
+              .orElse(Difficulty.ZERO);
       Difficulty thisDifficulty = parentDifficulty.add(blockHeader.getDifficulty());
       Difficulty terminalDifficulty = mergeContext.getTerminalTotalDifficulty();
       debugLambda(

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.DifficultyCalculator;
+import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -79,7 +80,6 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
   private final Wei minTransactionGasPrice;
   private final Double minBlockOccupancyRatio;
   protected final BlockHeader parentHeader;
-  protected final ProtocolSpec protocolSpec;
 
   private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
@@ -104,7 +104,6 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
     this.minTransactionGasPrice = minTransactionGasPrice;
     this.minBlockOccupancyRatio = minBlockOccupancyRatio;
     this.parentHeader = parentHeader;
-    this.protocolSpec = protocolSchedule.getByBlockNumber(parentHeader.getNumber() + 1);
     blockHeaderFunctions = ScheduleBasedBlockHeaderFunctions.create(protocolSchedule);
   }
 
@@ -154,8 +153,16 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       boolean rewardCoinbase) {
 
     try (final MutableWorldState disposableWorldState = duplicateWorldStateAtParent()) {
+      final ProtocolSpec newProtocolSpec =
+          protocolSchedule.getByBlockHeader(
+              BlockHeaderBuilder.fromHeader(parentHeader)
+                  .number(parentHeader.getNumber() + 1)
+                  .timestamp(timestamp)
+                  .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
+                  .buildBlockHeader());
+
       final ProcessableBlockHeader processableBlockHeader =
-          createPendingBlockHeader(timestamp, maybePrevRandao);
+          createPendingBlockHeader(timestamp, maybePrevRandao, newProtocolSpec);
       final Address miningBeneficiary =
           miningBeneficiaryCalculator.getMiningBeneficiary(processableBlockHeader.getNumber());
 
@@ -164,15 +171,15 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final List<BlockHeader> ommers = maybeOmmers.orElse(selectOmmers());
 
       throwIfStopped();
-
       final BlockTransactionSelector.TransactionSelectionResults transactionResults =
           selectTransactions(
-              processableBlockHeader, disposableWorldState, maybeTransactions, miningBeneficiary);
+              processableBlockHeader,
+              disposableWorldState,
+              maybeTransactions,
+              miningBeneficiary,
+              newProtocolSpec);
 
       throwIfStopped();
-
-      final ProtocolSpec newProtocolSpec =
-          protocolSchedule.getByBlockHeader(processableBlockHeader);
 
       final Optional<WithdrawalsProcessor> maybeWithdrawalsProcessor =
           newProtocolSpec.getWithdrawalsProcessor();
@@ -193,7 +200,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               ommers,
               miningBeneficiary,
               newProtocolSpec.getBlockReward(),
-              newProtocolSpec.isSkipZeroBlockRewards())) {
+              newProtocolSpec.isSkipZeroBlockRewards(),
+              newProtocolSpec)) {
         LOG.trace("Failed to apply mining reward, exiting.");
         throw new RuntimeException("Failed to apply mining reward.");
       }
@@ -228,9 +236,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       return new BlockCreationResult(block, transactionResults);
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);
-    } catch (final CancellationException ex) {
-      throw ex;
-    } catch (final StorageException ex) {
+    } catch (final CancellationException | StorageException ex) {
       throw ex;
     } catch (final Exception ex) {
       throw new IllegalStateException(
@@ -242,7 +248,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final ProcessableBlockHeader processableBlockHeader,
       final MutableWorldState disposableWorldState,
       final Optional<List<Transaction>> transactions,
-      final Address miningBeneficiary)
+      final Address miningBeneficiary,
+      final ProtocolSpec protocolSpec)
       throws RuntimeException {
     final MainnetTransactionProcessor transactionProcessor = protocolSpec.getTransactionProcessor();
 
@@ -300,7 +307,9 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
   }
 
   private ProcessableBlockHeader createPendingBlockHeader(
-      final long timestamp, final Optional<Bytes32> maybePrevRandao) {
+      final long timestamp,
+      final Optional<Bytes32> maybePrevRandao,
+      final ProtocolSpec protocolSpec) {
     final long newBlockNumber = parentHeader.getNumber() + 1;
     long gasLimit =
         protocolSpec
@@ -363,7 +372,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final List<BlockHeader> ommers,
       final Address miningBeneficiary,
       final Wei blockReward,
-      final boolean skipZeroBlockRewards) {
+      final boolean skipZeroBlockRewards,
+      final ProtocolSpec protocolSpec) {
 
     // TODO(tmm): Added to make this work, should come from blockProcessor.
     final int MAX_GENERATION = 6;


### PR DESCRIPTION


## PR description

Don't cache the protocol spec in the block creator.  With the new shanghaiTimestamp the correct spec may be a function of the timestamp not just the block number.  So every time we are asked to build a block re-query the spec.

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).