### PR TITLE
not pruning block during the initial sync

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/ChainPruningOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/ChainPruningOptions.java
@@ -31,7 +31,7 @@ public class ChainPruningOptions implements CLIOptions<ChainPrunerConfiguration>
       "--Xchain-pruning-blocks-retained";
   private static final String CHAIN_PRUNING_FREQUENCY_FLAG = "--Xchain-pruning-frequency";
   /** The constant DEFAULT_CHAIN_DATA_PRUNING_MIN_BLOCKS_RETAINED. */
-  public static final long DEFAULT_CHAIN_DATA_PRUNING_MIN_BLOCKS_RETAINED = 7200;
+  public static final long DEFAULT_CHAIN_DATA_PRUNING_MIN_BLOCKS_RETAINED = 512;
   /** The constant DEFAULT_CHAIN_DATA_PRUNING_FREQUENCY. */
   public static final int DEFAULT_CHAIN_DATA_PRUNING_FREQUENCY = 256;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -53,8 +53,7 @@ public class ChainDataPruner implements BlockAddedObserver {
   @Override
   public void onBlockAdded(final BlockAddedEvent event) {
     if (!isInitialSyncPhaseDoneSupplier.get()) {
-      LOG.debug(
-          "Unable to run block pruning because the initial synchronization is still in progress.");
+      // not run block pruning because the initial synchronization is still in progress.
       return;
     }
     final long blockNumber = event.getBlock().getHeader().getNumber();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/ChainDataPruner.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.plugin.services.storage.KeyValueStorageTransaction;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,22 +33,30 @@ public class ChainDataPruner implements BlockAddedObserver {
   private final long blocksToRetain;
   private final long pruningFrequency;
   private final ExecutorService pruningExecutor;
+  private final Supplier<Boolean> isInitialSyncPhaseDoneSupplier;
 
   public ChainDataPruner(
       final BlockchainStorage blockchainStorage,
       final ChainDataPrunerStorage prunerStorage,
       final long blocksToRetain,
       final long pruningFrequency,
+      final Supplier<Boolean> isInitialSyncPhaseDoneSupplier,
       final ExecutorService pruningExecutor) {
     this.blockchainStorage = blockchainStorage;
     this.prunerStorage = prunerStorage;
     this.blocksToRetain = blocksToRetain;
     this.pruningFrequency = pruningFrequency;
+    this.isInitialSyncPhaseDoneSupplier = isInitialSyncPhaseDoneSupplier;
     this.pruningExecutor = pruningExecutor;
   }
 
   @Override
   public void onBlockAdded(final BlockAddedEvent event) {
+    if (!isInitialSyncPhaseDoneSupplier.get()) {
+      LOG.debug(
+          "Unable to run block pruning because the initial synchronization is still in progress.");
+      return;
+    }
     final long blockNumber = event.getBlock().getHeader().getNumber();
     final long storedPruningMark = prunerStorage.getPruningMark().orElse(blockNumber);
     if (blockNumber < storedPruningMark) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/chain/ChainDataPrunerTest.java
@@ -48,6 +48,8 @@ public class ChainDataPrunerTest {
             new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
             512,
             0,
+            () -> true, // Set to 'true' to indicate that the initial synchronization phase has
+            // completed
             new BlockingExecutor());
     Block genesisBlock = gen.genesisBlock();
     final MutableBlockchain blockchain =
@@ -86,6 +88,8 @@ public class ChainDataPrunerTest {
             new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
             512,
             0,
+            () -> true, // Set to 'true' to indicate that the initial synchronization phase has
+            // completed
             new BlockingExecutor());
     Block genesisBlock = gen.genesisBlock();
     final MutableBlockchain blockchain =
@@ -113,6 +117,51 @@ public class ChainDataPrunerTest {
       assertThat(blockchain.getBlockByHash(canonicalChain.get(index - 512).getHash())).isEmpty();
       assertThat(blockchain.getBlockByHash(canonicalChain.get(i - 511).getHash())).isPresent();
       assertThat(blockchain.getBlockByHash(canonicalChain.get(index - 512).getHash())).isEmpty();
+      assertThat(blockchain.getBlockByHash(forkChain.get(i - 511).getHash())).isPresent();
+    }
+  }
+
+  @Test
+  public void disablePruningWhenInitialSyncPhaseRunning() {
+    final BlockDataGenerator gen = new BlockDataGenerator();
+    final BlockchainStorage blockchainStorage =
+        new KeyValueStoragePrefixedKeyBlockchainStorage(
+            new InMemoryKeyValueStorage(),
+            new VariablesKeyValueStorage(new InMemoryKeyValueStorage()),
+            new MainnetBlockHeaderFunctions());
+    final ChainDataPruner chainDataPruner =
+        new ChainDataPruner(
+            blockchainStorage,
+            new ChainDataPrunerStorage(new InMemoryKeyValueStorage()),
+            512,
+            0,
+            () -> false, // Set to 'false' to indicate that the initial synchronization phase is
+            // running.
+            new BlockingExecutor());
+    Block genesisBlock = gen.genesisBlock();
+    final MutableBlockchain blockchain =
+        DefaultBlockchain.createMutable(
+            genesisBlock, blockchainStorage, new NoOpMetricsSystem(), 0);
+    blockchain.observeBlockAdded(chainDataPruner);
+
+    List<Block> canonicalChain = gen.blockSequence(genesisBlock, 1000);
+    List<Block> forkChain = gen.blockSequence(genesisBlock, 16);
+    for (Block blk : forkChain) {
+      blockchain.storeBlock(blk, gen.receipts(blk));
+    }
+    for (int i = 0; i < 512; i++) {
+      Block blk = canonicalChain.get(i);
+      blockchain.appendBlock(blk, gen.receipts(blk));
+    }
+    // No prune happened
+    assertThat(blockchain.getBlockByHash(canonicalChain.get(0).getHash())).isPresent();
+    assertThat(blockchain.getBlockByHash(forkChain.get(0).getHash())).isPresent();
+    for (int i = 512; i < 527; i++) {
+      Block blk = canonicalChain.get(i);
+      blockchain.appendBlock(blk, gen.receipts(blk));
+      assertThat(blockchain.getBlockByHash(canonicalChain.get(i - 512).getHash())).isPresent();
+      assertThat(blockchain.getBlockByHash(canonicalChain.get(i - 511).getHash())).isPresent();
+      assertThat(blockchain.getBlockByHash(canonicalChain.get(i - 512).getHash())).isPresent();
       assertThat(blockchain.getBlockByHash(forkChain.get(i - 511).getHash())).isPresent();
     }
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

I propose a modification to the block pruning feature so that we can lower the minimum limit to 512 instead of 7200. Why 512? Simply to allow a minimum number of blocks close to the head. This is also the number we chose for the world state on Bonsai and seems to be a good compromise between pruning and accessibility of recent history.

7200 was chosen to avoid pruning during the initial sync, so I made a modification to prune during the initial sync by querying the SyncState.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->