### PR TITLE
Support running executable Gradle tasks on Windows with WSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,9 @@ def _strListCmdArg(name) {
   return _strListCmdArg(name, null)
 }
 
+// set the shell command to use according to os
+def shell = org.gradle.internal.os.OperatingSystem.current().isWindows() ? "${projectDir}\\wslsh.bat" : '/bin/bash'
+
 licenseReport {
   // This is for the allowed-licenses-file in checkLicense Task
   // Accepts File, URL or String path to local or remote file
@@ -760,7 +763,7 @@ task distDocker {
           println "Building for platform ${project.getProperty('docker-platform')}"
         }
         def gitDetails = getGitCommitDetails(10)
-        executable "sh"
+        executable shell
         workingDir dockerBuildDir
         args "-c", "docker build ${dockerPlatform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."
       }
@@ -768,12 +771,12 @@ task distDocker {
 
     // tag the "default" (which is the variant in the zero position)
     exec {
-      executable "sh"
+      executable shell
       args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:${dockerBuildVersion}'"
     }
     // create a static tag for the benchmark target
     exec {
-      executable "sh"
+      executable shell
       args "-c", "docker tag '${dockerImageName}:${dockerBuildVersion}-${dockerVariants[0]}' '${dockerImageName}:benchmark'"
     }
   }
@@ -792,8 +795,8 @@ task testDocker {
       exec {
         def image = project.hasProperty('release.releaseVersion') ? "${dockerImageName}:" + project.property('release.releaseVersion') : "${dockerImageName}:${project.version}"
         workingDir "${projectDir}/docker/${variant}"
-        executable "sh"
-        args "-c", "bash ../test.sh ${image}-${variant}"
+        executable shell
+        args "-c", "../test.sh ${image}-${variant}"
       }
     }
   }
@@ -821,7 +824,7 @@ task dockerUpload {
         def cmd = "docker tag '${variantImage}' '${archVariantImage}' && docker push '${archVariantImage}'"
         additionalTags.each { tag -> cmd += " && docker tag '${variantImage}' '${dockerImageName}:${tag.trim()}-${variant}-${architecture}' && docker push '${dockerImageName}:${tag.trim()}-${variant}-${architecture}'" }
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
     }
@@ -831,7 +834,7 @@ task dockerUpload {
       def cmd = "docker tag ${image} ${archImage} && docker push '${archImage}'"
       additionalTags.each { tag -> cmd += " && docker tag '${image}' '${dockerImageName}:${tag.trim()}-${architecture}' && docker push '${dockerImageName}:${tag.trim()}-${architecture}'" }
       println "Executing '${cmd}'"
-      executable "sh"
+      executable shell
       args "-c", cmd
     }
   }
@@ -848,13 +851,13 @@ task dockerUploadRelease {
         exec {
           def cmd = "docker pull '${variantImage}-${architecture}' && docker tag '${variantImage}-${architecture}' '${dockerImageName}:latest-${variant}-${architecture}'"
           println "Executing '${cmd}'"
-          executable "sh"
+          executable shell
           args "-c", cmd
         }
         exec {
           def cmd = "docker push '${dockerImageName}:latest-${variant}-${architecture}'"
           println "Executing '${cmd}'"
-          executable "sh"
+          executable shell
           args "-c", cmd
         }
       }
@@ -863,13 +866,13 @@ task dockerUploadRelease {
         def archImage = "${image}-${architecture}"
         def cmd = "docker pull '${archImage}' && docker tag ${archImage} '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
       exec {
         def cmd = "docker push '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
     }
@@ -899,13 +902,13 @@ task manifestDocker {
         exec {
           def cmd = "docker manifest create '${variantImage}' ${targets}"
           println "Executing '${cmd}'"
-          executable "sh"
+          executable shell
           args "-c", cmd
         }
         exec {
           def cmd = "docker manifest push '${variantImage}'"
           println "Executing '${cmd}'"
-          executable "sh"
+          executable shell
           args "-c", cmd
         }
       }
@@ -915,13 +918,13 @@ task manifestDocker {
         archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
         def cmd = "docker manifest create '${baseTag}' ${targets}"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
       exec {
         def cmd = "docker manifest push '${baseTag}'"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
     }
@@ -941,13 +944,13 @@ task manifestDockerRelease {
       exec {
         def cmd = "docker manifest create '${variantImage}' ${targets} --amend"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
       exec {
         def cmd = "docker manifest push '${variantImage}'"
         println "Executing '${cmd}'"
-        executable "sh"
+        executable shell
         args "-c", cmd
       }
     }
@@ -957,13 +960,13 @@ task manifestDockerRelease {
       archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
       def cmd = "docker manifest create '${baseTag}' ${targets} --amend"
       println "Executing '${cmd}'"
-      executable "sh"
+      executable shell
       args "-c", cmd
     }
     exec {
       def cmd = "docker manifest push '${baseTag}'"
       println "Executing '${cmd}'"
-      executable "sh"
+      executable shell
       args "-c", cmd
     }
   }

--- a/wslsh.bat
+++ b/wslsh.bat
@@ -1,0 +1,2 @@
+set WSLENV=architecture/u
+wsl /bin/bash %*


### PR DESCRIPTION
## PR description

With this PR it is possible to run Gradle tasks that require a shell to also run on Windows + WSL

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

