### PR TITLE
Use synchronized call to access the chain head block in `eth_estimateGas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Optimize RocksDB WAL files, allows for faster restart and a more linear disk space utilization [#6328](https://github.com/hyperledger/besu/pull/6328)
 
 ### Bug fixes
+- INTERNAL_ERROR from `eth_estimateGas` JSON/RPC calls [#6344](https://github.com/hyperledger/besu/issues/6344)
 
 ## 23.10.3
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -32,7 +32,12 @@ import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class EthEstimateGas extends AbstractEstimateGas {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EthEstimateGas.class);
 
   public EthEstimateGas(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
@@ -50,6 +55,7 @@ public class EthEstimateGas extends AbstractEstimateGas {
 
     final BlockHeader blockHeader = blockHeader();
     if (blockHeader == null) {
+      LOG.error("Chain head block not found");
       return errorResponse(requestContext, RpcErrorType.INTERNAL_ERROR);
     }
     if (!blockchainQueries
@@ -70,6 +76,7 @@ public class EthEstimateGas extends AbstractEstimateGas {
             blockHeader, modifiedCallParams, operationTracer, isAllowExceedingBalance);
 
     if (gasUsed.isEmpty()) {
+      LOG.error("gasUsed is empty after simulating transaction.");
       return errorResponse(requestContext, RpcErrorType.INTERNAL_ERROR);
     }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -78,10 +78,16 @@ public class EthCreateAccessListTest {
 
   @BeforeEach
   public void setUp() {
-    when(blockchainQueries.headBlockNumber()).thenReturn(1L);
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchainQueries.getWorldStateArchive()).thenReturn(worldStateArchive);
-    when(blockchain.getBlockHeader(eq(1L))).thenReturn(Optional.of(blockHeader));
+    when(blockchain.getChainHeadHash())
+        .thenReturn(
+            Hash.fromHexString(
+                "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3"));
+    when(blockchain.getBlockHeader(
+            Hash.fromHexString(
+                "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3")))
+        .thenReturn(Optional.of(blockHeader));
     when(blockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
     when(blockHeader.getNumber()).thenReturn(1L);
     when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(true);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
@@ -73,10 +74,16 @@ public class EthEstimateGasTest {
 
   @BeforeEach
   public void setUp() {
-    when(blockchainQueries.headBlockNumber()).thenReturn(1L);
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchainQueries.getWorldStateArchive()).thenReturn(worldStateArchive);
-    when(blockchain.getBlockHeader(eq(1L))).thenReturn(Optional.of(blockHeader));
+    when(blockchain.getChainHeadHash())
+        .thenReturn(
+            Hash.fromHexString(
+                "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3"));
+    when(blockchain.getBlockHeader(
+            Hash.fromHexString(
+                "0x3f07a9c83155594c000642e7d60e8a8a00038d03e9849171a05ed0e2d47acbb3")))
+        .thenReturn(Optional.of(blockHeader));
     when(blockHeader.getGasLimit()).thenReturn(Long.MAX_VALUE);
     when(blockHeader.getNumber()).thenReturn(1L);
     when(worldStateArchive.isWorldStateAvailable(any(), any())).thenReturn(true);


### PR DESCRIPTION
## PR description
Optimistically get the chain head block without taking a lock. If that fails, retry under the lock.

This is an identical fix to https://github.com/hyperledger/besu/pull/6143.

I did consider making a more generic helper/util function to wrap the logic for any place in the code that needs it, but looking through the code I can't see any other cases where the a failed attempt to get the chain head block results in an internal error or exception. Most others treat it as optional and just retry on the next go round.

## Fixed Issue(s)
Fixes https://github.com/hyperledger/besu/issues/6344