### PR TITLE
Revert "parallelization for unit tests (#5000)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,6 @@ jobs:
             done
 
   unitTests:
-    parallelism: 6
     executor: besu_executor_xl
     steps:
       - prepare
@@ -185,14 +184,7 @@ jobs:
           name: Build
           no_output_timeout: 20m
           command: |
-            GRADLE_ARGS=$(ls -d */src/test/java \
-              | sed 's/^/:/' \
-              | sed 's@src/test/java@@' \
-              | sed 's@/@:test@' \
-              | circleci tests split --split-by=timings)
-            # Format the arguments to "./gradlew test"
-            echo "Prepared arguments for Gradle: $GRADLE_ARGS"
-            ./gradlew --no-daemon $GRADLE_ARGS
+            ./gradlew --no-daemon build
       - capture_test_results
 
   integrationTests:


### PR DESCRIPTION
This reverts commit b22a52a88e42a5c11f0564f1c9603bff55687e9e.

Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

It seems not all tests are running. Needs more investigation.

See #4921 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).