### PR TITLE
use x86 for codeQL github action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,7 +22,7 @@ jobs:
       - name: spotless
         run: ./gradlew --no-daemon --parallel clean spotlessCheck
   javadoc_17:
-    runs-on: ubuntu-latest
+    runs-on: [besu,Linux,self-hosted,X64]
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   spotless:
-    runs-on: [besu,Linux,self-hosted]
+    runs-on: [besu,Linux,self-hosted,X64]
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout Repo

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [besu,Linux,self-hosted]
+    runs-on: [besu,Linux,self-hosted,X64]
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
A few  github actions explicitly uses amd64 binary version of java.  needs to specify they can only run on X64:
- codeql
- spotless
- javadoc_17

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->