### PR TITLE
split ATs into privacy/permissioning/etc and the rest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,9 +390,6 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
-      - acceptanceTestsNonMainnet:
-          requires:
-            - assemble
       - buildDocker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
           at: ~/project
       - run:
           name: AcceptanceTests (High Priority)
-          no_output_timeout: 30m
+          no_output_timeout: 20m
           command: |
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
               | sed 's@.*/src/test/java/@@' \
@@ -235,11 +235,11 @@ jobs:
               | circleci tests split --split-by=timings --timings-type=classname)
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            ./gradlew --no-daemon acceptanceTest $GRADLE_ARGS
+            ./gradlew --no-daemon acceptanceTestMainnet $GRADLE_ARGS
       - capture_test_results
       - capture_test_logs
 
-  acceptanceTestsLowPriority:
+  acceptanceTestsNonMainnet:
     parallelism: 6
     executor: xl_machine_executor # TODO maybe can reduce this since only running a subset of ATs
     steps:
@@ -248,7 +248,7 @@ jobs:
           at: ~/project
       - run:
           name: AcceptanceTests (Low Priority)
-          no_output_timeout: 30m
+          no_output_timeout: 20m
           command: |
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
               | sed 's@.*/src/test/java/@@' \
@@ -257,7 +257,7 @@ jobs:
               | circleci tests split --split-by=timings --timings-type=classname)
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            ./gradlew --no-daemon acceptanceTestLowPriority $GRADLE_ARGS
+            ./gradlew --no-daemon acceptanceTestNonMainnet $GRADLE_ARGS
       - capture_test_results
       - capture_test_logs
 
@@ -390,9 +390,6 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
-      - acceptanceTestsLowPriority:
-          requires:
-            - assemble
       - buildDocker:
           requires:
             - assemble
@@ -464,4 +461,4 @@ workflows:
     jobs:
       - assemble
       - dockerScan
-      - acceptanceTestsLowPriority
+      - acceptanceTestsNonMainnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: AcceptanceTests
+          name: AcceptanceTests (High Priority)
           no_output_timeout: 30m
           command: |
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
@@ -236,6 +236,28 @@ jobs:
             # Format the arguments to "./gradlew test"
             GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
             ./gradlew --no-daemon acceptanceTest $GRADLE_ARGS
+      - capture_test_results
+      - capture_test_logs
+
+  acceptanceTestsLowPriority:
+    parallelism: 6
+    executor: xl_machine_executor # TODO maybe can reduce this since only running a subset of ATs
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: AcceptanceTests (Low Priority)
+          no_output_timeout: 30m
+          command: |
+            CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
+              | sed 's@.*/src/test/java/@@' \
+              | sed 's@/@.@g' \
+              | sed 's/.\{5\}$//' \
+              | circleci tests split --split-by=timings --timings-type=classname)
+            # Format the arguments to "./gradlew test"
+            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
+            ./gradlew --no-daemon acceptanceTestLowPriority $GRADLE_ARGS
       - capture_test_results
       - capture_test_logs
 
@@ -368,6 +390,9 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
+      - acceptanceTestsLowPriority:
+          requires:
+            - assemble
       - buildDocker:
           requires:
             - assemble
@@ -439,3 +464,4 @@ workflows:
     jobs:
       - assemble
       - dockerScan
+      - acceptanceTestsLowPriority

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          name: AcceptanceTests (High Priority)
+          name: AcceptanceTests (Mainnet)
           no_output_timeout: 20m
           command: |
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
@@ -241,13 +241,13 @@ jobs:
 
   acceptanceTestsNonMainnet:
     parallelism: 6
-    executor: xl_machine_executor # TODO maybe can reduce this since only running a subset of ATs
+    executor: xl_machine_executor
     steps:
       - prepare
       - attach_workspace:
           at: ~/project
       - run:
-          name: AcceptanceTests (Low Priority)
+          name: AcceptanceTests (Non-Mainnet)
           no_output_timeout: 20m
           command: |
             CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
@@ -388,6 +388,9 @@ workflows:
           requires:
             - assemble
       - acceptanceTests:
+          requires:
+            - assemble
+      - acceptanceTestsNonMainnet:
           requires:
             - assemble
       - buildDocker:

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -100,13 +100,45 @@ processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar')
 
 task acceptanceTest(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
+  exclude '**/bft/**'
+  exclude '**/clique/**'
+  exclude '**/permissioning/**'
+  exclude '**/privacy/**'
 
   dependsOn(rootProject.installDist)
   setSystemProperties(test.getSystemProperties())
   systemProperty 'acctests.runBesuAsProcess', 'true'
   systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
   mustRunAfter rootProject.subprojects*.test
-  description = 'Runs Besu acceptance tests.'
+  description = 'Runs Besu acceptance tests (excluding permissioning, privacy and some other stable features).'
+  group = 'verification'
+
+  jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
+
+  testLogging {
+    exceptionFormat = 'full'
+    showStackTraces = true
+    showStandardStreams = Boolean.getBoolean('acctests.showStandardStreams')
+    showExceptions = true
+    showCauses = true
+  }
+
+  doFirst { mkdir "${buildDir}/jvmErrorLogs" }
+}
+
+task acceptanceTestLowPriority(type: Test) {
+  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
+  include '**/bft/**'
+  include '**/clique/**'
+  include '**/permissioning/**'
+  include '**/privacy/**'
+
+  dependsOn(rootProject.installDist)
+  setSystemProperties(test.getSystemProperties())
+  systemProperty 'acctests.runBesuAsProcess', 'true'
+  systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
+  mustRunAfter rootProject.subprojects*.test
+  description = 'Runs Besu acceptance tests for permissioning and privacy (excluding mainnet features).'
   group = 'verification'
 
   jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -100,6 +100,29 @@ processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar')
 
 task acceptanceTest(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
+
+  dependsOn(rootProject.installDist)
+  setSystemProperties(test.getSystemProperties())
+  systemProperty 'acctests.runBesuAsProcess', 'true'
+  systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
+  mustRunAfter rootProject.subprojects*.test
+  description = 'Runs ALL Besu acceptance tests (mainnet and non-mainnet).'
+  group = 'verification'
+
+  jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
+
+  testLogging {
+    exceptionFormat = 'full'
+    showStackTraces = true
+    showStandardStreams = Boolean.getBoolean('acctests.showStandardStreams')
+    showExceptions = true
+    showCauses = true
+  }
+
+  doFirst { mkdir "${buildDir}/jvmErrorLogs" }
+}
+task acceptanceTestMainnet(type: Test) {
+  inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
   exclude '**/bft/**'
   exclude '**/clique/**'
   exclude '**/permissioning/**'
@@ -110,7 +133,7 @@ task acceptanceTest(type: Test) {
   systemProperty 'acctests.runBesuAsProcess', 'true'
   systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
   mustRunAfter rootProject.subprojects*.test
-  description = 'Runs Besu acceptance tests (excluding permissioning, privacy and some other stable features).'
+  description = 'Runs MAINNET Besu acceptance tests (excluding permissioning, privacy and some other stable features).'
   group = 'verification'
 
   jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"
@@ -126,7 +149,7 @@ task acceptanceTest(type: Test) {
   doFirst { mkdir "${buildDir}/jvmErrorLogs" }
 }
 
-task acceptanceTestLowPriority(type: Test) {
+task acceptanceTestNonMainnet(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
   include '**/bft/**'
   include '**/clique/**'
@@ -138,7 +161,7 @@ task acceptanceTestLowPriority(type: Test) {
   systemProperty 'acctests.runBesuAsProcess', 'true'
   systemProperty 'java.security.properties', "${buildDir}/resources/test/acceptanceTesting.security"
   mustRunAfter rootProject.subprojects*.test
-  description = 'Runs Besu acceptance tests for permissioning and privacy (excluding mainnet features).'
+  description = 'Runs NON-MAINNET Besu acceptance tests for permissioning and privacy (excluding mainnet features).'
   group = 'verification'
 
   jvmArgs "-XX:ErrorFile=${buildDir}/jvmErrorLogs/java_err_pid%p.log"

--- a/container-tests/tests/build.gradle
+++ b/container-tests/tests/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 test.enabled = false
-
+// TODO make this run only on nightly
 task containerTests(type: Test) {
   description = 'Runs GoQuorum <> Besu container tests.'
   dependsOn(rootProject.distDocker)


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

Ref #4921 
* split ATs into two groups - mainnet and non-mainnet
* run "non-mainnet" ATs on nightly build
* did 2 runs with run both groups of ATs on PRs (to make sure it works - the right numbers of tests are run - see comments for details)

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).