### PR TITLE
fix for txpool inSync listener to honor initial sync state

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -174,7 +174,7 @@ public class TransactionPoolFactory {
     syncState.subscribeInSync(
         isInSync -> {
           if (isInSync != transactionPool.isEnabled()) {
-            if (isInSync) {
+            if (isInSync && syncState.isInitialSyncPhaseDone()) {
               LOG.info("Node is in sync, enabling transaction handling");
               enableTransactionHandling(
                   transactionTracker,
@@ -182,9 +182,11 @@ public class TransactionPoolFactory {
                   transactionsMessageHandler,
                   pooledTransactionsMessageHandler);
             } else {
-              LOG.info("Node out of sync, disabling transaction handling");
-              disableTransactionHandling(
-                  transactionPool, transactionsMessageHandler, pooledTransactionsMessageHandler);
+              if (transactionPool.isEnabled()) {
+                LOG.info("Node out of sync, disabling transaction handling");
+                disableTransactionHandling(
+                    transactionPool, transactionsMessageHandler, pooledTransactionsMessageHandler);
+              }
             }
           }
         });


### PR DESCRIPTION
## PR description
Fix and unit test for transaction pool inSync listener to ensure we account for initial sync state when enabling/disabling the pool.

The inSync listener responds to chain events only and does not take into account worldstate sync.  This pr adds an additional initial sync condition in the sync listener to ensure we do not enable the pool when the chain sync finishes, but the worldstate is incomplete (like in the case of a debug_resyncWorldState)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->