### PR TITLE
Revert "Replace getByBlockNumber by getByBlockHeader (#5020)"

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/chainimport/JsonBlockImporter.java
+++ b/besu/src/main/java/org/hyperledger/besu/chainimport/JsonBlockImporter.java
@@ -153,7 +153,10 @@ public class JsonBlockImporter {
 
   private void importBlock(final Block block) {
     final BlockImporter importer =
-        controller.getProtocolSchedule().getByBlockHeader(block.getHeader()).getBlockImporter();
+        controller
+            .getProtocolSchedule()
+            .getByBlockNumber(block.getHeader().getNumber())
+            .getBlockImporter();
 
     final BlockImportResult importResult =
         importer.importBlock(controller.getProtocolContext(), block, HeaderValidationMode.NONE);

--- a/besu/src/main/java/org/hyperledger/besu/chainimport/RlpBlockImporter.java
+++ b/besu/src/main/java/org/hyperledger/besu/chainimport/RlpBlockImporter.java
@@ -127,7 +127,7 @@ public class RlpBlockImporter implements Closeable {
         if (previousHeader == null) {
           previousHeader = lookupPreviousHeader(blockchain, header);
         }
-        final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(header);
+        final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(blockNumber);
         final BlockHeader lastHeader = previousHeader;
 
         final CompletableFuture<Void> validationFuture =

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -427,7 +427,8 @@ public final class RunnerTest {
 
     for (int i = 1; i < count + 1; ++i) {
       final Block block = blocks.get(i);
-      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+      final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       final BlockImportResult result =
           blockImporter.importBlock(protocolContext, block, HeaderValidationMode.FULL);

--- a/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/TransitionControllerBuilderTest.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -130,7 +131,7 @@ public class TransitionControllerBuilderTest {
     var preMergeProtocolSpec = mock(ProtocolSpec.class);
     when(mergeContext.isPostMerge()).thenReturn(Boolean.FALSE);
     when(mergeContext.getFinalized()).thenReturn(Optional.empty());
-    when(preMergeProtocolSchedule.getByBlockHeader(any())).thenReturn(preMergeProtocolSpec);
+    when(preMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(preMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(mockBlock))
         .isEqualTo(preMergeProtocolSpec);
   }
@@ -140,7 +141,7 @@ public class TransitionControllerBuilderTest {
     var mockBlock = new BlockHeaderTestFixture().buildHeader();
     var postMergeProtocolSpec = mock(ProtocolSpec.class);
     when(mergeContext.getFinalized()).thenReturn(Optional.of(mockBlock));
-    when(postMergeProtocolSchedule.getByBlockHeader(any())).thenReturn(postMergeProtocolSpec);
+    when(postMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(postMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(mockBlock))
         .isEqualTo(postMergeProtocolSpec);
   }
@@ -163,7 +164,7 @@ public class TransitionControllerBuilderTest {
     when(mockBlockchain.getTotalDifficultyByHash(any()))
         .thenReturn(Optional.of(Difficulty.of(1335L)));
 
-    when(preMergeProtocolSchedule.getByBlockHeader(any())).thenReturn(preMergeProtocolSpec);
+    when(preMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(preMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(mockBlock))
         .isEqualTo(preMergeProtocolSpec);
   }
@@ -186,7 +187,7 @@ public class TransitionControllerBuilderTest {
     when(mockBlockchain.getTotalDifficultyByHash(any()))
         .thenReturn(Optional.of(Difficulty.of(1337L)));
 
-    when(postMergeProtocolSchedule.getByBlockHeader(any())).thenReturn(postMergeProtocolSpec);
+    when(postMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(postMergeProtocolSpec);
     assertThat(transitionProtocolSchedule.getByBlockHeader(mockBlock))
         .isEqualTo(postMergeProtocolSpec);
   }
@@ -212,7 +213,7 @@ public class TransitionControllerBuilderTest {
     var preMergeProtocolSpec = mock(ProtocolSpec.class);
     when(preMergeProtocolSpec.getBlockHeaderValidator()).thenReturn(validator);
 
-    when(preMergeProtocolSchedule.getByBlockHeader(any())).thenReturn(preMergeProtocolSpec);
+    when(preMergeProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(preMergeProtocolSpec);
 
     var mockParentBlock =
         new BlockHeaderTestFixture()
@@ -234,7 +235,7 @@ public class TransitionControllerBuilderTest {
     var mergeFriendlyValidation =
         transitionProtocolSchedule
             .getPreMergeSchedule()
-            .getByBlockHeader(mockBlock)
+            .getByBlockNumber(1L)
             .getBlockHeaderValidator()
             .validateHeader(
                 mockBlock, mockParentBlock, protocolContext, HeaderValidationMode.DETACHED_ONLY);

--- a/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/BesuEventsImplTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -124,7 +125,7 @@ public class BesuEventsImplTest {
     when(mockEthPeers.streamAvailablePeers()).thenAnswer(z -> Stream.empty());
     when(mockProtocolContext.getBlockchain()).thenReturn(blockchain);
     when(mockProtocolContext.getWorldStateArchive()).thenReturn(mockWorldStateArchive);
-    when(mockProtocolSchedule.getByBlockHeader(any())).thenReturn(mockProtocolSpec);
+    when(mockProtocolSchedule.getByBlockNumber(anyLong())).thenReturn(mockProtocolSpec);
     when(mockProtocolSpec.getTransactionValidator()).thenReturn(mockTransactionValidator);
     when(mockProtocolSpec.getFeeMarket()).thenReturn(FeeMarket.london(0L));
     when(mockTransactionValidator.validate(any(), any(Optional.class), any()))

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
@@ -176,7 +176,7 @@ public class CliqueProtocolScheduleTest {
       final BlockHeader parentBlockHeader) {
 
     return schedule
-        .getByBlockHeader(blockHeader)
+        .getByBlockNumber(blockHeader.getNumber())
         .getBlockHeaderValidator()
         .validateHeader(blockHeader, parentBlockHeader, null, HeaderValidationMode.LIGHT);
   }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -102,7 +102,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
             LOG,
             "for {} returning a pre-merge schedule because we are not post-merge",
             blockHeader::toLogString);
-        return getPreMergeSchedule().getByBlockHeader(blockHeader);
+        return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
 
       // otherwise check to see if this block represents a re-org TTD block:
@@ -128,12 +128,12 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
             LOG,
             "returning a pre-merge schedule because block {} is pre-merge or TTD",
             blockHeader::toLogString);
-        return getPreMergeSchedule().getByBlockHeader(blockHeader);
+        return getPreMergeSchedule().getByBlockNumber(blockHeader.getNumber());
       }
     }
     // else return post-merge schedule
     debugLambda(LOG, " for {} returning a post-merge schedule", blockHeader::toLogString);
-    return getPostMergeSchedule().getByBlockHeader(blockHeader);
+    return getPostMergeSchedule().getByBlockNumber(blockHeader.getNumber());
   }
 
   /**

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -681,9 +681,9 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   @Override
   public Optional<Hash> getLatestValidAncestor(final Hash blockHash) {
     final var chain = protocolContext.getBlockchain();
-    final var chainHeadHeader = chain.getChainHeadHeader();
+    final var chainHeadNum = chain.getChainHeadBlockNumber();
     return findValidAncestor(
-        chain, blockHash, protocolSchedule.getByBlockHeader(chainHeadHeader).getBadBlocksManager());
+        chain, blockHash, protocolSchedule.getByBlockNumber(chainHeadNum).getBadBlocksManager());
   }
 
   @Override
@@ -692,7 +692,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
     final var self = chain.getBlockHeader(blockHeader.getHash());
 
     if (self.isEmpty()) {
-      final var badBlocks = protocolSchedule.getByBlockHeader(blockHeader).getBadBlocksManager();
+      final var badBlocks =
+          protocolSchedule.getByBlockNumber(blockHeader.getNumber()).getBadBlocksManager();
       return findValidAncestor(chain, blockHeader.getParentHash(), badBlocks);
     }
     return self.map(BlockHeader::getHash);
@@ -823,7 +824,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   @Override
   public void addBadBlock(final Block block, final Optional<Throwable> maybeCause) {
     protocolSchedule
-        .getByBlockHeader(protocolContext.getBlockchain().getChainHeadHeader())
+        .getByBlockNumber(protocolContext.getBlockchain().getChainHeadBlockNumber())
         .getBadBlocksManager()
         .addBadBlock(block, maybeCause);
   }
@@ -838,7 +839,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   private BadBlockManager getBadBlockManager() {
     final BadBlockManager badBlocksManager =
         protocolSchedule
-            .getByBlockHeader(protocolContext.getBlockchain().getChainHeadHeader())
+            .getByBlockNumber(protocolContext.getBlockchain().getChainHeadBlockNumber())
             .getBadBlocksManager();
     return badBlocksManager;
   }
@@ -846,7 +847,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   @Override
   public Optional<Hash> getLatestValidHashOfBadBlock(Hash blockHash) {
     return protocolSchedule
-        .getByBlockHeader(protocolContext.getBlockchain().getChainHeadHeader())
+        .getByBlockNumber(protocolContext.getBlockchain().getChainHeadBlockNumber())
         .getBadBlocksManager()
         .getLatestValidHash(blockHash);
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -175,7 +175,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
               return spec;
             })
         .when(protocolSchedule)
-        .getByBlockHeader(any(BlockHeader.class));
+        .getByBlockNumber(anyLong());
 
     protocolContext = new ProtocolContext(blockchain, worldStateArchive, mergeContext);
     var mutable = worldStateArchive.getMutable();

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -82,7 +82,8 @@ public class JsonRpcTestMethodsFactory {
     this.synchronizer = mock(Synchronizer.class);
 
     for (final Block block : importer.getBlocks()) {
-      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+      final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthGetBlockByNumberLatestDesyncIntegrationTest.java
@@ -71,7 +71,8 @@ public class EthGetBlockByNumberLatestDesyncIntegrationTest {
 
     for (final Block block : importer.getBlocks()) {
       final ProtocolSchedule protocolSchedule = importer.getProtocolSchedule();
-      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+      final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/DebugReplayBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/DebugReplayBlock.java
@@ -69,18 +69,20 @@ public class DebugReplayBlock extends AbstractBlockParameterMethod {
       return new JsonRpcErrorResponse(request.getRequest().getId(), UNKNOWN_BLOCK);
     }
 
-    final Block block = maybeBlock.get();
-
     // rewind to the block before the one we want to replay
     protocolContext.getBlockchain().rewindToBlock(blockNumber - 1);
 
     try {
       // replay block and persist it
       protocolSchedule
-          .getByBlockHeader(block.getHeader())
+          .getByBlockNumber(blockNumber)
           .getBlockValidator()
           .validateAndProcessBlock(
-              protocolContext, block, HeaderValidationMode.FULL, HeaderValidationMode.NONE, true);
+              protocolContext,
+              maybeBlock.get(),
+              HeaderValidationMode.FULL,
+              HeaderValidationMode.NONE,
+              true);
     } catch (Exception e) {
       LOG.error(e.getMessage());
       return new JsonRpcErrorResponse(request.getRequest().getId(), INTERNAL_ERROR);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
@@ -50,7 +50,7 @@ public class DebugGetBadBlocks implements JsonRpcMethod {
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
     final List<BadBlockResult> response =
         protocolSchedule
-            .getByBlockHeader(blockchain.headBlockHeader())
+            .getByBlockNumber(blockchain.headBlockNumber())
             .getBadBlocksManager()
             .getBadBlocks()
             .stream()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
@@ -44,7 +44,7 @@ public class DebugResyncWorldstate implements JsonRpcMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext request) {
     protocolSchedule
-        .getByBlockHeader(blockchain.getChainHeadHeader())
+        .getByBlockNumber(blockchain.getChainHeadBlockNumber())
         .getBadBlocksManager()
         .reset();
     return new JsonRpcSuccessResponse(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFile.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFile.java
@@ -60,7 +60,7 @@ public class DebugStandardTraceBadBlockToFile extends DebugStandardTraceBlockToF
 
     final Blockchain blockchain = blockchainQueries.get().getBlockchain();
     final ProtocolSpec protocolSpec =
-        protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader());
+        protocolSchedule.getByBlockNumber(blockchain.getChainHeadHeader().getNumber());
     final BadBlockManager badBlockManager = protocolSpec.getBadBlocksManager();
 
     return badBlockManager

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
@@ -79,7 +79,7 @@ public class EthGetMinerDataByBlockHash implements JsonRpcMethod {
       final ProtocolSchedule protocolSchedule,
       final BlockchainQueries blockchainQueries) {
     final BlockHeader blockHeader = block.getHeader();
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
+    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(blockHeader.getNumber());
     final Wei staticBlockReward = protocolSpec.getBlockReward();
     final Wei transactionFee =
         block.getTransactions().stream()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
@@ -336,7 +336,7 @@ public class FlatTraceGenerator {
     if ("STOP".equals(traceFrame.getOpcode()) && resultBuilder.isGasUsedEmpty()) {
       final long callStipend =
           protocolSchedule
-              .getByBlockHeader(block.getHeader())
+              .getByBlockNumber(block.getHeader().getNumber())
               .getGasCalculator()
               .getAdditionalCallStipend();
       tracesContexts.stream()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGenerator.java
@@ -46,7 +46,7 @@ public class RewardTraceGenerator {
 
     final BlockHeader blockHeader = block.getHeader();
     final List<BlockHeader> ommers = block.getBody().getOmmers();
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
+    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(blockHeader.getNumber());
     final Wei blockReward = protocolSpec.getBlockReward();
     final MiningBeneficiaryCalculator miningBeneficiaryCalculator =
         protocolSpec.getMiningBeneficiaryCalculator();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
@@ -89,7 +89,7 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
 
   public GasCalculator getGasCalculator() {
     return protocolSchedule
-        .getByBlockHeader(blockchainQueries.headBlockHeader())
+        .getByBlockNumber(blockchainQueries.headBlockNumber())
         .getGasCalculator();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -142,15 +142,6 @@ public class BlockchainQueries {
   }
 
   /**
-   * Return the header of the head of the chain.
-   *
-   * @return The header of the head of the chain.
-   */
-  public BlockHeader headBlockHeader() {
-    return blockchain.getChainHeadHeader();
-  }
-
-  /**
    * Return the header of the last finalized block.
    *
    * @return The header of the last finalized block.

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -214,7 +214,8 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
 
   void importBlock(final int n) {
     final Block block = BLOCKS.get(n);
-    final ProtocolSpec protocolSpec = PROTOCOL_SCHEDULE.getByBlockHeader(block.getHeader());
+    final ProtocolSpec protocolSpec =
+        PROTOCOL_SCHEDULE.getByBlockNumber(block.getHeader().getNumber());
     final BlockImporter blockImporter = protocolSpec.getBlockImporter();
     blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlockTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -95,8 +95,9 @@ public class DebugGetBadBlockTest {
 
     badBlockManager.addBadBlock(badBlockWithTransaction, Optional.empty());
     badBlockManager.addBadBlock(badBlockWoTransaction, Optional.empty());
+
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
-    when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getBadBlocksManager()).thenReturn(badBlockManager);
 
     final JsonRpcRequestContext request =
@@ -124,8 +125,7 @@ public class DebugGetBadBlockTest {
   @Test
   public void shouldReturnCorrectResponseWhenNoInvalidBlockFound() {
     final ProtocolSpec protocolSpec = mock(ProtocolSpec.class);
-
-    when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getBadBlocksManager()).thenReturn(badBlockManager);
 
     final JsonRpcRequestContext request =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
@@ -88,7 +88,7 @@ public class DebugStandardTraceBadBlockToFileTest {
     when(protocolSpec.getBadBlocksManager()).thenReturn(badBlockManager);
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchain.getChainHeadHeader()).thenReturn(new BlockHeaderTestFixture().buildHeader());
-    when(protocolSchedule.getByBlockHeader(blockHeader)).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(blockHeader.getNumber())).thenReturn(protocolSpec);
     when(transactionTracer.traceTransactionToFile(eq(block.getHash()), any(), any()))
         .thenReturn(paths);
     final JsonRpcSuccessResponse response =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHashTest.java
@@ -78,7 +78,7 @@ public class EthGetMinerDataByBlockHashTest {
             header, Collections.emptyList(), Collections.emptyList(), Difficulty.of(100L), 5);
 
     when(blockchainQueries.blockByHash(any())).thenReturn(Optional.of(blockWithMetadata));
-    when(protocolSchedule.getByBlockHeader(header)).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(header.getNumber())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockReward()).thenReturn(Wei.fromEth(2));
     when(blockchainQueries.getBlockchain()).thenReturn(blockChain);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumberTest.java
@@ -76,7 +76,7 @@ public class EthGetMinerDataByBlockNumberTest {
             header, Collections.emptyList(), Collections.emptyList(), Difficulty.of(100L), 5);
 
     when(blockchainQueries.blockByNumber(anyLong())).thenReturn(Optional.of(blockWithMetadata));
-    when(protocolSchedule.getByBlockHeader(header)).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(header.getNumber())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockReward()).thenReturn(Wei.fromEth(2));
     when(blockchainQueries.getBlockchain()).thenReturn(blockChain);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -72,7 +72,7 @@ public class RewardTraceGeneratorTest {
     final BlockHeader blockHeader =
         gen.header(0x0A, blockBody, new BlockDataGenerator.BlockOptions());
     block = new Block(blockHeader, blockBody);
-    when(protocolSchedule.getByBlockHeader(block.getHeader())).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(block.getHeader().getNumber())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockReward()).thenReturn(blockReward);
     when(protocolSpec.getMiningBeneficiaryCalculator()).thenReturn(miningBeneficiaryCalculator);
     when(miningBeneficiaryCalculator.calculateBeneficiary(block.getHeader()))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -197,17 +197,6 @@ public class BlockchainQueriesTest {
   }
 
   @Test
-  public void getHeadBlockHeader() {
-    final BlockchainWithData data = setupBlockchain(3);
-    final BlockchainQueries queries = data.blockchainQueries;
-
-    final BlockHeader targetBlockHeader = data.blockData.get(2).block.getHeader();
-
-    BlockHeader result = queries.headBlockHeader();
-    assertThat(targetBlockHeader).isEqualTo(result);
-  }
-
-  @Test
   public void getAccountStorageBlockNumber() {
     final List<Address> addresses = Arrays.asList(gen.address(), gen.address(), gen.address());
     final List<UInt256> storageKeys =

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockMiner.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/BlockMiner.java
@@ -141,7 +141,7 @@ public class BlockMiner<M extends AbstractBlockCreator> implements Runnable {
         block.getBody().getTransactions().size());
 
     final BlockImporter importer =
-        protocolSchedule.getByBlockHeader(block.getHeader()).getBlockImporter();
+        protocolSchedule.getByBlockNumber(block.getHeader().getNumber()).getBlockImporter();
     final BlockImportResult blockImportResult =
         importer.importBlock(protocolContext, block, HeaderValidationMode.FULL);
     if (blockImportResult.isImported()) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PrivateTransactionSimulator.java
@@ -125,7 +125,7 @@ public class PrivateTransactionSimulator {
     final PrivateTransaction transaction =
         getPrivateTransaction(callParams, header, privacyGroupId, disposablePrivateState);
 
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(header);
+    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(header.getNumber());
 
     final PrivateTransactionProcessor privateTransactionProcessor =
         protocolSpec.getPrivateTransactionProcessor();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateStorageMigration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/storage/migration/PrivateStorageMigration.java
@@ -93,7 +93,7 @@ public class PrivateStorageMigration {
 
       final int lastPmtIndex = findLastPMTIndexInBlock(block);
       if (lastPmtIndex >= 0) {
-        final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
+        final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(blockNumber);
         final PrivateMigrationBlockProcessor privateMigrationBlockProcessor =
             privateMigrationBlockProcessorBuilder.apply(protocolSpec);
 

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockchainSetupUtil.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockchainSetupUtil.java
@@ -243,7 +243,8 @@ public class BlockchainSetupUtil {
       if (block.getHeader().getNumber() == BlockHeader.GENESIS_BLOCK_NUMBER) {
         continue;
       }
-      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+      final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       final BlockImportResult result =
           blockImporter.importBlock(protocolContext, block, HeaderValidationMode.FULL);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/BlockPropagationManager.java
@@ -584,7 +584,8 @@ public class BlockPropagationManager implements UnverifiedForkchoiceListener {
                     new IllegalArgumentException(
                         "Incapable of retrieving header from non-existent parent of "
                             + block.toLogString()));
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+    final ProtocolSpec protocolSpec =
+        protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
     final BlockHeaderValidator blockHeaderValidator = protocolSpec.getBlockHeaderValidator();
     final BadBlockManager badBlockManager = protocolSpec.getBadBlocksManager();
     return ethContext

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/backwardsync/BackwardSyncContext.java
@@ -260,12 +260,12 @@ public class BackwardSyncContext {
     return protocolContext;
   }
 
-  public BlockValidator getBlockValidator(final BlockHeader blockHeader) {
-    return protocolSchedule.getByBlockHeader(blockHeader).getBlockValidator();
+  public BlockValidator getBlockValidator(final long blockNumber) {
+    return protocolSchedule.getByBlockNumber(blockNumber).getBlockValidator();
   }
 
   public BlockValidator getBlockValidatorForBlock(final Block block) {
-    return getBlockValidator(block.getHeader());
+    return getBlockValidator(block.getHeader().getNumber());
   }
 
   public boolean isReady() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStep.java
@@ -114,7 +114,7 @@ public class FastImportBlocksStep implements Consumer<List<BlockWithReceipts>> {
 
   protected boolean importBlock(final BlockWithReceipts blockWithReceipts) {
     final BlockImporter importer =
-        protocolSchedule.getByBlockHeader(blockWithReceipts.getHeader()).getBlockImporter();
+        protocolSchedule.getByBlockNumber(blockWithReceipts.getNumber()).getBlockImporter();
     final BlockImportResult blockImportResult =
         importer.fastImportBlock(
             protocolContext,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStep.java
@@ -58,7 +58,7 @@ public class FullImportBlockStep implements Consumer<Block> {
     final long blockNumber = block.getHeader().getNumber();
     final String blockHash = block.getHash().toHexString();
     final BlockImporter importer =
-        protocolSchedule.getByBlockHeader(block.getHeader()).getBlockImporter();
+        protocolSchedule.getByBlockNumber(blockNumber).getBlockImporter();
     final BlockImportResult blockImportResult =
         importer.importBlock(protocolContext, block, HeaderValidationMode.SKIP_DETACHED);
     if (!blockImportResult.isImported()) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/RangeHeadersValidationStep.java
@@ -75,7 +75,8 @@ public class RangeHeadersValidationStep implements Function<RangeHeaders, Stream
   }
 
   private boolean isValid(final BlockHeader expectedParent, final BlockHeader firstHeaderToImport) {
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(firstHeaderToImport);
+    final ProtocolSpec protocolSpec =
+        protocolSchedule.getByBlockNumber(firstHeaderToImport.getNumber());
     final BlockHeaderValidator validator = protocolSpec.getBlockHeaderValidator();
     return validator.validateHeader(
         firstHeaderToImport,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DownloadHeaderSequenceTask.java
@@ -194,7 +194,7 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
               child =
                   (headerIndex == segmentLength - 1) ? referenceHeader : headers[headerIndex + 1];
             }
-            final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(child);
+            final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(child.getNumber());
             final BadBlockManager badBlockManager = protocolSpec.getBadBlocksManager();
 
             if (!validateHeader(child, header)) {
@@ -253,7 +253,7 @@ public class DownloadHeaderSequenceTask extends AbstractRetryingPeerTask<List<Bl
       return false;
     }
 
-    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(child);
+    final ProtocolSpec protocolSpec = protocolSchedule.getByBlockNumber(child.getNumber());
     final BlockHeaderValidator blockHeaderValidator = protocolSpec.getBlockHeaderValidator();
     return blockHeaderValidator.validateHeader(
         child, header, protocolContext, validationPolicy.getValidationModeForNextBlock());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/tasks/PersistBlockTask.java
@@ -195,7 +195,8 @@ public class PersistBlockTask extends AbstractEthTask<Block> {
   @Override
   protected void executeTask() {
     try {
-      final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
+      final ProtocolSpec protocolSpec =
+          protocolSchedule.getByBlockNumber(block.getHeader().getNumber());
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       debugLambda(LOG, "Running import task for block {}", block::toLogString);
       blockImportResult = blockImporter.importBlock(protocolContext, block, validateHeaders);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -256,7 +256,7 @@ public class TransactionPool implements BlockAddedObserver {
 
   private MainnetTransactionValidator getTransactionValidator() {
     return protocolSchedule
-        .getByBlockHeader(protocolContext.getBlockchain().getChainHeadHeader())
+        .getByBlockNumber(protocolContext.getBlockchain().getChainHeadBlockNumber())
         .getTransactionValidator();
   }
 
@@ -285,7 +285,7 @@ public class TransactionPool implements BlockAddedObserver {
     }
 
     final FeeMarket feeMarket =
-        protocolSchedule.getByBlockHeader(chainHeadBlockHeader).getFeeMarket();
+        protocolSchedule.getByBlockNumber(chainHeadBlockHeader.getNumber()).getFeeMarket();
 
     final TransactionInvalidReason priceInvalidReason =
         validatePrice(transaction, isLocal, feeMarket);
@@ -396,8 +396,8 @@ public class TransactionPool implements BlockAddedObserver {
         && transactionReplaySupportedAtBlock(chainHeadBlockHeader);
   }
 
-  private boolean transactionReplaySupportedAtBlock(final BlockHeader blockHeader) {
-    return protocolSchedule.getByBlockHeader(blockHeader).isReplayProtectionSupported();
+  private boolean transactionReplaySupportedAtBlock(final BlockHeader block) {
+    return protocolSchedule.getByBlockNumber(block.getNumber()).isReplayProtectionSupported();
   }
 
   public Optional<Transaction> getTransactionByHash(final Hash hash) {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersValidationStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/RangeHeadersValidationStepTest.java
@@ -18,7 +18,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.DETACHED_ONLY;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -52,7 +52,6 @@ public class RangeHeadersValidationStepTest {
   @Mock private BlockHeaderValidator headerValidator;
   @Mock private ValidationPolicy validationPolicy;
   @Mock private EthPeer syncTarget;
-
   private final BlockDataGenerator gen = new BlockDataGenerator();
   private RangeHeadersValidationStep validationStep;
 
@@ -66,7 +65,7 @@ public class RangeHeadersValidationStepTest {
 
   @Before
   public void setUp() {
-    when(protocolSchedule.getByBlockHeader(any(BlockHeader.class))).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockHeaderValidator()).thenReturn(headerValidator);
     when(validationPolicy.getValidationModeForNextBlock()).thenReturn(DETACHED_ONLY);
 
@@ -80,7 +79,7 @@ public class RangeHeadersValidationStepTest {
         .thenReturn(true);
     final Stream<BlockHeader> result = validationStep.apply(rangeHeaders);
 
-    verify(protocolSchedule).getByBlockHeader(firstHeader);
+    verify(protocolSchedule).getByBlockNumber(firstHeader.getNumber());
     verify(validationPolicy).getValidationModeForNextBlock();
     verify(headerValidator).validateHeader(firstHeader, rangeStart, protocolContext, DETACHED_ONLY);
     verifyNoMoreInteractions(headerValidator, validationPolicy);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastImportBlocksStepTest.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.FULL;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.LIGHT;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,7 +60,7 @@ public class FastImportBlocksStepTest {
 
   @BeforeEach
   public void setUp() {
-    when(protocolSchedule.getByBlockHeader(any())).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);
     when(validationPolicy.getValidationModeForNextBlock()).thenReturn(FULL);
     when(ommerValidationPolicy.getValidationModeForNextBlock()).thenReturn(LIGHT);
@@ -95,7 +95,7 @@ public class FastImportBlocksStepTest {
     importBlocksStep.accept(blocksWithReceipts);
 
     for (final BlockWithReceipts blockWithReceipts : blocksWithReceipts) {
-      verify(protocolSchedule).getByBlockHeader(blockWithReceipts.getHeader());
+      verify(protocolSchedule).getByBlockNumber(blockWithReceipts.getNumber());
     }
     verify(validationPolicy, times(blocks.size())).getValidationModeForNextBlock();
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fullsync/FullImportBlockStepTest.java
@@ -16,14 +16,13 @@ package org.hyperledger.besu.ethereum.eth.sync.fullsync;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode.SKIP_DETACHED;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockImporter;
 import org.hyperledger.besu.ethereum.eth.sync.tasks.exceptions.InvalidBlockException;
 import org.hyperledger.besu.ethereum.mainnet.BlockImportResult;
@@ -49,7 +48,7 @@ public class FullImportBlockStepTest {
 
   @Before
   public void setUp() {
-    when(protocolSchedule.getByBlockHeader(any(BlockHeader.class))).thenReturn(protocolSpec);
+    when(protocolSchedule.getByBlockNumber(anyLong())).thenReturn(protocolSpec);
     when(protocolSpec.getBlockImporter()).thenReturn(blockImporter);
 
     importBlocksStep =
@@ -65,7 +64,7 @@ public class FullImportBlockStepTest {
         .thenReturn(new BlockImportResult(true));
     importBlocksStep.accept(block);
 
-    verify(protocolSchedule).getByBlockHeader(block.getHeader());
+    verify(protocolSchedule).getByBlockNumber(block.getHeader().getNumber());
     verify(blockImporter).importBlock(protocolContext, block, SKIP_DETACHED);
   }
 

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
@@ -256,8 +256,8 @@ public class RetestethContext {
     return blockchain.getChainHeadBlockNumber();
   }
 
-  public ProtocolSpec getProtocolSpec(final BlockHeader blockHeader) {
-    return getProtocolSchedule().getByBlockHeader(blockHeader);
+  public ProtocolSpec getProtocolSpec(final long blockNumber) {
+    return getProtocolSchedule().getByBlockNumber(blockNumber);
   }
 
   public BlockHeader getBlockHeader(final long blockNumber) {

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlock.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlock.java
@@ -79,7 +79,7 @@ public class TestImportRawBlock implements JsonRpcMethod {
     } else {
       // otherwise attempt to import the block
       final BlockImporter blockImporter =
-          context.getProtocolSpec(block.getHeader()).getBlockImporter();
+          context.getProtocolSpec(block.getHeader().getNumber()).getBlockImporter();
       final BlockImportResult result =
           blockImporter.importBlock(
               protocolContext,

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/methods/TestMineBlocks.java
@@ -81,7 +81,7 @@ public class TestMineBlocks implements JsonRpcMethod {
     retesethClock.advanceSeconds(1);
 
     final BlockImporter blockImporter =
-        protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()).getBlockImporter();
+        protocolSchedule.getByBlockNumber(blockchain.getChainHeadBlockNumber()).getBlockImporter();
     final BlockImportResult result =
         blockImporter.importBlock(
             protocolContext, block, headerValidationMode, headerValidationMode);


### PR DESCRIPTION
This reverts commit 9ceebc4a57f648ed412ed6dcbc12a42699fffe54.

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Revert commit #5020 getByBlockNumber by getByBlockHeader as this is breaking syncing on Goerli.

Goerli is failing to sync with error after this commit
`{"@timestamp":"2023-02-07T21:49:39,513","level":"INFO","thread":"EthScheduler-Workers-0","class":"CoinbaseHeaderValidationRule","message":"Invalid block header: No clique in/out voting may occur on epoch blocks (7470000)","throwable":""}
{"@timestamp":"2023-02-07T21:49:44,311","level":"WARN","thread":"EthScheduler-Services-800 (downloadHeaders)","class":"PipelineChainDownloader","message":"Invalid block detected (BREACH_OF_PROTOCOL). Disconnecting from sync target. Header failed validation.: Invalid block at #7470000 (0xaaea1696007267a518ee5c6550742f58c81333e71cdee6c38dc2403b628816e1)","throwable":""}`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).