### PR TITLE
Use binary search to eth_estimateGas more accurately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Change Forest to use TransactionDB instead of OptimisticTransactionDB [#5328](https://github.com/hyperledger/besu/pull/5328)
 - Performance: Reduced usage of UInt256 in EVM operations [#5331](https://github.com/hyperledger/besu/pull/5331)
 - Changed wrong error message "Invalid params" when private tx is reverted to "Execution reverted" with correct revert reason in data. [#5369](https://github.com/hyperledger/besu/pull/5369)
+- Changes to the way gas is estimated to provide an exact gas estimate [#5142](https://github.com/hyperledger/besu/pull/5142)
 
 ### Bug Fixes
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/CallSmartContractFunction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/CallSmartContractFunction.java
@@ -29,27 +29,36 @@ import org.web3j.tx.RawTransactionManager;
 public class CallSmartContractFunction implements Transaction<EthSendTransaction> {
 
   private static final BigInteger GAS_PRICE = BigInteger.valueOf(1000);
-  private static final BigInteger GAS_LIMIT = BigInteger.valueOf(3000000);
+
   private static final Credentials BENEFACTOR_ONE =
       Credentials.create(Accounts.GENESIS_ACCOUNT_ONE_PRIVATE_KEY);
 
-  private final String functionName;
+  private BigInteger gasLimit = BigInteger.valueOf(3000000);
+  private final String functionCall;
   private final String contractAddress;
 
-  public CallSmartContractFunction(final String functionName, final String contractAddress) {
-    this.functionName = functionName;
+  public CallSmartContractFunction(final String contractAddress, final String functionName) {
+    final Function function =
+        new Function(functionName, Collections.emptyList(), Collections.emptyList());
+
     this.contractAddress = contractAddress;
+    this.functionCall = FunctionEncoder.encode(function);
+  }
+
+  public CallSmartContractFunction(
+      final String contractAddress, final String functionCall, final BigInteger gasLimit) {
+    this.contractAddress = contractAddress;
+    this.functionCall = functionCall;
+    this.gasLimit = gasLimit;
   }
 
   @Override
   public EthSendTransaction execute(final NodeRequests node) {
-    final Function function =
-        new Function(functionName, Collections.emptyList(), Collections.emptyList());
     final RawTransactionManager transactionManager =
         new RawTransactionManager(node.eth(), BENEFACTOR_ONE);
     try {
       return transactionManager.sendTransaction(
-          GAS_PRICE, GAS_LIMIT, contractAddress, FunctionEncoder.encode(function), BigInteger.ZERO);
+          GAS_PRICE, gasLimit, contractAddress, functionCall, BigInteger.ZERO);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/contract/ContractTransactions.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/contract/ContractTransactions.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.tests.acceptance.dsl.transaction.contract;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.CallSmartContractFunction;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.DeploySmartContractTransaction;
 
+import java.math.BigInteger;
+
 import org.web3j.tx.Contract;
 
 public class ContractTransactions {
@@ -32,7 +34,12 @@ public class ContractTransactions {
   }
 
   public CallSmartContractFunction callSmartContract(
-      final String functionName, final String contractAddress) {
-    return new CallSmartContractFunction(functionName, contractAddress);
+      final String contractAddress, final String functionName) {
+    return new CallSmartContractFunction(contractAddress, functionName);
+  }
+
+  public CallSmartContractFunction callSmartContract(
+      final String contractAddress, final String functionCall, final BigInteger gasLimit) {
+    return new CallSmartContractFunction(contractAddress, functionCall, gasLimit);
   }
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthCallTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthCallTransaction.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.tests.acceptance.dsl.transaction.eth;
 
 import static org.web3j.protocol.core.DefaultBlockParameterName.LATEST;

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthCallTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthCallTransaction.java
@@ -1,0 +1,60 @@
+package org.hyperledger.besu.tests.acceptance.dsl.transaction.eth;
+
+import static org.web3j.protocol.core.DefaultBlockParameterName.LATEST;
+import static org.web3j.tx.gas.DefaultGasProvider.GAS_LIMIT;
+
+import org.hyperledger.besu.tests.acceptance.dsl.account.Accounts;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.core.methods.response.EthCall;
+
+public class EthCallTransaction implements Transaction<EthCall> {
+  private final String contractAddress;
+  private final String functionCall;
+  private BigInteger gasLimit = GAS_LIMIT;
+  private final String benefactorOneAddress =
+      Credentials.create(Accounts.GENESIS_ACCOUNT_ONE_PRIVATE_KEY).getAddress();
+
+  public EthCallTransaction(final String contractAddress, final String functionCall) {
+    this.contractAddress = contractAddress;
+    this.functionCall = functionCall;
+  }
+
+  public EthCallTransaction(
+      final String contractAddress, final String functionCall, final BigInteger gasLimit) {
+    this.contractAddress = contractAddress;
+    this.functionCall = functionCall;
+    this.gasLimit = gasLimit;
+  }
+
+  @Override
+  public EthCall execute(final NodeRequests node) {
+    try {
+
+      var transactionCount =
+          node.eth()
+              .ethGetTransactionCount(benefactorOneAddress, LATEST)
+              .send()
+              .getTransactionCount();
+
+      var transaction =
+          new org.web3j.protocol.core.methods.request.Transaction(
+              benefactorOneAddress,
+              transactionCount,
+              BigInteger.ZERO,
+              gasLimit,
+              contractAddress,
+              BigInteger.ZERO,
+              functionCall);
+
+      return node.eth().ethCall(transaction, LATEST).send();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.dsl.transaction.eth;
+
+import static org.web3j.protocol.core.DefaultBlockParameterName.LATEST;
+
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import org.web3j.protocol.core.methods.response.EthEstimateGas;
+
+public class EthEstimateGasTransaction implements Transaction<EthEstimateGas> {
+  private final String contractAddress;
+  private final String functionCall;
+  private final String from = "";
+
+  public EthEstimateGasTransaction(final String contractAddress, final String functionCall) {
+    this.contractAddress = contractAddress;
+    this.functionCall = functionCall;
+  }
+
+  @Override
+  public EthEstimateGas execute(final NodeRequests node) {
+    try {
+
+      node.eth().ethGetTransactionCount(from, LATEST);
+
+      return node.eth()
+          .ethEstimateGas(
+              new org.web3j.protocol.core.methods.request.Transaction(
+                  from,
+                  BigInteger.ONE,
+                  BigInteger.ZERO,
+                  BigInteger.ZERO,
+                  contractAddress,
+                  BigInteger.ZERO,
+                  functionCall))
+          .send();
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/transaction/eth/EthEstimateGasTransaction.java
@@ -14,8 +14,6 @@
  */
 package org.hyperledger.besu.tests.acceptance.dsl.transaction.eth;
 
-import static org.web3j.protocol.core.DefaultBlockParameterName.LATEST;
-
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.NodeRequests;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.Transaction;
 
@@ -37,8 +35,6 @@ public class EthEstimateGasTransaction implements Transaction<EthEstimateGas> {
   @Override
   public EthEstimateGas execute(final NodeRequests node) {
     try {
-
-      node.eth().ethGetTransactionCount(from, LATEST);
 
       return node.eth()
           .ethEstimateGas(

--- a/acceptance-tests/tests/contracts/TestDepth.sol
+++ b/acceptance-tests/tests/contracts/TestDepth.sol
@@ -1,0 +1,32 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+pragma solidity >=0.7.0 <0.9.0;
+
+contract TestDepth {
+    uint256 public x;
+
+    function depth(uint256 y) public {
+        // bool result;
+        if (y > 0) {
+            bytes memory call = abi.encodeWithSignature("depth(uint256)", --y);
+            (bool result,) = address(this).delegatecall(call);
+            require(result);
+        }
+        else {
+            // Save the remaining gas in storage so that we can access it later
+            x = gasleft();
+        }
+    }
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/EthEstimateGasAcceptanceTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.tests.acceptance.jsonrpc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
+import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthEstimateGasTransaction;
+import org.hyperledger.besu.tests.web3j.generated.TestDepth;
+
+import java.math.BigInteger;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.web3j.protocol.core.methods.response.EthEstimateGas;
+
+public class EthEstimateGasAcceptanceTest extends AcceptanceTestBase {
+
+  private BesuNode node;
+  private TestDepth testDepth;
+
+  @Before
+  public void setUp() throws Exception {
+    node = besu.createMinerNode("node1");
+    cluster.start(node);
+    testDepth = node.execute(contractTransactions.createSmartContract(TestDepth.class));
+  }
+
+  @Test
+  public void estimateGasWithDelegateCall() {
+
+    List<SimpleEntry<Integer, Long>> testCase = new ArrayList<>();
+    testCase.add(new SimpleEntry<>(1, 45554L));
+    testCase.add(new SimpleEntry<>(2, 47387L));
+    testCase.add(new SimpleEntry<>(3, 49249L));
+    testCase.add(new SimpleEntry<>(4, 51141L));
+    testCase.add(new SimpleEntry<>(5, 53063L));
+    testCase.add(new SimpleEntry<>(10, 63139L));
+    testCase.add(new SimpleEntry<>(65, 246462L));
+    // taken from geth
+
+    for (var test : testCase) {
+      var functionCall = testDepth.depth(BigInteger.valueOf(test.getKey())).encodeFunctionCall();
+      var ethEstimateGas =
+          new EthEstimateGasTransaction(testDepth.getContractAddress(), functionCall);
+
+      final EthEstimateGas response = node.execute(ethEstimateGas);
+      assertThat(response.getAmountUsed())
+          .withFailMessage(
+              "Depth %d expected gasEstimate %d but was %dL",
+              test.getKey(), test.getValue(), response.getAmountUsed())
+          .isEqualTo(BigInteger.valueOf(test.getValue()));
+    }
+  }
+}

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/RevertReasonAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/jsonrpc/RevertReasonAcceptanceTest.java
@@ -42,7 +42,7 @@ public class RevertReasonAcceptanceTest extends AcceptanceTestBase {
     final EthSendTransaction transaction =
         minerNode.execute(
             contractTransactions.callSmartContract(
-                FUNC_REVERTWITHREVERTREASON, revertReasonContract.getContractAddress()));
+                revertReasonContract.getContractAddress(), FUNC_REVERTWITHREVERTREASON));
     minerNode.verify(
         eth.expectSuccessfulTransactionReceiptWithReason(
             transaction.getTransactionHash(), "RevertReason"));
@@ -55,7 +55,7 @@ public class RevertReasonAcceptanceTest extends AcceptanceTestBase {
     final EthSendTransaction transaction =
         minerNode.execute(
             contractTransactions.callSmartContract(
-                FUNC_REVERTWITHOUTREVERTREASON, revertReasonContract.getContractAddress()));
+                revertReasonContract.getContractAddress(), FUNC_REVERTWITHOUTREVERTREASON));
     minerNode.verify(
         eth.expectSuccessfulTransactionReceiptWithoutReason(transaction.getTransactionHash()));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -80,12 +80,15 @@ public class EthEstimateGas extends AbstractEstimateGas {
     var lo = gasUsed.get().getResult().getEstimateGasUsedByTransaction();
     var hi = processEstimateGas(gasUsed.get(), operationTracer);
     var mid = hi;
-    while (lo+1 < hi) {
+    while (lo + 1 < hi) {
       mid = (hi + lo) / 2;
 
       var binarySearchResult =
           executeSimulation(
-              blockHeader, overrideGasLimitAndPrice(callParams, mid), operationTracer, isAllowExceedingBalance);
+              blockHeader,
+              overrideGasLimitAndPrice(callParams, mid),
+              operationTracer,
+              isAllowExceedingBalance);
       if (binarySearchResult.isEmpty() || !binarySearchResult.get().isSuccessful()) {
         lo = mid;
       } else {


### PR DESCRIPTION
## PR description

eth_estimateGas currently conservatively estimates gas this change will take that estimate and use it as a high bound and will use gasUsed as a lower bound to hone in on the most true gas limit required.

Outstanding Issues/questions

- The estimate comes back lower than geth, I suspect this is due to the protocol schedule being used in the acceptance tests.
- further optimise the binary search?
- ganache does a better job of getting an exact gas requirement with only a few runs https://github.com/trufflesuite/ganache-cli-archive/releases/tag/v6.4.2

## Fixed Issue(s)

fixes https://github.com/hyperledger/besu/issues/4244


## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).