### PR TITLE
Unsigned timestamps and blob gas used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1093,6 +1093,22 @@ distributions {
   }
 }
 
+configurations.all {
+  resolutionStrategy {
+    dependencySubstitution {
+      def os = System.getProperty("os.name").toLowerCase()
+      if (os.contains("windows")) {
+        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:3.124.0")
+      }
+      else if (os.contains("linux")) {
+        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:3.124.0")
+      }
+      else if (os.contains("mac")) {
+        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:3.124.0")
+      }
+    }
+  }
+}
 check.dependsOn checkSpdxHeader
 build.dependsOn verifyDistributions
 artifactoryPublish.dependsOn verifyDistributions

--- a/build.gradle
+++ b/build.gradle
@@ -1093,22 +1093,6 @@ distributions {
   }
 }
 
-configurations.all {
-  resolutionStrategy {
-    dependencySubstitution {
-      def os = System.getProperty("os.name").toLowerCase()
-      if (os.contains("windows")) {
-        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64:3.124.0")
-      }
-      else if (os.contains("linux")) {
-        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:3.124.0")
-      }
-      else if (os.contains("mac")) {
-        substitute module('org.eclipse.platform:org.eclipse.swt.${osgi.platform}') with module("org.eclipse.platform:org.eclipse.swt.cocoa.macosx.x86_64:3.124.0")
-      }
-    }
-  }
-}
 check.dependsOn checkSpdxHeader
 build.dependsOn verifyDistributions
 artifactoryPublish.dependsOn verifyDistributions

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -594,7 +594,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
     Optional<BlockHeader> parentOfNewHead = blockchain.getBlockHeader(newHead.getParentHash());
     if (parentOfNewHead.isPresent()
-        && parentOfNewHead.get().getTimestamp() >= newHead.getTimestamp()) {
+        && Long.compareUnsigned(newHead.getTimestamp(), parentOfNewHead.get().getTimestamp())
+            <= 0) {
       return ForkchoiceResult.withFailure(
           INVALID, "new head timestamp not greater than parent", latestValid);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -140,7 +140,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                                   .map(WithdrawalParameter::toWithdrawal)
                                   .collect(toList())));
       Optional<JsonRpcErrorResponse> maybeError =
-          isPayloadAttributesValid(requestId, payloadAttributes, withdrawals);
+          isPayloadAttributesValid(requestId, payloadAttributes);
       if (maybeError.isPresent()) {
         LOG.atWarn()
             .setMessage("RpcError {}: {}")
@@ -229,9 +229,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
   }
 
   protected abstract Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
-      final Object requestId,
-      final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals);
+      final Object requestId, final EnginePayloadAttributesParameter payloadAttribute);
 
   protected Optional<JsonRpcErrorResponse> isPayloadAttributeRelevantToNewHead(
       final Object requestId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -267,7 +267,8 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
 
     if (maybeParentHeader.isPresent()
-        && (blockParam.getTimestamp() <= maybeParentHeader.get().getTimestamp())) {
+        && (Long.compareUnsigned(maybeParentHeader.get().getTimestamp(), blockParam.getTimestamp())
+            >= 0)) {
       return respondWithInvalid(
           reqId,
           blockParam,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -20,10 +20,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
@@ -41,9 +39,7 @@ public class EngineForkchoiceUpdatedV1 extends AbstractEngineForkchoiceUpdated {
 
   @Override
   protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
-      final Object requestId,
-      final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals) {
+      final Object requestId, final EnginePayloadAttributesParameter payloadAttributes) {
     return Optional.empty();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -20,10 +20,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
@@ -52,9 +50,7 @@ public class EngineForkchoiceUpdatedV2 extends AbstractEngineForkchoiceUpdated {
 
   @Override
   protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
-      final Object requestId,
-      final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals) {
+      final Object requestId, final EnginePayloadAttributesParameter payloadAttributes) {
     if (payloadAttributes.getTimestamp() >= cancunTimestamp) {
       if (payloadAttributes.getParentBeaconBlockRoot() == null
           || payloadAttributes.getParentBeaconBlockRoot().isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -21,12 +21,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineForkc
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ScheduledProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 
-import java.util.List;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
@@ -91,9 +89,7 @@ public class EngineForkchoiceUpdatedV3 extends AbstractEngineForkchoiceUpdated {
 
   @Override
   protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
-      final Object requestId,
-      final EnginePayloadAttributesParameter payloadAttributes,
-      final Optional<List<Withdrawal>> maybeWithdrawals) {
+      final Object requestId, final EnginePayloadAttributesParameter payloadAttributes) {
     if (payloadAttributes.getParentBeaconBlockRoot() == null) {
       LOG.error(
           "Parent beacon block root hash not present in payload attributes after cancun hardfork");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
@@ -71,7 +71,8 @@ public class EngineNewPayloadV3 extends AbstractEngineNewPayload {
   @Override
   protected ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {
     if (protocolSchedule.isPresent()) {
-      if (cancun.isPresent() && blockTimestamp >= cancun.get().milestone()) {
+      if (cancun.isPresent()
+          && Long.compareUnsigned(blockTimestamp, cancun.get().milestone()) >= 0) {
         return ValidationResult.valid();
       } else {
         return ValidationResult.invalid(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -25,14 +25,16 @@ public class UnsignedLongParameter {
   @JsonCreator
   public UnsignedLongParameter(final String value) {
     checkArgument(value != null);
-    this.value = Long.decode(value);
-    checkArgument(this.value >= 0);
+    if (value.startsWith("0x")) {
+      this.value = Long.parseUnsignedLong(value.substring(2), 16);
+    } else {
+      this.value = Long.parseUnsignedLong(value, 16);
+    }
   }
 
   @JsonCreator
   public UnsignedLongParameter(final long value) {
     this.value = value;
-    checkArgument(this.value >= 0);
   }
 
   public long getValue() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -21,8 +21,7 @@ import org.checkerframework.checker.signedness.qual.Unsigned;
 
 public class UnsignedLongParameter {
 
-  @Unsigned
-  private final long value;
+  @Unsigned private final long value;
 
   @JsonCreator
   public UnsignedLongParameter(final String value) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -17,9 +17,11 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.checkerframework.checker.signedness.qual.Unsigned;
 
 public class UnsignedLongParameter {
 
+  @Unsigned
   private final long value;
 
   @JsonCreator
@@ -33,11 +35,11 @@ public class UnsignedLongParameter {
   }
 
   @JsonCreator
-  public UnsignedLongParameter(final long value) {
+  public UnsignedLongParameter(final @Unsigned long value) {
     this.value = value;
   }
 
-  public long getValue() {
+  public @Unsigned long getValue() {
     return value;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -238,7 +238,6 @@ public class BlockHeaderBuilder {
     checkState(this.difficulty != null, "Missing block difficulty");
     checkState(this.number > -1L, "Missing block number");
     checkState(this.gasLimit > -1L, "Missing gas limit");
-    // checkState(this.timestamp > -1L, "Missing timestamp");
   }
 
   private void validateSealableBlockHeader() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -238,7 +238,7 @@ public class BlockHeaderBuilder {
     checkState(this.difficulty != null, "Missing block difficulty");
     checkState(this.number > -1L, "Missing block number");
     checkState(this.gasLimit > -1L, "Missing gas limit");
-    checkState(this.timestamp > -1L, "Missing timestamp");
+    // checkState(this.timestamp > -1L, "Missing timestamp");
   }
 
   private void validateSealableBlockHeader() {
@@ -360,7 +360,6 @@ public class BlockHeaderBuilder {
   }
 
   public BlockHeaderBuilder timestamp(final long timestamp) {
-    checkArgument(timestamp >= 0);
     this.timestamp = timestamp;
     return this;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ParentBeaconBlockRootHelper.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ParentBeaconBlockRootHelper.java
@@ -18,6 +18,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.account.MutableAccount;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
+import com.google.common.primitives.Longs;
+import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
@@ -34,14 +36,15 @@ public interface ParentBeaconBlockRootHelper {
     /*
      see EIP-4788: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4788.md
     */
-    final long timestampReduced = timestamp % HISTORY_BUFFER_LENGTH;
+    final long timestampReduced = Long.remainderUnsigned(timestamp, HISTORY_BUFFER_LENGTH);
     final long timestampExtended = timestampReduced + HISTORY_BUFFER_LENGTH;
 
     final UInt256 timestampIndex = UInt256.valueOf(timestampReduced);
     final UInt256 rootIndex = UInt256.valueOf(timestampExtended);
 
     final MutableAccount account = worldUpdater.getOrCreate(BEACON_ROOTS_ADDRESS);
-    account.setStorageValue(timestampIndex, UInt256.valueOf(timestamp));
+    account.setStorageValue(
+        timestampIndex, UInt256.fromBytes(Bytes.of(Longs.toByteArray(timestamp))));
     account.setStorageValue(rootIndex, UInt256.fromBytes(root));
     worldUpdater.commit();
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
@@ -62,7 +62,8 @@ public interface ScheduledProtocolSpec {
 
     @Override
     public boolean isOnOrAfterMilestoneBoundary(final ProcessableBlockHeader header) {
-      return header.getTimestamp() >= timestamp;
+      return Long.compareUnsigned(header.getTimestamp(), timestamp) >= 0;
+      // return header.getTimestamp() >= timestamp;
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ScheduledProtocolSpec.java
@@ -63,7 +63,6 @@ public interface ScheduledProtocolSpec {
     @Override
     public boolean isOnOrAfterMilestoneBoundary(final ProcessableBlockHeader header) {
       return Long.compareUnsigned(header.getTimestamp(), timestamp) >= 0;
-      // return header.getTimestamp() >= timestamp;
     }
 
     @Override

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/IncrementalTimestampRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/IncrementalTimestampRule.java
@@ -28,6 +28,6 @@ public class IncrementalTimestampRule implements AttachedBlockHeaderValidationRu
     final long blockTimestamp = header.getTimestamp();
     final long parentTimestamp = parent.getTimestamp();
 
-    return blockTimestamp > parentTimestamp;
+    return Long.compareUnsigned(blockTimestamp, parentTimestamp) >= 0;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/IncrementalTimestampRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/IncrementalTimestampRule.java
@@ -28,6 +28,6 @@ public class IncrementalTimestampRule implements AttachedBlockHeaderValidationRu
     final long blockTimestamp = header.getTimestamp();
     final long parentTimestamp = parent.getTimestamp();
 
-    return Long.compareUnsigned(blockTimestamp, parentTimestamp) >= 0;
+    return Long.compareUnsigned(blockTimestamp, parentTimestamp) > 0;
   }
 }


### PR DESCRIPTION
Merge after pr #6037 , was built on top of that.

the pyspec simulator in Hive likes to check fields for max capacities, which showed us a lot of places where using signed longs is a problem. This pr fixes many of them.

broader adoption of CheckerFramework is suggested at a later time, so that we can see where else we are affected by this.