### PR TITLE
[MINOR] remove duplicate setting of default values for CLI options

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -838,7 +838,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @Option(
       names = {"--pruning-blocks-retained"},
-      defaultValue = "1024",
       paramLabel = "<INTEGER>",
       description =
           "Minimum number of recent blocks for which to keep entire world state (default: ${DEFAULT-VALUE})",
@@ -847,7 +846,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   @Option(
       names = {"--pruning-block-confirmations"},
-      defaultValue = "10",
       paramLabel = "<INTEGER>",
       description =
           "Minimum number of confirmations on a block before marking begins (default: ${DEFAULT-VALUE})",

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EvmOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/EvmOptions.java
@@ -47,7 +47,6 @@ public class EvmOptions implements CLIOptions<EvmConfiguration> {
           "size in kilobytes to allow the cache "
               + "of valid jump destinations to grow to before evicting the least recently used entry",
       fallbackValue = "32000",
-      defaultValue = "32000",
       hidden = true,
       arity = "1")
   private Long jumpDestCacheWeightKilobytes =
@@ -57,7 +56,6 @@ public class EvmOptions implements CLIOptions<EvmConfiguration> {
       names = {WORLDSTATE_UPDATE_MODE},
       description = "How to handle worldstate updates within a transaction",
       fallbackValue = "STACKED",
-      defaultValue = "STACKED",
       hidden = true,
       arity = "1")
   private EvmConfiguration.WorldUpdaterMode worldstateUpdateMode =

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/MetricsCLIOptions.java
@@ -30,7 +30,6 @@ public class MetricsCLIOptions implements CLIOptions<MetricsConfiguration.Builde
   @CommandLine.Option(
       names = TIMERS_ENABLED_FLAG,
       hidden = true,
-      defaultValue = "true",
       description = "Whether to enable timer metrics (default: ${DEFAULT-VALUE}).")
   private Boolean timersEnabled = MetricsConfiguration.DEFAULT_METRICS_TIMERS_ENABLED;
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/NetworkingOptions.java
@@ -42,7 +42,6 @@ public class NetworkingOptions implements CLIOptions<NetworkingConfiguration> {
   @CommandLine.Option(
       names = INITIATE_CONNECTIONS_FREQUENCY_FLAG,
       hidden = true,
-      defaultValue = "30",
       paramLabel = "<INTEGER>",
       description =
           "The frequency (in seconds) at which to initiate new outgoing connections (default: ${DEFAULT-VALUE})")
@@ -52,7 +51,6 @@ public class NetworkingOptions implements CLIOptions<NetworkingConfiguration> {
   @CommandLine.Option(
       names = CHECK_MAINTAINED_CONNECTIONS_FREQUENCY_FLAG,
       hidden = true,
-      defaultValue = "60",
       paramLabel = "<INTEGER>",
       description =
           "The frequency (in seconds) at which to check maintained connections (default: ${DEFAULT-VALUE})")
@@ -69,14 +67,12 @@ public class NetworkingOptions implements CLIOptions<NetworkingConfiguration> {
   @CommandLine.Option(
       names = DISCOVERY_PROTOCOL_V5_ENABLED,
       hidden = true,
-      defaultValue = "false",
       description = "Whether to enable P2P Discovery Protocol v5 (default: ${DEFAULT-VALUE})")
   private final Boolean isPeerDiscoveryV5Enabled = false;
 
   @CommandLine.Option(
       names = FILTER_ON_ENR_FORK_ID,
       hidden = true,
-      defaultValue = "true",
       description = "Whether to enable filtering of peers based on the ENR field ForkId)")
   private final Boolean filterOnEnrForkId = NetworkingConfiguration.DEFAULT_FILTER_ON_ENR_FORK_ID;
 


### PR DESCRIPTION
where the default is number/boolean/string, just leave it to the initialized value for the actual field.

same as was done for Sync Options in #6499