### PR TITLE
fix geth rlpx ping command

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/netty/AbstractHandshakeHandler.java
@@ -97,47 +97,47 @@ abstract class AbstractHandshakeHandler extends SimpleChannelInboundHandler<Byte
       ctx.writeAndFlush(nextMsg.get());
     } else if (handshaker.getStatus() != Handshaker.HandshakeStatus.SUCCESS) {
       LOG.debug("waiting for more bytes");
-    } else {
-
-      final Bytes nodeId = handshaker.partyPubKey().getEncodedBytes();
-      if (!localNode.isReady()) {
-        // If we're handling a connection before the node is fully up, just disconnect
-        LOG.debug("Rejecting connection because local node is not ready {}", nodeId);
-        disconnect(ctx, DisconnectMessage.DisconnectReason.UNKNOWN);
-        return;
-      }
-
-      LOG.trace("Sending framed hello");
-
-      // Exchange keys done
-      final Framer framer = this.framerProvider.buildFramer(handshaker.secrets());
-
-      final ByteToMessageDecoder deFramer =
-          new DeFramer(
-              framer,
-              subProtocols,
-              localNode,
-              expectedPeer,
-              connectionEventDispatcher,
-              connectionFuture,
-              metricsSystem,
-              inboundInitiated);
-
-      ctx.channel()
-          .pipeline()
-          .replace(this, "DeFramer", deFramer)
-          .addBefore("DeFramer", "validate", new ValidateFirstOutboundMessage(framer));
-
-      ctx.writeAndFlush(new OutboundMessage(null, HelloMessage.create(localNode.getPeerInfo())))
-          .addListener(
-              ff -> {
-                if (ff.isSuccess()) {
-                  LOG.trace("Successfully wrote hello message");
-                }
-              });
-      msg.retain();
-      ctx.fireChannelRead(msg);
+      return;
     }
+
+    final Bytes nodeId = handshaker.partyPubKey().getEncodedBytes();
+    if (!localNode.isReady()) {
+      // If we're handling a connection before the node is fully up, just disconnect
+      LOG.debug("Rejecting connection because local node is not ready {}", nodeId);
+      disconnect(ctx, DisconnectMessage.DisconnectReason.UNKNOWN);
+      return;
+    }
+
+    LOG.trace("Sending framed hello");
+
+    // Exchange keys done
+    final Framer framer = this.framerProvider.buildFramer(handshaker.secrets());
+
+    final ByteToMessageDecoder deFramer =
+        new DeFramer(
+            framer,
+            subProtocols,
+            localNode,
+            expectedPeer,
+            connectionEventDispatcher,
+            connectionFuture,
+            metricsSystem,
+            inboundInitiated);
+
+    ctx.channel()
+        .pipeline()
+        .replace(this, "DeFramer", deFramer)
+        .addBefore("DeFramer", "validate", new ValidateFirstOutboundMessage(framer));
+
+    ctx.writeAndFlush(new OutboundMessage(null, HelloMessage.create(localNode.getPeerInfo())))
+        .addListener(
+            ff -> {
+              if (ff.isSuccess()) {
+                LOG.trace("Successfully wrote hello message");
+              }
+            });
+    msg.retain();
+    ctx.fireChannelRead(msg);
   }
 
   private void disconnect(


### PR DESCRIPTION
## PR description
The geth cmd 
./build/bin/devp2p rlpx ping enodeAddress
expects the client with address enodeAddress to respond with a HelloMessage right after successfully receiving the handshake message from the initiator.
Existing behaviour in Besu is to wait for the HelloMessage from the initiator before sending the HelloMessage back.