### PR TITLE
add parent beacon block root to payload id calculation

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -254,7 +254,12 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
     final PayloadIdentifier payloadIdentifier =
         PayloadIdentifier.forPayloadParams(
-            parentHeader.getBlockHash(), timestamp, prevRandao, feeRecipient, withdrawals);
+            parentHeader.getBlockHash(),
+            timestamp,
+            prevRandao,
+            feeRecipient,
+            withdrawals,
+            parentBeaconBlockRoot);
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
@@ -62,6 +62,7 @@ public class PayloadIdentifier implements Quantity {
    * @param prevRandao the prev randao
    * @param feeRecipient the fee recipient
    * @param withdrawals the withdrawals
+   * @param parentBeaconBlockRoot the parent beacon block root
    * @return the payload identifier
    */
   public static PayloadIdentifier forPayloadParams(
@@ -69,7 +70,8 @@ public class PayloadIdentifier implements Quantity {
       final Long timestamp,
       final Bytes32 prevRandao,
       final Address feeRecipient,
-      final Optional<List<Withdrawal>> withdrawals) {
+      final Optional<List<Withdrawal>> withdrawals,
+      final Optional<Bytes32> parentBeaconBlockRoot) {
 
     return new PayloadIdentifier(
         timestamp
@@ -84,7 +86,8 @@ public class PayloadIdentifier implements Quantity {
                                 .sorted(Comparator.comparing(Withdrawal::getIndex))
                                 .map(Withdrawal::hashCode)
                                 .reduce(1, (a, b) -> a ^ (b * 31)))
-                    .orElse(0));
+                    .orElse(0)
+            ^ ((long) parentBeaconBlockRoot.hashCode()) << 40);
   }
 
   @Override

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -48,7 +48,12 @@ public class PayloadIdentifierTest {
   public void conversionCoverage() {
     var idTest =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, Bytes32.random(), Address.fromHexString("0x42"), Optional.empty());
+            Hash.ZERO,
+            1337L,
+            Bytes32.random(),
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty());
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
   }
@@ -82,10 +87,20 @@ public class PayloadIdentifierTest {
     final Bytes32 prevRandao = Bytes32.random();
     var idForWithdrawals1 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.of(withdrawals1));
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.of(withdrawals1),
+            Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.of(withdrawals2));
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.of(withdrawals2),
+            Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
 
@@ -118,10 +133,20 @@ public class PayloadIdentifierTest {
     final Bytes32 prevRandao = Bytes32.random();
     var idForWithdrawals1 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.of(withdrawals1));
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.of(withdrawals1),
+            Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.of(withdrawals2));
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.of(withdrawals2),
+            Optional.empty());
     assertThat(idForWithdrawals1).isEqualTo(idForWithdrawals2);
   }
 
@@ -130,10 +155,64 @@ public class PayloadIdentifierTest {
     final Bytes32 prevRandao = Bytes32.random();
     var idForWithdrawals1 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.empty());
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
-            Hash.ZERO, 1337L, prevRandao, Address.fromHexString("0x42"), Optional.of(emptyList()));
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.of(emptyList()),
+            Optional.empty());
+    assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
+  }
+
+  @Test
+  public void emptyOptionalAndNonEmptyParentBeaconBlockRootYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForWithdrawals1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty());
+    var idForWithdrawals2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.ZERO));
+    assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
+  }
+
+  @Test
+  public void differentParentBeaconBlockRootYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForWithdrawals1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.fromHexStringLenient("0x1")));
+    var idForWithdrawals2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.ZERO));
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -242,6 +242,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -518,6 +519,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -603,7 +605,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
-            withdrawals);
+            withdrawals,
+            Optional.empty());
 
     when(mergeCoordinator.preparePayload(
             mockHeader,
@@ -645,6 +648,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -85,7 +85,12 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
   protected static final BlockResultFactory factory = new BlockResultFactory();
   protected static final PayloadIdentifier mockPid =
       PayloadIdentifier.forPayloadParams(
-          Hash.ZERO, 1337L, Bytes32.random(), Address.fromHexString("0x42"), Optional.empty());
+          Hash.ZERO,
+          1337L,
+          Bytes32.random(),
+          Address.fromHexString("0x42"),
+          Optional.empty(),
+          Optional.empty());
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
   private static final Block mockBlock =
@@ -147,7 +152,12 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
         resp(
             getMethodName(),
             PayloadIdentifier.forPayloadParams(
-                Hash.ZERO, 0L, Bytes32.random(), Address.fromHexString("0x42"), Optional.empty()));
+                Hash.ZERO,
+                0L,
+                Bytes32.random(),
+                Address.fromHexString("0x42"),
+                Optional.empty(),
+                Optional.empty()));
     assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);
     verify(engineCallListener, times(1)).executionEngineCalled();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -104,6 +104,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             cancunHardfork.milestone(),
             Bytes32.random(),
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();


### PR DESCRIPTION
## PR description
This fixes a problem where two engine_forkchoiceUpdated RPC calls with the same parameters, except for the parentBeaconBlockRoot, caused besu to produce a block with the wrong block hash.
The beacon root was not used in the calculation of the payload id, which meant that we were not updating the block production after the second call.