### PR TITLE
Refactor PluginPrivacyController to fix parameter name

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PluginPrivacyController.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/privacy/PluginPrivacyController.java
@@ -124,7 +124,7 @@ public class PluginPrivacyController extends AbstractPrivacyController {
   @Override
   public Optional<PrivacyGroup> findPrivacyGroupByGroupId(
       final String privacyGroupId, final String privacyUserId) {
-    verifyPrivacyGroupContainsPrivacyUserId(privacyUserId, privacyGroupId);
+    verifyPrivacyGroupContainsPrivacyUserId(privacyGroupId, privacyUserId);
 
     return Optional.of(
         new PrivacyGroup(
@@ -155,7 +155,7 @@ public class PluginPrivacyController extends AbstractPrivacyController {
 
   @Override
   public void verifyPrivacyGroupContainsPrivacyUserId(
-      final String privacyUserId, final String privacyGroupId) {
-    verifyPrivacyGroupContainsPrivacyUserId(privacyUserId, privacyGroupId, Optional.empty());
+      final String privacyGroupId, final String privacyUserId) {
+    verifyPrivacyGroupContainsPrivacyUserId(privacyGroupId, privacyUserId, Optional.empty());
   }
 }


### PR DESCRIPTION
## PR description
Refactor PluginPrivacyController. Fix parameter name to match overridden method. Identified during errorprone plugin update.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [x] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`

