### PR TITLE
Only create DB data dir if it doesn't already exist

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -255,6 +255,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
   private int readDatabaseVersion(final BesuConfiguration commonConfiguration) throws IOException {
     final Path dataDir = commonConfiguration.getDataPath();
     final boolean databaseExists = commonConfiguration.getStoragePath().toFile().exists();
+    final boolean dataDirExists = dataDir.toFile().exists();
     final int databaseVersion;
     if (databaseExists) {
       databaseVersion = DatabaseMetadata.lookUpFrom(dataDir).getVersion();
@@ -265,7 +266,9 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
     } else {
       databaseVersion = commonConfiguration.getDatabaseVersion();
       LOG.info("No existing database detected at {}. Using version {}", dataDir, databaseVersion);
-      Files.createDirectories(dataDir);
+      if (!dataDirExists) {
+        Files.createDirectories(dataDir);
+      }
       new DatabaseMetadata(databaseVersion).writeToDirectory(dataDir);
     }
 


### PR DESCRIPTION
## PR description
This PR skips creation of the database directory if it exists. While the call to `Files.createDirectories()` (which we use to initialise it if the DB needs creating) should be a no-op in this case, symlinks cause it to fail so the safer thing to do is confirm that the directory doesn't actually exist before making that call.

## Fixed Issue(s)
Fixed https://github.com/hyperledger/besu/issues/4043