### PR TITLE
Remove `--engine-jwt-enabled` deprecated option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - The `trace-filter` method in JSON-RPC API now has a default block range limit of 1000, adjustable with `--rpc-max-trace-filter-range` (thanks @alyokaz) [#6446](https://github.com/hyperledger/besu/pull/6446)
 - Requesting the Ethereum Node Record (ENR) to acquire the fork id from bonded peers is now enabled by default, so the following change has been made [#5628](https://github.com/hyperledger/besu/pull/5628):
 - `--Xfilter-on-enr-fork-id` has been removed. To disable the feature use `--filter-on-enr-fork-id=false`.
-- `--engine-jwt-enabled` has been removed. Use `--engine-jwt-disabled` instead. 
+- `--engine-jwt-enabled` has been removed. Use `--engine-jwt-disabled` instead. [#6491](https://github.com/hyperledger/besu/pull/6491)
 
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Breaking Changes
 - The `trace-filter` method in JSON-RPC API now has a default block range limit of 1000, adjustable with `--rpc-max-trace-filter-range` (thanks @alyokaz) [#6446](https://github.com/hyperledger/besu/pull/6446)
 - Requesting the Ethereum Node Record (ENR) to acquire the fork id from bonded peers is now enabled by default, so the following change has been made [#5628](https://github.com/hyperledger/besu/pull/5628):
-  - `--Xfilter-on-enr-fork-id` has been removed. To disable the feature use `--filter-on-enr-fork-id=false`.
+- `--Xfilter-on-enr-fork-id` has been removed. To disable the feature use `--filter-on-enr-fork-id=false`.
+- `--engine-jwt-enabled` has been removed. Use `--engine-jwt-disabled` instead. 
+
 
 ### Deprecations
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -610,6 +610,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
         description = "Path to file containing shared secret key for JWT signature verification")
     private final Path engineJwtKeyFile = null;
+
     @Option(
         names = {"--engine-jwt-disabled"},
         description = "Disable authentication for Engine APIs (default: ${DEFAULT-VALUE})")

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -610,14 +610,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
         description = "Path to file containing shared secret key for JWT signature verification")
     private final Path engineJwtKeyFile = null;
-
-    @Option(
-        names = {"--engine-jwt-enabled"},
-        description = "deprecated option, engine jwt auth is enabled by default",
-        hidden = true)
-    @SuppressWarnings({"FieldCanBeFinal", "UnusedVariable"})
-    private final Boolean deprecatedIsEngineAuthEnabled = true;
-
     @Option(
         names = {"--engine-jwt-disabled"},
         description = "Disable authentication for Engine APIs (default: ${DEFAULT-VALUE})")


### PR DESCRIPTION
## PR description
Removes `--engine-jwt-enabled`. Replaced by `--engine-jwt-disabled`

It has been deprecated since 2022. 