### PR TITLE
During version check, create data dir if it doesn't exist

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -67,7 +67,14 @@ public class VersionMetadata {
   }
 
   private static File getDefaultMetadataFile(final Path dataDir) {
-    return dataDir.resolve(METADATA_FILENAME).toFile();
+    File metaDataFile = dataDir.resolve(METADATA_FILENAME).toFile();
+
+    // Create the data dir here if it doesn't exist yet
+    if (!metaDataFile.getParentFile().exists()) {
+      LOG.info("Data directory {} does not exist - creating it", dataDir);
+      metaDataFile.getParentFile().mkdirs();
+    }
+    return metaDataFile;
   }
 
   private static VersionMetadata resolveVersionMetadata(final File metadataFile)

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
@@ -50,6 +50,17 @@ class VersionMetadataTest {
   }
 
   @Test
+  void dataDirShouldBeCreatedIfNotPresent() throws Exception {
+    Files.deleteIfExists(temporaryFolder);
+    assertThat(Files.exists(temporaryFolder)).isFalse();
+
+    final VersionMetadata versionMetadata = VersionMetadata.lookUpFrom(temporaryFolder);
+    assertThat(versionMetadata).isNotNull();
+
+    assertThat(Files.exists(temporaryFolder)).isTrue();
+  }
+
+  @Test
   void compatibilityCheckShouldThrowExceptionIfEnabled() throws Exception {
     // The version file says the last version to start was 23.10.3
     final Path tempDataDir =


### PR DESCRIPTION
## PR description
Resolves breaking change in PR https://github.com/hyperledger/besu/pull/6307 that blocks Besu startup if the data dir doesn't exist already