### PR TITLE
ethereum/part5 - migrated tests from Junit4 to Junit5

### DIFF
--- a/ethereum/ethstats/build.gradle
+++ b/ethereum/ethstats/build.gradle
@@ -57,10 +57,8 @@ dependencies {
   testImplementation project(':testutil')
   testImplementation project(':metrics:core')
 
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'
-
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/EthStatsServiceTest.java
@@ -50,15 +50,18 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.WebSocket;
 import io.vertx.core.http.WebSocketConnectOptions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @SuppressWarnings("unchecked")
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EthStatsServiceTest {
 
   @Mock private Vertx vertx;
@@ -94,7 +97,7 @@ public class EthStatsServiceTest {
 
   private EthStatsService ethStatsService;
 
-  @Before
+  @BeforeEach
   public void initMocks() {
     when(ethProtocolManager.ethContext()).thenReturn(ethContext);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptionsTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/EthStatsConnectOptionsTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 

--- a/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/PrimusHeartBeatsHelperTest.java
+++ b/ethereum/ethstats/src/test/java/org/hyperledger/besu/ethstats/util/PrimusHeartBeatsHelperTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.verify;
 import java.util.regex.Pattern;
 
 import io.vertx.core.http.WebSocket;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 @SuppressWarnings("unchecked")

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -59,7 +59,6 @@ dependencies {
   annotationProcessor 'com.google.dagger:dagger-compiler'
   annotationProcessor 'info.picocli:picocli-codegen'
 
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/CodeValidationSubCommandTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/CodeValidationSubCommandTest.java
@@ -21,7 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 public class CodeValidationSubCommandTest {

--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/StateTestSubCommandTest.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 public class StateTestSubCommandTest {

--- a/ethereum/mock-p2p/build.gradle
+++ b/ethereum/mock-p2p/build.gradle
@@ -37,9 +37,6 @@ dependencies {
   implementation 'io.vertx:vertx-core'
   implementation 'io.tmio:tuweni-bytes'
 
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
-
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }

--- a/ethereum/mock-p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetworkTest.java
+++ b/ethereum/mock-p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/testing/MockNetworkTest.java
@@ -33,7 +33,7 @@ import java.util.function.Predicate;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link MockNetwork}. */
 public final class MockNetworkTest {


### PR DESCRIPTION
## PR description
This PR removes junit4 dependency from ethereum/ethstats, ethereum/evmtool, ethereum/mock-p2p files

Split part 5 PR from https://github.com/hyperledger/besu/pull/5678 

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/5564