### PR TITLE
[MINOR] fix log params for Failed to retrieve chain head

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -456,7 +456,11 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             message.getConnection());
       }
     } catch (final RLPException e) {
-      LOG.debug("Unable to parse status message from peer {}.", peer, e);
+      LOG.atDebug()
+          .setMessage("Unable to parse status message from peer {}... {}")
+          .addArgument(peer::getShortNodeId)
+          .addArgument(e)
+          .log();
       // Parsing errors can happen when clients broadcast network ids outside the int range,
       // So just disconnect with "subprotocol" error rather than "breach of protocol".
       peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/ChainHeadTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/ChainHeadTracker.java
@@ -95,7 +95,11 @@ public class ChainHeadTracker implements ConnectCallback {
                     .addArgument(peer::getShortNodeId)
                     .log();
               } else {
-                LOG.debug("Failed to retrieve chain head info. Disconnecting {}", peer, error);
+                LOG.atDebug()
+                    .setMessage("Failed to retrieve chain head info. Disconnecting {}... {}")
+                    .addArgument(peer::getShortNodeId)
+                    .addArgument(error)
+                    .log();
                 peer.disconnect(DisconnectReason.USELESS_PEER);
               }
             });


### PR DESCRIPTION
We are logging this:
LOG.debug("Failed to retrieve chain head info. Disconnecting {}", peer, error);
Error is not printed 

Also noticed a similar issue in EthProtocolManager

before
```
2023-12-07 09:51:03.857	
2023-12-06 23:51:03.857+00:00 | EthScheduler-Timer-0 | DEBUG | ChainHeadTracker | Failed to retrieve chain head info. Disconnecting PeerId: 0xcbbaacaf47a005cb38... PeerReputation score: 99, timeouts: {3=1}, useless: 0, validated? true, disconnected? false, client: Geth/v1.13.2-stable-dc34fe82/linux-amd64/go1.21.1, [Connection with hashCode 2029564766 inboundInitiated? false initAt 1701906657037],...
```

after

`2023-12-07 13:19:53.174+10:00 | EthScheduler-Timer-0 | DEBUG | ChainHeadTracker | Failed to retrieve chain head info. Disconnecting 0x82b8a8b80c6c37caad... java.util.concurrent.TimeoutException: Timeout after 5000 MILLISECONDS`