### PR TITLE
Fix block value calculation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
@@ -28,7 +28,7 @@ public class BlockValueCalculator {
     for (int i = 0; i < txs.size(); i++) {
       final Wei minerFee = txs.get(i).getEffectivePriorityFeePerGas(block.getHeader().getBaseFee());
       // we don't store gasUsed and need to calculate that on the fly
-      // receipts are fetched in ascendant sorted by cumulativeGasUsed
+      // receipts are fetched in ascending sorted by cumulativeGasUsed
       long gasUsed = receipts.get(i).getCumulativeGasUsed();
       if (i > 0) {
         gasUsed = gasUsed - receipts.get(i - 1).getCumulativeGasUsed();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockValueCalculator.java
@@ -27,7 +27,13 @@ public class BlockValueCalculator {
     Wei totalFee = Wei.ZERO;
     for (int i = 0; i < txs.size(); i++) {
       final Wei minerFee = txs.get(i).getEffectivePriorityFeePerGas(block.getHeader().getBaseFee());
-      totalFee = totalFee.add(minerFee.multiply(receipts.get(i).getCumulativeGasUsed()));
+      // we don't store gasUsed and need to calculate that on the fly
+      // receipts are fetched in ascendant sorted by cumulativeGasUsed
+      long gasUsed = receipts.get(i).getCumulativeGasUsed();
+      if (i > 0) {
+        gasUsed = gasUsed - receipts.get(i - 1).getCumulativeGasUsed();
+      }
+      totalFee = totalFee.add(minerFee.multiply(gasUsed));
     }
     return totalFee;
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/BlockValueCalculatorTest.java
@@ -88,8 +88,8 @@ public class BlockValueCalculatorTest {
         new BlockValueCalculator()
             .calculateBlockValue(
                 new BlockWithReceipts(block, List.of(receipt1, receipt2, receipt3)));
-    // Block value = 71 * 1 + 143 * 2 + 214 * 5 = 1427
-    assertThat(blockValue).isEqualTo(Wei.of(1427L));
+    // Block value = 71 * 1 + (143-71) * 2 + (214-143) * 5 = 1427
+    assertThat(blockValue).isEqualTo(Wei.of(570L));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR fix the block value calculation mechanism by using gasUsed instead of the cumulativeGas to calculate the block value.

This change has been tested against the hive test(GetPayloadV2 Block Value) for this feature.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #5040
## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).