### PR TITLE
Suppress ComparisonOutOfRange errorprone warning in AbstractGasLimitSpecification

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
@@ -47,7 +47,6 @@ public abstract class AbstractGasLimitSpecification {
    * @return true if within bounds
    */
   public static boolean isValidTargetGasLimit(final long targetGasLimit) {
-    // only check the lower bound as the upper bound is Long.MAX_VALUE
-    return targetGasLimit >= DEFAULT_MIN_GAS_LIMIT;
+    return DEFAULT_MIN_GAS_LIMIT <= targetGasLimit && DEFAULT_MAX_GAS_LIMIT >= targetGasLimit;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
@@ -46,6 +46,7 @@ public abstract class AbstractGasLimitSpecification {
    * @param targetGasLimit the target gas limit to validate
    * @return true if within bounds
    */
+  @SuppressWarnings("ComparisonOutOfRange")
   public static boolean isValidTargetGasLimit(final long targetGasLimit) {
     return DEFAULT_MIN_GAS_LIMIT <= targetGasLimit && DEFAULT_MAX_GAS_LIMIT >= targetGasLimit;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractGasLimitSpecification.java
@@ -40,7 +40,14 @@ public abstract class AbstractGasLimitSpecification {
     return Long.divideUnsigned(currentGasLimit, GAS_LIMIT_BOUND_DIVISOR);
   }
 
+  /**
+   * Verify that the target gas limit is within the allowed bounds.
+   *
+   * @param targetGasLimit the target gas limit to validate
+   * @return true if within bounds
+   */
   public static boolean isValidTargetGasLimit(final long targetGasLimit) {
-    return DEFAULT_MIN_GAS_LIMIT <= targetGasLimit && DEFAULT_MAX_GAS_LIMIT >= targetGasLimit;
+    // only check the lower bound as the upper bound is Long.MAX_VALUE
+    return targetGasLimit >= DEFAULT_MIN_GAS_LIMIT;
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
@@ -75,9 +75,8 @@ public class TargetingGasLimitCalculatorTest {
   @Test
   public void verifyMaxGasLimit() {
     assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT - 1))
-            .isTrue();
-    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT))
-            .isTrue();
+        .isTrue();
+    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT)).isTrue();
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
@@ -73,6 +73,14 @@ public class TargetingGasLimitCalculatorTest {
   }
 
   @Test
+  public void verifyMaxGasLimit() {
+    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT - 1))
+            .isTrue();
+    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT))
+            .isTrue();
+  }
+
+  @Test
   public void verifyWithinGasLimitDelta() {
     final long targetGasLimit = 10_000_000L;
     final long currentGasLimit = 1024L * 1024L;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/TargetingGasLimitCalculatorTest.java
@@ -74,9 +74,8 @@ public class TargetingGasLimitCalculatorTest {
 
   @Test
   public void verifyMaxGasLimit() {
-    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT - 1))
-        .isTrue();
-    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(DEFAULT_MAX_GAS_LIMIT)).isTrue();
+    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(Long.MAX_VALUE - 1)).isTrue();
+    assertThat(AbstractGasLimitSpecification.isValidTargetGasLimit(Long.MAX_VALUE)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
## PR description
Suppress ComparisonOutOfRange error-prone warning in AbstractGasLimitSpecification. This was reported during errorprone plugin update. Add a unit test to cover the max limit as well.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [x] locally run all unit tests via: `./gradlew build`
- [x] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [x] locally run all integration tests via: `./gradlew integrationTest`
- [x] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`
