### PR TITLE
Show correct revert reason data in priv_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Renamed --bonsai-maximum-back-layers-to-load option to --bonsai-historical-block-limit for clarity. Removed --Xbonsai-use-snapshots option as it is no longer functional [#5337](https://github.com/hyperledger/besu/pull/5337)
 - Change Forest to use TransactionDB instead of OptimisticTransactionDB [#5328](https://github.com/hyperledger/besu/pull/5328)
 - Performance: Reduced usage of UInt256 in EVM operations [#5331](https://github.com/hyperledger/besu/pull/5331)
+- Changed wrong error message "Invalid params" when private tx is reverted to "Execution reverted" with correct revert reason in data. [#5369](https://github.com/hyperledger/besu/pull/5369)
 
 ### Bug Fixes
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -116,7 +116,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
   }
 
   @Test
-  public void mustRevertwithRevertReason() throws Exception {
+  public void mustRevertWithRevertReason() throws Exception {
 
     final String privacyGroupId =
         minerNode.execute(createPrivacyGroup("myGroupName", "my group description", minerNode));
@@ -200,7 +200,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
         privCall(privacyGroupId, eventEmitter, true, false, false);
 
     final String errorMessage = priv_call.send().getError().getMessage();
-    assertThat(errorMessage).isEqualTo("Invalid params");
+    assertThat(errorMessage).isEqualTo("Execution reverted");
   }
 
   @Test

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -15,26 +15,31 @@
 package org.hyperledger.besu.tests.acceptance.privacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.tests.web3j.generated.RevertReason.FUNC_REVERTWITHREVERTREASON;
 import static org.web3j.utils.Restriction.UNRESTRICTED;
 
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.ParameterizedEnclaveTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.PrivacyNode;
 import org.hyperledger.besu.tests.acceptance.dsl.privacy.account.PrivacyAccountResolver;
 import org.hyperledger.besu.tests.web3j.generated.EventEmitter;
+import org.hyperledger.besu.tests.web3j.generated.RevertReason;
 import org.hyperledger.enclave.testutil.EnclaveEncryptorType;
 import org.hyperledger.enclave.testutil.EnclaveType;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
+import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import org.web3j.abi.FunctionEncoder;
 import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Bool;
 import org.web3j.abi.datatypes.Function;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.generated.Uint256;
@@ -93,7 +98,8 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
             eventEmitter.getContractAddress(), minerNode.getAddress().toString())
         .verify(eventEmitter);
 
-    final Request<Object, EthCall> priv_call = privCall(privacyGroupId, eventEmitter, false, false);
+    final Request<Object, EthCall> priv_call =
+        privCall(privacyGroupId, eventEmitter, false, false, false);
 
     EthCall resp = priv_call.send();
 
@@ -107,6 +113,38 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
     value = resp.getValue();
     assertThat(new BigInteger(value.substring(2), 16))
         .isEqualByComparingTo(BigInteger.valueOf(VALUE));
+  }
+
+  @Test
+  public void mustRevertwithRevertReason() throws Exception {
+
+    final String privacyGroupId =
+        minerNode.execute(createPrivacyGroup("myGroupName", "my group description", minerNode));
+
+    final RevertReason revertReasonContract =
+        minerNode.execute(
+            privateContractTransactions.createSmartContractWithPrivacyGroupId(
+                RevertReason.class,
+                minerNode.getTransactionSigningKey(),
+                restriction,
+                minerNode.getEnclaveKey(),
+                privacyGroupId));
+
+    privateContractVerifier
+        .validPrivateContractDeployed(
+            revertReasonContract.getContractAddress(), minerNode.getAddress().toString())
+        .verify(revertReasonContract);
+
+    final Request<Object, EthCall> priv_call =
+        privCall(privacyGroupId, revertReasonContract, false, false, true);
+
+    EthCall resp = priv_call.send();
+    assertThat(resp.getRevertReason()).isEqualTo("Execution reverted");
+
+    byte[] bytes = Hex.decode(resp.getError().getData().substring(3, 203));
+    String revertMessage =
+        new String(Arrays.copyOfRange(bytes, 4, bytes.length), Charset.defaultCharset()).trim();
+    assertThat(revertMessage).isEqualTo("RevertReason");
   }
 
   @Test
@@ -131,7 +169,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
 
     final String invalidPrivacyGroup = constructInvalidString(privacyGroupId);
     final Request<Object, EthCall> privCall =
-        privCall(invalidPrivacyGroup, eventEmitter, false, false);
+        privCall(invalidPrivacyGroup, eventEmitter, false, false, false);
 
     final EthCall result = privCall.send();
 
@@ -158,7 +196,8 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
             eventEmitter.getContractAddress(), minerNode.getAddress().toString())
         .verify(eventEmitter);
 
-    final Request<Object, EthCall> priv_call = privCall(privacyGroupId, eventEmitter, true, false);
+    final Request<Object, EthCall> priv_call =
+        privCall(privacyGroupId, eventEmitter, true, false, false);
 
     final String errorMessage = priv_call.send().getError().getMessage();
     assertThat(errorMessage).isEqualTo("Invalid params");
@@ -184,7 +223,8 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
             eventEmitter.getContractAddress(), minerNode.getAddress().toString())
         .verify(eventEmitter);
 
-    final Request<Object, EthCall> priv_call = privCall(privacyGroupId, eventEmitter, false, true);
+    final Request<Object, EthCall> priv_call =
+        privCall(privacyGroupId, eventEmitter, false, true, false);
 
     final EthCall result = priv_call.send();
 
@@ -206,9 +246,10 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
   @Nonnull
   private Request<Object, EthCall> privCall(
       final String privacyGroupId,
-      final Contract eventEmitter,
+      final Contract contract,
       final boolean useInvalidParameters,
-      final boolean useInvalidContractAddress) {
+      final boolean useInvalidContractAddress,
+      final boolean useRevertFunction) {
 
     final Uint256 invalid = new Uint256(BigInteger.TEN);
 
@@ -217,10 +258,15 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
         useInvalidParameters ? Arrays.asList(invalid) : Collections.emptyList();
 
     final Function function =
-        new Function(
-            "value",
-            inputParameters,
-            Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}));
+        useRevertFunction
+            ? new Function(
+                FUNC_REVERTWITHREVERTREASON,
+                inputParameters,
+                Arrays.<TypeReference<?>>asList(new TypeReference<Bool>() {}))
+            : new Function(
+                "value",
+                inputParameters,
+                Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}));
 
     final String encoded = FunctionEncoder.encode(function);
 
@@ -231,7 +277,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
                 + ":"
                 + minerNode.getBesu().getJsonRpcPort().get());
 
-    final String validContractAddress = eventEmitter.getContractAddress();
+    final String validContractAddress = contract.getContractAddress();
     final String invalidContractAddress = constructInvalidString(validContractAddress);
     final String contractAddress =
         useInvalidContractAddress ? invalidContractAddress : validContractAddress;

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/privacy/PrivCallAcceptanceTest.java
@@ -200,7 +200,7 @@ public class PrivCallAcceptanceTest extends ParameterizedEnclaveTestBase {
         privCall(privacyGroupId, eventEmitter, true, false, false);
 
     final String errorMessage = priv_call.send().getError().getMessage();
-    assertThat(errorMessage).isEqualTo("Execution reverted");
+    assertThat(errorMessage).isEqualTo("Invalid params");
   }
 
   @Test

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
@@ -22,11 +22,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.AbstractBlockP
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacyIdProvider;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
+import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
+import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
 public class PrivCall extends AbstractBlockParameterMethod {
 
@@ -72,8 +75,7 @@ public class PrivCall extends AbstractBlockParameterMethod {
                                 request.getRequest().getId(), result.getOutput().toString())),
                         reason ->
                             new JsonRpcErrorResponse(
-                                request.getRequest().getId(),
-                                JsonRpcErrorConverter.convertTransactionInvalidReason(reason))))
+                                request.getRequest().getId(), errorResponse(result, reason))))
         .orElse(validRequestBlockNotFound(request));
   }
 
@@ -84,6 +86,18 @@ public class PrivCall extends AbstractBlockParameterMethod {
   @Override
   public JsonRpcResponse response(final JsonRpcRequestContext requestContext) {
     return (JsonRpcResponse) findResultByParamType(requestContext);
+  }
+
+  private JsonRpcError errorResponse(
+      final TransactionProcessingResult result, final TransactionInvalidReason reason) {
+    final JsonRpcError jsonRpcError;
+    if (result.getRevertReason().isPresent()) {
+      jsonRpcError = JsonRpcError.REVERT_ERROR;
+      jsonRpcError.setData(result.getRevertReason().get().toHexString());
+    } else {
+      jsonRpcError = JsonRpcErrorConverter.convertTransactionInvalidReason(reason);
+    }
+    return jsonRpcError;
   }
 
   private JsonCallParameter validateAndGetCallParams(final JsonRpcRequestContext request) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
@@ -91,12 +91,13 @@ public class PrivCall extends AbstractBlockParameterMethod {
   private JsonRpcError errorResponse(
       final TransactionProcessingResult result, final TransactionInvalidReason reason) {
     final JsonRpcError jsonRpcError;
-    if (result.getRevertReason().isPresent()) {
+    if (result.getRevertReason().isPresent() && result.getRevertReason().get().size() >= 4) {
       jsonRpcError = JsonRpcError.REVERT_ERROR;
       jsonRpcError.setData(result.getRevertReason().get().toHexString());
     } else {
       jsonRpcError = JsonRpcErrorConverter.convertTransactionInvalidReason(reason);
     }
+
     return jsonRpcError;
   }
 

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -163,7 +163,7 @@ tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = '04f338a6e673a6b4d906ec9d6d2bc939309357a5'
+    def expectedHash = '080fe87c816ca3b4e1ba55eb7306d3ef323b75af'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
       exec {
@@ -179,14 +179,14 @@ tasks.register('validateReferenceTestSubmodule') {
 
     if (!result.toString().contains(expectedHash)) {
       throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
-  
-If this is a deliberate change where you are updating the reference tests 
-then update "expectedHash" in `ethereum/referencetests/build.gradle` as the 
+
+If this is a deliberate change where you are updating the reference tests
+then update "expectedHash" in `ethereum/referencetests/build.gradle` as the
 commit hash for this task.
 Expected hash   :  ${expectedHash}
 Full git output : ${result}
 
-If this is accidental you can correct the reference test versions with the 
+If this is accidental you can correct the reference test versions with the
 following commands:
     pushd ${submodulePath}
     git checkout ${expectedHash}

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -179,14 +179,14 @@ tasks.register('validateReferenceTestSubmodule') {
 
     if (!result.toString().contains(expectedHash)) {
       throw new GradleException("""For the Ethereum Reference Tests the git commit did not match what was expected.
-
-If this is a deliberate change where you are updating the reference tests
-then update "expectedHash" in `ethereum/referencetests/build.gradle` as the
+  
+If this is a deliberate change where you are updating the reference tests 
+then update "expectedHash" in `ethereum/referencetests/build.gradle` as the 
 commit hash for this task.
 Expected hash   :  ${expectedHash}
 Full git output : ${result}
 
-If this is accidental you can correct the reference test versions with the
+If this is accidental you can correct the reference test versions with the 
 following commands:
     pushd ${submodulePath}
     git checkout ${expectedHash}

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -163,7 +163,7 @@ tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = '080fe87c816ca3b4e1ba55eb7306d3ef323b75af'
+    def expectedHash = '04f338a6e673a6b4d906ec9d6d2bc939309357a5'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
       exec {


### PR DESCRIPTION
## PR description
priv_call was showing incorrect error -"invalid params" even when execution is reverted. PR fixes to show correct error - "REVERT_ERROR" and show correct revert reason data

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/5223