### PR TITLE
Cherry-pick of "bump max rpc batch size to 1024 #5108"

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/DefaultCommandValues.java
@@ -87,7 +87,7 @@ public interface DefaultCommandValues {
   /** The constant DEFAULT_HTTP_MAX_CONNECTIONS. */
   int DEFAULT_HTTP_MAX_CONNECTIONS = 80;
   /** The constant DEFAULT_HTTP_MAX_BATCH_SIZE. */
-  int DEFAULT_HTTP_MAX_BATCH_SIZE = 1000;
+  int DEFAULT_HTTP_MAX_BATCH_SIZE = 1024;
   /** The constant DEFAULT_WS_MAX_CONNECTIONS. */
   int DEFAULT_WS_MAX_CONNECTIONS = 80;
   /** The constant DEFAULT_WS_MAX_FRAME_SIZE. */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
@@ -36,7 +36,7 @@ public class JsonRpcConfiguration {
   public static final int DEFAULT_JSON_RPC_PORT = 8545;
   public static final int DEFAULT_ENGINE_JSON_RPC_PORT = 8551;
   public static final int DEFAULT_MAX_ACTIVE_CONNECTIONS = 80;
-  public static final int DEFAULT_MAX_BATCH_SIZE = 1000;
+  public static final int DEFAULT_MAX_BATCH_SIZE = 1024;
 
   private boolean enabled;
   private int port;


### PR DESCRIPTION
#5108 was released in 23.1.0 (via release-23.1.x branch)