### PR TITLE
Optimize RocksDB WAL file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Set Ethereum Classic mainnet activation block for Spiral network upgrade [#6267](https://github.com/hyperledger/besu/pull/6267)
 - Add custom genesis file name to config overview if specified [#6297](https://github.com/hyperledger/besu/pull/6297)
 - Update Gradle plugins and replace unmaintained License Gradle Plugin with the actively maintained Gradle License Report [#6275](https://github.com/hyperledger/besu/pull/6275)
+- Optimize RocksDB WAL files, allows for faster restart and a more linear disk space utilization [#6328](https://github.com/hyperledger/besu/pull/6328)
 
 ### Bug fixes
 

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -77,6 +77,11 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
   protected static final long ROCKSDB_BLOCKCACHE_SIZE_HIGH_SPEC = 1_073_741_824L;
   /** RocksDb memtable size when using the high spec option */
   protected static final long ROCKSDB_MEMTABLE_SIZE_HIGH_SPEC = 1_073_741_824L;
+  /** Max total size of all WAL file, after which a flush is triggered */
+  protected static final long WAL_MAX_TOTAL_SIZE = 1_073_741_824L;
+  /** Expected size of a single WAL file, to determine how many WAL files to keep around */
+  protected static final long EXPECTED_WAL_FILE_SIZE = 67_108_864L;
+
   /** RocksDb number of log files to keep on disk */
   private static final long NUMBER_OF_LOG_FILES_TO_KEEP = 7;
   /** RocksDb Time to roll a log file (1 day = 3600 * 24 seconds) */
@@ -237,6 +242,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
     options
         .setCreateIfMissing(true)
         .setMaxOpenFiles(configuration.getMaxOpenFiles())
+        .setMaxTotalWalSize(WAL_MAX_TOTAL_SIZE)
+        .setRecycleLogFileNum(WAL_MAX_TOTAL_SIZE / EXPECTED_WAL_FILE_SIZE)
         .setStatistics(stats)
         .setCreateMissingColumnFamilies(true)
         .setLogFileTimeToRoll(TIME_TO_ROLL_LOG_FILE)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

Currently Besu uses the default RocksDB WAL options, with the result that usually the WAL files could occupy ~15GB of disk space, due to the fact that different column families are flushed at very different intervals, this has also the bad effect of slow restarts, when Besu has to parse an reapply all these WAL files.

Capping the WAL files total size to 1GB and reusing old files when possible, has the advantage of a faster restart, and a more linear disk usage, instead of the classic saw tooth shape that we see today.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->