### PR TITLE
Revert "Keep Worldstate Storage open for Bonsai archive latest layer (#5039)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ tests are updated to use EC private keys instead of RSA keys.
 
 ### Bug Fixes
 - Mitigation fix for stale bonsai code storage leading to log rolling issues on contract recreates [#4906](https://github.com/hyperledger/besu/pull/4906)
-- Ensure latest cached layered worldstate is subscribed to storage, fix problem with RPC calls using 'latest' [#5039](https://github.com/hyperledger/besu/pull/5039)  
 
 
 ## 23.1.0-RC1

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiInMemoryWorldState.java
@@ -167,12 +167,7 @@ public class BonsaiInMemoryWorldState extends BonsaiPersistedWorldState
     final Hash newWorldStateRootHash = rootHash(localUpdater);
     archive
         .getTrieLogManager()
-        .saveTrieLog(
-            archive,
-            localUpdater,
-            newWorldStateRootHash,
-            blockHeader,
-            (BonsaiPersistedWorldState) this.copy());
+        .saveTrieLog(archive, localUpdater, newWorldStateRootHash, blockHeader, this);
     worldStateRootHash = newWorldStateRootHash;
     worldStateBlockHash = blockHeader.getBlockHash();
     isPersisted = true;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiLayeredWorldState.java
@@ -76,27 +76,7 @@ public class BonsaiLayeredWorldState implements MutableWorldState, BonsaiWorldVi
   }
 
   public void setNextWorldView(final Optional<BonsaiWorldView> nextWorldView) {
-    maybeUnSubscribe();
     this.nextWorldView = nextWorldView;
-  }
-
-  private void maybeUnSubscribe() {
-    nextWorldView
-        .filter(WorldState.class::isInstance)
-        .map(WorldState.class::cast)
-        .ifPresent(
-            ws -> {
-              try {
-                ws.close();
-              } catch (final Exception e) {
-                // no-op
-              }
-            });
-  }
-
-  @Override
-  public void close() throws Exception {
-    maybeUnSubscribe();
   }
 
   public TrieLogLayer getTrieLog() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsSorter.java
@@ -428,11 +428,7 @@ public abstract class AbstractPendingTransactionsSorter implements PendingTransa
             LOG,
             "Transaction {} not added because nonce too far in the future for sender {}",
             transaction::toTraceLog,
-            () ->
-                maybeSenderAccount
-                    .map(Account::getAddress)
-                    .map(Address::toString)
-                    .orElse("unknown"));
+            maybeSenderAccount::toString);
         return NONCE_TOO_FAR_IN_FUTURE_FOR_SENDER;
       }
 


### PR DESCRIPTION
This reverts commit e7150102ea208165ac29bd10986fe26bc9e176d0.

This is causing "Unable to copy Layered Worldstate" errors affecting canary nodes, devnets and the 23.1.0 burn-in