### PR TITLE
Snap sync client handle empty final account storage ranges

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Hash.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Hash.java
@@ -29,6 +29,9 @@ public class Hash extends DelegatingBytes32 {
   /** The constant ZERO. */
   public static final Hash ZERO = new Hash(Bytes32.ZERO);
 
+  /** Last hash */
+  public static final Hash LAST = new Hash(Bytes32.fromHexString("F".repeat(64)));
+
   /**
    * Hash of an RLP encoded trie hash with no content, or
    * "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
@@ -153,7 +153,7 @@ public class WorldStateProofProvider {
       final SortedMap<Bytes32, Bytes> keys) {
 
     // check if it's monotonic increasing
-    if (!Ordering.natural().isOrdered(keys.keySet())) {
+    if (keys.size() > 1 && !Ordering.natural().isOrdered(keys.keySet())) {
       return false;
     }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/PersistDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/PersistDataStep.java
@@ -56,19 +56,6 @@ public class PersistDataStep {
       final WorldStateStorage.Updater updater = worldStateStorage.updater();
       for (Task<SnapDataRequest> task : tasks) {
         if (task.getData().isResponseReceived()) {
-          // enqueue child requests
-          final Stream<SnapDataRequest> childRequests =
-              task.getData().getChildRequests(downloadState, worldStateStorage, snapSyncState);
-          if (!(task.getData() instanceof TrieNodeHealingRequest)) {
-            enqueueChildren(childRequests);
-          } else {
-            if (!task.getData().isExpired(snapSyncState)) {
-              enqueueChildren(childRequests);
-            } else {
-              continue;
-            }
-          }
-
           // persist nodes
           final int persistedNodes =
               task.getData()
@@ -83,6 +70,19 @@ public class PersistDataStep {
               downloadState.getMetricsManager().notifyTrieNodesHealed(persistedNodes);
             } else {
               downloadState.getMetricsManager().notifyNodesGenerated(persistedNodes);
+            }
+          }
+
+          // enqueue child requests
+          final Stream<SnapDataRequest> childRequests =
+              task.getData().getChildRequests(downloadState, worldStateStorage, snapSyncState);
+          if (!(task.getData() instanceof TrieNodeHealingRequest)) {
+            enqueueChildren(childRequests);
+          } else {
+            if (!task.getData().isExpired(snapSyncState)) {
+              enqueueChildren(childRequests);
+            } else {
+              continue;
             }
           }
         }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManager.java
@@ -38,8 +38,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class RangeManager {
 
   public static final Hash MIN_RANGE = Hash.wrap(Bytes32.ZERO);
-  public static final Hash MAX_RANGE =
-      Hash.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+  public static final Hash MAX_RANGE = Hash.LAST;
 
   private RangeManager() {}
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RangeManager.java
@@ -23,6 +23,7 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
@@ -43,7 +44,7 @@ public class RangeManager {
   private RangeManager() {}
 
   public static int getRangeCount(
-      final Bytes32 min, final Bytes32 max, final TreeMap<Bytes32, Bytes> items) {
+      final Bytes32 min, final Bytes32 max, final NavigableMap<Bytes32, Bytes> items) {
     if (min.equals(MIN_RANGE) && max.equals(MAX_RANGE)) {
       return MAX_RANGE
           .toUnsignedBigInteger()
@@ -120,7 +121,7 @@ public class RangeManager {
   public static Optional<Bytes32> findNewBeginElementInRange(
       final Bytes32 worldstateRootHash,
       final List<Bytes> proofs,
-      final TreeMap<Bytes32, Bytes> receivedKeys,
+      final NavigableMap<Bytes32, Bytes> receivedKeys,
       final Bytes32 endKeyHash) {
     if (receivedKeys.isEmpty() || receivedKeys.lastKey().compareTo(endKeyHash) >= 0) {
       return Optional.empty();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
@@ -143,10 +143,10 @@ public class RequestDataStep {
                   }
                 }
 
-                // if we received no slots, but a proof of exclusion, mark as done:
+                // if we received no slots, but we do get a proof, check the account during heal:
                 else if (response.proofs().size() > 0 && requestTasks.size() > 0) {
                   var lastTask = requestTasks.get(requestTasks.size() - 1);
-                  if (lastTask instanceof StorageRangeDataRequest storageRequest) {
+                  if (lastTask.getData() instanceof StorageRangeDataRequest storageRequest) {
                     storageRequest.addResponse(
                         downloadState,
                         worldStateProofProvider,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
@@ -143,13 +143,12 @@ public class RequestDataStep {
                   }
                 }
 
-                // if we received no slots, but do do get a proof of exclusion, add as a response:
+                // if we received no slots, but do get a proof of exclusion, add as a response:
                 else if (response.proofs().size() > 0 && requestTasks.size() > 0) {
                   requestTasks.stream()
-                      .findFirst()
                       .filter(task -> task instanceof StorageRangeDataRequest)
                       .map(StorageRangeDataRequest.class::cast)
-                      .ifPresent(
+                      .forEach(
                           storageRequest ->
                               storageRequest.addResponse(
                                   downloadState,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/RequestDataStep.java
@@ -143,16 +143,19 @@ public class RequestDataStep {
                   }
                 }
 
-                // if we received no slots, but we do get a proof, check the account during heal:
+                // if we received no slots, but do do get a proof of exclusion, add as a response:
                 else if (response.proofs().size() > 0 && requestTasks.size() > 0) {
-                  var lastTask = requestTasks.get(requestTasks.size() - 1);
-                  if (lastTask.getData() instanceof StorageRangeDataRequest storageRequest) {
-                    storageRequest.addResponse(
-                        downloadState,
-                        worldStateProofProvider,
-                        Collections.emptyNavigableMap(),
-                        response.proofs());
-                  }
+                  requestTasks.stream()
+                      .findFirst()
+                      .filter(task -> task instanceof StorageRangeDataRequest)
+                      .map(StorageRangeDataRequest.class::cast)
+                      .ifPresent(
+                          storageRequest ->
+                              storageRequest.addResponse(
+                                  downloadState,
+                                  worldStateProofProvider,
+                                  Collections.emptyNavigableMap(),
+                                  response.proofs()));
                 }
               }
               return requestTasks;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -72,7 +73,9 @@ public class StackTrie {
   }
 
   public void addElement(
-      final Bytes32 taskIdentifier, final List<Bytes> proofs, final TreeMap<Bytes32, Bytes> keys) {
+      final Bytes32 taskIdentifier,
+      final List<Bytes> proofs,
+      final NavigableMap<Bytes32, Bytes> keys) {
     this.elementsCount.addAndGet(keys.size());
     this.elements.put(
         taskIdentifier, ImmutableTaskElement.builder().proofs(proofs).keys(keys).build());
@@ -180,7 +183,7 @@ public class StackTrie {
     }
 
     @Value.Default
-    public TreeMap<Bytes32, Bytes> keys() {
+    public NavigableMap<Bytes32, Bytes> keys() {
       return new TreeMap<>();
     }
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
@@ -125,7 +125,7 @@ public class StackTrie {
               Function.identity(),
               Function.identity(),
               startKeyHash,
-              keys.lastKey(),
+              keys.size() > 0 ? keys.lastKey() : Hash.LAST,
               true);
 
       final MerkleTrie<Bytes, Bytes> trie =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/StackTrie.java
@@ -125,7 +125,7 @@ public class StackTrie {
               Function.identity(),
               Function.identity(),
               startKeyHash,
-              keys.size() > 0 ? keys.lastKey() : Hash.LAST,
+              keys.size() > 0 ? keys.lastKey() : RangeManager.MAX_RANGE,
               true);
 
       final MerkleTrie<Bytes, Bytes> trie =

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
@@ -167,7 +167,17 @@ public class AccountRangeDataRequest extends SnapDataRequest {
       final SnapSyncProcessState snapSyncState) {
     final List<SnapDataRequest> childRequests = new ArrayList<>();
 
+    if (!isProofValid.orElse(false)) {
+      return Stream.empty();
+    }
+
     final StackTrie.TaskElement taskElement = stackTrie.getElement(startKeyHash);
+
+    // if the proof is valid, but there are no entries, that implies the range is complete
+    if (taskElement.proofs().isEmpty()) {
+      return Stream.empty();
+    }
+
     // new request is added if the response does not match all the requested range
     findNewBeginElementInRange(getRootHash(), taskElement.proofs(), taskElement.keys(), endKeyHash)
         .ifPresentOrElse(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage.Updater;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -212,7 +213,7 @@ public class AccountRangeDataRequest extends SnapDataRequest {
   }
 
   @VisibleForTesting
-  public TreeMap<Bytes32, Bytes> getAccounts() {
+  public NavigableMap<Bytes32, Bytes> getAccounts() {
     return stackTrie.getElement(startKeyHash).keys();
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
@@ -97,6 +97,7 @@ public class StorageRangeDataRequest extends SnapDataRequest {
     final NodeUpdater nodeUpdater =
         (location, hash, value) -> {
           updater.putAccountStorageTrieNode(accountHash, location, hash, value);
+          nbNodesSaved.getAndIncrement();
         };
 
     StackTrie.FlatDatabaseUpdater flatDatabaseUpdater = noop();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
@@ -216,6 +216,11 @@ public class StorageRangeDataRequest extends SnapDataRequest {
     this.isProofValid = Optional.of(isProofValid);
   }
 
+  @VisibleForTesting
+  boolean isProofValid() {
+    return isProofValid.orElse(false);
+  }
+
   public void addStackTrie(final Optional<StackTrie> maybeStackTrie) {
     stackTrie =
         maybeStackTrie

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
@@ -37,8 +37,8 @@ import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage.Updater;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableMap;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -119,7 +119,7 @@ public class StorageRangeDataRequest extends SnapDataRequest {
   public void addResponse(
       final SnapWorldDownloadState downloadState,
       final WorldStateProofProvider worldStateProofProvider,
-      final TreeMap<Bytes32, Bytes> slots,
+      final NavigableMap<Bytes32, Bytes> slots,
       final ArrayDeque<Bytes> proofs) {
     if (!slots.isEmpty() || !proofs.isEmpty()) {
       if (!worldStateProofProvider.isValidRangeProof(
@@ -193,7 +193,7 @@ public class StorageRangeDataRequest extends SnapDataRequest {
     return storageRoot;
   }
 
-  public TreeMap<Bytes32, Bytes> getSlots() {
+  public NavigableMap<Bytes32, Bytes> getSlots() {
     return stackTrie.getElement(startKeyHash).keys();
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequest.java
@@ -164,6 +164,11 @@ public class StorageRangeDataRequest extends SnapDataRequest {
 
     final StackTrie.TaskElement taskElement = stackTrie.getElement(startKeyHash);
 
+    // if the proof is valid, but there are no entries, that implies the range is complete
+    if (taskElement.proofs().isEmpty()) {
+      return Stream.empty();
+    }
+
     findNewBeginElementInRange(storageRoot, taskElement.proofs(), taskElement.keys(), endKeyHash)
         .ifPresent(
             missingRightElement -> {

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/PersistDataStepTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/PersistDataStepTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 public class PersistDataStepTest {
 
   private final WorldStateStorage worldStateStorage =
-      new InMemoryKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.FOREST);
+      new InMemoryKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI);
   private final SnapSyncProcessState snapSyncState = mock(SnapSyncProcessState.class);
   private final SnapWorldDownloadState downloadState = mock(SnapWorldDownloadState.class);
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/TaskGenerator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/TaskGenerator.java
@@ -42,17 +42,26 @@ import org.apache.tuweni.bytes.Bytes32;
 public class TaskGenerator {
 
   public static List<Task<SnapDataRequest>> createAccountRequest(final boolean withData) {
+    return createAccountRequest(1, 1, 100, withData, null, false);
+  }
 
+  static List<Task<SnapDataRequest>> createAccountRequest(
+      final int nbAccounts,
+      final int accountLimit,
+      final int storageLimit,
+      final boolean withData,
+      final SnapWorldDownloadState downloadState,
+      final boolean includeProof) {
     final WorldStateStorage worldStateStorage =
-        new InMemoryKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.FOREST);
+        new InMemoryKeyValueStorageProvider().createWorldStateStorage(DataStorageFormat.BONSAI);
 
     final WorldStateProofProvider worldStateProofProvider =
         new WorldStateProofProvider(worldStateStorage);
 
-    final MerkleTrie<Bytes, Bytes> trie = TrieGenerator.generateTrie(worldStateStorage, 1);
+    final MerkleTrie<Bytes, Bytes> trie = TrieGenerator.generateTrie(worldStateStorage, nbAccounts);
     final RangeStorageEntriesCollector collector =
         RangeStorageEntriesCollector.createCollector(
-            Bytes32.ZERO, RangeManager.MAX_RANGE, 1, Integer.MAX_VALUE);
+            Bytes32.ZERO, RangeManager.MAX_RANGE, accountLimit, Integer.MAX_VALUE);
     final TrieIterator<Bytes> visitor = RangeStorageEntriesCollector.createVisitor(collector);
     final TreeMap<Bytes32, Bytes> accounts =
         (TreeMap<Bytes32, Bytes>)
@@ -81,7 +90,10 @@ public class TaskGenerator {
             rootHash,
             accountHash,
             stateTrieAccountValue.getStorageRoot(),
-            withData);
+            withData,
+            storageLimit,
+            downloadState,
+            includeProof);
     final BytecodeRequest bytecodeRequest =
         createBytecodeDataRequest(
             worldStateStorage,
@@ -102,11 +114,14 @@ public class TaskGenerator {
       final Hash rootHash,
       final Hash accountHash,
       final Bytes32 storageRoot,
-      final boolean withData) {
+      final boolean withData,
+      final int storageLimit,
+      final SnapWorldDownloadState downloadState,
+      final boolean includeProof) {
 
     final RangeStorageEntriesCollector collector =
         RangeStorageEntriesCollector.createCollector(
-            Bytes32.ZERO, RangeManager.MAX_RANGE, 100, Integer.MAX_VALUE);
+            Bytes32.ZERO, RangeManager.MAX_RANGE, storageLimit, Integer.MAX_VALUE);
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
             (location, hash) ->
@@ -128,7 +143,16 @@ public class TaskGenerator {
             rootHash, accountHash, storageRoot, RangeManager.MIN_RANGE, RangeManager.MAX_RANGE);
     if (withData) {
       request.setProofValid(true);
-      request.addResponse(null, worldStateProofProvider, slots, new ArrayDeque<>());
+      ArrayDeque<Bytes> proofNodes = new ArrayDeque<>();
+      if (includeProof) {
+        proofNodes.addAll(
+            worldStateProofProvider.getStorageProofRelatedNodes(
+                storageRoot, accountHash, RangeManager.MIN_RANGE));
+        proofNodes.addAll(
+            worldStateProofProvider.getStorageProofRelatedNodes(
+                storageRoot, accountHash, slots.lastKey()));
+      }
+      request.addResponse(downloadState, worldStateProofProvider, slots, proofNodes);
     }
     return request;
   }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.request;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapWorldDownloadState;
 import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
 
@@ -34,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class StorageRangeDataRequestTest {
 
   @Mock WorldStateStorage storage;
+  @Mock SnapWorldDownloadState downloadState;
   WorldStateProofProvider worldstateProofProvider = new WorldStateProofProvider(storage);
 
   @Test
@@ -47,7 +49,7 @@ public class StorageRangeDataRequestTest {
     proofs.add(0, Hash.EMPTY_TRIE_HASH);
 
     storageRangeRequest.addResponse(
-        null, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
+        downloadState, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
     // valid proof of exclusion received
     assertThat(storageRangeRequest.isProofValid()).isTrue();
     assertThat(storageRangeRequest.isResponseReceived()).isTrue();
@@ -57,15 +59,15 @@ public class StorageRangeDataRequestTest {
   public void assertEmptySlotsWithInvalidProofCompletes() {
     var storageRangeRequest =
         new StorageRangeDataRequest(
-            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.LAST);
+            Hash.ZERO, Bytes32.fromHexString("0x01"), Bytes32.ZERO, Bytes32.ZERO, Hash.LAST);
 
     var proofs = new ArrayDeque<Bytes>();
     proofs.add(0, Hash.ZERO);
 
     storageRangeRequest.addResponse(
-        null, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
-    // TODO: expect invalid proof, but response received:
-    // assertThat(storageRangeRequest.isProofValid()).isFalse();
+        downloadState, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
+    // expect invalid proof, but response received:
+    assertThat(storageRangeRequest.isProofValid()).isFalse();
     assertThat(storageRangeRequest.isResponseReceived()).isTrue();
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -1,0 +1,40 @@
+package org.hyperledger.besu.ethereum.eth.sync.snapsync.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
+
+import java.util.Collections;
+
+import kotlin.collections.ArrayDeque;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StorageRangeDataRequestTest {
+  private static final Hash HASH_LAST = Hash.fromHexString("F".repeat(64));
+
+  @Mock WorldStateStorage storage;
+
+  @Test
+  public void assertEmptySlotsWithProofOfExclusionCompletes() {
+    var worldstateProofProvider = new WorldStateProofProvider(storage);
+
+    var storageRangeRequest =
+        new StorageRangeDataRequest(
+            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, HASH_LAST);
+
+    var proofs = new ArrayDeque<Bytes>();
+    proofs.add(0, Hash.EMPTY_TRIE_HASH);
+
+    storageRangeRequest.addResponse(
+        null, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
+    assertThat(storageRangeRequest.isResponseReceived()).isTrue();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.eth.sync.snapsync.request;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.sync.snapsync.request;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.eth.sync.snapsync.RangeManager;
 import org.hyperledger.besu.ethereum.eth.sync.snapsync.SnapWorldDownloadState;
 import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorage;
@@ -43,7 +44,11 @@ public class StorageRangeDataRequestTest {
 
     var storageRangeRequest =
         new StorageRangeDataRequest(
-            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.LAST);
+            Hash.EMPTY_TRIE_HASH,
+            Bytes32.ZERO,
+            Hash.EMPTY_TRIE_HASH,
+            Bytes32.ZERO,
+            RangeManager.MAX_RANGE);
 
     var proofs = new ArrayDeque<Bytes>();
     proofs.add(0, Hash.EMPTY_TRIE_HASH);
@@ -59,7 +64,11 @@ public class StorageRangeDataRequestTest {
   public void assertEmptySlotsWithInvalidProofCompletes() {
     var storageRangeRequest =
         new StorageRangeDataRequest(
-            Hash.ZERO, Bytes32.fromHexString("0x01"), Bytes32.ZERO, Bytes32.ZERO, Hash.LAST);
+            Hash.ZERO,
+            Bytes32.fromHexString("0x01"),
+            Bytes32.ZERO,
+            Bytes32.ZERO,
+            RangeManager.MAX_RANGE);
 
     var proofs = new ArrayDeque<Bytes>();
     proofs.add(0, Hash.ZERO);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class StorageRangeDataRequestTest {
-  private static final Hash HASH_LAST = Hash.fromHexString("F".repeat(64));
 
   @Mock WorldStateStorage storage;
   WorldStateProofProvider worldstateProofProvider = new WorldStateProofProvider(storage);
@@ -28,7 +27,7 @@ public class StorageRangeDataRequestTest {
 
     var storageRangeRequest =
         new StorageRangeDataRequest(
-            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, HASH_LAST);
+            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.LAST);
 
     var proofs = new ArrayDeque<Bytes>();
     proofs.add(0, Hash.EMPTY_TRIE_HASH);
@@ -44,7 +43,7 @@ public class StorageRangeDataRequestTest {
   public void assertEmptySlotsWithInvalidProofCompletes() {
     var storageRangeRequest =
         new StorageRangeDataRequest(
-            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, HASH_LAST);
+            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.LAST);
 
     var proofs = new ArrayDeque<Bytes>();
     proofs.add(0, Hash.ZERO);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/StorageRangeDataRequestTest.java
@@ -21,10 +21,10 @@ public class StorageRangeDataRequestTest {
   private static final Hash HASH_LAST = Hash.fromHexString("F".repeat(64));
 
   @Mock WorldStateStorage storage;
+  WorldStateProofProvider worldstateProofProvider = new WorldStateProofProvider(storage);
 
   @Test
   public void assertEmptySlotsWithProofOfExclusionCompletes() {
-    var worldstateProofProvider = new WorldStateProofProvider(storage);
 
     var storageRangeRequest =
         new StorageRangeDataRequest(
@@ -35,6 +35,24 @@ public class StorageRangeDataRequestTest {
 
     storageRangeRequest.addResponse(
         null, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
+    // valid proof of exclusion received
+    assertThat(storageRangeRequest.isProofValid()).isTrue();
+    assertThat(storageRangeRequest.isResponseReceived()).isTrue();
+  }
+
+  @Test
+  public void assertEmptySlotsWithInvalidProofCompletes() {
+    var storageRangeRequest =
+        new StorageRangeDataRequest(
+            Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, Hash.EMPTY_TRIE_HASH, Bytes32.ZERO, HASH_LAST);
+
+    var proofs = new ArrayDeque<Bytes>();
+    proofs.add(0, Hash.ZERO);
+
+    storageRangeRequest.addResponse(
+        null, worldstateProofProvider, Collections.emptyNavigableMap(), proofs);
+    // TODO: expect invalid proof, but response received:
+    // assertThat(storageRangeRequest.isProofValid()).isFalse();
     assertThat(storageRangeRequest.isResponseReceived()).isTrue();
   }
 }

--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/InnerNodeDiscoveryManager.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/InnerNodeDiscoveryManager.java
@@ -121,9 +121,9 @@ public class InnerNodeDiscoveryManager<V> extends StoredNodeFactory<V> {
   }
 
   private boolean isInRange(final Bytes location) {
-    return !location.isEmpty()
-        && Arrays.compare(location.toArrayUnsafe(), startKeyHash.toArrayUnsafe()) >= 0
-        && Arrays.compare(location.toArrayUnsafe(), endKeyHash.toArrayUnsafe()) <= 0;
+    return location.isEmpty()
+        || (Arrays.compare(location.toArrayUnsafe(), startKeyHash.toArrayUnsafe()) >= 0
+            && Arrays.compare(location.toArrayUnsafe(), endKeyHash.toArrayUnsafe()) <= 0);
   }
 
   private Bytes createPath(final Bytes bytes) {

--- a/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/InnerNodeDiscoveryManager.java
+++ b/ethereum/trie/src/main/java/org/hyperledger/besu/ethereum/trie/InnerNodeDiscoveryManager.java
@@ -97,7 +97,8 @@ public class InnerNodeDiscoveryManager<V> extends StoredNodeFactory<V> {
       final Supplier<String> errMessage) {
     final LeafNode<V> vLeafNode = super.decodeLeaf(location, path, valueRlp, errMessage);
     final Bytes concatenatePath = Bytes.concatenate(location, path);
-    if (isInRange(concatenatePath.slice(0, concatenatePath.size() - 1))) {
+    if (!concatenatePath.isEmpty()
+        && isInRange(concatenatePath.slice(0, concatenatePath.size() - 1))) {
       innerNodes.add(ImmutableInnerNode.builder().location(location).path(path).build());
     }
     return vLeafNode;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operations/BlockHashOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operations/BlockHashOperationTest.java
@@ -38,8 +38,7 @@ class BlockHashOperationTest {
 
   @Test
   void shouldReturnZeroWhenArgIsBiggerThanALong() {
-    assertBlockHash(
-        Bytes32.fromHexString("F".repeat(64)), Bytes32.ZERO, 100, n -> Hash.EMPTY_LIST_HASH);
+    assertBlockHash(Hash.LAST, Bytes32.ZERO, 100, n -> Hash.EMPTY_LIST_HASH);
   }
 
   @Test


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Bugfix snap sync edge case.  When snap syncing large contract storage, if the final requested range is empty, but there is an accompanying proof of exclusion, besu will not mark the request complete and will endlessly retry.

This PR handles this case by marking the request complete as long as there is an accompanying proof

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->