### PR TITLE
Add `rpc-gas-cap` to CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Implement new `miner_setMinPriorityFee` and `miner_getMinPriorityFee` RPC methods [#6080](https://github.com/hyperledger/besu/pull/6080)
 - Clique config option `createemptyblocks` to not create empty blocks [#6082](https://github.com/hyperledger/besu/pull/6082)
 - Upgrade EVM Reference Tests to v13 (Cancun) [#6114](https://github.com/hyperledger/besu/pull/6114)
+- Add `rpc-gas-cap` to allow users to set gas limit to the RPC methods `eth_call` and `eth_getEstimateGas`[#6130](https://github.com/hyperledger/besu/pull/6130)
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - New option `--min-priority-fee` that sets the minimum priority fee a transaction must meet to be selected for a block. [#6080](https://github.com/hyperledger/besu/pull/6080) [#6083](https://github.com/hyperledger/besu/pull/6083)
 - Implement new `miner_setMinPriorityFee` and `miner_getMinPriorityFee` RPC methods [#6080](https://github.com/hyperledger/besu/pull/6080)
 - Clique config option `createemptyblocks` to not create empty blocks [#6082](https://github.com/hyperledger/besu/pull/6082)
+- Upgrade EVM Reference Tests to v13 (Cancun) [#6114](https://github.com/hyperledger/besu/pull/6114)
 
 ### Bug fixes
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -192,6 +192,7 @@ public class RunnerBuilder {
   private JsonRpcIpcConfiguration jsonRpcIpcConfiguration;
   private boolean legacyForkIdEnabled;
   private Optional<Long> rpcMaxLogsRange;
+  private Optional<Long> rpcGasCap;
   private Optional<EnodeDnsConfiguration> enodeDnsConfiguration;
 
   /**
@@ -583,6 +584,16 @@ public class RunnerBuilder {
    */
   public RunnerBuilder rpcMaxLogsRange(final Long rpcMaxLogsRange) {
     this.rpcMaxLogsRange = rpcMaxLogsRange > 0 ? Optional.of(rpcMaxLogsRange) : Optional.empty();
+    return this;
+  }
+  /**
+   * Add Rpc gas cap.
+   *
+   * @param rpcGasCap the max gas tx simulator methods can use
+   * @return the runner builder
+   */
+  public RunnerBuilder rpcGasCap(final Long rpcGasCap) {
+    this.rpcGasCap = rpcGasCap > 0 ? Optional.of(rpcGasCap) : Optional.empty();
     return this;
   }
 
@@ -1240,7 +1251,8 @@ public class RunnerBuilder {
                 besuController.getProtocolManager().ethContext().getEthPeers(),
                 consensusEngineServer,
                 rpcMaxLogsRange,
-                enodeDnsConfiguration);
+                enodeDnsConfiguration,
+                    rpcGasCap);
     methods.putAll(besuController.getAdditionalJsonRpcMethods(jsonRpcApis));
 
     final var pluginMethods =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -921,6 +921,7 @@ public class RunnerBuilder {
       graphQlContextMap.putIfAbsent(GraphQLContextType.SYNCHRONIZER, synchronizer);
       graphQlContextMap.putIfAbsent(
           GraphQLContextType.CHAIN_ID, protocolSchedule.getChainId().map(UInt256::valueOf));
+      graphQlContextMap.putIfAbsent(GraphQLContextType.GAS_CAP, rpcGasCap);
       final GraphQL graphQL;
       try {
         graphQL = GraphQLProvider.buildGraphQL(fetchers);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1252,7 +1252,7 @@ public class RunnerBuilder {
                 consensusEngineServer,
                 rpcMaxLogsRange,
                 enodeDnsConfiguration,
-                    rpcGasCap);
+                rpcGasCap);
     methods.putAll(besuController.getAdditionalJsonRpcMethods(jsonRpcApis));
 
     final var pluginMethods =

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -1116,7 +1116,8 @@ public class RunnerBuilder {
                   transactionSimulator,
                   metricsSystem,
                   blockchain,
-                  permissioningService.getConnectionPermissioningProviders());
+                  permissioningService.getConnectionPermissioningProviders(),
+                  rpcGasCap);
 
       return Optional.of(nodePermissioningController);
     } else if (permissioningService.getConnectionPermissioningProviders().size() > 0) {
@@ -1130,7 +1131,8 @@ public class RunnerBuilder {
                   transactionSimulator,
                   metricsSystem,
                   blockchain,
-                  permissioningService.getConnectionPermissioningProviders());
+                  permissioningService.getConnectionPermissioningProviders(),
+                  rpcGasCap);
 
       return Optional.of(nodePermissioningController);
     } else {
@@ -1146,7 +1148,7 @@ public class RunnerBuilder {
     if (permissioningConfiguration.isPresent()) {
       final Optional<AccountPermissioningController> accountPermissioningController =
           AccountPermissioningControllerFactory.create(
-              permissioningConfiguration.get(), transactionSimulator, metricsSystem);
+              permissioningConfiguration.get(), transactionSimulator, metricsSystem, rpcGasCap);
 
       accountPermissioningController.ifPresent(
           permissioningController ->

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1236,7 +1236,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @CommandLine.Option(
       names = {"--rpc-gas-cap"},
       description =
-          "Specifies the maximum number of blocks to retrieve logs from via RPC. Must be >=0. 0 specifies no limit  (default: ${DEFAULT-VALUE})")
+          "Caps the max gas limit the methods eth_call and eth_estimateGas can use. Must be >=0. 0 specifies no limit  (default: ${DEFAULT-VALUE})")
   private final Long rpcGasCap = 50_000_000L;
 
   @CommandLine.Option(

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1234,6 +1234,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final Long rpcMaxLogsRange = 5000L;
 
   @CommandLine.Option(
+      names = {"--rpc-gas-cap"},
+      description =
+          "Specifies the maximum number of blocks to retrieve logs from via RPC. Must be >=0. 0 specifies no limit  (default: ${DEFAULT-VALUE})")
+  private final Long rpcGasCap = 50_000_000L;
+
+  @CommandLine.Option(
       names = {"--cache-last-blocks"},
       description = "Specifies the number of last blocks to cache  (default: ${DEFAULT-VALUE})")
   private final Integer numberOfblocksToCache = 0;
@@ -2892,6 +2898,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .storageProvider(keyValueStorageProvider(keyValueStorageName))
             .rpcEndpointService(rpcEndpointServiceImpl)
             .rpcMaxLogsRange(rpcMaxLogsRange)
+            .rpcGasCap(rpcGasCap)
             .enodeDnsConfiguration(getEnodeDnsConfiguration())
             .build();
 

--- a/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerBuilderTest.java
@@ -167,6 +167,7 @@ public final class RunnerBuilderTest {
             .dataDir(dataDir.getRoot())
             .storageProvider(mock(KeyValueStorageProvider.class, RETURNS_DEEP_STUBS))
             .rpcEndpointService(new RpcEndpointServiceImpl())
+            .rpcGasCap(50_000_000L)
             .build();
     runner.startEthereumMainLoop();
 
@@ -211,6 +212,7 @@ public final class RunnerBuilderTest {
             .dataDir(dataDir.getRoot())
             .storageProvider(storageProvider)
             .rpcEndpointService(new RpcEndpointServiceImpl())
+            .rpcGasCap(50_000_000L)
             .build();
     runner.startEthereumMainLoop();
 
@@ -270,6 +272,7 @@ public final class RunnerBuilderTest {
             .storageProvider(mock(KeyValueStorageProvider.class, RETURNS_DEEP_STUBS))
             .rpcEndpointService(new RpcEndpointServiceImpl())
             .besuPluginContext(mock(BesuPluginContextImpl.class))
+            .rpcGasCap(50_000_000L)
             .build();
 
     assertThat(runner.getJsonRpcPort()).isPresent();
@@ -312,6 +315,7 @@ public final class RunnerBuilderTest {
             .storageProvider(mock(KeyValueStorageProvider.class, RETURNS_DEEP_STUBS))
             .rpcEndpointService(new RpcEndpointServiceImpl())
             .besuPluginContext(mock(BesuPluginContextImpl.class))
+            .rpcGasCap(50_000_000L)
             .build();
 
     assertThat(runner.getEngineJsonRpcPort()).isPresent();
@@ -353,6 +357,7 @@ public final class RunnerBuilderTest {
             .storageProvider(mock(KeyValueStorageProvider.class, RETURNS_DEEP_STUBS))
             .rpcEndpointService(new RpcEndpointServiceImpl())
             .besuPluginContext(mock(BesuPluginContextImpl.class))
+            .rpcGasCap(50_000_000L)
             .build();
 
     assertThat(runner.getEngineJsonRpcPort()).isPresent();
@@ -396,6 +401,7 @@ public final class RunnerBuilderTest {
             .rpcEndpointService(new RpcEndpointServiceImpl())
             .besuPluginContext(mock(BesuPluginContextImpl.class))
             .networkingConfiguration(NetworkingConfiguration.create())
+            .rpcGasCap(50_000_000L)
             .build();
 
     assertThat(runner.getJsonRpcPort()).isPresent();

--- a/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RunnerTest.java
@@ -192,7 +192,8 @@ public final class RunnerTest {
             .permissioningService(new PermissioningServiceImpl())
             .staticNodes(emptySet())
             .storageProvider(new InMemoryKeyValueStorageProvider())
-            .rpcEndpointService(new RpcEndpointServiceImpl());
+            .rpcEndpointService(new RpcEndpointServiceImpl())
+            .rpcGasCap(50_000_000L);
 
     Runner runnerBehind = null;
     final Runner runnerAhead =

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1556,7 +1556,7 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
-  public void maxpeersOptionMustBeUsed() {
+  public void maxPeersOptionMustBeUsed() {
 
     final int maxPeers = 123;
     parseCommand("--max-peers", String.valueOf(maxPeers));
@@ -1579,6 +1579,20 @@ public class BesuCommandTest extends CommandTestAbstract {
     verify(mockRunnerBuilder).build();
 
     assertThat(longArgumentCaptor.getValue()).isEqualTo(rpcMaxLogsRange);
+
+    assertThat(commandOutput.toString(UTF_8)).isEmpty();
+    assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
+  }
+
+  @Test
+  public void rpcGasCapOptionMustBeUsed() {
+    final long rpcGasCap = 150L;
+    parseCommand("--rpc-gas-cap", Long.toString(rpcGasCap));
+
+    verify(mockRunnerBuilder).rpcGasCap(longArgumentCaptor.capture());
+    verify(mockRunnerBuilder).build();
+
+    assertThat(longArgumentCaptor.getValue()).isEqualTo(rpcGasCap);
 
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -313,6 +313,7 @@ public abstract class CommandTestAbstract {
     when(mockRunnerBuilder.rpcEndpointService(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.legacyForkId(anyBoolean())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.rpcMaxLogsRange(any())).thenReturn(mockRunnerBuilder);
+    when(mockRunnerBuilder.rpcGasCap(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.enodeDnsConfiguration(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.build()).thenReturn(mockRunner);
 

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -89,7 +89,7 @@ rpc-http-max-request-content-length = 5242880
 rpc-max-logs-range=100
 json-pretty-print-enabled=false
 cache-last-blocks=512
-gas-cap = 50000000
+rpc-gas-cap = 50000000
 
 # PRIVACY TLS
 privacy-tls-enabled=false

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -89,6 +89,7 @@ rpc-http-max-request-content-length = 5242880
 rpc-max-logs-range=100
 json-pretty-print-enabled=false
 cache-last-blocks=512
+gas-cap = 50000000
 
 # PRIVACY TLS
 privacy-tls-enabled=false

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractController.java
@@ -98,7 +98,11 @@ public class ValidatorContractController {
             .isAllowExceedingBalance(true)
             .build();
     return transactionSimulator.process(
-        callParams, transactionValidationParams, OperationTracer.NO_TRACING, blockNumber);
+        callParams,
+        transactionValidationParams,
+        OperationTracer.NO_TRACING,
+        blockNumber,
+        Optional.empty());
   }
 
   @SuppressWarnings("rawtypes")

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractControllerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/ValidatorContractControllerTest.java
@@ -94,7 +94,8 @@ public class ValidatorContractControllerTest {
             callParameter,
             ALLOW_EXCEEDING_BALANCE_VALIDATION_PARAMS,
             OperationTracer.NO_TRACING,
-            1))
+            1,
+            Optional.empty()))
         .thenReturn(Optional.of(result));
 
     final ValidatorContractController validatorContractController =
@@ -116,7 +117,8 @@ public class ValidatorContractControllerTest {
             callParameter,
             ALLOW_EXCEEDING_BALANCE_VALIDATION_PARAMS,
             OperationTracer.NO_TRACING,
-            1))
+            1,
+            Optional.empty()))
         .thenReturn(Optional.of(result));
 
     final ValidatorContractController validatorContractController =
@@ -141,7 +143,8 @@ public class ValidatorContractControllerTest {
             callParameter,
             ALLOW_EXCEEDING_BALANCE_VALIDATION_PARAMS,
             OperationTracer.NO_TRACING,
-            1))
+            1,
+            Optional.empty()))
         .thenReturn(Optional.of(result));
 
     final ValidatorContractController validatorContractController =
@@ -163,7 +166,8 @@ public class ValidatorContractControllerTest {
             callParameter,
             ALLOW_EXCEEDING_BALANCE_VALIDATION_PARAMS,
             OperationTracer.NO_TRACING,
-            1))
+            1,
+            Optional.empty()))
         .thenReturn(Optional.of(result));
 
     final ValidatorContractController validatorContractController =
@@ -180,7 +184,8 @@ public class ValidatorContractControllerTest {
             callParameter,
             ALLOW_EXCEEDING_BALANCE_VALIDATION_PARAMS,
             OperationTracer.NO_TRACING,
-            1))
+            1,
+            Optional.empty()))
         .thenReturn(Optional.empty());
 
     final ValidatorContractController validatorContractController =

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -188,6 +188,7 @@ public class JsonRpcTestMethodsFactory {
             ethPeers,
             Vertx.vertx(new VertxOptions().setWorkerPoolSize(1)),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
@@ -22,5 +22,6 @@ public enum GraphQLContextType {
   MINING_COORDINATOR,
   SYNCHRONIZER,
   IS_ALIVE_HANDLER,
-  CHAIN_ID
+  CHAIN_ID,
+  GAS_CAP
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
@@ -208,12 +208,11 @@ public class BlockAdapterBase extends AdapterBase {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final ProtocolSchedule protocolSchedule =
         environment.getGraphQlContext().get(GraphQLContextType.PROTOCOL_SCHEDULE);
-    final long bn = header.getNumber();
 
     final TransactionSimulator transactionSimulator =
         new TransactionSimulator(
             query.getBlockchain(), query.getWorldStateArchive(), protocolSchedule);
-
+    final Optional<Long> gasCap = environment.getGraphQlContext().get(GraphQLContextType.GAS_CAP);
     long gasParam = -1;
     Wei gasPriceParam = null;
     Wei valueParam = null;
@@ -256,7 +255,8 @@ public class BlockAdapterBase extends AdapterBase {
                   }
                   return new CallResult(status, result.getGasEstimate(), result.getOutput());
                 }),
-        header);
+        header,
+        gasCap);
   }
 
   Bytes getRawHeader() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
@@ -92,6 +92,7 @@ public class PendingStateAdapter extends AdapterBase {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final ProtocolSchedule protocolSchedule =
         environment.getGraphQlContext().get(GraphQLContextType.PROTOCOL_SCHEDULE);
+    final Optional<Long> gasCap = environment.getGraphQlContext().get(GraphQLContextType.GAS_CAP);
 
     final TransactionSimulator transactionSimulator =
         new TransactionSimulator(
@@ -130,6 +131,7 @@ public class PendingStateAdapter extends AdapterBase {
                   }
                   return new CallResult(status, result.getGasEstimate(), result.getOutput());
                 }),
-        query.getBlockchain().getChainHeadHeader());
+        query.getBlockchain().getChainHeadHeader(),
+        gasCap);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -35,16 +35,19 @@ import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
 import java.util.Optional;
 
 public abstract class AbstractEstimateGas implements JsonRpcMethod {
-
   private static final double SUB_CALL_REMAINING_GAS_RATIO = 65D / 64D;
 
   protected final BlockchainQueries blockchainQueries;
   protected final TransactionSimulator transactionSimulator;
+  protected final Optional<Long> rpcGasCap;
 
   public AbstractEstimateGas(
-      final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
+      final BlockchainQueries blockchainQueries,
+      final TransactionSimulator transactionSimulator,
+      final Optional<Long> rpcGasCap) {
     this.blockchainQueries = blockchainQueries;
     this.transactionSimulator = transactionSimulator;
+    this.rpcGasCap = rpcGasCap;
   }
 
   protected BlockHeader blockHeader() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
@@ -35,7 +35,6 @@ import org.hyperledger.besu.ethereum.mainnet.ImmutableTransactionValidationParam
 import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
-import org.hyperledger.besu.ethereum.transaction.CallParameter;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
@@ -82,12 +81,9 @@ public class EthCall extends AbstractBlockParameterOrBlockHashMethod {
       final JsonRpcRequestContext request, final BlockHeader header) {
     JsonCallParameter callParams = JsonCallParameterUtil.validateAndGetCallParams(request);
 
-    // if gasCap has been set and is lower than the current gasLimit we cap it.
-    final CallParameter modifiedCallParameters = CallParameter.applyGasCap(callParams, rpcGasCap);
-
     return transactionSimulator
         .process(
-            modifiedCallParameters,
+            callParams,
             buildTransactionValidationParams(header, callParams),
             OperationTracer.NO_TRACING,
             (mutableWorldState, transactionSimulatorResult) ->
@@ -107,7 +103,8 @@ public class EthCall extends AbstractBlockParameterOrBlockHashMethod {
                                         request,
                                         JsonRpcErrorConverter.convertTransactionInvalidReason(
                                             reason)))),
-            header)
+            header,
+            rpcGasCap)
         .orElse(errorResponse(request, INTERNAL_ERROR));
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
@@ -40,8 +40,10 @@ import java.util.function.Function;
 public class EthCreateAccessList extends AbstractEstimateGas {
 
   public EthCreateAccessList(
-      final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
-    super(blockchainQueries, transactionSimulator);
+      final BlockchainQueries blockchainQueries,
+      final TransactionSimulator transactionSimulator,
+      final Optional<Long> rpcGasCap) {
+    super(blockchainQueries, transactionSimulator, rpcGasCap);
   }
 
   @Override
@@ -57,6 +59,7 @@ public class EthCreateAccessList extends AbstractEstimateGas {
     if (jsonRpcError.isPresent()) {
       return errorResponse(requestContext, jsonRpcError.get());
     }
+
     final AccessListSimulatorResult maybeResult =
         processTransaction(jsonCallParameter, blockHeader);
     // if the call accessList is different from the simulation result, calculate gas and return
@@ -132,12 +135,12 @@ public class EthCreateAccessList extends AbstractEstimateGas {
         transactionValidationParams(!jsonCallParameter.isMaybeStrict().orElse(Boolean.FALSE));
 
     final CallParameter callParams =
-        overrideGasLimitAndPrice(jsonCallParameter, blockHeader.getGasLimit());
+        overrideGasLimitAndPrice(jsonCallParameter, blockHeader().getGasLimit());
 
     final AccessListOperationTracer tracer = AccessListOperationTracer.create();
     final Optional<TransactionSimulatorResult> result =
         transactionSimulator.process(
-            callParams, transactionValidationParams, tracer, blockHeader.getNumber());
+            callParams, transactionValidationParams, tracer, blockHeader.getNumber(), rpcGasCap);
     return new AccessListSimulatorResult(result, tracer);
   }
 
@@ -154,7 +157,7 @@ public class EthCreateAccessList extends AbstractEstimateGas {
 
     final Optional<TransactionSimulatorResult> result =
         transactionSimulator.process(
-            callParameter, transactionValidationParams, tracer, blockHeader.getNumber());
+            callParameter, transactionValidationParams, tracer, blockHeader.getNumber(), rpcGasCap);
     return new AccessListSimulatorResult(result, tracer);
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -32,19 +32,13 @@ import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
 
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class EthEstimateGas extends AbstractEstimateGas {
-  private static final Logger LOG = LoggerFactory.getLogger(EthEstimateGas.class);
-  private final Optional<Long> rpcGasCap;
 
   public EthEstimateGas(
       final BlockchainQueries blockchainQueries,
       final TransactionSimulator transactionSimulator,
       final Optional<Long> rpcGasCap) {
-    super(blockchainQueries, transactionSimulator);
-    this.rpcGasCap = rpcGasCap;
+    super(blockchainQueries, transactionSimulator, rpcGasCap);
   }
 
   @Override
@@ -66,14 +60,8 @@ public class EthEstimateGas extends AbstractEstimateGas {
       return errorResponse(requestContext, RpcErrorType.WORLD_STATE_UNAVAILABLE);
     }
 
-    // gasLimit == -1 means no gasLimit was specified in the callParams
-    // so we apply the lowest between blockheader gasLimit and gasCap
-    long minGasCap =
-        rpcGasCap
-            .map(gasCap -> Math.min(gasCap, blockHeader.getGasLimit()))
-            .orElseGet(blockHeader::getGasLimit);
-    LOG.info("Capping gas limit to " + minGasCap);
-    final CallParameter modifiedCallParams = overrideGasLimitAndPrice(callParams, minGasCap);
+    final CallParameter modifiedCallParams =
+        overrideGasLimitAndPrice(callParams, blockHeader.getGasLimit());
 
     final boolean isAllowExceedingBalance = !callParams.isMaybeStrict().orElse(Boolean.FALSE);
 
@@ -137,6 +125,7 @@ public class EthEstimateGas extends AbstractEstimateGas {
             .isAllowExceedingBalance(allowExceedingBalance)
             .build(),
         operationTracer,
-        blockHeader.getNumber());
+        blockHeader.getNumber(),
+        rpcGasCap);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
@@ -38,12 +38,15 @@ import org.slf4j.LoggerFactory;
 
 public class TraceCall extends AbstractTraceByBlock implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceCall.class);
+  protected final Optional<Long> rpcGasCap;
 
   public TraceCall(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
-      final TransactionSimulator transactionSimulator) {
+      final TransactionSimulator transactionSimulator,
+      final Optional<Long> rpcGasCap) {
     super(blockchainQueries, protocolSchedule, transactionSimulator);
+    this.rpcGasCap = rpcGasCap;
   }
 
   @Override
@@ -56,6 +59,7 @@ public class TraceCall extends AbstractTraceByBlock implements JsonRpcMethod {
       final JsonRpcRequestContext requestContext, final long blockNumber) {
     final JsonCallParameter callParams =
         JsonCallParameterUtil.validateAndGetCallParams(requestContext);
+
     final TraceTypeParameter traceTypeParameter =
         requestContext.getRequiredParameter(1, TraceTypeParameter.class);
     final String blockNumberString = String.valueOf(blockNumber);
@@ -101,7 +105,8 @@ public class TraceCall extends AbstractTraceByBlock implements JsonRpcMethod {
                       return getTraceCallResult(
                           protocolSchedule, traceTypes, result, transactionTrace, block);
                     }),
-            maybeBlockHeader.get())
+            maybeBlockHeader.get(),
+            rpcGasCap)
         .orElse(new JsonRpcErrorResponse(requestContext.getRequest().getId(), INTERNAL_ERROR));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
@@ -52,8 +52,9 @@ public class TraceCallMany extends TraceCall implements JsonRpcMethod {
   public TraceCallMany(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
-      final TransactionSimulator transactionSimulator) {
-    super(blockchainQueries, protocolSchedule, transactionSimulator);
+      final TransactionSimulator transactionSimulator,
+      final Optional<Long> rpcGasCap) {
+    super(blockchainQueries, protocolSchedule, transactionSimulator, rpcGasCap);
   }
 
   @Override
@@ -154,9 +155,15 @@ public class TraceCallMany extends TraceCall implements JsonRpcMethod {
       final WorldUpdater worldUpdater) {
     final Set<TraceTypeParameter.TraceType> traceTypes = traceTypeParameter.getTraceTypes();
     final DebugOperationTracer tracer = new DebugOperationTracer(buildTraceOptions(traceTypes));
+
     final Optional<TransactionSimulatorResult> maybeSimulatorResult =
         transactionSimulator.processWithWorldUpdater(
-            callParameter, buildTransactionValidationParams(), tracer, header, worldUpdater);
+            callParameter,
+            buildTransactionValidationParams(),
+            tracer,
+            header,
+            worldUpdater,
+            rpcGasCap);
 
     LOG.trace("Executing {} call for transaction {}", traceTypeParameter, callParameter);
     if (maybeSimulatorResult.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceRawTransaction.java
@@ -121,7 +121,8 @@ public class TraceRawTransaction extends AbstractTraceByBlock implements JsonRpc
                       return new JsonRpcSuccessResponse(
                           requestContext.getRequest().getId(), response);
                     }),
-            headBlock)
+            headBlock,
+            Optional.empty())
         .orElse(new JsonRpcErrorResponse(requestContext.getRequest().getId(), INTERNAL_ERROR));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -88,6 +88,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final Set<Capability> supportedCapabilities;
   private final Optional<Long> maxLogRange;
 
+  private final Optional<Long> rpcGasCap;
+
   public EthJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final Synchronizer synchronizer,
@@ -96,7 +98,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
       final TransactionPool transactionPool,
       final MiningCoordinator miningCoordinator,
       final Set<Capability> supportedCapabilities,
-      final Optional<Long> maxLogRange) {
+      final Optional<Long> maxLogRange,
+      final Optional<Long> rpcGasCap) {
     this.blockchainQueries = blockchainQueries;
     this.synchronizer = synchronizer;
     this.protocolSchedule = protocolSchedule;
@@ -105,6 +108,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
     this.miningCoordinator = miningCoordinator;
     this.supportedCapabilities = supportedCapabilities;
     this.maxLogRange = maxLogRange;
+    this.rpcGasCap = rpcGasCap;
   }
 
   @Override
@@ -128,7 +132,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule)),
+                protocolSchedule),
+                rpcGasCap),
         new EthFeeHistory(protocolSchedule, blockchainQueries.getBlockchain()),
         new EthGetCode(blockchainQueries),
         new EthGetLogs(blockchainQueries, maxLogRange),
@@ -157,7 +162,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule)),
+                protocolSchedule),
+                rpcGasCap),
         new EthCreateAccessList(
             blockchainQueries,
             new TransactionSimulator(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -169,7 +169,8 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule)),
+                protocolSchedule),
+            rpcGasCap),
         new EthMining(miningCoordinator),
         new EthCoinbase(miningCoordinator),
         new EthProtocolVersion(supportedCapabilities),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -133,7 +133,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
                 protocolSchedule),
-                rpcGasCap),
+            rpcGasCap),
         new EthFeeHistory(protocolSchedule, blockchainQueries.getBlockchain()),
         new EthGetCode(blockchainQueries),
         new EthGetLogs(blockchainQueries, maxLogRange),
@@ -163,7 +163,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
                 protocolSchedule),
-                rpcGasCap),
+            rpcGasCap),
         new EthCreateAccessList(
             blockchainQueries,
             new TransactionSimulator(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -141,7 +141,7 @@ public class JsonRpcMethodsFactory {
               new PrivxJsonRpcMethods(
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
               new Web3JsonRpcMethods(clientVersion),
-              new TraceJsonRpcMethods(blockchainQueries, protocolSchedule),
+              new TraceJsonRpcMethods(blockchainQueries, protocolSchedule, rpcGasCap),
               new TxPoolJsonRpcMethods(transactionPool),
               new PluginsJsonRpcMethods(namedPlugins));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -80,7 +80,8 @@ public class JsonRpcMethodsFactory {
       final EthPeers ethPeers,
       final Vertx consensusEngineServer,
       final Optional<Long> maxLogRange,
-      final Optional<EnodeDnsConfiguration> enodeDnsConfiguration) {
+      final Optional<EnodeDnsConfiguration> enodeDnsConfiguration,
+      final Optional<Long> rpcGasCap) {
     final Map<String, JsonRpcMethod> enabled = new HashMap<>();
     if (!rpcApis.isEmpty()) {
       final JsonRpcMethod modules = new RpcModules(rpcApis);
@@ -121,7 +122,8 @@ public class JsonRpcMethodsFactory {
                   transactionPool,
                   miningCoordinator,
                   supportedCapabilities,
-                  maxLogRange),
+                  maxLogRange,
+                  rpcGasCap),
               new NetJsonRpcMethods(
                   p2pNetwork,
                   networkId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -31,16 +31,21 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockchainQueries blockchainQueries;
   private final ProtocolSchedule protocolSchedule;
+  private final Optional<Long> rpcGasCap;
 
   TraceJsonRpcMethods(
-      final BlockchainQueries blockchainQueries, final ProtocolSchedule protocolSchedule) {
+      final BlockchainQueries blockchainQueries,
+      final ProtocolSchedule protocolSchedule,
+      final Optional<Long> rpcGasCap) {
     this.blockchainQueries = blockchainQueries;
     this.protocolSchedule = protocolSchedule;
+    this.rpcGasCap = rpcGasCap;
   }
 
   @Override
@@ -65,14 +70,16 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule)),
+                protocolSchedule),
+            rpcGasCap),
         new TraceCallMany(
             blockchainQueries,
             protocolSchedule,
             new TransactionSimulator(
                 blockchainQueries.getBlockchain(),
                 blockchainQueries.getWorldStateArchive(),
-                protocolSchedule)),
+                protocolSchedule),
+            rpcGasCap),
         new TraceRawTransaction(
             protocolSchedule,
             blockchainQueries,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/AbstractEthGraphQLHttpServiceTest.java
@@ -85,7 +85,6 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
     final Synchronizer synchronizerMock = Mockito.mock(Synchronizer.class);
     final SyncStatus status = new DefaultSyncStatus(1, 2, 3, Optional.of(4L), Optional.of(5L));
     when(synchronizerMock.getSyncStatus()).thenReturn(Optional.of(status));
-
     final PoWMiningCoordinator miningCoordinatorMock = Mockito.mock(PoWMiningCoordinator.class);
     when(miningCoordinatorMock.getMinTransactionGasPrice()).thenReturn(Wei.of(16));
 
@@ -146,7 +145,9 @@ public abstract class AbstractEthGraphQLHttpServiceTest {
                 GraphQLContextType.MINING_COORDINATOR,
                 miningCoordinatorMock,
                 GraphQLContextType.SYNCHRONIZER,
-                synchronizerMock),
+                synchronizerMock,
+                GraphQLContextType.GAS_CAP,
+                Optional.empty()),
             Mockito.mock(EthScheduler.class));
     service.start().join();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -192,6 +192,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             mock(EthPeers.class),
             syncVertx,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -68,6 +68,7 @@ import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
 
 public abstract class AbstractJsonRpcHttpServiceTest {
   @TempDir private Path folder;
@@ -91,6 +92,9 @@ public abstract class AbstractJsonRpcHttpServiceTest {
   protected String baseUrl;
   protected final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   protected FilterManager filterManager;
+
+  @SuppressWarnings("unchecked")
+  protected Optional<Long> rpcGasCap = Mockito.mock(Optional.class);
 
   protected void setupBlockchain() {
     blockchainSetupUtil = getBlockchainSetupUtil(DataStorageFormat.FOREST);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
@@ -128,7 +128,8 @@ public class JsonRpcHttpServiceHostAllowlistTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
-                    Optional.empty()));
+                    Optional.empty(),
+                    Optional.of(50_000_000L)));
     service = createJsonRpcHttpService();
     service.start().join();
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -157,6 +157,7 @@ public class JsonRpcHttpServiceLoginTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
     service = createJsonRpcHttpService();
     jwtAuth = service.authenticationService.get().getJwtAuthProvider();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -230,7 +230,8 @@ public class JsonRpcHttpServiceRpcApisTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
-                    Optional.empty()));
+                    Optional.empty(),
+                    Optional.of(50_000_000L)));
     final JsonRpcHttpService jsonRpcHttpService =
         new JsonRpcHttpService(
             vertx,
@@ -339,6 +340,7 @@ public class JsonRpcHttpServiceRpcApisTest {
                     folder,
                     mock(EthPeers.class),
                     vertx,
+                    Optional.empty(),
                     Optional.empty(),
                     Optional.empty()));
     final JsonRpcHttpService jsonRpcHttpService =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
@@ -136,6 +136,7 @@ public class JsonRpcHttpServiceTestBase {
                     ethPeersMock,
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
     service = createJsonRpcHttpService(createLimitedJsonRpcConfig());
     service.start().join();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
@@ -141,6 +141,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
 
     System.setProperty("javax.net.ssl.trustStore", CLIENT_AS_CA_CERT.getKeyStoreFile().toString());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
@@ -130,6 +130,7 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -131,6 +131,7 @@ public class JsonRpcHttpServiceTlsTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
     service = createJsonRpcHttpService(createJsonRpcConfig());
     service.start().join();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -66,10 +66,8 @@ import org.mockito.quality.Strictness;
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class EthCreateAccessListTest {
-
   private final String METHOD = "eth_createAccessList";
   private EthCreateAccessList method;
-
   @Mock private BlockHeader blockHeader;
   @Mock private Blockchain blockchain;
   @Mock private BlockchainQueries blockchainQueries;
@@ -86,7 +84,7 @@ public class EthCreateAccessListTest {
     when(blockHeader.getNumber()).thenReturn(1L);
     when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(true);
 
-    method = new EthCreateAccessList(blockchainQueries, transactionSimulator);
+    method = new EthCreateAccessList(blockchainQueries, transactionSimulator, Optional.empty());
   }
 
   @Test
@@ -181,7 +179,7 @@ public class EthCreateAccessListTest {
     Assertions.assertThat(method.response(request))
         .usingRecursiveComparison()
         .isEqualTo(expectedResponse);
-    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong());
+    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong(), any());
   }
 
   @Test
@@ -202,7 +200,7 @@ public class EthCreateAccessListTest {
     Assertions.assertThat(responseWithMockTracer(request, tracer))
         .usingRecursiveComparison()
         .isEqualTo(expectedResponse);
-    verify(transactionSimulator, times(2)).process(any(), any(), any(), anyLong());
+    verify(transactionSimulator, times(2)).process(any(), any(), any(), anyLong(), any());
   }
 
   @Test
@@ -221,7 +219,7 @@ public class EthCreateAccessListTest {
     Assertions.assertThat(method.response(request))
         .usingRecursiveComparison()
         .isEqualTo(expectedResponse);
-    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong());
+    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong(), any());
   }
 
   @Test
@@ -242,7 +240,7 @@ public class EthCreateAccessListTest {
     Assertions.assertThat(responseWithMockTracer(request, tracer))
         .usingRecursiveComparison()
         .isEqualTo(expectedResponse);
-    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong());
+    verify(transactionSimulator, times(1)).process(any(), any(), any(), anyLong(), any());
   }
 
   @Test
@@ -266,7 +264,7 @@ public class EthCreateAccessListTest {
     Assertions.assertThat(responseWithMockTracer(request, tracer))
         .usingRecursiveComparison()
         .isEqualTo(expectedResponse);
-    verify(transactionSimulator, times(2)).process(any(), any(), any(), anyLong());
+    verify(transactionSimulator, times(2)).process(any(), any(), any(), anyLong(), any());
   }
 
   private JsonRpcResponse responseWithMockTracer(
@@ -288,7 +286,7 @@ public class EthCreateAccessListTest {
   private void mockTransactionSimulatorResult(
       final boolean isSuccessful, final boolean isReverted, final long estimateGas) {
     final TransactionSimulatorResult mockTxSimResult = mock(TransactionSimulatorResult.class);
-    when(transactionSimulator.process(any(), any(), any(), anyLong()))
+    when(transactionSimulator.process(any(), any(), any(), anyLong(), any()))
         .thenReturn(Optional.of(mockTxSimResult));
     final TransactionProcessingResult mockResult = mock(TransactionProcessingResult.class);
     when(mockResult.getEstimateGasUsedByTransaction()).thenReturn(estimateGas);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -72,7 +72,7 @@ public class EthEstimateGasTest {
   @Mock private TransactionSimulator transactionSimulator;
   @Mock private WorldStateArchive worldStateArchive;
 
-  private static final long GASCAP = 500;
+  private static final long GASCAP = 500L;
 
   @BeforeEach
   public void setUp() {
@@ -505,7 +505,7 @@ public class EthEstimateGasTest {
         Wei.ZERO,
         Optional.of(Wei.fromHexString("0x10")),
         Optional.of(Wei.fromHexString("0x10")),
-        Wei.ONE,
+        Wei.ZERO,
         Bytes.EMPTY,
         Optional.empty());
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -192,6 +192,7 @@ public class WebSocketServiceLoginTest {
                     mock(EthPeers.class),
                     vertx,
                     Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()));
 
     websocketMethods.putAll(rpcMethods);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -24,9 +24,13 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // Represents parameters for a eth_call or eth_estimateGas JSON-RPC methods.
 public class CallParameter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CallParameter.class);
 
   private final Address from;
 
@@ -157,5 +161,23 @@ public class CallParameter {
         Wei.fromQuantity(tx.getValue()),
         tx.getPayload(),
         tx.getAccessList());
+  }
+
+  public static CallParameter applyGasCap(
+      final CallParameter callParams, final Optional<Long> gasCap) {
+    if (gasCap.isPresent() && gasCap.get() < callParams.getGasLimit()) {
+      LOG.info("Capping gas limit to " + gasCap.get());
+      return new CallParameter(
+          callParams.getFrom(),
+          callParams.getTo(),
+          gasCap.get(),
+          callParams.getGasPrice(),
+          callParams.getMaxPriorityFeePerGas(),
+          callParams.getMaxFeePerGas(),
+          callParams.getValue(),
+          callParams.getPayload(),
+          callParams.getAccessList());
+    }
+    return callParams;
   }
 }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AbstractNodeSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/AbstractNodeSmartContractPermissioningController.java
@@ -32,6 +32,7 @@ public abstract class AbstractNodeSmartContractPermissioningController
 
   protected final Address contractAddress;
   protected final TransactionSimulator transactionSimulator;
+  protected final Optional<Long> gasCap;
 
   private final Counter checkCounter;
   private final Counter checkCounterPermitted;
@@ -47,9 +48,11 @@ public abstract class AbstractNodeSmartContractPermissioningController
   protected AbstractNodeSmartContractPermissioningController(
       final Address contractAddress,
       final TransactionSimulator transactionSimulator,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final Optional<Long> gasCap) {
     this.contractAddress = contractAddress;
     this.transactionSimulator = transactionSimulator;
+    this.gasCap = gasCap;
 
     this.checkCounter =
         metricsSystem.createCounter(

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodePermissioningControllerFactory.java
@@ -48,7 +48,8 @@ public class NodePermissioningControllerFactory {
       final TransactionSimulator transactionSimulator,
       final MetricsSystem metricsSystem,
       final Blockchain blockchain,
-      final List<NodeConnectionPermissioningProvider> pluginProviders) {
+      final List<NodeConnectionPermissioningProvider> pluginProviders,
+      final Optional<Long> gasCap) {
 
     ArrayList<NodeConnectionPermissioningProvider> providers = Lists.newArrayList(pluginProviders);
 
@@ -75,7 +76,7 @@ public class NodePermissioningControllerFactory {
             .isSmartContractNodeAllowlistEnabled()) {
 
       configureNodePermissioningSmartContractProvider(
-          permissioningConfiguration, transactionSimulator, metricsSystem, providers);
+          permissioningConfiguration, transactionSimulator, metricsSystem, providers, gasCap);
 
       if (fixedNodes.isEmpty()) {
         syncStatusProviderOptional = Optional.empty();
@@ -109,7 +110,8 @@ public class NodePermissioningControllerFactory {
       final PermissioningConfiguration permissioningConfiguration,
       final TransactionSimulator transactionSimulator,
       final MetricsSystem metricsSystem,
-      final List<NodeConnectionPermissioningProvider> providers) {
+      final List<NodeConnectionPermissioningProvider> providers,
+      final Optional<Long> gasCap) {
     final SmartContractPermissioningConfiguration smartContractPermissioningConfig =
         permissioningConfiguration.getSmartContractConfig().get();
     final Address nodePermissioningSmartContractAddress =
@@ -121,14 +123,20 @@ public class NodePermissioningControllerFactory {
         {
           smartContractProvider =
               new NodeSmartContractPermissioningController(
-                  nodePermissioningSmartContractAddress, transactionSimulator, metricsSystem);
+                  nodePermissioningSmartContractAddress,
+                  transactionSimulator,
+                  metricsSystem,
+                  gasCap);
           break;
         }
       case 2:
         {
           smartContractProvider =
               new NodeSmartContractV2PermissioningController(
-                  nodePermissioningSmartContractAddress, transactionSimulator, metricsSystem);
+                  nodePermissioningSmartContractAddress,
+                  transactionSimulator,
+                  metricsSystem,
+                  gasCap);
           break;
         }
       default:

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningController.java
@@ -58,8 +58,9 @@ public class NodeSmartContractPermissioningController
   public NodeSmartContractPermissioningController(
       final Address contractAddress,
       final TransactionSimulator transactionSimulator,
-      final MetricsSystem metricsSystem) {
-    super(contractAddress, transactionSimulator, metricsSystem);
+      final MetricsSystem metricsSystem,
+      final Optional<Long> gasCap) {
+    super(contractAddress, transactionSimulator, metricsSystem, gasCap);
   }
 
   @Override
@@ -68,7 +69,7 @@ public class NodeSmartContractPermissioningController
     final CallParameter callParams = buildCallParameters(payload);
 
     final Optional<TransactionSimulatorResult> result =
-        transactionSimulator.processAtHead(callParams);
+        transactionSimulator.processAtHead(callParams, gasCap);
 
     if (result.isPresent()) {
       switch (result.get().getResult().getStatus()) {

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningController.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import com.google.common.net.InetAddresses;
@@ -51,8 +52,9 @@ public class NodeSmartContractV2PermissioningController
   public NodeSmartContractV2PermissioningController(
       final Address contractAddress,
       final TransactionSimulator transactionSimulator,
-      final MetricsSystem metricsSystem) {
-    super(contractAddress, transactionSimulator, metricsSystem);
+      final MetricsSystem metricsSystem,
+      final Optional<Long> gasCap) {
+    super(contractAddress, transactionSimulator, metricsSystem, gasCap);
   }
 
   @Override
@@ -78,7 +80,7 @@ public class NodeSmartContractV2PermissioningController
   @Nonnull
   private Boolean getCallResult(final EnodeURL enode) {
     return transactionSimulator
-        .processAtHead(buildCallParameters(createPayload(enode)))
+        .processAtHead(buildCallParameters(createPayload(enode)), gasCap)
         .map(this::parseResult)
         .orElse(false);
   }

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningController.java
@@ -48,6 +48,7 @@ public class TransactionSmartContractPermissioningController
 
   private final Address contractAddress;
   private final TransactionSimulator transactionSimulator;
+  private final Optional<Long> gasCap;
 
   // full function signature for connection allowed call
   private static final String FUNCTION_SIGNATURE =
@@ -80,9 +81,11 @@ public class TransactionSmartContractPermissioningController
   public TransactionSmartContractPermissioningController(
       final Address contractAddress,
       final TransactionSimulator transactionSimulator,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final Optional<Long> gasCap) {
     this.contractAddress = contractAddress;
     this.transactionSimulator = transactionSimulator;
+    this.gasCap = gasCap;
 
     this.checkCounter =
         metricsSystem.createCounter(
@@ -131,7 +134,7 @@ public class TransactionSmartContractPermissioningController
     }
 
     final Optional<TransactionSimulatorResult> result =
-        transactionSimulator.processAtHead(callParams);
+        transactionSimulator.processAtHead(callParams, gasCap);
 
     if (result.isPresent()) {
       switch (result.get().getResult().getStatus()) {

--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactory.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactory.java
@@ -43,7 +43,8 @@ public class AccountPermissioningControllerFactory {
   public static Optional<AccountPermissioningController> create(
       final PermissioningConfiguration permissioningConfiguration,
       final TransactionSimulator transactionSimulator,
-      final MetricsSystem metricsSystem) {
+      final MetricsSystem metricsSystem,
+      final Optional<Long> gasCap) {
 
     if (permissioningConfiguration == null) {
       return Optional.empty();
@@ -56,7 +57,7 @@ public class AccountPermissioningControllerFactory {
     final Optional<TransactionSmartContractPermissioningController>
         transactionSmartContractPermissioningController =
             buildSmartContractPermissioningController(
-                permissioningConfiguration, transactionSimulator, metricsSystem);
+                permissioningConfiguration, transactionSimulator, metricsSystem, gasCap);
 
     if (accountLocalConfigPermissioningController.isPresent()
         || transactionSmartContractPermissioningController.isPresent()) {
@@ -76,7 +77,8 @@ public class AccountPermissioningControllerFactory {
       buildSmartContractPermissioningController(
           final PermissioningConfiguration permissioningConfiguration,
           final TransactionSimulator transactionSimulator,
-          final MetricsSystem metricsSystem) {
+          final MetricsSystem metricsSystem,
+          final Optional<Long> gasCap) {
 
     if (permissioningConfiguration.getSmartContractConfig().isPresent()) {
       final SmartContractPermissioningConfiguration smartContractPermissioningConfiguration =
@@ -90,7 +92,7 @@ public class AccountPermissioningControllerFactory {
             transactionSmartContractPermissioningController =
                 Optional.of(
                     new TransactionSmartContractPermissioningController(
-                        accountSmartContractAddress, transactionSimulator, metricsSystem));
+                        accountSmartContractAddress, transactionSimulator, metricsSystem, gasCap));
         validatePermissioningContract(transactionSmartContractPermissioningController.get());
 
         return transactionSmartContractPermissioningController;

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractPermissioningControllerTest.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.Resources;
@@ -91,7 +92,8 @@ public class NodeSmartContractPermissioningControllerTest {
             "Number of times the node smart contract permissioning provider has been checked and returned unpermitted"))
         .thenReturn(checkUnpermittedCounter);
 
-    return new NodeSmartContractPermissioningController(contractAddress, ts, metricsSystem);
+    return new NodeSmartContractPermissioningController(
+        contractAddress, ts, metricsSystem, Optional.empty());
   }
 
   private void verifyCountersUntouched() {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -89,7 +89,8 @@ public class NodeSmartContractV2PermissioningControllerTest {
     final TransactionSimulatorResult txSimulatorResult =
         transactionSimulatorResult(Bytes.random(10), ValidationResult.valid());
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     assertThatIllegalStateException()
@@ -105,7 +106,8 @@ public class NodeSmartContractV2PermissioningControllerTest {
         transactionSimulatorResult(
             NodeSmartContractV2PermissioningController.FALSE_RESPONSE, ValidationResult.valid());
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
@@ -120,7 +122,8 @@ public class NodeSmartContractV2PermissioningControllerTest {
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE,
             ValidationResult.invalid(TransactionInvalidReason.INTERNAL_ERROR));
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
@@ -134,16 +137,18 @@ public class NodeSmartContractV2PermissioningControllerTest {
         transactionSimulatorResult(
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
-    when(transactionSimulator.processAtHead(eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(2)).processAtHead(any());
+    verify(transactionSimulator, times(2)).processAtHead(any(), Optional.empty());
   }
 
   @Test
@@ -152,16 +157,18 @@ public class NodeSmartContractV2PermissioningControllerTest {
         transactionSimulatorResult(
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
-    when(transactionSimulator.processAtHead(eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV6, DESTINATION_ENODE_IPV6);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(2)).processAtHead(any());
+    verify(transactionSimulator, times(2)).processAtHead(any(), Optional.empty());
   }
 
   @Test
@@ -175,24 +182,27 @@ public class NodeSmartContractV2PermissioningControllerTest {
         transactionSimulatorResult(
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
-    when(transactionSimulator.processAtHead(eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResultFalse));
-    when(transactionSimulator.processAtHead(eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResultFalse));
 
     var sourcePayload = sourceEnodeExpectedPayloadDns();
-    when(transactionSimulator.processAtHead(eq(callParams(Bytes.fromHexString(sourcePayload)))))
+    when(transactionSimulator.processAtHead(
+            eq(callParams(Bytes.fromHexString(sourcePayload))), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResultTrue));
     var destinationPayload = destinationEnodeExpectedPayloadDns();
     when(transactionSimulator.processAtHead(
-            eq(callParams(Bytes.fromHexString(destinationPayload)))))
+            eq(callParams(Bytes.fromHexString(destinationPayload))), Optional.empty()))
         .thenReturn(Optional.of(txSimulatorResultTrue));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(4)).processAtHead(any());
+    verify(transactionSimulator, times(4)).processAtHead(any(), Optional.empty());
   }
 
   private CallParameter callParams(final Bytes payload) {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -81,7 +81,7 @@ public class NodeSmartContractV2PermissioningControllerTest {
   public void beforeEach() {
     permissioningController =
         new NodeSmartContractV2PermissioningController(
-            contractAddress, transactionSimulator, metricsSystem);
+            contractAddress, transactionSimulator, metricsSystem, Optional.empty());
   }
 
   @Test

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeSmartContractV2PermissioningControllerTest.java
@@ -90,7 +90,7 @@ public class NodeSmartContractV2PermissioningControllerTest {
         transactionSimulatorResult(Bytes.random(10), ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     assertThatIllegalStateException()
@@ -107,7 +107,7 @@ public class NodeSmartContractV2PermissioningControllerTest {
             NodeSmartContractV2PermissioningController.FALSE_RESPONSE, ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
@@ -123,7 +123,7 @@ public class NodeSmartContractV2PermissioningControllerTest {
             ValidationResult.invalid(TransactionInvalidReason.INTERNAL_ERROR));
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
@@ -138,17 +138,17 @@ public class NodeSmartContractV2PermissioningControllerTest {
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
     when(transactionSimulator.processAtHead(
-            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(2)).processAtHead(any(), Optional.empty());
+    verify(transactionSimulator, times(2)).processAtHead(any(), any());
   }
 
   @Test
@@ -158,17 +158,17 @@ public class NodeSmartContractV2PermissioningControllerTest {
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
     when(transactionSimulator.processAtHead(
-            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResult));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV6, DESTINATION_ENODE_IPV6);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(2)).processAtHead(any(), Optional.empty());
+    verify(transactionSimulator, times(2)).processAtHead(any(), any());
   }
 
   @Test
@@ -183,26 +183,26 @@ public class NodeSmartContractV2PermissioningControllerTest {
             NodeSmartContractV2PermissioningController.TRUE_RESPONSE, ValidationResult.valid());
 
     when(transactionSimulator.processAtHead(
-            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(SOURCE_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResultFalse));
     when(transactionSimulator.processAtHead(
-            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), Optional.empty()))
+            eq(callParams(DESTINATION_ENODE_EXPECTED_PAYLOAD_IP)), any()))
         .thenReturn(Optional.of(txSimulatorResultFalse));
 
     var sourcePayload = sourceEnodeExpectedPayloadDns();
     when(transactionSimulator.processAtHead(
-            eq(callParams(Bytes.fromHexString(sourcePayload))), Optional.empty()))
+            eq(callParams(Bytes.fromHexString(sourcePayload))), any()))
         .thenReturn(Optional.of(txSimulatorResultTrue));
     var destinationPayload = destinationEnodeExpectedPayloadDns();
     when(transactionSimulator.processAtHead(
-            eq(callParams(Bytes.fromHexString(destinationPayload))), Optional.empty()))
+            eq(callParams(Bytes.fromHexString(destinationPayload))), any()))
         .thenReturn(Optional.of(txSimulatorResultTrue));
 
     boolean isPermitted =
         permissioningController.checkSmartContractRules(SOURCE_ENODE_IPV4, DESTINATION_ENODE_IPV4);
     assertThat(isPermitted).isTrue();
 
-    verify(transactionSimulator, times(4)).processAtHead(any(), Optional.empty());
+    verify(transactionSimulator, times(4)).processAtHead(any(), any());
   }
 
   private CallParameter callParams(final Bytes payload) {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
@@ -71,7 +71,7 @@ public class TransactionSmartContractPermissioningControllerTest {
     genesisState.writeStateTo(worldArchive.getMutable());
 
     final TransactionSimulator ts =
-        new TransactionSimulator(blockchain, worldArchive, protocolSchedule);
+        new TransactionSimulator(blockchain, worldArchive, protocolSchedule, rpcGasCap);
     final Address contractAddress = Address.fromHexString(contractAddressString);
 
     when(metricsSystem.createCounter(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/TransactionSmartContractPermissioningControllerTest.java
@@ -41,6 +41,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Optional;
 
 import com.google.common.io.Resources;
 import org.apache.tuweni.bytes.Bytes;
@@ -71,7 +72,7 @@ public class TransactionSmartContractPermissioningControllerTest {
     genesisState.writeStateTo(worldArchive.getMutable());
 
     final TransactionSimulator ts =
-        new TransactionSimulator(blockchain, worldArchive, protocolSchedule, rpcGasCap);
+        new TransactionSimulator(blockchain, worldArchive, protocolSchedule);
     final Address contractAddress = Address.fromHexString(contractAddressString);
 
     when(metricsSystem.createCounter(
@@ -92,7 +93,8 @@ public class TransactionSmartContractPermissioningControllerTest {
             "Number of times the transaction smart contract permissioning provider has been checked and returned unpermitted"))
         .thenReturn(checkUnpermittedCounter);
 
-    return new TransactionSmartContractPermissioningController(contractAddress, ts, metricsSystem);
+    return new TransactionSmartContractPermissioningController(
+        contractAddress, ts, metricsSystem, Optional.empty());
   }
 
   private Transaction transactionForAccount(final Address address) {

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
@@ -128,8 +128,7 @@ public class AccountPermissioningControllerFactoryTest {
     PermissioningConfiguration permissioningConfiguration =
         new PermissioningConfiguration(Optional.empty(), Optional.of(onchainConfig));
 
-    when(transactionSimulator.processAtHead(any(), any()))
-        .thenThrow(new RuntimeException());
+    when(transactionSimulator.processAtHead(any(), any())).thenThrow(new RuntimeException());
 
     final Throwable thrown =
         catchThrowable(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
@@ -128,7 +128,7 @@ public class AccountPermissioningControllerFactoryTest {
     PermissioningConfiguration permissioningConfiguration =
         new PermissioningConfiguration(Optional.empty(), Optional.of(onchainConfig));
 
-    when(transactionSimulator.processAtHead(any(), Optional.empty()))
+    when(transactionSimulator.processAtHead(any(), any()))
         .thenThrow(new RuntimeException());
 
     final Throwable thrown =

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
@@ -127,7 +127,8 @@ public class AccountPermissioningControllerFactoryTest {
     PermissioningConfiguration permissioningConfiguration =
         new PermissioningConfiguration(Optional.empty(), Optional.of(onchainConfig));
 
-    when(transactionSimulator.processAtHead(any())).thenThrow(new RuntimeException());
+    when(transactionSimulator.processAtHead(any(), Optional.empty()))
+        .thenThrow(new RuntimeException());
 
     final Throwable thrown =
         catchThrowable(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/account/AccountPermissioningControllerFactoryTest.java
@@ -49,7 +49,8 @@ public class AccountPermissioningControllerFactoryTest {
   @Test
   public void createWithNullPermissioningConfigShouldReturnEmpty() {
     Optional<AccountPermissioningController> controller =
-        AccountPermissioningControllerFactory.create(null, transactionSimulator, metricsSystem);
+        AccountPermissioningControllerFactory.create(
+            null, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isEmpty();
   }
@@ -64,7 +65,7 @@ public class AccountPermissioningControllerFactoryTest {
 
     Optional<AccountPermissioningController> controller =
         AccountPermissioningControllerFactory.create(
-            permissioningConfiguration, transactionSimulator, metricsSystem);
+            permissioningConfiguration, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isEmpty();
   }
@@ -79,7 +80,7 @@ public class AccountPermissioningControllerFactoryTest {
 
     Optional<AccountPermissioningController> controller =
         AccountPermissioningControllerFactory.create(
-            permissioningConfiguration, transactionSimulator, metricsSystem);
+            permissioningConfiguration, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isNotEmpty();
     assertThat(controller.get().getAccountLocalConfigPermissioningController()).isNotEmpty();
@@ -97,7 +98,7 @@ public class AccountPermissioningControllerFactoryTest {
 
     Optional<AccountPermissioningController> controller =
         AccountPermissioningControllerFactory.create(
-            permissioningConfiguration, transactionSimulator, metricsSystem);
+            permissioningConfiguration, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isEmpty();
   }
@@ -112,7 +113,7 @@ public class AccountPermissioningControllerFactoryTest {
 
     Optional<AccountPermissioningController> controller =
         AccountPermissioningControllerFactory.create(
-            permissioningConfiguration, transactionSimulator, metricsSystem);
+            permissioningConfiguration, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isNotEmpty();
     assertThat(controller.get().getAccountLocalConfigPermissioningController()).isEmpty();
@@ -134,7 +135,10 @@ public class AccountPermissioningControllerFactoryTest {
         catchThrowable(
             () ->
                 AccountPermissioningControllerFactory.create(
-                    permissioningConfiguration, transactionSimulator, metricsSystem));
+                    permissioningConfiguration,
+                    transactionSimulator,
+                    metricsSystem,
+                    Optional.empty()));
 
     assertThat(thrown)
         .isInstanceOf(IllegalStateException.class)
@@ -154,7 +158,7 @@ public class AccountPermissioningControllerFactoryTest {
 
     Optional<AccountPermissioningController> controller =
         AccountPermissioningControllerFactory.create(
-            permissioningConfiguration, transactionSimulator, metricsSystem);
+            permissioningConfiguration, transactionSimulator, metricsSystem, Optional.empty());
 
     Assertions.assertThat(controller).isNotEmpty();
     assertThat(controller.get().getAccountLocalConfigPermissioningController()).isNotEmpty();

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -260,7 +260,8 @@ public class NodePermissioningControllerFactoryTest {
         new PermissioningConfiguration(
             Optional.empty(), Optional.of(smartContractPermissioningConfiguration));
 
-    when(transactionSimulator.processAtHead(any())).thenThrow(new RuntimeException());
+    when(transactionSimulator.processAtHead(any(), Optional.empty()))
+        .thenThrow(new RuntimeException());
 
     final Throwable thrown =
         catchThrowable(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -266,7 +266,7 @@ public class NodePermissioningControllerFactoryTest {
         new PermissioningConfiguration(
             Optional.empty(), Optional.of(smartContractPermissioningConfiguration));
 
-    when(transactionSimulator.processAtHead(any(), Optional.empty()))
+    when(transactionSimulator.processAtHead(any(), any()))
         .thenThrow(new RuntimeException());
 
     final Throwable thrown =

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -266,8 +266,7 @@ public class NodePermissioningControllerFactoryTest {
         new PermissioningConfiguration(
             Optional.empty(), Optional.of(smartContractPermissioningConfiguration));
 
-    when(transactionSimulator.processAtHead(any(), any()))
-        .thenThrow(new RuntimeException());
+    when(transactionSimulator.processAtHead(any(), any())).thenThrow(new RuntimeException());
 
     final Throwable thrown =
         catchThrowable(

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/node/NodePermissioningControllerFactoryTest.java
@@ -81,7 +81,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     List<NodeConnectionPermissioningProvider> providers = controller.getProviders();
     assertThat(providers.size()).isEqualTo(0);
@@ -108,7 +109,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     List<NodeConnectionPermissioningProvider> providers = controller.getProviders();
     assertThat(providers.size()).isEqualTo(1);
@@ -136,7 +138,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     List<NodeConnectionPermissioningProvider> providers = controller.getProviders();
     assertThat(providers.size()).isEqualTo(1);
@@ -172,7 +175,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     List<NodeConnectionPermissioningProvider> providers = controller.getProviders();
     assertThat(providers.size()).isEqualTo(1);
@@ -207,7 +211,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     List<NodeConnectionPermissioningProvider> providers = controller.getProviders();
     assertThat(providers.size()).isEqualTo(2);
@@ -245,7 +250,8 @@ public class NodePermissioningControllerFactoryTest {
             transactionSimulator,
             new NoOpMetricsSystem(),
             blockchain,
-            Collections.emptyList());
+            Collections.emptyList(),
+            Optional.empty());
 
     assertThat(controller.getSyncStatusNodePermissioningProvider()).isPresent();
   }
@@ -275,7 +281,8 @@ public class NodePermissioningControllerFactoryTest {
                         transactionSimulator,
                         new NoOpMetricsSystem(),
                         blockchain,
-                        Collections.emptyList()));
+                        Collections.emptyList(),
+                        Optional.empty()));
 
     assertThat(thrown)
         .isInstanceOf(IllegalStateException.class)

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -198,7 +198,7 @@ tasks.register('validateReferenceTestSubmodule') {
   description = "Checks that the reference tests submodule is not accidentally changed"
   doLast {
     def result = new ByteArrayOutputStream()
-    def expectedHash = '02c1859633abbdf776956136931ea247485c9f90'
+    def expectedHash = '428f218d7d6f4a52544e12684afbfe6e2882ffbf'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
       exec {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR introduces the CLi option`rpc-gas-cap` which allows users to limit the amount of gas used by the  RPC methods `eth_call` and `eth_getEstimateGas`. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #6042 