### PR TITLE
Add ETC Spiral EVM configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Bug fixes
 - Fix the way an advertised host configured with `--p2p-host` is treated when communicating with the originator of a PING packet [#6225](https://github.com/hyperledger/besu/pull/6225)
 - Fix `poa-block-txs-selection-max-time` option that was inadvertently reset to its default after being configured [#6444](https://github.com/hyperledger/besu/pull/6444)
+- Fix ETC Spiral upgrade breach of consensus [#6524](https://github.com/hyperledger/besu/pull/6524)
 
 ### Download Links
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicProtocolSpecs.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.core.feemarket.CoinbaseFeePriceCalculator;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
+import org.hyperledger.besu.evm.ClassicEVMs;
 import org.hyperledger.besu.evm.MainnetEVMs;
 import org.hyperledger.besu.evm.contractvalidation.MaxCodeSizeRule;
 import org.hyperledger.besu.evm.contractvalidation.PrefixCodeRule;
@@ -355,7 +356,7 @@ public class ClassicProtocolSpecs {
         // EIP-3855
         .evmBuilder(
             (gasCalculator, jdCacheConfig) ->
-                MainnetEVMs.shanghai(
+                ClassicEVMs.spiral(
                     gasCalculator, chainId.orElse(BigInteger.ZERO), evmConfiguration))
         // EIP-3651
         .transactionProcessorBuilder(

--- a/evm/src/main/java/org/hyperledger/besu/evm/ClassicEVMs.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/ClassicEVMs.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright contributors to Hyperledger Besu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm;
+
+import static org.hyperledger.besu.evm.MainnetEVMs.SHANGHAI_INIT_CODE_SIZE_LIMIT;
+import static org.hyperledger.besu.evm.MainnetEVMs.registerIstanbulOperations;
+
+import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.evm.operation.Create2Operation;
+import org.hyperledger.besu.evm.operation.CreateOperation;
+import org.hyperledger.besu.evm.operation.OperationRegistry;
+import org.hyperledger.besu.evm.operation.Push0Operation;
+
+import java.math.BigInteger;
+
+public class ClassicEVMs {
+
+  /**
+   * spiral evm.
+   *
+   * @param gasCalculator the gas calculator
+   * @param chainId the chain id
+   * @param evmConfiguration the evm configuration
+   * @return the evm
+   */
+  public static EVM spiral(
+      final GasCalculator gasCalculator,
+      final BigInteger chainId,
+      final EvmConfiguration evmConfiguration) {
+    return new EVM(
+        spiralOperations(gasCalculator, chainId),
+        gasCalculator,
+        evmConfiguration,
+        EvmSpecVersion.SHANGHAI);
+  }
+
+  /**
+   * spiral operations' registry.
+   *
+   * @param gasCalculator the gas calculator
+   * @param chainId the chain id
+   * @return the operation registry
+   */
+  public static OperationRegistry spiralOperations(
+      final GasCalculator gasCalculator, final BigInteger chainId) {
+    OperationRegistry registry = new OperationRegistry();
+    registerIstanbulOperations(registry, gasCalculator, chainId);
+    registry.put(new Push0Operation(gasCalculator));
+    registry.put(new CreateOperation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
+    registry.put(new Create2Operation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
+    return registry;
+  }
+}


### PR DESCRIPTION
## PR description
During the last ETC network upgrade, Besu nodes got stalled because, inadvertently, [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) was _included_ instead of _omitted_.

For the future, we'll also test omissions to the protocol and not only additions.