### PR TITLE
Add optional withdrawals to the NewPayload log

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -322,10 +322,10 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
 
   private void logImportedBlockInfo(final Block block, final double timeInS) {
     final StringBuilder message = new StringBuilder();
+    message.append("Imported #%,d / %d tx");
     final List<Object> messageArgs =
         new ArrayList<>(
             List.of(block.getHeader().getNumber(), block.getBody().getTransactions().size()));
-    message.append("Imported #%,d / %d tx");
     if (block.getBody().getWithdrawals().isPresent()) {
       message.append(" / %s ws");
       messageArgs.add(block.getBody().getWithdrawals().get().size());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -322,7 +322,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
 
   private void logImportedBlockInfo(final Block block, final double timeInS) {
     final StringBuilder message = new StringBuilder();
-    List<Object> messageArgs =
+    final List<Object> messageArgs =
         new ArrayList<>(
             List.of(block.getHeader().getNumber(), block.getBody().getTransactions().size()));
     message.append("Imported #%,d / %d tx");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -55,6 +55,7 @@ import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -320,16 +321,24 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
   }
 
   private void logImportedBlockInfo(final Block block, final double timeInS) {
-    LOG.info(
-        String.format(
-            "Imported #%,d / %d tx / base fee %s / %,d (%01.1f%%) gas / (%s) in %01.3fs. Peers: %d",
-            block.getHeader().getNumber(),
-            block.getBody().getTransactions().size(),
+    final StringBuilder message = new StringBuilder();
+    List<Object> messageArgs =
+        new ArrayList<>(
+            List.of(block.getHeader().getNumber(), block.getBody().getTransactions().size()));
+    message.append("Imported #%,d / %d tx");
+    if (block.getBody().getWithdrawals().isPresent()) {
+      message.append(" / %s ws");
+      messageArgs.add(block.getBody().getWithdrawals().get().size());
+    }
+    message.append(" / base fee %s / %,d (%01.1f%%) gas / (%s) in %01.3fs. Peers: %d");
+    messageArgs.addAll(
+        List.of(
             block.getHeader().getBaseFee().map(Wei::toHumanReadableString).orElse("N/A"),
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
             block.getHash().toHexString(),
             timeInS,
             ethPeers.peerCount()));
+    LOG.info(String.format(message.toString(), messageArgs.toArray()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -327,7 +327,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
         new ArrayList<>(
             List.of(block.getHeader().getNumber(), block.getBody().getTransactions().size()));
     if (block.getBody().getWithdrawals().isPresent()) {
-      message.append(" / %s ws");
+      message.append(" / %d ws");
       messageArgs.add(block.getBody().getWithdrawals().get().size());
     }
     message.append(" / base fee %s / %,d (%01.1f%%) gas / (%s) in %01.3fs. Peers: %d");


### PR DESCRIPTION
When withdrawals are null (i.e. disabled, pre-shanghai) then display nothing extra in the log.
When withdrawals are present, display their size, even when 0.

Chose 'ws' as a short name to keep the overall log small and since this is mostly useful for developers debugging rather than useful info for a node operator.

Tested on withdrawals-devnet-6, here's the Shanghai fork transition...
```
2023-01-30 20:53:44.059+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #304 / 0 tx / base fee 7 wei / 0 (0.0%) gas / (0x5d96179b829a1c2ba62774b9559a401b198375bc6d6b6a39521594ac6e5996e4) in 0.000s. Peers: 1
2023-01-30 20:53:44.818+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #305 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0x4199a28b76bc005897627cdbd7701e121be736c738294b1d09ccbb8291eadd2f) in 0.001s. Peers: 1
2023-01-30 20:53:46.078+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #306 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0xb68a8114d332339ec1e27cb53362626fa41e9a5ad6563334a6d181ea968f9211) in 0.000s. Peers: 1
2023-01-30 20:53:46.726+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #307 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0x66e995f758066e4abdbd1bb3928bd9bcd451b197d9eeb8b5c79de595508ec3d5) in 0.000s. Peers: 1
2023-01-30 20:53:47.008+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #308 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0xb93230252d104b6996b1e517ca766bbb157673270c5695a0c1608d98b616522a) in 0.001s. Peers: 3
2023-01-30 20:53:47.291+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #309 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0x152a3d68762b359abe5cb518567efc984445b588138a2cb8aee081c4692536f2) in 0.000s. Peers: 5
2023-01-30 20:53:47.839+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #310 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0xb79daa73a92dc261562488a012a9951cc67f2d95c0222b3b22d244686f475c8c) in 0.000s. Peers: 1
2023-01-30 20:53:48.552+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #311 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0xfb321669488d84e5fee40f3df6d6e904834ad2cec62051c920f70d9c31b8cf40) in 0.001s. Peers: 1
2023-01-30 20:53:48.722+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #312 / 0 tx / 0 ws / base fee 7 wei / 0 (0.0%) gas / (0x41e1cee974a10fd53dcdf663a7c231e7b0baf2ec8b8f246b0f9344a8fcebc612) in 0.001s. Peers: 1
2023-01-30 20:53:49.389+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #313 / 0 tx / 1 ws / base fee 7 wei / 0 (0.0%) gas / (0x9aef492f1e9833a0dd86aef0947032908b76c8fc4591aacea3b5d3e0791af93a) in 0.001s. Peers: 1
2023-01-30 20:53:49.820+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #314 / 0 tx / 11 ws / base fee 7 wei / 0 (0.0%) gas / (0x6fa79cb3ed0696dc8f94622accba4d86c137c56d7a23e709b8861b24b04ba678) in 0.003s. Peers: 1
2023-01-30 20:53:50.165+10:00 | vert.x-worker-thread-0 | INFO  | AbstractEngineNewPayload | Imported #315 / 0 tx / 16 ws / base fee 7 wei / 0 (0.0%) gas / (0x4773455ec25834ad1abe8f6ee107fa78bbd152ce6fc6f56acaa062ffda4e4154) in 0.001s. Peers: 2
```