### PR TITLE
Retrieve all transaction receipts for a block in one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - Fast Sync
 
 ### Additions and Improvements
+- Retrieve all transaction receipts for a block in one request [#6646](https://github.com/hyperledger/besu/pull/6646)
 
 ### Bug fixes
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
@@ -75,7 +75,7 @@ public class PendingStateAdapter extends AdapterBase {
     return transactionPool.getPendingTransactions().stream()
         .map(PendingTransaction::getTransaction)
         .map(TransactionWithMetadata::new)
-        .map(TransactionAdapter::new)
+        .map(tx -> new TransactionAdapter(tx, null))
         .toList();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.tuweni.bytes.Bytes;
@@ -67,9 +68,9 @@ public class TransactionAdapter extends AdapterBase {
 
   public TransactionAdapter(
       final @Nonnull TransactionWithMetadata transactionWithMetadata,
-      final @Nonnull TransactionReceiptWithMetadata transactionReceiptWithMetadata) {
+      final @Nullable TransactionReceiptWithMetadata transactionReceiptWithMetadata) {
     this.transactionWithMetadata = transactionWithMetadata;
-    this.transactionReceiptWithMetadata = Optional.of(transactionReceiptWithMetadata);
+    this.transactionReceiptWithMetadata = Optional.ofNullable(transactionReceiptWithMetadata);
   }
 
   private Optional<TransactionReceiptWithMetadata> getReceipt(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -66,6 +66,12 @@ public class TransactionAdapter extends AdapterBase {
     this.transactionWithMetadata = transactionWithMetadata;
   }
 
+  /**
+   * Constructs a new TransactionAdapter object with receipt.
+   *
+   * @param transactionWithMetadata the TransactionWithMetadata object to adapt.
+   * @param transactionReceiptWithMetadata the TransactionReceiptWithMetadata object to adapt.
+   */
   public TransactionAdapter(
       final @Nonnull TransactionWithMetadata transactionWithMetadata,
       final @Nullable TransactionReceiptWithMetadata transactionReceiptWithMetadata) {
@@ -73,6 +79,12 @@ public class TransactionAdapter extends AdapterBase {
     this.transactionReceiptWithMetadata = Optional.ofNullable(transactionReceiptWithMetadata);
   }
 
+  /**
+   * Reurns the receipt of the transaction.
+   *
+   * @param environment the data fetching environment.
+   * @return the receipt of the transaction.
+   */
   private Optional<TransactionReceiptWithMetadata> getReceipt(
       final DataFetchingEnvironment environment) {
     if (transactionReceiptWithMetadata == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -65,6 +65,13 @@ public class TransactionAdapter extends AdapterBase {
     this.transactionWithMetadata = transactionWithMetadata;
   }
 
+  public TransactionAdapter(
+      final @Nonnull TransactionWithMetadata transactionWithMetadata,
+      final @Nonnull TransactionReceiptWithMetadata transactionReceiptWithMetadata) {
+    this.transactionWithMetadata = transactionWithMetadata;
+    this.transactionReceiptWithMetadata = Optional.of(transactionReceiptWithMetadata);
+  }
+
   private Optional<TransactionReceiptWithMetadata> getReceipt(
       final DataFetchingEnvironment environment) {
     if (transactionReceiptWithMetadata == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceipts.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceipts.java
@@ -68,16 +68,8 @@ public class EthGetBlockReceipts extends AbstractBlockParameterOrBlockHashMethod
   }
 
   /*
-   * For a given transaction, get its receipt and if it exists, wrap in a transaction receipt of the correct type
+   * For a given block, get receipts of transactions in the block and if they exist, wrap in transaction receipts of the correct type
    */
-  private TransactionReceiptResult txReceipt(final TransactionReceiptWithMetadata receipt) {
-    if (receipt.getReceipt().getTransactionReceiptType() == TransactionReceiptType.ROOT) {
-      return new TransactionReceiptRootResult(receipt);
-    } else {
-      return new TransactionReceiptStatusResult(receipt);
-    }
-  }
-
   private BlockReceiptsResult getBlockReceiptsResult(final Hash blockHash) {
     final List<TransactionReceiptResult> receiptList =
         blockchainQueries
@@ -85,7 +77,11 @@ public class EthGetBlockReceipts extends AbstractBlockParameterOrBlockHashMethod
             .transactionReceiptsByBlockHash(blockHash, protocolSchedule)
             .orElse(new ArrayList<TransactionReceiptWithMetadata>())
             .stream()
-            .map(this::txReceipt)
+            .map(
+                receipt ->
+                    receipt.getReceipt().getTransactionReceiptType() == TransactionReceiptType.ROOT
+                        ? new TransactionReceiptRootResult(receipt)
+                        : new TransactionReceiptStatusResult(receipt))
             .collect(Collectors.toList());
 
     return new BlockReceiptsResult(receiptList);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.MinerDataResul
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.MinerDataResult.UncleRewardResult;
 import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.api.query.TransactionReceiptWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -91,19 +92,16 @@ public class EthGetMinerDataByBlockHash implements JsonRpcMethod {
     final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(blockHeader);
     final Wei staticBlockReward = protocolSpec.getBlockReward();
     final Wei transactionFee =
-        block.getTransactions().stream()
+        blockchainQueries
+            .transactionReceiptsByBlockHash(blockHeader.getHash(), protocolSchedule)
+            .orElse(new ArrayList<TransactionReceiptWithMetadata>())
+            .stream()
             .map(
-                t ->
-                    blockchainQueries
-                        .transactionReceiptByTransactionHash(
-                            t.getTransaction().getHash(), protocolSchedule)
-                        .map(
-                            receipt ->
-                                receipt
-                                    .getTransaction()
-                                    .getEffectiveGasPrice(receipt.getBaseFee())
-                                    .multiply(receipt.getGasUsed()))
-                        .orElse(Wei.ZERO))
+                receipt ->
+                    receipt
+                        .getTransaction()
+                        .getEffectivePriorityFeePerGas(receipt.getBaseFee())
+                        .multiply(receipt.getGasUsed()))
             .reduce(Wei.ZERO, BaseUInt256Value::add);
     final Wei uncleInclusionReward =
         staticBlockReward.multiply(block.getOmmers().size()).divide(32);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -331,6 +331,41 @@ public class BlockchainQueriesTest {
   }
 
   @Test
+  public void getTransactionReceiptsByHash() {
+    final BlockchainWithData data = setupBlockchain(3);
+    final BlockchainQueries queries = data.blockchainQueries;
+
+    final Block targetBlock = data.blockData.get(1).block;
+
+    final Optional<List<TransactionReceiptWithMetadata>> receipts =
+        queries.transactionReceiptsByBlockHash(
+            targetBlock.getHash(), Mockito.mock(ProtocolSchedule.class));
+    assertThat(receipts).isNotEmpty();
+
+    receipts
+        .get()
+        .forEach(
+            receipt -> {
+              final long gasUsed = receipt.getGasUsed();
+
+              assertThat(gasUsed)
+                  .isEqualTo(
+                      targetBlock.getHeader().getGasUsed()
+                          / targetBlock.getBody().getTransactions().size());
+            });
+  }
+
+  @Test
+  public void getTransactionReceiptsByInvalidHash() {
+    final BlockchainWithData data = setupBlockchain(3);
+    final BlockchainQueries queries = data.blockchainQueries;
+
+    final Optional<List<TransactionReceiptWithMetadata>> result =
+        queries.transactionReceiptsByBlockHash(gen.hash(), Mockito.mock(ProtocolSchedule.class));
+    assertThat(result).isEmpty();
+  }
+
+  @Test
   public void logsShouldBeFlaggedAsRemovedWhenBlockIsNotInCanonicalChain() {
     // create initial blockchain
     final BlockchainWithData data = setupBlockchain(3);


### PR DESCRIPTION
### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description

1. Retrieve all transaction receipts in a block in 1 call to blockchain query instead of a call for each transaction in a block
2. Calculate transaction fee reward for miner based on `effectivePriorityFeePerGas` instead of `effectiveGasPrice` because `baseFee` would be burnt.