### PR TITLE
Keep Worldstate Storage open for Bonsai archive latest layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ tests are updated to use EC private keys instead of RSA keys.
 
 ### Bug Fixes
 - Mitigation fix for stale bonsai code storage leading to log rolling issues on contract recreates [#4906](https://github.com/hyperledger/besu/pull/4906)
+- Ensure latest cached layered worldstate is subscribed to storage, fix problem with RPC calls using 'latest' [#5039](https://github.com/hyperledger/besu/pull/5039)  
 
 
 ## 23.1.0-RC1

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -150,7 +150,12 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState
     final Hash newWorldStateRootHash = rootHash(localUpdater);
     archive
         .getTrieLogManager()
-        .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader, this);
+        .saveTrieLog(
+            archive,
+            localUpdater,
+            newWorldStateRootHash,
+            blockHeader,
+            (BonsaiPersistedWorldState) this.copy());
     worldStateRootHash = newWorldStateRootHash;
     worldStateBlockHash = blockHeader.getBlockHash();
     isPersisted = true;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -18,6 +18,7 @@ package org.hyperledger.besu.ethereum.bonsai;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateKeyValueStorage.BonsaiStorageSubscriber;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
@@ -31,6 +32,7 @@ import org.hyperledger.besu.plugin.services.exception.StorageException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 import com.google.errorprone.annotations.MustBeClosed;
@@ -39,8 +41,9 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
 /** A World State backed first by trie log layer and then by another world state. */
-public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldView, WorldState {
+public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldView, WorldState, BonsaiStorageSubscriber {
   private Optional<BonsaiWorldView> nextWorldView;
+  private final AtomicLong worldStateSubscription;
   protected final long height;
   protected final TrieLogLayer trieLog;
   private final Hash worldStateRootHash;
@@ -61,6 +64,11 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
     this.height = height;
     this.worldStateRootHash = worldStateRootHash;
     this.trieLog = trieLog;
+    this.worldStateSubscription = new AtomicLong(nextWorldView
+            .filter(world -> world instanceof BonsaiPersistedWorldState)
+            .map(BonsaiPersistedWorldState.class::cast)
+            .map(ws -> ws.worldStateStorage.subscribe(this))
+            .orElse(Long.MAX_VALUE));
   }
 
   public Optional<BonsaiWorldView> getNextWorldView() {
@@ -75,7 +83,16 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   }
 
   public void setNextWorldView(final Optional<BonsaiWorldView> nextWorldView) {
+    maybeUnSubscribe();
     this.nextWorldView = nextWorldView;
+  }
+
+  private void maybeUnSubscribe() {
+    if (worldStateSubscription.get() != Long.MAX_VALUE) {
+      nextWorldView.map(BonsaiPersistedWorldState.class::cast)
+              .ifPresent(ws -> ws.worldStateStorage.unSubscribe(worldStateSubscription.get()));
+      worldStateSubscription.set(Long.MAX_VALUE);
+    }
   }
 
   public TrieLogLayer getTrieLog() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -328,13 +328,6 @@ public class TransactionPool implements BlockAddedObserver {
             .getWorldStateArchive()
             .getMutable(
                 chainHeadBlockHeader.getStateRoot(), chainHeadBlockHeader.getBlockHash(), false)
-            .map(
-                ws -> {
-                  if (!ws.isPersistable()) {
-                    return ws.copy();
-                  }
-                  return ws;
-                })
             .orElseThrow()) {
       final Account senderAccount = worldState.get(transaction.getSender());
       return new ValidationResultAndAccount(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -328,6 +328,13 @@ public class TransactionPool implements BlockAddedObserver {
             .getWorldStateArchive()
             .getMutable(
                 chainHeadBlockHeader.getStateRoot(), chainHeadBlockHeader.getBlockHash(), false)
+            .map(
+                ws -> {
+                  if (!ws.isPersistable()) {
+                    return ws.copy();
+                  }
+                  return ws;
+                })
             .orElseThrow()) {
       final Account senderAccount = worldState.get(transaction.getSender());
       return new ValidationResultAndAccount(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -428,7 +428,11 @@ public abstract class AbstractPendingTransactionsSorter implements PendingTransa
             LOG,
             "Transaction {} not added because nonce too far in the future for sender {}",
             transaction::toTraceLog,
-            maybeSenderAccount::toString);
+            () ->
+                maybeSenderAccount
+                    .map(Account::getAddress)
+                    .map(Address::toString)
+                    .orElse("unknown"));
         return NONCE_TOO_FAR_IN_FUTURE_FOR_SENDER;
       }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fixes an issue where the latest block in BonsaiWorldStateArchive had a closed worldstate.  Persisting BonsaiInMemoryWorldState instances were creating entries in the archive with a snapshot worldstate that would subsequently be closed.  The net result was that queries using the worldstate for the `latest` block would frequently return Optional.empty() when accessing the closed worldstate.

this PR:
* uses a dedicated copy of the Bonsai in memory worldstate when creating a trielog
* adds a close() override to Bonsai layered worldstate to ensure the worldstate resources are cleaned up
* makes minor log change 


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5038 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).