### PR TITLE
Disable RocksDB checksum verification on reads

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -56,6 +56,7 @@ import org.rocksdb.Env;
 import org.rocksdb.LRUCache;
 import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Options;
+import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -90,6 +91,8 @@ public class RocksDBColumnarKeyValueStorage
   private final RocksDBMetrics metrics;
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
+  final private ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);
+
 
   /**
    * Instantiates a new RocksDb columnar key value storage.
@@ -249,7 +252,7 @@ public class RocksDBColumnarKeyValueStorage
     throwIfClosed();
 
     try (final OperationTimer.TimingContext ignored = metrics.getReadLatency().startTimer()) {
-      return Optional.ofNullable(db.get(segment.get(), key));
+      return Optional.ofNullable(db.get(segment.get(), readOptions, key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -91,8 +91,7 @@ public class RocksDBColumnarKeyValueStorage
   private final RocksDBMetrics metrics;
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
-  final private ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);
-
+  private final ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);
 
   /**
    * Instantiates a new RocksDb columnar key value storage.

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -67,7 +67,8 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
     this.snapshot = new RocksDBSnapshot(db);
     this.writeOptions = new WriteOptions();
     this.snapTx = db.beginTransaction(writeOptions);
-    this.readOptions = new ReadOptions().setVerifyChecksums(false).setSnapshot(snapshot.markAndUseSnapshot());
+    this.readOptions =
+        new ReadOptions().setVerifyChecksums(false).setSnapshot(snapshot.markAndUseSnapshot());
   }
 
   private RocksDBSnapshotTransaction(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBSnapshotTransaction.java
@@ -67,7 +67,7 @@ public class RocksDBSnapshotTransaction implements KeyValueStorageTransaction, A
     this.snapshot = new RocksDBSnapshot(db);
     this.writeOptions = new WriteOptions();
     this.snapTx = db.beginTransaction(writeOptions);
-    this.readOptions = new ReadOptions().setSnapshot(snapshot.markAndUseSnapshot());
+    this.readOptions = new ReadOptions().setVerifyChecksums(false).setSnapshot(snapshot.markAndUseSnapshot());
   }
 
   private RocksDBSnapshotTransaction(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -39,6 +39,7 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.LRUCache;
 import org.rocksdb.OptimisticTransactionDB;
 import org.rocksdb.Options;
+import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Statistics;
@@ -62,6 +63,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   private final RocksDBMetrics rocksDBMetrics;
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
+  private final ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);
 
   /**
    * Instantiates a new Rocks db key value storage.
@@ -122,7 +124,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
 
     try (final OperationTimer.TimingContext ignored =
         rocksDBMetrics.getReadLatency().startTimer()) {
-      return Optional.ofNullable(db.get(key));
+      return Optional.ofNullable(db.get(readOptions, key));
     } catch (final RocksDBException e) {
       throw new StorageException(e);
     }


### PR DESCRIPTION
Signed-off-by: Ameziane H <ameziane.hamlat@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR will disable checksum verification on RocksDB during Block retrieva.
We could't do it before because there is this issue in RocksDB, you can find more context here : https://github.com/facebook/rocksdb/issues/11002

@matkt did a PR https://github.com/facebook/rocksdb/pull/11099 and fixed the issue, we can now enable it in Besu.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).