### PR TITLE
filter empty ipv4 and ipv6 ping packet source addresses

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -75,7 +75,7 @@ public abstract class PeerDiscoveryAgent {
   // clients ignore that, so we add in a little extra padding.
   private static final int MAX_PACKET_SIZE_BYTES = 1600;
   private static final List<String> PING_PACKET_SOURCE_IGNORED =
-      List.of("127.0.0.1", "255.255.255.255", "0.0.0.0", "[::]");
+      List.of("127.0.0.1", "255.255.255.255", "0.0.0.0", "::", "0:0:0:0:0:0:0:0");
 
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -75,7 +75,7 @@ public abstract class PeerDiscoveryAgent {
   // clients ignore that, so we add in a little extra padding.
   private static final int MAX_PACKET_SIZE_BYTES = 1600;
   private static final List<String> PING_PACKET_SOURCE_IGNORED =
-      List.of("127.0.0.1", "255.255.255.255");
+      List.of("127.0.0.1", "255.255.255.255", "0.0.0.0", "[::]");
 
   protected final List<DiscoveryPeer> bootstrapPeers;
   private final List<PeerRequirement> peerRequirements = new CopyOnWriteArrayList<>();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -840,7 +840,7 @@ public class PeerDiscoveryAgentTest {
   public void assertHostCorrectlyRevertsOnIgnoredPacketFrom() {
     final String sourceHost = "UDP_SOURCE_ORIGIN_HOST";
     final String emptyIPv4Host = "0.0.0.0";
-    final String emptyIPv6Host = "[::]";
+    final String emptyIPv6Host = "::";
     final String localHost = "127.0.0.1";
     final String broadcastDefaultHost = "255.255.255.255";
     final String routableHost = "50.50.50.50";

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgentTest.java
@@ -839,15 +839,31 @@ public class PeerDiscoveryAgentTest {
   @Test
   public void assertHostCorrectlyRevertsOnIgnoredPacketFrom() {
     final String sourceHost = "UDP_SOURCE_ORIGIN_HOST";
+    final String emptyIPv4Host = "0.0.0.0";
+    final String emptyIPv6Host = "[::]";
     final String localHost = "127.0.0.1";
     final String broadcastDefaultHost = "255.255.255.255";
     final String routableHost = "50.50.50.50";
 
     Endpoint source = new Endpoint(sourceHost, 30303, Optional.empty());
+    Endpoint emptyIPv4 = new Endpoint(emptyIPv4Host, 30303, Optional.empty());
+    Endpoint emptyIPv6 = new Endpoint(emptyIPv6Host, 30303, Optional.empty());
     Endpoint endpointLocal = new Endpoint(localHost, 30303, Optional.empty());
     Endpoint endpointBroadcast = new Endpoint(broadcastDefaultHost, 30303, Optional.empty());
     Endpoint endpointRoutable = new Endpoint(routableHost, 30303, Optional.empty());
 
+    Packet mockEmptyIPv4 =
+        when(mock(Packet.class).getPacketData(any()))
+            .thenReturn(
+                Optional.of(
+                    PingPacketData.create(Optional.of(emptyIPv4), endpointLocal, UInt64.ONE)))
+            .getMock();
+    Packet mockEmptyIPv6 =
+        when(mock(Packet.class).getPacketData(any()))
+            .thenReturn(
+                Optional.of(
+                    PingPacketData.create(Optional.of(emptyIPv6), endpointLocal, UInt64.ONE)))
+            .getMock();
     Packet mockLocal =
         when(mock(Packet.class).getPacketData(any()))
             .thenReturn(
@@ -869,6 +885,10 @@ public class PeerDiscoveryAgentTest {
                         Optional.of(endpointRoutable), endpointLocal, UInt64.ONE)))
             .getMock();
 
+    // assert a pingpacketdata with empty ipv4 address reverts to the udp source host
+    assertThat(PeerDiscoveryAgent.deriveHost(source, mockEmptyIPv4)).isEqualTo(sourceHost);
+    // assert a pingpacketdata with empty ipv6 address reverts to the udp source host
+    assertThat(PeerDiscoveryAgent.deriveHost(source, mockEmptyIPv6)).isEqualTo(sourceHost);
     // assert a pingpacketdata from address of 127.0.0.1 reverts to the udp source host
     assertThat(PeerDiscoveryAgent.deriveHost(source, mockLocal)).isEqualTo(sourceHost);
     // assert that 255.255.255.255 reverts to the udp source host


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
add empty source addresses to ping packet filter lsit

currently on main we are seeing packet errors like:
```
2024-01-27 07:21:53.144+00:00 | vert.x-eventloop-thread-1 | WARN  | VertxPeerDiscoveryAgent | Sending to peer DiscoveryPeer{status=bonding, enode=enode://b3af6e4685a1c54447b0510b29397c5534a66ce32224efd250e775ebd0f56c609e3f29d76fcae1893a1b437d6d383673915d9b1c60643be0e45e52acb2f2f335@[::]:28568, firstDiscovered=1706340111143, lastContacted=0, lastSeen=1706340111143} 
failed, native error code -97, packet: 0xc76f91fa10c899a6a7d270611aba4b9f931447770a3cac9722996ebae807e0d9a403e5c090ef23cec3d81b8a27db826322dd66964656ba0acc6964ee387753796cf000fdc92e10970ec4b6e3ae12f7895c6922a0c07754ce267b98b046c124da0101eb05cb847f000001829d6f829d6fd79000000000000000000000000000000000826f98826f988465b4af4d14, stacktrace: io.netty.channel.unix.Errors$NativeIoException: sendToAddress(..) failed: Address family not supported by protocol
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to #6224 