### PR TITLE
Quick fix to avoid a tight loop when processing added blocks in txpool

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -359,6 +359,13 @@ public class TransactionPool implements BlockAddedObserver {
                       } finally {
                         blockAddedLock.unlock();
                       }
+                    } else {
+                      try {
+                        // wait a bit before retrying
+                        Thread.sleep(100);
+                      } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                      }
                     }
                   }
                   return null;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

When a node is full syncing or backward syncing, it is possible the processing of block added in the txpool, causes a tight loop, with the result of high cpu consumption, that causes the node to basically halt doing other tasks.
This is a quick workaround, while a proper solution, that also avoids to process added blocks during full sync is in progress, and will be ready.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->