### PR TITLE
Silence vertx dns errors

### DIFF
--- a/besu/src/main/resources/log4j2.xml
+++ b/besu/src/main/resources/log4j2.xml
@@ -45,6 +45,9 @@
         <Logger name="org.apache.tuweni.discovery.DNSResolver">
             <RegexFilter regex="DNS query error with .*" onMatch="DENY" onMismatch="NEUTRAL" />
         </Logger>
+        <Logger name="io.vertx.core.dns.DnsException">
+            <RegexFilter regex="DNS query error occurred:.*" onMatch="DENY" onMismatch="NEUTRAL" />
+        </Logger>
         <Root level="${sys:root.log.level}">
             <AppenderRef ref="Router" />
         </Root>


### PR DESCRIPTION
### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [ ] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [ ] locally run all integration tests via: `./gradlew integrationTest`
- [ ] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description
quickie pr to silence the vertx counterpart to the tuweni dns errors

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->