### PR TITLE
Configure gradle AT tasks to run junit5 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,9 +401,6 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
-      - acceptanceTestsNonMainnet:
-          requires:
-            - assemble
       - buildDocker:
           requires:
             - assemble

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,9 @@ workflows:
       - acceptanceTests:
           requires:
             - assemble
+      - acceptanceTestsNonMainnet:
+          requires:
+            - assemble
       - buildDocker:
           requires:
             - assemble

--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -103,6 +103,8 @@ processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar')
 task acceptanceTest(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation
 
+  useJUnitPlatform {}
+
   dependsOn(rootProject.installDist)
   setSystemProperties(test.getSystemProperties())
   systemProperty 'acctests.runBesuAsProcess', 'true'
@@ -129,6 +131,8 @@ task acceptanceTestMainnet(type: Test) {
   exclude '**/clique/**'
   exclude '**/permissioning/**'
   exclude '**/privacy/**'
+
+  useJUnitPlatform {}
 
   dependsOn(rootProject.installDist)
   setSystemProperties(test.getSystemProperties())
@@ -157,6 +161,8 @@ task acceptanceTestNonMainnet(type: Test) {
   include '**/clique/**'
   include '**/permissioning/**'
   include '**/privacy/**'
+
+  useJUnitPlatform {}
 
   dependsOn(rootProject.installDist)
   setSystemProperties(test.getSystemProperties())


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Gradle tasks for the acceptance tests were not running any Junit5 tests.

current mainnet tests: 61
with this change mainnet tests: 137

current non-mainnet tests: 271
with this change non-mainnet tests: 279

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5299 