### PR TITLE
ethereum/p2p - migrated tests from Junit4 to Junit5

### DIFF
--- a/ethereum/p2p/build.gradle
+++ b/ethereum/p2p/build.gradle
@@ -77,11 +77,9 @@ dependencies {
   }
   testImplementation 'io.vertx:vertx-codegen'
   testImplementation 'io.vertx:vertx-unit'
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'
-
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfigurationTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/config/DiscoveryConfigurationTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DiscoveryConfigurationTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -54,7 +54,7 @@ import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryAgentTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBondingTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBondingTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryBondingTest {
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBootstrappingTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryBootstrappingTest.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryBootstrappingTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketPcapSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketPcapSedesTest.java
@@ -33,7 +33,7 @@ import io.vertx.core.buffer.Buffer;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.assertj.core.api.Condition;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryPacketPcapSedesTest {
   private static final String pingHexData =

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryPacketSedesTest.java
@@ -35,7 +35,7 @@ import java.util.Random;
 import io.vertx.core.buffer.Buffer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryPacketSedesTest {
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryTimestampsTest.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryTimestampsTest {
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/BucketTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/BucketTest.java
@@ -14,9 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.p2p.discovery.internal;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper;
@@ -24,7 +24,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryTestHelper;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BucketTest {
   private final PeerDiscoveryTestHelper helper = new PeerDiscoveryTestHelper();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRRequestPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRRequestPacketDataTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import java.time.Instant;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ENRRequestPacketDataTest {
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRResponsePacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRResponsePacketDataTest.java
@@ -26,7 +26,7 @@ import org.ethereum.beacon.discovery.schema.IdentitySchema;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.ethereum.beacon.discovery.util.Functions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ENRResponsePacketDataTest {
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/FindNeighborsPacketDataTest.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import java.time.Instant;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FindNeighborsPacketDataTest {
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/NeighborsPacketDataTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NeighborsPacketDataTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTest.java
@@ -26,7 +26,7 @@ import io.vertx.core.buffer.Buffer;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PacketTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTypeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PacketTypeTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.p2p.discovery.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PacketTypeTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerDistanceCalculatorTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerDistanceCalculatorTest.java
@@ -21,7 +21,7 @@ import static org.hyperledger.besu.ethereum.p2p.discovery.internal.PeerDistanceC
 import java.util.Random;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDiscoveryControllerDistanceCalculatorTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryControllerTest.java
@@ -78,9 +78,9 @@ import org.ethereum.beacon.discovery.schema.IdentitySchemaInterpreter;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.ethereum.beacon.discovery.schema.NodeRecordFactory;
 import org.jetbrains.annotations.NotNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class PeerDiscoveryControllerTest {
@@ -103,7 +103,7 @@ public class PeerDiscoveryControllerTest {
     return Math.max(100, prev * 2);
   }
 
-  @Before
+  @BeforeEach
   public void initializeMocks() {
     final List<NodeKey> nodeKeys = PeerDiscoveryTestHelper.generateNodeKeys(1);
     localNodeKey = nodeKeys.get(0);
@@ -111,7 +111,7 @@ public class PeerDiscoveryControllerTest {
     peerTable = new PeerTable(localPeer.getId());
   }
 
-  @After
+  @AfterEach
   public void stopTable() {
     if (controller != null) {
       controller.stop().join();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryTableRefreshTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerDiscoveryTableRefreshTest.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class PeerDiscoveryTableRefreshTest {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerRequirementCombineTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerRequirementCombineTest.java
@@ -18,17 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class PeerRequirementCombineTest {
   private static final PeerRequirement fulfilled = () -> true;
   private static final PeerRequirement notFulfilled = () -> false;
@@ -36,37 +33,28 @@ public class PeerRequirementCombineTest {
   private static final AtomicBoolean configurableIsFulfilled = new AtomicBoolean(true);
   private static final PeerRequirement configurable = configurableIsFulfilled::get;
 
-  private final List<PeerRequirement> requirements;
-  private final boolean expectedResult;
-
-  public PeerRequirementCombineTest(
-      final List<PeerRequirement> requirements, final boolean expectedResult) {
-    this.requirements = requirements;
-    this.expectedResult = expectedResult;
+  public static Stream<Object[]> data() {
+    return Stream.of(
+        new Object[] {Collections.emptyList(), true},
+        new Object[] {Arrays.asList(fulfilled), true},
+        new Object[] {Arrays.asList(notFulfilled), false},
+        new Object[] {Arrays.asList(notFulfilled, notFulfilled), false},
+        new Object[] {Arrays.asList(notFulfilled, fulfilled), false},
+        new Object[] {Arrays.asList(fulfilled, notFulfilled), false},
+        new Object[] {Arrays.asList(fulfilled, fulfilled), true});
   }
 
-  @Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(
-        new Object[][] {
-          {Collections.emptyList(), true},
-          {Arrays.asList(fulfilled), true},
-          {Arrays.asList(notFulfilled), false},
-          {Arrays.asList(notFulfilled, notFulfilled), false},
-          {Arrays.asList(notFulfilled, fulfilled), false},
-          {Arrays.asList(fulfilled, notFulfilled), false},
-          {Arrays.asList(fulfilled, fulfilled), true}
-        });
-  }
-
-  @Test
-  public void combine() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void combine(final List<PeerRequirement> requirements, final boolean expectedResult) {
     PeerRequirement combined = PeerRequirement.combine(requirements);
     assertThat(combined.hasSufficientPeers()).isEqualTo(expectedResult);
   }
 
-  @Test
-  public void combineAndModify() {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void combineAndModify(
+      final List<PeerRequirement> requirements, final boolean expectedResult) {
     List<PeerRequirement> modifiableRequirements = new ArrayList<>(requirements);
     modifiableRequirements.add(configurable);
 
@@ -82,7 +70,8 @@ public class PeerRequirementCombineTest {
     assertThat(combined.hasSufficientPeers()).isEqualTo(expectedResult);
   }
 
-  @Test
+  @ParameterizedTest
+  @MethodSource("data")
   public void combine_withOn() {
     PeerRequirement combined = PeerRequirement.combine(Collections.emptyList());
     assertThat(combined.hasSufficientPeers()).isTrue();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PeerTableTest.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerTableTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PingPacketDataTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PingPacketDataTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketDataTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/PongPacketDataTest.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PongPacketDataTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshStateTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshStateTest.java
@@ -35,8 +35,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RecursivePeerRefreshStateTest {
   private static final Bytes TARGET = createId(0);
@@ -62,7 +62,7 @@ public class RecursivePeerRefreshStateTest {
           5,
           100);
 
-  @Before
+  @BeforeEach
   public void setup() {
     // Default peerPermissions to be permissive
     when(peerPermissions.isAllowedInPeerTable(any())).thenReturn(true);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetworkTest.java
@@ -64,15 +64,15 @@ import io.vertx.core.dns.DnsClient;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.SECP256K1;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public final class DefaultP2PNetworkTest {
   final MaintainedPeers maintainedPeers = new MaintainedPeers();
   final SECP256K1.SecretKey mockKey =
@@ -92,7 +92,7 @@ public final class DefaultP2PNetworkTest {
                   .setBindPort(0)
                   .setSupportedProtocols(MockSubProtocol.create()));
 
-  @Before
+  @BeforeEach
   public void before() {
     lenient().when(rlpxAgent.start()).thenReturn(CompletableFuture.completedFuture(30303));
     lenient().when(rlpxAgent.stop()).thenReturn(CompletableFuture.completedFuture(null));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PNetworkTest.java
@@ -54,12 +54,12 @@ import java.util.stream.Stream;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class P2PNetworkTest {
   private final Vertx vertx = Vertx.vertx();
   private final NetworkingConfiguration config =
@@ -70,7 +70,7 @@ public class P2PNetworkTest {
                   .setBindPort(0)
                   .setSupportedProtocols(MockSubProtocol.create()));
 
-  @After
+  @AfterEach
   public void closeVertx() {
     vertx.close();
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PPlainNetworkTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/P2PPlainNetworkTest.java
@@ -64,12 +64,12 @@ import java.util.stream.Stream;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class P2PPlainNetworkTest {
   // See ethereum/p2p/src/test/resources/keys/README.md for certificates setup.
   private final Vertx vertx = Vertx.vertx();
@@ -81,7 +81,7 @@ public class P2PPlainNetworkTest {
                   .setBindPort(0)
                   .setSupportedProtocols(MockSubProtocol.create()));
 
-  @After
+  @AfterEach
   public void closeVertx() {
     vertx.close();
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerDenylistManagerTest {
   private final Peer localNode = generatePeer();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNodeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultLocalNodeTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultLocalNodeTest {
   private final String clientId = "test client";

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImplTest.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class EnodeURLImplTest {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/MaintainedPeersTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/MaintainedPeersTest.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MaintainedPeersTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/peers/PeerTest.java
@@ -17,13 +17,14 @@ package org.hyperledger.besu.ethereum.p2p.peers;
 import static org.apache.tuweni.bytes.Bytes.fromHexString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.hyperledger.besu.ethereum.p2p.discovery.DiscoveryPeer;
 import org.hyperledger.besu.ethereum.p2p.discovery.PeerDiscoveryStatus;
 
 import com.google.common.net.InetAddresses;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerTest {
 
@@ -112,20 +113,24 @@ public class PeerTest {
     assertThat(peer.getEnodeURL().getDiscoveryPortOrZero()).isEqualTo(30403);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void createFromURIFailsForWrongScheme() {
-    DefaultPeer.fromURI("http://user@foo:80");
+    assertThrows(IllegalArgumentException.class, () -> DefaultPeer.fromURI("http://user@foo:80"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void createFromURIFailsForMissingId() {
-    DefaultPeer.fromURI("enode://172.20.0.4:30303");
+    assertThrows(
+        IllegalArgumentException.class, () -> DefaultPeer.fromURI("enode://172.20.0.4:30303"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void createFromURIFailsForMissingHost() {
-    DefaultPeer.fromURI(
-        "enode://c7849b663d12a2b5bf05b1ebf5810364f4870d5f1053fbd7500d38bc54c705b453d7511ca8a4a86003d34d4c8ee0bbfcd387aa724f5b240b3ab4bbb994a1e09b@:30303");
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            DefaultPeer.fromURI(
+                "enode://c7849b663d12a2b5bf05b1ebf5810364f4870d5f1053fbd7500d38bc54c705b453d7511ca8a4a86003d34d4c8ee0bbfcd387aa724f5b240b3ab4bbb994a1e09b@:30303"));
   }
 
   @Test

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsDenylistTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsDenylistTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerPermissionsDenylistTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/permissions/PeerPermissionsTest.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.ethereum.p2p.permissions.PeerPermissions.Action;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PeerPermissionsTest {
   final Peer localPeer = createPeer();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/plain/MessageHandlerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/plain/MessageHandlerTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.netty.buffer.Unpooled;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MessageHandlerTest {
 
@@ -33,7 +33,7 @@ public class MessageHandlerTest {
   private static final int DATA_CODE = 1000;
 
   @Test
-  public void buildPingMessage() throws Exception {
+  public void buildPingMessage() {
     Bytes message = MessageHandler.buildMessage(MessageType.PING, PING_DATA);
     assertThat(message).isNotNull();
     PlainMessage parsed = MessageHandler.parseMessage(Unpooled.wrappedBuffer(message.toArray()));
@@ -43,7 +43,7 @@ public class MessageHandlerTest {
   }
 
   @Test
-  public void buildPongMessage() throws Exception {
+  public void buildPongMessage() {
     Bytes message = MessageHandler.buildMessage(MessageType.PONG, PONG_DATA);
     assertThat(message).isNotNull();
     PlainMessage parsed = MessageHandler.parseMessage(Unpooled.wrappedBuffer(message.toArray()));
@@ -53,7 +53,7 @@ public class MessageHandlerTest {
   }
 
   @Test
-  public void buildDataMessage() throws Exception {
+  public void buildDataMessage() {
     Bytes message = MessageHandler.buildMessage(MessageType.DATA, DATA_CODE, MESSAGE);
     assertThat(message).isNotNull();
     PlainMessage parsed = MessageHandler.parseMessage(Unpooled.wrappedBuffer(message.toArray()));

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgentTest.java
@@ -64,9 +64,9 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class RlpxAgentTest {
   private static final KeyPair KEY_PAIR = SignatureAlgorithmFactory.getInstance().generateKeyPair();
@@ -83,14 +83,14 @@ public class RlpxAgentTest {
   private final Supplier<Stream<PeerConnection>> allActiveConnectionsSupplier = Stream::empty;
   private RlpxAgent agent = agent();
 
-  @Before
+  @BeforeEach
   public void setup() {
     // Set basic defaults
     when(peerPrivileges.canExceedConnectionLimits(any())).thenReturn(false);
     agent.subscribeConnectRequest((a, b) -> true);
   }
 
-  @After
+  @AfterEach
   public void after() {
     connections = Collections.emptyList();
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnectionTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnectionTest.java
@@ -40,8 +40,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AbstractPeerConnectionTest {
   private final String connectionId = "1";
@@ -53,7 +53,7 @@ public class AbstractPeerConnectionTest {
 
   private TestPeerConnection connection;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     connection =
         new TestPeerConnection(

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/DeFramerTest.java
@@ -72,8 +72,8 @@ import io.netty.channel.EventLoop;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.concurrent.ScheduledFuture;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class DeFramerTest {
@@ -105,7 +105,7 @@ public class DeFramerTest {
 
   private final DeFramer deFramer = createDeFramer(null);
 
-  @Before
+  @BeforeEach
   @SuppressWarnings("unchecked")
   public void setup() {
     when(ctx.channel()).thenReturn(channel);

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/NettyTLSConnectionInitializerTest.java
@@ -44,13 +44,16 @@ import io.netty.handler.codec.compression.SnappyFrameDecoder;
 import io.netty.handler.codec.compression.SnappyFrameEncoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class NettyTLSConnectionInitializerTest {
 
   private static final String PEER_HOST = "hyperledger.org";
@@ -69,7 +72,7 @@ public class NettyTLSConnectionInitializerTest {
 
   private NettyTLSConnectionInitializer nettyTLSConnectionInitializer;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     nettyTLSConnectionInitializer = createNettyTLSConnectionInitializer(false);
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/TLSContextFactoryTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/TLSContextFactoryTest.java
@@ -46,9 +46,9 @@ import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import org.junit.Assume;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -225,11 +225,6 @@ class TLSContextFactoryTest {
     try {
       return new HardwareKeyStoreWrapper(keystorePassword, toPath(config), toPath(crlLocation));
     } catch (final Exception e) {
-      if (OS.MAC.isCurrentOs()) {
-        // nss3 is difficult to setup on mac correctly, don't let it break unit tests for dev
-        // machines.
-        Assume.assumeNoException("Failed to initialize hardware keystore", e);
-      }
       // Not a mac, probably a production build. Full failure.
       throw new PkiException("Failed to initialize hardware keystore", e);
     }
@@ -253,6 +248,7 @@ class TLSContextFactoryTest {
 
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("softwareKeysData")
+  @DisabledOnOs(OS.MAC)
   void testConnectionSoftwareKeys(
       final String ignoredTestDescription,
       final boolean testSuccess,
@@ -271,6 +267,7 @@ class TLSContextFactoryTest {
 
   @ParameterizedTest(name = "{index}: {0}")
   @MethodSource("hardwareKeysData")
+  @DisabledOnOs(OS.MAC)
   void testConnectionHardwareKeys(
       final String ignoredTestDescription,
       final boolean testSuccess,

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/FramerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/FramerTest.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xerial.snappy.Snappy;
 
 public class FramerTest {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/SnappyCompressorTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/framing/SnappyCompressorTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SnappyCompressorTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ECIESHandshakeTest.java
@@ -28,10 +28,9 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import junit.framework.AssertionFailedError;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Test vectors taken from https://gist.github.com/fjl/3a78780d17c755d22df2 */
 public class ECIESHandshakeTest {
@@ -147,7 +146,7 @@ public class ECIESHandshakeTest {
     final ByteBuf responderRp =
         responder
             .handleMessage(initiatorRq)
-            .orElseThrow(() -> new AssertionFailedError("Expected responder message"));
+            .orElseThrow(() -> new AssertionError("Expected responder message"));
     assertThat(responder.getPartyEphPubKey()).isEqualTo(initiator.getEphKeyPair().getPublicKey());
     assertThat(responder.getInitiatorNonce()).isEqualTo(initiator.getInitiatorNonce());
     assertThat(responder.partyPubKey()).isEqualTo(initiator.getNodeKey().getPublicKey());

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessageTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/EncryptedMessageTest.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link EncryptedMessage}. */
 public final class EncryptedMessageTest {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4Test.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4Test.java
@@ -26,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link InitiatorHandshakeMessageV4}. */
 public final class InitiatorHandshakeMessageV4Test {

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/CapabilityMultiplexerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/CapabilityMultiplexerTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CapabilityMultiplexerTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/WireMessagesSedesTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/WireMessagesSedesTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WireMessagesSedesTest {
 

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage.DisconnectReason;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DisconnectMessageTest {
 


### PR DESCRIPTION
## PR description
This PR removes junit4 dependency from ethereum/p2p files

Split part 6 PR from https://github.com/hyperledger/besu/pull/5678

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/5564