### PR TITLE
[WIP] Trie log pruning 

### DIFF
--- a/besu/build.gradle
+++ b/besu/build.gradle
@@ -77,6 +77,7 @@ dependencies {
   implementation 'org.springframework.security:spring-security-crypto'
   implementation 'org.xerial.snappy:snappy-java'
   implementation 'tech.pegasys:jc-kzg-4844'
+  implementation 'org.rocksdb:rocksdbjni'
 
   runtimeOnly 'org.apache.logging.log4j:log4j-jul'
   runtimeOnly 'com.splunk.logging:splunk-library-javalogging'

--- a/besu/src/main/java/org/hyperledger/besu/cli/error/BesuExecutionExceptionHandler.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/error/BesuExecutionExceptionHandler.java
@@ -27,9 +27,6 @@ public class BesuExecutionExceptionHandler implements IExecutionExceptionHandler
       final CommandLine.ParseResult parseResult) {
     final CommandSpec spec = commandLine.getCommandSpec();
     commandLine.getErr().println(ex);
-    // TODO SLD
-    commandLine.getErr().println(ex.getCause());
-    ex.printStackTrace(commandLine.getErr());
     return commandLine.getExitCodeExceptionMapper() != null
         ? commandLine.getExitCodeExceptionMapper().getExitCode(ex)
         : spec.exitCodeOnExecutionException();

--- a/besu/src/main/java/org/hyperledger/besu/cli/error/BesuExecutionExceptionHandler.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/error/BesuExecutionExceptionHandler.java
@@ -27,6 +27,9 @@ public class BesuExecutionExceptionHandler implements IExecutionExceptionHandler
       final CommandLine.ParseResult parseResult) {
     final CommandSpec spec = commandLine.getCommandSpec();
     commandLine.getErr().println(ex);
+    // TODO SLD
+    commandLine.getErr().println(ex.getCause());
+    ex.printStackTrace(commandLine.getErr());
     return commandLine.getExitCodeExceptionMapper() != null
         ? commandLine.getExitCodeExceptionMapper().getExitCode(ex)
         : spec.exitCodeOnExecutionException();

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommand.java
@@ -36,7 +36,8 @@ import picocli.CommandLine.Spec;
       GenerateBlockchainConfig.class,
       GenerateLogBloomCache.class,
       BackupState.class,
-      RestoreState.class
+      RestoreState.class,
+      TrieLogSubCommand.class
     })
 public class OperatorSubCommand implements Runnable {
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommand.java
@@ -37,7 +37,8 @@ import picocli.CommandLine.Spec;
       GenerateLogBloomCache.class,
       BackupState.class,
       RestoreState.class,
-      TrieLogSubCommand.class
+      TrieLogSubCommand.class,
+      RocksDbSubCommand.class
     })
 public class OperatorSubCommand implements Runnable {
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RocksDbSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RocksDbSubCommand.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.subcommands.operator;
+
+import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
+
+import org.hyperledger.besu.cli.util.VersionProvider;
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bouncycastle.util.Arrays;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyMetaData;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+/** The RocksDB subcommand. */
+@Command(
+    name = "x-rocksdb",
+    description = "Print RocksDB information",
+    mixinStandardHelpOptions = true,
+    versionProvider = VersionProvider.class,
+    subcommands = {RocksDbSubCommand.RocksDbUsage.class})
+public class RocksDbSubCommand implements Runnable {
+
+  @ParentCommand private OperatorSubCommand parentCommand;
+
+  @SuppressWarnings("unused")
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  @Override
+  public void run() {
+    spec.commandLine().usage(System.out);
+  }
+
+  @Command(
+      name = "usage",
+      description = "Prints disk usage",
+      mixinStandardHelpOptions = true,
+      versionProvider = VersionProvider.class)
+  static class RocksDbUsage implements Runnable {
+
+    @SuppressWarnings("unused")
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    @SuppressWarnings("unused")
+    @ParentCommand
+    private RocksDbSubCommand parentCommand;
+
+    @Override
+    public void run() {
+
+      final PrintWriter out = spec.commandLine().getOut();
+
+      final String dbPath =
+          parentCommand
+              .parentCommand
+              .parentCommand
+              .dataDir()
+              .toString()
+              .concat("/")
+              .concat(DATABASE_PATH);
+
+      RocksDB.loadLibrary();
+      Options options = new Options();
+      options.setCreateIfMissing(true);
+
+      // Open the RocksDB database with multiple column families
+      List<byte[]> cfNames = null;
+      try {
+        cfNames = RocksDB.listColumnFamilies(options, dbPath);
+      } catch (RocksDBException e) {
+        throw new RuntimeException(e);
+      }
+      List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
+      List<ColumnFamilyDescriptor> cfDescriptors = new ArrayList<>();
+      for (byte[] cfName : cfNames) {
+        cfDescriptors.add(new ColumnFamilyDescriptor(cfName));
+      }
+      boolean emptyColumnFamily;
+      try (final RocksDB rocksdb = RocksDB.openReadOnly(dbPath, cfDescriptors, cfHandles)) {
+        for (int i = 0; i < cfNames.size(); i++) {
+          emptyColumnFamily = false;
+          byte[] cfName = cfNames.get(i);
+          ColumnFamilyHandle cfHandle = cfHandles.get(i);
+          String size = rocksdb.getProperty(cfHandle, "rocksdb.estimate-live-data-size");
+          if (!size.isEmpty() && !size.isBlank()) {
+            long sizeLong = Long.parseLong(size);
+            if (sizeLong == 0) emptyColumnFamily = true;
+            if (!emptyColumnFamily) {
+              out.println(
+                  "****** Column family '"
+                      + getNameById(cfName)
+                      + "' size: "
+                      + formatOutputSize(sizeLong)
+                      + " ******");
+              // System.out.println("SST table : "+ rocksdb.getProperty(cfHandle,
+              // "rocksdb.sstables"));
+
+              out.println(
+                  "Number of live snapshots : "
+                      + rocksdb.getProperty(cfHandle, "rocksdb.num-snapshots"));
+              out.println(
+                  "Number of keys : " + rocksdb.getProperty(cfHandle, "rocksdb.estimate-num-keys"));
+
+              String totolSstFilesSize =
+                  rocksdb.getProperty(cfHandle, "rocksdb.total-sst-files-size");
+              if (!totolSstFilesSize.isEmpty() && !totolSstFilesSize.isBlank()) {
+                out.println(
+                    "Total size of SST Files : "
+                        + formatOutputSize(Long.parseLong(totolSstFilesSize)));
+              }
+              String liveSstFilesSize =
+                  rocksdb.getProperty(cfHandle, "rocksdb.live-sst-files-size");
+              if (!liveSstFilesSize.isEmpty() && !liveSstFilesSize.isBlank()) {
+                out.println(
+                    "Size of live SST Filess : "
+                        + formatOutputSize(Long.parseLong(liveSstFilesSize)));
+              }
+
+              ColumnFamilyMetaData columnFamilyMetaData = rocksdb.getColumnFamilyMetaData(cfHandle);
+              long sizeBytes = columnFamilyMetaData.size();
+              out.println(
+                  "Column family size (with getColumnFamilyMetaData) : "
+                      + formatOutputSize(sizeBytes));
+              out.println("");
+            }
+          }
+        }
+      } catch (RocksDBException e) {
+        throw new RuntimeException(e);
+      } finally {
+        for (ColumnFamilyHandle cfHandle : cfHandles) {
+          cfHandle.close();
+        }
+      }
+    }
+
+    private static String formatOutputSize(final long size) {
+      if (size > (1024 * 1024 * 1024)) {
+        long sizeInGiB = size / (1024 * 1024 * 1024);
+        return sizeInGiB + " GiB";
+      } else if (size > (1024 * 1024)) {
+        long sizeInMiB = size / (1024 * 1024);
+        return sizeInMiB + " MiB";
+      } else if (size > 1024) {
+        long sizeInKiB = size / 1024;
+        return sizeInKiB + " KiB";
+      } else {
+        return size + " B";
+      }
+    }
+
+    public static String getNameById(final byte[] id) {
+      for (KeyValueSegmentIdentifier segment : KeyValueSegmentIdentifier.values()) {
+        if (Arrays.areEqual(segment.getId(), id)) {
+          return segment.getName();
+        }
+      }
+      return null; // id not found
+    }
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RocksDbUsageHelper.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RocksDbUsageHelper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.cli.subcommands.operator;
+
+import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
+
+import java.io.PrintWriter;
+
+import org.bouncycastle.util.Arrays;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyMetaData;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+public class RocksDbUsageHelper {
+
+  static void printUsageForColumnFamily(
+      final RocksDB rocksdb, final ColumnFamilyHandle cfHandle, final PrintWriter out)
+      throws RocksDBException {
+    String size = rocksdb.getProperty(cfHandle, "rocksdb.estimate-live-data-size");
+    boolean emptyColumnFamily = false;
+    if (!size.isEmpty() && !size.isBlank()) {
+      long sizeLong = Long.parseLong(size);
+      if (sizeLong == 0) emptyColumnFamily = true;
+      if (!emptyColumnFamily) {
+        out.println(
+            "****** Column family '"
+                + getNameById(cfHandle.getName())
+                + "' size: "
+                + formatOutputSize(sizeLong)
+                + " ******");
+        // System.out.println("SST table : "+ rocksdb.getProperty(cfHandle,
+        // "rocksdb.sstables"));
+
+        out.println(
+            "Number of live snapshots : " + rocksdb.getProperty(cfHandle, "rocksdb.num-snapshots"));
+        out.println(
+            "Number of keys : " + rocksdb.getProperty(cfHandle, "rocksdb.estimate-num-keys"));
+
+        String totolSstFilesSize = rocksdb.getProperty(cfHandle, "rocksdb.total-sst-files-size");
+        if (!totolSstFilesSize.isEmpty() && !totolSstFilesSize.isBlank()) {
+          out.println(
+              "Total size of SST Files : " + formatOutputSize(Long.parseLong(totolSstFilesSize)));
+        }
+        String liveSstFilesSize = rocksdb.getProperty(cfHandle, "rocksdb.live-sst-files-size");
+        if (!liveSstFilesSize.isEmpty() && !liveSstFilesSize.isBlank()) {
+          out.println(
+              "Size of live SST Filess : " + formatOutputSize(Long.parseLong(liveSstFilesSize)));
+        }
+
+        ColumnFamilyMetaData columnFamilyMetaData = rocksdb.getColumnFamilyMetaData(cfHandle);
+        long sizeBytes = columnFamilyMetaData.size();
+        out.println(
+            "Column family size (with getColumnFamilyMetaData) : " + formatOutputSize(sizeBytes));
+        out.println("");
+      }
+    }
+  }
+
+  private static String formatOutputSize(final long size) {
+    if (size > (1024 * 1024 * 1024)) {
+      long sizeInGiB = size / (1024 * 1024 * 1024);
+      return sizeInGiB + " GiB";
+    } else if (size > (1024 * 1024)) {
+      long sizeInMiB = size / (1024 * 1024);
+      return sizeInMiB + " MiB";
+    } else if (size > 1024) {
+      long sizeInKiB = size / 1024;
+      return sizeInKiB + " KiB";
+    } else {
+      return size + " B";
+    }
+  }
+
+  public static String getNameById(final byte[] id) {
+    for (KeyValueSegmentIdentifier segment : KeyValueSegmentIdentifier.values()) {
+      if (Arrays.areEqual(segment.getId(), id)) {
+        return segment.getName();
+      }
+    }
+    return null; // id not found
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
@@ -114,6 +114,7 @@ public class TrieLogSubCommand implements Runnable {
       //              .log();
     } catch (final Exception e) {
       LOG.error("TODO SLD", e);
+      spec.commandLine().usage(System.out);
     }
   }
 
@@ -200,6 +201,11 @@ public class TrieLogSubCommand implements Runnable {
             besuController
                 .getStorageProvider()
                 .getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
+        out.println("list of trie logs:");
+        out.println(
+            "                    block hash (key)                               | block number");
+        out.println(
+            "___________________________________________________________________|__________________");
         trieLogStorage
             .streamKeys()
             .map(Bytes32::wrap)
@@ -208,13 +214,13 @@ public class TrieLogSubCommand implements Runnable {
             .forEach(
                 hash ->
                     out.printf(
-                        "trieLog for hash %s block: %s",
+                        "%s | %s\n",
                         hash,
                         blockchain
                             .getBlockHeader(hash)
                             .map(BlockHeader::getNumber)
                             .map(String::valueOf)
-                            .orElse("")));
+                            .orElse("not in blockchain")));
       } else {
         out.println("Subcommand only works with Bonsai");
       }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.subcommands.operator;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
+
+import org.hyperledger.besu.cli.util.VersionProvider;
+import org.hyperledger.besu.controller.BesuController;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.bonsai.BonsaiWorldStateProvider;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/** The Trie Log subcommand. */
+@Command(
+    name = "x-trie-log",
+    description = "Manipulate trie logs",
+    mixinStandardHelpOptions = true,
+    versionProvider = VersionProvider.class,
+    subcommands = {TrieLogSubCommand.DeleteTrieLog.class})
+public class TrieLogSubCommand implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TrieLogSubCommand.class);
+
+  @Option(
+      names = "--block",
+      paramLabel = MANDATORY_LONG_FORMAT_HELP,
+      description = "The block",
+      arity = "1..1")
+  private String targetBlockHash = "";
+
+  @ParentCommand private OperatorSubCommand parentCommand;
+
+  private BesuController besuController;
+  //  private WorldStateStorage.Updater updater;
+
+  @Override
+  public void run() {
+    try {
+      besuController = createBesuController();
+
+      // TODO SLD use TrieLogProvider instead?
+      //      parentCommand.parentCommand.parentCommand.besuPluginService
+
+      /* TODO SLD CacheWorldStorageManager vs BonsaiWorldStateProvider?
+      this.trieLogManager =
+          new CachedWorldStorageManager(
+              this,
+              blockchain,
+              worldStateStorage,
+              metricsSystem,
+              maxLayersToLoad.orElse(RETAINED_LAYERS),
+              pluginContext);
+       */
+      if (besuController.getProtocolContext().getWorldStateArchive()
+          instanceof BonsaiWorldStateProvider) {
+        Optional<? extends TrieLog> trieLogLayer =
+            ((BonsaiWorldStateProvider) besuController.getProtocolContext().getWorldStateArchive())
+                .getTrieLogManager()
+                .getTrieLogLayer(Hash.fromHexString(targetBlockHash.toString()));
+        if (trieLogLayer.isPresent()) {
+          LOG.atInfo().setMessage("result: {}").addArgument(trieLogLayer.get()).log();
+        } else {
+          LOG.info("No trie log found for block hash {}", targetBlockHash.toString());
+        }
+      } else {
+        LOG.info("Subcommand only works with Bonsai");
+      }
+
+      //      KeyValueStorage trieLogStorage =
+      // besuController.getStorageProvider().getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
+      //      Optional<byte[]> bytes =
+      // trieLogStorage.get(Bytes.fromHexString(targetBlockHash.toString()).toArrayUnsafe());
+      //      LOG.atInfo().setMessage("result: {}")
+      //              .addArgument(HexFormat.of().formatHex(bytes.orElse(new byte[0])))
+      //              .log();
+    } catch (final Exception e) {
+      LOG.error("TODO SLD", e);
+    }
+  }
+
+  private BesuController createBesuController() {
+    return parentCommand.parentCommand.buildController();
+  }
+
+  @Command(
+      name = "delete",
+      description = "This command deletes the trie log stored under the specified block.",
+      mixinStandardHelpOptions = true,
+      versionProvider = VersionProvider.class)
+  static class DeleteTrieLog implements Runnable {
+    private static final Logger LOG =
+        LoggerFactory.getLogger(TrieLogSubCommand.DeleteTrieLog.class);
+
+    @SuppressWarnings("unused")
+    @ParentCommand
+    private TrieLogSubCommand parentCommand;
+
+    private BesuController besuController;
+
+    @Override
+    public void run() {
+      checkNotNull(parentCommand);
+
+      besuController = parentCommand.createBesuController();
+
+      WorldStateArchive worldStateArchive =
+          besuController.getProtocolContext().getWorldStateArchive();
+
+      if (worldStateArchive instanceof BonsaiWorldStateProvider) {
+        boolean success =
+            ((BonsaiWorldStateProvider) worldStateArchive)
+                .getTrieLogManager()
+                .deleteTrieLogLayer(Hash.fromHexString(parentCommand.targetBlockHash.toString()));
+
+        //      KeyValueStorage trieLogStorage =
+        // besuController.getStorageProvider().getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
+        //      boolean success =
+        // trieLogStorage.tryDelete((Bytes.fromHexString(parentCommand.targetBlockHash.toString()).toArrayUnsafe()));
+        LOG.atInfo().setMessage("success? {}").addArgument(success).log();
+      } else {
+        LOG.info("Subcommand only works with Bonsai");
+      }
+    }
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
@@ -452,9 +452,11 @@ public class TrieLogSubCommand implements Runnable {
                       if (header.get().getNumber() < deleteBelowHere) {
                         // Prune canonical and fork trie logs below the block number
                         recordResult(trieLogStorage.tryDelete(hashAsBytes), prunedCount, hash);
-                      } else {
-                        LOG.atInfo().setMessage("Retain {}").addArgument(hash::toHexString).log();
                       }
+                      //                      else {
+                      //                        LOG.atInfo().setMessage("Retain
+                      // {}").addArgument(hash::toHexString).log();
+                      //                      }
                     }
                   });
           out.printf("Pruned %d trie logs\n", prunedCount.get());
@@ -508,7 +510,7 @@ public class TrieLogSubCommand implements Runnable {
         final boolean success, final AtomicInteger prunedCount, final Hash hash) {
       if (success) {
         prunedCount.getAndIncrement();
-        LOG.atInfo().setMessage("Pruned {}").addArgument(hash::toHexString).log();
+        //        LOG.atInfo().setMessage("Pruned {}").addArgument(hash::toHexString).log();
       } else {
         LOG.atInfo().setMessage("Failed to prune {}").addArgument(hash::toHexString).log();
       }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
@@ -402,9 +402,12 @@ public class TrieLogSubCommand implements Runnable {
       out.println("Current trie log disk usage:");
       printTrieLogDiskUsage(out);
 
+      out.printf("Current head block number: %d\n", blockchain.getChainHead().getHeight());
       out.printf("Trie log layers to retain: %d\n", layersToRetain);
-      final long deleteBelowHere = blockchain.getChainHead().getHeight() - layersToRetain;
-      out.printf("Attempting trie log layer prune below block %s...\n", deleteBelowHere);
+      final long deleteBelowHere = blockchain.getChainHead().getHeight() - layersToRetain + 1;
+      out.printf(
+          "Attempting trie log layer prune below block %s = (%s - %s + 1)...\n",
+          deleteBelowHere, blockchain.getChainHead().getHeight(), layersToRetain);
 
       WorldStateArchive worldStateArchive =
           besuController.getProtocolContext().getWorldStateArchive();

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/TrieLogSubCommand.java
@@ -127,13 +127,14 @@ public class TrieLogSubCommand implements Runnable {
         out.println("Subcommand only works with Bonsai");
       }
 
-      //      KeyValueStorage trieLogStorage =
+      //            KeyValueStorage trieLogStorage =
+      //
       // besuController.getStorageProvider().getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.TRIE_LOG_STORAGE);
-      //      Optional<byte[]> bytes =
-      // trieLogStorage.get(Bytes.fromHexString(targetBlockHash.toString()).toArrayUnsafe());
-      //      LOG.atInfo().setMessage("result: {}")
-      //              .addArgument(HexFormat.of().formatHex(bytes.orElse(new byte[0])))
-      //              .log();
+      //            Optional<byte[]> bytes =
+      //       trieLogStorage.get(Bytes.fromHexString(targetBlockHash.toString()).toArrayUnsafe());
+      //            LOG.atInfo().setMessage("result: {}")
+      //                    .addArgument(HexFormat.of().formatHex(bytes.orElse(new byte[0])))
+      //                    .log();
     } catch (final Exception e) {
       LOG.error("TODO SLD", e);
       spec.commandLine().usage(System.out);
@@ -415,7 +416,7 @@ public class TrieLogSubCommand implements Runnable {
                     Hash hash = Hash.wrap(Bytes32.wrap(hashAsBytes));
 
                     final Optional<BlockHeader> header = blockchain.getBlockHeader(hash);
-                    if (header.isEmpty()) {
+                    if (header.isEmpty()) { // TODO SLD what if we're still producing this block?
                       // Orphaned trie logs are neither in the canonical blockchain nor forks.
                       // Likely created during block production
                       recordResult(trieLogStorage.tryDelete(hashAsBytes), prunedCount, hash);

--- a/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
+++ b/crypto/algorithms/src/main/java/org/hyperledger/besu/crypto/KeyPairUtil.java
@@ -84,6 +84,7 @@ public class KeyPairUtil {
     final KeyPair key;
     if (keyFile.exists()) {
 
+      LOG.info("Attempting to load public key from {}", keyFile.getAbsolutePath());
       key = load(keyFile);
       LOG.info(
           "Loaded public key {} from {}", key.getPublicKey().toString(), keyFile.getAbsolutePath());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/BonsaiWorldStateProvider.java
@@ -153,6 +153,12 @@ public class BonsaiWorldStateProvider implements WorldStateArchive {
         || worldStateStorage.isWorldStateAvailable(rootHash, blockHash);
   }
 
+  // TODO SLD protection against pruned trie logs when rolling back/forward etc so we're not relying
+  // on 512 max layers config.
+
+  // TODO SLD during reorg, prune trie logs, then another reorg -> roll forward - could be a problem
+  // with roll forward?
+
   @Override
   public Optional<MutableWorldState> getMutable(
       final BlockHeader blockHeader, final boolean shouldPersistState) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
@@ -335,6 +335,10 @@ public class BonsaiWorldStateKeyValueStorage implements WorldStateStorage, AutoC
     throw new RuntimeException("Bonsai Tries do not work with pruning.");
   }
 
+  public boolean deleteTrieLog(final Hash blockHash) {
+    return trieLogStorage.tryDelete(blockHash.toArrayUnsafe());
+  }
+
   @Override
   public long addNodeAddedListener(final NodesAddedListener listener) {
     throw new RuntimeException("addNodeAddedListener not available");

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/AbstractTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/AbstractTrieLogManager.java
@@ -95,6 +95,11 @@ public abstract class AbstractTrieLogManager implements TrieLogManager {
     }
   }
 
+  @Override
+  public boolean deleteTrieLogLayer(final Hash blockHash) {
+    return rootWorldStateStorage.deleteTrieLog(blockHash);
+  }
+
   @VisibleForTesting
   TrieLog prepareTrieLog(
       final BlockHeader blockHeader, final BonsaiWorldStateUpdateAccumulator localUpdater) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/AbstractTrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/AbstractTrieLogManager.java
@@ -154,6 +154,7 @@ public abstract class AbstractTrieLogManager implements TrieLogManager {
 
   @Override
   public Optional<TrieLog> getTrieLogLayer(final Hash blockHash) {
+    // TODO SLD check CACHE1 first?
     return rootWorldStateStorage.getTrieLog(blockHash).map(trieLogFactory::deserialize);
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/TrieLogLayer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/TrieLogLayer.java
@@ -264,4 +264,22 @@ public class TrieLogLayer implements TrieLog {
         .append(storage)
         .toHashCode();
   }
+
+  @Override
+  public String toString() {
+    return "TrieLogLayer{"
+        + "blockHash="
+        + blockHash
+        + ", blockNumber="
+        + blockNumber
+        + ", accounts="
+        + accounts
+        + ", code="
+        + code
+        + ", storage="
+        + storage
+        + ", frozen="
+        + frozen
+        + '}';
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/trielog/TrieLogManager.java
@@ -33,6 +33,8 @@ public interface TrieLogManager {
       final BlockHeader forBlockHeader,
       final BonsaiWorldState forWorldState);
 
+  boolean deleteTrieLogLayer(final Hash blockHash);
+
   void addCachedLayer(
       BlockHeader blockHeader, Hash worldStateRootHash, BonsaiWorldState forWorldState);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/bonsai/worldview/BonsaiWorldState.java
@@ -393,6 +393,8 @@ public class BonsaiWorldState
         verifyWorldStateRoot(newWorldStateRootHash, blockHeader);
         saveTrieLog =
             () -> {
+              // TODO SLD if isFrozen pushTo CACHE1 else persist ? To avoid persisting when
+              // producing block (cache to keep optimisation between build and newPayload import)
               trieLogManager.saveTrieLog(localCopy, newWorldStateRootHash, blockHeader, this);
               // not save a frozen state in the cache
               if (!isFrozen) {

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BonsaiReferenceTestWorldState.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BonsaiReferenceTestWorldState.java
@@ -141,6 +141,11 @@ public class BonsaiReferenceTestWorldState extends BonsaiWorldState
     }
 
     @Override
+    public boolean deleteTrieLogLayer(final Hash blockHash) {
+      return false;
+    }
+
+    @Override
     public void addCachedLayer(
         final BlockHeader blockHeader,
         final Hash worldStateRootHash,


### PR DESCRIPTION
Added some subcommands for debugging...

(based on https://github.com/ahamlat/RocksdDB-Column-Families-Size)
```
Usage: besu operator x-rocksdb [-hV] [COMMAND]
Print RocksDB information
  -h, --help      Show this help message and exit.
  -V, --version   Print version information and exit.
Commands:
  usage  Prints disk usage
```

```
Usage: besu operator x-trie-log [-hV] [--block[=<LONG>]] [--from[=<LONG>]] [--to
                                [=<LONG>]] [COMMAND]
Manipulate trie logs
      --block[=<LONG>]   The block
      --from, --from-block-number[=<LONG>]
                         Start of the block number range
  -h, --help             Show this help message and exit.
      --to, --to-block-number[=<LONG>]
                         End of the block number range
  -V, --version          Print version information and exit.
Commands:
  count   This command counts all the trie logs
  list    This command lists all the trie logs
  delete  Deletes the trie logs stored under the specified hash or block number
            range.
  prune   This command prunes all trie log layers below the specified block
            number, including orphaned trie logs.
```

Steps to install on a box:
```
cd /opt/besu
sudo wget -O 6000.tar.gz https://output.circle-artifacts.com/output/job/4d3d3d9c-25d5-41f1-ba04-d888dc1e4413/artifacts/0/distributions/besu-23.10.1-SNAPSHOT.tar.gz
sudo tar zxf 6000.tar.gz --transform s/besu-23.10.1-SNAPSHOT/6000/
time sudo /opt/besu/6000/bin/besu --config-file=/etc/besu/config.toml operator x-rocksdb usage
```

```
# offline only command:
time sudo /opt/besu/6000/bin/besu --config-file=/etc/besu/config.toml operator x-trie-log list
```