### PR TITLE
Fix Issues decoding the ephemeral public key (#5177)

### DIFF
--- a/crypto/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
@@ -25,9 +25,12 @@ import org.apache.tuweni.bytes.MutableBytes;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.FixedPointCombMultiplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** The Secp public key. */
 public class SECPPublicKey implements java.security.PublicKey {
+  private static final Logger LOG = LoggerFactory.getLogger(SECPPublicKey.class);
 
   /** The constant BYTE_LENGTH. */
   public static final int BYTE_LENGTH = 64;
@@ -119,7 +122,13 @@ public class SECPPublicKey implements java.security.PublicKey {
   public ECPoint asEcPoint(final ECDomainParameters curve) {
     // 0x04 is the prefix for uncompressed keys.
     final Bytes val = Bytes.concatenate(Bytes.of(0x04), encoded);
-    return curve.getCurve().decodePoint(val.toArrayUnsafe());
+    ECPoint ecPoint = null;
+    try {
+      ecPoint = curve.getCurve().decodePoint(val.toArrayUnsafe());
+    } catch (final Exception e) {
+      LOG.debug("stefan: Msg: {}, encoded: {}", e.getMessage(), encoded);
+    }
+    return ecPoint;
   }
 
   @Override

--- a/crypto/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
+++ b/crypto/src/main/java/org/hyperledger/besu/crypto/SECPPublicKey.java
@@ -127,6 +127,7 @@ public class SECPPublicKey implements java.security.PublicKey {
       ecPoint = curve.getCurve().decodePoint(val.toArrayUnsafe());
     } catch (final Exception e) {
       LOG.debug("stefan: Msg: {}, encoded: {}", e.getMessage(), encoded);
+      throw e;
     }
     return ecPoint;
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.HelloMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.WireMessageCodes;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -89,6 +90,10 @@ abstract class AbstractHandshakeHandler extends SimpleChannelInboundHandler<Byte
 
   @Override
   protected final void channelRead0(final ChannelHandlerContext ctx, final ByteBuf msg) {
+    LOG.debug(
+        "stefan: ECIES instance {}, IP {}, msg {}",
+        System.identityHashCode(handshaker),
+        ((InetSocketAddress) ctx.channel().remoteAddress()));
     final Optional<ByteBuf> nextMsg = nextHandshakeMessage(msg);
     if (nextMsg.isPresent()) {
       ctx.writeAndFlush(nextMsg.get());

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -186,6 +186,10 @@ public class ECIESHandshaker implements Handshaker {
     Bytes bytes = Bytes.wrap(encryptedBytes);
 
     Bytes encryptedMsg = bytes;
+    LOG.debug(
+        "stefan: handleMessage ECIESHandshaker instance {}, encryptedMsg {}",
+        System.identityHashCode(this),
+        encryptedMsg);
     try {
       // Decrypt the message with our private key.
       try {
@@ -203,6 +207,8 @@ public class ECIESHandshaker implements Handshaker {
           throw new HandshakeException("Failed to decrypt handshake message");
         }
       } catch (final Exception ex) {
+        LOG.debug(
+            "stefan: ECIESHandshaker instance {} is NOT version 4", System.identityHashCode(this));
         bytes = EncryptedMessage.decryptMsg(bytes, nodeKey);
         version4 = false;
       }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -213,6 +213,9 @@ public class ECIESHandshaker implements Handshaker {
           bytes = EncryptedMessage.decryptMsgEIP8(encryptedMsg, nodeKey);
           version4 = true;
         } else {
+          LOG.debug(
+              "stefan: HandshakeException: Failed to decrypt handshake message, ECIES instance {}",
+              System.identityHashCode(this));
           throw new HandshakeException("Failed to decrypt handshake message");
         }
       } catch (final Exception ex) {
@@ -223,13 +226,17 @@ public class ECIESHandshaker implements Handshaker {
       }
     } catch (final InvalidCipherTextException e) {
       status.set(Handshaker.HandshakeStatus.FAILED);
+      LOG.debug(
+          "stefan: InvalidCipherTextException: Decrypting an incoming handshake message failed, ECIES instance {}",
+          System.identityHashCode(this));
       throw new HandshakeException("Decrypting an incoming handshake message failed", e);
     } catch (final SecurityModuleException e) {
       status.set(Handshaker.HandshakeStatus.FAILED);
       LOG.debug(
-          "stefan: Buffer in handleMessage(ECIESHandshaker): expectedLength: {}, encryptedMessage: {}",
+          "stefan: Buffer in handleMessage(ECIESHandshaker): expectedLength: {}, encryptedMessage: {}, ECIES instance: {}",
           expectedLength,
-          encryptedMsg);
+          encryptedMsg,
+          System.identityHashCode(this));
       throw new HandshakeException(
           "Unable to create ECDH Key agreement due to Crypto engine failure", e);
     }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -168,6 +168,14 @@ public class ECIESHandshaker implements Handshaker {
             ? ResponderHandshakeMessageV1.MESSAGE_LENGTH
             : InitiatorHandshakeMessageV1.MESSAGE_LENGTH;
 
+    buf.markReaderIndex();
+    LOG.debug(
+        "stefan: ECIESinstance {}, readableBytesLen {}, buf {}",
+        System.identityHashCode(this),
+        buf.readableBytes(),
+        buf.toString());
+    buf.resetReaderIndex();
+
     if (buf.readableBytes() < expectedLength) {
       buf.markReaderIndex();
       final int size = buf.readUnsignedShort();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -211,6 +211,10 @@ public class ECIESHandshaker implements Handshaker {
       throw new HandshakeException("Decrypting an incoming handshake message failed", e);
     } catch (final SecurityModuleException e) {
       status.set(Handshaker.HandshakeStatus.FAILED);
+      LOG.debug(
+          "stefan: Buffer in handleMessage(ECIESHandshaker): expectedLength: {}, encryptedMessage: {}",
+          expectedLength,
+          encryptedMsg);
       throw new HandshakeException(
           "Unable to create ECDH Key agreement due to Crypto engine failure", e);
     }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshaker.java
@@ -103,8 +103,9 @@ public class ECIESHandshaker implements Handshaker {
     this.partyPubKey = theirPubKey;
     this.initiatorNonce = Bytes32.wrap(random(32), 0);
     LOG.trace(
-        "Prepared ECIES handshake with node {}... under INITIATOR role",
-        theirPubKey.getEncodedBytes().slice(0, 16));
+        "Prepared ECIES handshake with node {} under INITIATOR role, ECIES instance {}",
+        theirPubKey.getEncodedBytes(),
+        System.identityHashCode(this));
   }
 
   @Override


### PR DESCRIPTION
## PR description
Fix an issue where Besu fails to decode an ephemeral public key when dealing with an inbound handshake (Rlpx)

## Fixed Issue(s)

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).