### PR TITLE
Copy also computed fields, when doing a Transaction detached copy

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -1007,24 +1007,33 @@ public class Transaction
             withCommitments ->
                 blobsWithCommitmentsDetachedCopy(withCommitments, detachedVersionedHashes.get()));
 
-    return new Transaction(
-        true,
-        transactionType,
-        nonce,
-        gasPrice,
-        maxPriorityFeePerGas,
-        maxFeePerGas,
-        maxFeePerBlobGas,
-        gasLimit,
-        detachedTo,
-        value,
-        signature,
-        payload.copy(),
-        detachedAccessList,
-        sender,
-        chainId,
-        detachedVersionedHashes,
-        detachedBlobsWithCommitments);
+    final var copiedTx =
+        new Transaction(
+            true,
+            transactionType,
+            nonce,
+            gasPrice,
+            maxPriorityFeePerGas,
+            maxFeePerGas,
+            maxFeePerBlobGas,
+            gasLimit,
+            detachedTo,
+            value,
+            signature,
+            payload.copy(),
+            detachedAccessList,
+            sender,
+            chainId,
+            detachedVersionedHashes,
+            detachedBlobsWithCommitments);
+
+    // copy also the computed fields, to avoid to recompute them
+    copiedTx.sender = this.sender;
+    copiedTx.hash = this.hash;
+    copiedTx.hashNoSignature = this.hashNoSignature;
+    copiedTx.size = this.size;
+
+    return copiedTx;
   }
 
   private AccessListEntry accessListDetachedCopy(final AccessListEntry accessListEntry) {


### PR DESCRIPTION
Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

When doing a detached copy of a transaction, copy also the computed fields to avoid to recompute them

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->