### PR TITLE
Add broadcast address to PingPacketData from filter

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -288,30 +288,7 @@ public abstract class PeerDiscoveryAgent {
             .flatMap(Endpoint::getTcpPort)
             .orElse(udpPort);
 
-    // If the host is present in the P2P PING packet itself, use that as the endpoint. If the P2P
-    // PING packet specifies 127.0.0.1 (the default if a custom value is not specified with
-    // --p2p-host or via a suitable --nat-method) we ignore it in favour of the UDP source address.
-    // The likelihood is that the UDP source will be 127.0.0.1 anyway, but this reduces the chance
-    // of an unexpected change in behaviour as a result of
-    // https://github.com/hyperledger/besu/issues/6224 being fixed.
-    final String host =
-        packet
-            .getPacketData(PingPacketData.class)
-            .flatMap(PingPacketData::getFrom)
-            .map(Endpoint::getHost)
-            .filter(
-                fromAddr ->
-                    (!PING_PACKET_SOURCE_IGNORED.contains(fromAddr)
-                        && InetAddresses.isInetAddress(fromAddr)))
-            .stream()
-            .peek(
-                h ->
-                    LOG.trace(
-                        "Using \"From\" endpoint {} specified in ping packet. Ignoring UDP source host {}",
-                        h,
-                        sourceEndpoint.getHost()))
-            .findFirst()
-            .orElseGet(sourceEndpoint::getHost);
+    final String host = deriveHost(sourceEndpoint, packet);
 
     // Notify the peer controller.
     final DiscoveryPeer peer =
@@ -324,6 +301,38 @@ public abstract class PeerDiscoveryAgent {
                 .build());
 
     controller.ifPresent(c -> c.onMessage(packet, peer));
+  }
+
+  /**
+   * method to derive the host from the source endpoint and the P2P PING packet. If the host is
+   * present in the P2P PING packet itself, use that as the endpoint. If the P2P PING packet
+   * specifies 127.0.0.1 (the default if a custom value is not specified with --p2p-host or via a
+   * suitable --nat-method) we ignore it in favour of the UDP source address. Some implementations
+   * send 127.0.0.1 or 255.255.255.255 anyway, but this reduces the chance of an unexpected change
+   * in behaviour as a result of https://github.com/hyperledger/besu/issues/6224 being fixed.
+   *
+   * @param sourceEndpoint source endpoint of the packet
+   * @param packet P2P PING packet
+   * @return host address as string
+   */
+  static String deriveHost(final Endpoint sourceEndpoint, final Packet packet) {
+    return packet
+        .getPacketData(PingPacketData.class)
+        .flatMap(PingPacketData::getFrom)
+        .map(Endpoint::getHost)
+        .filter(
+            fromAddr ->
+                (!PING_PACKET_SOURCE_IGNORED.contains(fromAddr)
+                    && InetAddresses.isInetAddress(fromAddr)))
+        .stream()
+        .peek(
+            h ->
+                LOG.trace(
+                    "Using \"From\" endpoint {} specified in ping packet. Ignoring UDP source host {}",
+                    h,
+                    sourceEndpoint.getHost()))
+        .findFirst()
+        .orElseGet(sourceEndpoint::getHost);
   }
 
   /**

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -74,6 +74,8 @@ public abstract class PeerDiscoveryAgent {
   // The devp2p specification says only accept packets up to 1280, but some
   // clients ignore that, so we add in a little extra padding.
   private static final int MAX_PACKET_SIZE_BYTES = 1600;
+  private static final List<String> PING_PACKET_SOURCE_IGNORED =
+      List.of("127.0.0.1", "255.255.255.255");
 
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();
@@ -299,7 +301,8 @@ public abstract class PeerDiscoveryAgent {
             .map(Endpoint::getHost)
             .filter(
                 fromAddr ->
-                    (!fromAddr.equals("127.0.0.1") && InetAddresses.isInetAddress(fromAddr)))
+                    (!PING_PACKET_SOURCE_IGNORED.contains(fromAddr)
+                        && InetAddresses.isInetAddress(fromAddr)))
             .stream()
             .peek(
                 h ->

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.ethereum.p2p.discovery.internal.MockPeerDiscoveryAge
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.NeighborsPacketData;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.Packet;
 import org.hyperledger.besu.ethereum.p2p.discovery.internal.PacketType;
+import org.hyperledger.besu.ethereum.p2p.discovery.internal.PingPacketData;
 import org.hyperledger.besu.ethereum.p2p.peers.DefaultPeer;
 import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.p2p.peers.Peer;
@@ -53,6 +54,7 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
 import org.junit.jupiter.api.Test;
 
@@ -832,6 +834,47 @@ public class PeerDiscoveryAgentTest {
     final MockPeerDiscoveryAgent agent = helper.startDiscoveryAgent(agentBuilder);
 
     assertThat(agent.isActive()).isFalse();
+  }
+
+  @Test
+  public void assertHostCorrectlyRevertsOnIgnoredPacketFrom() {
+    final String sourceHost = "UDP_SOURCE_ORIGIN_HOST";
+    final String localHost = "127.0.0.1";
+    final String broadcastDefaultHost = "255.255.255.255";
+    final String routableHost = "50.50.50.50";
+
+    Endpoint source = new Endpoint(sourceHost, 30303, Optional.empty());
+    Endpoint endpointLocal = new Endpoint(localHost, 30303, Optional.empty());
+    Endpoint endpointBroadcast = new Endpoint(broadcastDefaultHost, 30303, Optional.empty());
+    Endpoint endpointRoutable = new Endpoint(routableHost, 30303, Optional.empty());
+
+    Packet mockLocal =
+        when(mock(Packet.class).getPacketData(any()))
+            .thenReturn(
+                Optional.of(
+                    PingPacketData.create(Optional.of(endpointLocal), endpointLocal, UInt64.ONE)))
+            .getMock();
+    Packet mockBroadcast =
+        when(mock(Packet.class).getPacketData(any()))
+            .thenReturn(
+                Optional.of(
+                    PingPacketData.create(
+                        Optional.of(endpointBroadcast), endpointLocal, UInt64.ONE)))
+            .getMock();
+    Packet mockWellFormed =
+        when(mock(Packet.class).getPacketData(any()))
+            .thenReturn(
+                Optional.of(
+                    PingPacketData.create(
+                        Optional.of(endpointRoutable), endpointLocal, UInt64.ONE)))
+            .getMock();
+
+    // assert a pingpacketdata from address of 127.0.0.1 reverts to the udp source host
+    assertThat(PeerDiscoveryAgent.deriveHost(source, mockLocal)).isEqualTo(sourceHost);
+    // assert that 255.255.255.255 reverts to the udp source host
+    assertThat(PeerDiscoveryAgent.deriveHost(source, mockBroadcast)).isEqualTo(sourceHost);
+    // assert that a well-formed routable address in the ping packet data is used
+    assertThat(PeerDiscoveryAgent.deriveHost(source, mockWellFormed)).isEqualTo(routableHost);
   }
 
   protected void bondViaIncomingPing(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
address another pathological default PingPacketData from address we are seeing on mainnet - a broadcast address 255.255.255.255 seems to be a default value for some implementations.

For example we are seeing a lot of these log lines on mainnet:
```
{
   "@timestamp":"2024-01-24T06:18:16,129",
   "level":"WARN",
   "thread":"vert.x-eventloop-thread-3",
   "class":"VertxPeerDiscoveryAgent",
   "message":"Sending to peer DiscoveryPeer{status=bonding, enode=enode://5d01e72875f3485fdcce5255720696087ea7d704c6632282fbe39329db6417a6f5ef940cf05519677be7f9c31b6b553fe9192e9e9feed37db3fb97bcc7fd099e@255.255.255.255:30313, firstDiscovered=1706077069751, lastContacted=0, lastSeen=1706077069751} failed, native error code -13, packet: 0x3123aed37feabe25bd4cc2625a1d1e2b12a5a1bbe6f3ef594c1ea76abbfbae670ab30477655186a5a3bf4487f2fa183807dad26037e950e89cc07ba20eaf229437e69c2e56d44fe934082147098ca4a0bd99964d67d2046789d080f69d5be2c60101df05cb8489757c7882765f82765fcb84ffffffff8276698276698465b0abe402, stacktrace: io.netty.channel.unix.Errors$NativeIoException: sendToAddress(..) failed: Permission denied",
   "throwable":""
}
```

the functional change is minimal, but rearranges the host detection to be in a unit testable method.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to #6224 