### PR TITLE
Make smart contract permissioning features work with london fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Additions and Improvements
 
 ### Bug Fixes
+- Make smart contract permissioning features work with london fork [#5727](https://github.com/hyperledger/besu/pull/5727)
 
 ### Download Links
 

--- a/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_genesis.json
+++ b/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_genesis.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "chainId": 999,
-    "petersburgBlock": 0,
+    "londonBlock": 0,
+    "zeroBaseFee": true,
     "ethash": {
       "fixeddifficulty": 100
     }

--- a/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_ibft_genesis.json
+++ b/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_ibft_genesis.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "chainId": 999,
-    "petersburgBlock": 0,
+    "londonBlock": 0,
+    "zeroBaseFee": true,
     "ibft2": {
       "blockperiodseconds": 5,
       "epochlength": 30000,

--- a/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_v2_genesis.json
+++ b/acceptance-tests/tests/src/test/resources/permissioning/simple_permissioning_v2_genesis.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "chainId": 999,
-    "petersburgBlock": 0,
+    "londonBlock": 0,
+    "zeroBaseFee": true,
     "ethash": {
       "fixeddifficulty": 100
     }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderBuilder;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.mainnet.ImmutableTransactionValidationParams;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -102,7 +103,10 @@ public class TransactionSimulator {
   public Optional<TransactionSimulatorResult> processAtHead(final CallParameter callParams) {
     return process(
         callParams,
-        TransactionValidationParams.transactionSimulator(),
+        ImmutableTransactionValidationParams.builder()
+            .from(TransactionValidationParams.transactionSimulator())
+            .isAllowExceedingBalance(true)
+            .build(),
         OperationTracer.NO_TRACING,
         (mutableWorldState, transactionSimulatorResult) -> transactionSimulatorResult,
         blockchain.getChainHeadHeader());


### PR DESCRIPTION
Override the transactionSimulator's default TransactionValidationParams with one that allows for exceeding the account balance (which effectively zeros the baseFee). This mimics the way that eth_estimateGas and eth_call are implemented. Similar change to #5277

Update ATs to use londonBlock (existing genesis allocs necessitate zeroBaseFee as well)
