### PR TITLE
Fix NPE when running revert variable subcommand

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommand.java
@@ -24,6 +24,7 @@ import static org.hyperledger.besu.ethereum.chain.VariablesStorage.Keys.SEQ_NO_S
 
 import org.hyperledger.besu.cli.BesuCommand;
 import org.hyperledger.besu.cli.util.VersionProvider;
+import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
@@ -98,21 +99,19 @@ public class StorageSubCommand implements Runnable {
     public void run() {
       checkNotNull(parentCommand);
 
-      final var storageProvider = getStorageProvider();
+      final var storageProvider = createBesuController().getStorageProvider();
 
       revert(storageProvider);
     }
 
-    private StorageProvider getStorageProvider() {
-      // init collection of ignorable segments
-      parentCommand.besuCommand.setIgnorableStorageSegments();
-      return parentCommand.besuCommand.getStorageProvider();
+    private BesuController createBesuController() {
+      return parentCommand.besuCommand.buildController();
     }
 
     private void revert(final StorageProvider storageProvider) {
       final var variablesStorage = storageProvider.createVariablesStorage();
       final var blockchainStorage =
-          getStorageProvider().getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.BLOCKCHAIN);
+          storageProvider.getStorageBySegmentIdentifier(KeyValueSegmentIdentifier.BLOCKCHAIN);
       final var blockchainUpdater = blockchainStorage.startTransaction();
       final var variablesUpdater = variablesStorage.updater();
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -218,6 +218,7 @@ public abstract class CommandTestAbstract {
   @Mock protected WorldStateArchive mockWorldStateArchive;
   @Mock protected TransactionPool mockTransactionPool;
   @Mock protected PrivacyPluginServiceImpl privacyPluginService;
+  @Mock protected StorageProvider storageProvider;
 
   @SuppressWarnings("PrivateStaticFinalLoggers") // @Mocks are inited by JUnit
   @Mock
@@ -313,6 +314,7 @@ public abstract class CommandTestAbstract {
     when(mockProtocolContext.getBlockchain()).thenReturn(mockMutableBlockchain);
     lenient().when(mockProtocolContext.getWorldStateArchive()).thenReturn(mockWorldStateArchive);
     when(mockController.getTransactionPool()).thenReturn(mockTransactionPool);
+    when(mockController.getStorageProvider()).thenReturn(storageProvider);
 
     when(mockRunnerBuilder.vertx(any())).thenReturn(mockRunnerBuilder);
     when(mockRunnerBuilder.besuController(any())).thenReturn(mockRunnerBuilder);

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommandTest.java
@@ -25,16 +25,13 @@ import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.populate
 import static org.hyperledger.besu.ethereum.core.VariablesStorageHelper.populateVariablesStorage;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.VARIABLES;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.cli.CommandTestAbstract;
+import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 import org.hyperledger.besu.services.kvstore.SegmentedInMemoryKeyValueStorage;
 import org.hyperledger.besu.services.kvstore.SegmentedKeyValueStorageAdapter;
-
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,10 +64,10 @@ public class StorageSubCommandTest extends CommandTestAbstract {
     final var kvVariables = new SegmentedKeyValueStorageAdapter(VARIABLES, kvVariablesSeg);
     final var kvBlockchainSeg = new SegmentedInMemoryKeyValueStorage();
     final var kvBlockchain = new SegmentedKeyValueStorageAdapter(BLOCKCHAIN, kvBlockchainSeg);
-    when(rocksDBStorageFactory.create(eq(List.of(VARIABLES)), any(), any()))
-        .thenReturn(kvVariablesSeg);
-    when(rocksDBStorageFactory.create(eq(List.of(BLOCKCHAIN)), any(), any()))
-        .thenReturn(kvBlockchainSeg);
+    when(storageProvider.createVariablesStorage())
+        .thenReturn(new VariablesKeyValueStorage(kvVariables));
+    when(storageProvider.getStorageBySegmentIdentifier(BLOCKCHAIN)).thenReturn(kvBlockchain);
+
     final var variableValues = getSampleVariableValues();
     assertNoVariablesInStorage(kvBlockchain);
     populateVariablesStorage(kvVariables, variableValues);
@@ -87,10 +84,9 @@ public class StorageSubCommandTest extends CommandTestAbstract {
     final var kvVariables = new SegmentedKeyValueStorageAdapter(VARIABLES, kvVariablesSeg);
     final var kvBlockchainSeg = new SegmentedInMemoryKeyValueStorage();
     final var kvBlockchain = new SegmentedKeyValueStorageAdapter(BLOCKCHAIN, kvBlockchainSeg);
-    when(rocksDBStorageFactory.create(eq(List.of(VARIABLES)), any(), any()))
-        .thenReturn(kvVariablesSeg);
-    when(rocksDBStorageFactory.create(eq(List.of(BLOCKCHAIN)), any(), any()))
-        .thenReturn(kvBlockchainSeg);
+    when(storageProvider.createVariablesStorage())
+        .thenReturn(new VariablesKeyValueStorage(kvVariables));
+    when(storageProvider.getStorageBySegmentIdentifier(BLOCKCHAIN)).thenReturn(kvBlockchain);
 
     final var variableValues = getSampleVariableValues();
     variableValues.remove(FINALIZED_BLOCK_HASH);
@@ -108,8 +104,9 @@ public class StorageSubCommandTest extends CommandTestAbstract {
   public void doesNothingWhenVariablesAlreadyReverted() {
     final var kvVariables = new InMemoryKeyValueStorage();
     final var kvBlockchain = new InMemoryKeyValueStorage();
-    when(rocksDBStorageFactory.create(eq(VARIABLES), any(), any())).thenReturn(kvVariables);
-    when(rocksDBStorageFactory.create(eq(BLOCKCHAIN), any(), any())).thenReturn(kvBlockchain);
+    when(storageProvider.createVariablesStorage())
+        .thenReturn(new VariablesKeyValueStorage(kvVariables));
+    when(storageProvider.getStorageBySegmentIdentifier(BLOCKCHAIN)).thenReturn(kvBlockchain);
 
     final var variableValues = getSampleVariableValues();
     assertNoVariablesInStorage(kvVariables);


### PR DESCRIPTION
### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [ ] locally run all integration tests via: `./gradlew integrationTest`
- [ ] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description
Fixes NPE when running the revert variables subcommand. 

Due to changes in how the data storage configuration is handled the approach of using the storage provider directly from the `BesuSubcommand` no longer works. Instead changed the approach that to use what was used in the trielog subcommands and creates the BesuController using the `BesuCommand.buildController()` to get access to the `StorageProvider`. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #6614