### PR TITLE
Prevent rocksdb segfaults when accessing closed storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Unite the tx-pool CLI options under the same Tx Pool Options group in UX. [#5466](https://github.com/hyperledger/besu/issues/5466)
 
 ### Bug Fixes
+- check to ensure storage and transactions are not closed prior to reading/writing [#5527](https://github.com/hyperledger/besu/pull/5527) 
 
 ### Download Links
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -77,14 +77,23 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
             cf.complete(
                 resp.otherwise(
                         t -> {
-                          LOG.error(
-                              String.format("failed to exec consensus method %s", this.getName()),
-                              t);
+                          if (LOG.isDebugEnabled()) {
+                            LOG.atDebug()
+                                .setMessage("failed to exec consensus method {}")
+                                .addArgument(this.getName())
+                                .setCause(t)
+                                .log();
+                          } else {
+                            LOG.atError()
+                                .setMessage("failed to exec consensus method {}, error: {}")
+                                .addArgument(this.getName())
+                                .addArgument(t.getMessage())
+                                .log();
+                          }
                           return new JsonRpcErrorResponse(
                               request.getRequest().getId(), JsonRpcError.INVALID_REQUEST);
                         })
                     .result()));
-
     try {
       return cf.get();
     } catch (InterruptedException e) {

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'mNsOaygvwl0WK5sz4sDg8Msy87KpxgDwFnIH4J6SG+E='
+  knownHash = 'V3sh575rrexPv+Ywe8mURT4Z3fREDCDd79PpAISFx8A='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'gfED3Pzd/+CSSrTtDo1X+lkc7qwffDqF98EZIDMCOIc='
+  knownHash = 'mNsOaygvwl0WK5sz4sDg8Msy87KpxgDwFnIH4J6SG+E='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorage.java
@@ -116,7 +116,7 @@ public interface KeyValueStorage extends Closeable {
   KeyValueStorageTransaction startTransaction() throws StorageException;
 
   /**
-   * Return Whether the underlying storage is closed or not.
+   * Return Whether the underlying storage is closed.
    *
    * @return boolean indicating whether the storage is closed.
    */

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorage.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/storage/KeyValueStorage.java
@@ -114,4 +114,11 @@ public interface KeyValueStorage extends Closeable {
    * @throws StorageException problem encountered when starting a new transaction.
    */
   KeyValueStorageTransaction startTransaction() throws StorageException;
+
+  /**
+   * Return Whether the underlying storage is closed or not.
+   *
+   * @return boolean indicating whether the storage is closed.
+   */
+  boolean isClosed();
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
@@ -81,7 +81,8 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     final WriteOptions writeOptions = new WriteOptions();
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<>(
-        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions));
+        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions),
+        this.closed::get);
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/OptimisticRocksDBColumnarKeyValueStorage.java
@@ -81,8 +81,7 @@ public class OptimisticRocksDBColumnarKeyValueStorage extends RocksDBColumnarKey
     final WriteOptions writeOptions = new WriteOptions();
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<>(
-        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions),
-        this.closed::get);
+        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions), this.closed::get);
   }
 
   /**

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueSnapshot.java
@@ -109,6 +109,11 @@ public class RocksDBColumnarKeyValueSnapshot implements SnappedKeyValueStorage {
   }
 
   @Override
+  public boolean isClosed() {
+    return closed.get();
+  }
+
+  @Override
   public void clear() {
     throw new UnsupportedOperationException(
         "RocksDBColumnarKeyValueSnapshot does not support clear");

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -328,6 +328,11 @@ public abstract class RocksDBColumnarKeyValueStorage
     }
   }
 
+  @Override
+  public boolean isClosed() {
+    return closed.get();
+  }
+
   void throwIfClosed() {
     if (closed.get()) {
       LOG.error("Attempting to use a closed RocksDbKeyValueStorage");

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -87,7 +87,9 @@ public abstract class RocksDBColumnarKeyValueStorage
     RocksDbUtil.loadNativeLibrary();
   }
 
+  /** atomic boolean to track if the storage is closed */
   protected final AtomicBoolean closed = new AtomicBoolean(false);
+
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
   private final ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -87,7 +87,7 @@ public abstract class RocksDBColumnarKeyValueStorage
     RocksDbUtil.loadNativeLibrary();
   }
 
-  private final AtomicBoolean closed = new AtomicBoolean(false);
+  protected final AtomicBoolean closed = new AtomicBoolean(false);
   private final WriteOptions tryDeleteOptions =
       new WriteOptions().setNoSlowdown(true).setIgnoreMissingColumnFamilies(true);
   private final ReadOptions readOptions = new ReadOptions().setVerifyChecksums(false);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
@@ -86,6 +86,7 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     final WriteOptions writeOptions = new WriteOptions();
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<>(
-        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions));
+        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions),
+        this.closed::get);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
@@ -86,7 +86,6 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
     final WriteOptions writeOptions = new WriteOptions();
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<>(
-        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions),
-        this.closed::get);
+        new RocksDbTransaction(db.beginTransaction(writeOptions), writeOptions), this.closed::get);
   }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -187,6 +187,11 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   }
 
   @Override
+  public boolean isClosed() {
+    return closed.get();
+  }
+
+  @Override
   public void close() {
     if (closed.compareAndSet(false, true)) {
       tryDeleteOptions.close();

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/unsegmented/RocksDBKeyValueStorage.java
@@ -97,6 +97,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   @Override
   public void clear() throws StorageException {
     throwIfClosed();
+
     try (final RocksIterator rocksIterator = db.newIterator()) {
       rocksIterator.seekToFirst();
       if (rocksIterator.isValid()) {
@@ -141,6 +142,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   @Override
   public Stream<Pair<byte[], byte[]>> stream() {
     throwIfClosed();
+
     final RocksIterator rocksIterator = db.newIterator();
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStream();
@@ -149,6 +151,7 @@ public class RocksDBKeyValueStorage implements KeyValueStorage {
   @Override
   public Stream<byte[]> streamKeys() {
     throwIfClosed();
+
     final RocksIterator rocksIterator = db.newIterator();
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStreamKeys();

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryKeyValueStorage.java
@@ -154,6 +154,11 @@ public class InMemoryKeyValueStorage
     return new KeyValueStorageTransactionTransitionValidatorDecorator(new InMemoryTransaction());
   }
 
+  @Override
+  public boolean isClosed() {
+    return false;
+  }
+
   /**
    * Key set.
    *

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -176,7 +176,7 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
   private void throwIfClosed() {
     if (parent.isClosed()) {
       LOG.error("Attempting to use a closed RocksDBKeyValueStorage");
-      throw new IllegalStateException("Storage has been closed");
+      throw new StorageException("Storage has been closed");
     }
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -142,6 +142,7 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
   @Override
   public KeyValueStorageTransaction startTransaction() {
     throwIfClosed();
+
     return new KeyValueStorageTransactionTransitionValidatorDecorator(
         new InMemoryTransaction() {
           @Override

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LayeredKeyValueStorage.java
@@ -30,10 +30,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Key value storage which stores in memory all updates to a parent worldstate storage. */
 public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
     implements SnappedKeyValueStorage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LayeredKeyValueStorage.class);
 
   private final KeyValueStorage parent;
 
@@ -65,6 +69,8 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
 
   @Override
   public Optional<byte[]> get(final byte[] key) throws StorageException {
+    throwIfClosed();
+
     final Lock lock = rwLock.readLock();
     lock.lock();
     try {
@@ -82,6 +88,8 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
 
   @Override
   public Stream<Pair<byte[], byte[]>> stream() {
+    throwIfClosed();
+
     final Lock lock = rwLock.readLock();
     lock.lock();
     try {
@@ -104,6 +112,8 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
 
   @Override
   public Stream<byte[]> streamKeys() {
+    throwIfClosed();
+
     final Lock lock = rwLock.readLock();
     lock.lock();
     try {
@@ -131,6 +141,7 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
 
   @Override
   public KeyValueStorageTransaction startTransaction() {
+    throwIfClosed();
     return new KeyValueStorageTransactionTransitionValidatorDecorator(
         new InMemoryTransaction() {
           @Override
@@ -152,7 +163,19 @@ public class LayeredKeyValueStorage extends InMemoryKeyValueStorage
   }
 
   @Override
+  public boolean isClosed() {
+    return parent.isClosed();
+  }
+
+  @Override
   public SnappedKeyValueStorage clone() {
     return new LayeredKeyValueStorage(hashValueStore, parent);
+  }
+
+  private void throwIfClosed() {
+    if (parent.isClosed()) {
+      LOG.error("Attempting to use a closed RocksDBKeyValueStorage");
+      throw new IllegalStateException("Storage has been closed");
+    }
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/LimitedInMemoryKeyValueStorage.java
@@ -144,6 +144,11 @@ public class LimitedInMemoryKeyValueStorage implements KeyValueStorage {
     return new KeyValueStorageTransactionTransitionValidatorDecorator(new MemoryTransaction());
   }
 
+  @Override
+  public boolean isClosed() {
+    return false;
+  }
+
   private class MemoryTransaction implements KeyValueStorageTransaction {
 
     private Map<Bytes, byte[]> updatedValues = new HashMap<>();

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
@@ -123,6 +123,10 @@ public interface SegmentedKeyValueStorage<S> extends Closeable {
    */
   void clear(S segmentHandle);
 
+  /**
+   * Whether the underlying storage is closed or not.
+   * @return boolean indicating whether the underlying storage is closed or not.
+   */
   boolean isClosed();
 
   /**

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
@@ -125,6 +125,7 @@ public interface SegmentedKeyValueStorage<S> extends Closeable {
 
   /**
    * Whether the underlying storage is closed or not.
+   *
    * @return boolean indicating whether the underlying storage is closed or not.
    */
   boolean isClosed();

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
@@ -123,6 +123,8 @@ public interface SegmentedKeyValueStorage<S> extends Closeable {
    */
   void clear(S segmentHandle);
 
+  boolean isClosed();
+
   /**
    * Represents a set of changes to be committed atomically. A single transaction is not
    * thread-safe, but multiple transactions can execute concurrently.

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorage.java
@@ -124,9 +124,9 @@ public interface SegmentedKeyValueStorage<S> extends Closeable {
   void clear(S segmentHandle);
 
   /**
-   * Whether the underlying storage is closed or not.
+   * Whether the underlying storage is closed.
    *
-   * @return boolean indicating whether the underlying storage is closed or not.
+   * @return boolean indicating whether the underlying storage is closed.
    */
   boolean isClosed();
 

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
@@ -144,7 +144,7 @@ public class SegmentedKeyValueStorageAdapter<S> implements KeyValueStorage {
   private void throwIfClosed() {
     if (storage.isClosed()) {
       LOG.error("Attempting to use a closed Storage instance.");
-      throw new IllegalStateException("Storage has been closed");
+      throw new StorageException("Storage has been closed");
     }
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageAdapter.java
@@ -26,6 +26,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The type Segmented key value storage adapter.
@@ -34,6 +36,7 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class SegmentedKeyValueStorageAdapter<S> implements KeyValueStorage {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SegmentedKeyValueStorageAdapter.class);
   private final S segmentHandle;
   private final SegmentedKeyValueStorage<S> storage;
 
@@ -51,41 +54,49 @@ public class SegmentedKeyValueStorageAdapter<S> implements KeyValueStorage {
 
   @Override
   public void clear() {
+    throwIfClosed();
     storage.clear(segmentHandle);
   }
 
   @Override
   public boolean containsKey(final byte[] key) throws StorageException {
+    throwIfClosed();
     return storage.containsKey(segmentHandle, key);
   }
 
   @Override
   public Optional<byte[]> get(final byte[] key) throws StorageException {
+    throwIfClosed();
     return storage.get(segmentHandle, key);
   }
 
   @Override
   public Set<byte[]> getAllKeysThat(final Predicate<byte[]> returnCondition) {
+    throwIfClosed();
     return storage.getAllKeysThat(segmentHandle, returnCondition);
   }
 
   @Override
   public Set<byte[]> getAllValuesFromKeysThat(final Predicate<byte[]> returnCondition) {
+    throwIfClosed();
     return storage.getAllValuesFromKeysThat(segmentHandle, returnCondition);
   }
 
   @Override
   public Stream<Pair<byte[], byte[]>> stream() {
+    throwIfClosed();
     return storage.stream(segmentHandle);
   }
 
   @Override
   public Stream<byte[]> streamKeys() {
+    throwIfClosed();
     return storage.streamKeys(segmentHandle);
   }
 
   @Override
   public boolean tryDelete(final byte[] key) {
+    throwIfClosed();
     return storage.tryDelete(segmentHandle, key);
   }
 
@@ -101,23 +112,39 @@ public class SegmentedKeyValueStorageAdapter<S> implements KeyValueStorage {
 
       @Override
       public void put(final byte[] key, final byte[] value) {
+        throwIfClosed();
         transaction.put(segmentHandle, key, value);
       }
 
       @Override
       public void remove(final byte[] key) {
+        throwIfClosed();
         transaction.remove(segmentHandle, key);
       }
 
       @Override
       public void commit() throws StorageException {
+        throwIfClosed();
         transaction.commit();
       }
 
       @Override
       public void rollback() {
+        throwIfClosed();
         transaction.rollback();
       }
     };
+  }
+
+  @Override
+  public boolean isClosed() {
+    return storage.isClosed();
+  }
+
+  private void throwIfClosed() {
+    if (storage.isClosed()) {
+      LOG.error("Attempting to use a closed Storage instance.");
+      throw new IllegalStateException("Storage has been closed");
+    }
   }
 }

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionTransitionValidatorDecorator.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionTransitionValidatorDecorator.java
@@ -37,6 +37,7 @@ public class SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<S>
    * Instantiates a new Segmented key value storage transaction transition validator decorator.
    *
    * @param toDecorate the to decorate
+   * @param isClosed supplier that returns true if the storage is closed
    */
   public SegmentedKeyValueStorageTransactionTransitionValidatorDecorator(
       final Transaction<S> toDecorate, final Supplier<Boolean> isClosed) {

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionTransitionValidatorDecorator.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedKeyValueStorageTransactionTransitionValidatorDecorator.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkState;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
 import org.hyperledger.besu.services.kvstore.SegmentedKeyValueStorage.Transaction;
 
+import java.util.function.Supplier;
+
 /**
  * The Segmented key value storage transaction transition validator decorator.
  *
@@ -28,6 +30,7 @@ public class SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<S>
     implements Transaction<S> {
 
   private final Transaction<S> transaction;
+  private final Supplier<Boolean> isClosed;
   private boolean active = true;
 
   /**
@@ -36,25 +39,29 @@ public class SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<S>
    * @param toDecorate the to decorate
    */
   public SegmentedKeyValueStorageTransactionTransitionValidatorDecorator(
-      final Transaction<S> toDecorate) {
+      final Transaction<S> toDecorate, final Supplier<Boolean> isClosed) {
     this.transaction = toDecorate;
+    this.isClosed = isClosed;
   }
 
   @Override
   public final void put(final S segment, final byte[] key, final byte[] value) {
     checkState(active, "Cannot invoke put() on a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke put() on a closed storage.");
     transaction.put(segment, key, value);
   }
 
   @Override
   public final void remove(final S segment, final byte[] key) {
     checkState(active, "Cannot invoke remove() on a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke remove() on a closed storage.");
     transaction.remove(segment, key);
   }
 
   @Override
   public final void commit() throws StorageException {
     checkState(active, "Cannot commit a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke commit() on a closed storage.");
     active = false;
     transaction.commit();
   }
@@ -62,6 +69,7 @@ public class SegmentedKeyValueStorageTransactionTransitionValidatorDecorator<S>
   @Override
   public final void rollback() {
     checkState(active, "Cannot rollback a completed transaction.");
+    checkState(!isClosed.get(), "Cannot invoke rollback() on a closed storage.");
     active = false;
     transaction.rollback();
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
gate transaction access on whether the underlying storage has closed.  This prevents segfaults at shutdown when we close rocksdb, but there are async processes attempting to access the db.

Currently evaluating to ensure there is no noticeable performance regression.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#5362 