### PR TITLE
Ignore bin files when running the spdx license check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -977,6 +977,7 @@ task checkSpdxHeader(type: CheckSpdxHeader) {
     "(.*${sep}.gradle${sep}.*)",
     "(.*${sep}.idea${sep}.*)",
     "(.*${sep}out${sep}.*)",
+    "(.*${sep}bin${sep}.*)",
     "(.*${sep}build${sep}.*)",
     "(.*${sep}src${sep}[^${sep}]+${sep}generated${sep}.*)"
   ].join("|")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
Ignore generated files in `bin/` directories when running the SPDX license check.  Visual Studio Code generates build files in various bin directories, which causes this check to fail.  