### PR TITLE
Only accept an address from a peer if it is a valid IP address

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -293,7 +293,9 @@ public abstract class PeerDiscoveryAgent {
             .getPacketData(PingPacketData.class)
             .flatMap(PingPacketData::getFrom)
             .map(Endpoint::getHost)
-            .filter(abc -> !abc.equals("127.0.0.1"))
+            .filter(
+                fromAddr ->
+                    (!fromAddr.equals("127.0.0.1") && InetAddresses.isInetAddress(fromAddr)))
             .stream()
             .peek(
                 h ->


### PR DESCRIPTION
## PR description
When using the `From` address specified by a peer, ensure it is a valid IP address. Otherwise revert to using the UDP source host.

## Fixed Issue(s)
See comment https://github.com/hyperledger/besu/pull/6225#issuecomment-1900243754