### PR TITLE
Fixed eth_call before london fork for the calls without strict parameter

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
@@ -178,6 +178,6 @@ public class EthCall extends AbstractBlockParameterOrBlockHashMethod {
       }
     }
     // Prior 1559, when gas price == 0 or is not provided the balance is not checked
-    return isZeroGasPrice;
+    return !isZeroGasPrice;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -378,9 +378,9 @@ public class EthCallTest {
   }
 
   @Test
-  public void shouldAutoSelectIsAllowedExceedingBalanceToTrueWhenGasPriceIsZero() {
+  public void shouldAutoSelectIsAllowedExceedingBalanceToFalseWhenGasPriceIsZero() {
     final JsonCallParameter callParameters = callParameter(Wei.ZERO, null, null);
-    internalAutoSelectIsAllowedExceedingBalance(callParameters, Optional.empty(), true);
+    internalAutoSelectIsAllowedExceedingBalance(callParameters, Optional.empty(), false);
   }
 
   @Test
@@ -390,9 +390,9 @@ public class EthCallTest {
   }
 
   @Test
-  public void shouldAutoSelectIsAllowedExceedingBalanceToFalseWhenGasPriceIsNotZero() {
+  public void shouldAutoSelectIsAllowedExceedingBalanceToTrueWhenGasPriceIsNotZero() {
     final JsonCallParameter callParameters = callParameter(Wei.ONE, null, null);
-    internalAutoSelectIsAllowedExceedingBalance(callParameters, Optional.empty(), false);
+    internalAutoSelectIsAllowedExceedingBalance(callParameters, Optional.empty(), true);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Fixed eth_call before London fork for the calls without `strict` parameters.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fix #5943