### PR TITLE
don't check block timestamp drift for PoS

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockHeaderValidator.java
@@ -189,7 +189,6 @@ public final class MainnetBlockHeaderValidator {
         .addRule(
             new GasLimitRangeAndDeltaValidationRule(
                 MIN_GAS_LIMIT, Long.MAX_VALUE, Optional.of(baseFeeMarket)))
-        .addRule(new TimestampBoundedByFutureParameter(TIMESTAMP_TOLERANCE_S))
         .addRule(new ExtraDataMaxLengthValidationRule(BlockHeader.MAX_EXTRA_DATA_BYTES))
         .addRule((new BaseFeeMarketBlockHeaderGasPriceValidationRule(baseFeeMarket)))
         .addRule(new ConstantOmmersHashRule())


### PR DESCRIPTION
Geth has removed this check (block too far in the future) since the merge. Fixes #5800 - and 9 related hive tests that start with `cancun/eip4788_beacon_root/beacon_root_contract/`