### PR TITLE
Eth peer logging improvements

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -454,7 +454,7 @@ public class EthPeer implements Comparable<EthPeer> {
   }
 
   void handleDisconnect() {
-    LOG.debug("handleDisconnect - EthPeer {}", this);
+    LOG.trace("handleDisconnect - EthPeer {}", this);
 
     requestManagers.forEach(
         (protocolName, map) -> map.forEach((code, requestManager) -> requestManager.close()));

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -257,7 +257,11 @@ public class EthPeer implements Comparable<EthPeer> {
       throws PeerNotConnected {
     if (connectionToUse.getAgreedCapabilities().stream()
         .noneMatch(capability -> capability.getName().equalsIgnoreCase(protocolName))) {
-      LOG.debug("Protocol {} unavailable for this peer {}...", protocolName, this.getShortNodeId());
+      LOG.atDebug()
+          .setMessage("Protocol {} unavailable for this peer {}...")
+          .addArgument(protocolName)
+          .addArgument(this.getShortNodeId())
+          .log();
       return null;
     }
     if (permissioningProviders.stream()

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -257,14 +257,14 @@ public class EthPeer implements Comparable<EthPeer> {
       throws PeerNotConnected {
     if (connectionToUse.getAgreedCapabilities().stream()
         .noneMatch(capability -> capability.getName().equalsIgnoreCase(protocolName))) {
-      LOG.debug("Protocol {} unavailable for this peer {}", protocolName, this.getShortNodeId());
+      LOG.debug("Protocol {} unavailable for this peer {}...", protocolName, this.getShortNodeId());
       return null;
     }
     if (permissioningProviders.stream()
         .anyMatch(
             p -> !p.isMessagePermitted(connectionToUse.getRemoteEnode(), messageData.getCode()))) {
       LOG.info(
-          "Permissioning blocked sending of message code {} to {}",
+          "Permissioning blocked sending of message code {} to {}...",
           messageData.getCode(),
           this.getShortNodeId());
       if (LOG.isDebugEnabled()) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -394,7 +394,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final DisconnectReason reason,
       final boolean initiatedByPeer) {
     if (ethPeers.registerDisconnect(connection)) {
-      LOG.debug(
+      LOG.info(
           "Disconnect - {} - {} - {}... - {} peers left\n{}",
           initiatedByPeer ? "Inbound" : "Outbound",
           reason,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -400,7 +400,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
           reason,
           connection.getPeer().getId().slice(0, 8),
           ethPeers.peerCount());
-      LOG.trace(ethPeers.toString());
+      LOG.atTrace().addArgument(ethPeers).log();
     }
   }
 
@@ -410,9 +410,16 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     peer.getConnection().getPeer().setForkId(forkId);
     try {
       if (!status.networkId().equals(networkId)) {
-        LOG.debug(
-            "Mismatched network id: {}, EthPeer {}...", status.networkId(), peer.getShortNodeId());
-        LOG.trace("Mismatched network id: {}, EthPeer {}", status.networkId(), peer);
+        LOG.atDebug()
+            .setMessage("Mismatched network id: {}, EthPeer {}...")
+            .addArgument(status.networkId())
+            .addArgument(peer.getShortNodeId())
+            .log();
+        LOG.atTrace()
+            .setMessage("Mismatched network id: {}, EthPeer {}")
+            .addArgument(status.networkId())
+            .addArgument(peer)
+            .log();
         peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
       } else if (!forkIdManager.peerCheck(forkId) && status.protocolVersion() > 63) {
         LOG.debug(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -438,7 +438,10 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
         peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
       } else if (mergePeerFilter.isPresent()
           && mergePeerFilter.get().disconnectIfPoW(status, peer)) {
-        LOG.debug("Post-merge disconnect: peer still PoW {}", peer);
+        LOG.atDebug()
+            .setMessage("Post-merge disconnect: peer still PoW {}")
+            .addArgument(peer.getShortNodeId())
+            .log();
         handleDisconnect(peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED, false);
       } else {
         LOG.debug(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -394,12 +394,13 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final DisconnectReason reason,
       final boolean initiatedByPeer) {
     if (ethPeers.registerDisconnect(connection)) {
-      LOG.info(
-          "Disconnect - {} - {} - {}... - {} peers left",
-          initiatedByPeer ? "Inbound" : "Outbound",
-          reason,
-          connection.getPeer().getId().slice(0, 8),
-          ethPeers.peerCount());
+      LOG.atDebug()
+          .setMessage("Disconnect - {} - {} - {}... - {} peers left")
+          .addArgument(initiatedByPeer ? "Inbound" : "Outbound")
+          .addArgument(reason)
+          .addArgument(connection.getPeer().getId().slice(0, 8))
+          .addArgument(ethPeers.peerCount())
+          .log();
       LOG.atTrace().addArgument(ethPeers).log();
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -410,7 +410,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     peer.getConnection().getPeer().setForkId(forkId);
     try {
       if (!status.networkId().equals(networkId)) {
-        LOG.debug("Mismatched network id: {}, EthPeer {}", status.networkId(), peer);
+        LOG.trace("Mismatched network id: {}, EthPeer {}", status.networkId(), peer);
         peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
       } else if (!forkIdManager.peerCheck(forkId) && status.protocolVersion() > 63) {
         LOG.debug(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -395,12 +395,12 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       final boolean initiatedByPeer) {
     if (ethPeers.registerDisconnect(connection)) {
       LOG.info(
-          "Disconnect - {} - {} - {}... - {} peers left\n{}",
+          "Disconnect - {} - {} - {}... - {} peers left",
           initiatedByPeer ? "Inbound" : "Outbound",
           reason,
           connection.getPeer().getId().slice(0, 8),
-          ethPeers.peerCount(),
-          ethPeers);
+          ethPeers.peerCount());
+      LOG.trace(ethPeers.toString());
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -401,7 +401,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
           .addArgument(connection.getPeer().getId().slice(0, 8))
           .addArgument(ethPeers.peerCount())
           .log();
-      LOG.atTrace().addArgument(ethPeers).log();
+      LOG.trace("{}", ethPeers);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -410,6 +410,8 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     peer.getConnection().getPeer().setForkId(forkId);
     try {
       if (!status.networkId().equals(networkId)) {
+        LOG.debug(
+            "Mismatched network id: {}, EthPeer {}...", status.networkId(), peer.getShortNodeId());
         LOG.trace("Mismatched network id: {}, EthPeer {}", status.networkId(), peer);
         peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
       } else if (!forkIdManager.peerCheck(forkId) && status.protocolVersion() > 63) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -125,11 +125,12 @@ public abstract class AbstractGetHeadersFromPeerTask
       updatePeerChainState(peer, header);
     }
 
-    LOG.debug(
-        "Received {} of {} headers requested from peer {}...",
-        headersList.size(),
-        count,
-        peer.getShortNodeId());
+    LOG.atDebug()
+        .setMessage("Received {} of {} headers requested from peer {}...")
+        .addArgument(headersList.size())
+        .addArgument(count)
+        .addArgument(peer.getShortNodeId())
+        .log();
     return Optional.of(headersList);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -126,7 +126,7 @@ public abstract class AbstractGetHeadersFromPeerTask
     }
 
     LOG.debug(
-        "Received {} of {} headers requested from peer {}",
+        "Received {} of {} headers requested from peer {}...",
         headersList.size(),
         count,
         peer.getShortNodeId());
@@ -136,7 +136,7 @@ public abstract class AbstractGetHeadersFromPeerTask
   private void updatePeerChainState(final EthPeer peer, final BlockHeader blockHeader) {
     if (blockHeader.getNumber() > peer.chainState().getEstimatedHeight()) {
       LOG.atTrace()
-          .setMessage("Updating chain state for peer {} to block header {}")
+          .setMessage("Updating chain state for peer {}... to block header {}")
           .addArgument(peer::getShortNodeId)
           .addArgument(blockHeader::toLogString)
           .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
@@ -120,7 +120,7 @@ public class GetHeadersFromPeerByHashTask extends AbstractGetHeadersFromPeerTask
     return sendRequestToPeer(
         peer -> {
           LOG.debug(
-              "Requesting {} headers (hash {}...) from peer {}.",
+              "Requesting {} headers (hash {}...) from peer {}...",
               count,
               referenceHash.slice(0, 6),
               peer.getShortNodeId());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
@@ -119,11 +119,12 @@ public class GetHeadersFromPeerByHashTask extends AbstractGetHeadersFromPeerTask
   protected PendingPeerRequest sendRequest() {
     return sendRequestToPeer(
         peer -> {
-          LOG.debug(
-              "Requesting {} headers (hash {}...) from peer {}...",
-              count,
-              referenceHash.slice(0, 6),
-              peer.getShortNodeId());
+          LOG.atDebug()
+              .setMessage("Requesting {} headers (hash {}...) from peer {}...")
+              .addArgument(count)
+              .addArgument(referenceHash.slice(0, 6))
+              .addArgument(peer.getShortNodeId())
+              .log();
           return peer.getHeadersByHash(referenceHash, count, skip, reverse);
         },
         minimumRequiredBlockNumber);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshState.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/RecursivePeerRefreshState.java
@@ -74,8 +74,10 @@ public class RecursivePeerRefreshState {
   }
 
   void start(final List<DiscoveryPeer> initialPeers, final Bytes target) {
+    // TODO check this flag earlier
     if (iterativeSearchInProgress) {
-      LOG.debug("Skip peer search because previous search is still in progress.");
+      LOG.debug(
+          "Skip peer search because previous search ({}) is still in progress.", currentRound);
       return;
     }
     LOG.debug("Start peer search.");
@@ -93,7 +95,7 @@ public class RecursivePeerRefreshState {
   }
 
   private void addInitialPeers(final List<DiscoveryPeer> initialPeers) {
-    LOG.debug("INITIAL PEERS: {}", initialPeers);
+    LOG.debug("{} INITIAL PEERS: {}", initialPeers.size(), initialPeers);
     this.initialPeers = initialPeers;
     for (final DiscoveryPeer peer : initialPeers) {
       final MetadataPeer iterationParticipant =

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
@@ -84,8 +84,11 @@ public abstract class AbstractPeerConnection implements PeerConnection {
     this.inboundInitiated = inboundInitiated;
     this.initiatedAt = System.currentTimeMillis();
 
-    LOG.debug(
-        "New PeerConnection ({}) established with peer {}...", this, peer.getId().slice(0, 16));
+    LOG.atDebug()
+        .setMessage("New PeerConnection ({}) established with peer {}...")
+        .addArgument(this)
+        .addArgument(peer.getId().slice(0, 16))
+        .log();
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
@@ -84,7 +84,8 @@ public abstract class AbstractPeerConnection implements PeerConnection {
     this.inboundInitiated = inboundInitiated;
     this.initiatedAt = System.currentTimeMillis();
 
-    LOG.debug("New PeerConnection ({}) established with peer {}", this, peer.getId());
+    LOG.debug(
+        "New PeerConnection ({}) established with peer {}...", this, peer.getId().slice(0, 16));
   }
 
   @Override

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/connections/AbstractPeerConnection.java
@@ -168,7 +168,11 @@ public abstract class AbstractPeerConnection implements PeerConnection {
     // Always ensure the context gets closed immediately even if we previously sent a disconnect
     // message and are waiting to close.
     closeConnectionImmediately();
-    LOG.debug("Terminating connection {}, reason {}", this, reason);
+    LOG.atTrace()
+        .setMessage("Terminating connection {}, reason {}")
+        .addArgument(this)
+        .addArgument(reason)
+        .log();
   }
 
   protected abstract void closeConnectionImmediately();
@@ -180,11 +184,12 @@ public abstract class AbstractPeerConnection implements PeerConnection {
     if (disconnected.compareAndSet(false, true)) {
       connectionEventDispatcher.dispatchDisconnect(this, reason, false);
       doSend(null, DisconnectMessage.create(reason));
-      LOG.debug(
-          "Disconnecting connection {}, peer {}... reason {}",
-          System.identityHashCode(this),
-          peer.getId().slice(0, 16),
-          reason);
+      LOG.atDebug()
+          .setMessage("Disconnecting connection {}, peer {}... reason {}")
+          .addArgument(this.hashCode())
+          .addArgument(peer.getId().slice(0, 16))
+          .addArgument(reason)
+          .log();
       closeConnection();
     }
   }


### PR DESCRIPTION
* Moved the full "mismatched network id" message to TRACE and have a brief version at DEBUG
* moved "Disconnect - Outbound" brief message to INFO
* moved the EthPeers {} collection logging to TRACE