### PR TITLE
increased default to 5000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 ### Additions and Improvements
+- Increase default from 1000 to 5000 for `--rpc-max-logs-range` #5209
 
 ### Bug Fixes
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1312,7 +1312,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       names = {"--rpc-max-logs-range"},
       description =
           "Specifies the maximum number of blocks to retrieve logs from via RPC. Must be >=0. 0 specifies no limit  (default: ${DEFAULT-VALUE})")
-  private final Long rpcMaxLogsRange = 1000L;
+  private final Long rpcMaxLogsRange = 5000L;
 
   @Mixin private P2PTLSConfigOptions p2pTLSConfigOptions;
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -257,7 +257,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).metricsConfiguration(eq(DEFAULT_METRICS_CONFIGURATION));
     verify(mockRunnerBuilder).ethNetworkConfig(ethNetworkArg.capture());
     verify(mockRunnerBuilder).autoLogBloomCaching(eq(true));
-    verify(mockRunnerBuilder).rpcMaxLogsRange(eq(1000L));
+    verify(mockRunnerBuilder).rpcMaxLogsRange(eq(5000L));
     verify(mockRunnerBuilder).build();
 
     verify(mockControllerBuilderFactory)


### PR DESCRIPTION
Increase max log range to 5000 - was reduced to 1000 in #4597 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [x] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [x] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).