### PR TITLE
uncomment columns related to GoQuorum privacy

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
@@ -29,9 +29,12 @@ public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
   ACCOUNT_STORAGE_STORAGE(new byte[] {8}, new int[] {2}),
   TRIE_BRANCH_STORAGE(new byte[] {9}, new int[] {2}),
   TRIE_LOG_STORAGE(new byte[] {10}, new int[] {2}),
+
   // previously supported GoQuorum private states
-  //  GOQUORUM_PRIVATE_WORLD_STATE(new byte[] {11}),
-  //  GOQUORUM_PRIVATE_STORAGE(new byte[] {12}),
+  // no longer used but need to be retained for db backward compatibility
+  GOQUORUM_PRIVATE_WORLD_STATE(new byte[] {11}),
+  GOQUORUM_PRIVATE_STORAGE(new byte[] {12}),
+
   BACKWARD_SYNC_HEADERS(new byte[] {13}),
   BACKWARD_SYNC_BLOCKS(new byte[] {14}),
   BACKWARD_SYNC_CHAIN(new byte[] {15}),


### PR DESCRIPTION
Addresses database backwards compatibility broken by https://github.com/hyperledger/besu/commit/067a26337411833ad92d649f208255b1a7954268

Fixes `org.rocksdb.RocksDBException: Column families not opened:` error

See #5303