### PR TITLE
Retry on busy and locktimeout failures for rocksdb transactions

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
-import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
@@ -28,7 +27,6 @@ import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksD
 import org.hyperledger.besu.plugin.services.storage.rocksdb.configuration.RocksDBFactoryConfiguration;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.OptimisticRocksDBColumnarKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.RocksDBColumnarKeyValueStorage;
-import org.hyperledger.besu.plugin.services.storage.rocksdb.segmented.TransactionDBRocksDBColumnarKeyValueStorage;
 import org.hyperledger.besu.services.kvstore.SegmentedKeyValueStorageAdapter;
 
 import java.io.IOException;
@@ -166,8 +164,10 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
       final BesuConfiguration commonConfiguration,
       final MetricsSystem metricsSystem)
       throws StorageException {
-    final boolean isForestStorageFormat =
-        DataStorageFormat.FOREST.getDatabaseVersion() == commonConfiguration.getDatabaseVersion();
+    // TODO: removed for testing/discovery
+    // final boolean isForestStorageFormat =
+    //     DataStorageFormat.FOREST.getDatabaseVersion() ==
+    // commonConfiguration.getDatabaseVersion();
     if (requiresInit()) {
       init(commonConfiguration);
     }
@@ -192,25 +192,26 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
               configuredSegments.stream()
                   .filter(segmentId -> segmentId.includeInDatabaseVersion(databaseVersion))
                   .collect(Collectors.toList());
-          if (isForestStorageFormat) {
-            LOG.debug("FOREST mode detected, using TransactionDB.");
-            segmentedStorage =
-                new TransactionDBRocksDBColumnarKeyValueStorage(
-                    rocksDBConfiguration,
-                    segmentsForVersion,
-                    ignorableSegments,
-                    metricsSystem,
-                    rocksDBMetricsFactory);
-          } else {
-            LOG.debug("Using OptimisticTransactionDB.");
-            segmentedStorage =
-                new OptimisticRocksDBColumnarKeyValueStorage(
-                    rocksDBConfiguration,
-                    segmentsForVersion,
-                    ignorableSegments,
-                    metricsSystem,
-                    rocksDBMetricsFactory);
-          }
+          // TODO: removing TransactionDB for testing/discovery only:
+          // if (isForestStorageFormat) {
+          //  LOG.debug("FOREST mode detected, using TransactionDB.");
+          //  segmentedStorage =
+          //      new TransactionDBRocksDBColumnarKeyValueStorage(
+          //          rocksDBConfiguration,
+          //          segmentsForVersion,
+          //          ignorableSegments,
+          //          metricsSystem,
+          //          rocksDBMetricsFactory);
+          // } else {
+          LOG.debug("Using OptimisticTransactionDB.");
+          segmentedStorage =
+              new OptimisticRocksDBColumnarKeyValueStorage(
+                  rocksDBConfiguration,
+                  segmentsForVersion,
+                  ignorableSegments,
+                  metricsSystem,
+                  rocksDBMetricsFactory);
+          // }
         }
         return segmentedStorage;
       }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -90,7 +90,11 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
     commit(0, 3);
   }
 
-  /** commit transaction with an explicit number of retries. */
+  /**
+   * commit transaction with an explicit number of retries.
+   *
+   * @param retryLimit limit for the number of retry attempts
+   */
   public void commitWithRetries(final int retryLimit) throws StorageException {
     commit(0, retryLimit);
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -90,12 +90,7 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
     commit(0, 3);
   }
 
-  /**
-   * commit transaction with an explicit number of retries.
-   *
-   * @param retryLimit limit for the number of retry attempts
-   * @throws StorageException
-   */
+  /** commit transaction with an explicit number of retries. */
   public void commitWithRetries(final int retryLimit) throws StorageException {
     commit(0, retryLimit);
   }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -107,13 +107,13 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
         logger.error(e.getMessage());
         System.exit(0);
       } else if (e.getMessage().equals(ERR_BUSY) && attemptNumber < retryLimit) {
-        logger.info(
+        logger.warn(
             "RocksDB Busy exception caught on attempt {} of {}, retrying",
             attemptNumber,
             retryLimit);
         commit(attemptNumber + 1, retryLimit);
       } else if (e.getMessage().equals(ERR_LOCK_TIMED_OUT) && attemptNumber < retryLimit) {
-        logger.info(
+        logger.warn(
             "RocksDB Lock Timeout exception caught on attempt {} of {}, retrying",
             attemptNumber,
             retryLimit);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -106,13 +106,13 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
       if (e.getMessage().contains(ERR_NO_SPACE_LEFT_ON_DEVICE)) {
         logger.error(e.getMessage());
         System.exit(0);
-      } else if (e.getMessage().equals(ERR_BUSY) && attemptNumber < retryLimit) {
+      } else if (e.getMessage().contains(ERR_BUSY) && attemptNumber < retryLimit) {
         logger.warn(
             "RocksDB Busy exception caught on attempt {} of {}, retrying",
             attemptNumber,
             retryLimit);
         commit(attemptNumber + 1, retryLimit);
-      } else if (e.getMessage().equals(ERR_LOCK_TIMED_OUT) && attemptNumber < retryLimit) {
+      } else if (e.getMessage().contains(ERR_LOCK_TIMED_OUT) && attemptNumber < retryLimit) {
         logger.warn(
             "RocksDB Lock Timeout exception caught on attempt {} of {}, retrying",
             attemptNumber,

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransaction.java
@@ -90,6 +90,12 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
     commit(0, 3);
   }
 
+  /**
+   * commit transaction with an explicit number of retries.
+   *
+   * @param retryLimit limit for the number of retry attempts
+   * @throws StorageException
+   */
   public void commitWithRetries(final int retryLimit) throws StorageException {
     commit(0, retryLimit);
   }
@@ -102,13 +108,13 @@ public class RocksDBTransaction implements SegmentedKeyValueStorageTransaction {
         logger.error(e.getMessage());
         System.exit(0);
       } else if (e.getMessage().equals(ERR_BUSY) && attemptNumber < retryLimit) {
-        logger.trace(
+        logger.info(
             "RocksDB Busy exception caught on attempt {} of {}, retrying",
             attemptNumber,
             retryLimit);
         commit(attemptNumber + 1, retryLimit);
       } else if (e.getMessage().equals(ERR_LOCK_TIMED_OUT) && attemptNumber < retryLimit) {
-        logger.trace(
+        logger.info(
             "RocksDB Lock Timeout exception caught on attempt {} of {}, retrying",
             attemptNumber,
             retryLimit);

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/TransactionDBRocksDBColumnarKeyValueStorage.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.TransactionDB;
+import org.rocksdb.TransactionOptions;
 import org.rocksdb.WriteOptions;
 
 /** TransactionDB RocksDB Columnar key value storage */
@@ -85,10 +86,15 @@ public class TransactionDBRocksDBColumnarKeyValueStorage extends RocksDBColumnar
   public SegmentedKeyValueStorageTransaction startTransaction() throws StorageException {
     throwIfClosed();
     final WriteOptions writeOptions = new WriteOptions();
+    final TransactionOptions transactionOptions =
+        new TransactionOptions().setLockTimeout(5000).setDeadlockDetect(true);
     writeOptions.setIgnoreMissingColumnFamilies(true);
     return new SegmentedKeyValueStorageTransactionValidatorDecorator(
         new RocksDBTransaction(
-            this::safeColumnHandle, db.beginTransaction(writeOptions), writeOptions, metrics),
+            this::safeColumnHandle,
+            db.beginTransaction(writeOptions, transactionOptions),
+            writeOptions,
+            metrics),
         this.closed::get);
   }
 }

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
@@ -56,6 +56,7 @@ public class RocksDBTransactionTest {
   @BeforeEach
   void setupTx() {
     tx = spy(new RocksDBTransaction(__ -> null, mockTransaction, mockOptions, mockMetrics));
+    RocksDBTransaction.RetryableRocksDBAction.resetTimeout(1);
   }
 
   @Test

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
@@ -70,24 +70,6 @@ public class RocksDBTransactionTest {
   }
 
   @Test
-  public void assertExplicitBusyRetryBehavior() throws Exception {
-    doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doThrow(new RocksDBException("Busy"))
-        .doNothing()
-        .when(mockTransaction)
-        .commit();
-
-    assertThatCode(() -> tx.commitWithRetries(10)).doesNotThrowAnyException();
-  }
-
-  @Test
   public void assertLockTimeoutBusyRetryBehavior() throws Exception {
     doThrow(new RocksDBException("Busy"))
         .doThrow(new RocksDBException("TimedOut(LockTimeout)"))
@@ -96,7 +78,7 @@ public class RocksDBTransactionTest {
         .when(mockTransaction)
         .commit();
 
-    assertThatCode(() -> tx.commitWithRetries(7)).doesNotThrowAnyException();
+    assertThatCode(() -> tx.commit()).doesNotThrowAnyException();
   }
 
   @Test

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
@@ -106,7 +106,7 @@ public class RocksDBTransactionTest {
 
       doThrow(new RocksDBException("Busy"))
           .doThrow(new RocksDBException("Busy"))
-          .doNothing()
+          .doCallRealMethod()
           .when(innerTx)
           .commit();
 

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBTransactionTest.java
@@ -1,0 +1,116 @@
+package org.hyperledger.besu.plugin.services.storage.rocksdb;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import org.hyperledger.besu.plugin.services.exception.StorageException;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.rocksdb.OptimisticTransactionDB;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.Transaction;
+import org.rocksdb.WriteOptions;
+
+@ExtendWith(MockitoExtension.class)
+public class RocksDBTransactionTest {
+  @TempDir public Path folder;
+
+  @Mock(answer = RETURNS_DEEP_STUBS)
+  RocksDBMetrics mockMetrics;
+
+  @Mock Transaction mockTransaction;
+  @Mock WriteOptions mockOptions;
+
+  RocksDBTransaction tx;
+
+  @BeforeEach
+  void setupTx() {
+    tx = spy(new RocksDBTransaction(__ -> null, mockTransaction, mockOptions, mockMetrics));
+  }
+
+  @Test
+  public void assertNominalBehavior() throws Exception {
+    assertThatCode(tx::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void assertDefaultBusyRetryBehavior() throws Exception {
+    doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doNothing()
+        .when(mockTransaction)
+        .commit();
+
+    assertThatCode(tx::commit).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void assertExplicitBusyRetryBehavior() throws Exception {
+    doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("Busy"))
+        .doNothing()
+        .when(mockTransaction)
+        .commit();
+
+    assertThatCode(() -> tx.commitWithRetries(10)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void assertLockTimeoutBusyRetryBehavior() throws Exception {
+    doThrow(new RocksDBException("Busy"))
+        .doThrow(new RocksDBException("TimedOut(LockTimeout)"))
+        .doThrow(new RocksDBException("TimedOut(LockTimeout)"))
+        .doNothing()
+        .when(mockTransaction)
+        .commit();
+
+    assertThatCode(() -> tx.commitWithRetries(7)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void assertBusyRetryFailBehavior() throws Exception {
+    doThrow(new RocksDBException("Busy")).when(mockTransaction).commit();
+
+    assertThatThrownBy(tx::commit)
+        .isInstanceOf(StorageException.class)
+        .hasCauseInstanceOf(RocksDBException.class)
+        .hasMessageContaining("Busy");
+  }
+
+  @Test
+  public void assertRocksTxCloseOnRetryDoesNotThrow() throws Exception {
+    try (final OptimisticTransactionDB db =
+        OptimisticTransactionDB.open(new Options().setCreateIfMissing(true), folder.toString())) {
+      var writeOptions = new WriteOptions();
+      Transaction innerTx = spy(db.beginTransaction(writeOptions));
+
+      tx = spy(new RocksDBTransaction(__ -> null, innerTx, writeOptions, mockMetrics));
+
+      doThrow(new RocksDBException("Busy"))
+          .doThrow(new RocksDBException("Busy"))
+          .doNothing()
+          .when(innerTx)
+          .commit();
+
+      assertThatCode(tx::commit).doesNotThrowAnyException();
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Simple default retry policy for rocksdb busy and locktimeout exceptions.

**This may or may not remedy the busy exceptions encountered in the listed issues, but it will at a minimum provide better signal regarding whether these are transient issues due to compaction, or more systemic issues

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to #5911 
related to #5549 
related to #5807