### PR TITLE
Don't start the BFT mining coordinator when it is created, just enable it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Refactor and extend `TransactionPoolValidatorService` [#6636](https://github.com/hyperledger/besu/pull/6636)
 
 ### Bug fixes
+- Don't enable the BFT mining coordinator when running sub commands such as `blocks export` [#6675](https://github.com/hyperledger/besu/pull/6675)
 
 ### Download Links
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -235,11 +235,7 @@ public class IbftBesuControllerBuilder extends BftBesuControllerBuilder {
             bftEventQueue);
 
     if (syncState.isInitialSyncPhaseDone()) {
-      LOG.info("Starting IBFT mining coordinator");
       ibftMiningCoordinator.enable();
-      ibftMiningCoordinator.start();
-    } else {
-      LOG.info("IBFT mining coordinator not starting while initial sync in progress");
     }
 
     syncState.subscribeCompletionReached(

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -275,11 +275,7 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
             bftEventQueue);
 
     if (syncState.isInitialSyncPhaseDone()) {
-      LOG.info("Starting QBFT mining coordinator");
       miningCoordinator.enable();
-      miningCoordinator.start();
-    } else {
-      LOG.info("QBFT mining coordinator not starting while initial sync in progress");
     }
 
     syncState.subscribeCompletionReached(


### PR DESCRIPTION
## PR description
When creating a BFT mining coordinator, if the sync phase is already complete then enable the coordinator but don't start it.

Start will be done either during starting of the ethereum main loop, or on receiving an event notification that syncing has completed.

## Fixed Issue(s)
Fixes https://github.com/hyperledger/besu/issues/6674