### PR TITLE
Fix create block using wrong protocol schedule when parent is genesis

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -158,6 +158,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               BlockHeaderBuilder.fromHeader(parentHeader)
                   .number(parentHeader.getNumber() + 1)
                   .timestamp(timestamp)
+                  .parentHash(parentHeader.getHash())
                   .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
                   .buildBlockHeader());
 


### PR DESCRIPTION
Signed-off-by: Jason Frame <jason.frame@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fix create block using the wrong protocol schedule when the parent is genesis.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).