### PR TITLE
proposed "develop" build versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ allprojects {
   apply plugin: 'net.ltgt.errorprone'
   apply from: "${rootDir}/gradle/versions.gradle"
 
-  version = rootProject.version
+  version = calculateVersion()
 
   jacoco {
     toolVersion = '0.8.8'
@@ -1038,42 +1038,40 @@ def buildTime() {
   return df.format(new Date())
 }
 
-// Takes the version, and if -SNAPSHOT is part of it replaces SNAPSHOT
-// with the git commit version.
 @Memoized
 def calculateVersion() {
-  String version = rootProject.version
-  if (version.endsWith("-SNAPSHOT")) {
-    version = version.replace("-SNAPSHOT", "-dev-" + getCheckedOutGitCommitHash())
-  }
-  return version
+  def gitDetails = getGitCommitDetails(10) // Adjust length as needed
+  return "${gitDetails.date}-develop-${gitDetails.hash}"
 }
 
-def getCheckedOutGitCommitHash(length = 8) {
+def getGitCommitDetails(length = 8) {
   try {
     def gitFolder = "$projectDir/.git/"
     if (!file(gitFolder).isDirectory()) {
-      // We are in a submodule.  The file's contents are `gitdir: <gitFolder>\n`.
-      // Read the file, cut off the front, and trim the whitespace.
       gitFolder = file(gitFolder).text.substring(length).trim() + "/"
     }
     def takeFromHash = length
-    /*
-     * '.git/HEAD' contains either
-     *      in case of detached head: the currently checked out commit hash
-     *      otherwise: a reference to a file containing the current commit hash
-     */
-    def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
-    def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
+    def head = new File(gitFolder + "HEAD").text.split(":")
+    def isCommit = head.length == 1
 
-    if (isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
+    def commitHash, refHeadFile
+    if (isCommit) {
+      commitHash = head[0].trim().take(takeFromHash)
+      refHeadFile = new File(gitFolder + "HEAD")
+    } else {
+      refHeadFile = new File(gitFolder + head[1].trim())
+      commitHash = refHeadFile.text.trim().take(takeFromHash)
+    }
 
-    def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
-    refHead.text.trim().take takeFromHash
+    // Use file modification time as a proxy for the commit date
+    def lastModified = new Date(refHeadFile.lastModified())
+    def formattedDate = new SimpleDateFormat("yy.M.d").format(lastModified)
+
+    return [hash: commitHash, date: formattedDate]
   } catch (Exception e) {
-    logger.warn('Could not calculate git commit, using "xxxxxxxx" (run with --info for stacktrace)')
-    logger.info('Error retrieving git commit', e)
-    return "xxxxxxxx"
+    logger.warn('Could not calculate git commit details, using defaults (run with --info for stacktrace)')
+    logger.info('Error retrieving git commit details', e)
+    return [hash: "xxxxxxxx", date: "00.0.0"]
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1040,10 +1040,10 @@ def buildTime() {
 
 @Memoized
 def calculateVersion() {
-  // Regex pattern for basic semantic versioning
-  def semVerPattern = ~/\d+\.\d+\.\d+(-.*)?/
+  // Regex pattern for basic calendar versioning, with provision to omit patch rev
+  def calVerPattern = ~/\d+\.\d+(\.\d+)?(-.*)?/
 
-  if (project.hasProperty('version') && (project.version =~ semVerPattern)) {
+  if (project.hasProperty('version') && (project.version =~ calVerPattern)) {
     return "${project.version}"
   } else {
     // If no version is supplied or it doesn't match the semantic versioning, calculate from git
@@ -1072,15 +1072,16 @@ def getGitCommitDetails(length = 8) {
       commitHash = refHeadFile.text.trim().take(takeFromHash)
     }
 
-    // Use file modification time as a proxy for the commit date
+    // Use head file modification time as a proxy for the build date
     def lastModified = new Date(refHeadFile.lastModified())
-    def formattedDate = new SimpleDateFormat("yy.M.d").format(lastModified)
+    // Format the date as "yy.M" (e.g. 24.3 for March 2024)
+    def formattedDate = new SimpleDateFormat("yy.M").format(lastModified)
 
     return [hash: commitHash, date: formattedDate]
   } catch (Exception e) {
     logger.warn('Could not calculate git commit details, using defaults (run with --info for stacktrace)')
     logger.info('Error retrieving git commit details', e)
-    return [hash: "xxxxxxxx", date: "00.0.0"]
+    return [hash: "xxxxxxxx", date: "00.0"]
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1040,8 +1040,17 @@ def buildTime() {
 
 @Memoized
 def calculateVersion() {
-  def gitDetails = getGitCommitDetails(10) // Adjust length as needed
-  return "${gitDetails.date}-develop-${gitDetails.hash}"
+  // Regex pattern for basic semantic versioning
+  def semVerPattern = ~/\d+\.\d+\.\d+(-.*)?/
+
+  if (project.hasProperty('version') && (project.version =~ semVerPattern)) {
+    return "${project.version}"
+  } else {
+    // If no version is supplied or it doesn't match the semantic versioning, calculate from git
+    println("Generating project version as supplied is version not semver: ${project.version}")
+    def gitDetails = getGitCommitDetails(10) // Adjust length as needed
+    return "${gitDetails.date}-develop-${gitDetails.hash}"
+  }
 }
 
 def getGitCommitDetails(length = 8) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=24.2.0-SNAPSHOT
-
 org.gradle.welcome=never
 # Set exports/opens flags required by Google Java Format and ErrorProne plugins. (JEP-396)
 org.gradle.jvmargs=-Xmx4g \


### PR DESCRIPTION
## PR description
As part of our recent build and release changes, we no longer need to explicitly maintain the build version in gradle.properties file.

This PR is a proposal to change our "develop" builds to use git commit and HEAD details to specify a dynamic build version.

for example this PR, prior to committing the changes, produced a build named:
`besu-24.3.7-develop-610927511e.tar.gz`

After committing the gradle changes and rebuilding, it produced a build named:
`besu-24.3.7-develop-600d812d89.tar.gz`


Open to suggestions, feedback, and identifying corner cases




## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->