### PR TITLE
bonsai in ATs

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ProcessBesuNodeRunner.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.eth.transactions.ImmutableTransactionPoolCo
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.netty.TLSConfiguration;
 import org.hyperledger.besu.ethereum.permissioning.PermissioningConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.tests.acceptance.dsl.StaticNodesUtils;
@@ -114,9 +113,9 @@ public class ProcessBesuNodeRunner implements BesuNodeRunner {
 
     params.addAll(
         DataStorageOptions.fromConfig(
-                ImmutableDataStorageConfiguration.builder()
-                    .from(DataStorageConfiguration.DEFAULT_FOREST_CONFIG)
-                    .build())
+                node.getDataStorageConfiguration() == null
+                    ? DataStorageConfiguration.DEFAULT_BONSAI_CONFIG
+                    : node.getDataStorageConfiguration())
             .getCLIOptions());
 
     if (node.getMiningParameters().isMiningEnabled()) {

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -237,6 +237,11 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
 
     final int maxPeers = 25;
 
+    final DataStorageConfiguration dataStorageConfiguration =
+        node.getDataStorageConfiguration() == null
+            ? DataStorageConfiguration.DEFAULT_BONSAI_CONFIG
+            : node.getDataStorageConfiguration();
+
     builder
         .synchronizerConfiguration(new SynchronizerConfiguration.Builder().build())
         .dataDirectory(node.homeDirectory())
@@ -245,7 +250,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
         .nodeKey(new NodeKey(new KeyPairSecurityModule(KeyPairUtil.loadKeyPair(dataDir))))
         .metricsSystem(metricsSystem)
         .transactionPoolConfiguration(txPoolConfig)
-        .dataStorageConfiguration(DataStorageConfiguration.DEFAULT_FOREST_CONFIG)
+        .dataStorageConfiguration(dataStorageConfiguration)
         .ethProtocolConfiguration(EthProtocolConfiguration.defaultConfig())
         .clock(Clock.systemUTC())
         .isRevertReasonEnabled(node.isRevertReasonEnabled())

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/AbstractPreexistingNodeTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/AbstractPreexistingNodeTest.java
@@ -19,6 +19,7 @@ package org.hyperledger.besu.tests.acceptance;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.tests.acceptance.dsl.AcceptanceTestBase;
 import org.hyperledger.besu.tests.acceptance.dsl.node.configuration.BesuNodeConfigurationBuilder;
 
@@ -70,6 +71,8 @@ public class AbstractPreexistingNodeTest extends AcceptanceTestBase {
     return nodeBuilder
         .devMode(false)
         .dataPath(hostDataPath)
+        .dataStorageConfiguration(
+            DataStorageConfiguration.DEFAULT_FOREST_CONFIG) // existing db is forest
         .genesisConfigProvider((nodes) -> Optional.of(genesisData))
         .jsonRpcEnabled();
   }


### PR DESCRIPTION
## PR description

Change ProcessBesuNodeRunner and ThreadBesuNodeRunner to use DEFAULT_BONSAI_CONFIG

the AT flakiness seems to have resolved itself... fishy
- original PR which shows failure https://github.com/hyperledger/besu/pull/6619
- second PR which shows when it was failing https://github.com/hyperledger/besu/pull/6729 and is now passing (I thought maybe the last change https://github.com/hyperledger/besu/pull/6729/commits/a4d25082d9f6b37f2c8b7ed2c431674fc714e781   was making it pass)
- redux PR which has the same code (with and without that last change) and no failures https://github.com/hyperledger/besu/pull/6770


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Most advanced CI tests are deferred until PR approval, but you could:

- [ ] locally run all unit tests via: `./gradlew build`
- [ ] locally run all acceptance tests via: `./gradlew acceptanceTest`
- [ ] locally run all integration tests via: `./gradlew integrationTest`
- [ ] locally run all reference tests via: `./gradlew ethereum:referenceTests:referenceTests`

