### PR TITLE
[GHA] no DCO on merge_group

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,6 @@ name: dco
 on:
   pull_request:
   workflow_dispatch:
-  merge_group:
 
 jobs:
   dco:


### PR DESCRIPTION
argh dco does not support merge_group event - it's the same problem we had with merge to main https://github.com/hyperledger/besu/actions/runs/4400701640 


## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).