### PR TITLE
Minor improvements to logging

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -156,7 +156,7 @@ public class ConfigurationOverviewBuilder {
    */
   public String build() {
     final List<String> lines = new ArrayList<>();
-    lines.add("Besu " + BesuInfo.class.getPackage().getImplementationVersion());
+    lines.add("Besu version " + BesuInfo.class.getPackage().getImplementationVersion());
     lines.add("");
     lines.add("Configuration:");
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 public class EngineAuthService implements AuthenticationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineAuthService.class);
-  private static final int JWT_EXPIRATION_TIME = 60;
+  private static final int JWT_EXPIRATION_TIME_IN_SECONDS = 60;
 
   private final JWTAuth jwtAuthProvider;
 
@@ -169,6 +169,7 @@ public class EngineAuthService implements AuthenticationService {
   private boolean issuedRecently(final long iat) {
     long iatSecondsSinceEpoch = iat;
     long nowSecondsSinceEpoch = System.currentTimeMillis() / 1000;
-    return (Math.abs((nowSecondsSinceEpoch - iatSecondsSinceEpoch)) <= JWT_EXPIRATION_TIME);
+    return (Math.abs((nowSecondsSinceEpoch - iatSecondsSinceEpoch))
+        <= JWT_EXPIRATION_TIME_IN_SECONDS);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
@@ -136,4 +136,22 @@ public class JsonRpcRequest {
   public <T> Optional<T> getOptionalParameter(final int index, final Class<T> paramClass) {
     return parameterAccessor.optional(params, index, paramClass);
   }
+
+  @Override
+  public String toString() {
+    return "JsonRpcRequest{"
+        + "id="
+        + id
+        + ", method='"
+        + method
+        + '\''
+        + ", params="
+        + Arrays.toString(params)
+        + ", version='"
+        + version
+        + '\''
+        + ", isNotification="
+        + isNotification
+        + '}';
+  }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
@@ -103,7 +103,11 @@ public class EthGetLogs implements JsonRpcMethod {
                 });
 
     if (ex.get() != null) {
-      LOG.debug("eth_getLogs call failed: ", ex.get());
+      LOG.atDebug()
+          .setMessage("eth_getLogs request {} failed: {}")
+          .addArgument(requestContext.getRequest())
+          .setCause(ex.get())
+          .log();
       if (ex.get() instanceof IllegalArgumentException) {
         return new JsonRpcErrorResponse(
             requestContext.getRequest().getId(), JsonRpcError.EXCEEDS_RPC_MAX_BLOCK_RANGE);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
@@ -104,7 +104,7 @@ public class EthGetLogs implements JsonRpcMethod {
 
     if (ex.get() != null) {
       LOG.atDebug()
-          .setMessage("eth_getLogs request {} failed: {}")
+          .setMessage("eth_getLogs request {} failed:")
           .addArgument(requestContext.getRequest())
           .setCause(ex.get())
           .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloader.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloader.java
@@ -121,7 +121,7 @@ public class FastSyncDownloader<REQUEST> {
     } else {
       LOG.error(
           "Encountered an unexpected error during fast sync. Restarting sync in "
-              + FAST_SYNC_RETRY_DELAY
+              + FAST_SYNC_RETRY_DELAY.getSeconds()
               + " seconds.",
           error);
       return fastSyncActions.scheduleFutureTask(


### PR DESCRIPTION
* During startup print "Besu version ..." instead of just "Besu ..." to make searching for the version in the logs easier.

* eth_getLogs now prints request along with exception:
```
2023-03-20 12:42:17.918+10:00 | Test worker | DEBUG  | EthGetLogs | eth_getLogs request JsonRpcRequest{id=null, method='eth_getLogs', params=[FilterParameter{fromBlock=BlockParameter{type=NUMERIC, number=Optional[0]}, toBlock=BlockParameter{type=NUMERIC, number=Optional[50]}, fromAddress=[], toAddress=[], addresses=[], topics=[], maybeBlockHash=Optional.empty, logsQuery=LogsQuery{addresses=[], topics=[], after=Optional.empty, count=Optional.empty, isValid=true}], version='2.0', isNotification=true} failed
java.lang.IllegalArgumentException: Requested range exceeds maximum range limit
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetLogs.lambda$response$3(EthGetLogs.java:90) ~[main/:?]
	at java.util.Optional.orElseGet(Optional.java:364) ~[?:?]
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthGetLogs.response(EthGetLogs.java:70) ~[main/:?]
	...
```

* Better formatting of the fast sync retry interval: Instead of printing
```
ERROR | FastSyncDownloader | Encountered an unexpected error during fast sync. Restarting sync in PT5S seconds.
```
we now print:
```
ERROR | FastSyncDownloader | Encountered an unexpected error during fast sync. Restarting sync in 5 seconds.
```

