### PR TITLE
Filter Discovered peers for ipv6 support

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -321,7 +321,7 @@ public abstract class PeerDiscoveryAgent {
         .getPacketData(PingPacketData.class)
         .flatMap(PingPacketData::getFrom)
         .map(Endpoint::getHost)
-        // fall back to from endpoint if address does not meet these filters
+        // fall back to source endpoint "from" if ping packet from address does not satisfy filters
         .filter(InetAddresses::isInetAddress)
         .filter(h -> !NetworkUtility.isUnspecifiedAddress(h))
         .filter(h -> !NetworkUtility.isLocalhostAddress(h))

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -353,8 +353,8 @@ public abstract class PeerDiscoveryAgent {
         .findFirst()
         .orElseGet(
             () -> {
-              LOG.debug(
-                  "Ignoring \"From\" endpoint {} specified in ping packet. Using UDP source host {}",
+              LOG.trace(
+                  "Ignoring \"From\" endpoint {} in ping packet. Using UDP source host {}",
                   pingPacketHost.orElse("not specified"),
                   sourceEndpoint.getHost());
               return sourceEndpoint.getHost();

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -40,10 +40,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.util.NetworkUtility;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -328,19 +325,7 @@ public abstract class PeerDiscoveryAgent {
         .filter(InetAddresses::isInetAddress)
         .filter(h -> !NetworkUtility.isUnspecifiedAddress(h))
         .filter(h -> !NetworkUtility.isLocalhostAddress(h))
-        .filter(
-            h -> {
-              // filter ipv6 addresses if ipv6 is not available
-              if (isIpv6Available) {
-                return true;
-              } else {
-                try {
-                  return !(InetAddress.getByName(h) instanceof Inet6Address);
-                } catch (UnknownHostException e) {
-                  return false;
-                }
-              }
-            })
+        .filter(h -> isIpv6Available || !NetworkUtility.isIpV6Address(h))
         .stream()
         .peek(
             h ->

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/PeerDiscoveryAgent.java
@@ -338,10 +338,12 @@ public abstract class PeerDiscoveryAgent {
         .findFirst()
         .orElseGet(
             () -> {
-              LOG.trace(
-                  "Ignoring \"From\" endpoint {} in ping packet. Using UDP source host {}",
-                  pingPacketHost.orElse("not specified"),
-                  sourceEndpoint.getHost());
+              LOG.atTrace()
+                  .setMessage(
+                      "Ignoring \"From\" endpoint {} in ping packet. Using UDP source host {}")
+                  .addArgument(pingPacketHost.orElse("not specified"))
+                  .addArgument(sourceEndpoint.getHost())
+                  .log();
               return sourceEndpoint.getHost();
             });
   }

--- a/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
+++ b/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.util;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -26,6 +27,7 @@ import java.net.UnknownHostException;
 import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
+import com.google.common.net.InetAddresses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,5 +195,21 @@ public class NetworkUtility {
    */
   public static boolean isPortAvailable(final int port) {
     return isPortAvailableForTcp(port) && isPortAvailableForUdp(port);
+  }
+
+  public static boolean isIpV4Address(final String hostAddress) {
+    try {
+      return InetAddresses.forString(hostAddress) instanceof Inet4Address;
+    } catch (final IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public static boolean isIpV6Address(final String hostAddress) {
+    try {
+      return InetAddresses.forString(hostAddress) instanceof Inet6Address;
+    } catch (final IllegalArgumentException e) {
+      return false;
+    }
   }
 }

--- a/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
+++ b/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
@@ -133,7 +133,12 @@ public class NetworkUtility {
         || INADDR6_NONE.equals(ipAddress);
   }
 
-  /** Is local host address. */
+  /**
+   * Returns whether host address string is local host address.
+   *
+   * @param ipAddress the host address as a string
+   * @return true if the host address is a local host address
+   */
   public static boolean isLocalhostAddress(final String ipAddress) {
     return INADDR_LOCALHOST.equals(ipAddress) || INADDR6_LOCALHOST.equals(ipAddress);
   }

--- a/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
+++ b/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
@@ -197,6 +197,12 @@ public class NetworkUtility {
     return isPortAvailableForTcp(port) && isPortAvailableForUdp(port);
   }
 
+
+  /**
+   * Is hostAddress string an ip v4 address
+   * @param hostAddress the host address as a string
+   * @return true if the host address is an ip v4 address
+   */
   public static boolean isIpV4Address(final String hostAddress) {
     try {
       return InetAddresses.forString(hostAddress) instanceof Inet4Address;
@@ -205,6 +211,11 @@ public class NetworkUtility {
     }
   }
 
+  /**
+   * Is hostAddress string an ip v6 address
+   * @param hostAddress the host address as a string
+   * @return true if the host address is an ip v6 address
+   */
   public static boolean isIpV6Address(final String hostAddress) {
     try {
       return InetAddresses.forString(hostAddress) instanceof Inet6Address;

--- a/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
+++ b/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
@@ -197,9 +197,9 @@ public class NetworkUtility {
     return isPortAvailableForTcp(port) && isPortAvailableForUdp(port);
   }
 
-
   /**
    * Is hostAddress string an ip v4 address
+   *
    * @param hostAddress the host address as a string
    * @return true if the host address is an ip v4 address
    */
@@ -213,6 +213,7 @@ public class NetworkUtility {
 
   /**
    * Is hostAddress string an ip v6 address
+   *
    * @param hostAddress the host address as a string
    * @return true if the host address is an ip v6 address
    */

--- a/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
+++ b/util/src/main/java/org/hyperledger/besu/util/NetworkUtility.java
@@ -33,8 +33,16 @@ import org.slf4j.LoggerFactory;
 public class NetworkUtility {
   /** The constant INADDR_ANY. */
   public static final String INADDR_ANY = "0.0.0.0";
+  /** The constant INADDR_NONE. */
+  public static final String INADDR_NONE = "255.255.255.255";
   /** The constant INADDR6_ANY. */
   public static final String INADDR6_ANY = "0:0:0:0:0:0:0:0";
+  /** The constant INADDR6_NONE. */
+  public static final String INADDR6_NONE = "::";
+  /** The constant INADDR_LOCALHOST. */
+  public static final String INADDR_LOCALHOST = "127.0.0.1";
+  /** The constant INADDR6_LOCALHOST. */
+  public static final String INADDR6_LOCALHOST = "::1";
 
   private static final Logger LOG = LoggerFactory.getLogger(NetworkUtility.class);
 
@@ -119,7 +127,15 @@ public class NetworkUtility {
    * @return the boolean
    */
   public static boolean isUnspecifiedAddress(final String ipAddress) {
-    return INADDR_ANY.equals(ipAddress) || INADDR6_ANY.equals(ipAddress);
+    return INADDR_ANY.equals(ipAddress)
+        || INADDR6_ANY.equals(ipAddress)
+        || INADDR_NONE.equals(ipAddress)
+        || INADDR6_NONE.equals(ipAddress);
+  }
+
+  /** Is local host address. */
+  public static boolean isLocalhostAddress(final String ipAddress) {
+    return INADDR_LOCALHOST.equals(ipAddress) || INADDR6_LOCALHOST.equals(ipAddress);
   }
 
   /**

--- a/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
@@ -48,4 +48,27 @@ public class NetworkUtilityTest {
     assertThat(NetworkUtility.isLocalhostAddress("192.168.1.1")).isFalse();
     assertThat(NetworkUtility.isLocalhostAddress("::ffff:c0a8:101")).isFalse();
   }
+
+  @Test
+  public void assertIpV4Address() {
+    assertThat(NetworkUtility.isIpV4Address("127.0.0.1")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("10.0.0.0")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("172.16.1.1")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("127.0.0.")).isFalse();
+    assertThat(NetworkUtility.isIpV4Address("256.256.256.256")).isFalse();
+    // ipv6 compatible ipv4 address
+    assertThat(NetworkUtility.isIpV4Address("0000:0000:0000:0000:0000:ffff:c0a8:5801")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("::ffff:c0a8:5801")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("0:0:0:0:0:ffff:c0a8:5801")).isTrue();
+    assertThat(NetworkUtility.isIpV4Address("0000:0000:0000:0000:0000:ffff:c0a8:5801")).isTrue();
+  }
+
+  @Test
+  public void assertIpV6Address() {
+    assertThat(NetworkUtility.isIpV6Address("::1")).isTrue();
+    assertThat(NetworkUtility.isIpV6Address("::")).isTrue();
+    assertThat(NetworkUtility.isIpV6Address("2001:db8:3333:4444:5555:6666:7777:8888")).isTrue();
+    assertThat(NetworkUtility.isIpV6Address("00:00::00:00::00:00")).isFalse();
+    assertThat(NetworkUtility.isIpV6Address("00:00::00:00::00:00")).isFalse();
+  }
 }

--- a/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
@@ -57,7 +57,6 @@ public class NetworkUtilityTest {
     assertThat(NetworkUtility.isIpV4Address("127.0.0.")).isFalse();
     assertThat(NetworkUtility.isIpV4Address("256.256.256.256")).isFalse();
     // ipv6 compatible ipv4 address
-    assertThat(NetworkUtility.isIpV4Address("0000:0000:0000:0000:0000:ffff:c0a8:5801")).isTrue();
     assertThat(NetworkUtility.isIpV4Address("::ffff:c0a8:5801")).isTrue();
     assertThat(NetworkUtility.isIpV4Address("0:0:0:0:0:ffff:c0a8:5801")).isTrue();
     assertThat(NetworkUtility.isIpV4Address("0000:0000:0000:0000:0000:ffff:c0a8:5801")).isTrue();
@@ -68,7 +67,6 @@ public class NetworkUtilityTest {
     assertThat(NetworkUtility.isIpV6Address("::1")).isTrue();
     assertThat(NetworkUtility.isIpV6Address("::")).isTrue();
     assertThat(NetworkUtility.isIpV6Address("2001:db8:3333:4444:5555:6666:7777:8888")).isTrue();
-    assertThat(NetworkUtility.isIpV6Address("00:00::00:00::00:00")).isFalse();
     assertThat(NetworkUtility.isIpV6Address("00:00::00:00::00:00")).isFalse();
   }
 }

--- a/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/NetworkUtilityTest.java
@@ -40,4 +40,12 @@ public class NetworkUtilityTest {
     assertThat(!NetworkUtility.isPortAvailable(8541)).isEqualTo(true);
     serverSocket.close();
   }
+
+  @Test
+  public void assertLocalhostIdentification() {
+    assertThat(NetworkUtility.isLocalhostAddress("127.0.0.1")).isTrue();
+    assertThat(NetworkUtility.isLocalhostAddress("::1")).isTrue();
+    assertThat(NetworkUtility.isLocalhostAddress("192.168.1.1")).isFalse();
+    assertThat(NetworkUtility.isLocalhostAddress("::ffff:c0a8:101")).isFalse();
+  }
 }


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
updates PeerDiscoveryAgent to 
* use existing NetworkUtility to filter for any/none peers
* fall back to source address if ipv6 is not supported (like in a docker container)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #6475 