### PR TITLE
add extra gradle task dependency to silence warning

### DIFF
--- a/acceptance-tests/tests/build.gradle
+++ b/acceptance-tests/tests/build.gradle
@@ -98,7 +98,7 @@ sourceSets {
   }
 }
 
-processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar')
+processTestResources.dependsOn(':acceptance-tests:test-plugins:testPluginsJar',':acceptance-tests:test-plugins:jar')
 
 task acceptanceTest(type: Test) {
   inputs.property "integration.date", LocalTime.now() // so it runs at every invocation


### PR DESCRIPTION
Seems redundant but it fixes this warning

```
Execution optimizations have been disabled for task ':acceptance-tests:tests:processTestResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/Users/sallymacfarlane/workspace/b2/acceptance-tests/test-plugins/build/libs'. Reason: Task ':acceptance-tests:tests:processTestResources' uses this output of task ':acceptance-tests:test-plugins:jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```