### PR TITLE
[4844] Add Data Gas Excess Validation to the Header Validations

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.BaseFeeMarket
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.CalculatedDifficultyValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ConstantFieldValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ConstantOmmersHashRule;
+import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.DataGasValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ExtraDataMaxLengthValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasLimitRangeAndDeltaValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasUsageValidationRule;
@@ -32,6 +33,7 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.NoNonceRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ProofOfWorkValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMoreRecentThanParent;
+import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 
 import java.util.Optional;
 
@@ -194,5 +196,10 @@ public final class MainnetBlockHeaderValidator {
         .addRule(new NoNonceRule())
         .addRule(new NoDifficultyRule())
         .addRule(new IncrementalTimestampRule());
+  }
+
+  public static BlockHeaderValidator.Builder cancunBlockHeaderValidator(final FeeMarket feeMarket) {
+    return mergeBlockHeaderValidator(feeMarket)
+        .addRule(new DataGasValidationRule(new CancunGasCalculator()));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -717,6 +717,7 @@ public abstract class MainnetProtocolSpecs {
                         TransactionType.BLOB),
                     SHANGHAI_INIT_CODE_SIZE_LIMIT))
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::cancun)
+        .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator::cancunBlockHeaderValidator)
         .name("Cancun");
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/DataGasValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/DataGasValidationRule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import org.hyperledger.besu.datatypes.DataGas;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.DetachedBlockHeaderValidationRule;
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Validation rule to check if the block header's excess data gas matches the calculated value. */
+public class DataGasValidationRule implements DetachedBlockHeaderValidationRule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DataGasValidationRule.class);
+
+  private final GasCalculator gasCalculator;
+
+  public DataGasValidationRule(final GasCalculator gasCalculator) {
+    this.gasCalculator = gasCalculator;
+  }
+
+  /**
+   * Validates the block header by checking if the header's excess data gas matches the calculated
+   * value based on the parent header.
+   */
+  @Override
+  public boolean validate(final BlockHeader header, final BlockHeader parent) {
+    long headerExcessDataGas = header.getExcessDataGas().map(DataGas::toLong).orElse(0L);
+    long parentExcessDataGas = parent.getExcessDataGas().map(DataGas::toLong).orElse(0L);
+    long parentDataGasUsed = parent.getDataGasUsed();
+
+    long calculatedExcessDataGas =
+        gasCalculator.computeExcessDataGas(parentExcessDataGas, parentDataGasUsed);
+
+    if (headerExcessDataGas != calculatedExcessDataGas) {
+      LOG.info(
+          "Invalid block header: header excessDataGas {} and calculated excessDataGas {} do not match",
+          headerExcessDataGas,
+          calculatedExcessDataGas);
+      return false;
+    }
+    return true;
+  }
+}

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockHeaderTestFixture.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/BlockHeaderTestFixture.java
@@ -53,6 +53,7 @@ public class BlockHeaderTestFixture {
   private Optional<Hash> depositsRoot = Optional.empty();
   private BlockHeaderFunctions blockHeaderFunctions = new MainnetBlockHeaderFunctions();
   private Optional<DataGas> excessDataGas = Optional.empty();
+  private Optional<Long> dataGasUsed = Optional.empty();
 
   public BlockHeader buildHeader() {
     final BlockHeaderBuilder builder = BlockHeaderBuilder.create();
@@ -75,6 +76,7 @@ public class BlockHeaderTestFixture {
     builder.nonce(nonce);
     withdrawalsRoot.ifPresent(builder::withdrawalsRoot);
     excessDataGas.ifPresent(builder::excessDataGas);
+    dataGasUsed.ifPresent(builder::dataGasUsed);
     depositsRoot.ifPresent(builder::depositsRoot);
     builder.blockHeaderFunctions(blockHeaderFunctions);
 
@@ -178,6 +180,11 @@ public class BlockHeaderTestFixture {
 
   public BlockHeaderTestFixture excessDataGas(final DataGas excessDataGas) {
     this.excessDataGas = Optional.ofNullable(excessDataGas);
+    return this;
+  }
+
+  public BlockHeaderTestFixture dataGasUsed(final Long dataGasUsed) {
+    this.dataGasUsed = Optional.ofNullable(dataGasUsed);
     return this;
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/DataGasValidationRuleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/DataGasValidationRuleTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.ethereum.mainnet.headervalidationrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.DataGas;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the {@link DataGasValidationRule} class. */
+public class DataGasValidationRuleTest {
+
+  private CancunGasCalculator gasCalculator;
+  private DataGasValidationRule dataGasValidationRule;
+
+  @BeforeEach
+  public void setUp() {
+    gasCalculator = new CancunGasCalculator();
+    dataGasValidationRule = new DataGasValidationRule(gasCalculator);
+  }
+
+  /** Tests that the header data gas matches the calculated data gas and passes validation. */
+  @Test
+  public void validateHeader_DataGasMatchesCalculated_SuccessValidation() {
+    long target = gasCalculator.getTargetDataGasPerBlock();
+
+    // Create parent header
+    final BlockHeaderTestFixture parentBuilder = new BlockHeaderTestFixture();
+    parentBuilder.excessDataGas(DataGas.of(1L));
+    parentBuilder.dataGasUsed(target);
+    final BlockHeader parentHeader = parentBuilder.buildHeader();
+
+    // Create block header with matching excessDataGas
+    final BlockHeaderTestFixture headerBuilder = new BlockHeaderTestFixture();
+    headerBuilder.excessDataGas(DataGas.of(1L));
+    final BlockHeader header = headerBuilder.buildHeader();
+
+    assertThat(dataGasValidationRule.validate(header, parentHeader)).isTrue();
+  }
+
+  /**
+   * Tests that the header data gas is different from the calculated data gas and fails validation.
+   */
+  @Test
+  public void validateHeader_DataGasDifferentFromCalculated_FailsValidation() {
+    long target = gasCalculator.getTargetDataGasPerBlock();
+
+    // Create parent header
+    final BlockHeaderTestFixture parentBuilder = new BlockHeaderTestFixture();
+    parentBuilder.excessDataGas(DataGas.of(1L));
+    parentBuilder.dataGasUsed(target);
+    final BlockHeader parentHeader = parentBuilder.buildHeader();
+
+    // Create block header with different excessDataGas
+    final BlockHeaderTestFixture headerBuilder = new BlockHeaderTestFixture();
+    final BlockHeader header = headerBuilder.buildHeader();
+
+    assertThat(dataGasValidationRule.validate(header, parentHeader)).isFalse();
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculator.java
@@ -67,7 +67,7 @@ public class CancunGasCalculator extends ShanghaiGasCalculator {
    *
    * @return The target data gas per block.
    */
-  public static long getTargetDataGasPerBlock() {
+  public long getTargetDataGasPerBlock() {
     return TARGET_DATA_GAS_PER_BLOCK;
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculatorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/gascalculator/CancunGasCalculatorTest.java
@@ -20,12 +20,12 @@ import org.junit.jupiter.api.Test;
 
 public class CancunGasCalculatorTest {
 
-  private final GasCalculator gasCalculator = new CancunGasCalculator();
+  private final CancunGasCalculator gasCalculator = new CancunGasCalculator();
 
   @Test
   public void shouldCalculateExcessDataGasCorrectly() {
 
-    long target = CancunGasCalculator.getTargetDataGasPerBlock();
+    long target = gasCalculator.getTargetDataGasPerBlock();
     long excess = 1L;
 
     assertThat(gasCalculator.computeExcessDataGas(0L, 0L)).isEqualTo(0);


### PR DESCRIPTION
## PR description

Add dataGasExcess header validation according to https://eips.ethereum.org/EIPS/eip-4844

>     # check that the excess data gas was updated correctly
>     assert block.header.excess_data_gas == calc_excess_data_gas(block.parent.header)