### PR TITLE
Fix k8s nat manager logic and add `--Xnat-kube-service-namespace` flag

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -169,6 +169,7 @@ public class RunnerBuilder {
   private int p2pListenPort;
   private NatMethod natMethod = NatMethod.AUTO;
   private String natManagerServiceName;
+  private String natManagerServiceNamespace;
   private boolean natMethodFallbackEnabled;
   private EthNetworkConfig ethNetworkConfig;
   private EthstatsOptions ethstatsOptions;
@@ -338,6 +339,17 @@ public class RunnerBuilder {
    */
   public RunnerBuilder natManagerServiceName(final String natManagerServiceName) {
     this.natManagerServiceName = natManagerServiceName;
+    return this;
+  }
+
+  /**
+   * Add Nat manager service namespace.
+   *
+   * @param natManagerServiceNamespace the nat manager service namespace
+   * @return the runner builder
+   */
+  public RunnerBuilder natManagerServiceNamespace(final String natManagerServiceNamespace) {
+    this.natManagerServiceNamespace = natManagerServiceNamespace;
     return this;
   }
 
@@ -1161,7 +1173,8 @@ public class RunnerBuilder {
         return Optional.of(
             new DockerNatManager(p2pAdvertisedHost, p2pListenPort, jsonRpcConfiguration.getPort()));
       case KUBERNETES:
-        return Optional.of(new KubernetesNatManager(natManagerServiceName));
+        return Optional.of(
+            new KubernetesNatManager(natManagerServiceName, natManagerServiceNamespace));
       case NONE:
       default:
         return Optional.empty();

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -36,7 +36,8 @@ import static org.hyperledger.besu.metrics.BesuMetricCategory.DEFAULT_METRIC_CAT
 import static org.hyperledger.besu.metrics.MetricsProtocol.PROMETHEUS;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PORT;
 import static org.hyperledger.besu.metrics.prometheus.MetricsConfiguration.DEFAULT_METRICS_PUSH_PORT;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 
 import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.Runner;
@@ -1833,14 +1834,22 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @SuppressWarnings("ConstantConditions")
   private void validateNatParams() {
-    if (!(natMethod.equals(NatMethod.AUTO) || natMethod.equals(NatMethod.KUBERNETES))
-        && !unstableNatOptions
-            .getNatManagerServiceName()
-            .equals(DEFAULT_BESU_SERVICE_NAME_FILTER)) {
-      throw new ParameterException(
-          this.commandLine,
-          "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name"
-              + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+    if (!(natMethod.equals(NatMethod.AUTO) || natMethod.equals(NatMethod.KUBERNETES))) {
+      if (!unstableNatOptions.getNatManagerServiceName().equals(DEFAULT_BESU_SERVICE_NAME)) {
+        throw new ParameterException(
+            this.commandLine,
+            "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name"
+                + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+      }
+
+      if (!unstableNatOptions
+          .getNatManagerServiceNamespace()
+          .equals(DEFAULT_BESU_SERVICE_NAMESPACE)) {
+        throw new ParameterException(
+            this.commandLine,
+            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace"
+                + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+      }
     }
     if (natMethod.equals(NatMethod.AUTO) && !unstableNatOptions.getNatMethodFallbackEnabled()) {
       throw new ParameterException(
@@ -2863,6 +2872,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .p2pEnabled(p2pEnabled)
             .natMethod(natMethod)
             .natManagerServiceName(unstableNatOptions.getNatManagerServiceName())
+            .natManagerServiceNamespace(unstableNatOptions.getNatManagerServiceNamespace())
             .natMethodFallbackEnabled(unstableNatOptions.getNatMethodFallbackEnabled())
             .discovery(peerDiscoveryEnabled)
             .ethNetworkConfig(ethNetworkConfig)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1839,7 +1839,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         throw new ParameterException(
             this.commandLine,
             "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name"
-                + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+                + " or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
       }
 
       if (!unstableNatOptions

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1848,7 +1848,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         throw new ParameterException(
             this.commandLine,
             "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace"
-                + " or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+                + " or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
       }
     }
     if (natMethod.equals(NatMethod.AUTO) && !unstableNatOptions.getNatMethodFallbackEnabled()) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NatOptions.java
@@ -14,7 +14,8 @@
  */
 package org.hyperledger.besu.cli.options.unstable;
 
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 
 import picocli.CommandLine;
 
@@ -27,7 +28,15 @@ public class NatOptions {
       names = {"--Xnat-kube-service-name"},
       description =
           "Specify the name of the service that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
-  private String natManagerServiceName = DEFAULT_BESU_SERVICE_NAME_FILTER;
+  private String natManagerServiceName = DEFAULT_BESU_SERVICE_NAME;
+
+  @SuppressWarnings({"FieldCanBeFinal", "FieldMayBeFinal"}) // PicoCLI requires non-final Strings.
+  @CommandLine.Option(
+      hidden = true,
+      names = {"--Xnat-kube-service-namespace"},
+      description =
+          "Specify the namespace of the service that will be used by the nat manager in Kubernetes. (default: ${DEFAULT-VALUE})")
+  private String natManagerServiceNamespace = DEFAULT_BESU_SERVICE_NAMESPACE;
 
   @CommandLine.Option(
       hidden = true,
@@ -53,6 +62,15 @@ public class NatOptions {
    */
   public String getNatManagerServiceName() {
     return natManagerServiceName;
+  }
+
+  /**
+   * Gets nat manager service namespace.
+   *
+   * @return the nat manager service namespace
+   */
+  public String getNatManagerServiceNamespace() {
+    return natManagerServiceNamespace;
   }
 
   /**

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1969,7 +1969,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
         .contains(
-            "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+            "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
   }
 
   @Test
@@ -1979,7 +1979,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
         .contains(
-            "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+            "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2020,7 +2020,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
         .contains(
-            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2010,7 +2010,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
         .contains(
-            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat-method=KUBERNETES)");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -40,7 +40,8 @@ import static org.hyperledger.besu.ethereum.p2p.config.DefaultDiscoveryConfigura
 import static org.hyperledger.besu.ethereum.p2p.config.DefaultDiscoveryConfiguration.MAINNET_BOOTSTRAP_NODES;
 import static org.hyperledger.besu.ethereum.p2p.config.DefaultDiscoveryConfiguration.MAINNET_DISCOVERY_URL;
 import static org.hyperledger.besu.ethereum.worldstate.DataStorageFormat.BONSAI;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
@@ -1941,28 +1942,28 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
-  public void natManagerPodNamePropertyDefaultIsBesu() {
+  public void natManagerServiceNamePropertyDefaultIsBesu() {
     parseCommand();
 
-    verify(mockRunnerBuilder).natManagerServiceName(eq(DEFAULT_BESU_SERVICE_NAME_FILTER));
+    verify(mockRunnerBuilder).natManagerServiceName(eq(DEFAULT_BESU_SERVICE_NAME));
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
-  public void natManagerPodNamePropertyIsCorrectlyUpdated() {
-    final String podName = "besu-updated";
-    parseCommand("--Xnat-kube-service-name", podName);
+  public void natManagerServiceNamePropertyIsCorrectlyUpdated() {
+    final String serviceName = "besu-updated";
+    parseCommand("--Xnat-kube-service-name", serviceName);
 
-    verify(mockRunnerBuilder).natManagerServiceName(eq(podName));
+    verify(mockRunnerBuilder).natManagerServiceName(eq(serviceName));
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
-  public void natManagerPodNameCannotBeUsedWithNatDockerMethod() {
+  public void natManagerServiceNameCannotBeUsedWithNatDockerMethod() {
     parseCommand("--nat-method", "DOCKER", "--Xnat-kube-service-name", "besu-updated");
     Mockito.verifyNoInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
@@ -1972,13 +1973,54 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
-  public void natManagerPodNameCannotBeUsedWithNatNoneMethod() {
+  public void natManagerServiceNameCannotBeUsedWithNatNoneMethod() {
     parseCommand("--nat-method", "NONE", "--Xnat-kube-service-name", "besu-updated");
     Mockito.verifyNoInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
         .contains(
             "The `--Xnat-kube-service-name` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-name or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+  }
+
+  @Test
+  public void natManagerServiceNamespacePropertyDefaultIsBesu() {
+    parseCommand();
+
+    verify(mockRunnerBuilder).natManagerServiceNamespace(eq(DEFAULT_BESU_SERVICE_NAMESPACE));
+
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void natManagerServiceNamespacePropertyIsCorrectlyUpdated() {
+    final String serviceNamespace = "besu-updated";
+    parseCommand("--Xnat-kube-service-namespace", serviceNamespace);
+
+    verify(mockRunnerBuilder).natManagerServiceNamespace(eq(serviceNamespace));
+
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void natManagerServiceNamespaceCannotBeUsedWithNatDockerMethod() {
+    parseCommand("--nat-method", "DOCKER", "--Xnat-kube-service-namespace", "besu-updated");
+    Mockito.verifyNoInteractions(mockRunnerBuilder);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8))
+        .contains(
+            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
+  }
+
+  @Test
+  public void natManagerServiceNamespaceCannotBeUsedWithNatNoneMethod() {
+    parseCommand("--nat-method", "NONE", "--Xnat-kube-service-namespace", "besu-updated");
+    Mockito.verifyNoInteractions(mockRunnerBuilder);
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8))
+        .contains(
+            "The `--Xnat-kube-service-namespace` parameter is only used in kubernetes mode. Either remove --Xnat-kube-service-namespace or select the KUBERNETES mode (via --nat--method=KUBERNETES)");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -291,6 +291,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.p2pEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethod(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natManagerServiceName(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.natManagerServiceNamespace(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.natMethodFallbackEnabled(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.jsonRpcConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.engineJsonRpcConfiguration(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -25,6 +25,7 @@ identity="PegaSysEng"
 p2p-enabled=true
 nat-method="NONE"
 Xnat-kube-service-name="besu"
+Xnat-kube-service-namespace="besu"
 Xnat-method-fallback-enabled=true
 discovery-enabled=false
 bootnodes=[

--- a/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesClusterIpNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesClusterIpNatManagerTest.java
@@ -15,7 +15,8 @@
 package org.hyperledger.besu.nat.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
@@ -73,9 +74,9 @@ public final class KubernetesClusterIpNatManagerTest {
                             .name(NatServiceType.DISCOVERY.getValue())
                             .port(p2pPort)
                             .targetPort(new IntOrString(p2pPort)))));
-    when(v1Service.getMetadata())
-        .thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME_FILTER));
-    natManager = new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME_FILTER);
+    when(v1Service.getMetadata()).thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME));
+    natManager =
+        new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME, DEFAULT_BESU_SERVICE_NAMESPACE);
     try {
       natManager.start();
     } catch (Exception ignored) {

--- a/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesLoadManagerNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesLoadManagerNatManagerTest.java
@@ -15,7 +15,8 @@
 package org.hyperledger.besu.nat.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.nat.core.domain.NatPortMapping;
@@ -80,9 +81,9 @@ public final class KubernetesLoadManagerNatManagerTest {
                             .name(NatServiceType.DISCOVERY.getValue())
                             .port(p2pPort)
                             .targetPort(new IntOrString(p2pPort)))));
-    when(v1Service.getMetadata())
-        .thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME_FILTER));
-    natManager = new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME_FILTER);
+    when(v1Service.getMetadata()).thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME));
+    natManager =
+        new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME, DEFAULT_BESU_SERVICE_NAMESPACE);
     try {
       natManager.start();
     } catch (Exception ignored) {

--- a/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesUnknownNatManagerTest.java
+++ b/nat/src/test/java/org/hyperledger/besu/nat/kubernetes/KubernetesUnknownNatManagerTest.java
@@ -15,7 +15,8 @@
 package org.hyperledger.besu.nat.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME_FILTER;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAME;
+import static org.hyperledger.besu.nat.kubernetes.KubernetesNatManager.DEFAULT_BESU_SERVICE_NAMESPACE;
 import static org.mockito.Mockito.when;
 
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -38,9 +39,9 @@ public final class KubernetesUnknownNatManagerTest {
   public void initialize() {
 
     when(v1Service.getSpec()).thenReturn(new V1ServiceSpec().type("Unknown"));
-    when(v1Service.getMetadata())
-        .thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME_FILTER));
-    natManager = new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME_FILTER);
+    when(v1Service.getMetadata()).thenReturn(new V1ObjectMeta().name(DEFAULT_BESU_SERVICE_NAME));
+    natManager =
+        new KubernetesNatManager(DEFAULT_BESU_SERVICE_NAME, DEFAULT_BESU_SERVICE_NAMESPACE);
     try {
       natManager.start();
     } catch (Exception ignored) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Now the Kubernetes nat manager requires cluster-wide permissions (list service resources in all namespaces). Also, it has a bug: when multiple besu networks are configured in the same cluster with the same service names in different namespaces, the nat manager may set an inappropriate IP address for the besu node due to enumerating services from all namespaces and checking only their names.

I suggest adding a new flag: `--Xnat-kube-service-namespace` to specify a concrete besu node service namespace and not use a list of services, but a get request for a specific service.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #5002