### PR TITLE
Add getForNextBlockHeader to protocol schedule

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
@@ -75,7 +75,8 @@ public class EthFeeHistory implements JsonRpcMethod {
     final Optional<List<Double>> maybeRewardPercentiles =
         request.getOptionalParameter(2, Double[].class).map(Arrays::asList);
 
-    final long chainHeadBlockNumber = blockchain.getChainHeadBlockNumber();
+    final BlockHeader chainHeadHeader = blockchain.getChainHeadHeader();
+    final long chainHeadBlockNumber = chainHeadHeader.getNumber();
     final long resolvedHighestBlockNumber =
         highestBlock
             .getNumber()
@@ -106,7 +107,7 @@ public class EthFeeHistory implements JsonRpcMethod {
             .map(blockHeader -> blockHeader.getBaseFee().orElse(Wei.ZERO))
             .orElseGet(
                 () ->
-                    Optional.of(protocolSchedule.getByBlockNumber(nextBlockNumber).getFeeMarket())
+                    Optional.of(protocolSchedule.getForNextBlockHeader(chainHeadHeader, chainHeadHeader.getTimestamp()).getFeeMarket())
                         .filter(FeeMarket::implementsBaseFee)
                         .map(BaseFeeMarket.class::cast)
                         .map(

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -34,7 +34,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactions;
 import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.BodyValidation;
 import org.hyperledger.besu.ethereum.mainnet.DifficultyCalculator;
-import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -156,13 +155,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
 
     try (final MutableWorldState disposableWorldState = duplicateWorldStateAtParent()) {
       final ProtocolSpec newProtocolSpec =
-          protocolSchedule.getByBlockHeader(
-              BlockHeaderBuilder.fromHeader(parentHeader)
-                  .number(parentHeader.getNumber() + 1)
-                  .timestamp(timestamp)
-                  .parentHash(parentHeader.getHash())
-                  .blockHeaderFunctions(new MainnetBlockHeaderFunctions())
-                  .buildBlockHeader());
+          protocolSchedule.getForNextBlockHeader(parentHeader, timestamp);
 
       final ProcessableBlockHeader processableBlockHeader =
           createPendingBlockHeader(timestamp, maybePrevRandao, newProtocolSpec);

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutor.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWMinerExecutor.java
@@ -75,7 +75,10 @@ public class PoWMinerExecutor extends AbstractMinerExecutor<PoWBlockMiner> {
     final PoWSolver solver =
         new PoWSolver(
             nonceGenerator,
-            protocolSchedule.getByBlockNumber(parentHeader.getNumber() + 1).getPoWHasher().get(),
+            protocolSchedule
+                .getForNextBlockHeader(parentHeader, 0)
+                .getPoWHasher()
+                .get(), // timestamp schedule is never used for pow mining
             stratumMiningEnabled,
             ethHashObservers,
             epochCalculator,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/HeaderBasedProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/HeaderBasedProtocolSchedule.java
@@ -17,6 +17,8 @@
 
 package org.hyperledger.besu.ethereum.mainnet;
 
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.ProcessableBlockHeader;
 
 import java.math.BigInteger;
@@ -26,6 +28,17 @@ import java.util.stream.Stream;
 public interface HeaderBasedProtocolSchedule {
 
   ProtocolSpec getByBlockHeader(final ProcessableBlockHeader blockHeader);
+
+  default ProtocolSpec getForNextBlockHeader(
+      final BlockHeader parentBlockHeader, final long timestamp) {
+    final BlockHeader nextBlockHeader =
+        BlockHeaderBuilder.fromHeader(parentBlockHeader)
+            .number(parentBlockHeader.getNumber() + 1)
+            .timestamp(timestamp)
+            .parentHash(parentBlockHeader.getHash())
+            .buildBlockHeader();
+    return getByBlockHeader(nextBlockHeader);
+  }
 
   Optional<BigInteger> getChainId();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Add getForNextBlockHeader to protocol schedule

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).

## Acceptance Tests (Non Mainnet)

- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.

## Changelog

- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).