### PR TITLE
[4844] [Hive] Fix for genesis mismatch

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -246,14 +246,14 @@ public class GenesisConfigFile {
   public String getNonce() {
     return JsonUtil.getValueAsString(configRoot, "nonce", "0x0");
   }
-  
-    /**
+
+  /**
    * Gets excess data gas.
    *
    * @return the excess data gas
    */
   public String getExcessDataGas() {
-      return JsonUtil.getValueAsString(configRoot, "excessdatagas", "0x0");
+    return JsonUtil.getValueAsString(configRoot, "excessdatagas", "0x0");
   }
 
   /**
@@ -262,9 +262,8 @@ public class GenesisConfigFile {
    * @return the data gas used
    */
   public String getDataGasUsed() {
-      return JsonUtil.getValueAsString(configRoot, "datagasused", "0x0");
+    return JsonUtil.getValueAsString(configRoot, "datagasused", "0x0");
   }
-
 
   /**
    * Gets coinbase.

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -246,6 +246,25 @@ public class GenesisConfigFile {
   public String getNonce() {
     return JsonUtil.getValueAsString(configRoot, "nonce", "0x0");
   }
+  
+    /**
+   * Gets excess data gas.
+   *
+   * @return the excess data gas
+   */
+  public String getExcessDataGas() {
+      return JsonUtil.getValueAsString(configRoot, "excessdatagas", "0x0");
+  }
+
+  /**
+   * Gets data gas used.
+   *
+   * @return the data gas used
+   */
+  public String getDataGasUsed() {
+      return JsonUtil.getValueAsString(configRoot, "datagasused", "0x0");
+  }
+
 
   /**
    * Gets coinbase.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -19,8 +19,8 @@ import static java.util.Collections.emptyList;
 import org.hyperledger.besu.config.GenesisAllocation;
 import org.hyperledger.besu.config.GenesisConfigFile;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.DataGas;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
@@ -168,8 +168,8 @@ public final class GenesisState {
         .blockHeaderFunctions(ScheduleBasedBlockHeaderFunctions.create(protocolSchedule))
         .baseFee(genesis.getGenesisBaseFeePerGas().orElse(null))
         .withdrawalsRoot(isShanghaiAtGenesis(genesis) ? Hash.EMPTY_TRIE_HASH : null)
-        .dataGasUsed(isCancunAtGenesis(genesis) ? parseDataGasUsed(genesis) : 0L)
-        .excessDataGas(isCancunAtGenesis(genesis) ? parseExcessDataGas(genesis) : DataGas.ZERO)
+        .dataGasUsed(isCancunAtGenesis(genesis) ? parseDataGasUsed(genesis) : null)
+        .excessDataGas(isCancunAtGenesis(genesis) ? parseExcessDataGas(genesis) : null)
         .depositsRoot(isExperimentalEipsTimeAtGenesis(genesis) ? Hash.EMPTY_TRIE_HASH : null)
         .buildBlockHeader();
   }
@@ -219,14 +219,17 @@ public final class GenesisState {
   private static long parseNonce(final GenesisConfigFile genesis) {
     return withNiceErrorMessage("nonce", genesis.getNonce(), GenesisState::parseUnsignedLong);
   }
-  
+
   private static long parseDataGasUsed(final GenesisConfigFile genesis) {
-      return withNiceErrorMessage("dataGasUsed", genesis.getDataGasUsed(), GenesisState::parseUnsignedLong);
+    return withNiceErrorMessage(
+        "dataGasUsed", genesis.getDataGasUsed(), GenesisState::parseUnsignedLong);
   }
 
   private static DataGas parseExcessDataGas(final GenesisConfigFile genesis) {
-      long excessDataGas = withNiceErrorMessage("excessDataGas", genesis.getExcessDataGas(), GenesisState::parseUnsignedLong);
-      return DataGas.of(excessDataGas);
+    long excessDataGas =
+        withNiceErrorMessage(
+            "excessDataGas", genesis.getExcessDataGas(), GenesisState::parseUnsignedLong);
+    return DataGas.of(excessDataGas);
   }
 
   private static long parseUnsignedLong(final String value) {


### PR DESCRIPTION
## PR description

Fix from @spencer-tb 

https://github.com/hyperledger/besu/pull/5664#issuecomment-1620559037

> We recently added the hive pyspec simulator to https://hivecancun.ethdevops.io/, which runs the tests from https://github.com/ethereum/execution-spec-tests using the EngineAPI
> 
> In order to start running the tests the genesis state needs to include the `excessDataGas` and `dataGasUsed`, otherwise we get a genesis mismatch -> leading to a `SYNCING` status when adding the first block with `NewPayloadV3` via the EngineAPI, as opposed to a `VALID` or expected `INVALID` status.



> We recently added the hive pyspec simulator to https://hivecancun.ethdevops.io/, which runs the tests from https://github.com/ethereum/execution-spec-tests using the EngineAPI
> 
> In order to start running the tests the genesis state needs to include the `excessDataGas` and `dataGasUsed`, otherwise we get a genesis mismatch -> leading to a `SYNCING` status when adding the first block with `NewPayloadV3` via the EngineAPI, as opposed to a `VALID` or expected `INVALID` status.