### PR TITLE
Withdrawals processor delete empty account

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -45,7 +45,6 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -463,7 +463,7 @@ public class MainnetTransactionProcessor {
       initialFrame.getSelfDestructs().forEach(worldState::deleteAccount);
 
       if (clearEmptyAccounts) {
-        clearAccountsThatAreEmpty(worldState);
+        worldState.clearAccountsThatAreEmpty();
       }
 
       if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
@@ -487,11 +487,6 @@ public class MainnetTransactionProcessor {
 
   public MainnetTransactionValidator getTransactionValidator() {
     return transactionValidator;
-  }
-
-  private static void clearAccountsThatAreEmpty(final WorldUpdater worldState) {
-    new ArrayList<>(worldState.getTouchedAccounts())
-        .stream().filter(Account::isEmpty).forEach(a -> worldState.deleteAccount(a.getAddress()));
   }
 
   protected void process(final MessageFrame frame, final OperationTracer operationTracer) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessor.java
@@ -28,6 +28,7 @@ public class WithdrawalsProcessor {
       final EvmAccount account = worldUpdater.getOrCreate(withdrawal.getAddress());
       account.getMutable().incrementBalance(withdrawal.getAmount().getAsWei());
     }
+    worldUpdater.clearAccountsThatAreEmpty();
     worldUpdater.commit();
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 class WithdrawalsProcessorTest {
 
   @Test
-  void defaultProcessor_shouldProcessEmptyWithdrawalsWithoutChangingWorldState() {
+  void shouldProcessEmptyWithdrawalsWithoutChangingWorldState() {
     final MutableWorldState worldState =
         createWorldStateWithAccounts(List.of(entry("0x1", 1), entry("0x2", 2), entry("0x3", 3)));
     final MutableWorldState originalState = worldState.copy();
@@ -51,7 +51,7 @@ class WithdrawalsProcessorTest {
   }
 
   @Test
-  void defaultProcessor_shouldProcessWithdrawalsUpdatingExistingAccountsBalance() {
+  void shouldProcessWithdrawalsUpdatingExistingAccountsBalance() {
     final MutableWorldState worldState =
         createWorldStateWithAccounts(List.of(entry("0x1", 1), entry("0x2", 2), entry("0x3", 3)));
     final WorldUpdater updater = worldState.updater();
@@ -79,7 +79,7 @@ class WithdrawalsProcessorTest {
   }
 
   @Test
-  void defaultProcessor_shouldProcessWithdrawalsUpdatingEmptyAccountsBalance() {
+  void shouldProcessWithdrawalsUpdatingEmptyAccountsBalance() {
     final MutableWorldState worldState = createWorldStateWithAccounts(Collections.emptyList());
     final WorldUpdater updater = worldState.updater();
 
@@ -104,6 +104,32 @@ class WithdrawalsProcessorTest {
         .isEqualTo(GWei.of(200).getAsWei());
   }
 
+  @Test
+  void shouldDeleteEmptyAccounts() {
+    final MutableWorldState worldState =
+            createWorldStateWithAccounts(List.of(entry("0x1", 0), entry("0x2", 2)));
+    final WorldUpdater updater = worldState.updater();
+
+    final List<Withdrawal> withdrawals =
+            List.of(
+                    new Withdrawal(
+                            UInt64.valueOf(100),
+                            UInt64.valueOf(1000),
+                            Address.fromHexString("0x1"),
+                            GWei.ZERO),
+                    new Withdrawal(
+                            UInt64.valueOf(200),
+                            UInt64.valueOf(2000),
+                            Address.fromHexString("0x2"),
+                            GWei.of(200)));
+    final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
+    withdrawalsProcessor.processWithdrawals(withdrawals, updater);
+
+    assertThat(worldState.get(Address.fromHexString("0x1"))).isNull();
+    assertThat(worldState.get(Address.fromHexString("0x2")).getBalance())
+            .isEqualTo(GWei.of(200).getAsWei().add(2));
+  }
+
   private MutableWorldState createWorldStateWithAccounts(
       final List<Map.Entry<String, Integer>> accountBalances) {
     final MutableWorldState worldState = InMemoryKeyValueStorageProvider.createInMemoryWorldState();
@@ -111,7 +137,7 @@ class WithdrawalsProcessorTest {
     accountBalances.forEach(
         entry ->
             updater.createAccount(
-                Address.fromHexString(entry.getKey()), 1, Wei.of(entry.getValue())));
+                Address.fromHexString(entry.getKey()), 0, Wei.of(entry.getValue())));
     updater.commit();
     return worldState;
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
@@ -107,27 +107,24 @@ class WithdrawalsProcessorTest {
   @Test
   void shouldDeleteEmptyAccounts() {
     final MutableWorldState worldState =
-            createWorldStateWithAccounts(List.of(entry("0x1", 0), entry("0x2", 2)));
+        createWorldStateWithAccounts(List.of(entry("0x1", 0), entry("0x2", 2)));
     final WorldUpdater updater = worldState.updater();
 
     final List<Withdrawal> withdrawals =
-            List.of(
-                    new Withdrawal(
-                            UInt64.valueOf(100),
-                            UInt64.valueOf(1000),
-                            Address.fromHexString("0x1"),
-                            GWei.ZERO),
-                    new Withdrawal(
-                            UInt64.valueOf(200),
-                            UInt64.valueOf(2000),
-                            Address.fromHexString("0x2"),
-                            GWei.of(200)));
+        List.of(
+            new Withdrawal(
+                UInt64.valueOf(100), UInt64.valueOf(1000), Address.fromHexString("0x1"), GWei.ZERO),
+            new Withdrawal(
+                UInt64.valueOf(200),
+                UInt64.valueOf(2000),
+                Address.fromHexString("0x2"),
+                GWei.of(200)));
     final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
     withdrawalsProcessor.processWithdrawals(withdrawals, updater);
 
     assertThat(worldState.get(Address.fromHexString("0x1"))).isNull();
     assertThat(worldState.get(Address.fromHexString("0x2")).getBalance())
-            .isEqualTo(GWei.of(200).getAsWei().add(2));
+        .isEqualTo(GWei.of(200).getAsWei().add(2));
   }
 
   private MutableWorldState createWorldStateWithAccounts(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/WithdrawalsProcessorTest.java
@@ -106,8 +106,7 @@ class WithdrawalsProcessorTest {
 
   @Test
   void shouldDeleteEmptyAccounts() {
-    final MutableWorldState worldState =
-        createWorldStateWithAccounts(List.of(entry("0x1", 0), entry("0x2", 2)));
+    final MutableWorldState worldState = createWorldStateWithAccounts(List.of(entry("0x1", 0)));
     final WorldUpdater updater = worldState.updater();
 
     final List<Withdrawal> withdrawals =
@@ -118,13 +117,12 @@ class WithdrawalsProcessorTest {
                 UInt64.valueOf(200),
                 UInt64.valueOf(2000),
                 Address.fromHexString("0x2"),
-                GWei.of(200)));
+                GWei.ZERO));
     final WithdrawalsProcessor withdrawalsProcessor = new WithdrawalsProcessor();
     withdrawalsProcessor.processWithdrawals(withdrawals, updater);
 
     assertThat(worldState.get(Address.fromHexString("0x1"))).isNull();
-    assertThat(worldState.get(Address.fromHexString("0x2")).getBalance())
-        .isEqualTo(GWei.of(200).getAsWei().add(2));
+    assertThat(worldState.get(Address.fromHexString("0x2"))).isNull();
   }
 
   private MutableWorldState createWorldStateWithAccounts(

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
@@ -147,6 +147,7 @@ public interface WorldUpdater extends MutableWorldView {
    */
   Optional<WorldUpdater> parentUpdater();
 
+  /** Clears any accounts that are empty */
   default void clearAccountsThatAreEmpty() {
     new ArrayList<>(getTouchedAccounts())
         .stream().filter(Account::isEmpty).forEach(a -> deleteAccount(a.getAddress()));

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.evm.account.EvmAccount;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -145,4 +146,9 @@ public interface WorldUpdater extends MutableWorldView {
    * @return The parent WorldUpdater if this wraps another one, empty otherwise
    */
   Optional<WorldUpdater> parentUpdater();
+
+  default void clearAccountsThatAreEmpty() {
+    new ArrayList<>(getTouchedAccounts())
+            .stream().filter(Account::isEmpty).forEach(a -> deleteAccount(a.getAddress()));
+  }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
@@ -149,6 +149,6 @@ public interface WorldUpdater extends MutableWorldView {
 
   default void clearAccountsThatAreEmpty() {
     new ArrayList<>(getTouchedAccounts())
-            .stream().filter(Account::isEmpty).forEach(a -> deleteAccount(a.getAddress()));
+        .stream().filter(Account::isEmpty).forEach(a -> deleteAccount(a.getAddress()));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This fixes an issue that was found in the withdrawal reference tests where we update an account with a balance of zero. Ensure that the withdrawals processor clears empty accounts so that we conform to eip-158.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).