### PR TITLE
Write a DEBUG log entry to make it clear of a BFT node is a validator…

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BftFinalState.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/statemachine/BftFinalState.java
@@ -28,8 +28,14 @@ import org.hyperledger.besu.datatypes.Address;
 import java.time.Clock;
 import java.util.Collection;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /** This is the full data set, or context, required for many of the aspects of BFT workflows. */
 public class BftFinalState {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BftFinalState.class);
+
   private final ValidatorProvider validatorProvider;
   private final NodeKey nodeKey;
   private final Address localAddress;
@@ -126,7 +132,9 @@ public class BftFinalState {
    * @return the boolean
    */
   public boolean isLocalNodeValidator() {
-    return getValidators().contains(localAddress);
+    final boolean isValidator = getValidators().contains(localAddress);
+    LOG.debug(isValidator ? "Local node is a validator" : "Local node is a non-validator");
+    return isValidator;
   }
 
   /**


### PR DESCRIPTION
## PR description
Currently there is nothing specifically recorded in `INFO` or `DEBUG` logs to indicate if a node is currently a validator. This PR adds a `DEBUG` log which will be produced once per block if debug logging is enabled.

## Fixed Issue(s)
No issue for this PR