### PR TITLE
Fcu v2 defer fork validation

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -98,9 +98,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
             forkChoice.getHeadBlockHash(), forkChoice.getFinalizedBlockHash());
 
     ForkchoiceResult forkchoiceResult = null;
-    if (maybeNewHead.isEmpty()) {
-      return syncingResponse(requestId, forkChoice);
-    } else if (!isValidForkchoiceState(
+    if (!isValidForkchoiceState(
         forkChoice.getSafeBlockHash(), forkChoice.getFinalizedBlockHash(), maybeNewHead.get())) {
       logForkchoiceUpdatedCall(INVALID, forkChoice);
       return new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_FORKCHOICE_STATE);
@@ -148,16 +146,19 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     if (mergeCoordinator.isBadBlock(forkChoice.getHeadBlockHash())) {
       logForkchoiceUpdatedCall(INVALID, forkChoice);
       return new JsonRpcSuccessResponse(
-          requestId,
-          new EngineUpdateForkchoiceResult(
-              INVALID,
-              mergeCoordinator
-                  .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
-                  .orElse(Hash.ZERO),
-              null,
-              Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
+              requestId,
+              new EngineUpdateForkchoiceResult(
+                      INVALID,
+                      mergeCoordinator
+                              .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
+                              .orElse(Hash.ZERO),
+                      null,
+                      Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
     }
 
+    if (maybeNewHead.isEmpty()) {
+      return syncingResponse(requestId, forkChoice);
+    }
     final BlockHeader newHead = maybeNewHead.get();
     if (maybePayloadAttributes.isPresent()) {
       Optional<JsonRpcErrorResponse> maybeError =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -93,37 +93,26 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
             forkChoice.getSafeBlockHash(),
             forkChoice.getFinalizedBlockHash());
 
-    if (mergeCoordinator.isBadBlock(forkChoice.getHeadBlockHash())) {
-      logForkchoiceUpdatedCall(INVALID, forkChoice);
-      return new JsonRpcSuccessResponse(
-          requestId,
-          new EngineUpdateForkchoiceResult(
-              INVALID,
-              mergeCoordinator
-                  .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
-                  .orElse(Hash.ZERO),
-              null,
-              Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
-    }
-
     final Optional<BlockHeader> maybeNewHead =
         mergeCoordinator.getOrSyncHeadByHash(
             forkChoice.getHeadBlockHash(), forkChoice.getFinalizedBlockHash());
 
+    ForkchoiceResult forkchoiceResult = null;
     if (maybeNewHead.isEmpty()) {
       return syncingResponse(requestId, forkChoice);
-    }
-    Optional<List<Withdrawal>> withdrawals = Optional.empty();
-    final BlockHeader newHead = maybeNewHead.get();
-    if (!isValidForkchoiceState(
-        forkChoice.getSafeBlockHash(), forkChoice.getFinalizedBlockHash(), newHead)) {
+    } else if (!isValidForkchoiceState(
+        forkChoice.getSafeBlockHash(), forkChoice.getFinalizedBlockHash(), maybeNewHead.get())) {
       logForkchoiceUpdatedCall(INVALID, forkChoice);
       return new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_FORKCHOICE_STATE);
+    } else {
+      forkchoiceResult =
+          mergeCoordinator.updateForkChoice(
+              maybeNewHead.get(),
+              forkChoice.getFinalizedBlockHash(),
+              forkChoice.getSafeBlockHash());
     }
-    ForkchoiceResult result =
-        mergeCoordinator.updateForkChoice(
-            newHead, forkChoice.getFinalizedBlockHash(), forkChoice.getSafeBlockHash());
 
+    Optional<List<Withdrawal>> withdrawals = Optional.empty();
     if (maybePayloadAttributes.isPresent()) {
       final EnginePayloadAttributesParameter payloadAttributes = maybePayloadAttributes.get();
       withdrawals =
@@ -136,7 +125,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                                   .map(WithdrawalParameter::toWithdrawal)
                                   .collect(toList())));
       Optional<JsonRpcErrorResponse> maybeError =
-          isPayloadAttributesValid(requestId, payloadAttributes, withdrawals, newHead);
+          isPayloadAttributesValid(requestId, payloadAttributes, withdrawals);
       if (maybeError.isPresent()) {
         LOG.atWarn()
             .setMessage("RpcError {}: {}")
@@ -156,6 +145,33 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
       }
     }
 
+    if (mergeCoordinator.isBadBlock(forkChoice.getHeadBlockHash())) {
+      logForkchoiceUpdatedCall(INVALID, forkChoice);
+      return new JsonRpcSuccessResponse(
+          requestId,
+          new EngineUpdateForkchoiceResult(
+              INVALID,
+              mergeCoordinator
+                  .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
+                  .orElse(Hash.ZERO),
+              null,
+              Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
+    }
+
+    final BlockHeader newHead = maybeNewHead.get();
+    if (maybePayloadAttributes.isPresent()) {
+      Optional<JsonRpcErrorResponse> maybeError =
+          isPayloadAttributeRelevantToNewHead(requestId, maybePayloadAttributes.get(), newHead);
+      if (maybeError.isPresent()) {
+        return maybeError.get();
+      }
+      if (!getWithdrawalsValidator(
+              protocolSchedule.get(), newHead, maybePayloadAttributes.get().getTimestamp())
+          .validateWithdrawals(withdrawals)) {
+        return new JsonRpcErrorResponse(requestId, getInvalidPayloadError());
+      }
+    }
+
     ValidationResult<RpcErrorType> parameterValidationResult =
         validateParameter(forkChoice, maybePayloadAttributes);
     if (!parameterValidationResult.isValid()) {
@@ -169,13 +185,13 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     maybePayloadAttributes.ifPresentOrElse(
         this::logPayload, () -> LOG.debug("Payload attributes are null"));
 
-    if (result.shouldNotProceedToPayloadBuildProcess()) {
-      if (ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD.equals(result.getStatus())) {
+    if (forkchoiceResult.shouldNotProceedToPayloadBuildProcess()) {
+      if (ForkchoiceResult.Status.IGNORE_UPDATE_TO_OLD_HEAD.equals(forkchoiceResult.getStatus())) {
         logForkchoiceUpdatedCall(VALID, forkChoice);
       } else {
         logForkchoiceUpdatedCall(INVALID, forkChoice);
       }
-      return handleNonValidForkchoiceUpdate(requestId, result);
+      return handleNonValidForkchoiceUpdate(requestId, forkchoiceResult);
     }
 
     // begin preparing a block if we have a non-empty payload attributes param
@@ -205,25 +221,24 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
         requestId,
         new EngineUpdateForkchoiceResult(
             VALID,
-            result.getNewHead().map(BlockHeader::getHash).orElse(null),
+            forkchoiceResult.getNewHead().map(BlockHeader::getHash).orElse(null),
             payloadId.orElse(null),
             Optional.empty()));
   }
 
-  protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
+  protected abstract Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
       final Object requestId,
       final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals,
+      final Optional<List<Withdrawal>> maybeWithdrawals);
+
+  protected Optional<JsonRpcErrorResponse> isPayloadAttributeRelevantToNewHead(
+      final Object requestId,
+      final EnginePayloadAttributesParameter payloadAttributes,
       final BlockHeader headBlockHeader) {
 
     if (payloadAttributes.getTimestamp() <= headBlockHeader.getTimestamp()) {
       LOG.warn(
           "Payload attributes timestamp is smaller than timestamp of header in fork choice update");
-      return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadError()));
-    }
-    if (!getWithdrawalsValidator(
-            protocolSchedule.get(), headBlockHeader, payloadAttributes.getTimestamp())
-        .validateWithdrawals(maybeWithdrawals)) {
       return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadError()));
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -146,14 +146,14 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     if (mergeCoordinator.isBadBlock(forkChoice.getHeadBlockHash())) {
       logForkchoiceUpdatedCall(INVALID, forkChoice);
       return new JsonRpcSuccessResponse(
-              requestId,
-              new EngineUpdateForkchoiceResult(
-                      INVALID,
-                      mergeCoordinator
-                              .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
-                              .orElse(Hash.ZERO),
-                      null,
-                      Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
+          requestId,
+          new EngineUpdateForkchoiceResult(
+              INVALID,
+              mergeCoordinator
+                  .getLatestValidHashOfBadBlock(forkChoice.getHeadBlockHash())
+                  .orElse(Hash.ZERO),
+              null,
+              Optional.of(forkChoice.getHeadBlockHash() + " is an invalid block")));
     }
 
     if (maybeNewHead.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -17,8 +17,14 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+
+import java.util.List;
+import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
@@ -31,6 +37,14 @@ public class EngineForkchoiceUpdatedV1 extends AbstractEngineForkchoiceUpdated {
       final MergeMiningCoordinator mergeCoordinator,
       final EngineCallListener engineCallListener) {
     super(vertx, protocolSchedule, protocolContext, mergeCoordinator, engineCallListener);
+  }
+
+  @Override
+  protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
+      final Object requestId,
+      final EnginePayloadAttributesParameter payloadAttributes,
+      final Optional<List<Withdrawal>> maybeWithdrawals) {
+    return Optional.empty();
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
@@ -55,8 +54,7 @@ public class EngineForkchoiceUpdatedV2 extends AbstractEngineForkchoiceUpdated {
   protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
       final Object requestId,
       final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals,
-      final BlockHeader headBlockHeader) {
+      final Optional<List<Withdrawal>> maybeWithdrawals) {
     if (payloadAttributes.getTimestamp() >= cancunTimestamp) {
       if (payloadAttributes.getParentBeaconBlockRoot() == null
           || payloadAttributes.getParentBeaconBlockRoot().isEmpty()) {
@@ -64,14 +62,12 @@ public class EngineForkchoiceUpdatedV2 extends AbstractEngineForkchoiceUpdated {
       } else {
         return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));
       }
-    } else if (payloadAttributes.getParentBeaconBlockRoot() != null
-        || !payloadAttributes.getParentBeaconBlockRoot().isEmpty()) {
+    } else if (payloadAttributes.getParentBeaconBlockRoot() != null) {
       LOG.error(
           "Parent beacon block root hash present in payload attributes before cancun hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));
     } else {
-      return super.isPayloadAttributesValid(
-          requestId, payloadAttributes, maybeWithdrawals, headBlockHeader);
+      return Optional.empty();
     }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -59,12 +59,13 @@ public class EngineForkchoiceUpdatedV2 extends AbstractEngineForkchoiceUpdated {
       final BlockHeader headBlockHeader) {
     if (payloadAttributes.getTimestamp() >= cancunTimestamp) {
       if (payloadAttributes.getParentBeaconBlockRoot() == null
-          || payloadAttributes.getParentBeaconBlockRoot().isEmpty()
-          || payloadAttributes.getParentBeaconBlockRoot().isZero()) {
+          || payloadAttributes.getParentBeaconBlockRoot().isEmpty()) {
+        return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.UNSUPPORTED_FORK));
+      } else {
         return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));
       }
-      return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.UNSUPPORTED_FORK));
-    } else if (payloadAttributes.getParentBeaconBlockRoot() != null) {
+    } else if (payloadAttributes.getParentBeaconBlockRoot() != null
+        || !payloadAttributes.getParentBeaconBlockRoot().isEmpty()) {
       LOG.error(
           "Parent beacon block root hash present in payload attributes before cancun hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineForkc
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec;
@@ -94,14 +93,8 @@ public class EngineForkchoiceUpdatedV3 extends AbstractEngineForkchoiceUpdated {
   protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
       final Object requestId,
       final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals,
-      final BlockHeader headBlockHeader) {
-    Optional<JsonRpcErrorResponse> maybeError =
-        super.isPayloadAttributesValid(
-            requestId, payloadAttributes, maybeWithdrawals, headBlockHeader);
-    if (maybeError.isPresent()) {
-      return maybeError;
-    } else if (payloadAttributes.getParentBeaconBlockRoot() == null) {
+      final Optional<List<Withdrawal>> maybeWithdrawals) {
+    if (payloadAttributes.getParentBeaconBlockRoot() == null) {
       LOG.error(
           "Parent beacon block root hash not present in payload attributes after cancun hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));


### PR DESCRIPTION
re-orders the validity checking and priority on forkchoice updated calls.

- payloadAttributes needs to be validated apart from new head validity, so there are now two steps for checking so that we can fail differently if the head being built on is missing or irrelevant to the building payload.