### PR TITLE
Fail fast in case of downgrade done without reverting variables storage

### DIFF
--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStoragePrefixedKeyBlockchainStorageTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueStoragePrefixedKeyBlockchainStorageTest.java
@@ -14,14 +14,17 @@
  */
 package org.hyperledger.besu.ethereum.storage.keyvalue;
 
+import static org.hyperledger.besu.ethereum.chain.VariablesStorage.Keys.CHAIN_HEAD_HASH;
 import static org.hyperledger.besu.ethereum.chain.VariablesStorage.Keys.FINALIZED_BLOCK_HASH;
 import static org.hyperledger.besu.ethereum.chain.VariablesStorage.Keys.SAFE_BLOCK_HASH;
+import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.SAMPLE_CHAIN_HEAD;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.assertNoVariablesInStorage;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.assertVariablesPresentInVariablesStorage;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.assertVariablesReturnedByBlockchainStorage;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.getSampleVariableValues;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.populateBlockchainStorage;
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.populateVariablesStorage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.ethereum.chain.VariablesStorage;
@@ -99,5 +102,18 @@ public class KeyValueStoragePrefixedKeyBlockchainStorageTest {
     assertVariablesPresentInVariablesStorage(kvVariables, variableValues);
 
     assertVariablesReturnedByBlockchainStorage(blockchainStorage, variableValues);
+  }
+
+  @Test
+  public void failIfInconsistencyDetectedDuringVariablesMigration() {
+    populateBlockchainStorage(kvBlockchain, variableValues);
+    // create and inconsistency putting a different chain head in variables storage
+    variableValues.put(CHAIN_HEAD_HASH, SAMPLE_CHAIN_HEAD.shiftLeft(1));
+    populateVariablesStorage(kvVariables, variableValues);
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            new KeyValueStoragePrefixedKeyBlockchainStorage(
+                kvBlockchain, variablesStorage, blockHeaderFunctions));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

#5471 is backward incompatible, and there is a procedure to do before downgrading, but if the procedure is not followed the db becomes inconsistent, to avoid that this PR tries to detect this scenario and fail fast in case it founds a previous migration, giving the user a possibility to retry the rollback procedure.

If an inconsistency is found this log is printed

```
2023-06-23 16:06:21.885+00:00 | main | ERROR | KeyValueStoragePrefixedKeyBlockchainStorage | Inconsistency found when migrating chainHeadHash to variables storage, probably this is due to a downgrade done without running the `storage revert-variables` subcommand first, see https://github.com/hyperledger/besu/pull/5471
chainHeadHash mismatch: blockchain storage value=0x25a5cc106eea7138acab33231d7160d69cb777ee0c2c553fcddf5138993e6dd9, variables storage value=0x8a3d34ff1d0c4e57fad7c5ec2e316cad84e590e38bd93c386a3ade49deb0437f
```

Tested with this scenario:
1. Existing 23.4.1 Besu with already synced db
2. Upgrade to 23.4.3 and variables migrated
3. Downgrade to 23.4.1 *without* running `storage revert-variables` first, got `World State Root does not match expected value, header 0x5eb6e371a698b8d68f665192350ffcecbbbf322916f4b51bd79bb6887da3f494 calculated 0x0ec284a94272bbfe33f8455acb8f182401607bda6b71c75c3d5584d719e7d8e7`
4. Upgrade again to 23.4.3 and then Besu correctly fails to start since inconsistency detected, with the log reported above.
5. Run `storage revert-variables` successfully rollback variables storage
6. Downgrade again to 23.4.1 and this time Besu starts correctly
