### PR TITLE
Remove getByBlockNumber from dao classic specs

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import java.math.BigInteger;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -184,15 +185,21 @@ public class ProtocolScheduleBuilder extends AbstractProtocolScheduleBuilder {
   }
 
   @Override
-  protected void postBuildStep(final MainnetProtocolSpecFactory specFactory) {
+  protected void postBuildStep(
+      final MainnetProtocolSpecFactory specFactory, final TreeMap<Long, BuilderMapEntry> builders) {
     // NOTE: It is assumed that Daofork blocks will not be used for private networks
     // as too many risks exist around inserting a protocol-spec between daoBlock and daoBlock+10.
     config
         .getDaoForkBlock()
         .ifPresent(
             daoBlockNumber -> {
+              final BuilderMapEntry previousSpecBuilder =
+                  builders.floorEntry(daoBlockNumber).getValue();
               final ProtocolSpec originalProtocolSpec =
-                  protocolSchedule.getByBlockNumber(daoBlockNumber);
+                  getProtocolSpec(
+                      protocolSchedule,
+                      previousSpecBuilder.getBuilder(),
+                      previousSpecBuilder.getModifier());
               addProtocolSpec(
                   protocolSchedule,
                   daoBlockNumber,
@@ -212,8 +219,13 @@ public class ProtocolScheduleBuilder extends AbstractProtocolScheduleBuilder {
         .getClassicForkBlock()
         .ifPresent(
             classicBlockNumber -> {
+              final BuilderMapEntry previousSpecBuilder =
+                  builders.floorEntry(classicBlockNumber).getValue();
               final ProtocolSpec originalProtocolSpec =
-                  protocolSchedule.getByBlockNumber(classicBlockNumber);
+                  getProtocolSpec(
+                      protocolSchedule,
+                      previousSpecBuilder.getBuilder(),
+                      previousSpecBuilder.getModifier());
               addProtocolSpec(
                   protocolSchedule,
                   classicBlockNumber,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TimestampScheduleBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TimestampScheduleBuilder.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.math.BigInteger;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Stream;
 
 public class TimestampScheduleBuilder extends AbstractProtocolScheduleBuilder {
@@ -84,5 +85,7 @@ public class TimestampScheduleBuilder extends AbstractProtocolScheduleBuilder {
   }
 
   @Override
-  protected void postBuildStep(final MainnetProtocolSpecFactory specFactory) {}
+  protected void postBuildStep(
+      final MainnetProtocolSpecFactory specFactory,
+      final TreeMap<Long, BuilderMapEntry> builders) {}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR removes getByBlockNumber from the ProtocolScheduleBuilder using the existing builders to fetch the original Spec for the blocks where the Dao/Classic fork will be inserted.

This PR has successfully generated the same ProtocolSchedules for Sepolia/Goerli and Mainnet. 
Samples:
- Sepolia
`2023-03-10 16:42:13.691+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [London: 0, ParisFork: 1735371]
2023-03-10 16:42:13.695+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [Shanghai: 1677557088]`
- Goerli
`2023-03-10 16:47:02.803+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [Petersburg: 0, Istanbul: 1561651, Berlin: 4460644, London: 5062605]
2023-03-10 16:47:02.807+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [Shanghai: 1678832736]
`
- Mainnet
`2023-03-10 16:41:05.327+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [Frontier: 0, Homestead: 1150000, DaoRecoveryInit: 1920000, DaoRecoveryTransition: 1920001, Homestead: 1920010, TangerineWhistle: 2463000, SpuriousDragon: 2675000, Byzantium: 4370000, Petersburg: 7280000, Istanbul: 9069000, MuirGlacier: 9200000, Berlin: 12244000, London: 12965000, ArrowGlacier: 13773000, GrayGlacier: 15050000]
`
- Classic
`2023-03-10 16:39:19.567+11:00 | main | INFO  | AbstractProtocolScheduleBuilder | Protocol schedule created with milestones: [Frontier: 0, Homestead: 1150000, ClassicRecoveryInit: 1920000, Homestead: 1920001, TangerineWhistle: 2500000, DieHard: 3000000, Gotham: 5000000, DefuseDifficultyBomb: 5900000, Atlantis: 8772000, Agharta: 9573000, Phoenix: 10500839, Thanos: 11700000, Magneto: 13189133, Mystique: 14525000]
`

PR has also successfully synced:
- [x] Sepolia
- [x] Goerli
- [x] Mainnet
- [x] Ethereum Classic (by @diega )

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #5161

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).