### PR TITLE
Allow other users to read the /opt/besu dir when using docker

### DIFF
--- a/docker/graalvm/Dockerfile
+++ b/docker/graalvm/Dockerfile
@@ -3,7 +3,8 @@ FROM ghcr.io/graalvm/graalvm-ce:ol9-java17
 ARG VERSION="dev"
 
 RUN adduser --home /opt/besu besu && \
-    chown besu:besu /opt/besu
+    chown besu:besu /opt/besu && \
+    chmod 0755 /opt/besu
 
 USER besu
 WORKDIR /opt/besu

--- a/docker/openjdk-17-debug/Dockerfile
+++ b/docker/openjdk-17-debug/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update  && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \
-    chown besu:besu /opt/besu
+    chown besu:besu /opt/besu && \
+    chmod 0755 /opt/besu
 
 USER besu
 WORKDIR /opt/besu

--- a/docker/openjdk-17/Dockerfile
+++ b/docker/openjdk-17/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \
-    chown besu:besu /opt/besu
+    chown besu:besu /opt/besu && \
+    chmod 0755 /opt/besu
 
 USER besu
 WORKDIR /opt/besu

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \
-    chown besu:besu /opt/besu
+    chown besu:besu /opt/besu && \
+    chmod 0755 /opt/besu
 
 USER besu
 WORKDIR /opt/besu


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

Same issue existed on Teku: https://github.com/ConsenSys/teku/pull/6740 

## PR description

Can't use the docker image when running it with another user than root or `1000`.

```sh
$ docker pull consensys/besu 

# Running as root
$ docker run --rm -it --entrypoint ls  consensys/besu 
LICENSE  besu.autocomplete.sh  bin  lib  license-dependency.html 

# Running as user 1000 
$ docker run --rm -it --entrypoint ls --user=1000  consensys/besu 
LICENSE  besu.autocomplete.sh  bin  lib  license-dependency.html

# Running as user 1003
$ docker run --rm -it --entrypoint ls --user=1003  consensys/besu 
ls: cannot open directory '.': Permission denied
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).