### PR TITLE
throttled regular log of peers list at debug and trace

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.hyperledger.besu.util.log.LogUtil.throttledLog;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
@@ -79,6 +80,10 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
   private final BlockBroadcaster blockBroadcaster;
   private final List<PeerValidator> peerValidators;
   private final Optional<MergePeerFilter> mergePeerFilter;
+  private final AtomicBoolean logDebug = new AtomicBoolean(true);
+  private final int logDebugRepeatDelay = 120;
+  private final AtomicBoolean logTrace = new AtomicBoolean(true);
+  private final int logTraceRepeatDelay = 15;
 
   public EthProtocolManager(
       final Blockchain blockchain,
@@ -392,7 +397,10 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
     } catch (final PeerNotConnected peerNotConnected) {
       // Nothing to do.
     }
-    LOG.atTrace().setMessage("{}").addArgument(ethPeers::toString).log();
+    throttledLog(
+        LOG::trace, String.format("Current peers: %s", ethPeers), logTrace, logTraceRepeatDelay);
+    throttledLog(
+        LOG::debug, String.format("Current peers: %s", ethPeers), logDebug, logDebugRepeatDelay);
   }
 
   @Override
@@ -426,7 +434,10 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
           .addArgument(() -> connection.getPeer().getLoggableId())
           .addArgument(ethPeers::peerCount)
           .log();
-      LOG.atTrace().setMessage("{}").addArgument(ethPeers::toString).log();
+      throttledLog(
+          LOG::trace, String.format("Current peers: %s", ethPeers), logTrace, logTraceRepeatDelay);
+      throttledLog(
+          LOG::debug, String.format("Current peers: %s", ethPeers), logDebug, logDebugRepeatDelay);
     }
   }
 


### PR DESCRIPTION
## PR description
Instead of trace logging the full list of peers at each connect/disconnect, log it at a defined interval 15s (trace) 120s (debug)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

