### PR TITLE
TestWatcher junit5

### DIFF
--- a/acceptance-tests/dsl/build.gradle
+++ b/acceptance-tests/dsl/build.gradle
@@ -47,4 +47,5 @@ dependencies {
   implementation 'org.web3j:crypto'
 
   implementation 'org.testcontainers:testcontainers'
+  implementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -57,9 +57,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -56,7 +56,10 @@ import java.math.BigInteger;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.junit.After;
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +130,15 @@ public class AcceptanceTestBase {
     exitedSuccessfully = new ExitedWithCode(0);
   }
 
-  @After
+  @BeforeEach
+  public void setUp(final TestInfo testInfo) {
+    // log4j is configured to create a file per test
+    // build/acceptanceTestLogs/${ctx:class}.${ctx:test}.log
+    ThreadContext.put("class", this.getClass().getSimpleName());
+    ThreadContext.put("test", testInfo.getTestMethod().get().getName());
+  }
+
+  @AfterEach
   public void tearDownAcceptanceTestBase() {
     reportMemory();
     cluster.close();

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -49,7 +49,6 @@ import org.hyperledger.besu.tests.acceptance.dsl.transaction.txpool.TxPoolTransa
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.web3.Web3Transactions;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.ProcessBuilder.Redirect;
@@ -59,13 +58,12 @@ import java.util.concurrent.Executors;
 
 import org.junit.After;
 import org.junit.Rule;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.TestName;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
+@ExtendWith(AcceptanceTestBaseTestWatcher.class)
 public class AcceptanceTestBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(AcceptanceTestBase.class);
@@ -177,49 +175,6 @@ public class AcceptanceTestBase {
       LOG.warn("Failed to read output from memory information process: ", e);
     }
   }
-
-  @Rule
-  public TestWatcher logEraser =
-      new TestWatcher() {
-
-        @Override
-        protected void starting(final Description description) {
-          MDC.put("test", description.getMethodName());
-          MDC.put("class", description.getClassName());
-
-          final String errorMessage = "Uncaught exception in thread \"{}\"";
-          Thread.currentThread()
-              .setUncaughtExceptionHandler(
-                  (thread, error) -> LOG.error(errorMessage, thread.getName(), error));
-          Thread.setDefaultUncaughtExceptionHandler(
-              (thread, error) -> LOG.error(errorMessage, thread.getName(), error));
-        }
-
-        @Override
-        protected void failed(final Throwable e, final Description description) {
-          // add the result at the end of the log so it is self-sufficient
-          LOG.error(
-              "==========================================================================================");
-          LOG.error("Test failed. Reported Throwable at the point of failure:", e);
-          LOG.error(e.getMessage());
-        }
-
-        @Override
-        protected void succeeded(final Description description) {
-          // if so configured, delete logs of successful tests
-          if (!Boolean.getBoolean("acctests.keepLogsOfPassingTests")) {
-            String pathname =
-                "build/acceptanceTestLogs/"
-                    + description.getClassName()
-                    + "."
-                    + description.getMethodName()
-                    + ".log";
-            LOG.info("Test successful, deleting log at {}", pathname);
-            File file = new File(pathname);
-            file.delete();
-          }
-        }
-      };
 
   protected void waitForBlockHeight(final Node node, final long blockchainHeight) {
     WaitUtils.waitFor(

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBase.java
@@ -129,8 +129,6 @@ public class AcceptanceTestBase {
     exitedSuccessfully = new ExitedWithCode(0);
   }
 
-  @Rule public final TestName name = new TestName();
-
   @After
   public void tearDownAcceptanceTestBase() {
     reportMemory();

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBaseTestWatcher.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBaseTestWatcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.besu.tests.acceptance.dsl;
+
+import java.io.File;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AcceptanceTestBaseTestWatcher implements TestWatcher {
+  private static final Logger LOG = LoggerFactory.getLogger(AcceptanceTestBaseTestWatcher.class);
+
+  @Override
+  public void testAborted(final ExtensionContext extensionContext, final Throwable throwable) {
+    LOG.info("test aborted:" + extensionContext.getDisplayName());
+  }
+
+  @Override
+  public void testDisabled(
+      final ExtensionContext extensionContext, final Optional<String> optional) {
+    LOG.info("test disabled:" + extensionContext.getDisplayName());
+  }
+
+  @Override
+  public void testFailed(final ExtensionContext extensionContext, final Throwable e) {
+    // add the result at the end of the log, so it is self-sufficient
+    LOG.error(
+        "==========================================================================================");
+    LOG.error("Test failed. Reported Throwable at the point of failure:", e);
+    LOG.error(e.getMessage());
+  }
+
+  @Override
+  public void testSuccessful(final ExtensionContext extensionContext) {
+    // TODO where is the other side of this - what creates these log files?
+
+    // if so configured, delete logs of successful tests
+    if (!Boolean.getBoolean("acctests.keepLogsOfPassingTests")) {
+      String pathname = "build/acceptanceTestLogs/" + extensionContext.getDisplayName() + ".log";
+      LOG.info("Test successful, deleting log at {}", pathname);
+      File file = new File(pathname);
+      file.delete();
+    }
+  }
+}

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBaseTestWatcher.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/AcceptanceTestBaseTestWatcher.java
@@ -16,7 +16,6 @@
 package org.hyperledger.besu.tests.acceptance.dsl;
 
 import java.io.File;
-import java.util.Optional;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestWatcher;
@@ -25,17 +24,6 @@ import org.slf4j.LoggerFactory;
 
 public class AcceptanceTestBaseTestWatcher implements TestWatcher {
   private static final Logger LOG = LoggerFactory.getLogger(AcceptanceTestBaseTestWatcher.class);
-
-  @Override
-  public void testAborted(final ExtensionContext extensionContext, final Throwable throwable) {
-    LOG.info("test aborted:" + extensionContext.getDisplayName());
-  }
-
-  @Override
-  public void testDisabled(
-      final ExtensionContext extensionContext, final Optional<String> optional) {
-    LOG.info("test disabled:" + extensionContext.getDisplayName());
-  }
 
   @Override
   public void testFailed(final ExtensionContext extensionContext, final Throwable e) {
@@ -48,11 +36,16 @@ public class AcceptanceTestBaseTestWatcher implements TestWatcher {
 
   @Override
   public void testSuccessful(final ExtensionContext extensionContext) {
-    // TODO where is the other side of this - what creates these log files?
-
     // if so configured, delete logs of successful tests
     if (!Boolean.getBoolean("acctests.keepLogsOfPassingTests")) {
-      String pathname = "build/acceptanceTestLogs/" + extensionContext.getDisplayName() + ".log";
+      // log4j is configured to create a file per test
+      // build/acceptanceTestLogs/${ctx:class}.${ctx:test}.log
+      String pathname =
+          "build/acceptanceTestLogs/"
+              + extensionContext.getTestClass().get().getSimpleName()
+              + "."
+              + extensionContext.getTestMethod().get().getName()
+              + ".log";
       LOG.info("Test successful, deleting log at {}", pathname);
       File file = new File(pathname);
       file.delete();

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/bft/qbft/QbftContractAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/bft/qbft/QbftContractAcceptanceTest.java
@@ -14,13 +14,13 @@
  */
 package org.hyperledger.besu.tests.acceptance.bft.qbft;
 
-import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBaseJunit5;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class QbftContractAcceptanceTest extends AcceptanceTestBase {
+public class QbftContractAcceptanceTest extends AcceptanceTestBaseJunit5 {
 
   @Test
   public void shouldMineOnMultipleNodesEvenWhenClusterContainsNonValidator() throws Exception {

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPluginTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBaseJunit5;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.File;
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class BadCLIOptionsPluginTest extends AcceptanceTestBase {
+public class BadCLIOptionsPluginTest extends AcceptanceTestBaseJunit5 {
   private BesuNode node;
 
   @BeforeEach

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/BesuEventsPluginTest.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
-import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBaseJunit5;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 
 import java.io.File;
@@ -28,7 +28,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class BesuEventsPluginTest extends AcceptanceTestBase {
+public class BesuEventsPluginTest extends AcceptanceTestBaseJunit5 {
   private BesuNode pluginNode;
   private BesuNode minerNode;
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PermissioningPluginTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/plugins/PermissioningPluginTest.java
@@ -16,7 +16,7 @@
 package org.hyperledger.besu.tests.acceptance.plugins;
 
 import org.hyperledger.besu.datatypes.Hash;
-import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
+import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBaseJunit5;
 import org.hyperledger.besu.tests.acceptance.dsl.account.Account;
 import org.hyperledger.besu.tests.acceptance.dsl.blockchain.Amount;
 import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
@@ -28,7 +28,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class PermissioningPluginTest extends AcceptanceTestBase {
+public class PermissioningPluginTest extends AcceptanceTestBaseJunit5 {
   private BesuNode minerNode;
 
   private BesuNode aliceNode;


### PR DESCRIPTION
migrate the TestWatcher functionality from junit 4 Rule to junit 5
introduced a new superclass to be able to separate junit4 tests vs junit5 tests, to avoid having to change all at once.

fixes #6348
