### PR TITLE
Improved error message when verifying enode syntax with xdns-enabled

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
@@ -212,7 +212,7 @@ public class LocalPermissioningConfigurationValidatorTest {
     Files.write(toml, Resources.toByteArray(configFile));
 
     final ImmutableEnodeDnsConfiguration enodeDnsConfiguration =
-        ImmutableEnodeDnsConfiguration.builder().dnsEnabled(false).updateEnabled(false).build();
+        ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build();
 
     assertThatThrownBy(
             () ->
@@ -224,7 +224,6 @@ public class LocalPermissioningConfigurationValidatorTest {
                     toml.toAbsolutePath().toString()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Invalid enode URL syntax 'enode://6f8a80d14311c39f35f516fa664deaaaa13e85b2f7493f37f6144d86991ec012937307647bd3b9a82abe2974e1407241d54947bbb39763a4cac9f77166ad92a0@hostname:4567'. "
-                + "Enode URL should have the following format 'enode://<node_id>@<ip>:<listening_port>[?discport=<discovery_port>]'. Invalid ip address.");
+            "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.");
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
@@ -224,6 +224,6 @@ public class LocalPermissioningConfigurationValidatorTest {
                     toml.toAbsolutePath().toString()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.");
+            "Invalid IP address (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.");
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
@@ -80,13 +80,19 @@ public class EnodeURLImpl implements EnodeURL {
       checkStringArgumentNotEmpty(value, "Invalid empty value.");
       return fromURI(URI.create(value), enodeDnsConfiguration);
     } catch (final IllegalArgumentException e) {
-      String message =
-          String.format(
-              "Invalid enode URL syntax '%s'. Enode URL should have the following format 'enode://<node_id>@<ip>:<listening_port>[?discport=<discovery_port>]'.",
-              value);
-      if (e.getMessage() != null) {
-        message += " " + e.getMessage();
+      String message = "";
+      if (enodeDnsConfiguration.dnsEnabled() && !enodeDnsConfiguration.updateEnabled()){
+        message = "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
       }
+      else {
+        message = String.format(
+                "Invalid enode URL syntax '%s'. Enode URL should have the following format 'enode://<node_id>@<ip>:<listening_port>[?discport=<discovery_port>]'.",
+                value);
+        if (e.getMessage() != null) {
+          message += " " + e.getMessage();
+        }
+      }
+
       throw new IllegalArgumentException(message, e);
     }
   }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
@@ -81,11 +81,12 @@ public class EnodeURLImpl implements EnodeURL {
       return fromURI(URI.create(value), enodeDnsConfiguration);
     } catch (final IllegalArgumentException e) {
       String message = "";
-      if (enodeDnsConfiguration.dnsEnabled() && !enodeDnsConfiguration.updateEnabled()){
-        message = "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
-      }
-      else {
-        message = String.format(
+      if (enodeDnsConfiguration.dnsEnabled() && !enodeDnsConfiguration.updateEnabled()) {
+        message =
+            "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
+      } else {
+        message =
+            String.format(
                 "Invalid enode URL syntax '%s'. Enode URL should have the following format 'enode://<node_id>@<ip>:<listening_port>[?discport=<discovery_port>]'.",
                 value);
         if (e.getMessage() != null) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
@@ -83,7 +83,7 @@ public class EnodeURLImpl implements EnodeURL {
       String message = "";
       if (enodeDnsConfiguration.dnsEnabled() && !enodeDnsConfiguration.updateEnabled()) {
         message =
-            "Invalid IP address or DNS query resolved an invalid IP. --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
+            "Invalid IP address (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
       } else {
         message =
             String.format(

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
@@ -449,7 +449,7 @@ public class EnodeURLImplTest {
     final EnodeURL enodeURL =
         EnodeURLImpl.fromString(
             enodeURLString,
-            ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build());
+            ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(true).build());
     ;
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
@@ -449,7 +449,7 @@ public class EnodeURLImplTest {
     final EnodeURL enodeURL =
         EnodeURLImpl.fromString(
             enodeURLString,
-            ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(true).build());
+            ImmutableEnodeDnsConfiguration.builder().dnsEnabled(true).updateEnabled(false).build());
     ;
 
     assertThat(enodeURL).isEqualTo(expectedEnodeURL);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Improved error message when verifying enode syntax with xdns-enabled

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/2569