### PR TITLE
Only update peer with the first and last block

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -95,8 +95,9 @@ public abstract class AbstractGetHeadersFromPeerTask
     BlockHeader prevBlockHeader = firstHeader;
     updatePeerChainState(peer, firstHeader);
     final int expectedDelta = reverse ? -(skip + 1) : (skip + 1);
+    BlockHeader header = null;
     for (int i = 1; i < headers.size(); i++) {
-      final BlockHeader header = headers.get(i);
+      header = headers.get(i);
       if (header.getNumber() != prevBlockHeader.getNumber() + expectedDelta) {
         // Skip doesn't match, this isn't our data
         LOG.debug("header not matching the expected number. Peer: {}", peer);
@@ -116,8 +117,8 @@ public abstract class AbstractGetHeadersFromPeerTask
       }
       prevBlockHeader = header;
       headersList.add(header);
-      updatePeerChainState(peer, header);
     }
+    updatePeerChainState(peer, header);
 
     LOG.debug("Received {} of {} headers requested from peer {}", headersList.size(), count, peer);
     return Optional.of(headersList);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -118,6 +118,9 @@ public abstract class AbstractGetHeadersFromPeerTask
       prevBlockHeader = header;
       headersList.add(header);
     }
+    // if we have received more than one header we have to update the chain state with the last
+    // header as well, as the header with the highest block number can be the first or the last
+    // header.
     if (headers.size() > 1) {
       updatePeerChainState(peer, header);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -118,7 +118,9 @@ public abstract class AbstractGetHeadersFromPeerTask
       prevBlockHeader = header;
       headersList.add(header);
     }
-    updatePeerChainState(peer, header);
+    if (headers.size() > 1) {
+      updatePeerChainState(peer, header);
+    }
 
     LOG.debug("Received {} of {} headers requested from peer {}", headersList.size(), count, peer);
     return Optional.of(headersList);


### PR DESCRIPTION
## PR description
We only need to update the peers chain state with the highest block header, which is the first or the last block in the list. Currently we are trying to update with every block header, which can be 200 or so.