### PR TITLE
ethereum/permissioning - migrated tests from Junit4 to Junit5

### DIFF
--- a/ethereum/permissioning/build.gradle
+++ b/ethereum/permissioning/build.gradle
@@ -52,10 +52,8 @@ dependencies {
   testImplementation project(':testutil')
 
   testImplementation 'io.vertx:vertx-core'
-  testImplementation 'junit:junit'
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testImplementation 'org.mockito:mockito-core'
-
-  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 }

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AccountLocalConfigPermissioningControllerTest.java
@@ -39,13 +39,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AccountLocalConfigPermissioningControllerTest {
 
   private AccountLocalConfigPermissioningController controller;
@@ -56,7 +56,7 @@ public class AccountLocalConfigPermissioningControllerTest {
   @Mock private Counter checkPermittedCounter;
   @Mock private Counter checkUnpermittedCounter;
 
-  @Before
+  @BeforeEach
   public void before() {
 
     when(metricsSystem.createCounter(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AllowlistPersistorTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/AllowlistPersistorTest.java
@@ -30,9 +30,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AllowlistPersistorTest {
 
@@ -43,7 +43,7 @@ public class AllowlistPersistorTest {
   private final String nodesAllowlist =
       String.format("%s=[%s]", ALLOWLIST_TYPE.NODES.getTomlKey(), "\"node1\",\"node2\"");
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     List<String> lines = Lists.newArrayList(nodesAllowlist, accountsAllowlist);
     tempFile = File.createTempFile("test", "test");
@@ -136,7 +136,7 @@ public class AllowlistPersistorTest {
         .isInstanceOf(AllowlistFileSyncException.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     tempFile.delete();
   }

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationBuilderTest.java
@@ -30,7 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import com.google.common.io.Resources;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalPermissioningConfigurationBuilderTest {
 

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/LocalPermissioningConfigurationTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalPermissioningConfigurationTest {
 

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
@@ -49,13 +49,13 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class NodeLocalConfigPermissioningControllerTest {
 
   @Mock private AllowlistPersistor allowlistPersistor;
@@ -77,7 +77,7 @@ public class NodeLocalConfigPermissioningControllerTest {
   @Mock private Counter checkPermittedCounter;
   @Mock private Counter checkUnpermittedCounter;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     bootnodesList.clear();
 

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
@@ -41,12 +41,12 @@ import java.io.IOException;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.Resources;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class NodeSmartContractPermissioningControllerTest {
   @Mock private MetricsSystem metricsSystem;
   @Mock private Counter checkCounter;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -42,8 +42,8 @@ import java.net.UnknownHostException;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class NodeSmartContractV2PermissioningControllerTest {
 
@@ -77,7 +77,7 @@ public class NodeSmartContractV2PermissioningControllerTest {
 
   private NodeSmartContractV2PermissioningController permissioningController;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     permissioningController =
         new NodeSmartContractV2PermissioningController(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
@@ -44,12 +44,12 @@ import java.math.BigInteger;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.StrictStubs.class)
+@ExtendWith(MockitoExtension.class)
 public class TransactionSmartContractPermissioningControllerTest {
   @Mock private MetricsSystem metricsSystem;
   @Mock private Counter checkCounter;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
@@ -34,12 +34,12 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AccountPermissioningControllerFactoryTest {
 
   @Mock private TransactionSimulator transactionSimulator;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerTest.java
@@ -27,13 +27,13 @@ import org.hyperledger.besu.ethereum.permissioning.TransactionSmartContractPermi
 
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class AccountPermissioningControllerTest {
 
   private AccountPermissioningController permissioningController;
@@ -41,7 +41,7 @@ public class AccountPermissioningControllerTest {
   @Mock private AccountLocalConfigPermissioningController localConfigController;
   @Mock private TransactionSmartContractPermissioningController smartContractController;
 
-  @Before
+  @BeforeEach
   public void before() {
     permissioningController =
         new AccountPermissioningController(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProviderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/InsufficientPeersPermissioningProviderTest.java
@@ -32,14 +32,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class InsufficientPeersPermissioningProviderTest {
   @Mock private P2PNetwork p2pNetwork;
   private final EnodeURL SELF_ENODE =
@@ -58,7 +61,7 @@ public class InsufficientPeersPermissioningProviderTest {
       EnodeURLImpl.fromString(
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005@192.168.0.5:30303");
 
-  @Before
+  @BeforeEach
   public void setup() {
     when(p2pNetwork.getLocalEnode()).thenReturn(Optional.of(SELF_ENODE));
   }

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -39,13 +39,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class NodePermissioningControllerFactoryTest {
 
   @Mock private Synchronizer synchronizer;
@@ -60,7 +63,7 @@ public class NodePermissioningControllerFactoryTest {
   SmartContractPermissioningConfiguration smartContractPermissioningConfiguration;
   PermissioningConfiguration config;
 
-  @Before
+  @BeforeEach
   public void before() {
     when(transactionSimulator.doesAddressExistAtHead(any())).thenReturn(Optional.of(true));
   }

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerTest.java
@@ -33,13 +33,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class NodePermissioningControllerTest {
 
   private static final EnodeURL enode1 =
@@ -56,7 +56,7 @@ public class NodePermissioningControllerTest {
 
   private NodePermissioningController controller;
 
-  @Before
+  @BeforeEach
   public void before() {
     syncStatusNodePermissioningProviderOptional = Optional.of(syncStatusNodePermissioningProvider);
     List<NodeConnectionPermissioningProvider> emptyProviders = new ArrayList<>();

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapterTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/PeerPermissionsAdapterTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 public class PeerPermissionsAdapterTest {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProviderTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/provider/SyncStatusNodePermissioningProviderTest.java
@@ -37,14 +37,14 @@ import java.util.Collection;
 import java.util.function.IntSupplier;
 
 import com.google.common.collect.Lists;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class SyncStatusNodePermissioningProviderTest {
   @Mock private MetricsSystem metricsSystem;
   @Mock private Counter checkCounter;
@@ -67,7 +67,7 @@ public class SyncStatusNodePermissioningProviderTest {
   private SyncStatusNodePermissioningProvider provider;
   private InSyncListener inSyncListener;
 
-  @Before
+  @BeforeEach
   public void before() {
     final ArgumentCaptor<InSyncListener> inSyncSubscriberCaptor =
         ArgumentCaptor.forClass(InSyncListener.class);


### PR DESCRIPTION
## PR description
This PR removes junit4 dependency from ethereum/permissioning files

Split part 7 PR from https://github.com/hyperledger/besu/pull/5678

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/5564