### PR TITLE
Fix checkLicense gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,12 +54,12 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)) {
 
 group = 'org.hyperledger.besu'
 
-defaultTasks 'build', 'checkLicenses', 'javadoc'
+defaultTasks 'build', 'checkLicense', 'javadoc'
 
 def buildAliases = ['dev': [
     'spotlessApply',
     'build',
-    'checkLicenses',
+    'checkLicense',
     'javadoc'
   ]]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md -->

## PR description
I'm getting a gradle build failure due the "checkLicenses" task.  This looks like a misspelling:
```
% ./gradlew dev -x test

FAILURE: Build failed with an exception.

* What went wrong:
Task 'checkLicenses' not found in root project 'besu' and its subprojects. Some candidates are: 'checkLicense'.
```

Fix this by using the existin "checkLicense" task.