### PR TITLE
fix: use UID 1000 for besu user (#6358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 - New `EXECUTION_HALTED` error returned if there is an error executing or simulating a transaction, with the reason for execution being halted. Replaces the generic `INTERNAL_ERROR` return code in certain cases which some applications may be checking for [#6343](https://github.com/hyperledger/besu/pull/6343)
+- The Besu Docker images with `openjdk-latest` tags since 23.10.3 were incorrectly using UID 1001 instead of 1000 for the container's `besu` user. The user now uses 1000 again. Containers created from or migrated to images using UID 1001 will need to chown their persistent database files to UID 1000 [#6360](https://github.com/hyperledger/besu/pull/6360)
 
 ### Deprecations
 - Forest pruning (`pruning-enabled` options) is deprecated and will be removed soon. To save disk space consider switching to Bonsai data storage format [#6230](https://github.com/hyperledger/besu/pull/6230)
@@ -18,6 +19,7 @@
 
 ### Bug fixes
 - INTERNAL_ERROR from `eth_estimateGas` JSON/RPC calls [#6344](https://github.com/hyperledger/besu/issues/6344)
+- Fix Besu Docker images with `openjdk-latest` tags since 23.10.3 using UID 1001 instead of 1000 for the `besu` user [#6360](https://github.com/hyperledger/besu/pull/6360)
 
 ## 23.10.3
 

--- a/docker/openjdk-latest/Dockerfile
+++ b/docker/openjdk-latest/Dockerfile
@@ -6,7 +6,10 @@ RUN apt-get update && \
  apt-get install --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3* && \
  apt-get clean  && \
  rm -rf /var/lib/apt/lists/*  && \
- adduser --disabled-password --gecos "" --home /opt/besu besu && \
+ # Ubuntu 23.10 comes with an "ubuntu" user with uid 1000. We need 1000 for besu.
+ userdel ubuntu 2>/dev/null || true && rm -rf /home/ubuntu && \
+ # Ensure we use a stable UID for besu, as file permissions are tied to UIDs.
+ adduser --uid 1000 --disabled-password --gecos "" --home /opt/besu besu && \
     chown besu:besu /opt/besu && \
     chmod 0755 /opt/besu
 


### PR DESCRIPTION
## PR description

The openjdk-latest Docker image is using UID 1001 for besu, because its base image `ubuntu:23.10` now contains a default "ubuntu" user with UID 1000. (This UID change causes the besu user with UID 1001 to not have access to files created for past versions with UID 1000.)

This PR removes the default ubuntu user and explicitly uses UID 1000 when creating the besu user.

**Note that this change will re-break file permissions for people who've already changed besu file ownership from 1000 -> 1001 when upgrading to 23.10.3, as the besu user goes back to UID 1000, as it was in versions prior to 23.10.3.**

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->



## Fixed Issue(s)

Fixes #6358