### PR TITLE
fix: call OperationTracer.traceEndTx for failing transactions

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -505,9 +505,15 @@ public class MainnetTransactionProcessor {
             gasUsedByTransaction, refundedGas, validationResult, initialFrame.getRevertReason());
       }
     } catch (final MerkleTrieException re) {
+      operationTracer.traceEndTransaction(
+          worldState.updater(), transaction, false, Bytes.EMPTY, List.of(), 0, 0L);
+
       // need to throw to trigger the heal
       throw re;
     } catch (final RuntimeException re) {
+      operationTracer.traceEndTransaction(
+          worldState.updater(), transaction, false, Bytes.EMPTY, List.of(), 0, 0L);
+
       LOG.error("Critical Exception Processing Transaction", re);
       return TransactionProcessingResult.invalid(
           ValidationResult.invalid(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
@@ -163,8 +163,6 @@ class MainnetTransactionProcessorTest {
     Address senderAddress = Address.fromHexString("0x5555555555555555555555555555555555555555");
     Address coinbaseAddress = Address.fromHexString("0x4242424242424242424242424242424242424242");
 
-    when(receiverAccount.getCode()).thenReturn(Bytes.fromHexString("0x600101"));
-
     when(transaction.getTo()).thenReturn(toAddress);
     when(transaction.getHash()).thenReturn(Hash.EMPTY);
     when(transaction.getPayload()).thenReturn(Bytes.EMPTY);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
@@ -195,21 +195,6 @@ class MainnetTransactionProcessorTest {
     assertThat(tracer.traceEndTxCalled).isTrue();
   }
 
-  //  static class MockMessageProcessor extends AbstractMessageProcessor {
-  //
-  //    @Override
-  //    protected void start(final MessageFrame frame, final OperationTracer operationTracer) {}
-  //
-  //    @Override
-  //    protected void codeSuccess(final MessageFrame frame, final OperationTracer operationTracer)
-  // {}
-  //
-  //    @Override
-  //    public void process(final MessageFrame frame, final OperationTracer operationTracer) {
-  //      frame.
-  //    }
-  //  }
-
   static class TraceEndTxTracer implements OperationTracer {
     boolean traceEndTxCalled = false;
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessorTest.java
@@ -169,6 +169,14 @@ class MainnetTransactionProcessorTest {
     when(worldState.get(toAddresss.get())).thenReturn(receiverAccount);
     when(worldState.getAccount(toAddresss.get())).thenReturn(receiverAccount);
     when(worldState.updater()).thenReturn(worldState);
+    doAnswer(
+            invocation -> {
+              MessageFrame messageFrame = invocation.getArgument(0);
+              messageFrame.getMessageFrameStack().pop();
+              return null;
+            })
+        .when(messageCallProcessor)
+        .process(any(), any());
 
     final TraceEndTxTracer tracer = new TraceEndTxTracer();
     var transactionProcessor = createTransactionProcessor(true);
@@ -186,6 +194,21 @@ class MainnetTransactionProcessorTest {
 
     assertThat(tracer.traceEndTxCalled).isTrue();
   }
+
+  //  static class MockMessageProcessor extends AbstractMessageProcessor {
+  //
+  //    @Override
+  //    protected void start(final MessageFrame frame, final OperationTracer operationTracer) {}
+  //
+  //    @Override
+  //    protected void codeSuccess(final MessageFrame frame, final OperationTracer operationTracer)
+  // {}
+  //
+  //    @Override
+  //    public void process(final MessageFrame frame, final OperationTracer operationTracer) {
+  //      frame.
+  //    }
+  //  }
 
   static class TraceEndTxTracer implements OperationTracer {
     boolean traceEndTxCalled = false;


### PR DESCRIPTION
## PR description
Call `OperationTracer.traceEndTx` even when a transaction failed.

## Fixed Issue(s)
fixes #6312 