### PR TITLE
Minor optimization on Eth_feeHistory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next release
 - Cache last n blocks by using a new Besu flag --cache-last-blocks=n
+- Optimize performances of RPC method Eth_feeHistory
 
 ### Breaking Changes
 


### PR DESCRIPTION
This PR has a minor optimization on Eth_feeHistory, on top of [this other optimization on Eth_feeHistory ](https://github.com/hyperledger/besu/pull/6011).

Instead of sorting rewardPercentiles for each block header, this PR sorts only once and the sorted list is used as a parameter for each call to compute rewards.
