### PR TITLE
Add shanghaiTime to sepolia

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -24,14 +24,13 @@ import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.GenesisState;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.forkid.ForkId;
 import org.hyperledger.besu.ethereum.forkid.ForkIdManager;
-import org.hyperledger.besu.ethereum.mainnet.MainnetProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
-import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.util.Collection;
 import java.util.List;
@@ -73,8 +72,9 @@ public class ForkIdsNetworkConfigTest {
             NetworkName.SEPOLIA,
             List.of(
                 new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L),
-                new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 0L))
+                new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 1677557088L),
+                new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 0L),
+                new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 0L))
           },
           new Object[] {
             NetworkName.RINKEBY,
@@ -168,8 +168,7 @@ public class ForkIdsNetworkConfigTest {
       final GenesisConfigFile genesisConfigFile =
           GenesisConfigFile.fromConfig(EthNetworkConfig.jsonConfig(chainName));
       final GenesisConfigOptions configOptions = genesisConfigFile.getConfigOptions();
-      final ProtocolSchedule schedule =
-          MainnetProtocolSchedule.fromConfig(configOptions, EvmConfiguration.DEFAULT);
+      final ProtocolSchedule schedule = TransitionProtocolSchedule.fromConfig(configOptions);
       final GenesisState genesisState = GenesisState.fromConfig(genesisConfigFile, schedule);
       final Blockchain mockBlockchain = mock(Blockchain.class);
       final BlockHeader mockBlockHeader = mock(BlockHeader.class);
@@ -179,6 +178,7 @@ public class ForkIdsNetworkConfigTest {
       final AtomicLong blockNumber = new AtomicLong();
       when(mockBlockchain.getChainHeadHeader()).thenReturn(mockBlockHeader);
       when(mockBlockHeader.getNumber()).thenAnswer(o -> blockNumber.get());
+      when(mockBlockHeader.getTimestamp()).thenAnswer(o -> blockNumber.get());
 
       final ForkIdManager forkIdManager =
           new ForkIdManager(
@@ -187,7 +187,7 @@ public class ForkIdsNetworkConfigTest {
               genesisConfigFile.getForkTimestamps(),
               false);
 
-      final var actualForkIds =
+      final List<ForkId> actualForkIds =
           Streams.concat(schedule.streamMilestoneBlocks(), Stream.of(Long.MAX_VALUE))
               .map(
                   block -> {

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -596,10 +596,6 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
             getArrowGlacierBlockNumber(),
             getGrayGlacierBlockNumber(),
             getMergeNetSplitBlockNumber(),
-            getShanghaiTime(),
-            getCancunTime(),
-            getFutureEipsTime(),
-            getExperimentalEipsTime(),
             getEcip1015BlockNumber(),
             getDieHardBlockNumber(),
             getGothamBlockNumber(),
@@ -623,7 +619,9 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
 
   @Override
   public List<Long> getForkBlockTimestamps() {
-    Stream<OptionalLong> forkBlockTimestamps = Stream.of(getShanghaiTime(), getCancunTime());
+    Stream<OptionalLong> forkBlockTimestamps =
+        Stream.of(
+            getShanghaiTime(), getCancunTime(), getFutureEipsTime(), getExperimentalEipsTime());
     // when adding forks add an entry to ${REPO_ROOT}/config/src/test/resources/all_forks.json
 
     return forkBlockTimestamps

--- a/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
@@ -622,22 +622,22 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions {
   /**
    * Future EIPs Time block.
    *
-   * @param blockNumber the block number
+   * @param timestamp the block timestamp
    * @return the stub genesis config options
    */
-  public StubGenesisConfigOptions futureEipsTime(final long blockNumber) {
-    futureEipsTime = OptionalLong.of(blockNumber);
+  public StubGenesisConfigOptions futureEipsTime(final long timestamp) {
+    futureEipsTime = OptionalLong.of(timestamp);
     return this;
   }
 
   /**
    * Experimental EIPs Time block.
    *
-   * @param blockNumber the block number
+   * @param timestamp the block timestamp
    * @return the stub genesis config options
    */
-  public StubGenesisConfigOptions experimentalEipsTime(final long blockNumber) {
-    experimentalEipsTime = OptionalLong.of(blockNumber);
+  public StubGenesisConfigOptions experimentalEipsTime(final long timestamp) {
+    experimentalEipsTime = OptionalLong.of(timestamp);
     return this;
   }
 

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -13,6 +13,7 @@
     "londonBlock":0,
     "mergeNetSplitBlock": 1735371,
     "terminalTotalDifficulty": 17000000000000000,
+    "shanghaiTime": 1677557088,
     "ethash":{},
     "discovery": {
       "dns": "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.sepolia.ethdisco.net",

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -66,7 +66,8 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
   /**
    * Create a Proof-of-Stake protocol schedule from a config object
    *
-   * @param genesisConfigOptions {@link GenesisConfigOptions} containing the config options for the milestone starting points
+   * @param genesisConfigOptions {@link GenesisConfigOptions} containing the config options for the
+   *     milestone starting points
    * @return an initialised TransitionProtocolSchedule using post-merge defaults
    */
   public static TransitionProtocolSchedule fromConfig(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultTimestampSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultTimestampSchedule.java
@@ -26,6 +26,7 @@ import java.util.NavigableSet;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DefaultTimestampSchedule implements TimestampSchedule {
   private final NavigableSet<TimedProtocolSpec> protocolSpecs =
@@ -44,6 +45,11 @@ public class DefaultTimestampSchedule implements TimestampSchedule {
       }
     }
     return Optional.empty();
+  }
+
+  @Override
+  public Stream<Long> streamMilestoneBlocks() {
+    return protocolSpecs.stream().map(TimedProtocolSpec::getTimestamp);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultTimestampSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultTimestampSchedule.java
@@ -49,7 +49,7 @@ public class DefaultTimestampSchedule implements TimestampSchedule {
 
   @Override
   public Stream<Long> streamMilestoneBlocks() {
-    return protocolSpecs.stream().map(TimedProtocolSpec::getTimestamp);
+    return protocolSpecs.stream().map(TimedProtocolSpec::getTimestamp).sorted();
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/HeaderBasedProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/HeaderBasedProtocolSchedule.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 
 import java.math.BigInteger;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public interface HeaderBasedProtocolSchedule {
 
@@ -31,4 +32,6 @@ public interface HeaderBasedProtocolSchedule {
   void putMilestone(final long blockOrTimestamp, final ProtocolSpec protocolSpec);
 
   String listMilestones();
+
+  Stream<Long> streamMilestoneBlocks();
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
@@ -16,14 +16,10 @@ package org.hyperledger.besu.ethereum.mainnet;
 
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 
-import java.util.stream.Stream;
-
 public interface ProtocolSchedule
     extends HeaderBasedProtocolSchedule, PrivacySupportingProtocolSchedule {
 
   ProtocolSpec getByBlockNumber(long number);
-
-  Stream<Long> streamMilestoneBlocks();
 
   @Override
   default ProtocolSpec getByBlockHeader(final ProcessableBlockHeader blockHeader) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTest.java
@@ -313,11 +313,20 @@ public class ForkIdTest {
             empty()
           },
           {
-            "Sepolia // Future",
+            "Sepolia // Shanghai",
             Network.SEPOLIA,
             1735371L,
             0L,
-            ForkIdTestUtil.wantForkId("0xb96cbd13", 0L),
+            ForkIdTestUtil.wantForkId("0xb96cbd13", 1677557088L),
+            Optional.of(ForkIds.SEPOLIA),
+            empty()
+          },
+          {
+            "Sepolia // Future",
+            Network.SEPOLIA,
+            1735372L,
+            1677557088L,
+            ForkIdTestUtil.wantForkId("0xf7f9bc08", 0L),
             Optional.of(ForkIds.SEPOLIA),
             empty()
           },

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTestUtil.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTestUtil.java
@@ -73,8 +73,11 @@ public class ForkIdTestUtil {
         Arrays.asList(
             1920000L, 1150000L, 2463000L, 2675000L, 2675000L, 4370000L, 7280000L, 7280000L,
             9069000L, 9200000L, 12244000L, 12965000L, 13773000L, 15050000L);
-    public static final List<Long> SEPOLIA =
+    public static final List<Long> SEPOLIA_BLOCKNUMBERS =
         Arrays.asList(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 1735371L);
+
+    public static final List<Long> SEPOLIA_TIMESTAMPS = Arrays.asList(1677557088L);
+
     public static final List<Long> RINKEBY =
         Arrays.asList(1L, 2L, 3L, 3L, 1035301L, 3660663L, 4321234L, 5435345L);
     public static final List<Long> GOERLI = Arrays.asList(0L, 0L, 0L, 0L, 0L, 0L, 0L, 1561651L);
@@ -106,7 +109,8 @@ public class ForkIdTestUtil {
     public static final List<ForkId> SEPOLIA =
         Arrays.asList(
             new ForkId(Bytes.fromHexString("0xfe3366e7"), 1735371L),
-            new ForkId(Bytes.fromHexString("0xb96cbd13"), 0L));
+            new ForkId(Bytes.fromHexString("0xb96cbd13"), 1677557088L),
+            new ForkId(Bytes.fromHexString("0xf7f9bc08"), 0L)); // First Shanghai block (timestamp)
     public static final List<ForkId> RINKEBY =
         Arrays.asList(
             new ForkId(Bytes.fromHexString("0x3b8e0691"), 1L),
@@ -145,7 +149,8 @@ public class ForkIdTestUtil {
 
   public static class Network {
     public static final Network MAINNET = network(GenesisHash.MAINNET, Forks.MAINNET, emptyList());
-    public static final Network SEPOLIA = network(GenesisHash.SEPOLIA, Forks.SEPOLIA, emptyList());
+    public static final Network SEPOLIA =
+        network(GenesisHash.SEPOLIA, Forks.SEPOLIA_BLOCKNUMBERS, Forks.SEPOLIA_TIMESTAMPS);
     public static final Network RINKEBY = network(GenesisHash.RINKEBY, Forks.RINKEBY, emptyList());
     public static final Network GOERLI = network(GenesisHash.GOERLI, Forks.GOERLI, emptyList());
     public static final Network PRIVATE = network(GenesisHash.PRIVATE, Forks.PRIVATE, emptyList());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TimestampScheduleBuilderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TimestampScheduleBuilderTest.java
@@ -138,4 +138,15 @@ public class TimestampScheduleBuilderTest {
 
     assertThat(schedule.getByBlockHeader(BLOCK_HEADER)).isNull();
   }
+
+  @Test
+  public void streamMilestoneBlocksReturnTimestampsInOrder() {
+    config.shanghaiTime(FIRST_TIMESTAMP_FORK);
+    config.cancunTime(2L);
+    config.experimentalEipsTime(5L);
+    config.futureEipsTime(3L);
+    final TimestampSchedule schedule = builder.createTimestampSchedule();
+
+    assertThat(schedule.streamMilestoneBlocks()).containsExactly(FIRST_TIMESTAMP_FORK, 2L, 3L, 5L);
+  }
 }


### PR DESCRIPTION
Announced here: https://github.com/ethereum/execution-specs/pull/716

Move timestamp forks from getForkBlockNumbers to getForkBlockTimestamps in JsonGenesisConfigOptions - this ultimately gets used to popoulate the ForkIdManager which handles lists of blocks and timestamps the same way so this hasn't changed any actual behaviour, but rather supports the test fixes.

Implement TransitionProtocolSchedule.streamMilestoneBlocks as a concatenation of blockNumbers++blockTimestamps. This may have been a latent bug since it's used to update the node record when a fork transition occurs.