### PR TITLE
Update OpenJDK latest Docker image to use Java 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Implement debug_traceCall [#5885](https://github.com/hyperledger/besu/pull/5885)
 - Transactions that takes too long to evaluate, during block creation, are dropped from the txpool [#6163](https://github.com/hyperledger/besu/pull/6163)
 - New option `tx-pool-min-gas-price` to set a lower bound when accepting txs to the pool [#6098](https://github.com/hyperledger/besu/pull/6098)
+- Update OpenJDK latest Docker image to use Java 21 [#6189](https://github.com/hyperledger/besu/pull/6189)
 
 ## 23.10.2
 

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:rolling
 ARG VERSION="dev"
 
 RUN apt-get update && \
- apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless libjemalloc-dev adduser && \
+ apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -1,9 +1,9 @@
 
-FROM ubuntu:22.04
+FROM ubuntu:rolling
 ARG VERSION="dev"
 
 RUN apt-get update && \
- apt-get install --no-install-recommends -q --assume-yes openjdk-19-jre-headless=19* libjemalloc-dev=5.* && \
+ apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless libjemalloc-dev adduser && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
  adduser --disabled-password --gecos "" --home /opt/besu besu && \

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:rolling
+FROM ubuntu:23.10
 ARG VERSION="dev"
 
 RUN apt-get update && \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Switched base image to `ubuntu:rolling`, that follow any stable Ubuntu release, currently 23.10) since OpenJDK Java 21 is not available on latest LTS Ubuntu.