### PR TITLE
[MINOR] Use better savings estimate for x-trie-log prune

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RocksDbSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RocksDbSubCommand.java
@@ -74,9 +74,8 @@ public class RocksDbSubCommand implements Runnable {
               .storageSubCommand
               .besuCommand
               .dataDir()
-              .toString()
-              .concat("/")
-              .concat(DATABASE_PATH);
+              .resolve(DATABASE_PATH)
+              .toString();
 
       RocksDbHelper.printTableHeader(out);
 
@@ -120,9 +119,8 @@ public class RocksDbSubCommand implements Runnable {
               .storageSubCommand
               .besuCommand
               .dataDir()
-              .toString()
-              .concat("/")
-              .concat(DATABASE_PATH);
+              .resolve(DATABASE_PATH)
+              .toString();
 
       out.println("Column Family Stats...");
       RocksDbHelper.forEachColumnFamily(

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
@@ -180,10 +180,13 @@ public class TrieLogSubCommand implements Runnable {
             (rocksdb, cfHandle) -> {
               try {
                 if (Arrays.equals(cfHandle.getName(), TRIE_LOG_STORAGE.getId())) {
-                  // TODO SLD use sst + blob?
-                  estimatedSaving.set(
-                      Long.parseLong(
-                          rocksdb.getProperty(cfHandle, "rocksdb.estimate-live-data-size")));
+
+                  final long sstSize =
+                      Long.parseLong(rocksdb.getProperty(cfHandle, "rocksdb.total-sst-files-size"));
+                  final long blobSize =
+                      Long.parseLong(rocksdb.getProperty(cfHandle, "rocksdb.total-blob-file-size"));
+
+                  estimatedSaving.set(sstSize + blobSize);
                 }
               } catch (RocksDBException | NumberFormatException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
Following on from #6540, use `total-sst-files-size + total-blob-file-size` instead of `estimate-live-data-size` for x-trie-log prune estimate.