### PR TITLE
[build] - Update gradle build to invoke int test compile task on assemble task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -540,6 +540,13 @@ subprojects {
 
     dependencies { jmh 'org.slf4j:slf4j-api' }
   }
+
+  // making sure assemble task invokes integration test compile
+  afterEvaluate { project ->
+    if (project.tasks.findByName('compileIntegrationTestJava')) {
+      project.tasks.assemble.dependsOn compileIntegrationTestJava
+    }
+  }
 }
 
 jar { enabled = false }


### PR DESCRIPTION
### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [x] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description
The `assemble` task has been modified to additionally depends on `compileIntegrationTestJava` so that any compilation issues are reported earlier locally and in CI.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #6670 