### PR TITLE
Remove the fourth response element in eth_getWork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This update is required for the Goerli Shanghai/Capella upgrade and recommended 
 - Added the option --kzg-trusted-setup to pass a custom setup file for custom networks or to override the default one for named networks [#5084](https://github.com/hyperledger/besu/pull/5084)
 - Gas accounting for EIP-4844 [#4992](https://github.com/hyperledger/besu/pull/4992)
 - Goerli configs for shapella [#5151](https://github.com/hyperledger/besu/pull/5151)
+- Remove out of spec parameter in `eth_getWork`'s response [#5184](https://github.com/hyperledger/besu/pull/5184)
 
 ### Bug Fixes
 - Fix engine_getPayloadV2 block value calculation https://github.com/hyperledger/besu/issues/5040

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWork.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWork.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 import org.hyperledger.besu.ethereum.mainnet.DirectAcyclicGraphSeed;
@@ -63,8 +62,7 @@ public class EthGetWork implements JsonRpcMethod {
       final String[] result = {
         rawResult.getPrePowHash().toHexString(),
         "0x" + BaseEncoding.base16().lowerCase().encode(dagSeed),
-        rawResult.getTarget().toHexString(),
-        Quantity.create(rawResult.getBlockNumber())
+        rawResult.getTarget().toHexString()
       };
       return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), result);
     } else {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWorkTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWorkTest.java
@@ -69,8 +69,7 @@ public class EthGetWorkTest {
     final String[] expectedValue = {
       "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
       "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "0x0"
+      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     };
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), expectedValue);
@@ -94,8 +93,7 @@ public class EthGetWorkTest {
               .encode(
                   DirectAcyclicGraphSeed.dagSeed(
                       30000, new EpochCalculator.DefaultEpochCalculator())),
-      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "0x7530"
+      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     };
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), expectedValue);
@@ -120,8 +118,7 @@ public class EthGetWorkTest {
           + BaseEncoding.base16()
               .lowerCase()
               .encode(DirectAcyclicGraphSeed.dagSeed(60000, epochCalculator)),
-      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "0xea60"
+      "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     };
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(request.getRequest().getId(), expectedValue);


### PR DESCRIPTION
## PR description
The [spec](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getwork)  for `eth_getWork` only defines three return values and certain parsers rejects a longer response array.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).