### PR TITLE
Improve PluginRpcEndpointException

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginJsonRpcMethod.java
@@ -50,8 +50,8 @@ public class PluginJsonRpcMethod implements JsonRpcMethod {
       final Object result = function.apply(() -> request.getRequest().getParams());
       return new JsonRpcSuccessResponse(request.getRequest().getId(), result);
     } catch (final PluginRpcEndpointException ex) {
-      final JsonRpcError error = new JsonRpcError(ex.getRpcMethodError(), ex.getMessage());
-      LOG.error("Error calling plugin JSON-RPC endpoint", ex);
+      final JsonRpcError error = new JsonRpcError(ex.getRpcMethodError(), ex.getData());
+      LOG.debug("Error calling plugin JSON-RPC endpoint", ex);
       return new JsonRpcErrorResponse(request.getRequest().getId(), error);
     }
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestHelper.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestHelper.java
@@ -37,8 +37,16 @@ public class JsonRpcTestHelper {
   }
 
   protected void assertValidJsonRpcError(
-      final JsonObject json, final Object id, final int errorCode, final String errorMessage)
-      throws Exception {
+      final JsonObject json, final Object id, final int errorCode, final String errorMessage) {
+    assertValidJsonRpcError(json, id, errorCode, errorMessage, null);
+  }
+
+  protected void assertValidJsonRpcError(
+      final JsonObject json,
+      final Object id,
+      final int errorCode,
+      final String errorMessage,
+      final String data) {
     // Check all expected fieldnames are set
     final Set<String> fieldNames = json.fieldNames();
     assertThat(fieldNames.size()).isEqualTo(3);
@@ -53,13 +61,19 @@ public class JsonRpcTestHelper {
     // Check error format
     final JsonObject error = json.getJsonObject("error");
     final Set<String> errorFieldNames = error.fieldNames();
-    assertThat(errorFieldNames.size()).isEqualTo(2);
+    assertThat(errorFieldNames.size()).isEqualTo(data == null ? 2 : 3);
     assertThat(errorFieldNames.contains("code")).isTrue();
     assertThat(errorFieldNames.contains("message")).isTrue();
+    if (data != null) {
+      assertThat(errorFieldNames.contains("data")).isTrue();
+    }
 
     // Check error field values
     assertThat(error.getInteger("code")).isEqualTo(errorCode);
     assertThat(error.getString("message")).isEqualTo(errorMessage);
+    if (data != null) {
+      assertThat(error.getString("data")).isEqualTo(data);
+    }
   }
 
   protected void assertIdMatches(final JsonObject json, final Object expectedId) {

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -69,7 +69,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '0xiYCyr3M4oSrvqYXVkLgVDzlBg2T3fmrADub5tY5a0='
+  knownHash = '/FHIztl2tLW5Gzc0qnfEeuVQa6ljVfUce7YE6JLDdZU='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/exception/PluginRpcEndpointException.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/exception/PluginRpcEndpointException.java
@@ -20,6 +20,8 @@ import org.hyperledger.besu.plugin.services.rpc.RpcMethodError;
 public class PluginRpcEndpointException extends RuntimeException {
   /** The error */
   private final RpcMethodError rpcMethodError;
+  /** The data associated with the exception */
+  private final String data;
 
   /**
    * Constructs a new PluginRpcEndpointException exception with the specified error.
@@ -27,20 +29,18 @@ public class PluginRpcEndpointException extends RuntimeException {
    * @param rpcMethodError the error.
    */
   public PluginRpcEndpointException(final RpcMethodError rpcMethodError) {
-    super();
-    this.rpcMethodError = rpcMethodError;
+    this(rpcMethodError, null);
   }
 
   /**
    * Constructs a new PluginRpcEndpointException exception with the specified error and message.
    *
    * @param rpcMethodError the error.
-   * @param message the detail message (which is saved for later retrieval by the {@link
-   *     #getMessage()} method).
+   * @param data the data associated with the exception that could be parsed to extract more
+   *     information to return in the error response.
    */
-  public PluginRpcEndpointException(final RpcMethodError rpcMethodError, final String message) {
-    super(message);
-    this.rpcMethodError = rpcMethodError;
+  public PluginRpcEndpointException(final RpcMethodError rpcMethodError, final String data) {
+    this(rpcMethodError, data, null);
   }
 
   /**
@@ -48,16 +48,17 @@ public class PluginRpcEndpointException extends RuntimeException {
    * cause.
    *
    * @param rpcMethodError the error.
-   * @param message the detail message (which is saved for later retrieval by the {@link
-   *     #getMessage()} method).
+   * @param data the data associated with the exception that could be parsed to extract more
+   *     information to return in the error response.
    * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
    *     (A {@code null} value is permitted, and indicates that the cause is nonexistent or
    *     unknown.)
    */
   public PluginRpcEndpointException(
-      final RpcMethodError rpcMethodError, final String message, final Throwable cause) {
-    super(message, cause);
+      final RpcMethodError rpcMethodError, final String data, final Throwable cause) {
+    super(rpcMethodError.getMessage(), cause);
     this.rpcMethodError = rpcMethodError;
+    this.data = data;
   }
 
   /**
@@ -67,5 +68,14 @@ public class PluginRpcEndpointException extends RuntimeException {
    */
   public RpcMethodError getRpcMethodError() {
     return rpcMethodError;
+  }
+
+  /**
+   * Get the data associated with the exception
+   *
+   * @return data as string, could be null.
+   */
+  public String getData() {
+    return data;
   }
 }


### PR DESCRIPTION
## PR description

Move the logging to debug to reduce the noise, then explicit than the eventual string parameters passed to `PluginRpcEndpointException` is the additional data for the exception, the only use case now is for the revert reason, and not a free text message.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

