### PR TITLE
set the beacon root address to the correct value

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
@@ -59,28 +59,24 @@ public class Address extends DelegatingBytes {
   public static final Address BLAKE2B_F_COMPRESSION = Address.precompiled(0x09);
   /** The constant KZG_POINT_EVAL aka POINT_EVALUATION_PRECOMPILE_ADDRESS. */
   public static final Address KZG_POINT_EVAL = Address.precompiled(0xA);
-  /** The constant PARENT_BEACON_BLOCK_ROOT_REGISTRY aka HISTORY_STORAGE_ADDRESS. */
-  public static final Address PARENT_BEACON_BLOCK_ROOT_REGISTRY = Address.precompiled(0xB);
-  // TODO: this is not a precompile anymore. The address is correct for testnet 8. Fix after testnet
-  // 8 when we know what the real address is
   /** The constant BLS12_G1ADD. */
-  public static final Address BLS12_G1ADD = Address.precompiled(0xC);
+  public static final Address BLS12_G1ADD = Address.precompiled(0xB);
   /** The constant BLS12_G1MUL. */
-  public static final Address BLS12_G1MUL = Address.precompiled(0xD);
+  public static final Address BLS12_G1MUL = Address.precompiled(0xC);
   /** The constant BLS12_G1MULTIEXP. */
-  public static final Address BLS12_G1MULTIEXP = Address.precompiled(0xE);
+  public static final Address BLS12_G1MULTIEXP = Address.precompiled(0xD);
   /** The constant BLS12_G2ADD. */
-  public static final Address BLS12_G2ADD = Address.precompiled(0xF);
+  public static final Address BLS12_G2ADD = Address.precompiled(0xE);
   /** The constant BLS12_G2MUL. */
-  public static final Address BLS12_G2MUL = Address.precompiled(0x10);
+  public static final Address BLS12_G2MUL = Address.precompiled(0xF);
   /** The constant BLS12_G2MULTIEXP. */
-  public static final Address BLS12_G2MULTIEXP = Address.precompiled(0x11);
+  public static final Address BLS12_G2MULTIEXP = Address.precompiled(0x10);
   /** The constant BLS12_PAIRING. */
-  public static final Address BLS12_PAIRING = Address.precompiled(0x12);
+  public static final Address BLS12_PAIRING = Address.precompiled(0x11);
   /** The constant BLS12_MAP_FP_TO_G1. */
-  public static final Address BLS12_MAP_FP_TO_G1 = Address.precompiled(0x13);
+  public static final Address BLS12_MAP_FP_TO_G1 = Address.precompiled(0x12);
   /** The constant BLS12_MAP_FP2_TO_G2. */
-  public static final Address BLS12_MAP_FP2_TO_G2 = Address.precompiled(0x14);
+  public static final Address BLS12_MAP_FP2_TO_G2 = Address.precompiled(0x13);
   /** The constant ZERO. */
   public static final Address ZERO = Address.fromHexString("0x0");
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ParentBeaconBlockRootHelper.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ParentBeaconBlockRootHelper.java
@@ -26,24 +26,13 @@ public class ParentBeaconBlockRootHelper {
 
   // Modulus use to for the timestamp to store the  root
   public static final long HISTORICAL_ROOTS_MODULUS = 98304;
-
-  // Address of the system user, that is used to call the contract for storing the root
-  // public static final Address SYSTEM_ADDRESS =
-  // Address.fromHexString("0xfffffffffffffffffffffffffffffffffffffffe");
-
-  // The address of the contract that stores the roots
-  // public static final Address BEACON_ROOTS_ADDRESS =
-  // Address.fromHexString("0x89e64Be8700cC37EB34f9209c96466DEEDc0d8a6");
+  public static final Address BEACON_ROOTS_ADDRESS =
+      Address.fromHexString("0xbEac00dDB15f3B6d645C48263dC93862413A222D");
 
   public static void storeParentBeaconBlockRoot(
       final WorldUpdater worldUpdater, final long timestamp, final Bytes32 root) {
     /*
-     pseudo code from EIP 4788:
-     timestamp_as_uint256 = to_uint256_be(block_header.timestamp)
-     parent_beacon_block_root = block_header.parent_beacon_block_root
-
-     sstore(HISTORY_STORAGE_ADDRESS, timestamp_index, timestamp_as_uint256)
-     sstore(HISTORY_STORAGE_ADDRESS, root_index, parent_beacon_block_root)
+     see EIP-4788: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4788.md
     */
     final long timestampReduced = timestamp % HISTORICAL_ROOTS_MODULUS;
     final long timestampExtended = timestampReduced + HISTORICAL_ROOTS_MODULUS;
@@ -51,8 +40,7 @@ public class ParentBeaconBlockRootHelper {
     final UInt256 timestampIndex = UInt256.valueOf(timestampReduced);
     final UInt256 rootIndex = UInt256.valueOf(timestampExtended);
 
-    final MutableAccount account =
-        worldUpdater.getOrCreate(Address.PARENT_BEACON_BLOCK_ROOT_REGISTRY).getMutable();
+    final MutableAccount account = worldUpdater.getOrCreate(BEACON_ROOTS_ADDRESS).getMutable();
     account.setStorageValue(timestampIndex, UInt256.valueOf(timestamp));
     account.setStorageValue(rootIndex, UInt256.fromBytes(root));
     worldUpdater.commit();


### PR DESCRIPTION
## PR description
In EIP-4788 the address of the contract used to store and retrieve the parent beacon block roots has been changed. This PR sets the correct value.  