### PR TITLE
Enable limit on range Of JSON-RPC API trace_filter method (#5971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 24.1.2-SNAPSHOT
 
 ### Breaking Changes
-- The `trace-filter` method in JSON-RPC API now has a default block range limit of 1000, adjustable with `--rpc-max-logs-range` [#6446](https://github.com/hyperledger/besu/pull/6446)
+- The `trace-filter` method in JSON-RPC API now has a default block range limit of 1000, adjustable with `--rpc-max-trace-filter-range` [#6446](https://github.com/hyperledger/besu/pull/6446)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 24.1.2-SNAPSHOT
 
 ### Breaking Changes
+- A Limit on the range of blocks passed to the JSON-RPC API `trace-filter` method, that defaults to 1000 and can be set with `--rpc-max-logs-range`, has been enabled [#6446](https://github.com/hyperledger/besu/pull/6446)
 
 ### Deprecations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 24.1.2-SNAPSHOT
 
 ### Breaking Changes
-- A Limit on the range of blocks passed to the JSON-RPC API `trace-filter` method, that defaults to 1000 and can be set with `--rpc-max-logs-range`, has been enabled [#6446](https://github.com/hyperledger/besu/pull/6446)
+- The `trace-filter` method in JSON-RPC API now has a default block range limit of 1000, adjustable with `--rpc-max-logs-range` [#6446](https://github.com/hyperledger/besu/pull/6446)
 
 ### Deprecations
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1259,6 +1259,12 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       description = "Specifies the number of last blocks to cache  (default: ${DEFAULT-VALUE})")
   private final Integer numberOfblocksToCache = 0;
 
+  @Option(
+      names = {"--rpc-max-trace-range"},
+      description =
+          "Specifies the maximum number of blocks for the trace_filter method (default: $DEFAULT-VALUE)")
+  private final Long maxTraceRange = 1000L;
+
   @Mixin private P2PTLSConfigOptions p2pTLSConfigOptions;
 
   @Mixin private PkiBlockCreationOptions pkiBlockCreationOptions;
@@ -2526,7 +2532,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .gasPriceMax(apiGasPriceMax)
             .maxLogsRange(rpcMaxLogsRange)
             .gasCap(rpcGasCap)
-            .isGasAndPriorityFeeLimitingEnabled(apiGasAndPriorityFeeLimitingEnabled);
+            .isGasAndPriorityFeeLimitingEnabled(apiGasAndPriorityFeeLimitingEnabled)
+            .maxTraceRange(maxTraceRange);
     if (apiGasAndPriorityFeeLimitingEnabled) {
       if (apiGasAndPriorityFeeLowerBoundCoefficient > apiGasAndPriorityFeeUpperBoundCoefficient) {
         throw new ParameterException(

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1260,10 +1260,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final Integer numberOfblocksToCache = 0;
 
   @Option(
-      names = {"--rpc-max-trace-range"},
+      names = {"--rpc-max-trace-filter-range"},
       description =
-          "Specifies the maximum number of blocks for the trace_filter method (default: $DEFAULT-VALUE)")
-  private final Long maxTraceRange = 1000L;
+          "Specifies the maximum number of blocks for the trace_filter method. Must be >=0. 0 specifies no limit  (default: $DEFAULT-VALUE)")
+  private final Long maxTraceFilterRange = 1000L;
 
   @Mixin private P2PTLSConfigOptions p2pTLSConfigOptions;
 
@@ -2533,7 +2533,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .maxLogsRange(rpcMaxLogsRange)
             .gasCap(rpcGasCap)
             .isGasAndPriorityFeeLimitingEnabled(apiGasAndPriorityFeeLimitingEnabled)
-            .maxTraceRange(maxTraceRange);
+            .maxTraceFilterRange(maxTraceFilterRange);
     if (apiGasAndPriorityFeeLimitingEnabled) {
       if (apiGasAndPriorityFeeLowerBoundCoefficient > apiGasAndPriorityFeeUpperBoundCoefficient) {
         throw new ParameterException(

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -90,6 +90,7 @@ rpc-max-logs-range=100
 json-pretty-print-enabled=false
 cache-last-blocks=512
 rpc-gas-cap = 50000000
+rpc-max-trace-range=100
 
 # PRIVACY TLS
 privacy-tls-enabled=false

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -90,7 +90,7 @@ rpc-max-logs-range=100
 json-pretty-print-enabled=false
 cache-last-blocks=512
 rpc-gas-cap = 50000000
-rpc-max-trace-range=100
+rpc-max-trace-filter-range=100
 
 # PRIVACY TLS
 privacy-tls-enabled=false

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -79,7 +79,7 @@ public abstract class ApiConfiguration {
   }
 
   @Value.Default
-  public Long getMaxTraceRange() {
+  public Long getMaxTraceFilterRange() {
     return 1000L;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -77,4 +77,9 @@ public abstract class ApiConfiguration {
   public Long getUpperBoundGasAndPriorityFeeCoefficient() {
     return DEFAULT_UPPER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT;
   }
+
+  @Value.Default
+  public Long getMaxTraceRange() {
+    return 1000L;
+  }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
@@ -98,7 +98,7 @@ public class TraceFilter extends TraceBlock {
         throw new IllegalArgumentException(RpcErrorType.EXCEEDS_RPC_MAX_BLOCK_RANGE.getMessage());
     } catch (IllegalArgumentException ex) {
       LOG.atDebug()
-          .setMessage("eth_getLogs request {} failed:")
+          .setMessage("trace_filter request {} failed:")
           .addArgument(requestContext.getRequest())
           .setCause(ex.getCause())
           .log();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
@@ -93,14 +93,12 @@ public class TraceFilter extends TraceBlock {
     final long toBlock = resolveBlockNumber(filterParameter.getToBlock());
     LOG.trace("Received RPC rpcName={} fromBlock={} toBlock={}", getName(), fromBlock, toBlock);
 
-    try {
-      if (maxRange > 0 && toBlock - fromBlock > maxRange)
-        throw new IllegalArgumentException(RpcErrorType.EXCEEDS_RPC_MAX_BLOCK_RANGE.getMessage());
-    } catch (IllegalArgumentException ex) {
+    if (maxRange > 0 && toBlock - fromBlock > maxRange) {
       LOG.atDebug()
           .setMessage("trace_filter request {} failed:")
           .addArgument(requestContext.getRequest())
-          .setCause(ex.getCause())
+          .setCause(
+              new IllegalArgumentException(RpcErrorType.EXCEEDS_RPC_MAX_BLOCK_RANGE.getMessage()))
           .log();
       return new JsonRpcErrorResponse(
           requestContext.getRequest().getId(), RpcErrorType.EXCEEDS_RPC_MAX_BLOCK_RANGE);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -60,7 +60,11 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new BlockReplay(protocolSchedule, blockchainQueries.getBlockchain());
     return mapOf(
         new TraceReplayBlockTransactions(protocolSchedule, blockchainQueries),
-        new TraceFilter(() -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
+        new TraceFilter(
+            () -> new BlockTracer(blockReplay),
+            protocolSchedule,
+            blockchainQueries,
+            apiConfiguration.getMaxTraceRange()),
         new TraceGet(() -> new BlockTracer(blockReplay), blockchainQueries, protocolSchedule),
         new TraceTransaction(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -64,7 +64,7 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
             () -> new BlockTracer(blockReplay),
             protocolSchedule,
             blockchainQueries,
-            apiConfiguration.getMaxTraceRange()),
+            apiConfiguration.getMaxTraceFilterRange()),
         new TraceGet(() -> new BlockTracer(blockReplay), blockchainQueries, protocolSchedule),
         new TraceTransaction(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -1,4 +1,17 @@
-/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: Apache-2.0 */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Enable a limit on the range of blocks that can be supplied to the JSON-RPC trace_filter method.

The limit has a default value and can be overridden with a command line option at start up.

fixes #5971 