### PR TITLE
Cancun forkids for non-mainnets

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1795,7 +1795,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       if (kzgTrustedSetupFile != null) {
         KZGPointEvalPrecompiledContract.init(kzgTrustedSetupFile);
       } else {
-        KZGPointEvalPrecompiledContract.init(network.name());
+        KZGPointEvalPrecompiledContract.init();
       }
     } else if (kzgTrustedSetupFile != null) {
       throw new ParameterException(

--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -45,183 +45,173 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.Streams;
 import org.apache.tuweni.bytes.Bytes;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-@RunWith(Enclosed.class)
+@RunWith(Parameterized.class)
 public class ForkIdsNetworkConfigTest {
 
-  public static class NotParameterized {
-    @Test
-    public void testFromRaw() {
-      final ForkId forkId = new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L);
-      final List<List<Bytes>> forkIdAsBytesList = List.of(forkId.getForkIdAsBytesList());
-      assertThat(ForkId.fromRawForkId(forkIdAsBytesList).get()).isEqualTo(forkId);
-    }
+  @Parameterized.Parameter public NetworkName chainName;
+
+  @Parameterized.Parameter(1)
+  public List<ForkId> expectedForkIds;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> parameters() {
+    return List.of(
+        new Object[] {
+          NetworkName.SEPOLIA,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L),
+              new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 1677557088L),
+              new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 1706655072L),
+              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 0L))
+        },
+        new Object[] {
+          NetworkName.HOLESKY,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0xc61a6098L), 1696000704L),
+              new ForkId(Bytes.ofUnsignedInt(0xfd4f016bL), 1707305664L),
+              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 0L))
+        },
+        new Object[] {
+          NetworkName.GOERLI,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0xa3f5ab08L), 1561651L),
+              new ForkId(Bytes.ofUnsignedInt(0xc25efa5cL), 4460644L),
+              new ForkId(Bytes.ofUnsignedInt(0x757a1c47L), 5062605L),
+              new ForkId(Bytes.ofUnsignedInt(0xb8c6299dL), 1678832736L),
+              new ForkId(Bytes.ofUnsignedInt(0xf9843abfL), 1705473120),
+              new ForkId(Bytes.ofUnsignedInt(0x70cc14e2L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0x70cc14e2L), 0L))
+        },
+        new Object[] {
+          NetworkName.MAINNET,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0xfc64ec04L), 1150000L),
+              new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 1920000L),
+              new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
+              new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
+              new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
+              new ForkId(Bytes.ofUnsignedInt(0x7a64da13L), 2675000L),
+              new ForkId(Bytes.ofUnsignedInt(0x3edd5b10L), 4370000L),
+              new ForkId(Bytes.ofUnsignedInt(0xa00bc324L), 7280000L),
+              new ForkId(Bytes.ofUnsignedInt(0x668db0afL), 9069000L),
+              new ForkId(Bytes.ofUnsignedInt(0x879d6e30L), 9200000L),
+              new ForkId(Bytes.ofUnsignedInt(0xe029e991L), 12244000L),
+              new ForkId(Bytes.ofUnsignedInt(0xeb440f6L), 12965000L),
+              new ForkId(Bytes.ofUnsignedInt(0xb715077dL), 13773000L),
+              new ForkId(Bytes.ofUnsignedInt(0x20c327fcL), 15050000L),
+              new ForkId(Bytes.ofUnsignedInt(0xf0afd0e3L), 1681338455L),
+              new ForkId(Bytes.ofUnsignedInt(0xdce96c2dL), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0xdce96c2dL), 0L))
+        },
+        new Object[] {
+          NetworkName.MORDOR,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0x175782aaL), 301243L),
+              new ForkId(Bytes.ofUnsignedInt(0x604f6ee1L), 999983L),
+              new ForkId(Bytes.ofUnsignedInt(0xf42f5539L), 2520000L),
+              new ForkId(Bytes.ofUnsignedInt(0x66b5c286L), 3985893),
+              new ForkId(Bytes.ofUnsignedInt(0x92b323e0L), 5520000L),
+              new ForkId(Bytes.ofUnsignedInt(0x8c9b1797L), 9957000L),
+              new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L))
+        },
+        new Object[] {
+          NetworkName.CLASSIC,
+          List.of(
+              new ForkId(Bytes.ofUnsignedInt(0xfc64ec04L), 1150000L),
+              new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
+              new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
+              new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
+              new ForkId(Bytes.ofUnsignedInt(0xdb06803fL), 3000000L),
+              new ForkId(Bytes.ofUnsignedInt(0xaff4bed4L), 5000000L),
+              new ForkId(Bytes.ofUnsignedInt(0xf79a63c0L), 5900000L),
+              new ForkId(Bytes.ofUnsignedInt(0x744899d6L), 8772000L),
+              new ForkId(Bytes.ofUnsignedInt(0x518b59c6L), 9573000L),
+              new ForkId(Bytes.ofUnsignedInt(0x7ba22882L), 10500839L),
+              new ForkId(Bytes.ofUnsignedInt(0x9007bfccL), 11700000L),
+              new ForkId(Bytes.ofUnsignedInt(0xdb63a1caL), 13189133),
+              new ForkId(Bytes.ofUnsignedInt(0x0f6bf187L), 14525000L),
+              new ForkId(Bytes.ofUnsignedInt(0x7fd1bb25L), 19250000L),
+              new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L))
+        });
   }
 
-  @RunWith(Parameterized.class)
-  public static class ParametrizedForkIdTest {
+  @ParameterizedTest
+  @MethodSource("parameters")
+  public void testForkId(final NetworkName chainName, final List<ForkId> expectedForkIds) {
+    final GenesisConfigFile genesisConfigFile =
+        GenesisConfigFile.fromConfig(EthNetworkConfig.jsonConfig(chainName));
+    final MilestoneStreamingTransitionProtocolSchedule schedule = createSchedule(genesisConfigFile);
+    final GenesisState genesisState = GenesisState.fromConfig(genesisConfigFile, schedule);
+    final Blockchain mockBlockchain = mock(Blockchain.class);
+    final BlockHeader mockBlockHeader = mock(BlockHeader.class);
 
-    @Parameterized.Parameter public NetworkName chainName;
+    when(mockBlockchain.getGenesisBlock()).thenReturn(genesisState.getBlock());
 
-    @Parameterized.Parameter(1)
-    public List<ForkId> expectedForkIds;
+    final AtomicLong blockNumber = new AtomicLong();
+    when(mockBlockchain.getChainHeadHeader()).thenReturn(mockBlockHeader);
+    when(mockBlockHeader.getNumber()).thenAnswer(o -> blockNumber.get());
+    when(mockBlockHeader.getTimestamp()).thenAnswer(o -> blockNumber.get());
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> parameters() {
-      return List.of(
-          new Object[] {
-            NetworkName.SEPOLIA,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L),
-                new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 1677557088L),
-                new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 0L))
-          },
-          new Object[] {
-            NetworkName.HOLESKY,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0xc61a6098L), 1696000704L),
-                new ForkId(Bytes.ofUnsignedInt(0xfd4f016bL), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xfd4f016bL), 0L))
-          },
-          new Object[] {
-            NetworkName.GOERLI,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0xa3f5ab08L), 1561651L),
-                new ForkId(Bytes.ofUnsignedInt(0xc25efa5cL), 4460644L),
-                new ForkId(Bytes.ofUnsignedInt(0x757a1c47L), 5062605L),
-                new ForkId(Bytes.ofUnsignedInt(0xb8c6299dL), 1678832736L),
-                new ForkId(Bytes.ofUnsignedInt(0xf9843abfL), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xf9843abfL), 0L))
-          },
-          new Object[] {
-            NetworkName.MAINNET,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0xfc64ec04L), 1150000L),
-                new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 1920000L),
-                new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
-                new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
-                new ForkId(Bytes.ofUnsignedInt(0x91d1f948L), 2463000L),
-                new ForkId(Bytes.ofUnsignedInt(0x7a64da13L), 2675000L),
-                new ForkId(Bytes.ofUnsignedInt(0x3edd5b10L), 4370000L),
-                new ForkId(Bytes.ofUnsignedInt(0xa00bc324L), 7280000L),
-                new ForkId(Bytes.ofUnsignedInt(0x668db0afL), 9069000L),
-                new ForkId(Bytes.ofUnsignedInt(0x879d6e30L), 9200000L),
-                new ForkId(Bytes.ofUnsignedInt(0xe029e991L), 12244000L),
-                new ForkId(Bytes.ofUnsignedInt(0xeb440f6L), 12965000L),
-                new ForkId(Bytes.ofUnsignedInt(0xb715077dL), 13773000L),
-                new ForkId(Bytes.ofUnsignedInt(0x20c327fcL), 15050000L),
-                new ForkId(Bytes.ofUnsignedInt(0xf0afd0e3L), 1681338455L),
-                new ForkId(Bytes.ofUnsignedInt(0xdce96c2dL), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xdce96c2dL), 0L))
-          },
-          new Object[] {
-            NetworkName.MORDOR,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0x175782aaL), 301243L),
-                new ForkId(Bytes.ofUnsignedInt(0x604f6ee1L), 999983L),
-                new ForkId(Bytes.ofUnsignedInt(0xf42f5539L), 2520000L),
-                new ForkId(Bytes.ofUnsignedInt(0x66b5c286L), 3985893),
-                new ForkId(Bytes.ofUnsignedInt(0x92b323e0L), 5520000L),
-                new ForkId(Bytes.ofUnsignedInt(0x8c9b1797L), 9957000L),
-                new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0x3a6b00d7L), 0L))
-          },
-          new Object[] {
-            NetworkName.CLASSIC,
-            List.of(
-                new ForkId(Bytes.ofUnsignedInt(0xfc64ec04L), 1150000L),
-                new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
-                new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
-                new ForkId(Bytes.ofUnsignedInt(0x97c2c34cL), 2500000L),
-                new ForkId(Bytes.ofUnsignedInt(0xdb06803fL), 3000000L),
-                new ForkId(Bytes.ofUnsignedInt(0xaff4bed4L), 5000000L),
-                new ForkId(Bytes.ofUnsignedInt(0xf79a63c0L), 5900000L),
-                new ForkId(Bytes.ofUnsignedInt(0x744899d6L), 8772000L),
-                new ForkId(Bytes.ofUnsignedInt(0x518b59c6L), 9573000L),
-                new ForkId(Bytes.ofUnsignedInt(0x7ba22882L), 10500839L),
-                new ForkId(Bytes.ofUnsignedInt(0x9007bfccL), 11700000L),
-                new ForkId(Bytes.ofUnsignedInt(0xdb63a1caL), 13189133),
-                new ForkId(Bytes.ofUnsignedInt(0x0f6bf187L), 14525000L),
-                new ForkId(Bytes.ofUnsignedInt(0x7fd1bb25L), 19250000L),
-                new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L),
-                new ForkId(Bytes.ofUnsignedInt(0xbe46d57cL), 0L))
-          });
+    final ForkIdManager forkIdManager =
+        new ForkIdManager(
+            mockBlockchain,
+            genesisConfigFile.getForkBlockNumbers(),
+            genesisConfigFile.getForkTimestamps(),
+            false);
+
+    final List<ForkId> actualForkIds =
+        Streams.concat(schedule.streamMilestoneBlocks(), Stream.of(Long.MAX_VALUE))
+            .map(
+                block -> {
+                  blockNumber.set(block);
+                  return forkIdManager.getForkIdForChainHead();
+                })
+            .collect(Collectors.toList());
+
+    assertThat(actualForkIds).containsExactlyElementsOf(expectedForkIds);
+  }
+
+  private static MilestoneStreamingTransitionProtocolSchedule createSchedule(
+      final GenesisConfigFile genesisConfigFile) {
+    final GenesisConfigOptions configOptions = genesisConfigFile.getConfigOptions();
+    MilestoneStreamingProtocolSchedule preMergeProtocolSchedule =
+        new MilestoneStreamingProtocolSchedule(
+            (DefaultProtocolSchedule) MainnetProtocolSchedule.fromConfig(configOptions));
+    MilestoneStreamingProtocolSchedule postMergeProtocolSchedule =
+        new MilestoneStreamingProtocolSchedule(
+            (DefaultProtocolSchedule) MergeProtocolSchedule.create(configOptions, false));
+    final MilestoneStreamingTransitionProtocolSchedule schedule =
+        new MilestoneStreamingTransitionProtocolSchedule(
+            preMergeProtocolSchedule, postMergeProtocolSchedule);
+    return schedule;
+  }
+
+  public static class MilestoneStreamingTransitionProtocolSchedule
+      extends TransitionProtocolSchedule {
+
+    private final TransitionUtils<MilestoneStreamingProtocolSchedule> transitionUtils;
+
+    public MilestoneStreamingTransitionProtocolSchedule(
+        final MilestoneStreamingProtocolSchedule preMergeProtocolSchedule,
+        final MilestoneStreamingProtocolSchedule postMergeProtocolSchedule) {
+      super(preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
+      transitionUtils =
+          new TransitionUtils<>(
+              preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
     }
 
-    @Test
-    public void testForkId() {
-      final GenesisConfigFile genesisConfigFile =
-          GenesisConfigFile.fromConfig(EthNetworkConfig.jsonConfig(chainName));
-      final MilestoneStreamingTransitionProtocolSchedule schedule =
-          createSchedule(genesisConfigFile);
-      final GenesisState genesisState = GenesisState.fromConfig(genesisConfigFile, schedule);
-      final Blockchain mockBlockchain = mock(Blockchain.class);
-      final BlockHeader mockBlockHeader = mock(BlockHeader.class);
-
-      when(mockBlockchain.getGenesisBlock()).thenReturn(genesisState.getBlock());
-
-      final AtomicLong blockNumber = new AtomicLong();
-      when(mockBlockchain.getChainHeadHeader()).thenReturn(mockBlockHeader);
-      when(mockBlockHeader.getNumber()).thenAnswer(o -> blockNumber.get());
-      when(mockBlockHeader.getTimestamp()).thenAnswer(o -> blockNumber.get());
-
-      final ForkIdManager forkIdManager =
-          new ForkIdManager(
-              mockBlockchain,
-              genesisConfigFile.getForkBlockNumbers(),
-              genesisConfigFile.getForkTimestamps(),
-              false);
-
-      final List<ForkId> actualForkIds =
-          Streams.concat(schedule.streamMilestoneBlocks(), Stream.of(Long.MAX_VALUE))
-              .map(
-                  block -> {
-                    blockNumber.set(block);
-                    return forkIdManager.getForkIdForChainHead();
-                  })
-              .collect(Collectors.toList());
-
-      assertThat(actualForkIds).containsExactlyElementsOf(expectedForkIds);
-    }
-
-    private static MilestoneStreamingTransitionProtocolSchedule createSchedule(
-        final GenesisConfigFile genesisConfigFile) {
-      final GenesisConfigOptions configOptions = genesisConfigFile.getConfigOptions();
-      MilestoneStreamingProtocolSchedule preMergeProtocolSchedule =
-          new MilestoneStreamingProtocolSchedule(
-              (DefaultProtocolSchedule) MainnetProtocolSchedule.fromConfig(configOptions));
-      MilestoneStreamingProtocolSchedule postMergeProtocolSchedule =
-          new MilestoneStreamingProtocolSchedule(
-              (DefaultProtocolSchedule) MergeProtocolSchedule.create(configOptions, false));
-      final MilestoneStreamingTransitionProtocolSchedule schedule =
-          new MilestoneStreamingTransitionProtocolSchedule(
-              preMergeProtocolSchedule, postMergeProtocolSchedule);
-      return schedule;
-    }
-
-    public static class MilestoneStreamingTransitionProtocolSchedule
-        extends TransitionProtocolSchedule {
-
-      private final TransitionUtils<MilestoneStreamingProtocolSchedule> transitionUtils;
-
-      public MilestoneStreamingTransitionProtocolSchedule(
-          final MilestoneStreamingProtocolSchedule preMergeProtocolSchedule,
-          final MilestoneStreamingProtocolSchedule postMergeProtocolSchedule) {
-        super(preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
-        transitionUtils =
-            new TransitionUtils<>(
-                preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
-      }
-
-      public Stream<Long> streamMilestoneBlocks() {
-        return transitionUtils.dispatchFunctionAccordingToMergeState(
-            MilestoneStreamingProtocolSchedule::streamMilestoneBlocks);
-      }
+    public Stream<Long> streamMilestoneBlocks() {
+      return transitionUtils.dispatchFunctionAccordingToMergeState(
+          MilestoneStreamingProtocolSchedule::streamMilestoneBlocks);
     }
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/RawForkIdTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/RawForkIdTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Hyperledger Besu contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hyperledger.besu.ethereum.forkid.ForkId;
+
+import java.util.List;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.Test;
+
+public class RawForkIdTest {
+  @Test
+  public void testFromRaw() {
+    final ForkId forkId = new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L);
+    final List<List<Bytes>> forkIdAsBytesList = List.of(forkId.getForkIdAsBytesList());
+    assertThat(ForkId.fromRawForkId(forkIdAsBytesList).get()).isEqualTo(forkId);
+  }
+}

--- a/config/src/main/resources/goerli.json
+++ b/config/src/main/resources/goerli.json
@@ -7,6 +7,7 @@
     "londonBlock":5062605,
     "terminalTotalDifficulty": 10790000,
     "shanghaiTime": 1678832736,
+    "cancunTime": 1705473120,
     "clique":{
       "blockperiodseconds":15,
       "epochlength":30000

--- a/config/src/main/resources/holesky.json
+++ b/config/src/main/resources/holesky.json
@@ -14,6 +14,7 @@
     "preMergeForkBlock": 0,
     "terminalTotalDifficulty": 0,
     "shanghaiTime": 1696000704,
+    "cancunTime": 1707305664,
     "ethash": {},
     "discovery": {
       "bootnodes": [

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -14,6 +14,7 @@
     "mergeNetSplitBlock": 1735371,
     "terminalTotalDifficulty": 17000000000000000,
     "shanghaiTime": 1677557088,
+    "cancunTime": 1706655072,
     "ethash":{},
     "discovery": {
       "dns": "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.sepolia.ethdisco.net",

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -39,7 +39,7 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
 
   private static Bytes successResult;
 
-  private static void init() {
+  private static void loadLib() {
     CKZG4844JNI.loadNativeLibrary();
     Bytes fieldElementsPerBlob =
         Bytes32.wrap(Words.intBytes(CKZG4844JNI.FIELD_ELEMENTS_PER_BLOB).xor(Bytes32.ZERO));
@@ -57,7 +57,7 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
    */
   public static void init(final Path trustedSetupFile) {
     if (loaded.compareAndSet(false, true)) {
-      init();
+      loadLib();
       final String trustedSetupResourceName = trustedSetupFile.toAbsolutePath().toString();
       LOG.info("Loading trusted setup from user-specified resource {}", trustedSetupResourceName);
       CKZG4844JNI.loadTrustedSetup(trustedSetupResourceName);
@@ -67,17 +67,14 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
   }
 
   /**
-   * Init the C-KZG native lib using a resource identified by the passed network name as trusted
-   * setup
+   * Init the C-KZG native lib using mainnet trusted setup
    *
-   * @param networkName used to select the resource in /kzg-trusted-setups/ to use.
    * @throws IllegalStateException is the trusted setup was already loaded
    */
-  public static void init(final String networkName) {
+  public static void init() {
     if (loaded.compareAndSet(false, true)) {
-      init();
-      final String trustedSetupResourceName =
-          "/kzg-trusted-setups/" + networkName.toLowerCase() + ".txt";
+      loadLib();
+      final String trustedSetupResourceName = "/kzg-trusted-setups/mainnet.txt";
       LOG.info(
           "Loading network trusted setup from classpath resource {}", trustedSetupResourceName);
       CKZG4844JNI.loadTrustedSetupFromResource(

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompileContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompileContractTest.java
@@ -44,7 +44,7 @@ public class KZGPointEvalPrecompileContractTest {
 
   @BeforeAll
   public static void init() {
-    KZGPointEvalPrecompiledContract.init("mainnet");
+    KZGPointEvalPrecompiledContract.init();
     contract = new KZGPointEvalPrecompiledContract();
   }
 
@@ -55,7 +55,7 @@ public class KZGPointEvalPrecompileContractTest {
 
   @ParameterizedTest(name = "{index}")
   @MethodSource("getPointEvaluationPrecompileTestVectors")
-  public void testComputePrecompile(final PrecompileTestParameters parameters) {
+  void testComputePrecompile(final PrecompileTestParameters parameters) {
     when(toRun.getVersionedHashes()).thenReturn(Optional.of(List.of(parameters.versionedHash)));
     PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(parameters.input, toRun);


### PR DESCRIPTION
add new forkids for testnets, update forkid test to Junit5, no longer need named network specific trusted setups

