### PR TITLE
Speed up initcode validation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -20,7 +20,6 @@ import static org.hyperledger.besu.ethereum.mainnet.PrivateStateUtils.KEY_TRANSA
 import static org.hyperledger.besu.ethereum.mainnet.PrivateStateUtils.KEY_TRANSACTION_HASH;
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
@@ -378,9 +377,7 @@ public class MainnetTransactionProcessor {
                 .contract(contractAddress)
                 .inputData(Bytes.EMPTY)
                 .versionedHashes(transaction.getVersionedHashes())
-                .code(
-                    contractCreationProcessor.getCodeFromEVM(
-                        Hash.hash(initCodeBytes), initCodeBytes))
+                .code(contractCreationProcessor.getCodeFromEVM(null, initCodeBytes))
                 .build();
       } else {
         @SuppressWarnings("OptionalGetWithoutIsPresent") // isContractCall tests isPresent

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionProcessor.java
@@ -150,9 +150,7 @@ public class PrivateTransactionProcessor {
                 .address(privateContractAddress)
                 .contract(privateContractAddress)
                 .inputData(Bytes.EMPTY)
-                .code(
-                    contractCreationProcessor.getCodeFromEVM(
-                        Hash.hash(initCodeBytes), initCodeBytes))
+                .code(contractCreationProcessor.getCodeFromEVM(null, initCodeBytes))
                 .build();
       } else {
         final Address to = transaction.getTo().get();

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evmtool;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hyperledger.besu.evmtool.CodeValidateSubCommand.COMMAND_NAME;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.code.CodeFactory;
 import org.hyperledger.besu.evm.code.CodeInvalid;
 import org.hyperledger.besu.evm.code.EOFLayout;
@@ -117,7 +116,7 @@ public class CodeValidateSubCommand implements Runnable {
       return "err: layout - " + layout.getInvalidReason() + "\n";
     }
 
-    var code = CodeFactory.createCode(codeBytes, Hash.hash(codeBytes), 1, true);
+    var code = CodeFactory.createCode(codeBytes, 1, true);
     if (!code.isValid()) {
       return "err: " + ((CodeInvalid) code).getInvalidReason() + "\n";
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -349,11 +349,12 @@ public class EVM {
    * @return the code
    */
   public Code getCode(final Hash codeHash, final Bytes codeBytes) {
-    Code result = codeCache.getIfPresent(codeHash);
+    Code result = codeHash == null ? null : codeCache.getIfPresent(codeHash);
     if (result == null) {
-      result =
-          CodeFactory.createCode(codeBytes, codeHash, evmSpecVersion.getMaxEofVersion(), false);
-      codeCache.put(codeHash, result);
+      result = CodeFactory.createCode(codeBytes, evmSpecVersion.getMaxEofVersion(), false);
+      if (codeHash != null) {
+        codeCache.put(codeHash, result);
+      }
     }
     return result;
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeInvalid.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeInvalid.java
@@ -19,6 +19,9 @@ package org.hyperledger.besu.evm.code;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 
+import java.util.function.Supplier;
+
+import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 /**
@@ -27,7 +30,7 @@ import org.apache.tuweni.bytes.Bytes;
  */
 public class CodeInvalid implements Code {
 
-  private final Hash codeHash;
+  private final Supplier<Hash> codeHash;
   private final Bytes codeBytes;
 
   private final String invalidReason;
@@ -35,13 +38,12 @@ public class CodeInvalid implements Code {
   /**
    * Instantiates a new Code invalid.
    *
-   * @param codeHash the code hash
    * @param codeBytes the code bytes
    * @param invalidReason the invalid reason
    */
-  public CodeInvalid(final Hash codeHash, final Bytes codeBytes, final String invalidReason) {
-    this.codeHash = codeHash;
+  public CodeInvalid(final Bytes codeBytes, final String invalidReason) {
     this.codeBytes = codeBytes;
+    this.codeHash = Suppliers.memoize(() -> Hash.hash(codeBytes));
     this.invalidReason = invalidReason;
   }
 
@@ -66,7 +68,7 @@ public class CodeInvalid implements Code {
 
   @Override
   public Hash getCodeHash() {
-    return codeHash;
+    return codeHash.get();
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV0.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV0.java
@@ -19,22 +19,24 @@ package org.hyperledger.besu.evm.code;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.operation.JumpDestOperation;
-import org.hyperledger.besu.evm.operation.PushOperation;
+
+import java.util.function.Supplier;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The CodeV0. */
 public class CodeV0 implements Code {
 
   /** The constant EMPTY_CODE. */
-  public static final CodeV0 EMPTY_CODE = new CodeV0(Bytes.EMPTY, Hash.EMPTY);
+  public static final CodeV0 EMPTY_CODE = new CodeV0(Bytes.EMPTY);
 
   /** The bytes representing the code. */
   private final Bytes bytes;
 
   /** The hash of the code, needed for accessing metadata about the bytecode */
-  private final Hash codeHash;
+  private final Supplier<Hash> codeHash;
 
   /** Used to cache valid jump destinations. */
   private long[] validJumpDestinations;
@@ -46,11 +48,10 @@ public class CodeV0 implements Code {
    * Public constructor.
    *
    * @param bytes The byte representation of the code.
-   * @param codeHash the Hash of the bytes in the code.
    */
-  CodeV0(final Bytes bytes, final Hash codeHash) {
+  CodeV0(final Bytes bytes) {
     this.bytes = bytes;
-    this.codeHash = codeHash;
+    this.codeHash = Suppliers.memoize(() -> Hash.hash(bytes));
     this.codeSectionZero = new CodeSection(bytes.size(), 0, -1, -1, 0);
   }
 
@@ -97,7 +98,7 @@ public class CodeV0 implements Code {
 
   @Override
   public Hash getCodeHash() {
-    return codeHash;
+    return codeHash.get();
   }
 
   @Override
@@ -148,22 +149,150 @@ public class CodeV0 implements Code {
     final long[] bitmap = new long[(size >> 6) + 1];
     final byte[] rawCode = bytes.toArrayUnsafe();
     final int length = rawCode.length;
-    for (int i = 0; i < length; ) {
-      long thisEntry = 0L;
-      final int entryPos = i >> 6;
-      final int max = Math.min(64, length - (entryPos << 6));
-      int j = i & 0x3F;
-      for (; j < max; i++, j++) {
-        final byte operationNum = rawCode[i];
-        if (operationNum == JumpDestOperation.OPCODE) {
-          thisEntry |= 1L << j;
-        } else if (operationNum > PushOperation.PUSH_BASE) {
-          // not needed - && operationNum <= PushOperation.PUSH_MAX
-          // Java quirk, all bytes are signed, and PUSH32 is 127, which is Byte.MAX_VALUE
-          // so we don't need to check the upper bound as it will never be violated
-          final int multiByteDataLen = operationNum - PushOperation.PUSH_BASE;
-          j += multiByteDataLen;
-          i += multiByteDataLen;
+    long thisEntry = 0L;
+    int entryPos = 0;
+    for (int i = 0, j = 0; i < length; i++, j++) {
+      if (j > 0x3f) {
+        bitmap[entryPos] = thisEntry;
+        thisEntry = 0;
+        entryPos = i >> 6;
+        j = 0;
+      }
+      final byte operationNum = rawCode[i];
+      if (operationNum >= JumpDestOperation.OPCODE) {
+        switch (operationNum) {
+          case JumpDestOperation.OPCODE:
+            thisEntry |= 1L << (i & 0x3F);
+            break;
+          case 0x60:
+            i += 1;
+            j += 1;
+            break;
+          case 0x61:
+            i += 2;
+            j += 2;
+            break;
+          case 0x62:
+            i += 3;
+            j += 3;
+            break;
+          case 0x63:
+            i += 4;
+            j += 4;
+            break;
+          case 0x64:
+            i += 5;
+            j += 5;
+            break;
+          case 0x65:
+            i += 6;
+            j += 6;
+            break;
+          case 0x66:
+            i += 7;
+            j += 7;
+            break;
+          case 0x67:
+            i += 8;
+            j += 8;
+            break;
+          case 0x68:
+            i += 9;
+            j += 9;
+            break;
+          case 0x69:
+            i += 10;
+            j += 10;
+            break;
+          case 0x6a:
+            i += 11;
+            j += 11;
+            break;
+          case 0x6b:
+            i += 12;
+            j += 12;
+            break;
+          case 0x6c:
+            i += 13;
+            j += 13;
+            break;
+          case 0x6d:
+            i += 14;
+            j += 14;
+            break;
+          case 0x6e:
+            i += 15;
+            j += 15;
+            break;
+          case 0x6f:
+            i += 16;
+            j += 16;
+            break;
+          case 0x70:
+            i += 17;
+            j += 17;
+            break;
+          case 0x71:
+            i += 18;
+            j += 18;
+            break;
+          case 0x72:
+            i += 19;
+            j += 19;
+            break;
+          case 0x73:
+            i += 20;
+            j += 20;
+            break;
+          case 0x74:
+            i += 21;
+            j += 21;
+            break;
+          case 0x75:
+            i += 22;
+            j += 22;
+            break;
+          case 0x76:
+            i += 23;
+            j += 23;
+            break;
+          case 0x77:
+            i += 24;
+            j += 24;
+            break;
+          case 0x78:
+            i += 25;
+            j += 25;
+            break;
+          case 0x79:
+            i += 26;
+            j += 26;
+            break;
+          case 0x7a:
+            i += 27;
+            j += 27;
+            break;
+          case 0x7b:
+            i += 28;
+            j += 28;
+            break;
+          case 0x7c:
+            i += 29;
+            j += 29;
+            break;
+          case 0x7d:
+            i += 30;
+            j += 30;
+            break;
+          case 0x7e:
+            i += 31;
+            j += 31;
+            break;
+          case 0x7f:
+            i += 32;
+            j += 32;
+            break;
+          default:
         }
       }
       bitmap[entryPos] = thisEntry;

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV0.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV0.java
@@ -149,150 +149,148 @@ public class CodeV0 implements Code {
     final long[] bitmap = new long[(size >> 6) + 1];
     final byte[] rawCode = bytes.toArrayUnsafe();
     final int length = rawCode.length;
-    long thisEntry = 0L;
-    int entryPos = 0;
-    for (int i = 0, j = 0; i < length; i++, j++) {
-      if (j > 0x3f) {
-        bitmap[entryPos] = thisEntry;
-        thisEntry = 0;
-        entryPos = i >> 6;
-        j = 0;
-      }
-      final byte operationNum = rawCode[i];
-      if (operationNum >= JumpDestOperation.OPCODE) {
-        switch (operationNum) {
-          case JumpDestOperation.OPCODE:
-            thisEntry |= 1L << (i & 0x3F);
-            break;
-          case 0x60:
-            i += 1;
-            j += 1;
-            break;
-          case 0x61:
-            i += 2;
-            j += 2;
-            break;
-          case 0x62:
-            i += 3;
-            j += 3;
-            break;
-          case 0x63:
-            i += 4;
-            j += 4;
-            break;
-          case 0x64:
-            i += 5;
-            j += 5;
-            break;
-          case 0x65:
-            i += 6;
-            j += 6;
-            break;
-          case 0x66:
-            i += 7;
-            j += 7;
-            break;
-          case 0x67:
-            i += 8;
-            j += 8;
-            break;
-          case 0x68:
-            i += 9;
-            j += 9;
-            break;
-          case 0x69:
-            i += 10;
-            j += 10;
-            break;
-          case 0x6a:
-            i += 11;
-            j += 11;
-            break;
-          case 0x6b:
-            i += 12;
-            j += 12;
-            break;
-          case 0x6c:
-            i += 13;
-            j += 13;
-            break;
-          case 0x6d:
-            i += 14;
-            j += 14;
-            break;
-          case 0x6e:
-            i += 15;
-            j += 15;
-            break;
-          case 0x6f:
-            i += 16;
-            j += 16;
-            break;
-          case 0x70:
-            i += 17;
-            j += 17;
-            break;
-          case 0x71:
-            i += 18;
-            j += 18;
-            break;
-          case 0x72:
-            i += 19;
-            j += 19;
-            break;
-          case 0x73:
-            i += 20;
-            j += 20;
-            break;
-          case 0x74:
-            i += 21;
-            j += 21;
-            break;
-          case 0x75:
-            i += 22;
-            j += 22;
-            break;
-          case 0x76:
-            i += 23;
-            j += 23;
-            break;
-          case 0x77:
-            i += 24;
-            j += 24;
-            break;
-          case 0x78:
-            i += 25;
-            j += 25;
-            break;
-          case 0x79:
-            i += 26;
-            j += 26;
-            break;
-          case 0x7a:
-            i += 27;
-            j += 27;
-            break;
-          case 0x7b:
-            i += 28;
-            j += 28;
-            break;
-          case 0x7c:
-            i += 29;
-            j += 29;
-            break;
-          case 0x7d:
-            i += 30;
-            j += 30;
-            break;
-          case 0x7e:
-            i += 31;
-            j += 31;
-            break;
-          case 0x7f:
-            i += 32;
-            j += 32;
-            break;
-          default:
+    for (int i = 0; i < length; ) {
+      long thisEntry = 0L;
+      final int entryPos = i >> 6;
+      final int max = Math.min(64, length - (entryPos << 6));
+      int j = i & 0x3F;
+      for (; j < max; i++, j++) {
+        final byte operationNum = rawCode[i];
+        if (operationNum >= JumpDestOperation.OPCODE) {
+          switch (operationNum) {
+            case JumpDestOperation.OPCODE:
+              thisEntry |= 1L << j;
+              break;
+            case 0x60:
+              i += 1;
+              j += 1;
+              break;
+            case 0x61:
+              i += 2;
+              j += 2;
+              break;
+            case 0x62:
+              i += 3;
+              j += 3;
+              break;
+            case 0x63:
+              i += 4;
+              j += 4;
+              break;
+            case 0x64:
+              i += 5;
+              j += 5;
+              break;
+            case 0x65:
+              i += 6;
+              j += 6;
+              break;
+            case 0x66:
+              i += 7;
+              j += 7;
+              break;
+            case 0x67:
+              i += 8;
+              j += 8;
+              break;
+            case 0x68:
+              i += 9;
+              j += 9;
+              break;
+            case 0x69:
+              i += 10;
+              j += 10;
+              break;
+            case 0x6a:
+              i += 11;
+              j += 11;
+              break;
+            case 0x6b:
+              i += 12;
+              j += 12;
+              break;
+            case 0x6c:
+              i += 13;
+              j += 13;
+              break;
+            case 0x6d:
+              i += 14;
+              j += 14;
+              break;
+            case 0x6e:
+              i += 15;
+              j += 15;
+              break;
+            case 0x6f:
+              i += 16;
+              j += 16;
+              break;
+            case 0x70:
+              i += 17;
+              j += 17;
+              break;
+            case 0x71:
+              i += 18;
+              j += 18;
+              break;
+            case 0x72:
+              i += 19;
+              j += 19;
+              break;
+            case 0x73:
+              i += 20;
+              j += 20;
+              break;
+            case 0x74:
+              i += 21;
+              j += 21;
+              break;
+            case 0x75:
+              i += 22;
+              j += 22;
+              break;
+            case 0x76:
+              i += 23;
+              j += 23;
+              break;
+            case 0x77:
+              i += 24;
+              j += 24;
+              break;
+            case 0x78:
+              i += 25;
+              j += 25;
+              break;
+            case 0x79:
+              i += 26;
+              j += 26;
+              break;
+            case 0x7a:
+              i += 27;
+              j += 27;
+              break;
+            case 0x7b:
+              i += 28;
+              j += 28;
+              break;
+            case 0x7c:
+              i += 29;
+              j += 29;
+              break;
+            case 0x7d:
+              i += 30;
+              j += 30;
+              break;
+            case 0x7e:
+              i += 31;
+              j += 31;
+              break;
+            case 0x7f:
+              i += 32;
+              j += 32;
+              break;
+            default:
+          }
         }
       }
       bitmap[entryPos] = thisEntry;

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1.java
@@ -22,24 +22,25 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 
+import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The CodeV1. */
 public class CodeV1 implements Code {
 
-  private final Hash codeHash;
+  private final Supplier<Hash> codeHash;
   EOFLayout eofLayout;
 
   /**
    * Instantiates a new CodeV1.
    *
-   * @param codeHash the code hash
    * @param layout the layout
    */
-  CodeV1(final Hash codeHash, final EOFLayout layout) {
-    this.codeHash = codeHash;
+  CodeV1(final EOFLayout layout) {
     this.eofLayout = layout;
+    this.codeHash = Suppliers.memoize(() -> Hash.hash(eofLayout.getContainer()));
   }
 
   @Override
@@ -66,7 +67,7 @@ public class CodeV1 implements Code {
 
   @Override
   public Hash getCodeHash() {
-    return codeHash;
+    return codeHash.get();
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/CachedInvalidCodeRule.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/CachedInvalidCodeRule.java
@@ -16,7 +16,6 @@
 
 package org.hyperledger.besu.evm.contractvalidation;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.code.CodeFactory;
@@ -44,8 +43,7 @@ public class CachedInvalidCodeRule implements ContractValidationRule {
   @Override
   public Optional<ExceptionalHaltReason> validate(
       final Bytes contractCode, final MessageFrame frame) {
-    final Code code =
-        CodeFactory.createCode(contractCode, Hash.hash(contractCode), maxEofVersion, false);
+    final Code code = CodeFactory.createCode(contractCode, maxEofVersion, false);
     if (!code.isValid()) {
       return Optional.of(ExceptionalHaltReason.INVALID_CODE);
     } else {

--- a/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/EOFValidationCodeRule.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/EOFValidationCodeRule.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.evm.contractvalidation;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.code.CodeFactory;
 import org.hyperledger.besu.evm.code.CodeInvalid;
@@ -54,9 +53,7 @@ public class EOFValidationCodeRule implements ContractValidationRule {
   @Override
   public Optional<ExceptionalHaltReason> validate(
       final Bytes contractCode, final MessageFrame frame) {
-    Code code =
-        CodeFactory.createCode(
-            contractCode, Hash.hash(contractCode), maxEofVersion, inCreateTransaction);
+    Code code = CodeFactory.createCode(contractCode, maxEofVersion, inCreateTransaction);
     if (!code.isValid()) {
       LOG.trace("EOF Validation Error: {}", ((CodeInvalid) code).getInvalidReason());
       return Optional.of(ExceptionalHaltReason.INVALID_CODE);

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.code;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -181,7 +180,7 @@ class CodeFactoryTest {
   }
 
   private static void invalidCode(final String str) {
-    Code code = CodeFactory.createCode(Bytes.fromHexString(str), Hash.EMPTY, 1, true);
+    Code code = CodeFactory.createCode(Bytes.fromHexString(str), 1, true);
     assertThat(code.isValid()).isFalse();
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
@@ -65,8 +65,7 @@ public class CodeV0Test {
   public void shouldReuseJumpDestMap() {
     final JumpOperation operation = new JumpOperation(gasCalculator);
     final Bytes jumpBytes = Bytes.fromHexString("0x6003565b00");
-    final CodeV0 getsCached =
-        (CodeV0) spy(CodeFactory.createCode(jumpBytes, Hash.hash(jumpBytes), 0, false));
+    final CodeV0 getsCached = (CodeV0) spy(CodeFactory.createCode(jumpBytes, 0, false));
     MessageFrame frame = createJumpFrame(getsCached);
 
     OperationResult result = operation.execute(frame, evm);

--- a/evm/src/test/java/org/hyperledger/besu/evm/internal/CodeCacheTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/internal/CodeCacheTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.code.CodeFactory;
 import org.hyperledger.besu.evm.operation.JumpDestOperation;
@@ -34,8 +33,7 @@ public class CodeCacheTest {
     final Bytes contractBytes =
         Bytes.fromHexString("0xDEAD" + op + "BEEF" + op + "B0B0" + op + "C0DE" + op + "FACE");
     final CodeScale scale = new CodeScale();
-    final Code contractCode =
-        CodeFactory.createCode(contractBytes, Hash.hash(contractBytes), 0, false);
+    final Code contractCode = CodeFactory.createCode(contractBytes, 0, false);
     final int weight = scale.weigh(contractCode.getCodeHash(), contractCode);
     assertThat(weight)
         .isEqualTo(contractCode.getCodeHash().size() + (contractBytes.size() * 9 + 7) / 8);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operations/Create2OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operations/Create2OperationTest.java
@@ -155,7 +155,7 @@ public class Create2OperationTest {
             .sender(Address.fromHexString(sender))
             .value(Wei.ZERO)
             .apparentValue(Wei.ZERO)
-            .code(CodeFactory.createCode(codeBytes, Hash.hash(codeBytes), 0, true))
+            .code(CodeFactory.createCode(codeBytes, 0, true))
             .depth(1)
             .completer(__ -> {})
             .address(Address.fromHexString(sender))
@@ -179,10 +179,7 @@ public class Create2OperationTest {
     when(worldUpdater.getAccount(any())).thenReturn(account);
     when(worldUpdater.updater()).thenReturn(worldUpdater);
     when(evm.getCode(any(), any()))
-        .thenAnswer(
-            invocation ->
-                CodeFactory.createCode(
-                    invocation.getArgument(1), invocation.getArgument(0), 0, true));
+        .thenAnswer(invocation -> CodeFactory.createCode(invocation.getArgument(1), 0, true));
   }
 
   @ParameterizedTest
@@ -283,7 +280,7 @@ public class Create2OperationTest {
             .sender(Address.fromHexString(SENDER))
             .value(Wei.ZERO)
             .apparentValue(Wei.ZERO)
-            .code(CodeFactory.createCode(SIMPLE_CREATE, Hash.hash(SIMPLE_CREATE), 0, true))
+            .code(CodeFactory.createCode(SIMPLE_CREATE, 0, true))
             .depth(depth)
             .completer(__ -> {})
             .address(Address.fromHexString(SENDER))
@@ -312,7 +309,7 @@ public class Create2OperationTest {
     final UInt256 memoryLength = UInt256.valueOf(SIMPLE_CREATE.size());
     final MessageFrame messageFrame =
         new TestMessageFrameBuilder()
-            .code(CodeFactory.createCode(SIMPLE_EOF, Hash.hash(SIMPLE_EOF), 1, true))
+            .code(CodeFactory.createCode(SIMPLE_EOF, 1, true))
             .pushStackItem(Bytes.EMPTY)
             .pushStackItem(memoryLength)
             .pushStackItem(memoryOffset)
@@ -337,7 +334,7 @@ public class Create2OperationTest {
     final UInt256 memoryLength = UInt256.valueOf(SIMPLE_EOF.size());
     final MessageFrame messageFrame =
         new TestMessageFrameBuilder()
-            .code(CodeFactory.createCode(SIMPLE_CREATE, Hash.hash(SIMPLE_CREATE), 1, true))
+            .code(CodeFactory.createCode(SIMPLE_CREATE, 1, true))
             .pushStackItem(Bytes.EMPTY)
             .pushStackItem(memoryLength)
             .pushStackItem(memoryOffset)

--- a/evm/src/test/java/org/hyperledger/besu/evm/operations/CreateOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operations/CreateOperationTest.java
@@ -247,7 +247,7 @@ class CreateOperationTest {
     final UInt256 memoryLength = UInt256.valueOf(SIMPLE_CREATE.size());
     final MessageFrame messageFrame =
         new TestMessageFrameBuilder()
-            .code(CodeFactory.createCode(SIMPLE_EOF, Hash.hash(SIMPLE_EOF), 1, true))
+            .code(CodeFactory.createCode(SIMPLE_EOF, 1, true))
             .pushStackItem(memoryLength)
             .pushStackItem(memoryOffset)
             .pushStackItem(Bytes.EMPTY)
@@ -271,7 +271,7 @@ class CreateOperationTest {
     final UInt256 memoryLength = UInt256.valueOf(SIMPLE_EOF.size());
     final MessageFrame messageFrame =
         new TestMessageFrameBuilder()
-            .code(CodeFactory.createCode(SIMPLE_CREATE, Hash.hash(SIMPLE_CREATE), 1, true))
+            .code(CodeFactory.createCode(SIMPLE_CREATE, 1, true))
             .pushStackItem(memoryLength)
             .pushStackItem(memoryOffset)
             .pushStackItem(Bytes.EMPTY)
@@ -308,7 +308,7 @@ class CreateOperationTest {
             .sender(Address.fromHexString(SENDER))
             .value(Wei.ZERO)
             .apparentValue(Wei.ZERO)
-            .code(CodeFactory.createCode(SIMPLE_CREATE, Hash.hash(SIMPLE_CREATE), 0, true))
+            .code(CodeFactory.createCode(SIMPLE_CREATE, 0, true))
             .depth(depth)
             .completer(__ -> {})
             .address(Address.fromHexString(SENDER))

--- a/evm/src/test/java/org/hyperledger/besu/evm/operations/JumpOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operations/JumpOperationTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.code.CodeFactory;
@@ -75,7 +74,7 @@ public class JumpOperationTest {
     final MessageFrame frame =
         createMessageFrameBuilder(10_000L)
             .pushStackItem(UInt256.fromHexString("0x03"))
-            .code(CodeFactory.createCode(jumpBytes, Hash.hash(jumpBytes), 0, false))
+            .code(CodeFactory.createCode(jumpBytes, 0, false))
             .build();
     frame.setPC(CURRENT_PC);
 
@@ -90,7 +89,7 @@ public class JumpOperationTest {
     final MessageFrame frame =
         createMessageFrameBuilder(10_000L)
             .pushStackItem(UInt256.fromHexString("0x03"))
-            .code(CodeFactory.createCode(jumpBytes, Hash.hash(jumpBytes), 0, false))
+            .code(CodeFactory.createCode(jumpBytes, 0, false))
             .build();
     frame.setPC(CURRENT_PC);
 
@@ -105,7 +104,7 @@ public class JumpOperationTest {
     final MessageFrame frameDestinationGreaterThanCodeSize =
         createMessageFrameBuilder(100L)
             .pushStackItem(UInt256.fromHexString("0xFFFFFFFF"))
-            .code(CodeFactory.createCode(jumpBytes, Hash.hash(jumpBytes), 0, false))
+            .code(CodeFactory.createCode(jumpBytes, 0, false))
             .build();
     frameDestinationGreaterThanCodeSize.setPC(CURRENT_PC);
 
@@ -115,7 +114,7 @@ public class JumpOperationTest {
     final MessageFrame frameDestinationEqualsToCodeSize =
         createMessageFrameBuilder(100L)
             .pushStackItem(UInt256.fromHexString("0x04"))
-            .code(CodeFactory.createCode(badJump, Hash.hash(badJump), 0, false))
+            .code(CodeFactory.createCode(badJump, 0, false))
             .build();
     frameDestinationEqualsToCodeSize.setPC(CURRENT_PC);
 
@@ -133,7 +132,7 @@ public class JumpOperationTest {
     final MessageFrame longContract =
         createMessageFrameBuilder(100L)
             .pushStackItem(UInt256.fromHexString("0x12c"))
-            .code(CodeFactory.createCode(longCode, Hash.hash(longCode), 0, false))
+            .code(CodeFactory.createCode(longCode, 0, false))
             .build();
     longContract.setPC(255);
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
@@ -19,7 +19,6 @@ import static org.hyperledger.besu.evm.frame.MessageFrame.State.COMPLETED_SUCCES
 import static org.hyperledger.besu.evm.frame.MessageFrame.State.EXCEPTIONAL_HALT;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.code.CodeFactory;
@@ -185,9 +184,7 @@ public class ContractCreationProcessorTest {
         Bytes.fromHexString(
             "0xEF000101000C020003000b000200080300000000000002020100020100000260016002b00001b00002b101b160005360106000f3");
     final MessageFrame messageFrame =
-        new TestMessageFrameBuilder()
-            .code(CodeFactory.createCode(initCode, Hash.hash(initCode), 1, true))
-            .build();
+        new TestMessageFrameBuilder().code(CodeFactory.createCode(initCode, 1, true)).build();
     messageFrame.setOutputData(contractCode);
     messageFrame.setGasRemaining(100L);
 
@@ -255,11 +252,7 @@ public class ContractCreationProcessorTest {
     final MessageFrame messageFrame =
         new TestMessageFrameBuilder()
             .code(
-                CodeFactory.createCode(
-                    contractCreateCode,
-                    Hash.hash(contractCreateCode),
-                    evmSpecVersion.getMaxEofVersion(),
-                    true))
+                CodeFactory.createCode(contractCreateCode, evmSpecVersion.getMaxEofVersion(), true))
             .build();
     messageFrame.setOutputData(Bytes.fromHexString("0xef00010100010060"));
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Speedup initcode validation by
* optimizing the jumpdest loop
* not caching initcode in the code cache (but keep codecache for normal contracts).

Signed-off-by: Danno Ferrin <danno.ferrin@swirldslabs.com>

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).