### PR TITLE
Permissioning - Fix NullPointerException on createPayload (Issue #5370)

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -96,14 +96,15 @@ public class NodeSmartContractV2PermissioningController
   private Bytes createPayload(final EnodeURL enodeUrl) {
     try {
       final String hexNodeIdString = enodeUrl.getNodeId().toUnprefixedHexString();
-      final String address = enodeUrl.toURI().getHost();
+      final String host = enodeUrl.toURI().getHost();
+      final String address = host == null ? enodeUrl.getIpAsString() : host;
       final int port = enodeUrl.getListeningPortOrZero();
 
       final Function connectionAllowedFunction =
           FunctionEncoder.makeFunction(
               "connectionAllowed",
               List.of("string", "string", "uint16"),
-              List.of(hexNodeIdString, address, port),
+              List.of(hexNodeIdString, address == null ? "" : address, port),
               List.of(Bool.TYPE_NAME));
       return Bytes.fromHexString(FunctionEncoder.encode(connectionAllowedFunction));
     } catch (Exception e) {


### PR DESCRIPTION
## PR description
Tries not pass `null` value to `List.of` on method `org.hyperledger.besu.ethereum.permissioning.NodeSmartContractV2PermissioningController.createPayload`
Sometimes method `enodeUrl.toURI().getHost()` returns `null`. In this case, we use `enodeUrl.getIpAsString()` to get IP address. And, if this method returns `null`, use empty String in `List.of`.

## Fixed Issue(s)
fixes #5370

