### PR TITLE
[GHA] add separate dco yml for merge_group event

### DIFF
--- a/.github/workflows/dco-merge-group.yml
+++ b/.github/workflows/dco-merge-group.yml
@@ -1,0 +1,10 @@
+name: dco
+on:
+  merge_group:
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - run: echo "This DCO job runs on merge_queue event and doesn't check PR contents"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
+      - run: echo "This DCO job runs on pull_request event and workflow_dispatch"
       - name: Get PR Commits
         id: 'get-pr-commits'
         uses: tim-actions/get-pr-commits@v1.2.0


### PR DESCRIPTION
Add a separate yml file with the merge_group event trigger that doesn't invoke the PR based dco

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).