### PR TITLE
address case of block values exceeding long

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -106,7 +107,7 @@ public class BlockResultFactory {
             .map(Bytes::toHexString)
             .collect(Collectors.toList());
 
-    final long blockValue = new BlockValueCalculator().calculateBlockValue(blockWithReceipts);
+    final Wei blockValue = new BlockValueCalculator().calculateBlockValue(blockWithReceipts);
     return new EngineGetPayloadResultV2(
         blockWithReceipts.getHeader(),
         txs,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class BlockValueCalculator {
 
-  public long calculateBlockValue(final BlockWithReceipts blockWithReceipts) {
+  public Wei calculateBlockValue(final BlockWithReceipts blockWithReceipts) {
     final Block block = blockWithReceipts.getBlock();
     final List<Transaction> txs = block.getBody().getTransactions();
     final List<TransactionReceipt> receipts = blockWithReceipts.getReceipts();
@@ -29,6 +29,6 @@ public class BlockValueCalculator {
       final Wei minerFee = txs.get(i).getEffectivePriorityFeePerGas(block.getHeader().getBaseFee());
       totalFee = totalFee.add(minerFee.multiply(receipts.get(i).getCumulativeGasUsed()));
     }
-    return totalFee.toLong();
+    return totalFee;
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
@@ -104,7 +104,8 @@ public class BlockValueCalculatorTest {
             .type(TransactionType.EIP1559)
             .createTransaction(SignatureAlgorithmFactory.getInstance().generateKeyPair());
     final TransactionReceipt receipt1 =
-        new TransactionReceipt(Hash.EMPTY_TRIE_HASH, 21000, Collections.emptyList(), Optional.empty());
+        new TransactionReceipt(
+            Hash.EMPTY_TRIE_HASH, 21000L, Collections.emptyList(), Optional.empty());
     final BlockHeader blockHeader =
         new BlockHeaderTestFixture()
             .prevRandao(Bytes32.random())

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
@@ -40,10 +40,10 @@ public class BlockValueCalculatorTest {
             .buildHeader();
     final Block block =
         new Block(blockHeader, new BlockBody(Collections.emptyList(), Collections.emptyList()));
-    long blockValue =
+    Wei blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(new BlockWithReceipts(block, Collections.emptyList()));
-    assertThat(blockValue).isEqualTo(0);
+    assertThat(blockValue).isEqualTo(Wei.ZERO);
   }
 
   @Test
@@ -84,11 +84,38 @@ public class BlockValueCalculatorTest {
             .buildHeader();
     final Block block =
         new Block(blockHeader, new BlockBody(List.of(tx1, tx2, tx3), Collections.emptyList()));
-    long blockValue =
+    Wei blockValue =
         new BlockValueCalculator()
             .calculateBlockValue(
                 new BlockWithReceipts(block, List.of(receipt1, receipt2, receipt3)));
     // Block value = 71 * 1 + 143 * 2 + 214 * 5 = 1427
-    assertThat(blockValue).isEqualTo(1427);
+    assertThat(blockValue).isEqualTo(Wei.of(1427L));
+  }
+
+  @Test
+  public void shouldCalculateCorrectBlockValueExceedingLong() {
+    // Generate a block with one overpriced transaction where the resulting block value exceeds long
+    final long baseFee = 7L;
+    final long maxFee = 1L << 60L;
+    final Transaction tx1 =
+        new TransactionTestFixture()
+            .maxPriorityFeePerGas(Optional.of(Wei.of(maxFee - baseFee)))
+            .maxFeePerGas(Optional.of(Wei.of(maxFee)))
+            .type(TransactionType.EIP1559)
+            .createTransaction(SignatureAlgorithmFactory.getInstance().generateKeyPair());
+    final TransactionReceipt receipt1 =
+        new TransactionReceipt(Hash.EMPTY_TRIE_HASH, 21000, Collections.emptyList(), Optional.empty());
+    final BlockHeader blockHeader =
+        new BlockHeaderTestFixture()
+            .prevRandao(Bytes32.random())
+            .baseFeePerGas(Wei.of(baseFee))
+            .buildHeader();
+    final Block block =
+        new Block(blockHeader, new BlockBody(List.of(tx1), Collections.emptyList()));
+    Wei blockValue =
+        new BlockValueCalculator()
+            .calculateBlockValue(new BlockWithReceipts(block, List.of(receipt1)));
+    // Block value =~ max_long * 2
+    assertThat(blockValue).isGreaterThan(Wei.of(Long.MAX_VALUE));
   }
 }


### PR DESCRIPTION
Signed-off-by: garyschulte <garyschulte@gmail.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
address corner case where long does not fit the calculated block value included in engine_getPayloadV2.

Change BlockValueCalculator to use Wei rather than unnecessarily converting to long (just to later be converted again into a Quantity)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).