### PR TITLE
Remove BLS12 from cancun

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetPrecompiledContractRegistries.java
@@ -20,6 +20,7 @@ import static org.hyperledger.besu.ethereum.core.PrivacyParameters.PLUGIN_PRIVAC
 import static org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts.populateForByzantium;
 import static org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts.populateForCancun;
 import static org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts.populateForFrontier;
+import static org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts.populateForFutureEIPs;
 import static org.hyperledger.besu.evm.precompile.MainnetPrecompiledContracts.populateForIstanbul;
 
 import org.hyperledger.besu.ethereum.mainnet.precompiles.privacy.FlexiblePrivacyPrecompiledContract;
@@ -55,6 +56,13 @@ public interface MainnetPrecompiledContractRegistries {
       final PrecompiledContractConfiguration precompiledContractConfiguration) {
     final PrecompileContractRegistry registry = new PrecompileContractRegistry();
     populateForCancun(registry, precompiledContractConfiguration.getGasCalculator());
+    return registry;
+  }
+
+  static PrecompileContractRegistry futureEips(
+      final PrecompiledContractConfiguration precompiledContractConfiguration) {
+    final PrecompileContractRegistry registry = new PrecompileContractRegistry();
+    populateForFutureEIPs(registry, precompiledContractConfiguration.getGasCalculator());
     return registry;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -69,7 +69,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import com.google.common.io.Resources;
@@ -175,19 +174,11 @@ public abstract class MainnetProtocolSpecs {
     if (powAlgorithm == null) {
       return PoWHasher.UNSUPPORTED;
     }
-    switch (powAlgorithm) {
-      case ETHASH:
-        return PoWHasher.ETHASH_LIGHT;
-      case UNSUPPORTED:
-      default:
-        return PoWHasher.UNSUPPORTED;
-    }
+    return powAlgorithm == PowAlgorithm.ETHASH ? PoWHasher.ETHASH_LIGHT : PoWHasher.UNSUPPORTED;
   }
 
   public static BlockValidatorBuilder blockValidatorBuilder() {
-    return (blockHeaderValidator, blockBodyValidator, blockProcessor, badBlockManager) ->
-        new MainnetBlockValidator(
-            blockHeaderValidator, blockBodyValidator, blockProcessor, badBlockManager);
+    return MainnetBlockValidator::new;
   }
 
   public static ProtocolSpecBuilder homesteadDefinition(
@@ -739,6 +730,7 @@ public abstract class MainnetProtocolSpecs {
             (gasCalculator, jdCacheConfig) ->
                 MainnetEVMs.futureEips(
                     gasCalculator, chainId.orElse(BigInteger.ZERO), evmConfiguration))
+        .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::futureEips)
         .name("FutureEips");
   }
 
@@ -870,7 +862,7 @@ public abstract class MainnetProtocolSpecs {
             IntStream.range(0, json.size())
                 .mapToObj(json::getString)
                 .map(Address::fromHexString)
-                .collect(Collectors.toList());
+                .toList();
         final WorldUpdater worldUpdater = worldState.updater();
         final MutableAccount daoRefundContract =
             worldUpdater.getOrCreate(DAO_REFUND_CONTRACT_ADDRESS).getMutable();

--- a/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
@@ -622,6 +622,27 @@ public class MainnetEVMs {
   /**
    * Paris evm.
    *
+   * @param evmConfiguration the evm configuration
+   * @return the evm
+   */
+  public static EVM paris(final EvmConfiguration evmConfiguration) {
+    return paris(DEV_NET_CHAIN_ID, evmConfiguration);
+  }
+
+  /**
+   * Paris evm.
+   *
+   * @param chainId the chain id
+   * @param evmConfiguration the evm configuration
+   * @return the evm
+   */
+  public static EVM paris(final BigInteger chainId, final EvmConfiguration evmConfiguration) {
+    return paris(new LondonGasCalculator(), chainId, evmConfiguration);
+  }
+
+  /**
+   * Paris evm.
+   *
    * @param gasCalculator the gas calculator
    * @param chainId the chain id
    * @param evmConfiguration the evm configuration
@@ -665,6 +686,16 @@ public class MainnetEVMs {
       final BigInteger chainID) {
     registerLondonOperations(registry, gasCalculator, chainID);
     registry.put(new PrevRanDaoOperation(gasCalculator));
+  }
+
+  /**
+   * Shanghai evm.
+   *
+   * @param evmConfiguration the evm configuration
+   * @return the evm
+   */
+  public static EVM shanghai(final EvmConfiguration evmConfiguration) {
+    return shanghai(DEV_NET_CHAIN_ID, evmConfiguration);
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
@@ -231,6 +231,58 @@ public class EVMExecutor {
     return executor;
   }
 
+  /**
+   * Instantiate Paris evm executor.
+   *
+   * @param evmConfiguration the evm configuration
+   * @return the evm executor
+   */
+  public static EVMExecutor paris(final EvmConfiguration evmConfiguration) {
+    final EVMExecutor executor = new EVMExecutor(MainnetEVMs.paris(evmConfiguration));
+    executor.precompileContractRegistry =
+        MainnetPrecompiledContracts.istanbul(executor.evm.getGasCalculator());
+    return executor;
+  }
+
+  /**
+   * Instantiate Shanghai evm executor.
+   *
+   * @param evmConfiguration the evm configuration
+   * @return the evm executor
+   */
+  public static EVMExecutor shanghai(final EvmConfiguration evmConfiguration) {
+    final EVMExecutor executor = new EVMExecutor(MainnetEVMs.shanghai(evmConfiguration));
+    executor.precompileContractRegistry =
+        MainnetPrecompiledContracts.istanbul(executor.evm.getGasCalculator());
+    return executor;
+  }
+
+  /**
+   * Instantiate Cancun evm executor.
+   *
+   * @param evmConfiguration the evm configuration
+   * @return the evm executor
+   */
+  public static EVMExecutor cancun(final EvmConfiguration evmConfiguration) {
+    final EVMExecutor executor = new EVMExecutor(MainnetEVMs.cancun(evmConfiguration));
+    executor.precompileContractRegistry =
+        MainnetPrecompiledContracts.cancun(executor.evm.getGasCalculator());
+    return executor;
+  }
+
+  /**
+   * Instantiate Future EIPs evm executor.
+   *
+   * @param evmConfiguration the evm configuration
+   * @return the evm executor
+   */
+  public static EVMExecutor futureEIPs(final EvmConfiguration evmConfiguration) {
+    final EVMExecutor executor = new EVMExecutor(MainnetEVMs.cancun(evmConfiguration));
+    executor.precompileContractRegistry =
+        MainnetPrecompiledContracts.futureEIPs(executor.evm.getGasCalculator());
+    return executor;
+  }
+
   private MessageCallProcessor thisMessageCallProcessor() {
     return Objects.requireNonNullElseGet(
         messageCallProcessor, () -> new MessageCallProcessor(evm, precompileContractRegistry));

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/MainnetPrecompiledContracts.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/MainnetPrecompiledContracts.java
@@ -114,6 +114,18 @@ public interface MainnetPrecompiledContracts {
   }
 
   /**
+   * Cancun precompile contract registry.
+   *
+   * @param gasCalculator the gas calculator
+   * @return the precompile contract registry
+   */
+  static PrecompileContractRegistry cancun(final GasCalculator gasCalculator) {
+    PrecompileContractRegistry precompileContractRegistry = new PrecompileContractRegistry();
+    populateForCancun(precompileContractRegistry, gasCalculator);
+    return precompileContractRegistry;
+  }
+
+  /**
    * Populate registry for Cancun.
    *
    * @param registry the registry
@@ -122,6 +134,33 @@ public interface MainnetPrecompiledContracts {
   static void populateForCancun(
       final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
     populateForIstanbul(registry, gasCalculator);
+
+    // EIP-4844 - shard blob transactions
+    // TODO: allow override to be configured?
+    registry.put(Address.KZG_POINT_EVAL, new KZGPointEvalPrecompiledContract());
+  }
+
+  /**
+   * FutureEIPs precompile contract registry.
+   *
+   * @param gasCalculator the gas calculator
+   * @return the precompile contract registry
+   */
+  static PrecompileContractRegistry futureEIPs(final GasCalculator gasCalculator) {
+    PrecompileContractRegistry precompileContractRegistry = new PrecompileContractRegistry();
+    populateForFutureEIPs(precompileContractRegistry, gasCalculator);
+    return precompileContractRegistry;
+  }
+
+  /**
+   * Populate registry for Future EIPs.
+   *
+   * @param registry the registry
+   * @param gasCalculator the gas calculator
+   */
+  static void populateForFutureEIPs(
+      final PrecompileContractRegistry registry, final GasCalculator gasCalculator) {
+    populateForCancun(registry, gasCalculator);
 
     // EIP-2537 - BLS12-381 curve operations
     registry.put(Address.BLS12_G1ADD, new BLS12G1AddPrecompiledContract());
@@ -133,9 +172,5 @@ public interface MainnetPrecompiledContracts {
     registry.put(Address.BLS12_PAIRING, new BLS12PairingPrecompiledContract());
     registry.put(Address.BLS12_MAP_FP_TO_G1, new BLS12MapFpToG1PrecompiledContract());
     registry.put(Address.BLS12_MAP_FP2_TO_G2, new BLS12MapFp2ToG2PrecompiledContract());
-
-    // EIP-4844 - shard blob transactions
-    // TODO: allow override to be configured?
-    registry.put(Address.KZG_POINT_EVAL, new KZGPointEvalPrecompiledContract());
   }
 }


### PR DESCRIPTION
## PR description

BLS12 signatures were speculatively added in cancun in late 2022.  This is no longer accurate.  Move the implementation to the "Future_EIPs" fork so that it will remain testable and not accidentally get included accidentally.  Also add missing fluent APIs.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->