### PR TITLE
junit4 removed for ethereum/api

### DIFF
--- a/ethereum/api/build.gradle
+++ b/ethereum/api/build.gradle
@@ -93,18 +93,13 @@ dependencies {
   testImplementation 'com.squareup.okhttp3:okhttp'
   testImplementation 'io.vertx:vertx-auth-jwt'
   testImplementation 'io.vertx:vertx-junit5'
-  testImplementation 'io.vertx:vertx-unit'
   testImplementation 'io.vertx:vertx-web-client'
-  testImplementation 'junit:junit'
   testImplementation 'org.apache.logging.log4j:log4j-core'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
-  testImplementation 'org.junit.jupiter:junit-jupiter-params'
-  testImplementation 'org.junit.platform:junit-platform-runner'
+
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
-
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 
   testSupportImplementation 'org.bouncycastle:bcpkix-jdk18on'
 
@@ -115,7 +110,7 @@ dependencies {
   integrationTestImplementation project(':testutil')
 
   integrationTestImplementation 'org.assertj:assertj-core'
-  integrationTestImplementation 'org.junit.jupiter:junit-jupiter-api'
+  integrationTestImplementation 'org.junit.jupiter:junit-jupiter'
   integrationTestImplementation 'org.mockito:mockito-core'
   integrationTestImplementation 'org.mockito:mockito-junit-jupiter'
   integrationTestImplementation 'org.testcontainers:testcontainers'

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractDataFetcherTest.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import graphql.GraphQLContext;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
@@ -43,7 +43,7 @@ public abstract class AbstractDataFetcherTest {
 
   @Mock protected BlockHeader header;
 
-  @Before
+  @BeforeEach
   public void before() {
     final GraphQLDataFetchers fetchers = new GraphQLDataFetchers(supportedCapabilities);
     fetcher = fetchers.getBlockDataFetcher();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -48,16 +49,15 @@ import graphql.GraphQL;
 import io.vertx.core.Vertx;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public abstract class AbstractEthGraphQLHttpServiceTest {
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path tempDir;
 
   private static BlockchainSetupUtil blockchainSetupUtil;
 
@@ -72,7 +72,7 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
   final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   protected static final MediaType GRAPHQL = MediaType.parse("application/graphql; charset=utf-8");
 
-  @BeforeClass
+  @BeforeAll
   public static void setupConstants() {
     blockchainSetupUtil =
         BlockchainSetupUtil.createForEthashChain(
@@ -80,7 +80,7 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
     blockchainSetupUtil.importAllBlocks();
   }
 
-  @Before
+  @BeforeEach
   public void setupTest() throws Exception {
     final Synchronizer synchronizerMock = Mockito.mock(Synchronizer.class);
     final SyncStatus status = new DefaultSyncStatus(1, 2, 3, Optional.of(4L), Optional.of(5L));
@@ -133,7 +133,7 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
     service =
         new GraphQLHttpService(
             vertx,
-            folder.newFolder().toPath(),
+            tempDir,
             config,
             graphQL,
             Map.of(
@@ -154,7 +154,7 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
     baseUrl = service.url() + "/graphql/";
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     client.dispatcher().executorService().shutdown();
     client.connectionPool().evictAll();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/BlockDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/BlockDataFetcherTest.java
@@ -28,12 +28,12 @@ import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BlockDataFetcherTest extends AbstractDataFetcherTest {
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/EthGraphQLHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/EthGraphQLHttpBySpecTest.java
@@ -15,9 +15,7 @@
 package org.hyperledger.besu.ethereum.api.graphql;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.stream.Stream;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
@@ -26,108 +24,78 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class EthGraphQLHttpBySpecTest extends AbstractEthGraphQLHttpServiceTest {
 
-  private final String specFileName;
-
-  public EthGraphQLHttpBySpecTest(final String specFileName) {
-    this.specFileName = specFileName;
+  public static Stream<Arguments> specs() {
+    return Stream.of(
+        Arguments.of("eth_blockNumber"),
+        Arguments.of("eth_call_Block8"),
+        Arguments.of("eth_call_Block8_invalidHexBytesData"),
+        Arguments.of("eth_call_BlockLatest"),
+        Arguments.of("eth_call_from_contract"),
+        Arguments.of("eth_estimateGas_transfer"),
+        Arguments.of("eth_estimateGas_noParams"),
+        Arguments.of("eth_estimateGas_contractDeploy"),
+        Arguments.of("eth_estimateGas_from_contract"),
+        Arguments.of("eth_gasPrice"),
+        Arguments.of("eth_getBalance_0x19"),
+        Arguments.of("eth_getBalance_invalidAccountBlockNumber"),
+        Arguments.of("eth_getBalance_invalidAccountLatest"),
+        Arguments.of("eth_getBalance_latest"),
+        Arguments.of("eth_getBalance_toobig_bn"),
+        Arguments.of("eth_getBalance_without_addr"),
+        Arguments.of("eth_getBlock_byHash"),
+        Arguments.of("eth_getBlock_byHash_InvalidHexBytes32Hash"),
+        Arguments.of("eth_getBlock_byHashInvalid"),
+        Arguments.of("eth_getBlock_byNumber"),
+        Arguments.of("eth_getBlock_byNumberInvalid"),
+        Arguments.of("eth_getBlock_wrongParams"),
+        Arguments.of("eth_getBlockTransactionCount_byHash"),
+        Arguments.of("eth_getBlockTransactionCount_byNumber"),
+        Arguments.of("eth_getCode"),
+        Arguments.of("eth_getCode_noCode"),
+        Arguments.of("eth_getLogs_emptyListParam"),
+        Arguments.of("eth_getLogs_matchTopic"),
+        Arguments.of("eth_getLogs_matchAnyTopic"),
+        Arguments.of("eth_getLogs_range"),
+        Arguments.of("eth_getStorageAt"),
+        Arguments.of("eth_getStorageAt_illegalRangeGreaterThan"),
+        Arguments.of("eth_getTransaction_byBlockHashAndIndex"),
+        Arguments.of("eth_getTransaction_byBlockNumberAndIndex"),
+        Arguments.of("eth_getTransaction_byBlockNumberAndInvalidIndex"),
+        Arguments.of("eth_getTransaction_byHash"),
+        Arguments.of("eth_getTransaction_byHashNull"),
+        Arguments.of("eth_getTransactionCount"),
+        Arguments.of("eth_getTransactionReceipt"),
+        Arguments.of("eth_sendRawTransaction_contractCreation"),
+        Arguments.of("eth_sendRawTransaction_messageCall"),
+        Arguments.of("eth_sendRawTransaction_nonceTooLow"),
+        Arguments.of("eth_sendRawTransaction_transferEther"),
+        Arguments.of("eth_sendRawTransaction_unsignedTransaction"),
+        Arguments.of("eth_syncing"),
+        Arguments.of("graphql_blocks_byFrom"),
+        Arguments.of("graphql_blocks_byRange"),
+        Arguments.of("graphql_blocks_byWrongRange"),
+        Arguments.of("graphql_pending"),
+        Arguments.of("graphql_tooComplex"),
+        Arguments.of("graphql_tooComplexSchema"),
+        Arguments.of("graphql_variable_address"),
+        Arguments.of("graphql_variable_bytes"),
+        Arguments.of("graphql_variable_bytes32"),
+        Arguments.of("graphql_variable_long"),
+        Arguments.of("block_withdrawals_pre_shanghai"),
+        Arguments.of("block_withdrawals"),
+        Arguments.of("eth_getTransaction_type2"),
+        Arguments.of("eth_getBlock_shanghai"));
   }
 
-  @Parameters(name = "{index}: {0}")
-  public static Collection<String> specs() {
-    final List<String> specs = new ArrayList<>();
-
-    specs.add("eth_blockNumber");
-
-    specs.add("eth_call_Block8");
-    specs.add("eth_call_Block8_invalidHexBytesData");
-    specs.add("eth_call_BlockLatest");
-    specs.add("eth_call_from_contract");
-
-    specs.add("eth_estimateGas_transfer");
-    specs.add("eth_estimateGas_noParams");
-    specs.add("eth_estimateGas_contractDeploy");
-    specs.add("eth_estimateGas_from_contract");
-
-    specs.add("eth_gasPrice");
-
-    specs.add("eth_getBalance_0x19");
-    specs.add("eth_getBalance_invalidAccountBlockNumber");
-    specs.add("eth_getBalance_invalidAccountLatest");
-    specs.add("eth_getBalance_latest");
-    specs.add("eth_getBalance_toobig_bn");
-    specs.add("eth_getBalance_without_addr");
-
-    specs.add("eth_getBlock_byHash");
-    specs.add("eth_getBlock_byHash_InvalidHexBytes32Hash");
-    specs.add("eth_getBlock_byHashInvalid");
-    specs.add("eth_getBlock_byNumber");
-    specs.add("eth_getBlock_byNumberInvalid");
-    specs.add("eth_getBlock_wrongParams");
-
-    specs.add("eth_getBlockTransactionCount_byHash");
-    specs.add("eth_getBlockTransactionCount_byNumber");
-
-    specs.add("eth_getCode");
-    specs.add("eth_getCode_noCode");
-
-    specs.add("eth_getLogs_emptyListParam");
-    specs.add("eth_getLogs_matchTopic");
-    specs.add("eth_getLogs_matchAnyTopic");
-    specs.add("eth_getLogs_range");
-
-    specs.add("eth_getStorageAt");
-    specs.add("eth_getStorageAt_illegalRangeGreaterThan");
-
-    specs.add("eth_getTransaction_byBlockHashAndIndex");
-    specs.add("eth_getTransaction_byBlockNumberAndIndex");
-    specs.add("eth_getTransaction_byBlockNumberAndInvalidIndex");
-    specs.add("eth_getTransaction_byHash");
-    specs.add("eth_getTransaction_byHashNull");
-
-    specs.add("eth_getTransactionCount");
-
-    specs.add("eth_getTransactionReceipt");
-
-    specs.add("eth_sendRawTransaction_contractCreation");
-    specs.add("eth_sendRawTransaction_messageCall");
-    specs.add("eth_sendRawTransaction_nonceTooLow");
-    specs.add("eth_sendRawTransaction_transferEther");
-    specs.add("eth_sendRawTransaction_unsignedTransaction");
-
-    specs.add("eth_syncing");
-
-    specs.add("graphql_blocks_byFrom");
-    specs.add("graphql_blocks_byRange");
-    specs.add("graphql_blocks_byWrongRange");
-
-    specs.add("graphql_pending");
-
-    specs.add("graphql_tooComplex");
-    specs.add("graphql_tooComplexSchema");
-
-    specs.add("graphql_variable_address");
-    specs.add("graphql_variable_bytes");
-    specs.add("graphql_variable_bytes32");
-    specs.add("graphql_variable_long");
-
-    specs.add("block_withdrawals_pre_shanghai");
-    specs.add("block_withdrawals");
-    specs.add("eth_getTransaction_type2");
-    specs.add("eth_getBlock_shanghai");
-
-    return specs;
-  }
-
-  @Test
-  public void graphQLCallWithSpecFile() throws Exception {
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("specs")
+  public void graphQLCallWithSpecFile(final String specFileName) throws Exception {
     graphQLCall(specFileName);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLConfigurationTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.graphql;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GraphQLConfigurationTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceHostWhitelistTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,16 +38,15 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 public class GraphQLHttpServiceHostWhitelistTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   protected static Vertx vertx;
 
@@ -57,7 +57,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
   private final GraphQLConfiguration graphQLConfig = createGraphQLConfig();
   private final List<String> hostsWhitelist = Arrays.asList("ally", "friend");
 
-  @Before
+  @BeforeEach
   public void initServerAndClient() throws Exception {
     vertx = Vertx.vertx();
 
@@ -92,12 +92,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
     final GraphQL graphQL = GraphQLProvider.buildGraphQL(dataFetchers);
 
     return new GraphQLHttpService(
-        vertx,
-        folder.newFolder().toPath(),
-        graphQLConfig,
-        graphQL,
-        graphQLContextMap,
-        Mockito.mock(EthScheduler.class));
+        vertx, folder, graphQLConfig, graphQL, graphQLContextMap, Mockito.mock(EthScheduler.class));
   }
 
   private static GraphQLConfiguration createGraphQLConfig() {
@@ -106,7 +101,7 @@ public class GraphQLHttpServiceHostWhitelistTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     client.dispatcher().executorService().shutdown();
     client.connectionPool().evictAll();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.net.InetSocketAddress;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,17 +50,16 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class GraphQLHttpServiceTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private static final Vertx vertx = Vertx.vertx();
 
@@ -75,7 +75,7 @@ public class GraphQLHttpServiceTest {
 
   private final GraphQLTestHelper testHelper = new GraphQLTestHelper();
 
-  @BeforeClass
+  @BeforeAll
   public static void initServerAndClient() throws Exception {
     blockchainQueries = Mockito.mock(BlockchainQueries.class);
     final Synchronizer synchronizer = Mockito.mock(Synchronizer.class);
@@ -109,18 +109,13 @@ public class GraphQLHttpServiceTest {
   private static GraphQLHttpService createGraphQLHttpService(final GraphQLConfiguration config)
       throws Exception {
     return new GraphQLHttpService(
-        vertx,
-        folder.newFolder().toPath(),
-        config,
-        graphQL,
-        graphQlContextMap,
-        Mockito.mock(EthScheduler.class));
+        vertx, folder, config, graphQL, graphQlContextMap, Mockito.mock(EthScheduler.class));
   }
 
   private static GraphQLHttpService createGraphQLHttpService() throws Exception {
     return new GraphQLHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        folder,
         createGraphQLConfig(),
         graphQL,
         graphQlContextMap,
@@ -133,7 +128,7 @@ public class GraphQLHttpServiceTest {
     return config;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupConstants() {
     final URL blocksUrl = BlockTestUtil.getTestBlockchainUrl();
 
@@ -144,7 +139,7 @@ public class GraphQLHttpServiceTest {
   }
 
   /** Tears down the HTTP server. */
-  @AfterClass
+  @AfterAll
   public static void shutdownServer() {
     client.dispatcher().executorService().shutdown();
     client.connectionPool().evictAll();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/AddressScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/AddressScalarTest.java
@@ -30,8 +30,8 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AddressScalarTest {
 
@@ -125,7 +125,7 @@ public class AddressScalarTest {
         .isInstanceOf(CoercingParseLiteralException.class);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     scalar = Scalars.addressScalar();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/BigIntScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/BigIntScalarTest.java
@@ -30,8 +30,8 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BigIntScalarTest {
 
@@ -109,7 +109,7 @@ public class BigIntScalarTest {
         .isInstanceOf(CoercingParseLiteralException.class);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     scalar = Scalars.bigIntScalar();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/Bytes32ScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/Bytes32ScalarTest.java
@@ -30,8 +30,8 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class Bytes32ScalarTest {
 
@@ -121,7 +121,7 @@ public class Bytes32ScalarTest {
         .isInstanceOf(CoercingParseLiteralException.class);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     scalar = Scalars.bytes32Scalar();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/BytesScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/BytesScalarTest.java
@@ -30,8 +30,8 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BytesScalarTest {
 
@@ -121,7 +121,7 @@ public class BytesScalarTest {
         .isInstanceOf(CoercingParseLiteralException.class);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     scalar = Scalars.bytesScalar();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/LongScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/LongScalarTest.java
@@ -28,8 +28,8 @@ import graphql.schema.CoercingParseLiteralException;
 import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import graphql.schema.GraphQLScalarType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LongScalarTest {
 
@@ -140,7 +140,7 @@ public class LongScalarTest {
         .isInstanceOf(CoercingParseLiteralException.class);
   }
 
-  @Before
+  @BeforeEach
   public void before() {
     scalar = Scalars.longScalar();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpBySpecTest.java
@@ -44,11 +44,9 @@ import com.google.common.io.Resources;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpServiceTest {
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -59,15 +57,13 @@ public abstract class AbstractJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpS
   private static final Pattern GAS_MATCH_FOR_TRACE =
       Pattern.compile("\"gasUsed\":\"[x0-9a-fA-F]+\",");
 
-  private final URL specURL;
+  private URL specURL;
 
-  protected AbstractJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("specs")
+  public void jsonRPCCallWithSpecFile(final String specName, final URL specURL) throws Exception {
     this.specURL = specURL;
-  }
-
-  @Test
-  public void jsonRPCCallWithSpecFile() throws Exception {
-    jsonRPCCall(specURL);
+    jsonRPCCall(this.specURL);
   }
 
   /**

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -51,6 +51,7 @@ import org.hyperledger.besu.testutil.BlockTestUtil.ChainResources;
 
 import java.math.BigInteger;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,13 +64,12 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class AbstractJsonRpcHttpServiceTest {
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private Path folder;
 
   protected BlockchainSetupUtil blockchainSetupUtil;
 
@@ -115,7 +115,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
         new ChainResources(genesisURL, blocksURL), storageFormat);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     setupBlockchain();
   }
@@ -185,7 +185,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             mock(MetricsConfiguration.class),
             natService,
             new HashMap<>(),
-            folder.getRoot().toPath(),
+            folder,
             mock(EthPeers.class),
             syncVertx,
             Optional.empty(),
@@ -207,7 +207,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
     service =
         new JsonRpcHttpService(
             vertx,
-            folder.newFolder().toPath(),
+            folder,
             config,
             new NoOpMetricsSystem(),
             natService,
@@ -220,7 +220,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
     baseUrl = service.url();
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     client.dispatcher().executorService().shutdown();
     client.connectionPool().evictAll();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -37,15 +37,15 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(AdminJsonRpcHttpServiceTest.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     initServerAndClient();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamerTest.java
@@ -29,14 +29,17 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.impl.future.SucceededFuture;
 import io.vertx.core.net.SocketAddress;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class JsonResponseStreamerTest {
   private final SocketAddress testAddress = SocketAddress.domainSocketAddress("test");
 
@@ -44,7 +47,7 @@ public class JsonResponseStreamerTest {
 
   @Mock private HttpServerResponse failedResponse;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(httpResponse.write(any(Buffer.class))).thenReturn(new SucceededFuture<>(null, null));
     when(failedResponse.write(any(Buffer.class)))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfigurationTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.authentication.JwtAlgorithm;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonRpcConfigurationTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
@@ -44,6 +44,8 @@ import org.hyperledger.besu.nat.NatService;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,15 +61,14 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JsonRpcHttpServiceHostAllowlistTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private Path folder;
 
   protected static final Vertx vertx = Vertx.vertx();
 
@@ -84,7 +85,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
 
   private final List<String> hostsAllowlist = Arrays.asList("ally", "friend");
 
-  @Before
+  @BeforeEach
   public void initServerAndClient() throws Exception {
     final P2PNetwork peerDiscoveryMock = mock(P2PNetwork.class);
     final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
@@ -121,7 +122,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
                     mock(MetricsConfiguration.class),
                     natService,
                     new HashMap<>(),
-                    folder.getRoot().toPath(),
+                    folder,
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
@@ -136,7 +137,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
   private JsonRpcHttpService createJsonRpcHttpService() throws Exception {
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        Files.createTempDirectory(folder, "tempDir"),
         jsonRpcConfig,
         new NoOpMetricsSystem(),
         natService,
@@ -151,7 +152,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
     return config;
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     service.stop().join();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -49,6 +49,7 @@ import org.hyperledger.besu.nat.NatService;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -77,18 +78,17 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class JsonRpcHttpServiceLoginTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private static final Vertx vertx = Vertx.vertx();
 
@@ -112,7 +112,7 @@ public class JsonRpcHttpServiceLoginTest {
   protected final JsonRpcTestHelper testHelper = new JsonRpcTestHelper();
   protected static final NatService natService = new NatService(Optional.empty());
 
-  @BeforeClass
+  @BeforeAll
   public static void initServerAndClient() throws Exception {
     peerDiscoveryMock = mock(P2PNetwork.class);
     blockchainQueries = mock(BlockchainQueries.class);
@@ -151,7 +151,7 @@ public class JsonRpcHttpServiceLoginTest {
                     mock(MetricsConfiguration.class),
                     natService,
                     new HashMap<>(),
-                    folder.getRoot().toPath(),
+                    folder,
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
@@ -178,7 +178,7 @@ public class JsonRpcHttpServiceLoginTest {
 
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        folder,
         config,
         new NoOpMetricsSystem(),
         natService,
@@ -195,7 +195,7 @@ public class JsonRpcHttpServiceLoginTest {
   }
 
   /** Tears down the HTTP server. */
-  @AfterClass
+  @AfterAll
   public static void shutdownServer() {
     service.stop().join();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceParameterizedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceParameterizedTest.java
@@ -25,39 +25,31 @@ import java.util.Collection;
 import io.vertx.core.json.JsonObject;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class JsonRpcHttpServiceParameterizedTest extends JsonRpcHttpServiceTestBase {
 
-  private final String requestJson;
-
-  public JsonRpcHttpServiceParameterizedTest(final String requestJson) {
-    this.requestJson = requestJson;
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     initServerAndClient();
   }
 
   /** Tears down the HTTP server. */
-  @AfterClass
+  @AfterAll
   public static void shutdownServer() {
     service.stop().join();
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {{"\"a string\""}, {"a string"}, {"{bla"}, {""}});
   }
 
-  @Test
-  public void invalidJsonShouldReturnParseError() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void invalidJsonShouldReturnParseError(final String requestJson) throws Exception {
     final RequestBody body = RequestBody.create(requestJson, JSON);
 
     try (final Response resp = client.newCall(buildPostRequest(body)).execute()) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -58,14 +58,14 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     initServerAndClient();
   }
@@ -78,7 +78,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
   }
 
   /** Tears down the HTTP server. */
-  @AfterClass
+  @AfterAll
   public static void shutdownServer() {
     service.stop().join();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.nat.NatService;
 
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,13 +60,12 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import org.junit.AfterClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JsonRpcHttpServiceTestBase {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
   protected final JsonRpcTestHelper testHelper = new JsonRpcTestHelper();
 
   private static final Vertx vertx = Vertx.vertx();
@@ -130,7 +130,7 @@ public class JsonRpcHttpServiceTestBase {
                     mock(MetricsConfiguration.class),
                     natService,
                     new HashMap<>(),
-                    folder.getRoot().toPath(),
+                    folder,
                     ethPeersMock,
                     vertx,
                     Optional.empty(),
@@ -147,7 +147,7 @@ public class JsonRpcHttpServiceTestBase {
       throws Exception {
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        folder,
         config,
         new NoOpMetricsSystem(),
         natService,
@@ -159,7 +159,7 @@ public class JsonRpcHttpServiceTestBase {
   protected static JsonRpcHttpService createJsonRpcHttpService() throws Exception {
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        folder,
         createLimitedJsonRpcConfig(),
         new NoOpMetricsSystem(),
         natService,
@@ -186,7 +186,7 @@ public class JsonRpcHttpServiceTestBase {
   }
 
   /** Tears down the HTTP server. */
-  @AfterClass
+  @AfterAll
   public static void shutdownServer() {
     service.stop().join();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
@@ -71,14 +71,13 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JsonRpcHttpServiceTlsClientAuthTest {
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   protected static final Vertx vertx = Vertx.vertx();
 
@@ -99,7 +98,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
   private final FileBasedPasswordProvider fileBasedPasswordProvider =
       new FileBasedPasswordProvider(createPasswordFile(besuCertificate));
 
-  @Before
+  @BeforeEach
   public void initServer() throws Exception {
     final P2PNetwork peerDiscoveryMock = mock(P2PNetwork.class);
     final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
@@ -136,7 +135,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
                     mock(MetricsConfiguration.class),
                     natService,
                     Collections.emptyMap(),
-                    folder.getRoot().toPath(),
+                    folder,
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
@@ -155,7 +154,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
       throws Exception {
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        folder,
         jsonRpcConfig,
         new NoOpMetricsSystem(),
         natService,
@@ -217,13 +216,13 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
 
   private Path createTempFile() {
     try {
-      return folder.newFile().toPath();
+      return Files.createTempFile(folder, "newFile", "");
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     System.clearProperty("javax.net.ssl.trustStore");
     System.clearProperty("javax.net.ssl.trustStorePassword");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
@@ -194,7 +194,7 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
               Assertions.fail("service.start should have failed");
             })
         .withCauseInstanceOf(JsonRpcServiceException.class)
-        .withMessageContaining("Short read of DER length");
+        .withMessageContaining("Tag number over 30 is not supported");
   }
 
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -68,14 +68,13 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class JsonRpcHttpServiceTlsTest {
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private Path folder;
 
   protected static final Vertx vertx = Vertx.vertx();
 
@@ -89,7 +88,7 @@ public class JsonRpcHttpServiceTlsTest {
   private final JsonRpcTestHelper testHelper = new JsonRpcTestHelper();
   private final SelfSignedP12Certificate besuCertificate = SelfSignedP12Certificate.create();
 
-  @Before
+  @BeforeEach
   public void initServer() throws Exception {
     final P2PNetwork peerDiscoveryMock = mock(P2PNetwork.class);
     final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
@@ -126,7 +125,7 @@ public class JsonRpcHttpServiceTlsTest {
                     mock(MetricsConfiguration.class),
                     natService,
                     Collections.emptyMap(),
-                    folder.getRoot().toPath(),
+                    folder,
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
@@ -140,7 +139,7 @@ public class JsonRpcHttpServiceTlsTest {
       throws Exception {
     return new JsonRpcHttpService(
         vertx,
-        folder.newFolder().toPath(),
+        Files.createTempDirectory(folder, "newFolder"),
         jsonRpcConfig,
         new NoOpMetricsSystem(),
         natService,
@@ -178,13 +177,13 @@ public class JsonRpcHttpServiceTlsTest {
 
   private Path createTempFile() {
     try {
-      return folder.newFile().toPath();
+      return Files.createFile(folder.resolve("tempFile"));
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
   }
 
-  @After
+  @AfterEach
   public void shutdownServer() {
     service.stop().join();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/LatestNonceProviderTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/LatestNonceProviderTest.java
@@ -23,13 +23,13 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.OptionalLong;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LatestNonceProviderTest {
 
   private final Address senderAddress = Address.fromHexString("1");
@@ -39,7 +39,7 @@ public class LatestNonceProviderTest {
 
   @Mock private TransactionPool transactionPool;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     nonceProvider = new LatestNonceProvider(blockchainQueries, transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/LimitConnectionsJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/LimitConnectionsJsonRpcHttpServiceTest.java
@@ -22,12 +22,12 @@ import java.io.IOException;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class LimitConnectionsJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void initLimitedServerAndClient() throws Exception {
     maxConnections = 2;
     initServerAndClient();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MaxBatchSizeJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/MaxBatchSizeJsonRpcHttpServiceTest.java
@@ -23,7 +23,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MaxBatchSizeJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcErrorTypeConverterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcErrorTypeConverterTest.java
@@ -22,16 +22,11 @@ import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class RpcErrorTypeConverterTest {
 
-  @Parameters
   public static Collection<Object[]> expectedErrorMapping() {
     return Arrays.asList(
         new Object[][] {
@@ -77,14 +72,10 @@ public class RpcErrorTypeConverterTest {
         });
   }
 
-  @Parameter(0)
-  public TransactionInvalidReason txInvalidReason;
-
-  @Parameter(1)
-  public RpcErrorType expectedJsonRpcError;
-
-  @Test
-  public void expectedTransactionValidationToJsonRpcErrorConversion() {
+  @ParameterizedTest
+  @MethodSource("expectedErrorMapping")
+  public void expectedTransactionValidationToJsonRpcErrorConversion(
+      final TransactionInvalidReason txInvalidReason, final RpcErrorType expectedJsonRpcError) {
     assertThat(JsonRpcErrorConverter.convertTransactionInvalidReason(txInvalidReason))
         .isEqualTo(expectedJsonRpcError);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationServiceTest.java
@@ -30,7 +30,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.User;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AuthenticationServiceTest {
   private final Vertx vertx = Vertx.vertx();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtilsTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AuthenticationUtilsTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthServiceTest.java
@@ -34,7 +34,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EngineAuthServiceTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactoryTest.java
@@ -34,7 +34,7 @@ import io.vertx.ext.auth.jwt.JWTAuthOptions;
 import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JWTAuthOptionsFactoryTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUserTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUserTest.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TomlUserTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/DebugJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/DebugJsonRpcHttpBySpecTest.java
@@ -16,26 +16,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.bonsai;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class DebugJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public DebugJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBonsaiBlockchain();
     startService();
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return findSpecFiles(
         new String[] {"debug"},

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/EthByzantiumJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/EthByzantiumJsonRpcHttpBySpecTest.java
@@ -18,20 +18,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class EthByzantiumJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public EthByzantiumJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBonsaiBlockchain();
     startService();
@@ -43,7 +35,6 @@ public class EthByzantiumJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpec
         "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin", dataStorageFormat);
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return AbstractJsonRpcHttpBySpecTest.findSpecFiles(new String[] {"eth_latest"});
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/EthJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/EthJsonRpcHttpBySpecTest.java
@@ -16,26 +16,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.bonsai;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class EthJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public EthJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBonsaiBlockchain();
     startService();
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return findSpecFiles(
         new String[] {"eth"}, "getProof"); // getProof is not working with bonsai trie

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/bonsai/TraceJsonRpcHttpBySpecTest.java
@@ -18,20 +18,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public TraceJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBonsaiBlockchain();
     startService();
@@ -43,7 +35,6 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
         "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin", storageFormat);
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return AbstractJsonRpcHttpBySpecTest.findSpecFiles(
         new String[] {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/context/ContextKeyTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/context/ContextKeyTest.java
@@ -26,15 +26,11 @@ import java.util.function.Supplier;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ContextKeyTest<T> {
 
-  @Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
@@ -50,24 +46,14 @@ public class ContextKeyTest<T> {
   }
 
   private static final String JSON = "{\"key\": \"value\"}";
-  private final ContextKey key;
-  private final RoutingContext ctx;
-  private final Supplier<T> defaultSupplier;
-  private final T expected;
 
-  public ContextKeyTest(
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(
       final ContextKey key,
       final RoutingContext ctx,
       final Supplier<T> defaultSupplier,
       final T expected) {
-    this.key = key;
-    this.ctx = ctx;
-    this.defaultSupplier = defaultSupplier;
-    this.expected = expected;
-  }
-
-  @Test
-  public void test() {
     assertThat(key.extractFrom(ctx, defaultSupplier)).isEqualTo(expected);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/DebugJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/DebugJsonRpcHttpBySpecTest.java
@@ -16,26 +16,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.forest;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class DebugJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public DebugJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBlockchain();
     startService();
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return findSpecFiles(new String[] {"debug"});
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/EthByzantiumJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/EthByzantiumJsonRpcHttpBySpecTest.java
@@ -18,20 +18,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class EthByzantiumJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public EthByzantiumJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBlockchain();
     startService();
@@ -43,7 +35,6 @@ public class EthByzantiumJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpec
         "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin", storageFormat);
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return AbstractJsonRpcHttpBySpecTest.findSpecFiles(new String[] {"eth_latest"});
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/EthJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/EthJsonRpcHttpBySpecTest.java
@@ -16,26 +16,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.forest;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class EthJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public EthJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBlockchain();
     startService();
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return findSpecFiles(new String[] {"eth"});
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/TraceJsonRpcHttpBySpecTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/forest/TraceJsonRpcHttpBySpecTest.java
@@ -18,20 +18,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpBySpecTest;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 
-import java.net.URL;
+import org.junit.jupiter.api.BeforeEach;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-
-@RunWith(Parameterized.class)
 public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
 
-  public TraceJsonRpcHttpBySpecTest(final String specName, final URL specURL) {
-    super(specName, specURL);
-  }
-
   @Override
+  @BeforeEach
   public void setup() throws Exception {
     setupBlockchain();
     startService();
@@ -43,7 +35,6 @@ public class TraceJsonRpcHttpBySpecTest extends AbstractJsonRpcHttpBySpecTest {
         "trace/chain-data/genesis.json", "trace/chain-data/blocks.bin", storageFormat);
   }
 
-  @Parameters(name = "{index}: {0}")
   public static Object[][] specs() {
     return AbstractJsonRpcHttpBySpecTest.findSpecFiles(
         new String[] {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheckTest.java
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ReadinessCheckTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/EthJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/EthJsonRpcHttpServiceTest.java
@@ -31,7 +31,7 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EthJsonRpcHttpServiceTest extends AbstractJsonRpcHttpServiceTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterIdGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterIdGeneratorTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FilterIdGeneratorTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerLogFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerLogFilterTest.java
@@ -49,14 +49,14 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FilterManagerLogFilterTest {
 
   private static final String PRIVACY_GROUP_ID = "Ko2bVqD+nNlNYL5EE7y3IdOnviftjiizpjRt+HTuFBs=";
@@ -70,7 +70,7 @@ public class FilterManagerLogFilterTest {
   @Mock private TransactionPool transactionPool;
   @Spy private final FilterRepository filterRepository = new FilterRepository();
 
-  @Before
+  @BeforeEach
   public void setupTest() {
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     this.filterManager =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerTest.java
@@ -36,14 +36,14 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FilterManagerTest {
 
   private BlockDataGenerator blockGenerator;
@@ -55,7 +55,7 @@ public class FilterManagerTest {
   @Mock private TransactionPool transactionPool;
   @Spy final FilterRepository filterRepository = new FilterRepository();
 
-  @Before
+  @BeforeEach
   public void setupTest() {
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     this.blockGenerator = new BlockDataGenerator();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterRepositoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterRepositoryTest.java
@@ -21,14 +21,14 @@ import java.util.Collection;
 import java.util.Optional;
 
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FilterRepositoryTest {
 
   private FilterRepository repository;
 
-  @Before
+  @BeforeEach
   public void before() {
     repository = new FilterRepository();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FilterTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTimeoutMonitorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTimeoutMonitorTest.java
@@ -23,20 +23,20 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FilterTimeoutMonitorTest {
 
   @Mock private FilterRepository filterRepository;
 
   private FilterTimeoutMonitor timeoutMonitor;
 
-  @Before
+  @BeforeEach
   public void before() {
     timeoutMonitor = new FilterTimeoutMonitor(filterRepository);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogsQueryTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogsQueryTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeerTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminAddPeerTest {
 
   @Mock private P2PNetwork p2pNetwork;
@@ -69,7 +69,7 @@ public class AdminAddPeerTest {
       new JsonRpcRequestContext(
           new JsonRpcRequest("2.0", "admin_addPeer", new String[] {validDNSEnode}));
 
-  @Before
+  @BeforeEach
   public void setup() {
     method =
         new AdminAddPeer(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevelTest.java
@@ -25,19 +25,19 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.util.LogConfigurator;
 
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminChangeLogLevelTest {
 
   private AdminChangeLogLevel adminChangeLogLevel;
 
-  @Before
+  @BeforeEach
   public void before() {
     adminChangeLogLevel = new AdminChangeLogLevel();
     LogConfigurator.setLevel("", "INFO");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCacheTest.java
@@ -29,15 +29,15 @@ import org.hyperledger.besu.ethereum.api.query.cache.TransactionLogBloomCacher.C
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminGenerateLogBloomCacheTest {
 
   @Mock private BlockchainQueries blockchainQueries;
@@ -47,7 +47,7 @@ public class AdminGenerateLogBloomCacheTest {
 
   private AdminGenerateLogBloomCache method;
 
-  @Before
+  @BeforeEach
   public void setup() {
     method = new AdminGenerateLogBloomCache(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRemoveCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRemoveCacheTest.java
@@ -36,15 +36,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminLogsRemoveCacheTest {
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private Blockchain blockchain;
@@ -55,7 +55,7 @@ public class AdminLogsRemoveCacheTest {
 
   private AdminLogsRemoveCache adminLogsRemoveCache;
 
-  @Before
+  @BeforeEach
   public void setup() {
     adminLogsRemoveCache = new AdminLogsRemoveCache(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRepairCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRepairCacheTest.java
@@ -32,13 +32,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminLogsRepairCacheTest {
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private Blockchain blockchain;
@@ -47,7 +47,7 @@ public class AdminLogsRepairCacheTest {
 
   private AdminLogsRepairCache adminLogsRepairCache;
 
-  @Before
+  @BeforeEach
   public void setup() {
     adminLogsRepairCache = new AdminLogsRepairCache(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -50,13 +50,16 @@ import java.util.Optional;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class AdminNodeInfoTest {
 
   @Mock private P2PNetwork p2pNetwork;
@@ -81,7 +84,7 @@ public class AdminNodeInfoTest {
               .listeningPort(30303)
               .build());
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(blockHeader.getHash()).thenReturn(Hash.EMPTY);
     final ChainHead testChainHead = new ChainHead(blockHeader, Difficulty.ONE, 1L);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -43,13 +43,13 @@ import com.google.common.collect.Lists;
 import io.vertx.core.json.Json;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminPeersTest {
 
   private AdminPeers adminPeers;
@@ -59,7 +59,7 @@ public class AdminPeersTest {
 
   @Mock private EthPeers ethPeers;
 
-  @Before
+  @BeforeEach
   public void before() {
     adminPeers = new AdminPeers(ethPeers);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeerTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.p2p.peers.ImmutableEnodeDnsConfiguration;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class AdminRemovePeerTest {
 
   @Mock private P2PNetwork p2pNetwork;
@@ -69,7 +69,7 @@ public class AdminRemovePeerTest {
       new JsonRpcRequestContext(
           new JsonRpcRequest("2.0", "admin_removePeer", new String[] {validDNSEnode}));
 
-  @Before
+  @BeforeEach
   public void setup() {
     method =
         new AdminRemovePeer(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugBatchSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugBatchSendRawTransactionTest.java
@@ -29,13 +29,13 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
 public class DebugBatchSendRawTransactionTest {
 
@@ -44,7 +44,7 @@ public class DebugBatchSendRawTransactionTest {
   @Mock TransactionPool transactionPool;
   DebugBatchSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new DebugBatchSendRawTransaction(transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlockTest.java
@@ -42,7 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 public class DebugGetBadBlockTest {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugMetricsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugMetricsTest.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DebugMetricsTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFileTest.java
@@ -37,20 +37,20 @@ import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DebugStandardTraceBadBlockToFileTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private final BlockchainQueries blockchainQueries = mock(BlockchainQueries.class);
   private final Blockchain blockchain = mock(Blockchain.class);
@@ -62,9 +62,9 @@ public class DebugStandardTraceBadBlockToFileTest {
 
   private final DebugStandardTraceBadBlockToFile debugStandardTraceBadBlockToFile =
       new DebugStandardTraceBadBlockToFile(
-          () -> transactionTracer, blockchainQueries, protocolSchedule, folder.getRoot().toPath());
+          () -> transactionTracer, blockchainQueries, protocolSchedule, folder);
 
-  @Before
+  @BeforeEach
   public void setup() {
     doAnswer(
             invocation ->

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFileTest.java
@@ -32,19 +32,19 @@ import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 public class DebugStandardTraceBlockToFileTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private static Path folder;
 
   private final WorldStateArchive archive =
       mock(WorldStateArchive.class, Answers.RETURNS_DEEP_STUBS);
@@ -53,8 +53,7 @@ public class DebugStandardTraceBlockToFileTest {
       spy(new BlockchainQueries(blockchain, archive));
   private final TransactionTracer transactionTracer = mock(TransactionTracer.class);
   private final DebugStandardTraceBlockToFile debugStandardTraceBlockToFile =
-      new DebugStandardTraceBlockToFile(
-          () -> transactionTracer, blockchainQueries, folder.getRoot().toPath());
+      new DebugStandardTraceBlockToFile(() -> transactionTracer, blockchainQueries, folder);
 
   @Test
   public void nameShouldBeDebugTraceTransaction() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAtTest.java
@@ -55,8 +55,8 @@ import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.invocation.InvocationOnMock;
 
@@ -82,7 +82,7 @@ public class DebugStorageRangeAtTest {
       Hash.fromHexString("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
   private final Address accountAddress = Address.MODEXP;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(transaction.getHash()).thenReturn(transactionHash);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHashTest.java
@@ -44,8 +44,8 @@ import java.util.OptionalLong;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 public class DebugTraceBlockByHashTest {
@@ -62,7 +62,7 @@ public class DebugTraceBlockByHashTest {
   private final Hash blockHash =
       Hash.fromHexString("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     doAnswer(
             invocation ->

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumberTest.java
@@ -45,7 +45,7 @@ import java.util.OptionalLong;
 import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 public class DebugTraceBlockByNumberTest {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
@@ -49,7 +49,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 import org.mockito.Mockito;
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransactionTest.java
@@ -51,8 +51,8 @@ import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Answers;
 
 public class DebugTraceTransactionTest {
@@ -71,7 +71,7 @@ public class DebugTraceTransactionTest {
   private final Hash transactionHash =
       Hash.fromHexString("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-  @Before
+  @BeforeEach
   public void setup() {
     doAnswer(__ -> Optional.of(blockHeader))
         .when(blockchainQueries)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlockNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlockNumberTest.java
@@ -24,13 +24,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthBlockNumberTest {
 
   private final String JSON_RPC_VERSION = "2.0";
@@ -39,7 +39,7 @@ public class EthBlockNumberTest {
   @Mock private BlockchainQueries blockchainQueries;
   private EthBlockNumber method;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthBlockNumber(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -52,15 +52,18 @@ import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthCallTest {
 
   private EthCall method;
@@ -74,7 +77,7 @@ public class EthCallTest {
 
   @Captor ArgumentCaptor<PreCloseStateHandler<Optional<JsonRpcResponse>>> mapperCaptor;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthCall(blockchainQueries, transactionSimulator);
     blockHeader = mock(BlockHeader.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthChainIdTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthChainIdTest.java
@@ -25,15 +25,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthChainIdTest {
 
   private EthChainId method;
   private final BigInteger CHAIN_ID = BigInteger.ONE;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthChainId(Optional.of(CHAIN_ID));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCoinbaseTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCoinbaseTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthCoinbaseTest {
 
   @Mock private MiningCoordinator miningCoordinator;
@@ -44,7 +44,7 @@ public class EthCoinbaseTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_coinbase";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthCoinbase(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -53,15 +53,18 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthCreateAccessListTest {
 
   private final String METHOD = "eth_createAccessList";
@@ -73,7 +76,7 @@ public class EthCreateAccessListTest {
   @Mock private TransactionSimulator transactionSimulator;
   @Mock private WorldStateArchive worldStateArchive;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(blockchainQueries.headBlockNumber()).thenReturn(1L);
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -51,13 +51,16 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthEstimateGasTest {
 
   private EthEstimateGas method;
@@ -68,7 +71,7 @@ public class EthEstimateGasTest {
   @Mock private TransactionSimulator transactionSimulator;
   @Mock private WorldStateArchive worldStateArchive;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(blockchainQueries.headBlockNumber()).thenReturn(1L);
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistoryTest.java
@@ -43,8 +43,8 @@ import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthFeeHistoryTest {
   final BlockDataGenerator gen = new BlockDataGenerator();
@@ -52,7 +52,7 @@ public class EthFeeHistoryTest {
   private EthFeeHistory method;
   private ProtocolSchedule protocolSchedule;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     protocolSchedule = mock(ProtocolSchedule.class);
     final Block genesisBlock = gen.genesisBlock();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -42,14 +42,14 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.internal.verification.VerificationModeFactory;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGasPriceTest {
 
   @Mock private PoWMiningCoordinator miningCoordinator;
@@ -58,7 +58,7 @@ public class EthGasPriceTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_gasPrice";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method =
         new EthGasPrice(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHashTest.java
@@ -25,13 +25,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetBlockByHashTest {
 
   @Mock private BlockchainQueries blockchainQueries;
@@ -41,7 +41,7 @@ public class EthGetBlockByHashTest {
   private final String ETH_METHOD = "eth_getBlockByHash";
   private final String ZERO_HASH = String.valueOf(Hash.ZERO);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthGetBlockByHash(blockchainQueries, blockResult);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
@@ -42,13 +42,16 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthGetBlockByNumberTest {
   private static final String JSON_RPC_VERSION = "2.0";
   private static final String ETH_METHOD = "eth_getBlockByNumber";
@@ -64,7 +67,7 @@ public class EthGetBlockByNumberTest {
   @Mock private Synchronizer synchronizer;
   @Mock private WorldStateArchive worldStateArchive;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     blockchain = createInMemoryBlockchain(blockDataGenerator.genesisBlock());
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChangesTest.java
@@ -40,20 +40,20 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetFilterChangesTest {
 
   private EthGetFilterChanges method;
 
   @Mock FilterManager filterManager;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthGetFilterChanges(filterManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogsTest.java
@@ -39,20 +39,20 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetFilterLogsTest {
 
   private EthGetFilterLogs method;
 
   @Mock FilterManager filterManager;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthGetFilterLogs(filterManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogsTest.java
@@ -41,13 +41,13 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import java.util.ArrayList;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetLogsTest {
 
   private EthGetLogs method;
@@ -55,7 +55,7 @@ public class EthGetLogsTest {
   @Mock BlockchainQueries blockchainQueries;
   @Mock Optional<Long> maxLogRange;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthGetLogs(blockchainQueries, maxLogRange);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHashTest.java
@@ -43,13 +43,13 @@ import java.util.Optional;
 
 import com.google.common.base.Suppliers;
 import org.assertj.core.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetMinerDataByBlockHashTest {
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private ProtocolSchedule protocolSchedule;
@@ -59,7 +59,7 @@ public class EthGetMinerDataByBlockHashTest {
   private final String ETH_METHOD = "eth_getMinerDataByBlockHash";
   private final BlockHeaderTestFixture blockHeaderTestFixture = new BlockHeaderTestFixture();
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method =
         new EthGetMinerDataByBlockHash(Suppliers.ofInstance(blockchainQueries), protocolSchedule);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumberTest.java
@@ -42,13 +42,13 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.assertj.core.util.Arrays;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetMinerDataByBlockNumberTest {
   @Mock private BlockchainQueries blockchainQueries;
   @Mock private ProtocolSchedule protocolSchedule;
@@ -58,7 +58,7 @@ public class EthGetMinerDataByBlockNumberTest {
   private final String ETH_METHOD = "eth_getMinerDataByBlockNumber";
   private final BlockHeaderTestFixture blockHeaderTestFixture = new BlockHeaderTestFixture();
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new EthGetMinerDataByBlockNumber(blockchainQueries, protocolSchedule);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndexTest.java
@@ -26,12 +26,12 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetTransactionByBlockHashAndIndexTest {
   private EthGetTransactionByBlockHashAndIndex method;
   @Mock private BlockchainQueries blockchain;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHashTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHashTest.java
@@ -41,13 +41,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetTransactionByHashTest {
 
   private static final String VALID_TRANSACTION =
@@ -60,7 +60,7 @@ public class EthGetTransactionByHashTest {
 
   @Mock private TransactionPool transactionPool;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthGetTransactionByHash(blockchainQueries, transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -48,7 +48,7 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256s;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EthGetTransactionReceiptTest {
   private final TransactionReceipt statusReceipt =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndexTest.java
@@ -44,13 +44,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetUncleByBlockHashAndIndexTest {
 
   private final BlockHeaderTestFixture blockHeaderTestFixture = new BlockHeaderTestFixture();
@@ -61,7 +61,7 @@ public class EthGetUncleByBlockHashAndIndexTest {
 
   @Mock private BlockchainQueries blockchainQueries;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new EthGetUncleByBlockHashAndIndex(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndexTest.java
@@ -45,13 +45,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetUncleByBlockNumberAndIndexTest {
 
   private final BlockHeaderTestFixture blockHeaderTestFixture = new BlockHeaderTestFixture();
@@ -61,7 +61,7 @@ public class EthGetUncleByBlockNumberAndIndexTest {
 
   @Mock private BlockchainQueries blockchainQueries;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new EthGetUncleByBlockNumberAndIndex(blockchainQueries);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWorkTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWorkTest.java
@@ -34,13 +34,13 @@ import java.util.Optional;
 import com.google.common.io.BaseEncoding;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthGetWorkTest {
 
   private EthGetWork method;
@@ -50,7 +50,7 @@ public class EthGetWorkTest {
 
   @Mock private PoWMiningCoordinator miningCoordinator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(miningCoordinator.getEpochCalculator())
         .thenReturn(new EpochCalculator.DefaultEpochCalculator());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthHashrateTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthHashrateTest.java
@@ -25,13 +25,13 @@ import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthHashrateTest {
 
   @Mock private PoWMiningCoordinator miningCoordinator;
@@ -39,7 +39,7 @@ public class EthHashrateTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_hashrate";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthHashrate(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthMiningTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthMiningTest.java
@@ -25,13 +25,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthMiningTest {
 
   @Mock private PoWMiningCoordinator miningCoordinator;
@@ -39,7 +39,7 @@ public class EthMiningTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_mining";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthMining(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewBlockFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewBlockFilterTest.java
@@ -25,20 +25,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthNewBlockFilterTest {
 
   @Mock private FilterManager filterManager;
   private EthNewBlockFilter method;
   private final String ETH_METHOD = "eth_newBlockFilter";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthNewBlockFilter(filterManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilterTest.java
@@ -41,20 +41,20 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthNewFilterTest {
 
   @Mock private FilterManager filterManager;
   private EthNewFilter method;
   private final String ETH_METHOD = "eth_newFilter";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthNewFilter(filterManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthProtocolVersionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthProtocolVersionTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EthProtocolVersionTest {
   private EthProtocolVersion method;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransactionTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthSendRawTransactionTest {
 
   private static final String VALID_TRANSACTION =
@@ -45,7 +45,7 @@ public class EthSendRawTransactionTest {
   @Mock private TransactionPool transactionPool;
   private EthSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new EthSendRawTransaction(transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendTransactionTest.java
@@ -22,14 +22,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthSendTransactionTest {
 
   private JsonRpcMethod method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new EthSendTransaction();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWorkTest.java
@@ -34,13 +34,13 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthSubmitWorkTest {
 
   private EthSubmitWork method;
@@ -50,7 +50,7 @@ public class EthSubmitWorkTest {
 
   @Mock private PoWMiningCoordinator miningCoordinator;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthSubmitWork(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncingTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncingTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.plugin.data.SyncStatus;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EthSyncingTest {
 
   @Mock private Synchronizer synchronizer;
@@ -44,7 +44,7 @@ public class EthSyncingTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String ETH_METHOD = "eth_syncing";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new EthSyncing(synchronizer);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnodeTest.java
@@ -33,13 +33,13 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetEnodeTest {
 
   private NetEnode method;
@@ -61,7 +61,7 @@ public class NetEnodeTest {
 
   @Mock private P2PNetwork p2PNetwork;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new NetEnode(p2PNetwork);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetListeningTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetListeningTest.java
@@ -26,20 +26,20 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NetListeningTest {
 
   private NetListening method;
 
   @Mock private P2PNetwork p2PNetwork;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new NetListening(p2PNetwork);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersionTest.java
@@ -24,15 +24,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import java.math.BigInteger;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NetVersionTest {
 
   private NetVersion method;
   private final BigInteger NETWORK_ID = BigInteger.ONE;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new NetVersion(Optional.of(NETWORK_ID));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/RpcModulesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/RpcModulesTest.java
@@ -24,8 +24,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RpcModulesTest {
 
@@ -34,7 +34,7 @@ public class RpcModulesTest {
 
   private RpcModules method;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new RpcModules(ImmutableList.of(RpcApis.DEBUG.name()));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactionsTest.java
@@ -34,14 +34,17 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TxPoolBesuPendingTransactionsTest {
 
   @Mock private TransactionPool transactionPool;
@@ -50,7 +53,7 @@ public class TxPoolBesuPendingTransactionsTest {
   private final String TXPOOL_PENDING_TRANSACTIONS_METHOD = "txpool_besuPendingTransactions";
   private Set<PendingTransaction> listTrx;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     listTrx = getTransactionPool();
     method = new TxPoolBesuPendingTransactions(transactionPool);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatisticsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatisticsTest.java
@@ -26,13 +26,13 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TxPoolBesuStatisticsTest {
 
   @Mock private TransactionPool transactionPool;
@@ -40,7 +40,7 @@ public class TxPoolBesuStatisticsTest {
   private final String JSON_RPC_VERSION = "2.0";
   private final String TXPOOL_PENDING_TRANSACTIONS_METHOD = "txpool_besuStatistics";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new TxPoolBesuStatistics(transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuTransactionsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuTransactionsTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import java.time.Instant;
 
 import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TxPoolBesuTransactionsTest {
 
   @Mock private TransactionPool transactionPool;
@@ -46,7 +46,7 @@ public class TxPoolBesuTransactionsTest {
   private static final String TRANSACTION_HASH =
       "0xbac263fb39f2a51053fb5e1e52aeb4e980fba9e151aa7e4f12eca95a697aeac9";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new TxPoolBesuTransactions(transactionPool);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3ClientVersionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3ClientVersionTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Web3ClientVersionTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3Test.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Web3Sha3Test {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -63,14 +63,14 @@ import java.util.stream.Stream;
 
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractEngineForkchoiceUpdatedTest {
 
   @FunctionalInterface
@@ -111,7 +111,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
 
   @Mock private EngineCallListener engineCallListener;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -41,14 +41,14 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractEngineGetPayloadTest {
 
   @FunctionalInterface
@@ -108,7 +108,7 @@ public abstract class AbstractEngineGetPayloadTest {
 
   @Mock protected EngineCallListener engineCallListener;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(mergeContext.retrieveBlockById(mockPid)).thenReturn(Optional.of(mockBlockWithReceipts));
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -76,15 +76,15 @@ import java.util.concurrent.CompletableFuture;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public abstract class AbstractEngineNewPayloadTest {
 
   @FunctionalInterface
@@ -124,7 +124,7 @@ public abstract class AbstractEngineNewPayloadTest {
 
   @Mock protected EngineCallListener engineCallListener;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
@@ -373,7 +373,7 @@ public abstract class AbstractEngineNewPayloadTest {
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void shouldRespondWithInvalidTerminalPowBlock() {
     // TODO: implement this as part of https://github.com/hyperledger/besu/issues/3141
     // mergeContext is a mock

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
@@ -31,13 +31,13 @@ import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EngineExchangeCapabilitiesTest {
   private EngineExchangeCapabilities method;
   private static final Vertx vertx = Vertx.vertx();
@@ -46,7 +46,7 @@ public class EngineExchangeCapabilitiesTest {
 
   @Mock private EngineCallListener engineCallListener;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.method = new EngineExchangeCapabilities(vertx, protocolContext, engineCallListener);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -50,14 +50,14 @@ import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EngineExchangeTransitionConfigurationTest {
   private EngineExchangeTransitionConfiguration method;
   private static final Vertx vertx = Vertx.vertx();
@@ -68,7 +68,7 @@ public class EngineExchangeTransitionConfigurationTest {
 
   @Mock private EngineCallListener engineCallListener;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(protocolContext.safeConsensusContext(Mockito.any())).thenReturn(Optional.of(mergeContext));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1Test.java
@@ -28,11 +28,14 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineForkchoiceUpdatedV1Test extends AbstractEngineForkchoiceUpdatedTest {
 
   public EngineForkchoiceUpdatedV1Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -18,11 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineForkchoiceUpdatedV2Test extends AbstractEngineForkchoiceUpdatedTest {
 
   public EngineForkchoiceUpdatedV2Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
@@ -48,13 +48,16 @@ import java.util.Optional;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadBodiesByHashV1Test {
   private EngineGetPayloadBodiesByHashV1 method;
   private static final Vertx vertx = Vertx.vertx();
@@ -63,7 +66,7 @@ public class EngineGetPayloadBodiesByHashV1Test {
   @Mock private EngineCallListener engineCallListener;
   @Mock private MutableBlockchain blockchain;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     this.method =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
@@ -49,13 +49,16 @@ import java.util.Optional;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadBodiesByRangeV1Test {
   private EngineGetPayloadBodiesByRangeV1 method;
   private static final Vertx vertx = Vertx.vertx();
@@ -64,7 +67,7 @@ public class EngineGetPayloadBodiesByRangeV1Test {
   @Mock private EngineCallListener engineCallListener;
   @Mock private MutableBlockchain blockchain;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(protocolContext.getBlockchain()).thenReturn(blockchain);
     this.method =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1Test.java
@@ -25,11 +25,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineGetPaylo
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadV1Test extends AbstractEngineGetPayloadTest {
 
   public EngineGetPayloadV1Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2Test.java
@@ -27,11 +27,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineGetPayloadV2Test extends AbstractEngineGetPayloadTest {
 
   public EngineGetPayloadV2Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1Test.java
@@ -32,11 +32,14 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineNewPayloadV1Test extends AbstractEngineNewPayloadTest {
 
   public EngineNewPayloadV1Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2Test.java
@@ -16,11 +16,14 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EngineNewPayloadV2Test extends AbstractEngineNewPayloadTest {
 
   public EngineNewPayloadV2Test() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebugTest.java
@@ -34,14 +34,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePrepareP
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EnginePreparePayloadDebugTest {
   private static final Vertx vertx = Vertx.vertx();
   EnginePreparePayloadDebug method;
@@ -55,7 +55,7 @@ public class EnginePreparePayloadDebugTest {
 
   @Mock private EnginePreparePayloadParameter param;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(protocolContext.safeConsensusContext(MergeContext.class))
         .thenReturn(Optional.of(mergeContext));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimerTest.java
@@ -24,34 +24,34 @@ import static org.mockito.Mockito.verify;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.QosTimer;
 
 import io.vertx.core.Vertx;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class EngineQosTimerTest {
   private EngineQosTimer engineQosTimer;
   private Vertx vertx;
+  private VertxTestContext testContext;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     vertx = Vertx.vertx();
+    testContext = new VertxTestContext();
     engineQosTimer = new EngineQosTimer(vertx);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     vertx.close();
   }
 
   @Test
-  public void shouldNotWarnWhenCalledWithinTimeout(final TestContext ctx) {
+  public void shouldNotWarnWhenCalledWithinTimeout() {
     final long TEST_QOS_TIMEOUT = 75L;
-    final Async async = ctx.async();
     final var spyEngineQosTimer = spy(engineQosTimer);
     final var spyTimer =
         spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> spyEngineQosTimer.logTimeoutWarning()));
@@ -68,17 +68,16 @@ public class EngineQosTimerTest {
             verify(spyTimer, atLeast(2)).resetTimer();
             // should not warn
             verify(spyEngineQosTimer, never()).logTimeoutWarning();
-            async.complete();
+            testContext.completeNow();
           } catch (Exception ex) {
-            ctx.fail(ex);
+            testContext.failNow(ex);
           }
         });
   }
 
   @Test
-  public void shouldWarnWhenNotCalledWithinTimeout(final TestContext ctx) {
+  public void shouldWarnWhenNotCalledWithinTimeout() {
     final long TEST_QOS_TIMEOUT = 75L;
-    final Async async = ctx.async();
     final var spyEngineQosTimer = spy(engineQosTimer);
     final var spyTimer =
         spy(new QosTimer(vertx, TEST_QOS_TIMEOUT, z -> spyEngineQosTimer.logTimeoutWarning()));
@@ -92,9 +91,9 @@ public class EngineQosTimerTest {
             verify(spyTimer, atLeastOnce()).resetTimer();
             // should warn
             verify(spyEngineQosTimer, atLeastOnce()).logTimeoutWarning();
-            async.complete();
+            testContext.completeNow();
           } catch (Exception ex) {
-            ctx.fail(ex);
+            testContext.failNow(ex);
           }
         });
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerChangeTargetGasLimitTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerChangeTargetGasLimitTest.java
@@ -24,8 +24,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 public class MinerChangeTargetGasLimitTest {
@@ -33,7 +33,7 @@ public class MinerChangeTargetGasLimitTest {
   @Mock MiningCoordinator miningCoordinator;
   private MinerChangeTargetGasLimit minerChangeTargetGasLimit;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     initMocks(this);
     minerChangeTargetGasLimit = new MinerChangeTargetGasLimit(miningCoordinator);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbaseTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbaseTest.java
@@ -31,20 +31,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MinerSetCoinbaseTest {
 
   private MinerSetCoinbase method;
 
   @Mock private MiningCoordinator miningCoordinator;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new MinerSetCoinbase(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetEtherbaseTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetEtherbaseTest.java
@@ -21,21 +21,21 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MinerSetEtherbaseTest {
 
   private MinerSetEtherbase method;
 
   @Mock private MinerSetCoinbase minerSetCoinbase;
 
-  @Before
+  @BeforeEach
   public void before() {
     this.method = new MinerSetEtherbase(minerSetCoinbase);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStartTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStartTest.java
@@ -27,20 +27,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.CoinbaseNotSetException;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MinerStartTest {
 
   private MinerStart method;
 
   @Mock private PoWMiningCoordinator miningCoordinator;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new MinerStart(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStopTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStopTest.java
@@ -23,20 +23,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MinerStopTest {
 
   private MinerStop method;
 
   @Mock private PoWMiningCoordinator miningCoordinator;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new MinerStop(miningCoordinator);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToAllowlistTest.java
@@ -34,19 +34,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermAddAccountsToAllowlistTest {
 
   @Mock private AccountLocalConfigPermissioningController accountWhitelist;
   private PermAddAccountsToAllowlist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermAddAccountsToAllowlist(java.util.Optional.of(accountWhitelist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelistTest.java
@@ -34,20 +34,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermAddAccountsToWhitelistTest {
 
   @Mock private AccountLocalConfigPermissioningController accountWhitelist;
   private PermAddAccountsToWhitelist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermAddAccountsToWhitelist(java.util.Optional.of(accountWhitelist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToAllowlistTest.java
@@ -39,13 +39,13 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermAddNodesToAllowlistTest {
 
   private PermAddNodesToAllowlist method;
@@ -61,7 +61,7 @@ public class PermAddNodesToAllowlistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermAddNodesToAllowlist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelistTest.java
@@ -39,14 +39,14 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermAddNodesToWhitelistTest {
 
   private PermAddNodesToWhitelist method;
@@ -62,7 +62,7 @@ public class PermAddNodesToWhitelistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermAddNodesToWhitelist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsAllowlistTest.java
@@ -27,13 +27,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermGetAccountsAllowlistTest {
 
   private static final JsonRpcRequestContext request =
@@ -42,7 +42,7 @@ public class PermGetAccountsAllowlistTest {
   @Mock private AccountLocalConfigPermissioningController accountAllowlist;
   private PermGetAccountsAllowlist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermGetAccountsAllowlist(java.util.Optional.of(accountAllowlist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelistTest.java
@@ -27,14 +27,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermGetAccountsWhitelistTest {
 
   private static final JsonRpcRequestContext request =
@@ -43,7 +43,7 @@ public class PermGetAccountsWhitelistTest {
   @Mock private AccountLocalConfigPermissioningController accountWhitelist;
   private PermGetAccountsWhitelist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermGetAccountsWhitelist(java.util.Optional.of(accountWhitelist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesAllowlistTest.java
@@ -34,13 +34,13 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermGetNodesAllowlistTest {
 
   private PermGetNodesAllowlist method;
@@ -55,7 +55,7 @@ public class PermGetNodesAllowlistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermGetNodesAllowlist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelistTest.java
@@ -34,14 +34,14 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermGetNodesWhitelistTest {
 
   private PermGetNodesWhitelist method;
@@ -56,7 +56,7 @@ public class PermGetNodesWhitelistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermGetNodesWhitelist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermReloadPermissionsFromFileTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermReloadPermissionsFromFileTest.java
@@ -29,20 +29,20 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermReloadPermissionsFromFileTest {
 
   @Mock private AccountLocalConfigPermissioningController accountLocalConfigPermissioningController;
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
   private PermReloadPermissionsFromFile method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method =
         new PermReloadPermissionsFromFile(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromAllowlistTest.java
@@ -34,19 +34,19 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermRemoveAccountsFromAllowlistTest {
 
   @Mock private AccountLocalConfigPermissioningController accountAllowlist;
   private PermRemoveAccountsFromAllowlist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermRemoveAccountsFromAllowlist(java.util.Optional.of(accountAllowlist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelistTest.java
@@ -34,20 +34,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermRemoveAccountsFromWhitelistTest {
 
   @Mock private AccountLocalConfigPermissioningController accountWhitelist;
   private PermRemoveAccountsFromWhitelist method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PermRemoveAccountsFromWhitelist(java.util.Optional.of(accountWhitelist));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromAllowlistTest.java
@@ -39,13 +39,13 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermRemoveNodesFromAllowlistTest {
 
   private PermRemoveNodesFromAllowlist method;
@@ -61,7 +61,7 @@ public class PermRemoveNodesFromAllowlistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermRemoveNodesFromAllowlist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelistTest.java
@@ -39,14 +39,14 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @Deprecated
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermRemoveNodesFromWhitelistTest {
 
   private PermRemoveNodesFromWhitelist method;
@@ -62,7 +62,7 @@ public class PermRemoveNodesFromWhitelistTest {
 
   @Mock private NodeLocalConfigPermissioningController nodeLocalConfigPermissioningController;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PermRemoveNodesFromWhitelist(Optional.of(nodeLocalConfigPermissioningController));
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BlockParameterTest {
   @Test

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameterTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.core.Deposit;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DepositParameterTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
@@ -25,7 +25,7 @@ import org.hyperledger.besu.datatypes.GWei;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EnginePayloadAttributesParameterTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameterTest.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FilterParameterTest {
   private static final String TOPIC_FORMAT = "0x%064d";

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceTypeParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceTypeParameterTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TraceTypeParameterTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalParameterTest.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.datatypes.GWei;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
 
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WithdrawalParameterTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
@@ -30,12 +30,12 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MultiTenancyRpcMethodDecoratorTest {
 
   @Mock private JsonRpcMethod jsonRpcMethod;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtilTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtilTest.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MultiTenancyUserUtilTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/EeaSendRawTransactionTest.java
@@ -36,12 +36,12 @@ import org.hyperledger.besu.ethereum.privacy.MultiTenancyValidationException;
 import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class EeaSendRawTransactionTest extends BaseEeaSendRawTransaction {
 
   // RLP encode fails creating a transaction without privateFrom so must be manually encoded
@@ -58,7 +58,7 @@ public class EeaSendRawTransactionTest extends BaseEeaSendRawTransaction {
 
   RestrictedOffchainEeaSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void before() {
 
     method =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransactionTest.java
@@ -23,17 +23,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PluginEeaSendRawTransactionTest extends BaseEeaSendRawTransaction {
 
   PluginEeaSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method =
         new PluginEeaSendRawTransaction(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransactionTest.java
@@ -31,12 +31,12 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import java.util.Arrays;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RestrictedFlexibleEeaSendRawTransactionTest extends BaseEeaSendRawTransaction {
   static final String ENCLAVE_PUBLIC_KEY = "S28yYlZxRCtuTmxOWUw1RUU3eTNJZE9udmlmdGppaXo=";
 
@@ -44,7 +44,7 @@ public class RestrictedFlexibleEeaSendRawTransactionTest extends BaseEeaSendRawT
 
   RestrictedFlexibleEeaSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method =
         new RestrictedFlexibleEeaSendRawTransaction(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransactionTest.java
@@ -30,12 +30,12 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RestrictedOffchainEeaSendRawTransactionTest extends BaseEeaSendRawTransaction {
   static final String ENCLAVE_PUBLIC_KEY = "S28yYlZxRCtuTmxOWUw1RUU3eTNJZE9udmlmdGppaXo=";
 
@@ -43,7 +43,7 @@ public class RestrictedOffchainEeaSendRawTransactionTest extends BaseEeaSendRawT
 
   RestrictedOffchainEeaSendRawTransaction method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method =
         new RestrictedOffchainEeaSendRawTransaction(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCallTest.java
@@ -43,13 +43,13 @@ import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivCallTest {
 
   private PrivCall method;
@@ -62,7 +62,7 @@ public class PrivCallTest {
   private final PrivacyController privacyController =
       mock(RestrictedDefaultPrivacyController.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PrivCall(blockchainQueries, privacyController, privacyIdProvider);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroupTest.java
@@ -41,8 +41,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("MockNotUsedInProduction")
 public class PrivCreatePrivacyGroupTest {
@@ -60,7 +60,7 @@ public class PrivCreatePrivacyGroupTest {
       new UserImpl(new JsonObject().put("privacyPublicKey", ENCLAVE_PUBLIC_KEY), new JsonObject());
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(privacyParameters.getEnclave()).thenReturn(enclave);
     when(privacyParameters.isEnabled()).thenReturn(true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRootTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRootTest.java
@@ -43,8 +43,8 @@ import java.util.Collections;
 import java.util.Optional;
 
 import org.bouncycastle.util.encoders.Base64;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PrivDebugGetStateRootTest {
 
@@ -64,7 +64,7 @@ public class PrivDebugGetStateRootTest {
   private final PrivacyController privacyController =
       mock(RestrictedDefaultPrivacyController.class);
 
-  @Before
+  @BeforeEach
   public void setUp() {
     method = new PrivDebugGetStateRoot(blockchainQueries, privacyIdProvider, privacyController);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroupTest.java
@@ -33,8 +33,8 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PrivDeletePrivacyGroupTest {
   private static final String ENCLAVE_PUBLIC_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -46,7 +46,7 @@ public class PrivDeletePrivacyGroupTest {
   private final PrivacyIdProvider privacyIdProvider = (user) -> ENCLAVE_PUBLIC_KEY;
   private JsonRpcRequestContext request;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request =
         new JsonRpcRequestContext(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransactionTest.java
@@ -39,13 +39,13 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivDistributeRawTransactionTest {
 
   private static final String VALID_PRIVATE_TRANSACTION_RLP_PRIVACY_GROUP =
@@ -66,7 +66,7 @@ public class PrivDistributeRawTransactionTest {
   private PrivDistributeRawTransaction method;
   @Mock private PrivacyController privacyController;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PrivDistributeRawTransaction(privacyController, privacyIdProvider, false);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroupTest.java
@@ -40,8 +40,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("MockNotUsedInProduction")
 public class PrivFindPrivacyGroupTest {
@@ -61,7 +61,7 @@ public class PrivFindPrivacyGroupTest {
   private JsonRpcRequestContext request;
   private PrivacyGroup privacyGroup;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     when(privacyParameters.getEnclave()).thenReturn(enclave);
     when(privacyParameters.isEnabled()).thenReturn(true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCodeTest.java
@@ -35,13 +35,16 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class PrivGetCodeTest {
 
   @Mock private PrivacyController privacyController;
@@ -58,7 +61,7 @@ public class PrivGetCodeTest {
   private PrivGetCode method;
   private JsonRpcRequestContext privGetCodeRequest;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(privacyIdProvider.getPrivacyUserId(any())).thenReturn(enclavePublicKey);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetFilterChangesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetFilterChangesTest.java
@@ -46,13 +46,13 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivGetFilterChangesTest {
 
   private final String FILTER_ID = "0xdbdb02abb65a2ba57a1cc0336c17ef75";
@@ -65,7 +65,7 @@ public class PrivGetFilterChangesTest {
 
   private PrivGetFilterChanges method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PrivGetFilterChanges(filterManager, privacyController, privacyIdProvider);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetFilterLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetFilterLogsTest.java
@@ -41,13 +41,13 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivGetFilterLogsTest {
 
   private final String FILTER_ID = "0xdbdb02abb65a2ba57a1cc0336c17ef75";
@@ -59,7 +59,7 @@ public class PrivGetFilterLogsTest {
 
   private PrivGetFilterLogs method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PrivGetFilterLogs(filterManager, privacyController, privacyIdProvider);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogsTest.java
@@ -52,13 +52,13 @@ import java.util.stream.IntStream;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivGetLogsTest {
 
   private final String PRIVACY_GROUP_ID = "B1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -70,7 +70,7 @@ public class PrivGetLogsTest {
 
   private PrivGetLogs method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method =
         new PrivGetLogs(blockchainQueries, privacyQueries, privacyController, privacyIdProvider);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddressTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddressTest.java
@@ -27,7 +27,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PrivGetPrivacyPrecompileAddressTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransactionTest.java
@@ -42,13 +42,13 @@ import java.util.Optional;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivGetPrivateTransactionTest {
 
   @Mock private PrivacyController privacyController;
@@ -63,7 +63,7 @@ public class PrivGetPrivateTransactionTest {
   private PrivGetPrivateTransaction privGetPrivateTransaction;
   private Transaction markerTransaction;
 
-  @Before
+  @BeforeEach
   public void before() {
     privGetPrivateTransaction = new PrivGetPrivateTransaction(privacyController, privacyIdProvider);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceiptTest.java
@@ -49,13 +49,16 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class PrivGetTransactionReceiptTest {
 
   final Bytes internalPrivacyGroupId = Bytes.random(32);
@@ -72,7 +75,7 @@ public class PrivGetTransactionReceiptTest {
   private final PrivacyIdProvider privacyIdProvider =
       (user) -> VALID_BASE64_ENCLAVE_KEY.toBase64String();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final PrivateTransactionReceipt receipt =
         new PrivateTransactionReceipt(1, Collections.emptyList(), Bytes.EMPTY, Optional.empty());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilterTest.java
@@ -44,13 +44,13 @@ import java.util.Optional;
 
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivNewFilterTest {
 
   private final String ENCLAVE_KEY = "enclave_key";
@@ -62,7 +62,7 @@ public class PrivNewFilterTest {
 
   private PrivNewFilter method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PrivNewFilter(filterManager, privacyController, privacyIdProvider);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUninstallFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUninstallFilterTest.java
@@ -27,13 +27,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivUn
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacyIdProvider;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivUninstallFilterTest {
 
   private final String FILTER_ID = "0xdbdb02abb65a2ba57a1cc0336c17ef75";
@@ -45,7 +45,7 @@ public class PrivUninstallFilterTest {
 
   private PrivUninstallFilter method;
 
-  @Before
+  @BeforeEach
   public void before() {
     method = new PrivUninstallFilter(filterManager, privacyController, privacyIdProvider);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroupTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroupTest.java
@@ -37,8 +37,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
 import org.assertj.core.util.Lists;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PrivxFindFlexiblePrivacyGroupTest {
   private static final String ENCLAVE_PUBLIC_KEY = "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -57,7 +57,7 @@ public class PrivxFindFlexiblePrivacyGroupTest {
   private PrivacyGroup privacyGroup;
   private PrivxFindFlexiblePrivacyGroup privxFindFlexiblePrivacyGroup;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     request =
         new JsonRpcRequestContext(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracerTest.java
@@ -49,18 +49,20 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TransactionTracerTest {
 
-  @Rule public TemporaryFolder traceDir = new TemporaryFolder();
+  @TempDir private static Path traceDir;
 
   @Mock private ProtocolSchedule protocolSchedule;
   @Mock private Blockchain blockchain;
@@ -98,7 +100,7 @@ public class TransactionTracerTest {
   private final Hash invalidBlockHash =
       Hash.fromHexString("1111111111111111111111111111111111111111111111111111111111111111");
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     transactionTracer = new TransactionTracer(new BlockReplay(protocolSchedule, blockchain));
     when(transaction.getHash()).thenReturn(transactionHash);
@@ -230,7 +232,7 @@ public class TransactionTracerTest {
             mutableWorldState,
             blockHash,
             Optional.of(ImmutableTransactionTraceParams.builder().build()),
-            traceDir.getRoot().toPath());
+            traceDir);
 
     assertThat(transactionTraces).isEmpty();
   }
@@ -273,7 +275,7 @@ public class TransactionTracerTest {
             mutableWorldState,
             blockHash,
             Optional.of(ImmutableTransactionTraceParams.builder().build()),
-            traceDir.getRoot().toPath());
+            traceDir);
 
     assertThat(transactionTraces.size()).isEqualTo(1);
     assertThat(Files.readString(Path.of(transactionTraces.get(0))))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/NetworkResultTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/NetworkResultTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NetworkResultTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResultTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResultTest.java
@@ -30,7 +30,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransactionCompleteResultTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGeneratorTest.java
@@ -29,13 +29,13 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FlatTraceGeneratorTest {
   @Mock private Transaction transaction;
   @Mock private TransactionProcessingResult transactionProcessingResult;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGeneratorTest.java
@@ -40,13 +40,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RewardTraceGeneratorTest {
 
   private final BlockDataGenerator gen = new BlockDataGenerator();
@@ -65,7 +65,7 @@ public class RewardTraceGeneratorTest {
   private final OptionalLong eraRounds = OptionalLong.of(5000000);
   private Block block;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     final BlockBody blockBody = new BlockBody(Collections.emptyList(), List.of(ommerHeader));
     final BlockHeader blockHeader =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/PendingPermissionTransactionFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/PendingPermissionTransactionFilterTest.java
@@ -38,16 +38,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class PendingPermissionTransactionFilterTest {
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return asList(
         new Object[][] {
@@ -93,32 +89,20 @@ public class PendingPermissionTransactionFilterTest {
 
   private final PendingTransactionFilter pendingTransactionFilter = new PendingTransactionFilter();
 
-  private final List<Filter> filters;
-  private final int limit;
-  private final List<String> expectedListOfTransactionHash;
-
-  public PendingPermissionTransactionFilterTest(
+  @ParameterizedTest
+  @MethodSource("data")
+  public void PendingPermissionTransactionFilterTest(
       final List<Filter> filters,
       final int limit,
       final List<String> expectedListOfTransactionHash) {
-    this.filters = filters;
-    this.limit = limit;
-    this.expectedListOfTransactionHash =
-        expectedListOfTransactionHash.stream()
-            .map(Hash::fromHexStringLenient)
-            .map(Hash::toHexString)
-            .collect(Collectors.toList());
-  }
-
-  @Test
-  public void localAndRemoteAddressShouldNotStartWithForwardSlash() {
 
     final Collection<Transaction> filteredList =
         pendingTransactionFilter.reduce(getPendingTransactions(), filters, limit);
 
     assertThat(filteredList.size()).isEqualTo(expectedListOfTransactionHash.size());
     for (Transaction trx : filteredList) {
-      assertThat(expectedListOfTransactionHash).contains(trx.getHash().toHexString());
+      assertThat(expectedListOfTransactionHash)
+          .contains(String.valueOf(trx.getHash().toBigInteger()));
     }
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethodsTest.java
@@ -46,13 +46,13 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PermJsonRpcMethodsTest {
 
   @Mock private AccountLocalConfigPermissioningController accountLocalConfigPermissioningController;
@@ -60,7 +60,7 @@ public class PermJsonRpcMethodsTest {
 
   private PermJsonRpcMethods permJsonRpcMethods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     permJsonRpcMethods =
         new PermJsonRpcMethods(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethodsTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivJsonRpcMethodsTest {
 
   @Mock private BlockchainQueries blockchainQueries;
@@ -47,7 +47,7 @@ public class PrivJsonRpcMethodsTest {
 
   private PrivJsonRpcMethods privJsonRpcMethods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privJsonRpcMethods =
         new PrivJsonRpcMethods(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
@@ -42,13 +42,13 @@ import java.util.Optional;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.impl.UserImpl;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivacyApiGroupJsonRpcMethodsTest {
   private static final String DEFAULT_ENCLAVE_PUBLIC_KEY =
       "A1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -61,7 +61,7 @@ public class PrivacyApiGroupJsonRpcMethodsTest {
 
   private TestPrivacyApiGroupJsonRpcMethods privacyApiGroupJsonRpcMethods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(rpcMethod.getName()).thenReturn("priv_method");
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethodsTest.java
@@ -30,13 +30,13 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivxJsonRpcMethodsTest {
 
   @Mock private BlockchainQueries blockchainQueries;
@@ -46,7 +46,7 @@ public class PrivxJsonRpcMethodsTest {
 
   private PrivxJsonRpcMethods privxJsonRpcMethods;
 
-  @Before
+  @BeforeEach
   public void setup() {
     privxJsonRpcMethods =
         new PrivxJsonRpcMethods(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/parameters/TraceCallManyParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/parameters/TraceCallManyParameterTest.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TraceCallManyParameterTest {
   static final String emptyParamsJson = "[]";
@@ -57,7 +57,7 @@ public class TraceCallManyParameterTest {
 
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mapper = new ObjectMapper();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/timeout/TimeoutHandlerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/timeout/TimeoutHandlerTest.java
@@ -39,16 +39,12 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
-@RunWith(Parameterized.class)
 public class TimeoutHandlerTest {
 
-  @Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
         new Object[][] {
@@ -59,24 +55,14 @@ public class TimeoutHandlerTest {
   }
 
   private static final TimeoutOptions DEFAULT_OPTS = TimeoutOptions.defaultOptions();
-  private final Optional<TimeoutOptions> globalOptions;
-  private final RpcMethod method;
-  private final long timeoutSec;
-  private final boolean timerMustBeSet;
 
-  public TimeoutHandlerTest(
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(
       final Optional<TimeoutOptions> globalOptions,
       final RpcMethod method,
       final long timeoutSec,
       final boolean timerMustBeSet) {
-    this.globalOptions = globalOptions;
-    this.method = method;
-    this.timeoutSec = timeoutSec;
-    this.timerMustBeSet = timerMustBeSet;
-  }
-
-  @Test
-  public void test() {
     final Map<String, TimeoutOptions> options;
     if (timerMustBeSet) {
       options =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamerTest.java
@@ -28,21 +28,24 @@ import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.impl.future.FailedFuture;
 import io.vertx.core.impl.future.SucceededFuture;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class JsonResponseStreamerTest {
 
   @Mock private ServerWebSocket response;
 
   @Mock private ServerWebSocket failedResponse;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(response.writeFrame(any(WebSocketFrame.class)))
         .thenReturn(new SucceededFuture<>(null, null));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
@@ -55,24 +56,20 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.json.Json;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class JsonRpcJWTTest {
-
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  private static final int VERTX_AWAIT_TIMEOUT_MILLIS = 10000;
   public static final String HOSTNAME = "127.0.0.1";
 
   protected static Vertx vertx;
-
+  private VertxTestContext testContext;
   private final JsonRpcConfiguration jsonRpcConfiguration =
       JsonRpcConfiguration.createEngineDefault();
   private HttpClient httpClient;
@@ -82,7 +79,7 @@ public class JsonRpcJWTTest {
   private Path bufferDir;
   private Map<String, JsonRpcMethod> websocketMethods;
 
-  @Before
+  @BeforeEach
   public void initServerAndClient() {
     jsonRpcConfiguration.setPort(0);
     jsonRpcConfiguration.setHostsAllowlist(List.of("*"));
@@ -93,6 +90,7 @@ public class JsonRpcJWTTest {
       fail("couldn't load jwt key from jwt.hex in classpath");
     }
     vertx = Vertx.vertx();
+    testContext = new VertxTestContext();
 
     websocketMethods =
         new WebSocketMethodsFactory(
@@ -125,11 +123,11 @@ public class JsonRpcJWTTest {
     scheduler = new EthScheduler(1, 1, 1, new NoOpMetricsSystem());
   }
 
-  @After
+  @AfterEach
   public void after() {}
 
   @Test
-  public void unauthenticatedWebsocketAllowedWithoutJWTAuth(final TestContext context) {
+  public void unauthenticatedWebsocketAllowedWithoutJWTAuth() throws InterruptedException {
 
     EngineJsonRpcService engineJsonRpcService =
         new EngineJsonRpcService(
@@ -160,7 +158,6 @@ public class JsonRpcJWTTest {
     wsOpts.setHost(HOSTNAME);
     wsOpts.setURI("/");
 
-    final Async async = context.async();
     httpClient.webSocket(
         wsOpts,
         connected -> {
@@ -178,18 +175,18 @@ public class JsonRpcJWTTest {
                 MutableJsonRpcSuccessResponse messageReply =
                     Json.decodeValue(resp.textData(), MutableJsonRpcSuccessResponse.class);
                 assertThat(messageReply.getResult()).isEqualTo("0x1");
-                async.complete();
+                testContext.completeNow();
               });
           ws.writeTextMessage(Json.encode(req));
         });
 
-    async.awaitSuccess(10000);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     engineJsonRpcService.stop();
     httpClient.close();
   }
 
   @Test
-  public void httpRequestWithDefaultHeaderAndValidJWTIsAccepted(final TestContext context) {
+  public void httpRequestWithDefaultHeaderAndValidJWTIsAccepted() throws InterruptedException {
 
     EngineJsonRpcService engineJsonRpcService =
         new EngineJsonRpcService(
@@ -223,7 +220,6 @@ public class JsonRpcJWTTest {
         "Authorization", "Bearer " + ((EngineAuthService) jwtAuth.get()).createToken());
     wsOpts.addHeader(HttpHeaders.HOST, "anything");
 
-    final Async async = context.async();
     httpClient.webSocket(
         wsOpts,
         connected -> {
@@ -242,18 +238,18 @@ public class JsonRpcJWTTest {
                 MutableJsonRpcSuccessResponse messageReply =
                     Json.decodeValue(resp.textData(), MutableJsonRpcSuccessResponse.class);
                 assertThat(messageReply.getResult()).isEqualTo("0x1");
-                async.complete();
+                testContext.completeNow();
               });
           ws.writeTextMessage(Json.encode(req));
         });
 
-    async.awaitSuccess(10000);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     engineJsonRpcService.stop();
     httpClient.close();
   }
 
   @Test
-  public void wsRequestFromBadHostAndValidJWTIsDenied(final TestContext context) {
+  public void wsRequestFromBadHostAndValidJWTIsDenied() throws InterruptedException {
 
     JsonRpcConfiguration strictHost = JsonRpcConfiguration.createEngineDefault();
     strictHost.setHostsAllowlist(List.of("localhost"));
@@ -298,7 +294,6 @@ public class JsonRpcJWTTest {
         "Authorization", "Bearer " + ((EngineAuthService) jwtAuth.get()).createToken());
     wsOpts.addHeader(HttpHeaders.HOST, "bogushost");
 
-    final Async async = context.async();
     httpClient.webSocket(
         wsOpts,
         connected -> {
@@ -306,17 +301,17 @@ public class JsonRpcJWTTest {
             connected.cause().printStackTrace();
           }
           assertThat(connected.succeeded()).isFalse();
-          async.complete();
+          testContext.completeNow();
         });
 
-    async.awaitSuccess(10000);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     engineJsonRpcService.stop();
 
     httpClient.close();
   }
 
   @Test
-  public void httpRequestFromBadHostAndValidJWTIsDenied(final TestContext context) {
+  public void httpRequestFromBadHostAndValidJWTIsDenied() throws InterruptedException {
 
     JsonRpcConfiguration strictHost = JsonRpcConfiguration.createEngineDefault();
     strictHost.setHostsAllowlist(List.of("localhost"));
@@ -358,7 +353,6 @@ public class JsonRpcJWTTest {
                 "Authorization", "Bearer " + ((EngineAuthService) jwtAuth.get()).createToken())
             .set(HttpHeaders.HOST, "bogushost");
 
-    final Async async = context.async();
     httpClient.request(
         HttpMethod.GET,
         "/",
@@ -372,18 +366,18 @@ public class JsonRpcJWTTest {
               response -> {
                 assertThat(response.result().statusCode()).isNotEqualTo(500);
                 assertThat(response.result().statusCode()).isEqualTo(403);
-                async.complete();
+                testContext.completeNow();
               });
         });
 
-    async.awaitSuccess(10000);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     engineJsonRpcService.stop();
 
     httpClient.close();
   }
 
   @Test
-  public void httpRequestWithDefaultHeaderAndInvalidJWTIsDenied(final TestContext context) {
+  public void httpRequestWithDefaultHeaderAndInvalidJWTIsDenied() throws InterruptedException {
 
     EngineJsonRpcService engineJsonRpcService =
         new EngineJsonRpcService(
@@ -415,7 +409,6 @@ public class JsonRpcJWTTest {
     wsOpts.setURI("/");
     wsOpts.addHeader("Authorization", "Bearer totallyunparseablenonsense");
 
-    final Async async = context.async();
     httpClient.webSocket(
         wsOpts,
         connected -> {
@@ -423,10 +416,10 @@ public class JsonRpcJWTTest {
             connected.cause().printStackTrace();
           }
           assertThat(connected.succeeded()).isFalse();
-          async.complete();
+          testContext.completeNow();
         });
 
-    async.awaitSuccess(10000);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     engineJsonRpcService.stop();
     httpClient.close();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketConfigurationTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WebSocketConfigurationTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketHostAllowlistTest.java
@@ -35,28 +35,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class WebSocketHostAllowlistTest {
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
-
   protected static Vertx vertx;
-
+  private VertxTestContext testContext;
   private final List<String> hostsAllowlist = Arrays.asList("ally", "friend");
 
   private final WebSocketConfiguration webSocketConfiguration =
@@ -67,10 +63,11 @@ public class WebSocketHostAllowlistTest {
   private static final int VERTX_AWAIT_TIMEOUT_MILLIS = 10000;
   private int websocketPort;
 
-  @Before
+  @BeforeEach
   public void initServerAndClient() {
     webSocketConfiguration.setPort(0);
     vertx = Vertx.vertx();
+    testContext = new VertxTestContext();
 
     final Map<String, JsonRpcMethod> websocketMethods =
         new WebSocketMethodsFactory(
@@ -99,7 +96,7 @@ public class WebSocketHostAllowlistTest {
     httpClient = vertx.createHttpClient(httpClientOptions);
   }
 
-  @After
+  @AfterEach
   public void after() {
     reset(webSocketMessageHandlerSpy);
     websocketService.stop();
@@ -112,8 +109,8 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithDefaultHeaderAndDefaultConfigIsAccepted(final TestContext context) {
-    doHttpRequestAndVerify(context, "localhost:50012", 400);
+  public void httpRequestWithDefaultHeaderAndDefaultConfigIsAccepted() throws InterruptedException {
+    doHttpRequestAndVerify(testContext, "localhost:50012", 400);
   }
 
   @Test
@@ -122,8 +119,8 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithEmptyHeaderAndDefaultConfigIsRejected(final TestContext context) {
-    doHttpRequestAndVerify(context, "", 403);
+  public void httpRequestWithEmptyHeaderAndDefaultConfigIsRejected() throws InterruptedException {
+    doHttpRequestAndVerify(testContext, "", 403);
   }
 
   @Test
@@ -134,10 +131,10 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithAnyHostnameAndWildcardConfigIsAccepted(final TestContext context) {
+  public void httpRequestWithAnyHostnameAndWildcardConfigIsAccepted() throws InterruptedException {
     webSocketConfiguration.setHostsAllowlist(Collections.singletonList("*"));
-    doHttpRequestAndVerify(context, "ally", 400);
-    doHttpRequestAndVerify(context, "foe", 400);
+    doHttpRequestAndVerify(testContext, "ally", 400);
+    doHttpRequestAndVerify(testContext, "foe", 400);
   }
 
   @Test
@@ -149,11 +146,11 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithAllowedHostIsAccepted(final TestContext context) {
+  public void httpRequestWithAllowedHostIsAccepted() throws InterruptedException {
     webSocketConfiguration.setHostsAllowlist(hostsAllowlist);
-    doHttpRequestAndVerify(context, "ally", 400);
-    doHttpRequestAndVerify(context, "ally:12345", 400);
-    doHttpRequestAndVerify(context, "friend", 400);
+    doHttpRequestAndVerify(testContext, "ally", 400);
+    doHttpRequestAndVerify(testContext, "ally:12345", 400);
+    doHttpRequestAndVerify(testContext, "friend", 400);
   }
 
   @Test
@@ -163,9 +160,9 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithUnknownHostIsRejected(final TestContext context) {
+  public void httpRequestWithUnknownHostIsRejected() throws InterruptedException {
     webSocketConfiguration.setHostsAllowlist(hostsAllowlist);
-    doHttpRequestAndVerify(context, "foe", 403);
+    doHttpRequestAndVerify(testContext, "foe", 403);
   }
 
   @Test
@@ -179,17 +176,17 @@ public class WebSocketHostAllowlistTest {
   }
 
   @Test
-  public void httpRequestWithMalformedHostIsRejected(final TestContext context) {
+  public void httpRequestWithMalformedHostIsRejected() throws InterruptedException {
     webSocketConfiguration.setAuthenticationEnabled(false);
     webSocketConfiguration.setHostsAllowlist(hostsAllowlist);
-    doHttpRequestAndVerify(context, "ally:friend", 400);
-    doHttpRequestAndVerify(context, "ally:123456", 403);
-    doHttpRequestAndVerify(context, "ally:friend:1234", 403);
+    doHttpRequestAndVerify(testContext, "ally:friend", 400);
+    doHttpRequestAndVerify(testContext, "ally:123456", 403);
+    doHttpRequestAndVerify(testContext, "ally:friend:1234", 403);
   }
 
   private void doHttpRequestAndVerify(
-      final TestContext context, final String hostname, final int expectedResponse) {
-    final Async async = context.async();
+      final VertxTestContext testContext, final String hostname, final int expectedResponse)
+      throws InterruptedException {
 
     httpClient.request(
         HttpMethod.POST,
@@ -204,9 +201,9 @@ public class WebSocketHostAllowlistTest {
               .send(
                   response -> {
                     assertThat(response.result().statusCode()).isEqualTo(expectedResponse);
-                    async.complete();
+                    testContext.completeNow();
                   });
         });
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandlerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandlerTest.java
@@ -39,40 +39,42 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class WebSocketMessageHandlerTest {
 
   private static final int VERTX_AWAIT_TIMEOUT_MILLIS = 10000;
-
   private Vertx vertx;
+  private VertxTestContext testContext;
   private WebSocketMessageHandler handler;
   private JsonRpcMethod jsonRpcMethodMock;
   private ServerWebSocket websocketMock;
   private final Map<String, JsonRpcMethod> methods = new HashMap<>();
 
-  @Before
-  public void before(final TestContext context) {
-    vertx = Vertx.vertx();
+  @BeforeEach
+  public void before() {
+    vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+    testContext = new VertxTestContext();
 
     jsonRpcMethodMock = mock(JsonRpcMethod.class);
     websocketMock = mock(ServerWebSocket.class);
@@ -88,16 +90,14 @@ public class WebSocketMessageHandlerTest {
             TimeoutOptions.defaultOptions().getTimeoutSeconds());
   }
 
-  @After
-  public void after(final TestContext context) {
+  @AfterEach
+  public void after() throws Throwable {
     Mockito.reset(jsonRpcMethodMock);
     Mockito.reset(websocketMock);
-    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
-  public void handlerDeliversResponseSuccessfully(final TestContext context) {
-    final Async async = context.async();
+  public void handlerDeliversResponseSuccessfully() throws InterruptedException {
 
     final JsonObject requestJson = new JsonObject().put("id", 1).put("method", "eth_x");
     final JsonRpcRequest requestBody = requestJson.mapTo(WebSocketRpcRequest.class);
@@ -108,11 +108,13 @@ public class WebSocketMessageHandlerTest {
 
     when(jsonRpcMethodMock.response(eq(expectedRequest))).thenReturn(expectedResponse);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, requestJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -121,8 +123,7 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void handlerBatchRequestDeliversResponseSuccessfully(final TestContext context) {
-    final Async async = context.async();
+  public void handlerBatchRequestDeliversResponseSuccessfully() throws InterruptedException {
 
     final JsonObject requestJson = new JsonObject().put("id", 1).put("method", "eth_x");
     final JsonArray arrayJson = new JsonArray(List.of(requestJson, requestJson));
@@ -136,11 +137,13 @@ public class WebSocketMessageHandlerTest {
 
     when(jsonRpcMethodMock.response(eq(expectedRequest))).thenReturn(expectedSingleResponse);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, arrayJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedBatchResponse))));
     verify(websocketMock).writeFrame(argThat(this::isFinalFrame));
@@ -148,8 +151,8 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void handlerBatchRequestContainingErrorsShouldRespondWithBatchErrors(
-      final TestContext context) {
+  public void handlerBatchRequestContainingErrorsShouldRespondWithBatchErrors()
+      throws InterruptedException {
     ServerWebSocket websocketMock = mock(ServerWebSocket.class);
 
     when(websocketMock.textHandlerID()).thenReturn(UUID.randomUUID().toString());
@@ -161,8 +164,6 @@ public class WebSocketMessageHandlerTest {
             mock(EthScheduler.class),
             TimeoutOptions.defaultOptions().getTimeoutSeconds());
 
-    final Async async = context.async();
-
     final JsonObject requestJson =
         new JsonObject().put("id", 1).put("method", "eth_nonexistentMethod");
     final JsonRpcErrorResponse expectedErrorResponse1 =
@@ -173,11 +174,13 @@ public class WebSocketMessageHandlerTest {
     final JsonArray expectedBatchResponse =
         new JsonArray(List.of(expectedErrorResponse1, expectedErrorResponse1));
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handleBadCalls.handle(websocketMock, arrayJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedBatchResponse))));
@@ -186,17 +189,18 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void jsonDecodeFailureShouldRespondInvalidRequest(final TestContext context) {
-    final Async async = context.async();
+  public void jsonDecodeFailureShouldRespondInvalidRequest() throws InterruptedException {
 
     final JsonRpcErrorResponse expectedResponse =
         new JsonRpcErrorResponse(null, RpcErrorType.INVALID_REQUEST);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, Buffer.buffer(), Optional.empty());
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -205,17 +209,18 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void objectMapperFailureShouldRespondInvalidRequest(final TestContext context) {
-    final Async async = context.async();
+  public void objectMapperFailureShouldRespondInvalidRequest() throws InterruptedException {
 
     final JsonRpcErrorResponse expectedResponse =
         new JsonRpcErrorResponse(null, RpcErrorType.INVALID_REQUEST);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, new JsonObject().toBuffer(), Optional.empty());
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -224,19 +229,20 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void absentMethodShouldRespondMethodNotFound(final TestContext context) {
-    final Async async = context.async();
+  public void absentMethodShouldRespondMethodNotFound() throws InterruptedException {
 
     final JsonObject requestJson =
         new JsonObject().put("id", 1).put("method", "eth_nonexistentMethod");
     final JsonRpcErrorResponse expectedResponse =
         new JsonRpcErrorResponse(1, RpcErrorType.METHOD_NOT_FOUND);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, requestJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
     verify(websocketMock).writeFrame(argThat(this::isFinalFrame));
@@ -244,9 +250,8 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void onInvalidJsonRpcParametersExceptionProcessingRequestShouldRespondInvalidParams(
-      final TestContext context) {
-    final Async async = context.async();
+  public void onInvalidJsonRpcParametersExceptionProcessingRequestShouldRespondInvalidParams()
+      throws InterruptedException {
 
     final JsonObject requestJson = new JsonObject().put("id", 1).put("method", "eth_x");
     final JsonRpcRequestContext expectedRequest =
@@ -256,11 +261,13 @@ public class WebSocketMessageHandlerTest {
     final JsonRpcErrorResponse expectedResponse =
         new JsonRpcErrorResponse(1, RpcErrorType.INVALID_PARAMS);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, requestJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -268,8 +275,7 @@ public class WebSocketMessageHandlerTest {
   }
 
   @Test
-  public void onExceptionProcessingRequestShouldRespondInternalError(final TestContext context) {
-    final Async async = context.async();
+  public void onExceptionProcessingRequestShouldRespondInternalError() throws InterruptedException {
 
     final JsonObject requestJson = new JsonObject().put("id", 1).put("method", "eth_x");
     final JsonRpcRequestContext expectedRequest =
@@ -278,11 +284,13 @@ public class WebSocketMessageHandlerTest {
     final JsonRpcErrorResponse expectedResponse =
         new JsonRpcErrorResponse(1, RpcErrorType.INTERNAL_ERROR);
 
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     handler.handle(websocketMock, requestJson.toBuffer(), Optional.empty());
 
-    async.awaitSuccess(WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(
+        WebSocketMessageHandlerTest.VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
 
     // can verify only after async not before
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -297,9 +305,9 @@ public class WebSocketMessageHandlerTest {
     return frame.isFinal();
   }
 
-  private Answer<Future<Void>> completeOnLastFrame(final Async async) {
+  private Answer<Future<Void>> completeOnLastFrame(final VertxTestContext testContext) {
     return invocation -> {
-      async.complete();
+      testContext.completeNow();
       return Future.succeededFuture();
     };
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -18,6 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.Lists.list;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -55,6 +56,7 @@ import org.hyperledger.besu.nat.NatService;
 
 import java.math.BigInteger;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,6 +69,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
@@ -85,26 +88,25 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.JWTOptions;
 import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class WebSocketServiceLoginTest {
   private static final int VERTX_AWAIT_TIMEOUT_MILLIS = 10000;
 
-  @ClassRule public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private Path folder;
 
   private Vertx vertx;
+  private VertxTestContext testContext;
   protected static Map<String, JsonRpcMethod> rpcMethods;
   protected static JsonRpcHttpService service;
   protected static OkHttpClient client;
@@ -127,9 +129,10 @@ public class WebSocketServiceLoginTest {
   private WebSocketService websocketService;
   private HttpClient httpClient;
 
-  @Before
+  @BeforeEach
   public void before() throws URISyntaxException {
     vertx = Vertx.vertx();
+    testContext = new VertxTestContext();
 
     final String authTomlPath =
         Paths.get(ClassLoader.getSystemResource("JsonRpcHttpService/auth.toml").toURI())
@@ -183,7 +186,7 @@ public class WebSocketServiceLoginTest {
                     mock(MetricsConfiguration.class),
                     natService,
                     new HashMap<>(),
-                    folder.getRoot().toPath(),
+                    folder,
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
@@ -219,15 +222,14 @@ public class WebSocketServiceLoginTest {
     httpClient = vertx.createHttpClient(httpClientOptions);
   }
 
-  @After
+  @AfterEach
   public void after() {
     reset(webSocketMessageHandlerSpy);
     websocketService.stop();
   }
 
   @Test
-  public void loginWithBadCredentials(final TestContext context) {
-    final Async async = context.async();
+  public void loginWithBadCredentials() throws InterruptedException {
     httpClient.request(
         HttpMethod.POST,
         websocketConfiguration.getPort(),
@@ -242,16 +244,15 @@ public class WebSocketServiceLoginTest {
                   response -> {
                     assertThat(response.result().statusCode()).isEqualTo(401);
                     assertThat(response.result().statusMessage()).isEqualTo("Unauthorized");
-                    async.complete();
+                    testContext.completeNow();
                   });
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void loginWithGoodCredentials(final TestContext context) {
-    final Async async = context.async();
+  public void loginWithGoodCredentials() throws InterruptedException {
     Handler<AsyncResult<HttpClientResponse>> responseHandler =
         response -> {
           assertThat(response.result().statusCode()).isEqualTo(200);
@@ -296,7 +297,7 @@ public class WebSocketServiceLoginTest {
                                   (authed) -> {
                                     assertThat(authed.succeeded()).isTrue();
                                     assertThat(authed.result()).isTrue();
-                                    async.complete();
+                                    testContext.completeNow();
                                   });
                             });
                   });
@@ -314,12 +315,11 @@ public class WebSocketServiceLoginTest {
         "/login",
         requestHandler);
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void websocketServiceWithBadHeaderAuthenticationToken(final TestContext context) {
-    final Async async = context.async();
+  public void websocketServiceWithBadHeaderAuthenticationToken() throws InterruptedException {
 
     final String request = "{\"id\": 1, \"method\": \"eth_subscribe\", \"params\": [\"syncing\"]}";
     final String expectedResponse =
@@ -339,18 +339,19 @@ public class WebSocketServiceLoginTest {
           webSocket
               .result()
               .handler(
-                  buffer -> {
-                    context.assertEquals(expectedResponse, buffer.toString());
-                    async.complete();
-                  });
+                  buffer ->
+                      testContext.verify(
+                          () -> {
+                            assertEquals(expectedResponse, buffer.toString());
+                            testContext.completeNow();
+                          }));
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void netServicesSucceedWithNoAuth(final TestContext context) {
-    final Async async = context.async();
+  public void netServicesSucceedWithNoAuth() throws InterruptedException {
 
     final String id = "123";
     final String request =
@@ -370,18 +371,19 @@ public class WebSocketServiceLoginTest {
           webSocket
               .result()
               .handler(
-                  buffer -> {
-                    context.assertEquals(expectedResponse, buffer.toString());
-                    async.complete();
-                  });
+                  buffer ->
+                      testContext.verify(
+                          () -> {
+                            assertEquals(expectedResponse, buffer.toString());
+                            testContext.completeNow();
+                          }));
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void websocketServiceWithGoodHeaderAuthenticationToken(final TestContext context) {
-    final Async async = context.async();
+  public void websocketServiceWithGoodHeaderAuthenticationToken() throws InterruptedException {
 
     final JWTOptions jwtOptions = new JWTOptions().setExpiresInMinutes(5).setAlgorithm("RS256");
 
@@ -408,18 +410,19 @@ public class WebSocketServiceLoginTest {
           webSocket
               .result()
               .handler(
-                  buffer -> {
-                    context.assertEquals(expectedResponse, buffer.toString());
-                    async.complete();
-                  });
+                  buffer ->
+                      testContext.verify(
+                          () -> {
+                            assertEquals(expectedResponse, buffer.toString());
+                            testContext.completeNow();
+                          }));
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void loginPopulatesJWTPayloadWithRequiredValues(final TestContext context) {
-    final Async async = context.async();
+  public void loginPopulatesJWTPayloadWithRequiredValues() throws InterruptedException {
     httpClient.request(
         HttpMethod.POST,
         websocketConfiguration.getPort(),
@@ -462,12 +465,12 @@ public class WebSocketServiceLoginTest {
                                   jwtPayload.getLong("exp") - jwtPayload.getLong("iat");
                               assertThat(tokenExpiry).isEqualTo(MINUTES.toSeconds(5));
 
-                              async.complete();
+                              testContext.completeNow();
                             });
                   });
         });
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   private JsonObject decodeJwtPayload(final String token) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthSubscribeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthSubscribeTest.java
@@ -32,8 +32,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 
 import io.vertx.core.json.Json;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthSubscribeTest {
 
@@ -41,7 +41,7 @@ public class EthSubscribeTest {
   private SubscriptionManager subscriptionManagerMock;
   private SubscriptionRequestMapper mapperMock;
 
-  @Before
+  @BeforeEach
   public void before() {
     subscriptionManagerMock = mock(SubscriptionManager.class);
     mapperMock = mock(SubscriptionRequestMapper.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribeIntegrationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribeIntegrationTest.java
@@ -34,34 +34,37 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.HashMap;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.core.http.ServerWebSocket;
 import io.vertx.core.http.WebSocketFrame;
 import io.vertx.core.json.Json;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.stubbing.Answer;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class EthUnsubscribeIntegrationTest {
 
   private Vertx vertx;
+  private VertxTestContext testContext;
   private WebSocketMessageHandler webSocketMessageHandler;
   private SubscriptionManager subscriptionManager;
   private WebSocketMethodsFactory webSocketMethodsFactory;
   private final int ASYNC_TIMEOUT = 5000;
   private final String CONNECTION_ID = "test-connection-id-1";
 
-  @Before
+  @BeforeEach
   public void before() {
-    vertx = Vertx.vertx();
+    vertx = Vertx.vertx(new VertxOptions().setPreferNativeTransport(true));
+    testContext = new VertxTestContext();
     subscriptionManager = new SubscriptionManager(new NoOpMetricsSystem());
     webSocketMethodsFactory = new WebSocketMethodsFactory(subscriptionManager, new HashMap<>());
     webSocketMessageHandler =
@@ -73,8 +76,7 @@ public class EthUnsubscribeIntegrationTest {
   }
 
   @Test
-  public void shouldRemoveConnectionWithSingleSubscriptionFromMap(final TestContext context) {
-    final Async async = context.async();
+  public void shouldRemoveConnectionWithSingleSubscriptionFromMap() throws InterruptedException {
 
     // Add the subscription we'd like to remove
     final SubscribeRequest subscribeRequest =
@@ -90,20 +92,20 @@ public class EthUnsubscribeIntegrationTest {
 
     final ServerWebSocket websocketMock = mock(ServerWebSocket.class);
     when(websocketMock.textHandlerID()).thenReturn(CONNECTION_ID);
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     webSocketMessageHandler.handle(
         websocketMock, Json.encodeToBuffer(unsubscribeRequestBody), Optional.empty());
 
-    async.awaitSuccess(ASYNC_TIMEOUT);
+    testContext.awaitCompletion(ASYNC_TIMEOUT, TimeUnit.MILLISECONDS);
     assertThat(subscriptionManager.getSubscriptionById(subscriptionId)).isNull();
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
     verify(websocketMock).writeFrame(argThat(this::isFinalFrame));
   }
 
   @Test
-  public void shouldRemoveSubscriptionAndKeepConnection(final TestContext context) {
-    final Async async = context.async();
+  public void shouldRemoveSubscriptionAndKeepConnection() throws InterruptedException {
 
     // Add the subscriptions we'd like to remove
     final SubscribeRequest subscribeRequest =
@@ -122,12 +124,13 @@ public class EthUnsubscribeIntegrationTest {
 
     final ServerWebSocket websocketMock = mock(ServerWebSocket.class);
     when(websocketMock.textHandlerID()).thenReturn(CONNECTION_ID);
-    when(websocketMock.writeFrame(argThat(this::isFinalFrame))).then(completeOnLastFrame(async));
+    when(websocketMock.writeFrame(argThat(this::isFinalFrame)))
+        .then(completeOnLastFrame(testContext));
 
     webSocketMessageHandler.handle(
         websocketMock, Json.encodeToBuffer(unsubscribeRequestBody), Optional.empty());
 
-    async.awaitSuccess(ASYNC_TIMEOUT);
+    testContext.awaitCompletion(ASYNC_TIMEOUT, TimeUnit.MILLISECONDS);
     assertThat(subscriptionManager.getSubscriptionById(subscriptionId1)).isNotNull();
     assertThat(subscriptionManager.getSubscriptionById(subscriptionId2)).isNull();
     verify(websocketMock).writeFrame(argThat(isFrameWithText(Json.encode(expectedResponse))));
@@ -153,9 +156,9 @@ public class EthUnsubscribeIntegrationTest {
     return frame.isFinal();
   }
 
-  private Answer<Future<Void>> completeOnLastFrame(final Async async) {
+  private Answer<Future<Void>> completeOnLastFrame(final VertxTestContext testContext) {
     return invocation -> {
-      async.complete();
+      testContext.completeNow();
       return Future.succeededFuture();
     };
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribeTest.java
@@ -32,8 +32,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.UnsubscribeRequest;
 
 import io.vertx.core.json.Json;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class EthUnsubscribeTest {
 
@@ -42,7 +42,7 @@ public class EthUnsubscribeTest {
   private SubscriptionRequestMapper mapperMock;
   private final String CONNECTION_ID = "test-connection-id";
 
-  @Before
+  @BeforeEach
   public void before() {
     subscriptionManagerMock = mock(SubscriptionManager.class);
     mapperMock = mock(SubscriptionRequestMapper.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivSubscribeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivSubscribeTest.java
@@ -36,13 +36,13 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import io.vertx.core.json.Json;
 import io.vertx.ext.auth.User;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivSubscribeTest {
 
   private final String ENCLAVE_KEY = "enclave_key";
@@ -55,7 +55,7 @@ public class PrivSubscribeTest {
 
   private PrivSubscribe privSubscribe;
 
-  @Before
+  @BeforeEach
   public void before() {
     privSubscribe =
         new PrivSubscribe(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivUnsubscribeTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivUnsubscribeTest.java
@@ -34,13 +34,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import io.vertx.core.json.Json;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PrivUnsubscribeTest {
 
   private final String PRIVACY_GROUP_ID = "B1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -53,7 +53,7 @@ public class PrivUnsubscribeTest {
 
   private PrivUnsubscribe privUnsubscribe;
 
-  @Before
+  @BeforeEach
   public void before() {
     privUnsubscribe =
         new PrivUnsubscribe(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactoryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactoryTest.java
@@ -23,13 +23,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscrip
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class WebSocketMethodsFactoryTest {
 
   private WebSocketMethodsFactory factory;
@@ -37,7 +37,7 @@ public class WebSocketMethodsFactoryTest {
   @Mock private SubscriptionManager subscriptionManager;
   private final Map<String, JsonRpcMethod> jsonRpcMethods = new HashMap<>();
 
-  @Before
+  @BeforeEach
   public void before() {
     jsonRpcMethods.put("eth_unsubscribe", jsonRpcMethod());
     factory = new WebSocketMethodsFactory(subscriptionManager, jsonRpcMethods);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilderTest.java
@@ -29,15 +29,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing.
 
 import java.util.function.Function;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionBuilderTest {
 
   private static final String CONNECTION_ID = "connectionId";
   private SubscriptionBuilder subscriptionBuilder;
 
-  @Before
+  @BeforeEach
   public void before() {
     subscriptionBuilder = new SubscriptionBuilder();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerSendMessageTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerSendMessageTest.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.JsonRpcResult;
@@ -24,36 +24,39 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.response
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.Json;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class SubscriptionManagerSendMessageTest {
 
   private static final int VERTX_AWAIT_TIMEOUT_MILLIS = 10000;
 
   private Vertx vertx;
+  private VertxTestContext testContext;
   private SubscriptionManager subscriptionManager;
 
-  @Before
-  public void before(final TestContext context) {
+  @BeforeEach
+  public void before() {
     vertx = Vertx.vertx();
+    testContext = new VertxTestContext();
     subscriptionManager = new SubscriptionManager(new NoOpMetricsSystem());
-    vertx.deployVerticle(subscriptionManager, context.asyncAssertSuccess());
+    vertx.deployVerticle(subscriptionManager, testContext.succeedingThenComplete());
   }
 
   @Test
-  @Ignore
-  public void shouldSendMessageOnTheConnectionIdEventBusAddressForExistingSubscription(
-      final TestContext context) {
+  @Disabled
+  public void shouldSendMessageOnTheConnectionIdEventBusAddressForExistingSubscription()
+      throws InterruptedException {
     final String connectionId = UUID.randomUUID().toString();
     final SubscribeRequest subscribeRequest =
         new SubscribeRequest(SubscriptionType.SYNCING, null, null, connectionId);
@@ -66,41 +69,37 @@ public class SubscriptionManagerSendMessageTest {
 
     final Long subscriptionId = subscriptionManager.subscribe(subscribeRequest);
 
-    final Async async = context.async();
-
     vertx
         .eventBus()
         .consumer(connectionId)
         .handler(
             msg -> {
-              context.assertEquals(Json.encode(expectedResponse), msg.body());
-              async.complete();
+              assertEquals(Json.encode(expectedResponse), msg.body());
+              testContext.completeNow();
             })
         .completionHandler(v -> subscriptionManager.sendMessage(subscriptionId, expectedResult));
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 
   @Test
-  public void shouldNotSendMessageOnTheConnectionIdEventBusAddressForAbsentSubscription(
-      final TestContext context) {
+  public void shouldNotSendMessageOnTheConnectionIdEventBusAddressForAbsentSubscription()
+      throws InterruptedException {
     final String connectionId = UUID.randomUUID().toString();
-
-    final Async async = context.async();
 
     vertx
         .eventBus()
         .consumer(connectionId)
         .handler(
             msg -> {
-              fail("Shouldn't receive message");
-              async.complete();
+              Assertions.fail("Shouldn't receive message");
+              testContext.completeNow();
             })
         .completionHandler(v -> subscriptionManager.sendMessage(1L, mock(JsonRpcResult.class)));
 
     // if it doesn't receive the message in 5 seconds we assume it won't receive anymore
-    vertx.setPeriodic(5000, v -> async.complete());
+    vertx.setPeriodic(5000, v -> testContext.completeNow());
 
-    async.awaitSuccess(VERTX_AWAIT_TIMEOUT_MILLIS);
+    testContext.awaitCompletion(VERTX_AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionManagerTest.java
@@ -33,15 +33,15 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionManagerTest {
 
   private SubscriptionManager subscriptionManager;
   private final String CONNECTION_ID = "test-connection-id";
 
-  @Before
+  @BeforeEach
   public void before() {
     subscriptionManager = new SubscriptionManager(new NoOpMetricsSystem());
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionServiceTest.java
@@ -42,16 +42,16 @@ import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NewBlockHeadersSubscriptionServiceTest {
 
   @Captor ArgumentCaptor<Long> subscriptionIdCaptor;
@@ -76,7 +76,7 @@ public class NewBlockHeadersSubscriptionServiceTest {
   private final BlockchainQueries blockchainQueriesSpy =
       Mockito.spy(new BlockchainQueries(blockchain, createInMemoryWorldStateArchive()));
 
-  @Before
+  @BeforeEach
   public void before() {
     final NewBlockHeadersSubscriptionService newBlockHeadersSubscriptionService =
         new NewBlockHeadersSubscriptionService(subscriptionManagerSpy, blockchainQueriesSpy);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionServiceTest.java
@@ -54,14 +54,14 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LogsSubscriptionServiceTest {
 
   private final BlockDataGenerator gen = new BlockDataGenerator(1);
@@ -75,7 +75,7 @@ public class LogsSubscriptionServiceTest {
 
   @Mock private PrivacyQueries privacyQueries;
 
-  @Before
+  @BeforeEach
   public void before() {
     logsSubscriptionService =
         new LogsSubscriptionService(subscriptionManager, Optional.of(privacyQueries));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionServiceTest.java
@@ -36,13 +36,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PendingTransactionDroppedSubscriptionServiceTest {
 
   private static final Hash TX_ONE =
@@ -54,7 +54,7 @@ public class PendingTransactionDroppedSubscriptionServiceTest {
 
   private PendingTransactionDroppedSubscriptionService service;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     service = new PendingTransactionDroppedSubscriptionService(subscriptionManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionSubscriptionServiceTest.java
@@ -36,13 +36,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class PendingTransactionSubscriptionServiceTest {
 
   private static final Hash TX_ONE =
@@ -54,7 +54,7 @@ public class PendingTransactionSubscriptionServiceTest {
 
   private PendingTransactionSubscriptionService service;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     service = new PendingTransactionSubscriptionService(subscriptionManager);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapperTest.java
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import io.vertx.core.json.Json;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SubscriptionRequestMapperTest {
 
@@ -43,7 +43,7 @@ public class SubscriptionRequestMapperTest {
   private final String CONNECTION_ID = null;
   private static final String ENCLAVE_PUBLIC_KEY = "enclave_public_key";
 
-  @Before
+  @BeforeEach
   public void before() {
     mapper = new SubscriptionRequestMapper();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionServiceTest.java
@@ -34,22 +34,22 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SyncingSubscriptionServiceTest {
 
   @Mock private SubscriptionManager subscriptionManager;
   @Mock private Synchronizer synchronizer;
   private SyncStatusListener syncStatusListener;
 
-  @Before
+  @BeforeEach
   public void before() {
     final ArgumentCaptor<SyncStatusListener> captor =
         ArgumentCaptor.forClass(SyncStatusListener.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BackendQueryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BackendQueryTest.java
@@ -17,52 +17,33 @@ package org.hyperledger.besu.ethereum.api.query;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class BackendQueryTest<T> {
-
-  private final Supplier<Boolean> alive;
-  private final Object wantReturn;
-  private final boolean wantException;
-  private final Class<T> wantExceptionClass;
-  private final String wantExceptionMessage;
-
-  public BackendQueryTest(
-      final Supplier<Boolean> alive,
-      final Object wantReturn,
-      final boolean wantException,
-      final Class<T> wantExceptionClass,
-      final String wantExceptionMessage) {
-    this.alive = alive;
-    this.wantReturn = wantReturn;
-    this.wantException = wantException;
-    this.wantExceptionClass = wantExceptionClass;
-    this.wantExceptionMessage = wantExceptionMessage;
-  }
-
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {supplierOf(false), null, true, RuntimeException.class, "Timeout expired"},
-          {supplierOf(true), "expected return", false, null, null}
-        });
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(supplierOf(false), null, true, RuntimeException.class, "Timeout expired"),
+        Arguments.of(supplierOf(true), "expected return", false, null, null));
   }
 
   private static Supplier<Boolean> supplierOf(final boolean val) {
     return () -> val;
   }
 
-  @Test
-  public void test() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void test(
+      final Supplier<Boolean> alive,
+      final Object wantReturn,
+      final boolean wantException,
+      final Class<T> wantExceptionClass,
+      final String wantExceptionMessage)
+      throws Exception {
     if (wantException) {
       assertThatThrownBy(() -> BackendQuery.runIfAlive(() -> wantReturn, alive))
           .isInstanceOf(wantExceptionClass)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -38,24 +38,27 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class BlockchainQueriesLogCacheTest {
 
-  @ClassRule public static TemporaryFolder cacheDir = new TemporaryFolder();
+  @TempDir private static Path cacheDir;
 
   private static LogsQuery logsQuery;
   private Hash testHash;
@@ -66,7 +69,7 @@ public class BlockchainQueriesLogCacheTest {
   @Mock EthScheduler scheduler;
   private BlockchainQueries blockchainQueries;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws IOException {
     final Address testAddress = Address.fromHexString("0x123456");
     final Bytes testMessage = Bytes.fromHexString("0x9876");
@@ -76,7 +79,7 @@ public class BlockchainQueriesLogCacheTest {
 
     for (int i = 0; i < 2; i++) {
       final RandomAccessFile file =
-          new RandomAccessFile(cacheDir.newFile("logBloom-" + i + ".cache"), "rws");
+          new RandomAccessFile(cacheDir.resolve("logBloom-" + i + ".cache").toFile(), "rws");
       writeThreeEntries(testLogsBloomFilter, file);
       file.seek((BLOCKS_PER_BLOOM_CACHE - 3) * LogsBloomFilter.BYTE_SIZE);
       writeThreeEntries(testLogsBloomFilter, file);
@@ -90,7 +93,7 @@ public class BlockchainQueriesLogCacheTest {
     file.write(filter.toArray());
   }
 
-  @Before
+  @BeforeEach
   public void setup() {
     final BlockHeader fakeHeader =
         new BlockHeader(
@@ -123,10 +126,7 @@ public class BlockchainQueriesLogCacheTest {
     when(blockchain.getBlockBody(any())).thenReturn(Optional.of(fakeBody));
     blockchainQueries =
         new BlockchainQueries(
-            blockchain,
-            worldStateArchive,
-            Optional.of(cacheDir.getRoot().toPath()),
-            Optional.of(scheduler));
+            blockchain, worldStateArchive, Optional.of(cacheDir), Optional.of(scheduler));
   }
 
   /**

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -46,14 +46,14 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.apache.tuweni.units.bigints.UInt256;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BlockchainQueriesTest {
   private BlockDataGenerator gen;
   private EthScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     gen = new BlockDataGenerator();
     scheduler = new EthScheduler(1, 1, 1, 1, new NoOpMetricsSystem());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/LogsQueryTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/LogsQueryTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.evm.log.LogTopic;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogsQueryTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/PrivacyQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/PrivacyQueriesTest.java
@@ -42,13 +42,16 @@ import java.util.stream.LongStream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class PrivacyQueriesTest {
 
   private final String PRIVACY_GROUP_ID = "B1aVtMxLCUHmBVHXoZzzBgPbW/wj5axDpW9X8l91SGo=";
@@ -63,7 +66,7 @@ public class PrivacyQueriesTest {
 
   private PrivacyQueries privacyQueries;
 
-  @Before
+  @BeforeEach
   public void before() {
     privacyQueries = new PrivacyQueries(blockchainQueries, privateWorldStateReader);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/StateBackupServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/StateBackupServiceTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StateBackupServiceTest {
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacherTest.java
@@ -36,6 +36,8 @@ import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,20 +45,22 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @SuppressWarnings("unused")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TransactionLogBloomCacherTest {
 
-  @Rule public TemporaryFolder cacheDir = new TemporaryFolder();
+  @TempDir private Path cacheDir;
 
   private Hash testHash;
   private static LogsBloomFilter testLogsBloomFilter;
@@ -65,7 +69,7 @@ public class TransactionLogBloomCacherTest {
   @Mock EthScheduler scheduler;
   private TransactionLogBloomCacher transactionLogBloomCacher;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() {
     final Address testAddress = Address.fromHexString("0x123456");
     final Bytes testMessage = Bytes.fromHexString("0x9876");
@@ -81,7 +85,7 @@ public class TransactionLogBloomCacherTest {
   }
 
   @SuppressWarnings({"unchecked", "ReturnValueIgnored"})
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     final BlockHeader fakeHeader =
         new BlockHeader(
@@ -119,22 +123,21 @@ public class TransactionLogBloomCacherTest {
               invocation.getArgument(0, Supplier.class).get();
               return null;
             });
-    transactionLogBloomCacher =
-        new TransactionLogBloomCacher(blockchain, cacheDir.getRoot().toPath(), scheduler);
+    transactionLogBloomCacher = new TransactionLogBloomCacher(blockchain, cacheDir, scheduler);
   }
 
   @Test
   public void shouldSplitLogsIntoSeveralFiles() {
 
     when(blockchain.getChainHeadBlockNumber()).thenReturn(200003L);
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(0);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(0);
     transactionLogBloomCacher.cacheAll();
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(2);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(2);
   }
 
   @Test
   public void shouldUpdateCacheWhenBlockAdded() throws IOException {
-    final File logBloom = cacheDir.newFile("logBloom-0.cache");
+    final File logBloom = Files.createFile(cacheDir.resolve("logBloom-0.cache")).toFile();
 
     createLogBloomCache(logBloom);
 
@@ -146,12 +149,12 @@ public class TransactionLogBloomCacherTest {
         header, Optional.empty(), Optional.of(logBloom));
 
     assertThat(logBloom.length()).isEqualTo(BLOOM_BITS_LENGTH * 4);
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(1);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(1);
   }
 
   @Test
   public void shouldReloadCacheWhenBLockIsMissing() throws IOException {
-    final File logBloom = cacheDir.newFile("logBloom-0.cache");
+    final File logBloom = Files.createFile(cacheDir.resolve("logBloom-0.cache")).toFile();
 
     createLogBloomCache(logBloom);
     assertThat(logBloom.length()).isEqualTo(BLOOM_BITS_LENGTH * 3);
@@ -170,31 +173,32 @@ public class TransactionLogBloomCacherTest {
     }
 
     assertThat(logBloom.length()).isEqualTo(BLOOM_BITS_LENGTH * 5);
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(1);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(1);
   }
 
   @Test
   public void shouldReloadCacheWhenFileIsInvalid() throws IOException {
-    final File logBloom = cacheDir.newFile("logBloom-0.cache");
-    final File logBloom1 = cacheDir.newFile("logBloom-1.cache");
+    final File logBloom = Files.createFile(cacheDir.resolve("logBloom-0.cache")).toFile();
+
+    final File logBloom1 = Files.createFile(cacheDir.resolve("logBloom-1.cache")).toFile();
 
     when(blockchain.getChainHeadBlockNumber()).thenReturn(100003L);
     assertThat(logBloom.length()).isEqualTo(0);
     assertThat(logBloom1.length()).isEqualTo(0);
 
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(2);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(2);
 
     transactionLogBloomCacher.cacheAll();
 
     assertThat(logBloom.length()).isEqualTo(BLOOM_BITS_LENGTH * BLOCKS_PER_BLOOM_CACHE);
     assertThat(logBloom1.length()).isEqualTo(0);
 
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(2);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(2);
   }
 
   @Test
   public void shouldUpdateCacheWhenChainReorgFired() throws IOException {
-    final File logBloom = cacheDir.newFile("logBloom-0.cache");
+    final File logBloom = Files.createFile(cacheDir.resolve("logBloom-0.cache")).toFile();
 
     final List<BlockHeader> firstBranch = new ArrayList<>();
 
@@ -229,7 +233,7 @@ public class TransactionLogBloomCacherTest {
         forkBranch.get(1), Optional.empty(), Optional.of(logBloom));
     assertThat(logBloom.length()).isEqualTo(BLOOM_BITS_LENGTH * 2);
 
-    assertThat(cacheDir.getRoot().list().length).isEqualTo(1);
+    assertThat(cacheDir.toFile().list().length).isEqualTo(1);
   }
 
   private void createLogBloomCache(final File logBloom) throws IOException {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/tls/FileBasedPasswordProviderTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/tls/FileBasedPasswordProviderTest.java
@@ -22,17 +22,16 @@ import java.nio.file.Path;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class FileBasedPasswordProviderTest {
 
-  @Rule public final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir private Path folder;
 
   @Test
   public void passwordCanBeReadFromFile() throws IOException {
-    final Path passwordFile = folder.newFile().toPath();
+    final Path passwordFile = folder.resolve("pass1");
     Files.write(passwordFile, List.of("line1", "line2"));
 
     final String password = new FileBasedPasswordProvider(passwordFile).get();
@@ -41,7 +40,7 @@ public class FileBasedPasswordProviderTest {
 
   @Test
   public void exceptionRaisedFromReadingEmptyFile() throws IOException {
-    final Path passwordFile = folder.newFile().toPath();
+    final Path passwordFile = folder.resolve("pass2");
     Files.write(passwordFile, new byte[0]);
 
     Assertions.assertThatExceptionOfType(TlsConfigurationException.class)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtilsTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DomainObjectDecodeUtilsTest {
 


### PR DESCRIPTION
## PR description
This PR removes junit4 dependency from ethereum/api files
Converts junit4 tests to junit5 according to https://blogs.oracle.com/javamagazine/post/migrating-from-junit-4-to-junit-5-important-differences-and-benefits

Split part 1 PR from https://github.com/hyperledger/besu/pull/5678

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/5564