### PR TITLE
Remove push metrics port from effective ports

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -3410,10 +3410,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     addPortIfEnabled(
         effectivePorts, metricsOptionGroup.metricsPort, metricsOptionGroup.isMetricsEnabled);
     addPortIfEnabled(
-        effectivePorts,
-        metricsOptionGroup.metricsPushPort,
-        metricsOptionGroup.isMetricsPushEnabled);
-    addPortIfEnabled(
         effectivePorts, minerOptionGroup.stratumPort, minerOptionGroup.iStratumMiningEnabled);
     return effectivePorts;
   }


### PR DESCRIPTION
This results in a port conflict check however the push metrics port refers to a push gateway for besu to connect to rather than a port it is serving itself.

If you run besu with push metrics [following this guide](https://besu.hyperledger.org/en/stable/public-networks/how-to/monitor/metrics/#run-prometheus-with-besu-in-push-mode) then the bug fixed by this PR is that you have to run besu first, followed by the push gateway.

Now you can start either besu or push gateway in any order.