### PR TITLE
[MINOR] Move potentially spammy peer discovery warn log to debug

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/VertxPeerDiscoveryAgent.java
@@ -220,12 +220,14 @@ public class VertxPeerDiscoveryAgent extends PeerDiscoveryAgent {
             .addArgument(err)
             .log();
       } else {
-        LOG.warn(
-            "Sending to peer {} failed, native error code {}, packet: {}, stacktrace: {}",
-            peer,
-            nativeErr.expectedErr(),
-            wrapBuffer(packet.encode()),
-            err);
+        LOG.atDebug()
+            .setMessage(
+                "Sending to peer {} failed, native error code {}, packet: {}, stacktrace: {}")
+            .addArgument(peer)
+            .addArgument(nativeErr.expectedErr())
+            .addArgument(wrapBuffer(packet.encode()))
+            .addArgument(err)
+            .log();
       }
     } else if (err instanceof SocketException && err.getMessage().contains("unreachable")) {
       LOG.atDebug()


### PR DESCRIPTION
For one user, this log was appearing every couple of seconds.

We determined that it shouldn't affect the peers required for the node to function therefore there's potentially nothing to act on WARN level is too high.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [ ] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [ ] locally run all integration tests via: `./gradlew integrationTest`
- [ ] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`


## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->