### PR TITLE
[4844] Fix Data Gas Price Calculation

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.services;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
 
 import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Hash;
@@ -112,7 +113,9 @@ public class TraceServiceImpl implements TraceService {
                             .getFeeMarket()
                             .dataPricePerGas(
                                 maybeParentHeader
-                                    .flatMap(BlockHeader::getExcessDataGas)
+                                    .map(
+                                        parent ->
+                                            calculateExcessDataGasForParent(protocolSpec, parent))
                                     .orElse(DataGas.ZERO));
                     final TransactionProcessingResult result =
                         transactionProcessor.processTransaction(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
+
 import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
@@ -90,7 +92,9 @@ public class ExecuteTransactionStep implements Function<TransactionTrace, Transa
           protocolSpec
               .getFeeMarket()
               .dataPricePerGas(
-                  maybeParentHeader.flatMap(BlockHeader::getExcessDataGas).orElse(DataGas.ZERO));
+                  maybeParentHeader
+                      .map(parent -> calculateExcessDataGasForParent(protocolSpec, parent))
+                      .orElse(DataGas.ZERO));
       final BlockHashLookup blockHashLookup = new CachingBlockHashLookup(header, blockchain);
       result =
           transactionProcessor.processTransaction(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor;
 
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
+
 import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -55,7 +57,7 @@ public class BlockReplay {
                   .dataPricePerGas(
                       blockchain
                           .getBlockHeader(header.getParentHash())
-                          .flatMap(BlockHeader::getExcessDataGas)
+                          .map(parent -> calculateExcessDataGasForParent(protocolSpec, parent))
                           .orElse(DataGas.ZERO));
 
           final List<TransactionTrace> transactionTraces =
@@ -89,7 +91,7 @@ public class BlockReplay {
                   .dataPricePerGas(
                       blockchain
                           .getBlockHeader(header.getParentHash())
-                          .flatMap(BlockHeader::getExcessDataGas)
+                          .map(parent -> calculateExcessDataGasForParent(protocolSpec, parent))
                           .orElse(DataGas.ZERO));
 
           for (final Transaction transaction : body.getTransactions()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor;
 
 import static java.util.function.Predicate.isEqual;
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
 
 import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Hash;
@@ -121,7 +122,7 @@ public class TransactionTracer {
                       .dataPricePerGas(
                           blockchain
                               .getBlockHeader(header.getParentHash())
-                              .flatMap(BlockHeader::getExcessDataGas)
+                              .map(parent -> calculateExcessDataGasForParent(protocolSpec, parent))
                               .orElse(DataGas.ZERO));
               for (int i = 0; i < body.getTransactions().size(); i++) {
                 ((StackedUpdater<?, ?>) stackedUpdater).markTransactionBoundary();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -16,9 +16,9 @@ package org.hyperledger.besu.ethereum.api.query;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.ethereum.api.query.cache.TransactionLogBloomCacher.BLOCKS_PER_BLOOM_CACHE;
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.ApiConfiguration;
@@ -695,7 +695,8 @@ public class BlockchainQueries {
               parentHeader ->
                   protocolSpec
                       .getFeeMarket()
-                      .dataPricePerGas(parentHeader.getExcessDataGas().orElse(DataGas.ZERO)));
+                      .dataPricePerGas(
+                          calculateExcessDataGasForParent(protocolSpec, parentHeader)));
     }
     return Optional.empty();
   }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.blockcreation;
 
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
+
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Hash;
@@ -169,10 +171,10 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
           createPendingBlockHeader(timestamp, maybePrevRandao, newProtocolSpec);
       final Address miningBeneficiary =
           miningBeneficiaryCalculator.getMiningBeneficiary(processableBlockHeader.getNumber());
-      final Wei dataGasPrice =
+      Wei dataGasPrice =
           newProtocolSpec
               .getFeeMarket()
-              .dataPricePerGas(parentHeader.getExcessDataGas().orElse(DataGas.ZERO));
+              .dataPricePerGas(calculateExcessDataGasForParent(newProtocolSpec, parentHeader));
 
       throwIfStopped();
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -243,7 +243,7 @@ public final class GenesisState {
   private static boolean isShanghaiAtGenesis(final GenesisConfigFile genesis) {
     final OptionalLong shanghaiTimestamp = genesis.getConfigOptions().getShanghaiTime();
     if (shanghaiTimestamp.isPresent()) {
-      return shanghaiTimestamp.getAsLong() == genesis.getTimestamp();
+      return genesis.getTimestamp() >= shanghaiTimestamp.getAsLong();
     }
     return false;
   }
@@ -251,7 +251,7 @@ public final class GenesisState {
   private static boolean isCancunAtGenesis(final GenesisConfigFile genesis) {
     final OptionalLong cancunTimestamp = genesis.getConfigOptions().getCancunTime();
     if (cancunTimestamp.isPresent()) {
-      return cancunTimestamp.getAsLong() == genesis.getTimestamp();
+      return genesis.getTimestamp() >= cancunTimestamp.getAsLong();
     }
     return false;
   }
@@ -259,7 +259,7 @@ public final class GenesisState {
   private static boolean isExperimentalEipsTimeAtGenesis(final GenesisConfigFile genesis) {
     final OptionalLong experimentalEipsTime = genesis.getConfigOptions().getExperimentalEipsTime();
     if (experimentalEipsTime.isPresent()) {
-      return experimentalEipsTime.getAsLong() == genesis.getTimestamp();
+      return  genesis.getTimestamp() >= experimentalEipsTime.getAsLong();
     }
     return false;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeader.java
@@ -320,6 +320,9 @@ public class BlockHeader extends SealableBlockHeader
     if (withdrawalsRoot != null) {
       sb.append("withdrawalsRoot=").append(withdrawalsRoot).append(", ");
     }
+    if (dataGasUsed != null) {
+      sb.append("dataGasUsed=").append(dataGasUsed).append(", ");
+    }
     if (excessDataGas != null) {
       sb.append("excessDataGas=").append(excessDataGas).append(", ");
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -73,8 +73,7 @@ public class BlockHeaderBuilder {
   // instead of an invalid identifier such as -1.
   private OptionalLong nonce = OptionalLong.empty();
 
-  private Long dataGasUsed;
-
+  private Long dataGasUsed = null;
   private DataGas excessDataGas = null;
 
   public static BlockHeaderBuilder create() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -14,8 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
+
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.DataGas;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockProcessingOutputs;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
@@ -112,14 +113,19 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       final BlockHashLookup blockHashLookup = new CachingBlockHashLookup(blockHeader, blockchain);
       final Address miningBeneficiary =
           miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
-      final Wei dataGasPrice =
-          protocolSpec
-              .getFeeMarket()
-              .dataPricePerGas(
-                  blockchain
-                      .getBlockHeader(blockHeader.getParentHash())
-                      .flatMap(BlockHeader::getExcessDataGas)
-                      .orElse(DataGas.ZERO));
+
+      Optional<BlockHeader> maybeParentHeader =
+          blockchain.getBlockHeader(blockHeader.getParentHash());
+
+      Wei dataGasPrice =
+          maybeParentHeader
+              .map(
+                  (parentHeader) ->
+                      protocolSpec
+                          .getFeeMarket()
+                          .dataPricePerGas(
+                              calculateExcessDataGasForParent(protocolSpec, parentHeader)))
+              .orElse(Wei.ZERO);
 
       final TransactionProcessingResult result =
           transactionProcessor.processTransaction(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ExcessDataGasCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/feemarket/ExcessDataGasCalculator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.mainnet.feemarket;
+
+import org.hyperledger.besu.datatypes.DataGas;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+
+/**
+
+ Calculates the excess data gas for a parent block header.
+ */
+public class ExcessDataGasCalculator {
+  /**
+public class ExcessDataGasCalculator {
+  /**
+   Calculates the excess data gas for a parent block header.
+   @param protocolSpec The protocol specification.
+   @param parentHeader The parent block header.
+   @return The excess data gas.
+   */
+  public static DataGas calculateExcessDataGasForParent(
+      final ProtocolSpec protocolSpec, final BlockHeader parentHeader) {
+// Blob Data Excess
+    long headerExcess =
+        protocolSpec
+            .getGasCalculator()
+            .computeExcessDataGas(
+                parentHeader.getExcessDataGas().map(DataGas::toLong).orElse(0L),
+                parentHeader.getDataGasUsed().orElse(0L));
+    return DataGas.of(headerExcess);
+  }
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.transaction;
 
+import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessDataGasCalculator.calculateExcessDataGasForParent;
+
 import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
@@ -231,7 +233,9 @@ public class TransactionSimulator {
         protocolSpec
             .getFeeMarket()
             .dataPricePerGas(
-                maybeParentHeader.flatMap(BlockHeader::getExcessDataGas).orElse(DataGas.ZERO));
+                maybeParentHeader
+                    .map(parent -> calculateExcessDataGasForParent(protocolSpec, parent))
+                    .orElse(DataGas.ZERO));
 
     final Transaction transaction = maybeTransaction.get();
     final TransactionProcessingResult result =


### PR DESCRIPTION
## PR description

- Fix Data Gas Price Calculation
- Fix genesis state methods to verify forks

### Data Gas Price Calculation

The assertion, when creating blocks and processing transactions did not work:

>             # ensure that the user was willing to at least pay the current data gasprice
>             assert tx.max_fee_per_data_gas >= get_data_gasprice(block.header)


The previous calculation considered only the parent.excessDataGas to calculate the dataPricePerGas. This did not consider the data gas that the header used.

When a lot of transactions were sent and the gas increased, we were generating blocks with transactions that should not be included due the price.

From the spec:

```
def get_data_gasprice(header: Header) -> int:
    return fake_exponential(
        MIN_DATA_GASPRICE,
        header.excess_data_gas,
        DATA_GASPRICE_UPDATE_FRACTION
    )

def calc_excess_data_gas(parent: Header) -> int:
    if parent.excess_data_gas + parent.data_gas_used < TARGET_DATA_GAS_PER_BLOCK:
        return 0
    else:
        return parent.excess_data_gas + parent.data_gas_used - TARGET_DATA_GAS_PER_BLOCK
```

### Genesis State was not including WithdrawsRoot in the genesis block for Cancun:
This PR changes:
`return shanghaiTimestamp.getAsLong() == genesis.getTimestamp();`
to 
`return genesis.getTimestamp() >= shanghaiTimestamp.getAsLong();`