### PR TITLE
Migrate util from JUnit 4.0 to JUnit 5.0

### DIFF
--- a/util/build.gradle
+++ b/util/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
   implementation 'org.xerial.snappy:snappy-java'
 
-  testImplementation 'junit:junit'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'

--- a/util/src/test/java/org/hyperledger/besu/util/ExceptionUtilsTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/ExceptionUtilsTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CompletionException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExceptionUtilsTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/FutureUtilsTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/FutureUtilsTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FutureUtilsTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/LimitedSetTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/LimitedSetTest.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.util.LimitedSet.Mode;
 
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LimitedSetTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NetworkUtilityTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/SubscribersTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/SubscribersTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SubscribersTest {
   private final Runnable subscriber1 = mock(Runnable.class);

--- a/util/src/test/java/org/hyperledger/besu/util/number/FractionTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/number/FractionTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.util.number;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FractionTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/number/PercentageTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/number/PercentageTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.util.number;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PercentageTest {
 

--- a/util/src/test/java/org/hyperledger/besu/util/number/PositiveNumberTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/number/PositiveNumberTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.util.number;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PositiveNumberTest {
 


### PR DESCRIPTION
Migrate util tests from JUnit 4.0 to JUnit 5.0
fixes: #5556 