### PR TITLE
Simplify protocolSchedule query

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduleBasedBlockHeaderFunctions.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduleBasedBlockHeaderFunctions.java
@@ -47,12 +47,6 @@ public class ScheduleBasedBlockHeaderFunctions implements BlockHeaderFunctions {
   }
 
   private BlockHeaderFunctions getBlockHeaderFunctions(final SealableBlockHeader header) {
-    if (protocolSchedule instanceof ProtocolSchedule) {
-      return ((ProtocolSchedule) protocolSchedule)
-          .getByBlockNumber(header.getNumber())
-          .getBlockHeaderFunctions();
-    } else {
-      return protocolSchedule.getByBlockHeader(header).getBlockHeaderFunctions();
-    }
+    return protocolSchedule.getByBlockHeader(header).getBlockHeaderFunctions();
   }
 }


### PR DESCRIPTION
Related to referencetests/evmtool, @shemnon did this: https://github.com/hyperledger/besu/commit/a080bffcbab3d4cd9f9a264285f6b0c39b53a54b

If we revert this, withdrawals referencetests still pass so I think it's the right thing to do.