### PR TITLE
Add --amend to docker manifest create to fix docker latest tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -870,7 +870,7 @@ task manifestDockerRelease {
       archs.forEach { arch -> targets += "'${variantImage}-${arch}' " }
 
       exec {
-        def cmd = "docker manifest create '${variantImage}' ${targets}"
+        def cmd = "docker manifest create '${variantImage}' ${targets} --amend"
         println "Executing '${cmd}'"
         executable "sh"
         args "-c", cmd
@@ -886,7 +886,7 @@ task manifestDockerRelease {
     exec {
       def targets = ""
       archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
-      def cmd = "docker manifest create '${baseTag}' ${targets}"
+      def cmd = "docker manifest create '${baseTag}' ${targets} --amend"
       println "Executing '${cmd}'"
       executable "sh"
       args "-c", cmd


### PR DESCRIPTION
We need to replace previous release's latest tag. Might be broken due to a recent change in the docker command implementation
