### PR TITLE
consider peer reputation score when deciding to disconnect

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -391,7 +391,7 @@ public class EthPeers {
             peer -> {
               LOG.atDebug()
                   .setMessage(
-                      "disconnecting peer {}.... Waiting for better peers. Current {} of max {}")
+                      "disconnecting peer {}... Waiting for better peers. Current {} of max {}")
                   .addArgument(peer::getShortNodeId)
                   .addArgument(this::peerCount)
                   .addArgument(this::getMaxPeers)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -197,7 +197,7 @@ public class EthPeers {
         disconnectCallbacks.forEach(callback -> callback.onDisconnect(peer));
         peer.handleDisconnect();
         abortPendingRequestsAssignedToDisconnectedPeers();
-        LOG.debug("Disconnected EthPeer {}", peer.getShortNodeId());
+        LOG.debug("Disconnected EthPeer {}...", peer.getShortNodeId());
         LOG.trace("Disconnected EthPeer {}", peer);
       }
     }
@@ -391,7 +391,7 @@ public class EthPeers {
             peer -> {
               LOG.atDebug()
                   .setMessage(
-                      "disconnecting peer {}. Waiting for better peers. Current {} of max {}")
+                      "disconnecting peer {}.... Waiting for better peers. Current {} of max {}")
                   .addArgument(peer::getShortNodeId)
                   .addArgument(this::peerCount)
                   .addArgument(this::getMaxPeers)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -398,7 +398,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
           "Disconnect - {} - {} - {}... - {} peers left\n{}",
           initiatedByPeer ? "Inbound" : "Outbound",
           reason,
-          connection.getPeer().getId().slice(0, 16),
+          connection.getPeer().getId().slice(0, 8),
           ethPeers.peerCount(),
           ethPeers);
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -37,7 +37,7 @@ public class PeerReputation implements Comparable<PeerReputation> {
   static final int DEFAULT_MAX_SCORE = 200;
   // how much above the initial score you need to be to not get disconnected for timeouts/useless
   // responses
-  static final int HAS_BEEN_USEFUL_SCORE_INCREASE = 10;
+  private final int hasBeenUsefulThreshold;
   static final int DEFAULT_INITIAL_SCORE = 100;
   private static final Logger LOG = LoggerFactory.getLogger(PeerReputation.class);
   private static final int TIMEOUT_THRESHOLD = 5;
@@ -49,8 +49,6 @@ public class PeerReputation implements Comparable<PeerReputation> {
 
   private static final int SMALL_ADJUSTMENT = 1;
   private static final int LARGE_ADJUSTMENT = 5;
-
-  private final int initialScore;
   private int score;
 
   private final int maxScore;
@@ -63,7 +61,7 @@ public class PeerReputation implements Comparable<PeerReputation> {
     checkArgument(
         initialScore <= maxScore, "Initial score must be less than or equal to max score");
     this.maxScore = maxScore;
-    this.initialScore = initialScore;
+    this.hasBeenUsefulThreshold = Math.min(maxScore, initialScore + 10);
     this.score = initialScore;
   }
 
@@ -93,7 +91,7 @@ public class PeerReputation implements Comparable<PeerReputation> {
   }
 
   private boolean peerHasNotBeenUseful() {
-    return score - initialScore < HAS_BEEN_USEFUL_SCORE_INCREASE;
+    return score < hasBeenUsefulThreshold;
   }
 
   public void resetTimeoutCount(final int requestCode) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -34,10 +34,13 @@ import org.slf4j.LoggerFactory;
 public class PeerReputation implements Comparable<PeerReputation> {
   static final long USELESS_RESPONSE_WINDOW_IN_MILLIS =
       TimeUnit.MILLISECONDS.convert(1, TimeUnit.MINUTES);
-  static final int DEFAULT_MAX_SCORE = 150;
+  static final int DEFAULT_MAX_SCORE = 200;
+  // how much above the initial score you need to be to not get disconnected for timeouts/useless
+  // responses
+  static final int HAS_BEEN_USEFUL_SCORE_INCREASE = 10;
   static final int DEFAULT_INITIAL_SCORE = 100;
   private static final Logger LOG = LoggerFactory.getLogger(PeerReputation.class);
-  private static final int TIMEOUT_THRESHOLD = 3;
+  private static final int TIMEOUT_THRESHOLD = 5;
   private static final int USELESS_RESPONSE_THRESHOLD = 5;
 
   private final ConcurrentMap<Integer, AtomicInteger> timeoutCountByRequestType =
@@ -45,8 +48,9 @@ public class PeerReputation implements Comparable<PeerReputation> {
   private final Queue<Long> uselessResponseTimes = new ConcurrentLinkedQueue<>();
 
   private static final int SMALL_ADJUSTMENT = 1;
-  private static final int LARGE_ADJUSTMENT = 10;
+  private static final int LARGE_ADJUSTMENT = 5;
 
+  private final int initialScore;
   private int score;
 
   private final int maxScore;
@@ -59,22 +63,37 @@ public class PeerReputation implements Comparable<PeerReputation> {
     checkArgument(
         initialScore <= maxScore, "Initial score must be less than or equal to max score");
     this.maxScore = maxScore;
+    this.initialScore = initialScore;
     this.score = initialScore;
   }
 
   public Optional<DisconnectReason> recordRequestTimeout(final int requestCode) {
     final int newTimeoutCount = getOrCreateTimeoutCount(requestCode).incrementAndGet();
     if (newTimeoutCount >= TIMEOUT_THRESHOLD) {
-      LOG.debug(
-          "Disconnection triggered by {} repeated timeouts for requestCode {}",
-          newTimeoutCount,
-          requestCode);
       score -= LARGE_ADJUSTMENT;
-      return Optional.of(DisconnectReason.TIMEOUT);
+      // don't trigger disconnect if this peer has a sufficiently high reputation score
+      if (peerHasNotBeenUseful()) {
+        LOG.debug(
+            "Disconnection triggered by {} repeated timeouts for requestCode {}, peer score {}",
+            newTimeoutCount,
+            requestCode,
+            score);
+        return Optional.of(DisconnectReason.TIMEOUT);
+      }
+
+      LOG.trace(
+          "Not triggering disconnect for {} repeated timeouts for requestCode {} because peer has high score {}",
+          newTimeoutCount,
+          requestCode,
+          score);
     } else {
       score -= SMALL_ADJUSTMENT;
-      return Optional.empty();
     }
+    return Optional.empty();
+  }
+
+  private boolean peerHasNotBeenUseful() {
+    return score - initialScore < HAS_BEEN_USEFUL_SCORE_INCREASE;
   }
 
   public void resetTimeoutCount(final int requestCode) {
@@ -96,12 +115,19 @@ public class PeerReputation implements Comparable<PeerReputation> {
     }
     if (uselessResponseTimes.size() >= USELESS_RESPONSE_THRESHOLD) {
       score -= LARGE_ADJUSTMENT;
-      LOG.debug("Disconnection triggered by exceeding useless response threshold");
-      return Optional.of(DisconnectReason.USELESS_PEER);
+      // don't trigger disconnect if this peer has a sufficiently high reputation score
+      if (peerHasNotBeenUseful()) {
+        LOG.debug(
+            "Disconnection triggered by exceeding useless response threshold, score {}", score);
+        return Optional.of(DisconnectReason.USELESS_PEER);
+      }
+      LOG.trace(
+          "Not triggering disconnect for exceeding useless response threshold because peer has high score {}",
+          score);
     } else {
       score -= SMALL_ADJUSTMENT;
-      return Optional.empty();
     }
+    return Optional.empty();
   }
 
   public void recordUsefulResponse() {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
@@ -47,6 +47,8 @@ public class PeerReputationTest {
   public void shouldTrackTimeoutsSeparatelyForDifferentRequestTypes() {
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
 
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputationTest.java
@@ -38,6 +38,8 @@ public class PeerReputationTest {
   public void shouldOnlyDisconnectWhenTimeoutLimitReached() {
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).contains(TIMEOUT);
   }
 
@@ -45,6 +47,9 @@ public class PeerReputationTest {
   public void shouldTrackTimeoutsSeparatelyForDifferentRequestTypes() {
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
+
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
 
@@ -57,6 +62,8 @@ public class PeerReputationTest {
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_HEADERS)).isEmpty();
 
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
+    assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
     assertThat(reputation.recordRequestTimeout(EthPV62.GET_BLOCK_BODIES)).isEmpty();
 


### PR DESCRIPTION
Noticed in peering logs we are disconnecting quite useful peers with timeouts and "useless responses". This exacerbates peering issues because we are quite early to disconnect, whereas if we just wait a bit longer the peer can still be useful. More of an issue in low peer count networks. 
* consider peer reputation score when deciding whether to disconnect peer for repeated timeouts/useless responses
* increase threshold for timeout counts
* decrease score points deducted for timeout/useless response


```
➜  besu grep  "Disconnect - Outbound" besu03.log
2023-11-17 17:47:27.730+10:00 | nioEventLoopGroup-3-5 | DEBUG | EthProtocolManager | Disconnect - Outbound - 0x0b TIMEOUT - 0x45d5... - 5 peers left
2023-11-17 17:49:10.232+10:00 | nioEventLoopGroup-3-1 | DEBUG | EthProtocolManager | Disconnect - Outbound - 0x0b TIMEOUT - 0xcbba... - 4 peers left
2023-11-17 18:02:33.476+10:00 | nioEventLoopGroup-3-8 | DEBUG | EthProtocolManager | Disconnect - Outbound - 0x03 USELESS_PEER - 0x6a7... - 3 peers left
```