### PR TITLE
[MINOR] Include Enode URL in error message if parsing exception

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -3246,7 +3246,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   /**
-   * Besu CLI Paramaters exception handler used by VertX. Visible for testing.
+   * Besu CLI Parameters exception handler used by VertX. Visible for testing.
    *
    * @return instance of BesuParameterExceptionHandler
    */

--- a/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/util/LocalPermissioningConfigurationValidatorTest.java
@@ -232,7 +232,6 @@ public class LocalPermissioningConfigurationValidatorTest {
                     true,
                     toml.toAbsolutePath().toString()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(
-            "Invalid IP address (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.");
+        .hasMessageContaining("Invalid IP address");
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/EnodeURLImpl.java
@@ -83,7 +83,9 @@ public class EnodeURLImpl implements EnodeURL {
       String message = "";
       if (enodeDnsConfiguration.dnsEnabled() && !enodeDnsConfiguration.updateEnabled()) {
         message =
-            "Invalid IP address (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.";
+            String.format(
+                "Invalid IP address '%s' (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.",
+                value);
       } else {
         message =
             String.format(

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
@@ -191,7 +191,7 @@ public class ReferenceTestBlockchain implements Blockchain {
   public Comparator<BlockHeader> getBlockChoiceRule() {
     return (a, b) -> {
       throw new NonDeterministicOperationException(
-          "ReferenceTestBlockchian for VMTest Chains do not support fork choice rules");
+          "ReferenceTestBlockchain for VMTest Chains do not support fork choice rules");
     };
   }
 


### PR DESCRIPTION
eg in bootnodes config

Before

2023-12-13 12:08:50.949+10:00 | main | ERROR | Besu | Failed to start Besu Invalid IP address (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.


After

2023-12-13 12:11:14.581+10:00 | main | ERROR | Besu | Failed to start Besu Invalid IP address 'enode://bob@bob:8000' (or DNS query resolved an invalid IP). --Xdns-enabled is true but --Xdns-update-enabled flag is false.
