### PR TITLE
Start with txpool disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Breaking Changes
 
 ### Additions and Improvements
-- EvmTool now executes the `execution-spec-tests` via the `t8n` and `b11r`. See the [README](ethereum/evmtool/README.md) in EvmTool for more instructions. 
+- EvmTool now executes the `execution-spec-tests` via the `t8n` and `b11r`. See the [README](ethereum/evmtool/README.md) in EvmTool for more instructions.
+- Improve lifecycle management of the transaction pool [#5634](https://github.com/hyperledger/besu/pull/5634)
 
 ### Bug Fixes
 - Use the node's configuration to determine if DNS enode URLs are allowed in calls to `admin_addPeer` and `admin_removePeer` [#5584](https://github.com/hyperledger/besu/pull/5584)
 - Align the implementation of Eth/68 `NewPooledTransactionHashes` to other clients, using unsigned int for encoding size. [#5640](https://github.com/hyperledger/besu/pull/5640)
+- Failure at startup when enabling layered txpool before initial sync done [#5636](https://github.com/hyperledger/besu/issues/5636)
 
 ### Download Links
 

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -197,7 +197,7 @@ public class Runner implements AutoCloseable {
         service ->
             waitForServiceToStop(
                 "ipcJsonRpc", service.stop().toCompletionStage().toCompletableFuture()));
-    waitForServiceToStop("Transaction Pool", besuController.getTransactionPool()::saveToDisk);
+    waitForServiceToStop("Transaction Pool", besuController.getTransactionPool()::setDisabled);
     metrics.ifPresent(service -> waitForServiceToStop("metrics", service.stop()));
     ethStatsService.ifPresent(EthStatsService::stop);
     besuController.getMiningCoordinator().stop();

--- a/besu/src/main/java/org/hyperledger/besu/Runner.java
+++ b/besu/src/main/java/org/hyperledger/besu/Runner.java
@@ -197,7 +197,7 @@ public class Runner implements AutoCloseable {
         service ->
             waitForServiceToStop(
                 "ipcJsonRpc", service.stop().toCompletionStage().toCompletableFuture()));
-    waitForServiceToStop("Transaction Pool", besuController.getTransactionPool()::setDisabled);
+    waitForServiceToStop("Transaction Pool", besuController.getTransactionPool().setDisabled());
     metrics.ifPresent(service -> waitForServiceToStop("metrics", service.stop()));
     ethStatsService.ifPresent(EthStatsService::stop);
     besuController.getMiningCoordinator().stop();

--- a/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
@@ -128,7 +128,8 @@ public final class RunnerBuilderTest {
     when(besuController.getNodeKey()).thenReturn(nodeKey);
     when(besuController.getMiningParameters()).thenReturn(mock(MiningParameters.class));
     when(besuController.getPrivacyParameters()).thenReturn(mock(PrivacyParameters.class));
-    when(besuController.getTransactionPool()).thenReturn(mock(TransactionPool.class));
+    when(besuController.getTransactionPool())
+        .thenReturn(mock(TransactionPool.class, RETURNS_DEEP_STUBS));
     when(besuController.getSynchronizer()).thenReturn(mock(Synchronizer.class));
     when(besuController.getMiningCoordinator()).thenReturn(mock(MiningCoordinator.class));
     when(besuController.getMiningCoordinator()).thenReturn(mock(MergeMiningCoordinator.class));

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -112,7 +112,7 @@ public class EthGetFilterChangesIntegrationTest {
 
     transactionPool =
         new TransactionPool(
-            transactions,
+            () -> transactions,
             executionContext.getProtocolSchedule(),
             protocolContext,
             batchAddedListener,
@@ -120,6 +120,7 @@ public class EthGetFilterChangesIntegrationTest {
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),
             new TransactionPoolMetrics(metricsSystem),
             TransactionPoolConfiguration.DEFAULT);
+    transactionPool.setEnabled();
     final BlockchainQueries blockchainQueries =
         new BlockchainQueries(blockchain, protocolContext.getWorldStateArchive());
     filterManager =

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -112,7 +112,7 @@ public class EthGetFilterChangesIntegrationTest {
 
     transactionPool =
         new TransactionPool(
-            transactions,
+            () -> transactions,
             executionContext.getProtocolSchedule(),
             protocolContext,
             batchAddedListener,
@@ -120,6 +120,7 @@ public class EthGetFilterChangesIntegrationTest {
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ZERO).build(),
             new TransactionPoolMetrics(metricsSystem),
             TransactionPoolConfiguration.DEFAULT);
+    transactionPool.setEnabled();
     final BlockchainQueries blockchainQueries =
         new BlockchainQueries(blockchain, protocolContext.getWorldStateArchive());
     filterManager =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
@@ -75,6 +75,8 @@ public class JsonRpcErrorConverter {
         return JsonRpcError.LOWER_NONCE_INVALID_TRANSACTION_EXISTS;
       case TOTAL_DATA_GAS_TOO_HIGH:
         return JsonRpcError.TOTAL_DATA_GAS_TOO_HIGH;
+      case TX_POOL_DISABLED:
+        return JsonRpcError.TX_POOL_DISABLED;
       default:
         return JsonRpcError.INTERNAL_ERROR;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -30,8 +30,10 @@ public enum JsonRpcError {
   INVALID_PARAMS(-32602, "Invalid params"),
   INTERNAL_ERROR(-32603, "Internal error"),
   TIMEOUT_ERROR(-32603, "Timeout expired"),
-
   METHOD_NOT_ENABLED(-32604, "Method not enabled"),
+
+  // Resource unavailable error
+  TX_POOL_DISABLED(-32002, "Transaction pool not enabled"),
 
   // eth_getBlockByNumber specific error message
   UNKNOWN_BLOCK(-39001, "Unknown block"),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionInvalidReason.java
@@ -46,6 +46,7 @@ public enum TransactionInvalidReason {
   MAX_FEE_PER_GAS_BELOW_CURRENT_BASE_FEE,
   TX_FEECAP_EXCEEDED,
   INTERNAL_ERROR,
+  TX_POOL_DISABLED,
 
   // Private Transaction Invalid Reasons
   PRIVATE_TRANSACTION_INVALID,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/DisabledPendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/DisabledPendingTransactions.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.transactions;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
+import org.hyperledger.besu.evm.account.Account;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/** This is a no-op implementation, that is used when the txpool is disabled */
+public class DisabledPendingTransactions implements PendingTransactions {
+
+  @Override
+  public void reset() {}
+
+  @Override
+  public void evictOldTransactions() {}
+
+  @Override
+  public List<Transaction> getLocalTransactions() {
+    return List.of();
+  }
+
+  @Override
+  public TransactionAddedResult addRemoteTransaction(
+      final Transaction transaction, final Optional<Account> maybeSenderAccount) {
+    return TransactionAddedResult.DISABLED;
+  }
+
+  @Override
+  public TransactionAddedResult addLocalTransaction(
+      final Transaction transaction, final Optional<Account> maybeSenderAccount) {
+    return TransactionAddedResult.DISABLED;
+  }
+
+  @Override
+  public void selectTransactions(final TransactionSelector selector) {}
+
+  @Override
+  public long maxSize() {
+    return 0;
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public boolean containsTransaction(final Transaction transaction) {
+    return false;
+  }
+
+  @Override
+  public Optional<Transaction> getTransactionByHash(final Hash transactionHash) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Collection<PendingTransaction> getPendingTransactions() {
+    return List.of();
+  }
+
+  @Override
+  public long subscribePendingTransactions(final PendingTransactionAddedListener listener) {
+    return 0;
+  }
+
+  @Override
+  public void unsubscribePendingTransactions(final long id) {}
+
+  @Override
+  public long subscribeDroppedTransactions(final PendingTransactionDroppedListener listener) {
+    return 0;
+  }
+
+  @Override
+  public void unsubscribeDroppedTransactions(final long id) {}
+
+  @Override
+  public OptionalLong getNextNonceForSender(final Address sender) {
+    return OptionalLong.empty();
+  }
+
+  @Override
+  public void manageBlockAdded(
+      final BlockHeader blockHeader,
+      final List<Transaction> confirmedTransactions,
+      final List<Transaction> reorgTransactions,
+      final FeeMarket feeMarket) {}
+
+  @Override
+  public String toTraceLog() {
+    return "Disabled";
+  }
+
+  @Override
+  public String logStats() {
+    return "Disabled";
+  }
+
+  @Override
+  public boolean isLocalSender(final Address sender) {
+    return false;
+  }
+}

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageHandler.java
@@ -32,7 +32,7 @@ class NewPooledTransactionHashesMessageHandler implements EthMessages.MessageCal
   private final NewPooledTransactionHashesMessageProcessor transactionsMessageProcessor;
   private final EthScheduler scheduler;
   private final Duration txMsgKeepAlive;
-  private final AtomicBoolean isEnabled = new AtomicBoolean(true);
+  private final AtomicBoolean isEnabled = new AtomicBoolean(false);
 
   public NewPooledTransactionHashesMessageHandler(
       final EthScheduler scheduler,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionAddedResult.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionAddedResult.java
@@ -46,6 +46,8 @@ public final class TransactionAddedResult {
 
   public static final TransactionAddedResult INTERNAL_ERROR =
       new TransactionAddedResult(Status.INTERNAL_ERROR);
+  public static final TransactionAddedResult DISABLED =
+      new TransactionAddedResult(TransactionInvalidReason.TX_POOL_DISABLED);
 
   private final Optional<TransactionInvalidReason> rejectReason;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcaster.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionBroadcaster.java
@@ -43,7 +43,6 @@ public class TransactionBroadcaster implements TransactionBatchAddedListener {
   private static final Boolean HASH_ONLY_BROADCAST = Boolean.TRUE;
   private static final Boolean FULL_BROADCAST = Boolean.FALSE;
 
-  private final PendingTransactions pendingTransactions;
   private final PeerTransactionTracker transactionTracker;
   private final TransactionsMessageSender transactionsMessageSender;
   private final NewPooledTransactionHashesMessageSender newPooledTransactionHashesMessageSender;
@@ -51,25 +50,22 @@ public class TransactionBroadcaster implements TransactionBatchAddedListener {
 
   public TransactionBroadcaster(
       final EthContext ethContext,
-      final PendingTransactions pendingTransactions,
       final PeerTransactionTracker transactionTracker,
       final TransactionsMessageSender transactionsMessageSender,
       final NewPooledTransactionHashesMessageSender newPooledTransactionHashesMessageSender) {
-    this.pendingTransactions = pendingTransactions;
     this.transactionTracker = transactionTracker;
     this.transactionsMessageSender = transactionsMessageSender;
     this.newPooledTransactionHashesMessageSender = newPooledTransactionHashesMessageSender;
     this.ethContext = ethContext;
   }
 
-  public void relayTransactionPoolTo(final EthPeer peer) {
-    final Collection<PendingTransaction> allPendingTransactions =
-        pendingTransactions.getPendingTransactions();
-    if (!allPendingTransactions.isEmpty()) {
+  public void relayTransactionPoolTo(
+      final EthPeer peer, final Collection<PendingTransaction> pendingTransactions) {
+    if (!pendingTransactions.isEmpty()) {
       if (peer.hasSupportForMessage(EthPV65.NEW_POOLED_TRANSACTION_HASHES)) {
-        sendTransactionHashes(toTransactionList(allPendingTransactions), List.of(peer));
+        sendTransactionHashes(toTransactionList(pendingTransactions), List.of(peer));
       } else {
-        sendFullTransactions(toTransactionList(allPendingTransactions), List.of(peer));
+        sendFullTransactions(toTransactionList(pendingTransactions), List.of(peer));
       }
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -531,7 +531,13 @@ public class TransactionPool implements BlockAddedObserver {
       isPoolEnabled.set(true);
       subscribeConnectId =
           OptionalLong.of(ethContext.getEthPeers().subscribeConnect(this::handleConnect));
-      return saveRestoreManager.loadFromDisk();
+      return saveRestoreManager
+          .loadFromDisk()
+          .exceptionally(
+              t -> {
+                LOG.error("Error while restoring transaction pool from disk", t);
+                return null;
+              });
     }
     return CompletableFuture.completedFuture(null);
   }
@@ -543,7 +549,13 @@ public class TransactionPool implements BlockAddedObserver {
       pendingTransactionsListenersProxy.unsubscribe();
       final PendingTransactions pendingTransactionsToSave = pendingTransactions;
       pendingTransactions = new DisabledPendingTransactions();
-      return saveRestoreManager.saveToDisk(pendingTransactionsToSave);
+      return saveRestoreManager
+          .saveToDisk(pendingTransactionsToSave)
+          .exceptionally(
+              t -> {
+                LOG.error("Error while saving transaction pool to disk", t);
+                return null;
+              });
     }
     return CompletableFuture.completedFuture(null);
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolEvictionService.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolEvictionService.java
@@ -35,7 +35,11 @@ public class TransactionPoolEvictionService {
         Optional.of(
             vertx.setPeriodic(
                 TimeUnit.MINUTES.toMillis(1),
-                id -> transactionPool.getPendingTransactions().evictOldTransactions()));
+                id -> {
+                  if (transactionPool.isEnabled()) {
+                    transactionPool.getPendingTransactions().evictOldTransactions();
+                  }
+                }));
   }
 
   public void stop() {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -141,6 +141,8 @@ public class TransactionPoolFactory {
       pooledTransactionsMessageHandler.setEnabled();
       transactionsMessageHandler.setEnabled();
       transactionPool.setEnabled();
+    } else {
+      LOG.info("Transaction pool disabled while initial sync in progress");
     }
 
     syncState.subscribeCompletionReached(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageHandler.java
@@ -30,7 +30,7 @@ class TransactionsMessageHandler implements EthMessages.MessageCallback {
   private final TransactionsMessageProcessor transactionsMessageProcessor;
   private final EthScheduler scheduler;
   private final Duration txMsgKeepAlive;
-  private final AtomicBoolean isEnabled = new AtomicBoolean(true);
+  private final AtomicBoolean isEnabled = new AtomicBoolean(false);
 
   public TransactionsMessageHandler(
       final EthScheduler scheduler,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
@@ -154,7 +154,6 @@ public abstract class AbstractTransactionPoolTest {
         spy(
             new TransactionBroadcaster(
                 ethContext,
-                transactions,
                 peerTransactionTracker,
                 transactionsMessageSender,
                 newPooledTransactionHashesMessageSender));
@@ -175,15 +174,19 @@ public abstract class AbstractTransactionPoolTest {
     configConsumer.accept(configBuilder);
     final TransactionPoolConfiguration config = configBuilder.build();
 
-    return new TransactionPool(
-        transactions,
-        protocolSchedule,
-        protocolContext,
-        transactionBroadcaster,
-        ethContext,
-        miningParameters,
-        new TransactionPoolMetrics(metricsSystem),
-        config);
+    final TransactionPool txPool =
+        new TransactionPool(
+            () -> transactions,
+            protocolSchedule,
+            protocolContext,
+            transactionBroadcaster,
+            ethContext,
+            miningParameters,
+            new TransactionPoolMetrics(metricsSystem),
+            config);
+
+    txPool.setEnabled();
+    return txPool;
   }
 
   @ParameterizedTest
@@ -438,7 +441,6 @@ public abstract class AbstractTransactionPoolTest {
 
     verify(transactions).containsTransaction(transaction1);
     verifyNoInteractions(transactionValidator);
-    verifyNoMoreInteractions(transactions);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionsLayeredPendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionsLayeredPendingTransactionsTest.java
@@ -181,20 +181,21 @@ public abstract class AbstractTransactionsLayeredPendingTransactionsTest {
         spy(
             new TransactionBroadcaster(
                 ethContext,
-                transactions,
                 peerTransactionTracker,
                 transactionsMessageSender,
                 newPooledTransactionHashesMessageSender));
-
-    return new TransactionPool(
-        transactions,
-        protocolSchedule,
-        protocolContext,
-        transactionBroadcaster,
-        ethContext,
-        miningParameters,
-        new TransactionPoolMetrics(metricsSystem),
-        poolConfig);
+    final TransactionPool txPool =
+        new TransactionPool(
+            () -> transactions,
+            protocolSchedule,
+            protocolContext,
+            transactionBroadcaster,
+            ethContext,
+            miningParameters,
+            new TransactionPoolMetrics(metricsSystem),
+            poolConfig);
+    txPool.setEnabled();
+    return txPool;
   }
 
   @Test
@@ -423,7 +424,6 @@ public abstract class AbstractTransactionsLayeredPendingTransactionsTest {
 
     verify(transactions).containsTransaction(transaction0);
     verifyNoInteractions(transactionValidator);
-    verifyNoMoreInteractions(transactions);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
@@ -243,6 +243,7 @@ public class TransactionPoolFactoryTest {
             schedule,
             context,
             ethContext,
+            TestClock.fixed(),
             new TransactionPoolMetrics(new NoOpMetricsSystem()),
             syncState,
             new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),
@@ -251,7 +252,6 @@ public class TransactionPoolFactoryTest {
                 .txMessageKeepAliveSeconds(1)
                 .pendingTxRetentionPeriod(1)
                 .build(),
-            pendingTransactions,
             peerTransactionTracker,
             transactionsMessageSender,
             newPooledTransactionHashesMessageSender);
@@ -311,18 +311,22 @@ public class TransactionPoolFactoryTest {
   }
 
   private TransactionPool createTransactionPool() {
-    return TransactionPoolFactory.createTransactionPool(
-        schedule,
-        protocolContext,
-        ethContext,
-        TestClock.fixed(),
-        new NoOpMetricsSystem(),
-        syncState,
-        new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),
-        ImmutableTransactionPoolConfiguration.builder()
-            .txPoolMaxSize(1)
-            .txMessageKeepAliveSeconds(1)
-            .pendingTxRetentionPeriod(1)
-            .build());
+    final TransactionPool txPool =
+        TransactionPoolFactory.createTransactionPool(
+            schedule,
+            protocolContext,
+            ethContext,
+            TestClock.fixed(),
+            new NoOpMetricsSystem(),
+            syncState,
+            new MiningParameters.Builder().minTransactionGasPrice(Wei.ONE).build(),
+            ImmutableTransactionPoolConfiguration.builder()
+                .txPoolMaxSize(1)
+                .txMessageKeepAliveSeconds(1)
+                .pendingTxRetentionPeriod(1)
+                .build());
+
+    txPool.setEnabled();
+    return txPool;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR review the way the txpool is enabled/disabled in a more intuitive way and also[ fix a bug ](https://github.com/hyperledger/besu/issues/5636)that happens when enabling the layered txpool when not synced.

The main point of disabling the txpool, is to avoid its overhead during the initial sync (or resync) phases, since pending transactions are always evaluated and processed against the current head, so if we are syncing there is no value in processing them, and we can wait until the sync is done to enabled the txpool.
The current implementation is a bit convoluted, since the txpool is always enabled at startup, but if the initial sync is not done, then the txpool is disabled, to be re-enabled after the sync is done, while it is straightforward to just start with the txpool disabled, and enabled it when the sync is done.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #5636 