### PR TITLE
increase timeout for websocket pub/sub tests

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/pubsub/WebSocket.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/pubsub/WebSocket.java
@@ -53,6 +53,6 @@ public class WebSocket {
 
   public void verifyTotalEventsReceived(final int expectedTotalEventCount) {
     WaitUtils.waitFor(
-        () -> assertThat(connection.getSubscriptionEvents()).hasSize(expectedTotalEventCount));
+        60, () -> assertThat(connection.getSubscriptionEvents()).hasSize(expectedTotalEventCount));
   }
 }


### PR DESCRIPTION
Increase timeout for websocket ATs since a few of them are flaky eg https://app.circleci.com/pipelines/github/hyperledger/besu/27037/workflows/036ea38e-b0b0-4e2e-8d9c-a280f53134e3/jobs/179105/tests#failed-test-0