### PR TITLE
continue despite test failures

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew build sonarqube --info
+        run: ./gradlew --continue build sonarqube --info
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --continue build sonarqube --info
+        run: ./gradlew build sonarqube --continue --info
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   Analysis:
     runs-on: ubuntu-latest
-
+    if: github.repository == 'hyperledger/besu'
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I would like to propose some blasphemy:

we should run the weekly sonarqube job with gradle --continue so it proceeds on, regardless of test failure.

this week a flaky test failed, and so we got no analysis.
the sonarqube job produces no artifacts of any use, it is meant as a weekly diagnostic, so while blasphemous, I believe this to be safe.