### PR TITLE
Log missing chain head as warning, not trace

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -270,7 +270,7 @@ public class TransactionPool implements BlockAddedObserver {
         return ValidationResult.invalid(rejectReason);
       }
     } else {
-      LOG.atTrace()
+      LOG.atWarn()
           .setMessage("Discard invalid transaction {}, reason {}")
           .addArgument(transaction::toTraceLog)
           .addArgument(validationResult.result::getInvalidReason)
@@ -415,7 +415,7 @@ public class TransactionPool implements BlockAddedObserver {
 
     final BlockHeader chainHeadBlockHeader = getChainHeadBlockHeader().orElse(null);
     if (chainHeadBlockHeader == null) {
-      LOG.atTrace()
+      LOG.atWarn()
           .setMessage("rejecting transaction {} due to chain head not available yet")
           .addArgument(transaction::getHash)
           .log();


### PR DESCRIPTION
## PR description
Change `CHAIN_HEAD_NOT_AVAILABLE` to a warning, not a trace log entry

## Fixed Issue(s)
Fixes #6126 