### PR TITLE
[4844] [Hive] Fix fcuV3 parameter return 

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -91,13 +91,13 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
       ValidationResult<RpcErrorType> forkValidationResult =
           validateForkSupported(payloadAttributes.getTimestamp());
       if (!forkValidationResult.isValid()) {
-        return new JsonRpcSuccessResponse(requestId, forkValidationResult);
+        return new JsonRpcErrorResponse(requestId, forkValidationResult);
       }
     }
 
     ValidationResult<RpcErrorType> parameterValidationResult = validateParameter(forkChoice);
     if (!parameterValidationResult.isValid()) {
-      return new JsonRpcSuccessResponse(requestId, parameterValidationResult);
+      return new JsonRpcErrorResponse(requestId, parameterValidationResult);
     }
 
     mergeContext

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -69,7 +69,8 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
   }
 
   protected ValidationResult<RpcErrorType> validateParameter(
-      final EngineForkchoiceUpdatedParameter forkchoiceUpdatedParameter) {
+      final EngineForkchoiceUpdatedParameter forkchoiceUpdatedParameter,
+      final Optional<EnginePayloadAttributesParameter> maybePayloadAttributes) {
     return ValidationResult.valid();
   }
 
@@ -85,6 +86,11 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
         requestContext.getOptionalParameter(1, EnginePayloadAttributesParameter.class);
 
     LOG.debug("Forkchoice parameters {}", forkChoice);
+    ValidationResult<RpcErrorType> parameterValidationResult =
+        validateParameter(forkChoice, maybePayloadAttributes);
+    if (!parameterValidationResult.isValid()) {
+      return new JsonRpcErrorResponse(requestId, parameterValidationResult);
+    }
 
     if (maybePayloadAttributes.isPresent()) {
       final EnginePayloadAttributesParameter payloadAttributes = maybePayloadAttributes.get();
@@ -93,11 +99,6 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
       if (!forkValidationResult.isValid()) {
         return new JsonRpcErrorResponse(requestId, forkValidationResult);
       }
-    }
-
-    ValidationResult<RpcErrorType> parameterValidationResult = validateParameter(forkChoice);
-    if (!parameterValidationResult.isValid()) {
-      return new JsonRpcErrorResponse(requestId, parameterValidationResult);
     }
 
     mergeContext

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
@@ -79,7 +79,7 @@ public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMet
       ValidationResult<RpcErrorType> forkValidationResult =
           validateForkSupported(proposal.getHeader().getTimestamp());
       if (!forkValidationResult.isValid()) {
-        return new JsonRpcSuccessResponse(request.getRequest().getId(), forkValidationResult);
+        return new JsonRpcErrorResponse(request.getRequest().getId(), forkValidationResult);
       }
       return createResponse(request, payloadId, proposal);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.ExecutionEngineJsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.core.BlockHeader;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineForkchoiceUpdatedParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec;
@@ -48,13 +49,20 @@ public class EngineForkchoiceUpdatedV3 extends AbstractEngineForkchoiceUpdated {
 
   @Override
   protected ValidationResult<RpcErrorType> validateParameter(
-      final EngineForkchoiceUpdatedParameter fcuParameter) {
+      final EngineForkchoiceUpdatedParameter fcuParameter,
+      final Optional<EnginePayloadAttributesParameter> maybePayloadAttributes) {
     if (fcuParameter.getHeadBlockHash() == null) {
       return ValidationResult.invalid(RpcErrorType.INVALID_PARAMS, "Missing head block hash");
     } else if (fcuParameter.getSafeBlockHash() == null) {
       return ValidationResult.invalid(RpcErrorType.INVALID_PARAMS, "Missing safe block hash");
     } else if (fcuParameter.getFinalizedBlockHash() == null) {
       return ValidationResult.invalid(RpcErrorType.INVALID_PARAMS, "Missing finalized block hash");
+    }
+    if (maybePayloadAttributes.isPresent()) {
+      if (maybePayloadAttributes.get().getParentBeaconBlockRoot() == null) {
+        return ValidationResult.invalid(
+            RpcErrorType.INVALID_PARAMS, "Missing parent beacon block root hash");
+      }
     }
     return ValidationResult.valid();
   }


### PR DESCRIPTION
## PR description
Fix some hive tests

- Return JsonRpcErrorResponse instead of JsonRpcSuccessResponse when fork not supported or parameters invalid.
- Validate parameter before fork validation
- Validate getParentBeaconBlockRoot on EngineForkchoiceUpdatedV3 
