### PR TITLE
Allow Xpoa-block-txs-selection-max-time to be greater than 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
 ### Additions and Improvements
 - Optimize RocksDB WAL files, allows for faster restart and a more linear disk space utilization [#6328](https://github.com/hyperledger/besu/pull/6328)
 - Disable transaction handling when the node is not in sync, to avoid unnecessary transaction validation work [#6302](https://github.com/hyperledger/besu/pull/6302)
-- Introduce TransactionEvaluationContext to pass data between transaction selectors and plugin, during block creation [#6381](https://github.com/hyperledger/besu/pull/6381) 
+- Introduce TransactionEvaluationContext to pass data between transaction selectors and plugin, during block creation [#6381](https://github.com/hyperledger/besu/pull/6381)
 - Upgrade dependencies [#6377](https://github.com/hyperledger/besu/pull/6377)
-- Upgrade `com.fasterxml.jackson` dependencies [#6378](https://github.com/hyperledger/besu/pull/6378) 
+- Upgrade `com.fasterxml.jackson` dependencies [#6378](https://github.com/hyperledger/besu/pull/6378)
 - Upgrade Guava dependency [#6396](https://github.com/hyperledger/besu/pull/6396)
+- Allow `Xpoa-block-txs-selection-max-time` option to take value greater than 100% [#6407](https://github.com/hyperledger/besu/pull/6407)
 
 ### Bug fixes
 - INTERNAL_ERROR from `eth_estimateGas` JSON/RPC calls [#6344](https://github.com/hyperledger/besu/issues/6344)

--- a/besu/src/main/java/org/hyperledger/besu/cli/converter/PositiveNumberConverter.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/converter/PositiveNumberConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/besu/src/main/java/org/hyperledger/besu/cli/converter/PositiveNumberConverter.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/converter/PositiveNumberConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.converter;
+
+import org.hyperledger.besu.cli.converter.exception.PercentageConversionException;
+import org.hyperledger.besu.util.number.PositiveNumber;
+
+import picocli.CommandLine;
+
+/** The PositiveNumber Cli type converter. */
+public class PositiveNumberConverter implements CommandLine.ITypeConverter<PositiveNumber> {
+
+  @Override
+  public PositiveNumber convert(final String value) throws PercentageConversionException {
+    try {
+      return PositiveNumber.fromString(value);
+    } catch (NullPointerException | IllegalArgumentException e) {
+      throw new PercentageConversionException(value);
+    }
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/converter/exception/PositiveNumberConversionException.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/converter/exception/PositiveNumberConversionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/besu/src/main/java/org/hyperledger/besu/cli/converter/exception/PositiveNumberConversionException.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/converter/exception/PositiveNumberConversionException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.converter.exception;
+
+import static java.lang.String.format;
+
+/** The custom PositiveNumber conversion exception. */
+public final class PositiveNumberConversionException extends Exception {
+
+  /**
+   * Instantiates a new PositiveNumber conversion exception.
+   *
+   * @param value the invalid value to add in exception message
+   */
+  public PositiveNumberConversionException(final String value) {
+    super(format("Invalid value: %s, should be a positive number >0.", value));
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/MiningOptions.java
@@ -29,7 +29,7 @@ import static org.hyperledger.besu.ethereum.core.MiningParameters.Unstable.DEFAU
 import static org.hyperledger.besu.ethereum.core.MiningParameters.Unstable.DEFAULT_REMOTE_SEALERS_LIMIT;
 import static org.hyperledger.besu.ethereum.core.MiningParameters.Unstable.DEFAULT_REMOTE_SEALERS_TTL;
 
-import org.hyperledger.besu.cli.converter.PercentageConverter;
+import org.hyperledger.besu.cli.converter.PositiveNumberConverter;
 import org.hyperledger.besu.cli.util.CommandLineUtils;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.datatypes.Address;
@@ -37,7 +37,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters.MutableInitValues;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
-import org.hyperledger.besu.util.number.Percentage;
+import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.util.List;
 
@@ -181,12 +181,12 @@ public class MiningOptions implements CLIOptions<MiningParameters> {
     @CommandLine.Option(
         hidden = true,
         names = {"--Xpoa-block-txs-selection-max-time"},
-        converter = PercentageConverter.class,
+        converter = PositiveNumberConverter.class,
         description =
             "Specifies the maximum time that could be spent selecting transactions to be included in the block, as a percentage of the fixed block time of the PoA network."
                 + " To be only used on PoA networks, for other networks see Xblock-txs-selection-max-time."
                 + " (default: ${DEFAULT-VALUE})")
-    private Percentage poaBlockTxsSelectionMaxTime = DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
+    private PositiveNumber poaBlockTxsSelectionMaxTime = DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
   }
 
   private MiningOptions() {}

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters.MutableInitValues;
 import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters.Unstable;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
-import org.hyperledger.besu.util.number.Percentage;
+import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -361,7 +361,7 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningParameters, 
     internalTestSuccess(
         miningParams ->
             assertThat(miningParams.getUnstable().getPoaBlockTxsSelectionMaxTime())
-                .isEqualTo(Percentage.fromInt(80)),
+                .isEqualTo(PositiveNumber.fromInt(80)),
         "--genesis-file",
         genesisFileIBFT2.toString(),
         "--Xpoa-block-txs-selection-max-time",
@@ -369,11 +369,16 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningParameters, 
   }
 
   @Test
-  public void poaBlockTxsSelectionMaxTimeOutOfAllowedRange() {
-    internalTestFailure(
-        "Invalid value for option '--Xpoa-block-txs-selection-max-time': cannot convert '110' to Percentage",
+  public void poaBlockTxsSelectionMaxTimeOptionOver100Percent() throws IOException {
+    final Path genesisFileIBFT2 = createFakeGenesisFile(VALID_GENESIS_IBFT2_POST_LONDON);
+    internalTestSuccess(
+        miningParams ->
+            assertThat(miningParams.getUnstable().getPoaBlockTxsSelectionMaxTime())
+                .isEqualTo(PositiveNumber.fromInt(200)),
+        "--genesis-file",
+        genesisFileIBFT2.toString(),
         "--Xpoa-block-txs-selection-max-time",
-        "110");
+        "200");
   }
 
   @Test

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockTransactionSelectorTest.java
@@ -85,7 +85,7 @@ import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelecto
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
 import org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
-import org.hyperledger.besu.util.number.Percentage;
+import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.math.BigInteger;
 import java.time.Instant;
@@ -987,7 +987,10 @@ public abstract class AbstractBlockTransactionSelectorTest {
         createBlockSelectorAndSetupTxPool(
             isPoa
                 ? createMiningParameters(
-                    Wei.ZERO, MIN_OCCUPANCY_100_PERCENT, poaMinBlockTime, Percentage.fromInt(75))
+                    Wei.ZERO,
+                    MIN_OCCUPANCY_100_PERCENT,
+                    poaMinBlockTime,
+                    PositiveNumber.fromInt(75))
                 : createMiningParameters(
                     Wei.ZERO, MIN_OCCUPANCY_100_PERCENT, blockTxsSelectionMaxTime),
             transactionProcessor,
@@ -1191,7 +1194,7 @@ public abstract class AbstractBlockTransactionSelectorTest {
       final Wei minGasPrice,
       final double minBlockOccupancyRatio,
       final int minBlockTime,
-      final Percentage minBlockTimePercentage) {
+      final PositiveNumber minBlockTimePercentage) {
     return ImmutableMiningParameters.builder()
         .mutableInitValues(
             MutableInitValues.builder()

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningParameters.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningParameters.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.core;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.util.number.Percentage;
+import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.time.Duration;
 import java.util.Objects;
@@ -267,7 +267,7 @@ public abstract class MiningParameters {
     long DEFAULT_POS_BLOCK_CREATION_MAX_TIME = Duration.ofSeconds(12).toMillis();
     long DEFAULT_POS_BLOCK_CREATION_REPETITION_MIN_DURATION = Duration.ofMillis(500).toMillis();
     long DEFAULT_NON_POA_BLOCK_TXS_SELECTION_MAX_TIME = Duration.ofSeconds(5).toMillis();
-    Percentage DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME = Percentage.fromInt(75);
+    PositiveNumber DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME = PositiveNumber.fromInt(75);
 
     MiningParameters.Unstable DEFAULT = ImmutableMiningParameters.Unstable.builder().build();
 
@@ -312,7 +312,7 @@ public abstract class MiningParameters {
     }
 
     @Value.Default
-    default Percentage getPoaBlockTxsSelectionMaxTime() {
+    default PositiveNumber getPoaBlockTxsSelectionMaxTime() {
       return DEFAULT_POA_BLOCK_TXS_SELECTION_MAX_TIME;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description

In #6044 `Xpoa-block-txs-selection-max-time` options has been introduced to limit the block creation time to a fraction of the genesis block time, but there are cases where it is useful to let the block creation time last more, so with this PR is it possible to specify value greater than 100%

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->