### PR TITLE
[minor] Improve message when existing database is different from the configuration

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageFormat.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageFormat.java
@@ -29,4 +29,13 @@ public enum DataStorageFormat {
   public int getDatabaseVersion() {
     return databaseVersion;
   }
+
+  public static String getName(final int databaseVersion) {
+    for (DataStorageFormat format : DataStorageFormat.values()) {
+      if (format.getDatabaseVersion() == databaseVersion) {
+        return format.name();
+      }
+    }
+    return "Unknown";
+  }
 }

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -261,8 +261,13 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
       if (databaseVersion != commonConfiguration.getDatabaseVersion()) {
         String error =
             String.format(
-                "Mismatch detected: Database at %s is version '%s', but configuration expects version '%s'.",
-                dataDir, databaseVersion, commonConfiguration.getDatabaseVersion());
+                "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Verify config.",
+                dataDir,
+                DataStorageFormat.getName(databaseVersion),
+                databaseVersion,
+                DataStorageFormat.getName(commonConfiguration.getDatabaseVersion()),
+                commonConfiguration.getDatabaseVersion());
+
         throw new StorageException(error);
       }
       LOG.info(

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactory.java
@@ -261,7 +261,7 @@ public class RocksDBKeyValueStorageFactory implements KeyValueStorageFactory {
       if (databaseVersion != commonConfiguration.getDatabaseVersion()) {
         String error =
             String.format(
-                "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Verify config.",
+                "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Please check your config.",
                 dataDir,
                 DataStorageFormat.getName(databaseVersion),
                 databaseVersion,

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactoryTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactoryTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import org.hyperledger.besu.ethereum.worldstate.DataStorageFormat;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
@@ -152,8 +153,8 @@ public class RocksDBKeyValueStorageFactoryTest {
   public void shouldThrowExceptionWhenExistingDatabaseVersionDifferentFromConfig()
       throws Exception {
 
-    final int actualDatabaseVersion = 1;
-    final int expectedDatabaseVersion = 2;
+    final int actualDatabaseVersion = DataStorageFormat.FOREST.getDatabaseVersion();
+    final int expectedDatabaseVersion = DataStorageFormat.BONSAI.getDatabaseVersion();
 
     final Path tempDataDir = temporaryFolder.resolve("data");
     final Path tempDatabaseDir = temporaryFolder.resolve("db");
@@ -163,6 +164,16 @@ public class RocksDBKeyValueStorageFactoryTest {
     when(commonConfiguration.getDatabaseVersion()).thenReturn(expectedDatabaseVersion);
 
     new DatabaseMetadata(actualDatabaseVersion).writeToDirectory(tempDataDir);
+
+    String exceptionMessage =
+        String.format(
+            "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Verify config.",
+            tempDataDir.toAbsolutePath(),
+            DataStorageFormat.getName(actualDatabaseVersion),
+            actualDatabaseVersion,
+            DataStorageFormat.getName(expectedDatabaseVersion),
+            expectedDatabaseVersion);
+
     assertThatThrownBy(
             () ->
                 new RocksDBKeyValueStorageFactory(
@@ -171,10 +182,7 @@ public class RocksDBKeyValueStorageFactoryTest {
                         RocksDBMetricsFactory.PUBLIC_ROCKS_DB_METRICS)
                     .create(segment, commonConfiguration, metricsSystem))
         .isInstanceOf(StorageException.class)
-        .hasMessage(
-            String.format(
-                "Mismatch detected: Database at %s is version '%s', but configuration expects version '%s'.",
-                tempDataDir.toAbsolutePath(), actualDatabaseVersion, expectedDatabaseVersion));
+        .hasMessage(exceptionMessage);
   }
 
   @Test

--- a/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactoryTest.java
+++ b/plugins/rocksdb/src/test/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBKeyValueStorageFactoryTest.java
@@ -167,7 +167,7 @@ public class RocksDBKeyValueStorageFactoryTest {
 
     String exceptionMessage =
         String.format(
-            "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Verify config.",
+            "Mismatch: DB at %s is %s (Version %s) but config expects %s (Version %s). Please check your config.",
             tempDataDir.toAbsolutePath(),
             DataStorageFormat.getName(actualDatabaseVersion),
             actualDatabaseVersion,


### PR DESCRIPTION
## PR description

Improve message error when existing database with a different version is detected

`Mismatch: DB at '/path' is FOREST (Version 1) but config expects BONSAI (Version 2). Please check your config.`

see: #5926