### PR TITLE
obfuscate jwt trace logs

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Streams.stream;
 import static org.apache.tuweni.net.tls.VertxTrustOptions.allowlistClients;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils.truncToken;
 
 import org.hyperledger.besu.ethereum.api.handlers.HandlerFactory;
 import org.hyperledger.besu.ethereum.api.handlers.TimeoutOptions;
@@ -327,7 +328,10 @@ public class EngineJsonRpcService {
           AuthenticationUtils.getJwtTokenFromAuthorizationHeaderValue(
               websocket.headers().get("Authorization"));
       if (token != null) {
-        LOG.trace("Websocket authentication token {}", token);
+        LOG.atTrace()
+            .setMessage("JWT authentication token {}")
+            .addArgument(() -> truncToken(token))
+            .log();
       }
 
       if (!hostIsInAllowlist(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
+import java.util.Optional;
+
 public class AuthenticationUtils {
 
   public static String getJwtTokenFromAuthorizationHeaderValue(final String value) {
@@ -24,5 +26,16 @@ public class AuthenticationUtils {
       }
     }
     return null;
+  }
+
+  public static String truncToken(final String jwtToken) {
+    return Optional.ofNullable(jwtToken)
+        .map(
+            token ->
+                token
+                    .substring(0, 8)
+                    .concat("...")
+                    .concat(token.substring(token.length() - 8, token.length())))
+        .orElse("Invalid JWT");
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket;
 
 import static com.google.common.collect.Streams.stream;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils.truncToken;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.AuthenticationUtils;
@@ -129,7 +130,10 @@ public class WebSocketService {
       final String connectionId = websocket.textHandlerID();
       final String token = getAuthToken(websocket);
       if (token != null) {
-        LOG.trace("Websocket authentication token {}", token);
+        LOG.atTrace()
+            .setMessage("Websocket authentication token {}")
+            .addArgument(() -> truncToken(token))
+            .log();
       }
 
       if (!hasAllowedHostnameHeader(Optional.ofNullable(websocket.headers().get("Host")))) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
@@ -21,6 +21,27 @@ import org.junit.Test;
 public class AuthenticationUtilsTest {
 
   @Test
+  public void obfuscateTokenShouldReturnExpected() {
+    String header = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9";
+    String token = AuthenticationUtils.getJwtTokenFromAuthorizationHeaderValue(header);
+    assertThat(AuthenticationUtils.truncToken(token)).isNotEqualTo(token);
+    assertThat(AuthenticationUtils.truncToken(token)).isEqualTo("eyJ0eXAi...UzI1NiJ9");
+  }
+
+  @Test
+  public void obfuscateNullTokenShouldReturnInvalid() {
+    String token = AuthenticationUtils.getJwtTokenFromAuthorizationHeaderValue(null);
+    assertThat(AuthenticationUtils.truncToken(token)).isEqualTo("Invalid JWT");
+  }
+
+  @Test
+  public void obfuscateEmptyTokenShouldReturnInvalid() {
+    String header = "";
+    String token = AuthenticationUtils.getJwtTokenFromAuthorizationHeaderValue(header);
+    assertThat(AuthenticationUtils.truncToken(token)).isEqualTo("Invalid JWT");
+  }
+
+  @Test
   public void getJwtTokenFromNullStringShouldReturnNull() {
     final String headerValue = null;
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Obfuscate JWT token in trace logs, leaving enough to compare with what would have been sent for debugging purposes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
addresses static analysis alerts 597 and 810