### PR TITLE
Fix BFT creating invalid blocks on London when zero base fee is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,9 +401,6 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
-      - acceptanceTestsNonMainnet:
-          requires:
-          - assemble
       - buildDocker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,9 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
+      - acceptanceTestsNonMainnet:
+          requires:
+          - assemble
       - buildDocker:
           requires:
             - assemble

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Upgrade RocksDB version from 7.7.3 to 8.0.0. Besu Team [contributed](https://github.com/facebook/rocksdb/pull/11099) to this release to make disabling checksum verification work. 
 
 ### Bug Fixes
+- Fix QBFT and IBFT unable to propose blocks on London when zeroBaseFee is used [#5276](https://github.com/hyperledger/besu/pull/5276) 
 
 ### Download Links
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarket.java
@@ -38,9 +38,4 @@ public class ZeroBaseFeeMarket extends LondonFeeMarket {
   public ValidationMode baseFeeValidationMode(final long blockNumber) {
     return ValidationMode.NONE;
   }
-
-  @Override
-  public boolean implementsDataFee() {
-    return false;
-  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarket.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarket.java
@@ -41,6 +41,6 @@ public class ZeroBaseFeeMarket extends LondonFeeMarket {
 
   @Override
   public boolean implementsDataFee() {
-    return true;
+    return false;
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarketTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ZeroBaseFeeMarketTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
@@ -137,5 +138,15 @@ public class ZeroBaseFeeMarketTest {
     final ZeroBaseFeeMarket zeroBaseFeeMarket = new ZeroBaseFeeMarket(10);
     assertThat(zeroBaseFeeMarket.isBeforeForkBlock(10)).isFalse();
     assertThat(zeroBaseFeeMarket.isBeforeForkBlock(11)).isFalse();
+  }
+
+  @Test
+  public void implementsDataFeedShouldReturnFalse() {
+    assertThat(zeroBaseFeeMarket.implementsDataFee()).isFalse();
+  }
+
+  @Test
+  public void dataPriceShouldReturnsZero() {
+    assertThat(zeroBaseFeeMarket.dataPrice(DataGas.ONE)).isEqualTo(Wei.ZERO);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This fixes an issue where on IBFT and QBFT invalid blocks are created by the proposer when using London with a zeroBaseFee.

The cause of this is that the ZeroBaseFeeMarket was returning true for the implementsDataFee check which meant that the excessDataGas field was added to the block header. This is only valid after Shanghai.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5270 