### PR TITLE
EngineNewPayload -  Fix Invalid Block Hash return

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -225,12 +225,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
               "Computed block hash %s does not match block hash parameter %s",
               newBlockHeader.getBlockHash(), blockParam.getBlockHash());
       LOG.debug(errorMessage);
-      return respondWithInvalid(
-          reqId,
-          blockParam,
-          mergeCoordinator.getLatestValidAncestor(blockParam.getParentHash()).orElse(null),
-          getInvalidBlockHashStatus(),
-          errorMessage);
+      return respondWithInvalid(reqId, blockParam, null, getInvalidBlockHashStatus(), errorMessage);
     }
 
     ValidationResult<RpcErrorType> blobValidationResult =


### PR DESCRIPTION
EngineNewPayload should not return the  latestValidHash when blockHash validation fails:

Current:
{status: INVALID_BLOCK_HASH, latestValidHash: `latestValidHash`, validationError: errorMessage | null} if the blockHash validation has failed

Expected:
{status: INVALID_BLOCK_HASH, latestValidHash: `null`, validationError: errorMessage | null} if the blockHash validation has failed

