### PR TITLE
tx-pool allow/reject list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Added configuration options for `pragueTime` to genesis file for Prague fork development [#6473](https://github.com/hyperledger/besu/pull/6473)
 - Moving trielog storage to RocksDB's blobdb to improve write amplications [#6289](https://github.com/hyperledger/besu/pull/6289)
 - Support for `shanghaiTime` fork and Shanghai EVM smart contracts in QBFT/IBFT chains [#6353](https://github.com/hyperledger/besu/pull/6353)
+- Allow configurable allow/reject list of addresses to accept/reject transactions from those addresses [#6521](https://github.com/hyperledger/besu/pull/6521)
 
 ### Bug fixes
 - Fix the way an advertised host configured with `--p2p-host` is treated when communicating with the originator of a PING packet [#6225](https://github.com/hyperledger/besu/pull/6225)

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -298,6 +298,49 @@ public class TransactionPoolOptionsTest
             + prioritySender3.toHexString());
   }
 
+  // Tests here
+  @Test
+  public void emptyAllowListByDefault(){
+    internalTestSuccess(config -> assertThat(config.getSendersAllowList()).isEmpty());
+  }
+
+  @Test
+  public void nonEmptyAllowList(){
+    final Address address1 = Address.fromHexString("0xABC123");
+    final Address address2 = Address.fromHexString("0xDEF456");
+    final Address address3 = Address.fromHexString("0xCBA789");
+    internalTestSuccess(config -> assertThat(config.getSendersAllowList())
+      .containsExactly(address1, address2, address3),
+      "--tx-pool-allow-list", address1.toHexString(), address2.toHexString(), address3.toHexString()
+      );
+  }
+
+  @Test
+  public void emptyRejectListByDefault(){
+    internalTestSuccess(config -> assertThat(config.getSendersRejectList()).isEmpty());
+  }
+
+  @Test
+  public void nonEmptyRejectList(){
+    final Address address1 = Address.fromHexString("0xABC123");
+    final Address address2 = Address.fromHexString("0xDEF456");
+    final Address address3 = Address.fromHexString("0xCBA789");
+    internalTestSuccess(config -> assertThat(config.getSendersRejectList())
+      .containsExactly(address1, address2, address3),
+      "--tx-pool-reject-list", address1.toHexString(), address2.toHexString(), address3.toHexString()
+      );
+  }
+  
+  @Test
+  public void cannotPassBothOptions(){
+    final Address allowedAddress = Address.fromHexString("0xABC123");
+    final Address rejectAddress = Address.fromHexString("0xDEF456");
+    internalTestFailure(
+      "Can only set either Reject list or allow list of senders",
+      "--tx-pool-allow-list", allowedAddress.toHexString(),  
+      "--tx-pool-reject-list", rejectAddress.toHexString());
+  }
+
   @Test
   public void txMessageKeepAliveSeconds() {
     final int txMessageKeepAliveSeconds = 999;

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -192,6 +192,8 @@ tx-pool-retention-hours=999
 tx-pool-max-size=1234
 tx-pool-limit-by-account-percentage=0.017
 tx-pool-min-gas-price=1000
+tx-pool-allow-list=["0xABC0000000000000000000000000000000001234"]
+tx-pool-reject-list=["0xDEF0000000000000000000000000000000001234"]
 
 # Revert Reason
 revert-reason-enabled=false

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -70,6 +70,8 @@ public interface TransactionPoolConfiguration {
   int DEFAULT_MAX_FUTURE_BY_SENDER = 200;
   Implementation DEFAULT_TX_POOL_IMPLEMENTATION = Implementation.LAYERED;
   Set<Address> DEFAULT_PRIORITY_SENDERS = Set.of();
+  Set<Address> DEFAULT_SENDER_ALLOW_LIST = Set.of();
+  Set<Address> DEFAULT_SENDER_REJECT_LIST = Set.of();
   Wei DEFAULT_TX_POOL_MIN_GAS_PRICE = Wei.of(1000);
 
   TransactionPoolConfiguration DEFAULT = ImmutableTransactionPoolConfiguration.builder().build();
@@ -147,6 +149,16 @@ public interface TransactionPoolConfiguration {
   @Value.Default
   default Set<Address> getPrioritySenders() {
     return DEFAULT_PRIORITY_SENDERS;
+  }
+
+  @Value.Default
+  default Set<Address> getSendersAllowList() {
+    return DEFAULT_SENDER_ALLOW_LIST;
+  }
+
+  @Value.Default
+  default Set<Address> getSendersRejectList() {
+    return DEFAULT_SENDER_REJECT_LIST;
   }
 
   @Value.Default


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
This PR adds the following flags to configure allow/reject list of sender addresses 

- `--tx-pool-allow-list=<comma-seprated-list-of-addresses>` - Local/Remote transactions submitted from these addresses are only allowed to be added in the pool, while transactions from other sender addresses are reject with reason `Sender account not authorized to send transactions`
- `--tx-pool-reject-list=<comma-seprated-list-of-addresses>` - Local/Remote transactions submitted from these addresses are rejected before being added to the pool with reason `Sender account not authorized to send transactions`, while transactions from other sender addresses are allowed.
- Both these flags are not allowed together, only one can be set at a time. 

**Sample Besu Log**
Setting the following config for test addresses and sending test transaction from these accounts 
`tx-pool-reject-list=["0x8C7d8409bDBA3322A65825bbe3f75ac71b9de3cf,0xe547BAa69dB4fCFd6225f428De424888dB566a41"]` for test 
```
2024-02-04 21:47:20.559+00:00 | vert.x-worker-thread-1 | TRACE | AbstractJsonRpcExecutor | {"jsonrpc":"2.0","id":83,"method":"eth_sendRawTransaction","params":["0xf8868080830f4240944fca308301a110a0118448c644654efeecf9a91180a460fe47b10000000000000000000000000000000000000000000000000000000000003039820ff1a0777743d184749836701b2bdc63c35f89523ae804291696cf6d5778e24aa1240aa07ff93a28da5138dd50277ec7b3249b03736eaa8cc99c035503131eccb6e5b04c"]}
2024-02-04 21:47:20.559+00:00 | vert.x-worker-thread-1 | DEBUG | JsonRpcExecutor | JSON-RPC request -> eth_sendRawTransaction ["0xf8868080830f4240944fca308301a110a0118448c644654efeecf9a91180a460fe47b10000000000000000000000000000000000000000000000000000000000003039820ff1a0777743d184749836701b2bdc63c35f89523ae804291696cf6d5778e24aa1240aa07ff93a28da5138dd50277ec7b3249b03736eaa8cc99c035503131eccb6e5b04c"]
2024-02-04 21:47:20.560+00:00 | vert.x-worker-thread-1 | TRACE | EthSendRawTransaction | Received local transaction MessageCall{type=FRONTIER, nonce=0, gasPrice=0 wei, gasLimit=1000000, to=0x4fca308301a110a0118448c644654efeecf9a911, value=0x0000000000000000000000000000000000000000000000000000000000000000, sig=Signature{r=54035951847700603082610381881786735130294417072039064688183051346590583301130, s=57884078091882121988970232755018579959487602981021234593703990990705896304716, recId=0}, chainId=2023, payload=0x60fe47b10000000000000000000000000000000000000000000000000000000000003039}
2024-02-04 21:47:20.560+00:00 | vert.x-worker-thread-1 | TRACE | TransactionPool | Discarded transaction from unauthorized sender 0x8c7d8409bdba3322a65825bbe3f75ac71b9de3cf
2024-02-04 21:47:20.560+00:00 | vert.x-worker-thread-1 | TRACE | AbstractJsonRpcExecutor | {"jsonrpc":"2.0","id":83,"error":{"code":-32007,"message":"Sender account not authorized to send transactions"}}
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes Issue https://github.com/hyperledger/besu/issues/5243