### PR TITLE
full sync - don't fail startup if sync-min-peers specified

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -23,6 +23,7 @@ import static org.hyperledger.besu.cli.DefaultCommandValues.getDefaultBesuDataPa
 import static org.hyperledger.besu.cli.config.NetworkName.MAINNET;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPENDENCY_WARNING_MSG;
 import static org.hyperledger.besu.cli.util.CommandLineUtils.DEPRECATION_WARNING_MSG;
+import static org.hyperledger.besu.cli.util.CommandLineUtils.isOptionSet;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 import static org.hyperledger.besu.ethereum.api.graphql.GraphQLConfiguration.DEFAULT_GRAPHQL_HTTP_PORT;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration.DEFAULT_ENGINE_JSON_RPC_PORT;
@@ -2027,11 +2028,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             "--p2p-port",
             "--remote-connections-max-percentage"));
 
-    CommandLineUtils.failIfOptionDoesntMeetRequirement(
-        commandLine,
-        "--fast-sync-min-peers can't be used with FULL sync-mode",
-        !SyncMode.isFullSync(getDefaultSyncModeIfNotSet()),
-        singletonList("--fast-sync-min-peers"));
+    if (SyncMode.isFullSync(getDefaultSyncModeIfNotSet())
+        && isOptionSet(commandLine, "--sync-min-peers")) {
+      logger.warn("--sync-min-peers is ignored in FULL sync-mode");
+    }
 
     CommandLineUtils.failIfOptionDoesntMeetRequirement(
         commandLine,

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -5066,8 +5066,7 @@ public class BesuCommandTest extends CommandTestAbstract {
   @Test
   public void logWarnIfFastSyncMinPeersUsedWithFullSync() {
     parseCommand("--sync-mode", "FULL", "--fast-sync-min-peers", "1");
-    assertThat(commandErrorOutput.toString(UTF_8))
-        .contains("--fast-sync-min-peers can't be used with FULL sync-mode");
+    verify(mockLogger).warn("--sync-min-peers is ignored in FULL sync-mode");
   }
 
   @Test


### PR DESCRIPTION
Log a warning instead of failing startup

fixes #6327 

Before:
```
➜  b2 git:(sync-min-peers) ✗ besu --sync-mode="full" --sync-min-peers=1
2024-01-09 12:17:57.498+10:00 | main | INFO  | Besu | Starting Besu
2024-01-09 12:17:57.866+10:00 | main | ERROR | Besu | Failed to start Besu
picocli.CommandLine$ParameterException: --sync-min-peers can't be used with FULL sync-mode [--sync-min-peers]
	at org.hyperledger.besu.cli.util.CommandLineUtils.failIfOptionDoesntMeetRequirement(CommandLineUtils.java:129)
```
and startup fails.

After:

```
➜  b2 git:(sync-min-peers) ✗ besu --sync-mode="full" --sync-min-peers=1
2024-01-09 12:24:50.728+10:00 | main | INFO  | Besu | Starting Besu
2024-01-09 12:24:51.539+10:00 | main | WARN  | Besu | --sync-min-peers is ignored in FULL sync-mode
2024-01-09 12:24:51.818+10:00 | main | INFO  | Besu | Connecting to 0 static nodes.
```
and startup continues