### PR TITLE
Set noisy TransactionLogBloomCacher debug log to trace

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
@@ -159,7 +159,7 @@ public class TransactionLogBloomCacher {
         return;
       }
       final long blockNumber = blockHeader.getNumber();
-      LOG.atDebug()
+      LOG.atTrace()
           .setMessage("Caching logs bloom for block {}")
           .addArgument(() -> "0x" + Long.toHexString(blockNumber))
           .log();


### PR DESCRIPTION
Example log:
> Caching logs bloom for block 0x127804

During sync with DEBUG enabled, this is extremely noisy...printed nearly 600K times during a holesky sync in < 1 hour...
<img width="1259" alt="Screenshot 2024-03-26 at 4 09 35 PM" src="https://github.com/hyperledger/besu/assets/2893793/b17e0ff0-9ed3-494b-9fdd-b1d43e10b675">
