### PR TITLE
Logging improvements for Bonsai historical queries 

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/DiffBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/DiffBasedWorldStateProvider.java
@@ -132,7 +132,7 @@ public abstract class DiffBasedWorldStateProvider implements WorldStateArchive {
       if (chainHeadBlockHeader.getNumber() - blockHeader.getNumber()
           >= trieLogManager.getMaxLayersToLoad()) {
         LOG.warn(
-            "Exceeded the limit of back layers that can be loaded ({})",
+            "Exceeded the limit of historical blocks that can be loaded ({}). If you need to make older historical queries, configure your `--bonsai-historical-block-limit`.",
             trieLogManager.getMaxLayersToLoad());
         return Optional.empty();
       }


### PR DESCRIPTION
## PR description
Makes the logs more clear about historical queries in Bonsai when you exceed the `bonsai-historical-block-limit`

## Fixed Issue(s)
None