### PR TITLE
remove parallelism from AT task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,6 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    parallelism: 6
     executor: xl_machine_executor
     steps:
       - prepare
@@ -229,14 +228,7 @@ jobs:
           name: AcceptanceTests (Mainnet)
           no_output_timeout: 20m
           command: |
-            CLASSNAMES=$(circleci tests glob "acceptance-tests/tests/src/test/java/**/*.java" \
-              | sed 's@.*/src/test/java/@@' \
-              | sed 's@/@.@g' \
-              | sed 's/.\{5\}$//' \
-              | circleci tests split --split-by=timings --timings-type=classname)
-            # Format the arguments to "./gradlew test"
-            GRADLE_ARGS=$(echo $CLASSNAMES | awk '{for (i=1; i<=NF; i++) print "--tests",$i}')
-            ./gradlew --no-daemon acceptanceTestMainnet $GRADLE_ARGS
+            ./gradlew --no-daemon acceptanceTestMainnet
       - capture_test_results
       - capture_test_logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - capture_test_results
 
   acceptanceTests:
-    executor: xl_machine_executor
+    executor: besu_executor_xl
     steps:
       - prepare
       - attach_workspace:


### PR DESCRIPTION
This task is now only taking 3 minutes with parallelism at 6. If it takes less than unit tests without parallelism there's no need. 

Occasionally seeing this error on 1 of the 6 runners `No tests found for given includes` 
Because for the parallelism, we're still passing all the AT classes into the splitter, it is possible that none of them match
https://app.circleci.com/pipelines/github/hyperledger/besu/21077/workflows/d91f36d9-7103-44c0-887a-46430e0331b9/jobs/129673/parallel-runs/1?filterBy=FAILED
