### PR TITLE
feat: add `OperationTracer.tracePrepareTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Deprecations
 
 ### Additions and Improvements
+- Add `OperationTracer.tracePrepareTransaction`, where the sender account has not yet been altered[#6453](https://github.com/hyperledger/besu/pull/6453)
 
 ### Bug fixes
 - Fix the way an advertised host configured with `--p2p-host` is treated when communicating with the originator of a PING packet [#6225](https://github.com/hyperledger/besu/pull/6225)

--- a/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
@@ -115,6 +115,7 @@ class TraceServiceImplTest {
         .getTransactions()
         .forEach(
             tx -> {
+              verify(opTracer).tracePrepareTransaction(any(), eq(tx));
               verify(opTracer).traceStartTransaction(any(), eq(tx));
               verify(opTracer)
                   .traceEndTransaction(
@@ -162,6 +163,7 @@ class TraceServiceImplTest {
                   .getTransactions()
                   .forEach(
                       tx -> {
+                        verify(opTracer).tracePrepareTransaction(any(), eq(tx));
                         verify(opTracer).traceStartTransaction(any(), eq(tx));
                         verify(opTracer)
                             .traceEndTransaction(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -293,6 +293,8 @@ public class MainnetTransactionProcessor {
         return TransactionProcessingResult.invalid(validationResult);
       }
 
+      operationTracer.tracePrepareTransaction(worldState, transaction);
+
       final long previousNonce = sender.incrementNonce();
       LOG.trace(
           "Incremented sender {} nonce ({} -> {})",

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
@@ -271,6 +271,7 @@ public class T8nExecutor {
       final TransactionProcessingResult result;
       try {
         tracer = tracerManager.getManagedTracer(i, transaction.getHash());
+        tracer.tracePrepareTransaction(worldStateUpdater, transaction);
         tracer.traceStartTransaction(worldStateUpdater, transaction);
         result =
             processor.processTransaction(

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
@@ -68,7 +68,15 @@ public interface OperationTracer {
       final MessageFrame frame, final Optional<ExceptionalHaltReason> haltReason) {}
 
   /**
-   * Trace the start of a transaction.
+   * Trace the start of a transaction, before sender account alteration but after validation.
+   *
+   * @param worldView an immutable view of the execution context
+   * @param transaction the transaction which will be processed
+   */
+  default void tracePrepareTransaction(final WorldView worldView, final Transaction transaction) {}
+
+  /**
+   * Trace the start of a transaction, before execution but after sender account alteration.
    *
    * @param worldView an immutable view of the execution context
    * @param transaction the transaction which will be processed


### PR DESCRIPTION
## PR description

`OperationTracer.traceStartTransaction` is triggered before the EVM execution, but after the sender account has been updated (i.e. its balance decreased from the upfront cost and its nonce increased), hiding its actual initial state from the `OperationTracer`.

This PR adds a new hook, `OperationTracer.tracePrepareTransaction`, that is triggered after the transaction has been validated for execution, but before any change to the sender account, hence presenting its pristine state to the `OperationTracer`.