### PR TITLE
Fix: Fallback to getName when canonicalName is null in BlockHeaderValidator DEBUG log

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
@@ -87,7 +87,7 @@ public class BlockHeaderValidator {
                 String canonicalName = rule.innerRuleClass().getCanonicalName();
                 LOG.debug(
                     "{} rule failed",
-                    canonicalName == null ? rule.innerRuleClass().getSimpleName() : canonicalName);
+                    canonicalName == null ? rule.innerRuleClass().getName() : canonicalName);
               }
               return worked;
             });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
@@ -84,7 +84,11 @@ public class BlockHeaderValidator {
             rule -> {
               boolean worked = rule.validate(header, parent, protocolContext);
               if (!worked) {
-                LOG.debug("{} rule failed", rule.innerRuleClass().getCanonicalName());
+                String canonicalName = rule.innerRuleClass().getCanonicalName();
+                LOG.debug("{} rule failed", canonicalName == null ?
+                        rule.innerRuleClass().getSimpleName() :
+                        canonicalName
+                );
               }
               return worked;
             });

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockHeaderValidator.java
@@ -85,10 +85,9 @@ public class BlockHeaderValidator {
               boolean worked = rule.validate(header, parent, protocolContext);
               if (!worked) {
                 String canonicalName = rule.innerRuleClass().getCanonicalName();
-                LOG.debug("{} rule failed", canonicalName == null ?
-                        rule.innerRuleClass().getSimpleName() :
-                        canonicalName
-                );
+                LOG.debug(
+                    "{} rule failed",
+                    canonicalName == null ? rule.innerRuleClass().getSimpleName() : canonicalName);
               }
               return worked;
             });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
When a validation rule fails in `BlockHeaderValidator`, debug message falls back to using just name when canonical name is not available.

## Fixed Issue(s)
Fixes #6177 
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->