### PR TITLE
Eth call with 4844 params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `--Xfilter-on-enr-fork-id` has been removed. To disable the feature use `--filter-on-enr-fork-id=false`.
 - `--engine-jwt-enabled` has been removed. Use `--engine-jwt-disabled` instead. [#6491](https://github.com/hyperledger/besu/pull/6491)
 - Release docker images now provided at ghcr.io instead of dockerhub
+- `eth_call` support for blob transactions [#6661](https://github.com/hyperledger/besu/pull/6661)
+
 
 ### Deprecations
 - X_SNAP and X_CHECKPOINT are marked for deprecation and will be removed in 24.4.0 in favor of SNAP and CHECKPOINT [#6405](https://github.com/hyperledger/besu/pull/6405)

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCallIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCallIntegrationTest.java
@@ -75,6 +75,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -98,6 +100,8 @@ public class EthCallIntegrationTest {
             null,
             null,
             Bytes.fromHexString("0x12a7b914"),
+            null,
+            null,
             null,
             null,
             null);
@@ -126,6 +130,8 @@ public class EthCallIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -152,6 +158,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -176,6 +184,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             true,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -200,6 +210,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             false,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -225,6 +237,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -247,6 +261,8 @@ public class EthCallIntegrationTest {
             null,
             null,
             Bytes.fromHexString("0x12a7b914"),
+            null,
+            null,
             null,
             null,
             null);
@@ -274,6 +290,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -296,6 +314,8 @@ public class EthCallIntegrationTest {
             null,
             null,
             Bytes.fromHexString("0x12a7b914"),
+            null,
+            null,
             null,
             null,
             null);
@@ -323,6 +343,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -348,6 +370,8 @@ public class EthCallIntegrationTest {
             Bytes.fromHexString("0x12a7b914"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
@@ -365,6 +389,8 @@ public class EthCallIntegrationTest {
         new JsonCallParameter(
             null,
             Address.fromHexString("0x6295ee1b4f6dd65047762f924ecd367c17eabf8f"),
+            null,
+            null,
             null,
             null,
             null,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCreateAccessListIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthCreateAccessListIntegrationTest.java
@@ -140,7 +140,8 @@ public class EthCreateAccessListIntegrationTest {
   @Test
   public void shouldReturnExpectedValueForEmptyCallParameter() {
     final JsonCallParameter callParameter =
-        new JsonCallParameter(null, null, null, null, null, null, null, null, null, null, null);
+        new JsonCallParameter(
+            null, null, null, null, null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(null, new CreateAccessListResult(new ArrayList<>(), 0xcf08));
@@ -161,6 +162,8 @@ public class EthCreateAccessListIntegrationTest {
             null,
             null,
             Wei.ZERO,
+            null,
+            null,
             null,
             null,
             null,
@@ -189,6 +192,8 @@ public class EthCreateAccessListIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse =
@@ -214,6 +219,8 @@ public class EthCreateAccessListIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             false,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse =
@@ -227,7 +234,8 @@ public class EthCreateAccessListIntegrationTest {
   @Test
   public void shouldReturnExpectedValueForInsufficientGas() {
     final JsonCallParameter callParameter =
-        new JsonCallParameter(null, null, 1L, null, null, null, null, null, null, null, null);
+        new JsonCallParameter(
+            null, null, 1L, null, null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(null, new CreateAccessListResult(new ArrayList<>(), 0xcf08));
@@ -262,7 +270,9 @@ public class EthCreateAccessListIntegrationTest {
         null,
         null,
         null,
-        accessList);
+        accessList,
+        null,
+        null);
   }
 
   private JsonRpcRequestContext requestWithParams(final Object... params) {

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthEstimateGasIntegrationTest.java
@@ -65,7 +65,8 @@ public class EthEstimateGasIntegrationTest {
   @Test
   public void shouldReturnExpectedValueForEmptyCallParameter() {
     final JsonCallParameter callParameter =
-        new JsonCallParameter(null, null, null, null, null, null, null, null, null, null, null);
+        new JsonCallParameter(
+            null, null, null, null, null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x5208");
 
@@ -85,6 +86,8 @@ public class EthEstimateGasIntegrationTest {
             null,
             null,
             Wei.ONE,
+            null,
+            null,
             null,
             null,
             null,
@@ -112,6 +115,8 @@ public class EthEstimateGasIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x1b551");
@@ -136,6 +141,8 @@ public class EthEstimateGasIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             false,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x1b551");
@@ -160,6 +167,8 @@ public class EthEstimateGasIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             true,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
 
@@ -176,7 +185,8 @@ public class EthEstimateGasIntegrationTest {
   @Test
   public void shouldReturnExpectedValueForInsufficientGas() {
     final JsonCallParameter callParameter =
-        new JsonCallParameter(null, null, 1L, null, null, null, null, null, null, null, null);
+        new JsonCallParameter(
+            null, null, 1L, null, null, null, null, null, null, null, null, null, null);
     final JsonRpcRequestContext request = requestWithParams(callParameter);
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x5208");
 

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
@@ -73,9 +73,9 @@ public class EthCallIntegrationTest {
             null,
             null,
             Bytes.fromHexString("0x2e64cec1"),
-                null,
-                null,
-                null,
+            null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -101,8 +101,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -127,8 +127,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -154,8 +154,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -180,8 +180,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -207,8 +207,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -234,8 +234,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -260,8 +260,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -287,8 +287,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthCallIntegrationTest.java
@@ -73,7 +73,9 @@ public class EthCallIntegrationTest {
             null,
             null,
             Bytes.fromHexString("0x2e64cec1"),
-            null,
+                null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -99,6 +101,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -123,6 +127,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -148,6 +154,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -172,6 +180,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -197,6 +207,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -222,6 +234,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -246,6 +260,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");
@@ -271,6 +287,8 @@ public class EthCallIntegrationTest {
             null,
             Bytes.fromHexString("0x2e64cec1"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcRequestContext request = requestWithParams(callParameter, "latest");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthEstimateGasIntegrationTest.java
@@ -77,8 +77,8 @@ public class EthEstimateGasIntegrationTest {
             Wei.ONE,
             null,
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
 
@@ -102,8 +102,9 @@ public class EthEstimateGasIntegrationTest {
             null,
             null,
             null,
-            createAccessList(), null, null
-        );
+            createAccessList(),
+            null,
+            null);
 
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x62d4");
@@ -124,8 +125,8 @@ public class EthEstimateGasIntegrationTest {
             Bytes.fromHexString(
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
-                null,
-                null,
+            null,
+            null,
             null,
             null);
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
@@ -148,7 +149,9 @@ public class EthEstimateGasIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             null,
-            createAccessList(), null, null);
+            createAccessList(),
+            null,
+            null);
 
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x2014d");

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthEstimateGasIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthEstimateGasIntegrationTest.java
@@ -77,6 +77,8 @@ public class EthEstimateGasIntegrationTest {
             Wei.ONE,
             null,
             null,
+                null,
+                null,
             null,
             null);
 
@@ -100,7 +102,8 @@ public class EthEstimateGasIntegrationTest {
             null,
             null,
             null,
-            createAccessList());
+            createAccessList(), null, null
+        );
 
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x62d4");
@@ -121,6 +124,8 @@ public class EthEstimateGasIntegrationTest {
             Bytes.fromHexString(
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
+                null,
+                null,
             null,
             null);
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
@@ -143,7 +148,7 @@ public class EthEstimateGasIntegrationTest {
                 "0x608060405234801561001057600080fd5b50610157806100206000396000f30060806040526004361061004c576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680633bdab8bf146100515780639ae97baa14610068575b600080fd5b34801561005d57600080fd5b5061006661007f565b005b34801561007457600080fd5b5061007d6100b9565b005b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60016040518082815260200191505060405180910390a1565b7fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60026040518082815260200191505060405180910390a17fa53887c1eed04528e23301f55ad49a91634ef5021aa83a97d07fd16ed71c039a60036040518082815260200191505060405180910390a15600a165627a7a7230582010ddaa52e73a98c06dbcd22b234b97206c1d7ed64a7c048e10c2043a3d2309cb0029"),
             null,
             null,
-            createAccessList());
+            createAccessList(), null, null);
 
     final JsonRpcResponse response = method.response(requestWithParams(callParameter));
     final JsonRpcResponse expectedResponse = new JsonRpcSuccessResponse(null, "0x2014d");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.json.HexLongDeserializer;
 import org.hyperledger.besu.ethereum.core.json.HexStringDeserializer;
@@ -53,7 +54,9 @@ public class JsonCallParameter extends CallParameter {
       @JsonDeserialize(using = HexStringDeserializer.class) @JsonProperty("input")
           final Bytes input,
       @JsonProperty("strict") final Boolean strict,
-      @JsonProperty("accessList") final List<AccessListEntry> accessList) {
+      @JsonProperty("accessList") final List<AccessListEntry> accessList,
+      @JsonProperty("maxFeePerBlobGas") final Wei maxFeePerBlobGas,
+      @JsonProperty("blobVersionedHashes") final List<VersionedHash> blobVersionedHashes) {
 
     super(
         from,
@@ -64,7 +67,9 @@ public class JsonCallParameter extends CallParameter {
         Optional.ofNullable(maxFeePerGas),
         value,
         Optional.ofNullable(input != null ? input : data).orElse(null),
-        Optional.ofNullable(accessList));
+        Optional.ofNullable(accessList),
+        Optional.ofNullable(maxFeePerBlobGas),
+        Optional.ofNullable(blobVersionedHashes));
 
     if (input != null && data != null) {
       throw new IllegalArgumentException("Only one of 'input' or 'data' should be provided");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -116,7 +116,7 @@ public class EthCallTest {
   public void shouldAcceptRequestWhenMissingOptionalFields() {
     final JsonCallParameter callParameter =
         new JsonCallParameter(
-            null, null, null, null, null, null, null, null, null, Boolean.FALSE, null);
+            null, null, null, null, null, null, null, null, null, Boolean.FALSE, null, null, null);
     final JsonRpcRequestContext request = ethCallRequest(callParameter, "latest");
     final JsonRpcResponse expectedResponse =
         new JsonRpcSuccessResponse(null, Bytes.of().toString());
@@ -453,6 +453,8 @@ public class EthCallTest {
         maxPriorityFeesPerGas,
         Wei.ZERO,
         Bytes.EMPTY,
+        null,
+        null,
         null,
         null,
         null);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessListTest.java
@@ -316,6 +316,8 @@ public class EthCreateAccessListTest {
         Bytes.EMPTY,
         null,
         false,
+        null,
+        null,
         null);
   }
 
@@ -345,7 +347,9 @@ public class EthCreateAccessListTest {
         Bytes.EMPTY,
         null,
         false,
-        accessListEntries);
+        accessListEntries,
+        null,
+        null);
   }
 
   private List<AccessListEntry> createAccessList() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -473,6 +473,8 @@ public class EthEstimateGasTest {
         Bytes.EMPTY,
         null,
         isStrict,
+        null,
+        null,
         null);
   }
 
@@ -505,6 +507,8 @@ public class EthEstimateGasTest {
         Bytes.EMPTY,
         null,
         false,
+        null,
+        null,
         null);
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCallTest.java
@@ -86,6 +86,8 @@ public class PrivCallTest {
             Bytes.EMPTY,
             null,
             null,
+            null,
+            null,
             null);
     final JsonRpcRequestContext request = ethCallRequest(privacyGroupId, callParameter, "latest");
 
@@ -114,6 +116,8 @@ public class PrivCallTest {
         new JsonCallParameter(
             null,
             Address.fromHexString("0x0"),
+            null,
+            null,
             null,
             null,
             null,
@@ -201,6 +205,8 @@ public class PrivCallTest {
         null,
         Wei.ZERO,
         Bytes.EMPTY,
+        null,
+        null,
         null,
         null,
         null);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -210,7 +210,7 @@ public class CallParameter {
         Wei.fromQuantity(tx.getValue()),
         tx.getPayload(),
         tx.getAccessList(),
-        Optional.of(Wei.fromQuantity(tx.getMaxFeePerBlobGas().orElseGet(() -> Wei.ZERO))),
+        tx.getMaxFeePerBlobGas(),
         tx.getVersionedHashes());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -137,13 +137,14 @@ public class CallParameter {
         && Objects.equals(maxPriorityFeePerGas, that.maxPriorityFeePerGas)
         && Objects.equals(maxFeePerGas, that.maxFeePerGas)
         && Objects.equals(value, that.value)
-        && Objects.equals(payload, that.payload);
+        && Objects.equals(payload, that.payload)
+        && Objects.equals(accessList, that.accessList);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        from, to, gasLimit, gasPrice, maxPriorityFeePerGas, maxFeePerGas, value, payload);
+        from, to, gasLimit, gasPrice, maxPriorityFeePerGas, maxFeePerGas, value, payload, accessList);
   }
 
   public static CallParameter fromTransaction(final Transaction tx) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -153,6 +153,14 @@ public class CallParameter {
     return accessList;
   }
 
+  public Optional<Wei> getMaxFeePerBlobGas() {
+    return maxFeePerBlobGas;
+  }
+
+  public Optional<List<VersionedHash>> getBlobVersionedHashes() {
+    return blobVersionedHashes;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -202,7 +210,7 @@ public class CallParameter {
         Wei.fromQuantity(tx.getValue()),
         tx.getPayload(),
         tx.getAccessList(),
-        tx.getMaxFeePerBlobGas(),
+        Optional.of(Wei.fromQuantity(tx.getMaxFeePerBlobGas().orElseGet(() -> Wei.ZERO))),
         tx.getVersionedHashes());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/CallParameter.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.transaction;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 
@@ -37,6 +38,7 @@ public class CallParameter {
   private final Optional<Wei> maxPriorityFeePerGas;
 
   private final Optional<Wei> maxFeePerGas;
+  private final Optional<Wei> maxFeePerBlobGas;
 
   private final Wei gasPrice;
 
@@ -45,6 +47,7 @@ public class CallParameter {
   private final Bytes payload;
 
   private final Optional<List<AccessListEntry>> accessList;
+  private final Optional<List<VersionedHash>> blobVersionedHashes;
 
   public CallParameter(
       final Address from,
@@ -62,6 +65,8 @@ public class CallParameter {
     this.gasPrice = gasPrice;
     this.value = value;
     this.payload = payload;
+    this.maxFeePerBlobGas = Optional.empty();
+    this.blobVersionedHashes = Optional.empty();
   }
 
   public CallParameter(
@@ -83,6 +88,33 @@ public class CallParameter {
     this.value = value;
     this.payload = payload;
     this.accessList = accessList;
+    this.maxFeePerBlobGas = Optional.empty();
+    this.blobVersionedHashes = Optional.empty();
+  }
+
+  public CallParameter(
+      final Address from,
+      final Address to,
+      final long gasLimit,
+      final Wei gasPrice,
+      final Optional<Wei> maxPriorityFeePerGas,
+      final Optional<Wei> maxFeePerGas,
+      final Wei value,
+      final Bytes payload,
+      final Optional<List<AccessListEntry>> accessList,
+      final Optional<Wei> maxFeePerBlobGas,
+      final Optional<List<VersionedHash>> blobVersionedHashes) {
+    this.from = from;
+    this.to = to;
+    this.gasLimit = gasLimit;
+    this.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    this.maxFeePerGas = maxFeePerGas;
+    this.gasPrice = gasPrice;
+    this.value = value;
+    this.payload = payload;
+    this.accessList = accessList;
+    this.maxFeePerBlobGas = maxFeePerBlobGas;
+    this.blobVersionedHashes = blobVersionedHashes;
   }
 
   public Address getFrom() {
@@ -138,13 +170,25 @@ public class CallParameter {
         && Objects.equals(maxFeePerGas, that.maxFeePerGas)
         && Objects.equals(value, that.value)
         && Objects.equals(payload, that.payload)
-        && Objects.equals(accessList, that.accessList);
+        && Objects.equals(accessList, that.accessList)
+        && Objects.equals(maxFeePerBlobGas, that.maxFeePerBlobGas)
+        && Objects.equals(blobVersionedHashes, that.blobVersionedHashes);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        from, to, gasLimit, gasPrice, maxPriorityFeePerGas, maxFeePerGas, value, payload, accessList);
+        from,
+        to,
+        gasLimit,
+        gasPrice,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        value,
+        payload,
+        accessList,
+        maxFeePerBlobGas,
+        blobVersionedHashes);
   }
 
   public static CallParameter fromTransaction(final Transaction tx) {
@@ -157,6 +201,8 @@ public class CallParameter {
         tx.getMaxFeePerGas(),
         Wei.fromQuantity(tx.getValue()),
         tx.getPayload(),
-        tx.getAccessList());
+        tx.getAccessList(),
+        tx.getMaxFeePerBlobGas(),
+        tx.getVersionedHashes());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -294,6 +294,11 @@ public class TransactionSimulator {
 
     // Set access list if present
     callParams.getAccessList().ifPresent(transactionBuilder::accessList);
+    // Set versioned hashes if present
+    callParams.getBlobVersionedHashes().ifPresent(transactionBuilder::versionedHashes);
+    // Set max fee per blob gas if present
+    // TODO blob gas fee calculation - do we need to do anything else with this value
+    callParams.getMaxFeePerBlobGas().ifPresent(transactionBuilder::maxFeePerBlobGas);
 
     final Wei gasPrice;
     final Wei maxFeePerGas;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -57,7 +57,6 @@ import java.util.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -605,11 +604,10 @@ public class TransactionSimulatorTest {
 
   @Test
   public void shouldReturnSuccessfulResultWhenBlobTransactionProcessingIsSuccessful() {
-    final List<VersionedHash> versionedHashes =
-        List.of(
-            new VersionedHash(
-                Bytes32.fromHexString(
-                    "0x0148b0d226ded90804ec8a9ce337cc7abc86d718ceea7ae0cbb6acf4fdee215f")));
+    final Hash fakedHash = Hash.hash(Bytes.fromBase64String("ThisIsAFakeHash"));
+    final VersionedHash fakeVersionedHash =
+        new VersionedHash(VersionedHash.SHA256_VERSION_ID, fakedHash);
+    final List<VersionedHash> versionedHashes = List.of(fakeVersionedHash);
     final CallParameter callParameter =
         blobTransactionCallParameter(Wei.ONE, Wei.ONE, Wei.ONE, 300, versionedHashes);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -26,11 +26,12 @@ import org.hyperledger.besu.crypto.SECPSignature;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.BlobsWithCommitments;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.TransactionType;
-import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlobTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -51,7 +52,6 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.math.BigInteger;
-import java.util.List;
 import java.util.Optional;
 
 import com.google.common.base.Supplier;
@@ -604,12 +604,8 @@ public class TransactionSimulatorTest {
 
   @Test
   public void shouldReturnSuccessfulResultWhenBlobTransactionProcessingIsSuccessful() {
-    final Hash fakedHash = Hash.hash(Bytes.fromBase64String("ThisIsAFakeHash"));
-    final VersionedHash fakeVersionedHash =
-        new VersionedHash(VersionedHash.SHA256_VERSION_ID, fakedHash);
-    final List<VersionedHash> versionedHashes = List.of(fakeVersionedHash);
     final CallParameter callParameter =
-        blobTransactionCallParameter(Wei.ONE, Wei.ONE, Wei.ONE, 300, versionedHashes);
+        blobTransactionCallParameter(Wei.ONE, Wei.ONE, Wei.ONE, 300, 3);
 
     final BlockHeader blockHeader = mockBlockHeader(Hash.ZERO, 1L, Wei.ONE);
 
@@ -628,8 +624,8 @@ public class TransactionSimulatorTest {
             .sender(callParameter.getFrom())
             .value(callParameter.getValue())
             .payload(callParameter.getPayload())
-            .maxFeePerBlobGas(Wei.ONE)
-            .versionedHashes(versionedHashes)
+            .maxFeePerBlobGas(callParameter.getMaxFeePerBlobGas().get())
+            .versionedHashes(callParameter.getBlobVersionedHashes().get())
             .signature(FAKE_SIGNATURE)
             .build();
     mockProcessorStatusForTransaction(expectedTransaction, Status.SUCCESSFUL);
@@ -771,7 +767,8 @@ public class TransactionSimulatorTest {
       final Wei maxFeePerGas,
       final Wei maxPriorityFeePerGas,
       final long gasLimit,
-      final List<VersionedHash> versionedHashes) {
+      final int numberOfBlobs) {
+    BlobsWithCommitments bwc = new BlobTestFixture().createBlobsWithCommitments(numberOfBlobs);
     return new CallParameter(
         Address.fromHexString("0x0"),
         Address.fromHexString("0x0"),
@@ -783,6 +780,6 @@ public class TransactionSimulatorTest {
         Bytes.EMPTY,
         Optional.empty(),
         Optional.of(maxFeePerBlobGas),
-        Optional.of(versionedHashes));
+        Optional.of(bwc.getVersionedHashes()));
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulatorTest.java
@@ -628,6 +628,11 @@ public class TransactionSimulatorTest {
             .versionedHashes(callParameter.getBlobVersionedHashes().get())
             .signature(FAKE_SIGNATURE)
             .build();
+
+    final CallParameter reverseEngineeredCallParam =
+        CallParameter.fromTransaction(expectedTransaction);
+    assertThat(reverseEngineeredCallParam).isEqualTo(callParameter);
+
     mockProcessorStatusForTransaction(expectedTransaction, Status.SUCCESSFUL);
 
     final Optional<TransactionSimulatorResult> result =


### PR DESCRIPTION
Added support for `maxFeePerBlobGas` and `versionedHashes` to eth_call 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [x] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description

## Fixed Issue(s)
refs #6657 