### PR TITLE
add missing check for static peers to allow them to exceed the connection limit

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -198,7 +198,7 @@ public class EthPeers {
         abortPendingRequestsAssignedToDisconnectedPeers();
         if (peer.getReputation().getScore() > USEFULL_PEER_SCORE_THRESHOLD) {
           LOG.debug("Disonnected USEFULL peer {}", peer);
-        } else if (!LOG.isTraceEnabled()) {
+        } else {
           LOG.debug("Disconnected EthPeer {}", peer.getShortNodeId());
         }
       }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -66,6 +66,7 @@ public class EthPeers {
       Comparator.comparing(EthPeer::outstandingRequests)
           .thenComparing(EthPeer::getLastRequestTimestamp);
   public static final int NODE_ID_LENGTH = 64;
+  public static final int USEFULL_PEER_SCORE_THRESHOLD = 102;
 
   private final Map<Bytes, EthPeer> completeConnections = new ConcurrentHashMap<>();
 
@@ -195,7 +196,7 @@ public class EthPeers {
         disconnectCallbacks.forEach(callback -> callback.onDisconnect(peer));
         peer.handleDisconnect();
         abortPendingRequestsAssignedToDisconnectedPeers();
-        if (peer.getReputation().getScore() > 102) {
+        if (peer.getReputation().getScore() > USEFULL_PEER_SCORE_THRESHOLD) {
           LOG.debug("Disonnected USEFULL peer {}", peer);
         } else if (!LOG.isTraceEnabled()) {
           LOG.debug("Disconnected EthPeer {}", peer.getShortNodeId());
@@ -223,10 +224,6 @@ public class EthPeers {
   public EthPeer peer(final PeerConnection connection) {
     final EthPeer ethPeer = incompleteConnections.getIfPresent(connection);
     return ethPeer != null ? ethPeer : completeConnections.get(connection.getPeer().getId());
-  }
-
-  public EthPeer peer(final Bytes peerId) {
-    return completeConnections.get(peerId);
   }
 
   public PendingPeerRequest executePeerRequest(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractRetryingSwitchingPeerTask.java
@@ -140,7 +140,7 @@ public abstract class AbstractRetryingSwitchingPeerTask<T> extends AbstractRetry
       failedPeers.stream()
           .filter(peer -> !peer.isDisconnected())
           .findAny()
-          .or(() -> peers.streamAvailablePeers().sorted(peers.getBestChainComparator()).findFirst())
+          .or(() -> peers.streamAvailablePeers().min(peers.getBestChainComparator()))
           .ifPresent(
               peer -> {
                 LOG.atDebug()

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/peervalidation/AbstractPeerBlockValidatorTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractPeerBlockValidatorTest {
 
     final PeerValidator validator = createValidator(blockNumber, 0);
 
-    final int peerCount = 1000;
+    final int peerCount = 24;
     final List<RespondingEthPeer> otherPeers =
         Stream.generate(
                 () -> EthProtocolManagerTestUtil.createPeer(ethProtocolManager, blockNumber))

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/DefaultPeerPrivileges.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.p2p.peers;
 
+import org.apache.tuweni.bytes.Bytes;
+
 public class DefaultPeerPrivileges implements PeerPrivileges {
   private final MaintainedPeers maintainedPeers;
 
@@ -22,7 +24,7 @@ public class DefaultPeerPrivileges implements PeerPrivileges {
   }
 
   @Override
-  public boolean canExceedConnectionLimits(final Peer peer) {
-    return maintainedPeers.contains(peer);
+  public boolean canExceedConnectionLimits(final Bytes peerId) {
+    return maintainedPeers.streamPeers().anyMatch(p -> p.getId().equals(peerId));
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/PeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/PeerPrivileges.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.p2p.peers;
 
+import org.apache.tuweni.bytes.Bytes;
+
 public interface PeerPrivileges {
 
   /**
@@ -23,5 +25,5 @@ public interface PeerPrivileges {
    * @param peer The peer to be checked.
    * @return {@code true} if the peer should be allowed to connect regardless of connection limits.
    */
-  boolean canExceedConnectionLimits(final Peer peer);
+  boolean canExceedConnectionLimits(final Bytes peerId);
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/PeerPrivileges.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/peers/PeerPrivileges.java
@@ -22,7 +22,7 @@ public interface PeerPrivileges {
    * If true, the given peer can connect or remain connected even if the max connection limit or the
    * maximum remote connection limit has been reached or exceeded.
    *
-   * @param peer The peer to be checked.
+   * @param peerId The peer id to be checked.
    * @return {@code true} if the peer should be allowed to connect regardless of connection limits.
    */
   boolean canExceedConnectionLimits(final Bytes peerId);

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/RlpxAgent.java
@@ -310,8 +310,8 @@ public class RlpxAgent {
             });
   }
 
-  public boolean canExceedConnectionLimits(final Peer peer) {
-    return peerPrivileges.canExceedConnectionLimits(peer);
+  public boolean canExceedConnectionLimits(final Bytes peerId) {
+    return peerPrivileges.canExceedConnectionLimits(peerId);
   }
 
   private void handleIncomingConnection(final PeerConnection peerConnection) {


### PR DESCRIPTION
## PR description
In one place there was a check missing to allow static peers to exceed the connection limit.
Another improvement is that streamBestPeers() does only return fully validated peers.