### PR TITLE
GraphQL serializes BlobVersionedHashes

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/Scalars.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/Scalars.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.graphql.internal;
 
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 
 import java.math.BigInteger;
@@ -256,6 +257,8 @@ public class Scalars {
                 return null;
               }
             }
+          } else if (input instanceof VersionedHash versionedHash) {
+            return versionedHash.toBytes();
           } else {
             return null;
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -239,7 +239,7 @@ public enum RpcErrorType implements RpcMethodError {
   }
 
   RpcErrorType(
-      final int code, final String message, Function<String, Optional<String>> dataDecoder) {
+      final int code, final String message, final Function<String, Optional<String>> dataDecoder) {
     this.code = code;
     this.message = message;
     this.dataDecoder = dataDecoder;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/Bytes32ScalarTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/scalar/Bytes32ScalarTest.java
@@ -17,6 +17,8 @@ package org.hyperledger.besu.ethereum.api.graphql.scalar;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.VersionedHash;
 import org.hyperledger.besu.ethereum.api.graphql.internal.Scalars;
 
 import java.util.Locale;
@@ -41,6 +43,8 @@ public class Bytes32ScalarTest {
   private final Bytes32 value = Bytes32.fromHexString(str);
   private final StringValue strValue = StringValue.newStringValue(str).build();
   private final StringValue invalidStrValue = StringValue.newStringValue("0xgh").build();
+
+  private final VersionedHash versionedHash = new VersionedHash((byte)1, Hash.hash(value));
 
   @Test
   public void pareValueTest() {
@@ -119,6 +123,12 @@ public class Bytes32ScalarTest {
                         GraphQLContext.newContext().build(),
                         Locale.ENGLISH))
         .isInstanceOf(CoercingParseLiteralException.class);
+  }
+
+  @Test
+  public void parseVersionedHash() {
+    assertThat(scalar.getCoercing().serialize(versionedHash, GraphQLContext.newContext().build(), Locale.ENGLISH))
+        .isEqualTo(versionedHash.toString());
   }
 
   @BeforeEach


### PR DESCRIPTION
## PR description

Fix error where GraphQL fails to serialize the versioned hash of a blob transaction.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [ ] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [ ] locally run all integration tests via: `./gradlew integrationTest`
- [ ] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`

