### PR TITLE
Modify the message when the selection of transactions is interrupted

### DIFF
--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -192,7 +192,7 @@ public class BlockTransactionSelector {
         isTimeout.set(true);
       }
       LOG.warn(
-          "Interrupting transaction selection since it is taking more than the max configured time of "
+          "Interrupting the selection of transactions for block inclusion as it exceeds the maximum configured duration of "
               + blockTxsSelectionMaxTime
               + "ms",
           e);


### PR DESCRIPTION

## PR description

Update the interruption message for transaction selection to clarify that the process involves multiple transactions exceeding the configured time limit. This change aims to eliminate ambiguity, explicitly indicating that the interruption occurs when the cumulative selection process surpasses the configured duration, rather than being related to a single transaction.