### PR TITLE
ETC mainnet 'Spiral' activation block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Additions and Improvements
 - Add error messages on authentication failures with username and password [#6212](https://github.com/hyperledger/besu/pull/6212)
 - New `Sequenced` transaction pool. The pool is an evolution of the `legacy` pool and is likely to be more suitable to enterprise or permissioned chains than the `layered` transaction pool. Select to use this pool with `--tx-pool=sequenced`. Supports the same options as the `legacy` pool [#6211](https://github.com/hyperledger/besu/issues/6211)
+- Set Ethereum Classic mainnet activation block for Spiral network upgrade [#6267](https://github.com/hyperledger/besu/pull/6267)
 
 ### Bug fixes
 

--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -147,8 +147,9 @@ public class ForkIdsNetworkConfigTest {
                 new ForkId(Bytes.ofUnsignedInt(0x9007bfccL), 11700000L),
                 new ForkId(Bytes.ofUnsignedInt(0xdb63a1caL), 13189133),
                 new ForkId(Bytes.ofUnsignedInt(0x0f6bf187L), 14525000L),
-                new ForkId(Bytes.ofUnsignedInt(0x7fd1bb25L), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0x7fd1bb25L), 0L))
+                new ForkId(Bytes.ofUnsignedInt(0x7fd1bb25L), 19250000L),
+                new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L),
+                new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L))
           });
     }
 

--- a/config/src/main/resources/classic.json
+++ b/config/src/main/resources/classic.json
@@ -13,6 +13,7 @@
     "thanosBlock": 11700000,
     "magnetoBlock": 13189133,
     "mystiqueBlock": 14525000,
+    "spiralBlock": 19250000,
     "ethash": {
 
     },

--- a/config/src/main/resources/classic.json
+++ b/config/src/main/resources/classic.json
@@ -17,6 +17,7 @@
 
     },
     "discovery" : {
+      "dns": "enrtree://AJE62Q4DUX4QMMXEHCSSCSC65TDHZYSMONSD64P3WULVLSF6MRQ3K@all.classic.blockd.info",
       "bootnodes" : [
         "enode://8e73168affd8d445edda09c561d607081ca5d7963317caae2702f701eb6546b06948b7f8687a795de576f6a5f33c44828e25a90aa63de18db380a11e660dd06f@159.203.37.80:30303",
         "enode://2b1ef75e8b7119b6e0294f2e51ead2cf1a5400472452c199e9587727ada99e7e2b1199e36adcad6cbae65dce2410559546e4d83d8c93d45a559e723e56444c03@67.207.93.100:30303",


### PR DESCRIPTION
## PR description
This PR sets ETC Mainnet activation block as defined in [ECIP-1109](https://ecips.ethereumclassic.org/ECIPs/ecip-1109) to `19_250_000`. This change was already merged in core-geth in https://github.com/etclabscore/core-geth/pull/595
I also set the DNS discovery tree to what's in [core-geth#bootnodes_classic.go](https://github.com/etclabscore/core-geth/blob/v1.12.17/params/bootnodes_classic.go#L28)