### PR TITLE
Fix log index in transaction receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bug fixes
 - Fix Docker image name clash between Besu and evmtool [#6194](https://github.com/hyperledger/besu/pull/6194)
+- Fix `logIndex` in `eth_getTransactionReceipt` JSON RPC method [#6206](https://github.com/hyperledger/besu/pull/6206)
 
 ## 23.10.2
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
@@ -92,7 +92,8 @@ public abstract class TransactionReceiptResult {
             receiptWithMetadata.getBlockNumber(),
             txn.getHash(),
             receiptWithMetadata.getBlockHash(),
-            receiptWithMetadata.getTransactionIndex());
+            receiptWithMetadata.getTransactionIndex(),
+            receiptWithMetadata.getLogIndexOffset());
     this.logsBloom = receipt.getBloomFilter().toString();
     this.to = txn.getTo().map(Bytes::toHexString).orElse(null);
     this.transactionHash = txn.getHash().toString();
@@ -192,14 +193,15 @@ public abstract class TransactionReceiptResult {
       final long blockNumber,
       final Hash transactionHash,
       final Hash blockHash,
-      final int transactionIndex) {
+      final int transactionIndex,
+      final int logIndexOffset) {
     final List<TransactionReceiptLogResult> logResults = new ArrayList<>(logs.size());
 
     for (int i = 0; i < logs.size(); i++) {
       final Log log = logs.get(i);
       logResults.add(
           new TransactionReceiptLogResult(
-              log, blockNumber, transactionHash, blockHash, transactionIndex, i));
+              log, blockNumber, transactionHash, blockHash, transactionIndex, i + logIndexOffset));
     }
 
     return logResults;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -624,17 +624,16 @@ public class BlockchainQueries {
     // getTransactionLocation should not return if the TX or block doesn't exist, so throwing
     // on a missing optional is appropriate.
     final TransactionLocation location = maybeLocation.get();
-    final Block block = blockchain.getBlockByHash(location.getBlockHash()).orElseThrow();
-    final List<Transaction> transactions = block.getBody().getTransactions();
-    final Transaction transaction = transactions.get(location.getTransactionIndex());
-
     final Hash blockhash = location.getBlockHash();
     final int transactionIndex = location.getTransactionIndex();
+
+    final Block block = blockchain.getBlockByHash(blockhash).orElseThrow();
+    final Transaction transaction = block.getBody().getTransactions().get(transactionIndex);
+
     final BlockHeader header = block.getHeader();
     final List<TransactionReceipt> transactionReceipts =
         blockchain.getTxReceipts(blockhash).orElseThrow();
-    final TransactionReceipt transactionReceipt =
-        transactionReceipts.get(location.getTransactionIndex());
+    final TransactionReceipt transactionReceipt = transactionReceipts.get(transactionIndex);
 
     long gasUsed = transactionReceipt.getCumulativeGasUsed();
     int logIndexOffset = 0;
@@ -658,7 +657,7 @@ public class BlockchainQueries {
             transactionReceipt,
             transaction,
             transactionHash,
-            location.getTransactionIndex(),
+            transactionIndex,
             gasUsed,
             header.getBaseFee(),
             blockhash,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -641,7 +641,6 @@ public class BlockchainQueries {
       gasUsed -= transactionReceipts.get(transactionIndex - 1).getCumulativeGasUsed();
       logIndexOffset =
           IntStream.range(0, transactionIndex)
-              .parallel()
               .map(i -> transactionReceipts.get(i).getLogs().size())
               .sum();
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -625,8 +625,8 @@ public class BlockchainQueries {
     // on a missing optional is appropriate.
     final TransactionLocation location = maybeLocation.get();
     final Block block = blockchain.getBlockByHash(location.getBlockHash()).orElseThrow();
-    final Transaction transaction =
-        block.getBody().getTransactions().get(location.getTransactionIndex());
+    final List<Transaction> transactions = block.getBody().getTransactions();
+    final Transaction transaction = transactions.get(location.getTransactionIndex());
 
     final Hash blockhash = location.getBlockHash();
     final BlockHeader header = block.getHeader();
@@ -648,6 +648,8 @@ public class BlockchainQueries {
     Optional<Wei> maybeBlobGasPrice =
         getBlobGasPrice(transaction, header, protocolSchedule.getByBlockHeader(header));
 
+    final int logIndexOffset = logIndexOffset(transactionHash, transactionReceipts, transactions);
+
     return Optional.of(
         TransactionReceiptWithMetadata.create(
             transactionReceipt,
@@ -659,7 +661,8 @@ public class BlockchainQueries {
             blockhash,
             header.getNumber(),
             maybeBlobGasUsed,
-            maybeBlobGasPrice));
+            maybeBlobGasPrice,
+            logIndexOffset));
   }
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -183,8 +183,7 @@ public class BlockchainQueries {
    */
   public Optional<UInt256> storageAt(
       final Address address, final UInt256 storageIndex, final long blockNumber) {
-    final Hash blockHash =
-        getBlockHeaderByNumber(blockNumber).map(BlockHeader::getHash).orElse(Hash.EMPTY);
+    final Hash blockHash = getBlockHashByNumber(blockNumber).orElse(Hash.EMPTY);
 
     return storageAt(address, storageIndex, blockHash);
   }
@@ -211,8 +210,7 @@ public class BlockchainQueries {
    * @return The balance of the account in Wei.
    */
   public Optional<Wei> accountBalance(final Address address, final long blockNumber) {
-    final Hash blockHash =
-        getBlockHeaderByNumber(blockNumber).map(BlockHeader::getHash).orElse(Hash.EMPTY);
+    final Hash blockHash = getBlockHashByNumber(blockNumber).orElse(Hash.EMPTY);
 
     return accountBalance(address, blockHash);
   }
@@ -236,8 +234,7 @@ public class BlockchainQueries {
    * @return The code associated with this address.
    */
   public Optional<Bytes> getCode(final Address address, final long blockNumber) {
-    final Hash blockHash =
-        getBlockHeaderByNumber(blockNumber).map(BlockHeader::getHash).orElse(Hash.EMPTY);
+    final Hash blockHash = getBlockHashByNumber(blockNumber).orElse(Hash.EMPTY);
 
     return getCode(address, blockHash);
   }
@@ -263,13 +260,7 @@ public class BlockchainQueries {
     if (outsideBlockchainRange(blockNumber)) {
       return Optional.empty();
     }
-    return Optional.of(
-        blockchain
-            .getBlockHashByNumber(blockNumber)
-            .flatMap(this::blockByHashWithTxHashes)
-            .map(BlockWithMetadata::getTransactions)
-            .map(List::size)
-            .orElse(-1));
+    return blockchain.getBlockHashByNumber(blockNumber).map(this::getTransactionCount);
   }
 
   /**
@@ -641,7 +632,7 @@ public class BlockchainQueries {
       gasUsed -= transactionReceipts.get(transactionIndex - 1).getCumulativeGasUsed();
       logIndexOffset =
           IntStream.range(0, transactionIndex)
-              .map(i -> transactionReceipts.get(i).getLogs().size())
+              .map(i -> transactionReceipts.get(i).getLogsList().size())
               .sum();
     }
 
@@ -1079,7 +1070,7 @@ public class BlockchainQueries {
         break;
       }
 
-      logIndexOffset += receipts.get(i).getLogs().size();
+      logIndexOffset += receipts.get(i).getLogsList().size();
     }
 
     return logIndexOffset;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -639,7 +639,7 @@ public class BlockchainQueries {
     long gasUsed = transactionReceipt.getCumulativeGasUsed();
     int logIndexOffset = 0;
     if (transactionIndex > 0) {
-      gasUsed = gasUsed - transactionReceipts.get(transactionIndex - 1).getCumulativeGasUsed();
+      gasUsed -= transactionReceipts.get(transactionIndex - 1).getCumulativeGasUsed();
       logIndexOffset =
           IntStream.range(0, transactionIndex)
               .parallel()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionReceiptWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionReceiptWithMetadata.java
@@ -32,6 +32,7 @@ public class TransactionReceiptWithMetadata {
   private final Transaction transaction;
   private final Optional<Long> blobGasUsed;
   private final Optional<Wei> blobGasPrice;
+  private final int logIndexOffset;
 
   private TransactionReceiptWithMetadata(
       final TransactionReceipt receipt,
@@ -43,7 +44,8 @@ public class TransactionReceiptWithMetadata {
       final Hash blockHash,
       final long blockNumber,
       final Optional<Long> blobGasUsed,
-      final Optional<Wei> blobGasPrice) {
+      final Optional<Wei> blobGasPrice,
+      final int logIndexOffset) {
     this.receipt = receipt;
     this.transactionHash = transactionHash;
     this.transactionIndex = transactionIndex;
@@ -54,6 +56,7 @@ public class TransactionReceiptWithMetadata {
     this.transaction = transaction;
     this.blobGasUsed = blobGasUsed;
     this.blobGasPrice = blobGasPrice;
+    this.logIndexOffset = logIndexOffset;
   }
 
   public static TransactionReceiptWithMetadata create(
@@ -66,7 +69,8 @@ public class TransactionReceiptWithMetadata {
       final Hash blockHash,
       final long blockNumber,
       final Optional<Long> blobGasUsed,
-      final Optional<Wei> blobGasPrice) {
+      final Optional<Wei> blobGasPrice,
+      final int logIndexOffset) {
     return new TransactionReceiptWithMetadata(
         receipt,
         transaction,
@@ -77,7 +81,8 @@ public class TransactionReceiptWithMetadata {
         blockHash,
         blockNumber,
         blobGasUsed,
-        blobGasPrice);
+        blobGasPrice,
+        logIndexOffset);
   }
 
   public TransactionReceipt getReceipt() {
@@ -120,5 +125,9 @@ public class TransactionReceiptWithMetadata {
 
   public Optional<Wei> getBlobGasPrice() {
     return blobGasPrice;
+  }
+
+  public int getLogIndexOffset() {
+    return logIndexOffset;
   }
 }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/TransactionDataFetcherTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/TransactionDataFetcherTest.java
@@ -75,7 +75,8 @@ class TransactionDataFetcherTest extends AbstractDataFetcherTest {
             fakedHash,
             1,
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
     when(query.transactionReceiptByTransactionHash(any(), any()))
         .thenReturn(Optional.of(transactionReceiptWithMetadata));
 
@@ -109,7 +110,8 @@ class TransactionDataFetcherTest extends AbstractDataFetcherTest {
             fakedHash,
             1,
             Optional.of(0L),
-            Optional.of(Wei.ZERO));
+            Optional.of(Wei.ZERO),
+            0);
     when(query.transactionReceiptByTransactionHash(any(), any()))
         .thenReturn(Optional.of(transactionReceiptWithMetadata));
 
@@ -143,7 +145,8 @@ class TransactionDataFetcherTest extends AbstractDataFetcherTest {
             fakedHash,
             1,
             Optional.of(blobGasUsed),
-            Optional.of(blobGasPrice));
+            Optional.of(blobGasPrice),
+            0);
     when(query.transactionReceiptByTransactionHash(any(), any()))
         .thenReturn(Optional.of(transactionReceiptWithMetadata));
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -103,7 +103,8 @@ public class EthGetTransactionReceiptTest {
           blockHash,
           4,
           Optional.empty(),
-          Optional.empty());
+          Optional.empty(),
+          0);
   private final TransactionReceiptWithMetadata rootReceiptWithMetaData =
       TransactionReceiptWithMetadata.create(
           rootReceipt,
@@ -115,7 +116,8 @@ public class EthGetTransactionReceiptTest {
           blockHash,
           4,
           Optional.empty(),
-          Optional.empty());
+          Optional.empty(),
+          0);
 
   private final ProtocolSpec rootTransactionTypeSpec =
       new ProtocolSpec(
@@ -243,7 +245,8 @@ public class EthGetTransactionReceiptTest {
             blockHash,
             4,
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
     when(blockchainQueries.transactionReceiptByTransactionHash(receiptHash, protocolSchedule))
         .thenReturn(Optional.of(transactionReceiptWithMetadata));
     when(protocolSchedule.getByBlockHeader(blockHeader(1))).thenReturn(rootTransactionTypeSpec);


### PR DESCRIPTION
## PR description
Assign log index to transaction receipt according to position in block instead of in transaction.

## Fixed Issue(s)
fixes #6204 