### PR TITLE
Make referencetests build script Windows friendly

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -47,7 +47,7 @@ def eipBlockchainReferenceTests = tasks.register("eipBlockchainReferenceTests") 
   generateTestFiles(
     fileTree(referenceTestsPath),
     file("src/reference-test/templates/BlockchainReferenceTest.java.template"),
-    "EIPTests/BlockchainTests",
+    "EIPTests${File.separatorChar}BlockchainTests",
     "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/eip",
     "EIPBlockchainReferenceTest",
     )
@@ -62,7 +62,7 @@ def eipStateReferenceTests = tasks.register("eipStateReferenceTests")  {
   generateTestFiles(
     fileTree(referenceTestsPath),
     file("src/reference-test/templates/GeneralStateReferenceTest.java.template"),
-    "EIPTests/StateTests",
+    "EIPTests${File.separatorChar}StateTests",
     "$generatedTestsPath/org/hyperledger/besu/ethereum/vm/eip",
     "EIPStateReferenceTest",
     )


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

#5774 broken builds on Windows due to the different separation char, this PR just replace the '/' with the system separator char as provided by the jvm
