### PR TITLE
Eth/68: treat transaction size as scalar unsigned int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 - Use the node's configuration to determine if DNS enode URLs are allowed in calls to `admin_addPeer` and `admin_removePeer` [#5584](https://github.com/hyperledger/besu/pull/5584)
+- Align the implementation of Eth/68 `NewPooledTransactionHashes` to other clients, using unsigned int for encoding size. [#5640](https://github.com/hyperledger/besu/pull/5640)
 
 ### Download Links
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementDecoder.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementDecoder.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.tuweni.bytes.Bytes;
+
 public class TransactionAnnouncementDecoder {
 
   @FunctionalInterface
@@ -65,7 +67,7 @@ public class TransactionAnnouncementDecoder {
    * Decode the list of transactions in the NewPooledTransactionHashesMessage
    *
    * @param input input used to decode the NewPooledTransactionHashesMessage after Eth/68
-   *     <p>format: [[type_0: B_1, type_1: B_1, ...], [size_0: B_4, size_1: B_4, ...], ...]
+   *     <p>format: [[type_0: B_1, type_1: B_1, ...], [size_0: P, size_1: P, ...], ...]
    * @return the list of TransactionAnnouncement decoded from the message with size, type and hash
    */
   private static List<TransactionAnnouncement> decodeForEth68(final RLPInput input) {
@@ -77,7 +79,22 @@ public class TransactionAnnouncementDecoder {
       types.add(b == 0 ? TransactionType.FRONTIER : TransactionType.of(b));
     }
 
-    final List<Long> sizes = input.readList(in -> (long) in.readBytes().toInt());
+    List<Long> sizes =
+        input.readList(
+            in -> {
+              // for backward compatibility with previous Besu implementation be lenient and support
+              // also unsigned int with leading zeros.
+              // ToDo: this could be replaced with the simpler `RLPInput::readUnsignedIntScalar`
+              // after some months it has been released, since most of the Besus
+              // will be using the new implementation.
+              final Bytes intBytes = in.readBytes();
+              if (intBytes.size() > 4) {
+                throw new RLPException(
+                    "Expected max 4 bytes for unsigned int, but got " + intBytes.size() + " bytes");
+              }
+              return intBytes.toLong();
+            });
+
     final List<Hash> hashes = input.readList(rlp -> Hash.wrap(rlp.readBytes32()));
     input.leaveList();
     if (!(types.size() == hashes.size() && hashes.size() == sizes.size())) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementEncoder.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/encoding/TransactionAnnouncementEncoder.java
@@ -69,7 +69,7 @@ public class TransactionAnnouncementEncoder {
   /**
    * Encode a list of transactions for the NewPooledTransactionHashesMessage using the Eth/68
    *
-   * <p>format: [[type_0: B_1, type_1: B_1, ...], [size_0: B_4, size_1: B_4, ...], ...]
+   * <p>format: [[type_0: B_1, type_1: B_1, ...], [size_0: P, size_1: P, ...], ...]
    *
    * @param transactions the list to encode
    * @return the encoded value. The message data will contain hashes, types and sizes.
@@ -112,7 +112,7 @@ public class TransactionAnnouncementEncoder {
     }
     out.startList();
     out.writeBytes(Bytes.wrap((types)));
-    out.writeList(sizes, (h, w) -> w.writeInt(h));
+    out.writeList(sizes, (h, w) -> w.writeUnsignedInt(h));
     out.writeList(hashes, (h, w) -> w.writeBytes(h));
     out.endList();
     return out.encoded();

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/AbstractRLPInput.java
@@ -318,6 +318,12 @@ abstract class AbstractRLPInput implements RLPInput {
   }
 
   @Override
+  public long readUnsignedIntScalar() {
+    checkScalar("unsigned int scalar", 4);
+    return readLongScalar();
+  }
+
+  @Override
   public BigInteger readBigIntegerScalar() {
     checkScalar("arbitrary precision scalar");
     final BigInteger res = getUnsignedBigInteger(currentPayloadOffset, currentPayloadSize);

--- a/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
+++ b/ethereum/rlp/src/main/java/org/hyperledger/besu/ethereum/rlp/RLPInput.java
@@ -263,6 +263,15 @@ public interface RLPInput {
   }
 
   /**
+   * Reads a scalar from the input and return is as an unsigned int contained in a long
+   *
+   * @return The next scalar item of this input as an unsigned int value as long
+   * @throws RLPException if the next item to read is a list, the input is at the end of its current
+   *     list (and {@link #leaveList()} hasn't been called) or if the next item is either too big to
+   *     fit an unsigned int or has leading zeros.
+   */
+  long readUnsignedIntScalar();
+  /**
    * Reads an inet address from this input.
    *
    * @return The inet address corresponding to the next item of this input.

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPInputTest.java
@@ -151,6 +151,25 @@ public class BytesValueRLPInputTest {
   }
 
   @Test
+  public void assertUnsignedIntScalar() {
+    // Scalar should be encoded as the minimal byte array representing the number. For 0, that means
+    // the empty byte array, which is a short element of zero-length, so 0x80.
+    assertUnsignedIntScalar(0L, h("0x80"));
+
+    assertUnsignedIntScalar(1L, h("0x01"));
+    assertUnsignedIntScalar(15L, h("0x0F"));
+    assertUnsignedIntScalar(1024L, h("0x820400"));
+    assertUnsignedIntScalar((1L << 32) - 1, h("0x84ffffffff"));
+  }
+
+  private void assertUnsignedIntScalar(final long expected, final Bytes toTest) {
+    final RLPInput in = RLP.input(toTest);
+    assertThat(in.isDone()).isFalse();
+    assertThat(in.readUnsignedIntScalar()).isEqualTo(expected);
+    assertThat(in.isDone()).isTrue();
+  }
+
+  @Test
   public void assertLongScalar() {
     // Scalar should be encoded as the minimal byte array representing the number. For 0, that means
     // the empty byte array, which is a short element of zero-length, so 0x80.

--- a/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPOutputTest.java
+++ b/ethereum/rlp/src/test/java/org/hyperledger/besu/ethereum/rlp/BytesValueRLPOutputTest.java
@@ -162,6 +162,24 @@ public class BytesValueRLPOutputTest {
   }
 
   @Test
+  public void unsignedIntScalar() {
+    // Scalar should be encoded as the minimal byte array representing the number. For 0, that means
+    // the empty byte array, which is a short element of zero-length, so 0x80.
+    assertUnsignedIntScalar(h("0x80"), 0);
+
+    assertUnsignedIntScalar(h("0x01"), 1);
+    assertUnsignedIntScalar(h("0x0F"), 15);
+    assertUnsignedIntScalar(h("0x820400"), 1024);
+    assertUnsignedIntScalar(h("0x84ffffffff"), (1L << 32) - 1);
+  }
+
+  private void assertUnsignedIntScalar(final Bytes expected, final long toTest) {
+    final BytesValueRLPOutput out = new BytesValueRLPOutput();
+    out.writeUnsignedInt(toTest);
+    assertThat(out.encoded()).isEqualTo(expected);
+  }
+
+  @Test
   public void longScalar() {
     // Scalar should be encoded as the minimal byte array representing the number. For 0, that means
     // the empty byte array, which is a short element of zero-length, so 0x80.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Align Besu to what other clients are doing, treating the sizes as an array of scalar ints and not 4 bytes, this also prevent being disconnected from Geth due to `invalid-message` error:

```
DEBUG[06-19|15:15:40.347] Ethereum peer connected                  id=a1697db12e1f2986 conn=inbound name=besu/v23.4.0/linux-x...
DEBUG[06-19|15:15:40.360] Message handling failed in `eth`         id=a1697db12e1f2986 conn=inbound err="invalid message: message msg #8 (157028 bytes): invalid message: (code 8) (size 157028) rlp: non-canonical integer (leading zero bytes) for uint32, decoding into (eth.NewPooledTransactionHashesPacket68).Sizes[0]"
DEBUG[06-19|15:15:40.360] Removing p2p peer                        peercount=10 id=a1697db12e1f2986 duration=12.956ms     req=false err="invalid message: message msg #8 (157028 bytes): invalid message: (code 8) (size 157028) rlp: non-canonical integer (leading zero bytes) for uint32, decoding into (eth.NewPooledTransactionHashesPacket68).Sizes[0]"
```

Contacting the author of the EIP for making it clearer in which data type is used for this message, see https://github.com/ethereum/EIPs/pull/7233

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->