### PR TITLE
Change to optional orElseGet

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
@@ -95,7 +95,9 @@ public class TransactionCompleteResult implements TransactionResult {
         tx.getTransaction().getMaxFeePerGas().map(Wei::toShortHexString).orElse(null);
     this.gasPrice =
         Quantity.create(
-            transaction.getGasPrice().orElse(transaction.getEffectiveGasPrice(tx.getBaseFee())));
+            transaction
+                .getGasPrice()
+                .orElseGet(() -> transaction.getEffectiveGasPrice(tx.getBaseFee())));
     this.hash = transaction.getHash().toString();
     this.input = transaction.getPayload().toString();
     this.nonce = Quantity.create(transaction.getNonce());


### PR DESCRIPTION
Fix do not evaluate second expression if the value is present.

Signed-off-by: ħþ <12281088+helderjnpinto@users.noreply.github.com>

## PR description

This is causing some issues when we got a earlier version of besu after this PR https://github.com/hyperledger/besu/pull/3065, the problem is caused by gasPrice existing in transaction but is too big to fit in Long types.
Evaluating the second expression is not needed if the gasPrice is present also causing extra processing.

