### PR TITLE
[CI] publish tasks don't depend on test tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,10 +443,6 @@ workflows:
                 - /^release-.*/
           requires:
             - assemble
-            - integrationTests
-            - unitTests
-            - acceptanceTests
-            - referenceTests
             - buildDocker
       - publishDocker:
           filters:
@@ -456,10 +452,6 @@ workflows:
                 - /^release-.*/
           requires:
             - assemble
-            - integrationTests
-            - unitTests
-            - acceptanceTests
-            - referenceTests
             - buildDocker
           context:
             - besu-dockerhub-rw
@@ -470,10 +462,6 @@ workflows:
                 - main
                 - /^release-.*/
           requires:
-            - integrationTests
-            - unitTests
-            - acceptanceTests
-            - referenceTests
             - buildArm64Docker
           context:
             - besu-dockerhub-rw


### PR DESCRIPTION
occasional flakiness eg https://app.circleci.com/pipelines/gh/hyperledger/besu/26365/workflows/c1646864-be7d-4a67-95dc-ab22876dbdde should not stop publish tasks

all required test tasks have already passed on PR runs