### PR TITLE
Return all not selected transactions, not only invalid ones

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -240,7 +240,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               .ommersHash(BodyValidation.ommersHash(ommers))
               .stateRoot(disposableWorldState.rootHash())
               .transactionsRoot(
-                  BodyValidation.transactionsRoot(transactionResults.getTransactions()))
+                  BodyValidation.transactionsRoot(transactionResults.getSelectedTransactions()))
               .receiptsRoot(BodyValidation.receiptsRoot(transactionResults.getReceipts()))
               .logsBloom(BodyValidation.logsBloom(transactionResults.getReceipts()))
               .gasUsed(transactionResults.getCumulativeGasUsed())
@@ -264,7 +264,10 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
           new Block(
               blockHeader,
               new BlockBody(
-                  transactionResults.getTransactions(), ommers, withdrawals, maybeDeposits));
+                  transactionResults.getSelectedTransactions(),
+                  ommers,
+                  withdrawals,
+                  maybeDeposits));
       return new BlockCreationResult(block, transactionResults);
     } catch (final SecurityModuleException ex) {
       throw new IllegalStateException("Failed to create block signature", ex);

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/LondonFeeMarketBlockTransactionSelectorTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.blockcreation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.config.GenesisConfigFile;
@@ -36,6 +37,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecAdapters;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import org.hyperledger.besu.testutil.TestClock;
 
 import java.time.ZoneId;
@@ -116,7 +118,9 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector.TransactionSelectionResults results =
         selector.buildTransactionListForBlock();
 
-    assertThat(results.getTransactions().size()).isEqualTo(0);
+    assertThat(results.getSelectedTransactions()).isEmpty();
+    assertThat(results.getNotSelectedTransactions())
+        .containsOnly(entry(tx, TransactionSelectionResult.CURRENT_TX_PRICE_BELOW_MIN));
     assertThat(transactionPool.count()).isEqualTo(1);
   }
 
@@ -144,8 +148,8 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector.TransactionSelectionResults results =
         selector.buildTransactionListForBlock();
 
-    assertThat(results.getTransactions().size()).isEqualTo(1);
-    assertThat(transactionPool.count()).isEqualTo(1);
+    assertThat(results.getSelectedTransactions()).containsExactly(tx);
+    assertThat(results.getNotSelectedTransactions()).isEmpty();
   }
 
   @Test
@@ -174,8 +178,8 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector.TransactionSelectionResults results =
         selector.buildTransactionListForBlock();
 
-    assertThat(results.getTransactions().size()).isEqualTo(1);
-    assertThat(transactionPool.count()).isEqualTo(1);
+    assertThat(results.getSelectedTransactions()).containsExactly(tx);
+    assertThat(results.getNotSelectedTransactions()).isEmpty();
   }
 
   @Test
@@ -207,7 +211,8 @@ public class LondonFeeMarketBlockTransactionSelectorTest
     final BlockTransactionSelector.TransactionSelectionResults results =
         selector.buildTransactionListForBlock();
 
-    assertThat(results.getTransactions())
+    assertThat(results.getSelectedTransactions())
         .containsExactly(txFrontier1, txLondon1, txFrontier2, txLondon2);
+    assertThat(results.getNotSelectedTransactions()).isEmpty();
   }
 }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'Tv7ZbXqvytaHJFsEtGuGFrhITRAlJ02T4/54GjhEI5Y='
+  knownHash = 'kmY3fycbIcbEHpf8aezNlZs3M8dD3lDf74lvedkDDu0='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/TransactionSelectionResult.java
@@ -143,6 +143,15 @@ public class TransactionSelectionResult {
     return Status.SELECTED.equals(status);
   }
 
+  /**
+   * Optionally return the reason why the transaction is invalid if present
+   *
+   * @return an optional with the invalid reason
+   */
+  public Optional<String> maybeInvalidReason() {
+    return maybeInvalidReason;
+  }
+
   @Override
   public String toString() {
     return status.name() + maybeInvalidReason.map(ir -> "(" + ir + ")").orElse("");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Apart from some little code cleanup, the main goal of this PR is to add, to the result of a block transaction selection, all the evaluated but the not selected transactions, with the reason they were not selected, this will potentially give more data during block creation, that could try different strategies to include some of the invalid transient transactions.
