### PR TITLE
re-default global max rpc batch size to 1k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ tests are updated to use EC private keys instead of RSA keys.
 - Change eth_feeHistory parameter `blockCount` to accept hexadecimal string (was accepting plain integer) [#5047](https://github.com/hyperledger/besu/pull/5047)
 
 ### Additions and Improvements
-- Default rpc batch request to 1000 []()
+- Default rpc batch request to 1000 [#5104](https://github.com/hyperledger/besu/pull/5104)
 - Add a new CLI option to limit the number of requests in a single RPC batch request. [#4965](https://github.com/hyperledger/besu/pull/4965)
 - Support for new DATAHASH opcode as part of EIP-4844 [#4823](https://github.com/hyperledger/besu/issues/4823)
 - Send only hash announcement for blob transaction type [#4940](https://github.com/hyperledger/besu/pull/4940)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 23.1.0-RC2
 
 ### Breaking Changes
-- Add a new CLI option to limit the number of requests in a single RPC batch request. Default=1 [#4965](https://github.com/hyperledger/besu/pull/4965)
 - Change JsonRpc http service to return the error -32602 (Invalid params) with a 200 http status code
 - Besu requires minimum Java 17 and up to build and run [#3320](https://github.com/hyperledger/besu/issues/3320)
 - PKCS11 with nss module (PKCS11 based HSM can be used in DevP2P TLS and QBFT PKI) does not work with RSA keys 
@@ -12,6 +11,8 @@ tests are updated to use EC private keys instead of RSA keys.
 - Change eth_feeHistory parameter `blockCount` to accept hexadecimal string (was accepting plain integer) [#5047](https://github.com/hyperledger/besu/pull/5047)
 
 ### Additions and Improvements
+- Default rpc batch request to 1000 []()
+- Add a new CLI option to limit the number of requests in a single RPC batch request. [#4965](https://github.com/hyperledger/besu/pull/4965)
 - Support for new DATAHASH opcode as part of EIP-4844 [#4823](https://github.com/hyperledger/besu/issues/4823)
 - Send only hash announcement for blob transaction type [#4940](https://github.com/hyperledger/besu/pull/4940)
 - Add `excess_data_gas` field to block header [#4958](https://github.com/hyperledger/besu/pull/4958)

--- a/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
@@ -87,7 +87,7 @@ public interface DefaultCommandValues {
   /** The constant DEFAULT_HTTP_MAX_CONNECTIONS. */
   int DEFAULT_HTTP_MAX_CONNECTIONS = 80;
   /** The constant DEFAULT_HTTP_MAX_BATCH_SIZE. */
-  int DEFAULT_HTTP_MAX_BATCH_SIZE = 1;
+  int DEFAULT_HTTP_MAX_BATCH_SIZE = 1000;
   /** The constant DEFAULT_WS_MAX_CONNECTIONS. */
   int DEFAULT_WS_MAX_CONNECTIONS = 80;
   /** The constant DEFAULT_WS_MAX_FRAME_SIZE. */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
@@ -36,7 +36,7 @@ public class JsonRpcConfiguration {
   public static final int DEFAULT_JSON_RPC_PORT = 8545;
   public static final int DEFAULT_ENGINE_JSON_RPC_PORT = 8551;
   public static final int DEFAULT_MAX_ACTIVE_CONNECTIONS = 80;
-  public static final int DEFAULT_MAX_BATCH_SIZE = 1;
+  public static final int DEFAULT_MAX_BATCH_SIZE = 1000;
 
   private boolean enabled;
   private int port;
@@ -208,6 +208,7 @@ public class JsonRpcConfiguration {
         .add("tlsConfiguration", tlsConfiguration)
         .add("httpTimeoutSec", httpTimeoutSec)
         .add("maxActiveConnections", maxActiveConnections)
+        .add("maxBatchSize", maxBatchSize)
         .toString();
   }
 
@@ -228,7 +229,8 @@ public class JsonRpcConfiguration {
         && Objects.equals(rpcApis, that.rpcApis)
         && Objects.equals(hostsAllowlist, that.hostsAllowlist)
         && Objects.equals(authenticationCredentialsFile, that.authenticationCredentialsFile)
-        && Objects.equals(authenticationPublicKeyFile, that.authenticationPublicKeyFile);
+        && Objects.equals(authenticationPublicKeyFile, that.authenticationPublicKeyFile)
+        && Objects.equals(maxBatchSize, that.maxBatchSize);
   }
 
   @Override
@@ -242,7 +244,8 @@ public class JsonRpcConfiguration {
         hostsAllowlist,
         authenticationEnabled,
         authenticationCredentialsFile,
-        authenticationPublicKeyFile);
+        authenticationPublicKeyFile,
+        maxBatchSize);
   }
 
   public int getMaxActiveConnections() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
@@ -230,7 +230,7 @@ public class JsonRpcConfiguration {
         && Objects.equals(hostsAllowlist, that.hostsAllowlist)
         && Objects.equals(authenticationCredentialsFile, that.authenticationCredentialsFile)
         && Objects.equals(authenticationPublicKeyFile, that.authenticationPublicKeyFile)
-        && Objects.equals(maxBatchSize, that.maxBatchSize);
+        && maxBatchSize == that.maxBatchSize;
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
default global rpc max batch size to 1000 for 23.1.0, revisit in 23.1.1


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).