### PR TITLE
Fix Docker image failing to start Besu with NoClassDefFoundError for org.xerial.snappy.Snappy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 - Fix eth_feeHistory response for the case in which blockCount is higher than highestBlock requested. [#5397](https://github.com/hyperledger/besu/pull/5397)
+- Fix Besu failing to start due to NoClassDefFoundError with org.xerial.snappy.Snappy library. [#5462](https://github.com/hyperledger/besu/pull/5462)
 
 ### Download Links
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Bug Fixes
 - Fix eth_feeHistory response for the case in which blockCount is higher than highestBlock requested. [#5397](https://github.com/hyperledger/besu/pull/5397)
-- Fix Besu failing to start due to NoClassDefFoundError with org.xerial.snappy.Snappy library. [#5462](https://github.com/hyperledger/besu/pull/5462)
+- Fix Besu Docker image failing to start due to NoClassDefFoundError with org.xerial.snappy.Snappy library. [#5462](https://github.com/hyperledger/besu/pull/5462)
 
 ### Download Links
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Remove launcher command line utility [#5355](https://github.com/hyperledger/besu/pull/5355)
 - Remove deprecated `tx-pool-future-max-by-account` option, see instead: `tx-pool-limit-by-account-percentage` [#5361](https://github.com/hyperledger/besu/pull/5361)
 - Default configuration for the deprecated ECIP-1049 network has been removed from the CLI network list [#5371](https://github.com/hyperledger/besu/pull/5371)
+- Besu now requires glibc 2.32 or later to run. Ubuntu 20.04 users will need to update to a newer version of Ubuntu, 22.04 or later to run Besu
 
 ### Additions and Improvements
 - An alternate build target for the EVM using GraalVM AOT compilation was added.  [#5192](https://github.com/hyperledger/besu/pull/5192)

--- a/docker/openjdk-17-debug/Dockerfile
+++ b/docker/openjdk-17-debug/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 
 ARG VERSION="dev"
 RUN apt-get update  && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
  apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.21* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \

--- a/docker/openjdk-17-debug/Dockerfile
+++ b/docker/openjdk-17-debug/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 
 ARG VERSION="dev"
 RUN apt-get update  && \
- apt-get install --no-install-recommends -q --assume-yes curl=7* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
+ apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.21* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \

--- a/docker/openjdk-17-debug/Dockerfile
+++ b/docker/openjdk-17-debug/Dockerfile
@@ -1,9 +1,9 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG VERSION="dev"
 RUN apt-get update  && \
- apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.20* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
+ apt-get install --no-install-recommends -q --assume-yes curl=7* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \

--- a/docker/openjdk-17/Dockerfile
+++ b/docker/openjdk-17/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \

--- a/docker/openjdk-17/Dockerfile
+++ b/docker/openjdk-17/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
  apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
  apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fix Besu failing to start when using Docker 23.4.0 due to `NoClassDefFoundError` for `org.xerial.snappy.Snappy`.

The cause was that we are using an older version of glibc for some Docker images due to the older version of the Ubuntu distro being used.

Changes
- Updated docker images to use Ubuntu 22.04 so that a newer version of glibc is used. This fixes an issue with snappy library where the library cannot be loaded.
- Included ca-certificates-java as a separate install to fix Java install issue on Ubuntu https://github.com/adoptium/installer/issues/105

Related to the update of the snappy library https://github.com/xerial/snappy-java/issues/417#issuecomment-1513916298

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5463 