### PR TITLE
Make the return of hardforkfor optional

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -204,7 +204,7 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
   }
 
   @Override
-  public ScheduledProtocolSpec.Hardfork hardforkFor(
+  public Optional<ScheduledProtocolSpec.Hardfork> hardforkFor(
       final Predicate<ScheduledProtocolSpec> predicate) {
     return this.transitionUtils.dispatchFunctionAccordingToMergeState(
         schedule -> schedule.hardforkFor(predicate));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -110,7 +110,7 @@ public abstract class AbstractEngineGetPayloadTest {
     when(mergeContext.retrieveBlockById(mockPid)).thenReturn(Optional.of(mockBlockWithReceipts));
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolSchedule.hardforkFor(any()))
-        .thenReturn(new ScheduledProtocolSpec.Hardfork("shanghai", SHANGHAI_AT));
+        .thenReturn(Optional.of(new ScheduledProtocolSpec.Hardfork("shanghai", SHANGHAI_AT)));
     this.method =
         methodFactory.create(
             vertx,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DefaultProtocolSchedule.java
@@ -122,15 +122,12 @@ public class DefaultProtocolSchedule implements ProtocolSchedule {
   }
 
   @Override
-  public ScheduledProtocolSpec.Hardfork hardforkFor(
+  public Optional<ScheduledProtocolSpec.Hardfork> hardforkFor(
       final Predicate<ScheduledProtocolSpec> predicate) {
-    ScheduledProtocolSpec spec =
-        this.protocolSpecs.stream()
-            .filter(predicate)
-            .findFirst()
-            .orElseThrow(
-                () -> new IllegalStateException("No hardfork found for predicate " + predicate));
-    return spec.fork();
+    return this.protocolSpecs.stream()
+        .filter(predicate)
+        .findFirst()
+        .map(ScheduledProtocolSpec::fork);
   }
 
   @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolSchedule.java
@@ -47,7 +47,7 @@ public interface ProtocolSchedule extends PrivacySupportingProtocolSchedule {
 
   void putTimestampMilestone(final long timestamp, final ProtocolSpec protocolSpec);
 
-  default ScheduledProtocolSpec.Hardfork hardforkFor(
+  default Optional<ScheduledProtocolSpec.Hardfork> hardforkFor(
       final Predicate<ScheduledProtocolSpec> predicate) {
     throw new UnsupportedOperationException("Not implemented");
   }

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/NoRewardProtocolScheduleWrapper.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/NoRewardProtocolScheduleWrapper.java
@@ -115,7 +115,7 @@ public class NoRewardProtocolScheduleWrapper implements ProtocolSchedule {
   }
 
   @Override
-  public ScheduledProtocolSpec.Hardfork hardforkFor(
+  public Optional<ScheduledProtocolSpec.Hardfork> hardforkFor(
       final Predicate<ScheduledProtocolSpec> predicate) {
     return delegate.hardforkFor(predicate);
   }


### PR DESCRIPTION
## PR description
Make the return of hardforkfor optional.

For the EngineGetPayloadV3, when Shanghai and Cancun had the same milestone, an exception was 

```
java.lang.IllegalStateException: No hardfork found for predicate org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadV3$$Lambda$840/0x00000008010a4838@237b2852
	at org.hyperledger.besu.ethereum.mainnet.DefaultProtocolSchedule.lambda$hardforkFor$4(DefaultProtocolSchedule.java:132)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at org.hyperledger.besu.ethereum.mainnet.DefaultProtocolSchedule.hardforkFor(DefaultProtocolSchedule.java:131)
	at org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule.lambda$hardforkFor$3(TransitionProtocolSchedule.java:210)
	at org.hyperledger.besu.consensus.merge.TransitionUtils.dispatchFunctionAccordingToMergeState(TransitionUtils.java:75)
	at org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule.hardforkFor(TransitionProtocolSchedule.java:209)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadV3.<init>(EngineGetPayloadV3.java:55)
	at org.hyperledger.besu.ethereum.api.jsonrpc.methods.ExecutionEngineJsonRpcMethods.create(ExecutionEngineJsonRpcMethods.java:157)
	at org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods.create(ApiGroupJsonRpcMethods.java:30)
	at org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory.methods(JsonRpcMethodsFactory.java:144)
	at org.hyperledger.besu.RunnerBuilder.jsonRpcMethods(RunnerBuilder.java:1201)
	at org.hyperledger.besu.RunnerBuilder.build(RunnerBuilder.java:831)
	at org.hyperledger.besu.cli.BesuCommand.synchronize(BesuCommand.java:3086)
	at org.hyperledger.besu.cli.BesuCommand.buildRunner(BesuCommand.java:1725)
	at org.hyperledger.besu.cli.BesuCommand.run(BesuCommand.java:1560)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2026)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at org.hyperledger.besu.cli.util.ConfigOptionSearchAndRunHandler.handle(ConfigOptionSearchAndRunHandler.java:62)
	at org.hyperledger.besu.cli.util.ConfigOptionSearchAndRunHandler.handle(ConfigOptionSearchAndRunHandler.java:33)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at org.hyperledger.besu.cli.BesuCommand.parse(BesuCommand.java:1717)
	at org.hyperledger.besu.cli.BesuCommand.parse(BesuCommand.java:1512)
	at org.hyperledger.besu.Besu.main(Besu.java:39)
```


