### PR TITLE
Refactor BadBlockReason enum out of BadBlockCause

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockCause.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockCause.java
@@ -15,19 +15,14 @@
  */
 package org.hyperledger.besu.ethereum.chain;
 
+import static org.hyperledger.besu.ethereum.chain.BadBlockReason.DESCENDS_FROM_BAD_BLOCK;
+import static org.hyperledger.besu.ethereum.chain.BadBlockReason.SPEC_VALIDATION_FAILURE;
+
 import org.hyperledger.besu.ethereum.core.Block;
 
 import com.google.common.base.MoreObjects;
 
 public class BadBlockCause {
-  public enum BadBlockReason {
-    // Standard spec-related validation failures
-    SPEC_VALIDATION_FAILURE,
-    // When an unexpected exception occurs during block processing
-    EXCEPTIONAL_BLOCK_PROCESSING,
-    // This block is bad because it descends from a bad block
-    DESCENDS_FROM_BAD_BLOCK,
-  }
 
   private final BadBlockReason reason;
   private final String description;
@@ -35,11 +30,11 @@ public class BadBlockCause {
   public static BadBlockCause fromBadAncestorBlock(final Block badAncestor) {
     final String description =
         String.format("Descends from bad block %s", badAncestor.toLogString());
-    return new BadBlockCause(BadBlockReason.DESCENDS_FROM_BAD_BLOCK, description);
+    return new BadBlockCause(DESCENDS_FROM_BAD_BLOCK, description);
   }
 
   public static BadBlockCause fromValidationFailure(final String failureMessage) {
-    return new BadBlockCause(BadBlockReason.SPEC_VALIDATION_FAILURE, failureMessage);
+    return new BadBlockCause(SPEC_VALIDATION_FAILURE, failureMessage);
   }
 
   private BadBlockCause(final BadBlockReason reason, final String description) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockReason.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockReason.java
@@ -17,8 +17,6 @@ package org.hyperledger.besu.ethereum.chain;
 public enum BadBlockReason {
   // Standard spec-related validation failures
   SPEC_VALIDATION_FAILURE,
-  // When an unexpected exception occurs during block processing
-  EXCEPTIONAL_BLOCK_PROCESSING,
   // This block is bad because it descends from a bad block
   DESCENDS_FROM_BAD_BLOCK,
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockReason.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/BadBlockReason.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Hyperledger Besu Contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.chain;
+
+public enum BadBlockReason {
+  // Standard spec-related validation failures
+  SPEC_VALIDATION_FAILURE,
+  // When an unexpected exception occurs during block processing
+  EXCEPTIONAL_BLOCK_PROCESSING,
+  // This block is bad because it descends from a bad block
+  DESCENDS_FROM_BAD_BLOCK,
+}


### PR DESCRIPTION
### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [x] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description
BadBlockReason was an non-static inner enum in BadBlockCause and it was used in static context. This caused one of our custom errorprone checks to not pick up the "method param not final argument" correctly. Refactoring it out as an static top level class. Now all the checks are applied correctly.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#6685 