### PR TITLE
[GHA] Checklist action

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,16 +6,3 @@
 ## Fixed Issue(s)
 <!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
 <!-- Example: "fixes #2" -->
-
-## Documentation
-
-- [ ] I thought about documentation and added the `doc-change-required` label to this PR if
-    [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
-
-## Acceptance Tests (Non Mainnet)
-
-- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.
-
-## Changelog
-
-- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -17,4 +17,4 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: '- [ ] I thought about documentation and added the `doc-change-required` label to this PR if [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).\n- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.\n- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).'
-    })
+            })

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -9,7 +9,7 @@ on:
       - 'release*'
 
 jobs:
-  comment:
+  checklist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -1,14 +1,13 @@
 name: comment on pr with checklist
-
 on:
   pull_request_target:
     types:
       - opened
     branches:
       - main
-
 jobs:
   checklist:
+    name: "add checklist as a comment on newly opened PRs"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v5

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -6,7 +6,7 @@ on:
       - opened
     branches:
       - main
-      - release*
+      - 'release*'
 
 jobs:
   comment:

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -3,10 +3,9 @@ on:
   pull_request_target:
     types:
       - opened
-    branches:
-      - main
+    branches: [ main ]
 jobs:
-  checklist:
+  ckl:
     name: "add checklist as a comment on newly opened PRs"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -1,11 +1,10 @@
-name: comment on pr with checklist
+name: "comment on pr with checklist"
 on:
   pull_request_target:
-    types:
-      - opened
+    types: [ opened ]
     branches: [ main ]
 jobs:
-  ckl:
+  checklist:
     name: "add checklist as a comment on newly opened PRs"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -6,7 +6,6 @@ on:
       - opened
     branches:
       - main
-      - 'release*'
 
 jobs:
   checklist:

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -1,0 +1,23 @@
+name: comment on pr with checklist
+
+on:
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '- [ ] I thought about documentation and added the `doc-change-required` label to this PR if [updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).\n- [ ] I have considered running `./gradlew acceptanceTestNonMainnet` locally if my PR affects non-mainnet modules.\n- [ ] I thought about the changelog and included a [changelog update if required](https://wiki.hyperledger.org/display/BESU/Changelog).'
+    })

--- a/.github/workflows/pr-checklist-on-open.yml
+++ b/.github/workflows/pr-checklist-on-open.yml
@@ -6,6 +6,7 @@ on:
       - opened
     branches:
       - main
+      - release*
 
 jobs:
   comment:


### PR DESCRIPTION
This GHA will add the checklist that's currently in the PR template, as a comment, on newly opened PRs. 

Because it needs write access (to add the comment), it needs to run on the `pull_request_target` action, which means you won't see the outcome on _this_ PR, but only once it's merged in, you'll see it on subsequent PRs - example - https://github.com/daisy-row/vigilant-octo-umbrella/pull/51