### PR TITLE
[4844] Add toString to VersionedHash

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/blobs/VersionedHash.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/blobs/VersionedHash.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Hash;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
@@ -70,4 +71,10 @@ public class VersionedHash {
 
   public static final VersionedHash DEFAULT_VERSIONED_HASH =
       new VersionedHash((byte) 0x01, Hash.wrap(Bytes32.wrap(Bytes.repeat((byte) 42, 32))));
+
+  @JsonValue
+  @Override
+  public String toString() {
+    return this.toBytes().toHexString();
+  }
 }


### PR DESCRIPTION
## PR description
Add toString to VersionedHash and set it to be the JsonValue of the VersionedHash object

Actual: 
```
{
...
  blobVersionedHashes: [{
      versionId: 1
  }, {
      versionId: 1
  }, {
      versionId: 1
  }, {
      versionId: 1
  }, {
      versionId: 1
  }, {
      versionId: 1
  }],
 ...
}
```
Expected:

```
{
...
  blobVersionedHashes: ["0x01a8a4a49dcd1b91c376c87d7d6a6e73ee3792205864bf61781e8e3ad19d0092", 
"0x01069693395fb9a698b257e6c25380f32393bc0cf17a290f9e7fcea3c4ae7b8b", 
"0x01111dafbfcc0caa0803fc22f697fd3b9171252504e14ec0443f04a2b3288715", 
"0x01d1dfff9c15b3201980d8f9b958a8ade73e3e1e0ca76c54785a33e09519be7a", 
"0x01a7b4b55dd68d59685abcd629708c5de44c8e9edf3671602538eba23375893c", 
"0x013586020d67ab6808e681c2e6a2d1e854c84e5bc49df2ed34e218eace844f8b"],
...
}
```
