### PR TITLE
ETC 'Spiral' network upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ### Download Links
 
+## 23.10.2
+
+### Breaking Changes
+
+### Deprecations
+
+### Additions and Improvements
+
+### Bug fixes
+
+### Download Links
+
 ## 23.10.1
 - Cache last n blocks by using a new Besu flag --cache-last-blocks=n [#6009](https://github.com/hyperledger/besu/pull/6009)
 - Optimize performances of RPC method Eth_feeHistory [#6011](https://github.com/hyperledger/besu/pull/6011)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Deprecations
 
 ### Additions and Improvements
+- Ethereum Classic Spiral network upgrade [#6078](https://github.com/hyperledger/besu/pull/6078)
 
 ### Bug fixes
 

--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -127,8 +127,9 @@ public class ForkIdsNetworkConfigTest {
                 new ForkId(Bytes.ofUnsignedInt(0xf42f5539L), 2520000L),
                 new ForkId(Bytes.ofUnsignedInt(0x66b5c286L), 3985893),
                 new ForkId(Bytes.ofUnsignedInt(0x92b323e0L), 5520000L),
-                new ForkId(Bytes.ofUnsignedInt(0x8c9b1797L), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0x8c9b1797L), 0L))
+                new ForkId(Bytes.ofUnsignedInt(0x8c9b1797L), 9957000L),
+                new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L),
+                new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L))
           },
           new Object[] {
             NetworkName.CLASSIC,

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigOptions.java
@@ -420,6 +420,15 @@ public interface GenesisConfigOptions {
   OptionalLong getMystiqueBlockNumber();
 
   /**
+   * Block number to activate Spiral on Classic networks.
+   *
+   * @return block number of Spiral fork on Classic networks
+   * @see <a
+   *     href="https://ecips.ethereumclassic.org/ECIPs/ecip-1109">https://ecips.ethereumclassic.org/ECIPs/ecip-1109</a>
+   */
+  OptionalLong getSpiralBlockNumber();
+
+  /**
    * Gets chain id.
    *
    * @return the chain id

--- a/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonGenesisConfigOptions.java
@@ -381,6 +381,11 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
   }
 
   @Override
+  public OptionalLong getSpiralBlockNumber() {
+    return getOptionalLong("spiralblock");
+  }
+
+  @Override
   public Optional<BigInteger> getChainId() {
     return getOptionalBigInteger("chainid");
   }
@@ -460,6 +465,7 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
     getThanosBlockNumber().ifPresent(l -> builder.put("thanosBlock", l));
     getMagnetoBlockNumber().ifPresent(l -> builder.put("magnetoBlock", l));
     getMystiqueBlockNumber().ifPresent(l -> builder.put("mystiqueBlock", l));
+    getSpiralBlockNumber().ifPresent(l -> builder.put("spiralBlock", l));
 
     getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
     getEvmStackSize().ifPresent(l -> builder.put("evmstacksize", l));
@@ -567,7 +573,8 @@ public class JsonGenesisConfigOptions implements GenesisConfigOptions {
             getPhoenixBlockNumber(),
             getThanosBlockNumber(),
             getMagnetoBlockNumber(),
-            getMystiqueBlockNumber());
+            getMystiqueBlockNumber(),
+            getSpiralBlockNumber());
     // when adding forks add an entry to ${REPO_ROOT}/config/src/test/resources/all_forks.json
 
     return forkBlockNumbers

--- a/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/StubGenesisConfigOptions.java
@@ -66,6 +66,7 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions, Cloneable
   private OptionalLong thanosBlockNumber = OptionalLong.empty();
   private OptionalLong magnetoBlockNumber = OptionalLong.empty();
   private OptionalLong mystiqueBlockNumber = OptionalLong.empty();
+  private OptionalLong spiralBlockNumber = OptionalLong.empty();
   private Optional<BigInteger> chainId = Optional.empty();
   private OptionalInt contractSizeLimit = OptionalInt.empty();
   private OptionalInt stackSizeLimit = OptionalInt.empty();
@@ -317,6 +318,11 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions, Cloneable
   }
 
   @Override
+  public OptionalLong getSpiralBlockNumber() {
+    return spiralBlockNumber;
+  }
+
+  @Override
   public OptionalInt getContractSizeLimit() {
     return contractSizeLimit;
   }
@@ -374,6 +380,7 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions, Cloneable
     getThanosBlockNumber().ifPresent(l -> builder.put("thanosBlock", l));
     getMagnetoBlockNumber().ifPresent(l -> builder.put("magnetoBlock", l));
     getMystiqueBlockNumber().ifPresent(l -> builder.put("mystiqueBlock", l));
+    getSpiralBlockNumber().ifPresent(l -> builder.put("spiralBlock", l));
 
     getContractSizeLimit().ifPresent(l -> builder.put("contractSizeLimit", l));
     getEvmStackSize().ifPresent(l -> builder.put("evmStackSize", l));
@@ -797,6 +804,17 @@ public class StubGenesisConfigOptions implements GenesisConfigOptions, Cloneable
    */
   public StubGenesisConfigOptions mystique(final long blockNumber) {
     mystiqueBlockNumber = OptionalLong.of(blockNumber);
+    return this;
+  }
+
+  /**
+   * Spiral stub genesis config options.
+   *
+   * @param blockNumber the block number
+   * @return the stub genesis config options
+   */
+  public StubGenesisConfigOptions spiral(final long blockNumber) {
+    spiralBlockNumber = OptionalLong.of(blockNumber);
     return this;
   }
 

--- a/config/src/main/resources/mordor.json
+++ b/config/src/main/resources/mordor.json
@@ -10,6 +10,7 @@
     "mystiqueBlock": 5520000,
     "ethash": {},
     "discovery": {
+      "dns": "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K@all.mordor.blockd.info",
       "bootnodes": [
         "enode://642cf9650dd8869d42525dbf6858012e3b4d64f475e733847ab6f7742341a4397414865d953874e8f5ed91b0e4e1c533dee14ad1d6bb276a5459b2471460ff0d@157.230.152.87:30303",
         "enode://651b484b652c07c72adebfaaf8bc2bd95b420b16952ef3de76a9c00ef63f07cca02a20bd2363426f9e6fe372cef96a42b0fec3c747d118f79fd5e02f2a4ebd4e@51.158.190.99:45678",

--- a/config/src/main/resources/mordor.json
+++ b/config/src/main/resources/mordor.json
@@ -8,6 +8,7 @@
     "thanosBlock": 2520000,
     "magnetoBlock": 3985893,
     "mystiqueBlock": 5520000,
+    "spiralBlock": 9957000,
     "ethash": {},
     "discovery": {
       "dns": "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K@all.mordor.blockd.info",

--- a/config/src/test/resources/all_forks.json
+++ b/config/src/test/resources/all_forks.json
@@ -27,6 +27,7 @@
     "phoenixBlock": 108,
     "thanosBlock": 109,
     "magnetoBlock": 110,
-    "mystiqueBlock": 111
+    "mystiqueBlock": 111,
+    "spiralBlock": 112
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfoTest.java
@@ -377,7 +377,8 @@ public class AdminNodeInfoTest {
             .phoenix(8)
             .thanos(9)
             .magneto(10)
-            .mystique(12);
+            .mystique(11)
+            .spiral(12);
 
     final AdminNodeInfo methodClassic =
         new AdminNodeInfo(
@@ -403,7 +404,8 @@ public class AdminNodeInfoTest {
                 "phoenixBlock", 8L,
                 "thanosBlock", 9L,
                 "magnetoBlock", 10L));
-    expectedConfig.put("mystiqueBlock", 12L);
+    expectedConfig.put("mystiqueBlock", 11L);
+    expectedConfig.put("spiralBlock", 12L);
 
     final JsonRpcResponse response = methodClassic.response(request);
     assertThat(response).isInstanceOf(JsonRpcSuccessResponse.class);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.evm.gascalculator.DieHardGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.IstanbulGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.LondonGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PetersburgGasCalculator;
+import org.hyperledger.besu.evm.gascalculator.ShanghaiGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.SpuriousDragonGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.TangerineWhistleGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
@@ -332,5 +333,47 @@ public class ClassicProtocolSpecs {
                     List.of(MaxCodeSizeRule.of(contractSizeLimit), PrefixCodeRule.of()),
                     1))
         .name("Mystique");
+  }
+
+  public static ProtocolSpecBuilder spiralDefinition(
+      final Optional<BigInteger> chainId,
+      final OptionalInt configContractSizeLimit,
+      final OptionalInt configStackSizeLimit,
+      final boolean enableRevertReason,
+      final OptionalLong ecip1017EraRounds,
+      final EvmConfiguration evmConfiguration) {
+    final int stackSizeLimit = configStackSizeLimit.orElse(MessageFrame.DEFAULT_MAX_STACK_SIZE);
+    return mystiqueDefinition(
+            chainId,
+            configContractSizeLimit,
+            configStackSizeLimit,
+            enableRevertReason,
+            ecip1017EraRounds,
+            evmConfiguration)
+        // EIP-3860
+        .gasCalculator(ShanghaiGasCalculator::new)
+        // EIP-3855
+        .evmBuilder(
+            (gasCalculator, jdCacheConfig) ->
+                MainnetEVMs.shanghai(
+                    gasCalculator, chainId.orElse(BigInteger.ZERO), evmConfiguration))
+        // EIP-3651
+        .transactionProcessorBuilder(
+            (gasCalculator,
+                feeMarket,
+                transactionValidatorFactory,
+                contractCreationProcessor,
+                messageCallProcessor) ->
+                new MainnetTransactionProcessor(
+                    gasCalculator,
+                    transactionValidatorFactory,
+                    contractCreationProcessor,
+                    messageCallProcessor,
+                    true,
+                    true,
+                    stackSizeLimit,
+                    feeMarket,
+                    CoinbaseFeePriceCalculator.frontier()))
+        .name("Spiral");
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecFactory.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecFactory.java
@@ -287,4 +287,14 @@ public class MainnetProtocolSpecFactory {
         ecip1017EraRounds,
         evmConfiguration);
   }
+
+  public ProtocolSpecBuilder spiralDefinition() {
+    return ClassicProtocolSpecs.spiralDefinition(
+        chainId,
+        contractSizeLimit,
+        evmStackSize,
+        isRevertReasonEnabled,
+        ecip1017EraRounds,
+        evmConfiguration);
+  }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ProtocolScheduleBuilder.java
@@ -258,6 +258,7 @@ public class ProtocolScheduleBuilder {
     lastForkBlock = validateForkOrder("Thanos", config.getThanosBlockNumber(), lastForkBlock);
     lastForkBlock = validateForkOrder("Magneto", config.getMagnetoBlockNumber(), lastForkBlock);
     lastForkBlock = validateForkOrder("Mystique", config.getMystiqueBlockNumber(), lastForkBlock);
+    lastForkBlock = validateForkOrder("Spiral", config.getSpiralBlockNumber(), lastForkBlock);
     assert (lastForkBlock >= 0);
   }
 
@@ -329,7 +330,8 @@ public class ProtocolScheduleBuilder {
         blockNumberMilestone(config.getPhoenixBlockNumber(), specFactory.phoenixDefinition()),
         blockNumberMilestone(config.getThanosBlockNumber(), specFactory.thanosDefinition()),
         blockNumberMilestone(config.getMagnetoBlockNumber(), specFactory.magnetoDefinition()),
-        blockNumberMilestone(config.getMystiqueBlockNumber(), specFactory.mystiqueDefinition()));
+        blockNumberMilestone(config.getMystiqueBlockNumber(), specFactory.mystiqueDefinition()),
+        blockNumberMilestone(config.getSpiralBlockNumber(), specFactory.spiralDefinition()));
   }
 
   private Optional<BuilderMapEntry> timestampMilestone(


### PR DESCRIPTION
## PR description
This PR adds support to [ECIP-1109](https://ecips.ethereumclassic.org/ECIPs/ecip-1109).
Block number is set to https://github.com/ethereumclassic/ECIPs/pull/514, already set in core-geth in https://github.com/etclabscore/core-geth/pull/571
I also set the DNS discovery tree to what's in [core-geth#bootnodes_mordor.go](https://github.com/etclabscore/core-geth/blob/v1.12.14/params/bootnodes_mordor.go#L29)