### PR TITLE
Add Nick and George as maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@
 | Gary Schulte     | garyschulte      | GarySchulte      | 
 | Jiri Peinlich    | gezero           | JiriPeinlich     |
 | Gabriel Fukushima| gfukushima       | gfukushima       |
+| George Tebrean   | gtebrean         | gtebrean         |
 | Justin Florentine| jflo             | RoboCopsGoneMad  |
 | Jason Frame      | jframe           | jframe           |
 | Joshua Fernandes | joshuafernandes  | joshuafernandes  |
@@ -27,6 +28,7 @@
 | Karim Taam       | matkt            | matkt            |
 | Matthew Whitehead| matthew1001      | matthew.whitehead      |
 | Meredith Baxter  | mbaxter          | mbaxter          |
+| Nischal Sharma   | nicksneo         | nicks1106        |
 | Stefan Pingel    | pinges           | pinges           |
 | Danno Ferrin     | shemnon          | shemnon          |
 | Simon Dudley     | siladu           | siladu           |


### PR DESCRIPTION
I propose to add @nicksneo and @gtebrean as Besu project maintainers. In addition to quality code contributions, they have been contributing to Besu community via contributing to discussions in Discord. 

Nick has made a number of code contributions including -
* show correct revert reason data in priv_call
* removed GoQuorum permissioning interop
* migrated several packages from Junit4 to Junit5

Nick’s PRs: https://github.com/hyperledger/besu/pulls?q=is%3Apr+is%3Aclosed+author%3ANickSneo

George has made a number of code contributions including - 
* bugfix in eth_feeHistory
* decoupled JsonRPCError enum from the data field
* made pretty JSON feature user-configurable

George's PRs: https://github.com/hyperledger/besu/pulls?q=is%3Apr+is%3Aclosed+author%3Agtebrean

Voting ends two weeks from today.

For more information on this process see the Becoming a Maintainer section in the MAINTAINERS.md file.