### PR TITLE
fix checked out git commit hash for docker builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -766,9 +766,10 @@ task distDocker {
           dockerPlatform = "--platform ${project.getProperty('docker-platform')}"
           println "Building for platform ${project.getProperty('docker-platform')}"
         }
+        def gitDetails = getGitCommitDetails(10)
         executable "sh"
         workingDir dockerBuildDir
-        args "-c", "docker build ${dockerPlatform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+        args "-c", "docker build ${dockerPlatform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."
       }
     }
 

--- a/ethereum/evmtool/build.gradle
+++ b/ethereum/evmtool/build.gradle
@@ -120,8 +120,9 @@ tasks.register('distDocker', Exec) {
     }
   }
 
+  def gitDetails = getGitCommitDetails(10)
   executable "sh"
-  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."
 }
 
 tasks.register('dockerUpload', Exec) {


### PR DESCRIPTION
`getCheckedOutGitCommitHash` was removed in https://github.com/hyperledger/besu/pull/6699

This updates to use the new function