### PR TITLE
[skip ci] Add trace functionality for transaction selection

### DIFF
--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionSelector.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionSelector.java
@@ -16,6 +16,7 @@
 package org.hyperledger.besu.plugin.services.txselection;
 
 import org.hyperledger.besu.datatypes.PendingTransaction;
+import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.Unstable;
 import org.hyperledger.besu.plugin.data.TransactionProcessingResult;
 import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
@@ -43,4 +44,13 @@ public interface TransactionSelector {
    */
   TransactionSelectionResult evaluateTransactionPostProcessing(
       PendingTransaction pendingTransaction, TransactionProcessingResult processingResult);
+
+  /**
+   * Method to get the tracer for the transaction selection for the current block
+   *
+   * @return the tracer
+   */
+  default OperationTracer getTracer() {
+    return OperationTracer.NO_TRACING;
+  }
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionSelectorFactory.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionSelectorFactory.java
@@ -24,9 +24,9 @@ import java.util.List;
 public interface TransactionSelectorFactory {
 
   /**
-   * Create a list of transaction selectors
+   * Create a transaction selector
    *
-   * @return the transaction selector list
+   * @return the transaction selector
    */
-  List<TransactionSelector> create();
+  TransactionSelector create();
 }


### PR DESCRIPTION
## PR description
This change in the API allows the plugin to provide a tracer that will be used while executing transaction that could be selected for the block