### PR TITLE
Improve MainnetBlockBodyValidator logging

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -189,9 +189,7 @@ public class MainnetBlockValidator implements BlockValidator {
       if (result.errorMessage.isPresent()) {
         LOG.info("Invalid block {}: {}", invalidBlock.toLogString(), result.errorMessage);
       } else {
-        LOG.info(
-            "Invalid block {}: Block import failed with no error message",
-            invalidBlock.toLogString());
+        LOG.info("Invalid block {}", invalidBlock.toLogString());
       }
     }
     badBlockManager.addBadBlock(invalidBlock, result.causedBy());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -180,16 +180,18 @@ public class MainnetBlockValidator implements BlockValidator {
       final Block invalidBlock, final BlockValidationResult result) {
     if (result.causedBy().isPresent()) {
       LOG.info(
-          "{}. Block {}, caused by {}",
-          result.errorMessage,
+          "Invalid block {}: {}, caused by {}",
           invalidBlock.toLogString(),
+          result.errorMessage,
           result.causedBy().get());
       LOG.debug("with stack", result.causedBy().get());
     } else {
       if (result.errorMessage.isPresent()) {
-        LOG.info("{}. Block {}", result.errorMessage, invalidBlock.toLogString());
+        LOG.info("Invalid block {}: {}", invalidBlock.toLogString(), result.errorMessage);
       } else {
-        LOG.info("Block import failed with no error message. Block {}", invalidBlock.toLogString());
+        LOG.info(
+            "Invalid block {}: Block import failed with no error message",
+            invalidBlock.toLogString());
       }
     }
     badBlockManager.addBadBlock(invalidBlock, result.causedBy());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -186,7 +186,11 @@ public class MainnetBlockValidator implements BlockValidator {
           result.causedBy().get());
       LOG.debug("with stack", result.causedBy().get());
     } else {
-      LOG.info("{}. Block {}", result.errorMessage, invalidBlock.toLogString());
+      if (result.errorMessage.isPresent()) {
+        LOG.info("{}. Block {}", result.errorMessage, invalidBlock.toLogString());
+      } else {
+        LOG.info("Block import failed with no error message. Block {}", invalidBlock.toLogString());
+      }
     }
     badBlockManager.addBadBlock(invalidBlock, result.causedBy());
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockBodyValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockBodyValidator.java
@@ -109,13 +109,12 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
 
   private static boolean validateTransactionsRoot(
       final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
-    LOG.info(
-        "Invalid block {} ({}): transaction root mismatch (expected={}, actual={})",
-        header.getNumber(),
-        header.getBlockHash(),
-        expected,
-        actual);
     if (!expected.equals(actual)) {
+      LOG.info(
+          "Invalid block {}: transaction root mismatch (expected={}, actual={})",
+          header.toLogString(),
+          expected,
+          actual);
       return false;
     }
 
@@ -126,9 +125,8 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final BlockHeader header, final LogsBloomFilter expected, final LogsBloomFilter actual) {
     if (!expected.equals(actual)) {
       LOG.warn(
-          "Invalid block {} ({}): logs bloom filter mismatch (expected={}, actual={})",
-          header.getNumber(),
-          header.getBlockHash(),
+          "Invalid block {}: logs bloom filter mismatch (expected={}, actual={})",
+          header.toLogString(),
           expected,
           actual);
       return false;
@@ -141,9 +139,8 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final BlockHeader header, final long expected, final long actual) {
     if (expected != actual) {
       LOG.warn(
-          "Invalid block {} ({}): gas used mismatch (expected={}, actual={})",
-          header.getNumber(),
-          header.getBlockHash(),
+          "Invalid block {}: gas used mismatch (expected={}, actual={})",
+          header.toLogString(),
           expected,
           actual);
       return false;
@@ -154,13 +151,12 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
 
   private static boolean validateReceiptsRoot(
       final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
-    LOG.warn(
-        "Invalid block {} ({}): receipts root mismatch (expected={}, actual={})",
-        header.getNumber(),
-        header.getBlockHash(),
-        expected,
-        actual);
     if (!expected.equals(actual)) {
+      LOG.warn(
+          "Invalid block {}: receipts root mismatch (expected={}, actual={})",
+          header.toLogString(),
+          expected,
+          actual);
       return false;
     }
 
@@ -171,9 +167,8 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
     if (!expected.equals(actual)) {
       LOG.warn(
-          "Invalid block {} ({}): state root mismatch (expected={}, actual={})",
-          header.getNumber(),
-          header.getBlockHash(),
+          "Invalid block {}: state root mismatch (expected={}, actual={})",
+          header.toLogString(),
           expected,
           actual);
       return false;
@@ -205,9 +200,8 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
     if (!expected.equals(actual)) {
       LOG.warn(
-          "Invalid block {} ({}): ommers hash mismatch (expected={}, actual={})",
-          header.getNumber(),
-          header.getBlockHash(),
+          "Invalid block {}: ommers hash mismatch (expected={}, actual={})",
+          header.toLogString(),
           expected,
           actual);
       return false;
@@ -223,26 +217,21 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final HeaderValidationMode ommerValidationMode) {
     if (ommers.size() > MAX_OMMERS) {
       LOG.warn(
-          "Invalid block {} ({}): ommer count {} exceeds ommer limit {}",
-          header.getNumber(),
-          header.getBlockHash(),
+          "Invalid block {}: ommer count {} exceeds ommer limit {}",
+          header.toLogString(),
           ommers.size(),
           MAX_OMMERS);
       return false;
     }
 
     if (!areOmmersUnique(ommers)) {
-      LOG.warn(
-          "Invalid block {} ({}): ommers are not unique",
-          header.getNumber(),
-          header.getBlockHash());
+      LOG.warn("Invalid block {}: ommers are not unique", header.toLogString());
       return false;
     }
 
     for (final BlockHeader ommer : ommers) {
       if (!isOmmerValid(context, header, ommer, ommerValidationMode)) {
-        LOG.warn(
-            "Invalid block {} ({}): ommer is invalid", header.getNumber(), header.getBlockHash());
+        LOG.warn("Invalid block {}: ommer is invalid", header.toLogString());
         return false;
       }
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockBodyValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockBodyValidator.java
@@ -55,7 +55,8 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       return false;
     }
 
-    if (!validateStateRoot(block.getHeader().getStateRoot(), worldStateRootHash)) {
+    if (!validateStateRoot(
+        block.getHeader(), block.getHeader().getStateRoot(), worldStateRootHash)) {
       LOG.warn("Invalid block RLP : {}", block.toRlp().toHexString());
       receipts.forEach(
           receipt ->
@@ -76,22 +77,22 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
     final BlockBody body = block.getBody();
 
     final Bytes32 transactionsRoot = BodyValidation.transactionsRoot(body.getTransactions());
-    if (!validateTransactionsRoot(header.getTransactionsRoot(), transactionsRoot)) {
+    if (!validateTransactionsRoot(header, header.getTransactionsRoot(), transactionsRoot)) {
       return false;
     }
 
     final Bytes32 receiptsRoot = BodyValidation.receiptsRoot(receipts);
-    if (!validateReceiptsRoot(header.getReceiptsRoot(), receiptsRoot)) {
+    if (!validateReceiptsRoot(header, header.getReceiptsRoot(), receiptsRoot)) {
       return false;
     }
 
     final long gasUsed =
         receipts.isEmpty() ? 0 : receipts.get(receipts.size() - 1).getCumulativeGasUsed();
-    if (!validateGasUsed(header.getGasUsed(), gasUsed)) {
+    if (!validateGasUsed(header, header.getGasUsed(), gasUsed)) {
       return false;
     }
 
-    if (!validateLogsBloom(header.getLogsBloom(), BodyValidation.logsBloom(receipts))) {
+    if (!validateLogsBloom(header, header.getLogsBloom(), BodyValidation.logsBloom(receipts))) {
       return false;
     }
 
@@ -106,10 +107,15 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
     return true;
   }
 
-  private static boolean validateTransactionsRoot(final Bytes32 expected, final Bytes32 actual) {
+  private static boolean validateTransactionsRoot(
+      final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
+    LOG.info(
+        "Invalid block {} ({}): transaction root mismatch (expected={}, actual={})",
+        header.getNumber(),
+        header.getBlockHash(),
+        expected,
+        actual);
     if (!expected.equals(actual)) {
-      LOG.info(
-          "Invalid block: transaction root mismatch (expected={}, actual={})", expected, actual);
       return false;
     }
 
@@ -117,37 +123,59 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
   }
 
   private static boolean validateLogsBloom(
-      final LogsBloomFilter expected, final LogsBloomFilter actual) {
+      final BlockHeader header, final LogsBloomFilter expected, final LogsBloomFilter actual) {
     if (!expected.equals(actual)) {
       LOG.warn(
-          "Invalid block: logs bloom filter mismatch (expected={}, actual={})", expected, actual);
+          "Invalid block {} ({}): logs bloom filter mismatch (expected={}, actual={})",
+          header.getNumber(),
+          header.getBlockHash(),
+          expected,
+          actual);
       return false;
     }
 
     return true;
   }
 
-  private static boolean validateGasUsed(final long expected, final long actual) {
+  private static boolean validateGasUsed(
+      final BlockHeader header, final long expected, final long actual) {
     if (expected != actual) {
-      LOG.warn("Invalid block: gas used mismatch (expected={}, actual={})", expected, actual);
+      LOG.warn(
+          "Invalid block {} ({}): gas used mismatch (expected={}, actual={})",
+          header.getNumber(),
+          header.getBlockHash(),
+          expected,
+          actual);
       return false;
     }
 
     return true;
   }
 
-  private static boolean validateReceiptsRoot(final Bytes32 expected, final Bytes32 actual) {
+  private static boolean validateReceiptsRoot(
+      final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
+    LOG.warn(
+        "Invalid block {} ({}): receipts root mismatch (expected={}, actual={})",
+        header.getNumber(),
+        header.getBlockHash(),
+        expected,
+        actual);
     if (!expected.equals(actual)) {
-      LOG.warn("Invalid block: receipts root mismatch (expected={}, actual={})", expected, actual);
       return false;
     }
 
     return true;
   }
 
-  private static boolean validateStateRoot(final Bytes32 expected, final Bytes32 actual) {
+  private static boolean validateStateRoot(
+      final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
     if (!expected.equals(actual)) {
-      LOG.warn("Invalid block: state root mismatch (expected={}, actual={})", expected, actual);
+      LOG.warn(
+          "Invalid block {} ({}): state root mismatch (expected={}, actual={})",
+          header.getNumber(),
+          header.getBlockHash(),
+          expected,
+          actual);
       return false;
     }
 
@@ -162,7 +190,7 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
     final BlockBody body = block.getBody();
 
     final Bytes32 ommerHash = BodyValidation.ommersHash(body.getOmmers());
-    if (!validateOmmersHash(header.getOmmersHash(), ommerHash)) {
+    if (!validateOmmersHash(header, header.getOmmersHash(), ommerHash)) {
       return false;
     }
 
@@ -173,9 +201,15 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
     return true;
   }
 
-  private static boolean validateOmmersHash(final Bytes32 expected, final Bytes32 actual) {
+  private static boolean validateOmmersHash(
+      final BlockHeader header, final Bytes32 expected, final Bytes32 actual) {
     if (!expected.equals(actual)) {
-      LOG.warn("Invalid block: ommers hash mismatch (expected={}, actual={})", expected, actual);
+      LOG.warn(
+          "Invalid block {} ({}): ommers hash mismatch (expected={}, actual={})",
+          header.getNumber(),
+          header.getBlockHash(),
+          expected,
+          actual);
       return false;
     }
 
@@ -188,18 +222,27 @@ public class MainnetBlockBodyValidator implements BlockBodyValidator {
       final List<BlockHeader> ommers,
       final HeaderValidationMode ommerValidationMode) {
     if (ommers.size() > MAX_OMMERS) {
-      LOG.warn("Invalid block: ommer count {} exceeds ommer limit {}", ommers.size(), MAX_OMMERS);
+      LOG.warn(
+          "Invalid block {} ({}): ommer count {} exceeds ommer limit {}",
+          header.getNumber(),
+          header.getBlockHash(),
+          ommers.size(),
+          MAX_OMMERS);
       return false;
     }
 
     if (!areOmmersUnique(ommers)) {
-      LOG.warn("Invalid block: ommers are not unique");
+      LOG.warn(
+          "Invalid block {} ({}): ommers are not unique",
+          header.getNumber(),
+          header.getBlockHash());
       return false;
     }
 
     for (final BlockHeader ommer : ommers) {
       if (!isOmmerValid(context, header, ommer, ommerValidationMode)) {
-        LOG.warn("Invalid block: ommer is invalid");
+        LOG.warn(
+            "Invalid block {} ({}): ommer is invalid", header.getNumber(), header.getBlockHash());
         return false;
       }
     }


### PR DESCRIPTION
* Associate block number and hash with the various invalid block warnings, in the format:
`Invalid block {blockNumber} ({blockHash}): ... mismatch (expected=..., actual=...)`

Instead of 
```
WARN  | MainnetBlockBodyValidator | Invalid block: receipts root mismatch (expected=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, actual=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421) 
```

we now have 
```
WARN  | MainnetBlockBodyValidator | Invalid block 1 (0xd2ce6fb30db1ab80b0a5c137f3c8a83d12052e5a40366eba4c15b229c6a863e6): receipts root mismatch (expected=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421, actual=0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421) 
```

---

* Print a less obscure message when there's no error message:

Instead of 
```
INFO  | MainnetBlockValidator | Optional.empty. Block 11 (0x8edd340dd4718e884ffe327bab2d3e3874bac2799cde83a085e5cae66d53c3b5)
```

we now have

```
INFO  | MainnetBlockValidator | Invalid block 11 (0x8edd340dd4718e884ffe327bab2d3e3874bac2799cde83a085e5cae66d53c3b5)
```