### PR TITLE
Reuse --bonsai-historical-block-limit for trie log pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Upgrade Mockito [#6397](https://github.com/hyperledger/besu/pull/6397)
 - Upgrade `tech.pegasys.discovery:discovery` [#6414](https://github.com/hyperledger/besu/pull/6414)
 - Options to tune the max allowed time that can be spent selecting transactions during block creation are now stable [#6423](https://github.com/hyperledger/besu/pull/6423)
+- Introduce `--Xbonsai-limit-trie-logs-enabled` experimental feature which by default will only retain the latest 512 trie logs, saving about 3GB per week in database growth [#5390](https://github.com/hyperledger/besu/issues/5390)
+- Introduce `besu storage x-trie-log prune` experimental offline subcommand which will prune all redundant trie logs except the latest 512 [#6303](https://github.com/hyperledger/besu/pull/6303)
 
 ### Bug fixes
 - INTERNAL_ERROR from `eth_estimateGas` JSON/RPC calls [#6344](https://github.com/hyperledger/besu/issues/6344)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -3546,7 +3546,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     if (dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogPruningEnabled()) {
       builder.setTrieLogPruningEnabled();
       builder.setTrieLogRetentionThreshold(
-          dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogRetentionThreshold());
+          dataStorageOptions.toDomainObject().getBonsaiMaxLayersToLoad());
       builder.setTrieLogPruningLimit(
           dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogPruningLimit());
     }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -3543,12 +3543,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       builder.setHighSpecEnabled();
     }
 
-    if (dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogPruningEnabled()) {
-      builder.setTrieLogPruningEnabled();
-      builder.setTrieLogRetentionThreshold(
+    if (dataStorageOptions.toDomainObject().getUnstable().getBonsaiLimitTrieLogsEnabled()) {
+      builder.setLimitTrieLogsEnabled();
+      builder.setTrieLogRetentionLimit(
           dataStorageOptions.toDomainObject().getBonsaiMaxLayersToLoad());
-      builder.setTrieLogPruningLimit(
-          dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogPruningLimit());
+      builder.setTrieLogsPruningWindowSize(
+          dataStorageOptions.toDomainObject().getUnstable().getBonsaiTrieLogPruningWindowSize());
     }
 
     builder.setTxPoolImplementation(buildTransactionPoolConfiguration().getTxPoolImplementation());

--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -51,9 +51,9 @@ public class ConfigurationOverviewBuilder {
   private Collection<String> engineApis;
   private String engineJwtFilePath;
   private boolean isHighSpec = false;
-  private boolean isTrieLogPruningEnabled = false;
-  private long trieLogRetentionThreshold = 0;
-  private Integer trieLogPruningLimit = null;
+  private boolean isBonsaiLimitTrieLogsEnabled = false;
+  private long trieLogRetentionLimit = 0;
+  private Integer trieLogsPruningWindowSize = null;
   private TransactionPoolConfiguration.Implementation txPoolImplementation;
   private EvmConfiguration.WorldUpdaterMode worldStateUpdateMode;
   private Map<String, String> environment;
@@ -187,34 +187,34 @@ public class ConfigurationOverviewBuilder {
   }
 
   /**
-   * Sets trie log pruning enabled
+   * Sets limit trie logs enabled
    *
    * @return the builder
    */
-  public ConfigurationOverviewBuilder setTrieLogPruningEnabled() {
-    isTrieLogPruningEnabled = true;
+  public ConfigurationOverviewBuilder setLimitTrieLogsEnabled() {
+    isBonsaiLimitTrieLogsEnabled = true;
     return this;
   }
 
   /**
-   * Sets trie log retention threshold
+   * Sets trie log retention limit
    *
-   * @param threshold the number of blocks to retain trie logs for
+   * @param limit the number of blocks to retain trie logs for
    * @return the builder
    */
-  public ConfigurationOverviewBuilder setTrieLogRetentionThreshold(final long threshold) {
-    trieLogRetentionThreshold = threshold;
+  public ConfigurationOverviewBuilder setTrieLogRetentionLimit(final long limit) {
+    trieLogRetentionLimit = limit;
     return this;
   }
 
   /**
-   * Sets trie log pruning limit
+   * Sets trie logs pruning window size
    *
-   * @param limit the max number of blocks to load and prune trie logs for at startup
+   * @param size the max number of blocks to load and prune trie logs for at startup
    * @return the builder
    */
-  public ConfigurationOverviewBuilder setTrieLogPruningLimit(final int limit) {
-    trieLogPruningLimit = limit;
+  public ConfigurationOverviewBuilder setTrieLogsPruningWindowSize(final int size) {
+    trieLogsPruningWindowSize = size;
     return this;
   }
 
@@ -323,13 +323,13 @@ public class ConfigurationOverviewBuilder {
 
     lines.add("Using " + worldStateUpdateMode + " worldstate update mode");
 
-    if (isTrieLogPruningEnabled) {
+    if (isBonsaiLimitTrieLogsEnabled) {
       final StringBuilder trieLogPruningString = new StringBuilder();
       trieLogPruningString
-          .append("Trie log pruning enabled: retention: ")
-          .append(trieLogRetentionThreshold);
-      if (trieLogPruningLimit != null) {
-        trieLogPruningString.append("; prune limit: ").append(trieLogPruningLimit);
+          .append("Limit trie logs enabled: retention: ")
+          .append(trieLogRetentionLimit);
+      if (trieLogsPruningWindowSize != null) {
+        trieLogPruningString.append("; prune window: ").append(trieLogsPruningWindowSize);
       }
       lines.add(trieLogPruningString.toString());
     }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
@@ -248,24 +248,25 @@ public class TrieLogHelper {
   void validatePruneConfiguration(final DataStorageConfiguration config) {
     checkArgument(
         config.getBonsaiMaxLayersToLoad()
-            >= DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD,
+            >= DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT,
         String.format(
             DataStorageOptions.BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD + " minimum value is %d",
-            DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD));
+            DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT));
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogPruningLimit() > 0,
+        config.getUnstable().getBonsaiTrieLogPruningWindowSize() > 0,
         String.format(
-            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_LIMIT
+            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
                 + "=%d must be greater than 0",
-            config.getUnstable().getBonsaiTrieLogPruningLimit()));
+            config.getUnstable().getBonsaiTrieLogPruningWindowSize()));
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogPruningLimit() > config.getBonsaiMaxLayersToLoad(),
+        config.getUnstable().getBonsaiTrieLogPruningWindowSize()
+            > config.getBonsaiMaxLayersToLoad(),
         String.format(
-            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_LIMIT
-                + "=%d must greater than "
+            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
+                + "=%d must be greater than "
                 + DataStorageOptions.BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD
                 + "=%d",
-            config.getUnstable().getBonsaiTrieLogPruningLimit(),
+            config.getUnstable().getBonsaiTrieLogPruningWindowSize(),
             config.getBonsaiMaxLayersToLoad()));
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
@@ -18,6 +18,7 @@ package org.hyperledger.besu.cli.subcommands.storage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 
+import org.hyperledger.besu.cli.options.stable.DataStorageOptions;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
@@ -56,7 +58,7 @@ public class TrieLogHelper {
   private static final int ROCKSDB_MAX_INSERTS_PER_TRANSACTION = 1000;
   private static final Logger LOG = LoggerFactory.getLogger(TrieLogHelper.class);
 
-  static void prune(
+  void prune(
       final DataStorageConfiguration config,
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final MutableBlockchain blockchain,
@@ -66,7 +68,7 @@ public class TrieLogHelper {
 
     validatePruneConfiguration(config);
 
-    final long layersToRetain = config.getUnstable().getBonsaiTrieLogRetentionThreshold();
+    final long layersToRetain = config.getBonsaiMaxLayersToLoad();
 
     final long chainHeight = blockchain.getChainHeadBlockNumber();
 
@@ -94,7 +96,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static void processTrieLogBatches(
+  private void processTrieLogBatches(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final MutableBlockchain blockchain,
       final long chainHeight,
@@ -122,7 +124,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static void saveTrieLogBatches(
+  private void saveTrieLogBatches(
       final String batchFileName,
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final List<Hash> trieLogKeys) {
@@ -135,7 +137,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static void restoreTrieLogBatches(
+  private void restoreTrieLogBatches(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final long batchNumber,
       final String batchFileNameBase) {
@@ -149,7 +151,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static void deleteFiles(final String batchFileNameBase, final long numberOfBatches) {
+  private void deleteFiles(final String batchFileNameBase, final long numberOfBatches) {
 
     LOG.info("Deleting files...");
 
@@ -161,7 +163,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static List<Hash> getTrieLogKeysForBlocks(
+  private List<Hash> getTrieLogKeysForBlocks(
       final MutableBlockchain blockchain,
       final long firstBlockOfBatch,
       final long lastBlockOfBatch) {
@@ -175,11 +177,11 @@ public class TrieLogHelper {
     return trieLogKeys;
   }
 
-  private static long calculateNumberofBatches(final long layersToRetain) {
+  private long calculateNumberofBatches(final long layersToRetain) {
     return layersToRetain / BATCH_SIZE + ((layersToRetain % BATCH_SIZE == 0) ? 0 : 1);
   }
 
-  private static boolean validPruneRequirements(
+  private boolean validPruneRequirements(
       final MutableBlockchain blockchain,
       final long chainHeight,
       final long lastBlockNumberToRetainTrieLogsFor) {
@@ -206,7 +208,7 @@ public class TrieLogHelper {
     return true;
   }
 
-  private static void recreateTrieLogs(
+  private void recreateTrieLogs(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final long batchNumber,
       final String batchFileNameBase)
@@ -222,7 +224,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static void processTransactionChunk(
+  private void processTransactionChunk(
       final int startIndex,
       final int chunkSize,
       final List<byte[]> keys,
@@ -242,28 +244,32 @@ public class TrieLogHelper {
     updater.getTrieLogStorageTransaction().commit();
   }
 
-  private static void validatePruneConfiguration(final DataStorageConfiguration config) {
+  @VisibleForTesting
+  void validatePruneConfiguration(final DataStorageConfiguration config) {
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogRetentionThreshold()
-            >= config.getBonsaiMaxLayersToLoad(),
+        config.getBonsaiMaxLayersToLoad()
+            >= DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD,
         String.format(
-            "--Xbonsai-trie-log-retention-threshold minimum value is %d",
-            config.getBonsaiMaxLayersToLoad()));
+            DataStorageOptions.BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD + " minimum value is %d",
+            DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD));
     checkArgument(
         config.getUnstable().getBonsaiTrieLogPruningLimit() > 0,
         String.format(
-            "--Xbonsai-trie-log-pruning-limit=%d must be greater than 0",
+            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_LIMIT
+                + "=%d must be greater than 0",
             config.getUnstable().getBonsaiTrieLogPruningLimit()));
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogPruningLimit()
-            > config.getUnstable().getBonsaiTrieLogRetentionThreshold(),
+        config.getUnstable().getBonsaiTrieLogPruningLimit() > config.getBonsaiMaxLayersToLoad(),
         String.format(
-            "--Xbonsai-trie-log-pruning-limit=%d must greater than --Xbonsai-trie-log-retention-threshold=%d",
+            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_LIMIT
+                + "=%d must greater than "
+                + DataStorageOptions.BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD
+                + "=%d",
             config.getUnstable().getBonsaiTrieLogPruningLimit(),
-            config.getUnstable().getBonsaiTrieLogRetentionThreshold()));
+            config.getBonsaiMaxLayersToLoad()));
   }
 
-  private static void saveTrieLogsInFile(
+  private void saveTrieLogsInFile(
       final List<Hash> trieLogsKeys,
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final String batchFileName)
@@ -285,7 +291,7 @@ public class TrieLogHelper {
   }
 
   @SuppressWarnings("unchecked")
-  static IdentityHashMap<byte[], byte[]> readTrieLogsFromFile(final String batchFileName) {
+  IdentityHashMap<byte[], byte[]> readTrieLogsFromFile(final String batchFileName) {
 
     IdentityHashMap<byte[], byte[]> trieLogs;
     try (FileInputStream fis = new FileInputStream(batchFileName);
@@ -300,7 +306,7 @@ public class TrieLogHelper {
     return trieLogs;
   }
 
-  private static void saveTrieLogsAsRlpInFile(
+  private void saveTrieLogsAsRlpInFile(
       final List<Hash> trieLogsKeys,
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final String batchFileName) {
@@ -325,7 +331,7 @@ public class TrieLogHelper {
     }
   }
 
-  static IdentityHashMap<byte[], byte[]> readTrieLogsAsRlpFromFile(final String batchFileName) {
+  IdentityHashMap<byte[], byte[]> readTrieLogsAsRlpFromFile(final String batchFileName) {
     try {
       final Bytes file = Bytes.wrap(Files.readAllBytes(Path.of(batchFileName)));
       final BytesValueRLPInput input = new BytesValueRLPInput(file, false);
@@ -346,7 +352,7 @@ public class TrieLogHelper {
     }
   }
 
-  private static IdentityHashMap<byte[], byte[]> getTrieLogs(
+  private IdentityHashMap<byte[], byte[]> getTrieLogs(
       final List<Hash> trieLogKeys, final BonsaiWorldStateKeyValueStorage rootWorldStateStorage) {
     IdentityHashMap<byte[], byte[]> trieLogsToRetain = new IdentityHashMap<>();
 
@@ -359,7 +365,7 @@ public class TrieLogHelper {
     return trieLogsToRetain;
   }
 
-  static TrieLogCount getCount(
+  TrieLogCount getCount(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final int limit,
       final Blockchain blockchain) {
@@ -394,13 +400,13 @@ public class TrieLogHelper {
     return new TrieLogCount(total.get(), canonicalCount.get(), forkCount.get(), orphanCount.get());
   }
 
-  static void printCount(final PrintWriter out, final TrieLogCount count) {
+  void printCount(final PrintWriter out, final TrieLogCount count) {
     out.printf(
         "trieLog count: %s\n - canonical count: %s\n - fork count: %s\n - orphaned count: %s\n",
         count.total, count.canonicalCount, count.forkCount, count.orphanCount);
   }
 
-  static void importTrieLog(
+  void importTrieLog(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage, final Path trieLogFilePath) {
 
     var trieLog = readTrieLogsAsRlpFromFile(trieLogFilePath.toString());
@@ -410,7 +416,7 @@ public class TrieLogHelper {
     updater.getTrieLogStorageTransaction().commit();
   }
 
-  static void exportTrieLog(
+  void exportTrieLog(
       final BonsaiWorldStateKeyValueStorage rootWorldStateStorage,
       final List<Hash> trieLogHash,
       final Path directoryPath)

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
@@ -89,14 +89,15 @@ public class TrieLogSubCommand implements Runnable {
 
     @Override
     public void run() {
-      TrieLogContext context = getTrieLogContext();
+      final TrieLogContext context = getTrieLogContext();
 
       final PrintWriter out = spec.commandLine().getOut();
 
       out.println("Counting trie logs...");
-      TrieLogHelper.printCount(
+      final TrieLogHelper trieLogHelper = new TrieLogHelper();
+      trieLogHelper.printCount(
           out,
-          TrieLogHelper.getCount(
+          trieLogHelper.getCount(
               context.rootWorldStateStorage, Integer.MAX_VALUE, context.blockchain));
     }
   }
@@ -119,11 +120,12 @@ public class TrieLogSubCommand implements Runnable {
 
     @Override
     public void run() {
-      TrieLogContext context = getTrieLogContext();
+      final TrieLogContext context = getTrieLogContext();
       final Path dataDirectoryPath =
           Paths.get(
               TrieLogSubCommand.parentCommand.parentCommand.dataDir().toAbsolutePath().toString());
-      TrieLogHelper.prune(
+      final TrieLogHelper trieLogHelper = new TrieLogHelper();
+      trieLogHelper.prune(
           context.config(),
           context.rootWorldStateStorage(),
           context.blockchain(),
@@ -173,13 +175,15 @@ public class TrieLogSubCommand implements Runnable {
                     .toString());
       }
 
-      TrieLogContext context = getTrieLogContext();
+      final TrieLogContext context = getTrieLogContext();
 
       final List<Hash> listOfBlockHashes =
           trieLogBlockHashList.stream().map(Hash::fromHexString).toList();
 
+      final TrieLogHelper trieLogHelper = new TrieLogHelper();
+
       try {
-        TrieLogHelper.exportTrieLog(
+        trieLogHelper.exportTrieLog(
             context.rootWorldStateStorage(), listOfBlockHashes, trieLogFilePath);
       } catch (IOException e) {
         throw new RuntimeException(e);
@@ -222,8 +226,8 @@ public class TrieLogSubCommand implements Runnable {
       }
 
       TrieLogContext context = getTrieLogContext();
-
-      TrieLogHelper.importTrieLog(context.rootWorldStateStorage(), trieLogFilePath);
+      final TrieLogHelper trieLogHelper = new TrieLogHelper();
+      trieLogHelper.importTrieLog(context.rootWorldStateStorage(), trieLogFilePath);
     }
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
@@ -105,7 +105,7 @@ public class TrieLogSubCommand implements Runnable {
   @Command(
       name = "prune",
       description =
-          "This command prunes all trie log layers below the retention threshold, including orphaned trie logs.",
+          "This command prunes all trie log layers below the retention limit, including orphaned trie logs.",
       mixinStandardHelpOptions = true,
       versionProvider = VersionProvider.class)
   static class PruneTrieLog implements Runnable {
@@ -148,6 +148,7 @@ public class TrieLogSubCommand implements Runnable {
     @CommandLine.Spec
     private CommandLine.Model.CommandSpec spec; // Picocli injects reference to command spec
 
+    @SuppressWarnings("unused")
     @CommandLine.Option(
         names = "--trie-log-block-hash",
         description =

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -782,7 +782,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final JsonRpcMethods additionalJsonRpcMethodFactory =
         createAdditionalJsonRpcMethodFactory(protocolContext);
 
-    if (dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningEnabled()
+    if (dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled()
         && DataStorageFormat.BONSAI.equals(dataStorageConfiguration.getDataStorageFormat())) {
       final TrieLogManager trieLogManager =
           ((BonsaiWorldStateProvider) worldStateArchive).getTrieLogManager();
@@ -831,8 +831,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             (BonsaiWorldStateKeyValueStorage) worldStateStorage,
             blockchain,
             scheduler::executeServiceTask,
-            dataStorageConfiguration.getUnstable().getBonsaiTrieLogRetentionThreshold(),
-            dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningLimit(),
+            dataStorageConfiguration.getBonsaiMaxLayersToLoad(),
+            dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize(),
             isProofOfStake);
     trieLogPruner.initialize();
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -1078,7 +1078,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
                 ? new TrieLogPruner(
                     (BonsaiWorldStateKeyValueStorage) worldStateStorage,
                     blockchain,
-                    dataStorageConfiguration.getUnstable().getBonsaiTrieLogRetentionThreshold(),
+                    dataStorageConfiguration.getBonsaiMaxLayersToLoad(),
                     dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningLimit(),
                     isProofOfStake)
                 : TrieLogPruner.noOpTrieLogPruner();

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -1074,12 +1074,12 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
         final boolean isProofOfStake =
             genesisConfigOptions.getTerminalTotalDifficulty().isPresent();
         final TrieLogPruner trieLogPruner =
-            dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningEnabled()
+            dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled()
                 ? new TrieLogPruner(
                     (BonsaiWorldStateKeyValueStorage) worldStateStorage,
                     blockchain,
                     dataStorageConfiguration.getBonsaiMaxLayersToLoad(),
-                    dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningLimit(),
+                    dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize(),
                     isProofOfStake)
                 : TrieLogPruner.noOpTrieLogPruner();
         trieLogPruner.initialize();

--- a/besu/src/test/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilderTest.java
@@ -151,21 +151,21 @@ class ConfigurationOverviewBuilderTest {
   }
 
   @Test
-  void setTrieLogPruningEnabled() {
-    final String noTrieLogRetentionThresholdSet = builder.build();
-    assertThat(noTrieLogRetentionThresholdSet).doesNotContain("Trie log pruning enabled");
+  void setBonsaiLimitTrieLogsEnabled() {
+    final String noTrieLogRetentionLimitSet = builder.build();
+    assertThat(noTrieLogRetentionLimitSet).doesNotContain("Limit trie logs enabled");
 
-    builder.setTrieLogPruningEnabled();
-    builder.setTrieLogRetentionThreshold(42);
-    String trieLogRetentionThresholdSet = builder.build();
-    assertThat(trieLogRetentionThresholdSet)
-        .contains("Trie log pruning enabled")
+    builder.setLimitTrieLogsEnabled();
+    builder.setTrieLogRetentionLimit(42);
+    String trieLogRetentionLimitSet = builder.build();
+    assertThat(trieLogRetentionLimitSet)
+        .contains("Limit trie logs enabled")
         .contains("retention: 42");
-    assertThat(trieLogRetentionThresholdSet).doesNotContain("prune limit");
+    assertThat(trieLogRetentionLimitSet).doesNotContain("prune window");
 
-    builder.setTrieLogPruningLimit(1000);
-    trieLogRetentionThresholdSet = builder.build();
-    assertThat(trieLogRetentionThresholdSet).contains("prune limit: 1000");
+    builder.setTrieLogsPruningWindowSize(1000);
+    trieLogRetentionLimitSet = builder.build();
+    assertThat(trieLogRetentionLimitSet).contains("prune window: 1000");
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
@@ -16,7 +16,7 @@
 package org.hyperledger.besu.cli.options.stable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT;
 
 import org.hyperledger.besu.cli.options.AbstractCLIOptionsTest;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
@@ -32,46 +32,55 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogPruningLimitOption() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningLimit())
-                .isEqualTo(1),
+            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize())
+                .isEqualTo(600),
         "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-pruning-limit",
-        "1");
+        "--Xbonsai-trie-logs-pruning-window-size",
+        "600");
   }
 
   @Test
-  public void bonsaiTrieLogPruningLimitShouldBePositive() {
+  public void bonsaiTrieLogPruningWindowSizeShouldBePositive() {
     internalTestFailure(
-        "--Xbonsai-trie-logs-pruning-limit=0 must be greater than 0",
+        "--Xbonsai-trie-logs-pruning-window-size=0 must be greater than 0",
         "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-pruning-limit",
+        "--Xbonsai-trie-logs-pruning-window-size",
         "0");
   }
 
   @Test
-  public void bonsaiTrieLogRetentionThresholdOption() {
+  public void bonsaiTrieLogPruningWindowSizeShouldBeAboveRetentionLimit() {
+    internalTestFailure(
+        "--Xbonsai-trie-logs-pruning-window-size=512 must be greater than --bonsai-historical-block-limit=512",
+        "--Xbonsai-limit-trie-logs-enabled",
+        "--Xbonsai-trie-logs-pruning-window-size",
+        "512");
+  }
+
+  @Test
+  public void bonsaiTrieLogRetentionLimitOption() {
     internalTestSuccess(
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
-                .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD + 1),
+                .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT + 1),
         "--Xbonsai-limit-trie-logs-enabled",
         "--bonsai-historical-block-limit",
         "513");
   }
 
   @Test
-  public void bonsaiTrieLogRetentionThresholdOption_boundaryTest() {
+  public void bonsaiTrieLogRetentionLimitOption_boundaryTest() {
     internalTestSuccess(
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
-                .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD),
+                .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT),
         "--Xbonsai-limit-trie-logs-enabled",
         "--bonsai-historical-block-limit",
         "512");
   }
 
   @Test
-  public void bonsaiTrieLogRetentionThresholdShouldBeAboveMinimum() {
+  public void bonsaiTrieLogRetentionLimitShouldBeAboveMinimum() {
     internalTestFailure(
         "--bonsai-historical-block-limit minimum value is 512",
         "--Xbonsai-limit-trie-logs-enabled",
@@ -91,8 +100,8 @@ public class DataStorageOptionsTest
         .bonsaiMaxLayersToLoad(513L)
         .unstable(
             ImmutableDataStorageConfiguration.Unstable.builder()
-                .bonsaiTrieLogPruningEnabled(true)
-                .bonsaiTrieLogPruningLimit(20)
+                .bonsaiLimitTrieLogsEnabled(true)
+                .bonsaiTrieLogPruningWindowSize(514)
                 .build())
         .build();
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
@@ -42,7 +42,7 @@ public class DataStorageOptionsTest
   @Test
   public void bonsaiTrieLogPruningLimitShouldBePositive() {
     internalTestFailure(
-        "--Xbonsai-trie-log-pruning-limit=0 must be greater than 0",
+        "--Xbonsai-trie-logs-pruning-limit=0 must be greater than 0",
         "--Xbonsai-limit-trie-logs-enabled",
         "--Xbonsai-trie-logs-pruning-limit",
         "0");
@@ -52,10 +52,10 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogRetentionThresholdOption() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogRetentionThreshold())
+            assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
                 .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD + 1),
         "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-retention-threshold",
+        "--bonsai-historical-block-limit",
         "513");
   }
 
@@ -63,19 +63,19 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogRetentionThresholdOption_boundaryTest() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogRetentionThreshold())
+            assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
                 .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD),
         "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-retention-threshold",
+        "--bonsai-historical-block-limit",
         "512");
   }
 
   @Test
   public void bonsaiTrieLogRetentionThresholdShouldBeAboveMinimum() {
     internalTestFailure(
-        "--Xbonsai-trie-log-retention-threshold minimum value is 512",
+        "--bonsai-historical-block-limit minimum value is 512",
         "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-retention-threshold",
+        "--bonsai-historical-block-limit",
         "511");
   }
 
@@ -88,11 +88,10 @@ public class DataStorageOptionsTest
   protected DataStorageConfiguration createCustomizedDomainObject() {
     return ImmutableDataStorageConfiguration.builder()
         .dataStorageFormat(DataStorageFormat.BONSAI)
-        .bonsaiMaxLayersToLoad(100L)
+        .bonsaiMaxLayersToLoad(513L)
         .unstable(
             ImmutableDataStorageConfiguration.Unstable.builder()
                 .bonsaiTrieLogPruningEnabled(true)
-                .bonsaiTrieLogRetentionThreshold(1000L)
                 .bonsaiTrieLogPruningLimit(20)
                 .build())
         .build();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
@@ -44,8 +44,7 @@ public interface DataStorageConfiguration {
   interface Unstable {
 
     boolean DEFAULT_BONSAI_TRIE_LOG_PRUNING_ENABLED = false;
-    long DEFAULT_BONSAI_TRIE_LOG_RETENTION_THRESHOLD = 512L;
-    long MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD = DEFAULT_BONSAI_TRIE_LOG_RETENTION_THRESHOLD;
+    long MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
     int DEFAULT_BONSAI_TRIE_LOG_PRUNING_LIMIT = 30_000;
 
     DataStorageConfiguration.Unstable DEFAULT =
@@ -54,11 +53,6 @@ public interface DataStorageConfiguration {
     @Value.Default
     default boolean getBonsaiTrieLogPruningEnabled() {
       return DEFAULT_BONSAI_TRIE_LOG_PRUNING_ENABLED;
-    }
-
-    @Value.Default
-    default long getBonsaiTrieLogRetentionThreshold() {
-      return DEFAULT_BONSAI_TRIE_LOG_RETENTION_THRESHOLD;
     }
 
     @Value.Default

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
@@ -43,21 +43,21 @@ public interface DataStorageConfiguration {
   @Value.Immutable
   interface Unstable {
 
-    boolean DEFAULT_BONSAI_TRIE_LOG_PRUNING_ENABLED = false;
-    long MINIMUM_BONSAI_TRIE_LOG_RETENTION_THRESHOLD = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
-    int DEFAULT_BONSAI_TRIE_LOG_PRUNING_LIMIT = 30_000;
+    boolean DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED = false;
+    long MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
+    int DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE = 30_000;
 
     DataStorageConfiguration.Unstable DEFAULT =
         ImmutableDataStorageConfiguration.Unstable.builder().build();
 
     @Value.Default
-    default boolean getBonsaiTrieLogPruningEnabled() {
-      return DEFAULT_BONSAI_TRIE_LOG_PRUNING_ENABLED;
+    default boolean getBonsaiLimitTrieLogsEnabled() {
+      return DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
     }
 
     @Value.Default
-    default int getBonsaiTrieLogPruningLimit() {
-      return DEFAULT_BONSAI_TRIE_LOG_PRUNING_LIMIT;
+    default int getBonsaiTrieLogPruningWindowSize() {
+      return DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
     }
   }
 }


### PR DESCRIPTION
Part of https://github.com/hyperledger/besu/issues/5390

* `$BESU --Xbonsai-limit-trie-logs-enabled=true` will use the default value of `--bonsai-historical-block-limit=512`
* `$BESU --Xbonsai-limit-trie-logs-enabled=true --bonsai-historical-block-limit=511` throws error as must be >= 512
* `$BESU --Xbonsai-limit-trie-logs-enabled=false --bonsai-historical-block-limit=511` does not throw error as this is allowed until limit-trie-logs-enabled.

This implementation avoids a breaking change for anyone that has a node with --bonsai-historical-block-limit already set to < 512 (could be noone?)

However, we should be aware that if `--Xbonsai-limit-trie-logs-enabled` ever becomes default then this breaking change will come back again