### PR TITLE
fix: Remove maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,6 @@
 | Joshua Fernandes | joshuafernandes  | joshuafernandes  |
 | Lucas Saldanha   | lucassaldanha    | lucassaldanha    |
 | Sally MacFarlane | macfarla         | macfarla         |
-| Mark Terry       | mark-terry       | m.terry          |
 | Karim Taam       | matkt            | matkt            |
 | Meredith Baxter  | mbaxter          | mbaxter          |
 | Stefan Pingel    | pinges           | pinges           |


### PR DESCRIPTION
I propose moving maintainer @mark-terry to Emeritus status, pursuant to the inactivity clause. These maintainers have had no activity since January 2023.

We very much appreciate their contributions, but moving their status to emeritus (and thus revoking PR approval privileges) is in the interest of an orderly project. If any of these maintainers express in this PR that they intend to make contributions in the next quarter, then they will not be moved to emeritus status.

I propose this vote remain open until either @mark-terry confirms on this PR acceptance of this change, OR an absolute majority of active maintainers votes for the same outcome, OR until two weeks has passed, after which a voting majority will determine the outcome (with a tie resulting in no change).
