### PR TITLE
Restore transactions from disk searially to avoid blocking other threads

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -163,7 +163,6 @@ public class TransactionPool implements BlockAddedObserver {
             new BufferedReader(new FileReader(saveFile, StandardCharsets.US_ASCII))) {
           final IntSummaryStatistics stats =
               br.lines()
-                  .parallel()
                   .mapToInt(
                       line -> {
                         final boolean isLocal = line.charAt(0) == 'l';


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

I could happen that when restoring many transactions from disk, to have Vertx thread blocked exception, to avoid that is it safer to restore transactions serially than in parallel.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->