### PR TITLE
Cleanup after GHA docker user

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -22,3 +22,6 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint Repo
         run: bundle exec /app/bin/repolinter.js --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/main/repo_structure/repolint.json --format markdown
+      - name: Cleanup file permissions created by docker user
+        run: |
+          sudo chown -R ${{ env.runner_uid }} .

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -24,4 +24,6 @@ jobs:
         run: bundle exec /app/bin/repolinter.js --rulesetUrl https://raw.githubusercontent.com/hyperledger-labs/hyperledger-community-management-tools/main/repo_structure/repolint.json --format markdown
       - name: Cleanup file permissions created by docker user
         run: |
-          sudo chown -R ${{ env.runner_uid }} .
+          USER_ID=$(id -u)
+          GROUP_ID=$(id -g)
+          chown -R "$USER_ID:$GROUP_ID" .


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Docker actions that write to files during actions leave files in the repository owned by the docker user rather than the runner user.  This leaves the runner filesystem in a state that makes non-docker actions fail.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->