### PR TITLE
fixing trielog generation when selfdestruct/create2 on same block

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/bonsai/worldview/BonsaiWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/bonsai/worldview/BonsaiWorldState.java
@@ -341,59 +341,55 @@ public class BonsaiWorldState
       final Optional<BonsaiWorldStateKeyValueStorage.BonsaiUpdater> maybeStateUpdater,
       final BonsaiWorldStateUpdateAccumulator worldStateUpdater) {
 
-    maybeStateUpdater.ifPresent(
-        bonsaiUpdater -> {
-          for (final Address address : worldStateUpdater.getStorageToClear()) {
-            // because we are clearing persisted values we need the account root as persisted
-            final BonsaiAccount oldAccount =
-                worldStateStorage
-                    .getAccount(address.addressHash())
-                    .map(
-                        bytes -> BonsaiAccount.fromRLP(BonsaiWorldState.this, address, bytes, true))
-                    .orElse(null);
-            if (oldAccount == null) {
-              // This is when an account is both created and deleted within the scope of the same
-              // block.  A not-uncommon DeFi bot pattern.
-              continue;
-            }
-            final Hash addressHash = address.addressHash();
-            final MerkleTrie<Bytes, Bytes> storageTrie =
-                createTrie(
-                    (location, key) -> getStorageTrieNode(addressHash, location, key),
-                    oldAccount.getStorageRoot());
-            try {
-
-              final StorageConsumingMap<StorageSlotKey, BonsaiValue<UInt256>> storageToDelete =
-                  worldStateUpdater.getStorageToUpdate().get(address);
-              Map<Bytes32, Bytes> entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
-              while (!entriesToDelete.isEmpty()) {
-                entriesToDelete.forEach(
-                    (k, v) -> {
-                      final StorageSlotKey storageSlotKey =
-                          new StorageSlotKey(Hash.wrap(k), Optional.empty());
-                      final UInt256 slotValue =
-                          UInt256.fromBytes(Bytes32.leftPad(RLP.decodeValue(v)));
-                      bonsaiUpdater.removeStorageValueBySlotHash(
-                          address.addressHash(), storageSlotKey.getSlotHash());
-                      storageToDelete
-                          .computeIfAbsent(
-                              storageSlotKey, key -> new BonsaiValue<>(slotValue, null, true))
-                          .setPrior(slotValue);
-                    });
-                entriesToDelete.keySet().forEach(storageTrie::remove);
-                if (entriesToDelete.size() == 256) {
-                  entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
-                } else {
-                  break;
-                }
-              }
-            } catch (MerkleTrieException e) {
-              // need to throw to trigger the heal
-              throw new MerkleTrieException(
-                  e.getMessage(), Optional.of(Address.wrap(address)), e.getHash(), e.getLocation());
-            }
+    for (final Address address : worldStateUpdater.getStorageToClear()) {
+      // because we are clearing persisted values we need the account root as persisted
+      final BonsaiAccount oldAccount =
+          worldStateStorage
+              .getAccount(address.addressHash())
+              .map(bytes -> BonsaiAccount.fromRLP(BonsaiWorldState.this, address, bytes, true))
+              .orElse(null);
+      if (oldAccount == null) {
+        // This is when an account is both created and deleted within the scope of the same
+        // block.  A not-uncommon DeFi bot pattern.
+        continue;
+      }
+      final Hash addressHash = address.addressHash();
+      final MerkleTrie<Bytes, Bytes> storageTrie =
+          createTrie(
+              (location, key) -> getStorageTrieNode(addressHash, location, key),
+              oldAccount.getStorageRoot());
+      try {
+        final StorageConsumingMap<StorageSlotKey, BonsaiValue<UInt256>> storageToDelete =
+            worldStateUpdater.getStorageToUpdate().get(address);
+        Map<Bytes32, Bytes> entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
+        while (!entriesToDelete.isEmpty()) {
+          entriesToDelete.forEach(
+              (k, v) -> {
+                final StorageSlotKey storageSlotKey =
+                    new StorageSlotKey(Hash.wrap(k), Optional.empty());
+                final UInt256 slotValue = UInt256.fromBytes(Bytes32.leftPad(RLP.decodeValue(v)));
+                maybeStateUpdater.ifPresent(
+                    bonsaiUpdater ->
+                        bonsaiUpdater.removeStorageValueBySlotHash(
+                            address.addressHash(), storageSlotKey.getSlotHash()));
+                storageToDelete
+                    .computeIfAbsent(
+                        storageSlotKey, key -> new BonsaiValue<>(slotValue, null, true))
+                    .setPrior(slotValue);
+              });
+          entriesToDelete.keySet().forEach(storageTrie::remove);
+          if (entriesToDelete.size() == 256) {
+            entriesToDelete = storageTrie.entriesFrom(Bytes32.ZERO, 256);
+          } else {
+            break;
           }
-        });
+        }
+      } catch (MerkleTrieException e) {
+        // need to throw to trigger the heal
+        throw new MerkleTrieException(
+            e.getMessage(), Optional.of(Address.wrap(address)), e.getHash(), e.getLocation());
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

This PR fixes a bug in the generation of the trie log when we have a selfdestruct and create2 of the same account in the same block, and if this contract contains a non-empty storage. This bug occurred on the mainnet, and we were able to reproduce the bug and validate that the fix resolves the problem. We had a previous PR to fix this bug but it was not completly fixed on this one

This bug was fixed when we create the trie log with a persistent BonsaiWorldstate, but not with a non-persistent BonsaiWorldstate, which is what happens with the call of the newPayload method. BackwardSync uses the persistent worldstate, and that's why the BackwardSync unlocks the situation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#6357 