### PR TITLE
Unpin ca-certificates-java version

### DIFF
--- a/docker/openjdk-17-debug/Dockerfile
+++ b/docker/openjdk-17-debug/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 
 ARG VERSION="dev"
 RUN apt-get update  && \
- apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909* && \
  apt-get install --no-install-recommends -q --assume-yes curl=7* wget=1.21* jq=1.6* net-tools=1.60* openjdk-17-jdk-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \

--- a/docker/openjdk-17/Dockerfile
+++ b/docker/openjdk-17/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \
- apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909* && \
  apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* libjemalloc-dev=5.* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:22.04
 ARG VERSION="dev"
 
 RUN apt-get update && \
- apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909 && \
+ apt-get install --no-install-recommends -q --assume-yes ca-certificates-java=20190909* && \
  apt-get install --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

CI builds are currently broken because an ubuntu package update breaks with ca-certificates-java version 20190909. If we allow it to use updates to the version (such as 20190909ubuntu1.2) the build un-breaks.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->