### PR TITLE
fix ForkId if there are no Forks and the starting timestamp is not 0

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/forkid/ForkIdManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/forkid/ForkIdManager.java
@@ -45,7 +45,7 @@ public class ForkIdManager {
 
   private final Supplier<BlockHeader> chainHeadSupplier;
   private final long forkNext;
-  private final boolean onlyZerosForkBlocks;
+  private final boolean noForksAvailable;
   private final long highestKnownFork;
   private Bytes genesisHashCrc;
   private final boolean legacyEth64;
@@ -77,11 +77,11 @@ public class ForkIdManager {
     final List<Long> allForkNumbers =
         Stream.concat(blockNumberForks.stream(), timestampForks.stream())
             .collect(Collectors.toList());
-    this.onlyZerosForkBlocks = allForkNumbers.stream().allMatch(value -> 0L == value);
     this.forkNext = createForkIds();
     this.allForkIds =
         Stream.concat(blockNumbersForkIds.stream(), timestampsForkIds.stream())
             .collect(Collectors.toList());
+    this.noForksAvailable = allForkIds.isEmpty();
     this.highestKnownFork =
         !allForkNumbers.isEmpty() ? allForkNumbers.get(allForkNumbers.size() - 1) : 0L;
   }
@@ -128,7 +128,7 @@ public class ForkIdManager {
    * @return boolean (peer valid (true) or invalid (false))
    */
   public boolean peerCheck(final ForkId forkId) {
-    if (forkId == null || onlyZerosForkBlocks) {
+    if (forkId == null || noForksAvailable) {
       return true; // Another method must be used to validate (i.e. genesis hash)
     }
     // Run the fork checksum validation rule set:

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/forkid/ForkIdTest.java
@@ -619,4 +619,18 @@ public class ForkIdTest {
     assertThat(forkIdManager.getAllForkIds().get(0).getNext()).isEqualTo(2L);
     assertThat(forkIdManager.getAllForkIds().get(1).getNext()).isEqualTo(0L);
   }
+
+  @Test
+  public void testNoBlockNoForksAndNoTimestampForksGreaterThanGenesisTimestamp() {
+    final ForkIdManager forkIdManager =
+        new ForkIdManager(
+            mockBlockchain(Hash.ZERO.toHexString(), 10L, 1L),
+            Collections.emptyList(),
+            List.of(1L),
+            false);
+    assertThat(forkIdManager.getAllForkIds().size()).isEqualTo(0);
+    // There is no ForkId, so peerCheck always has to return true
+    assertThat(forkIdManager.peerCheck(new ForkId(Bytes.fromHexString("0xdeadbeef"), 100L)))
+        .isEqualTo(true);
+  }
 }


### PR DESCRIPTION
## PR description
Make sure that we are passing the fork id check if there are no forks and the genesis timestamp is not 0
