### PR TITLE
Fix: correctly convert percentage options in TOML configuration file

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigFileDefaultProvider.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.cli.util;
 
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
 
 import java.io.File;
@@ -91,6 +92,8 @@ public class TomlConfigFileDefaultProvider implements IDefaultValueProvider {
     } else if (optionSpec.type().equals(Float.class) || optionSpec.type().equals(float.class)) {
       defaultValue = getNumericEntryAsString(optionSpec);
     } else if (optionSpec.type().equals(Percentage.class)) {
+      defaultValue = getNumericEntryAsString(optionSpec);
+    } else if (optionSpec.type().equals(Fraction.class)) {
       defaultValue = getNumericEntryAsString(optionSpec);
     } else { // else will be treated as String
       defaultValue = getEntryAsString(optionSpec);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Fix for a regression introduced by #5772 that causes the following exception when the option `tx-pool-limit-by-account-percentage` is defined as a number in the configuration file

```
TomlInvalidTypeException: Value of 'tx-pool-limit-by-account-percentage' is a float while processing argument at or before arg[0] '--config-file=./config.toml' in [--config-file=./config.toml]: org.apache.tuweni.toml.TomlInvalidTypeException: Value of 'tx-pool-limit-by-account-percentage' is a float
```

the fix is to simply convert percentage options to string when parsing the file