### PR TITLE
workaround for broken publishing of buildinfo

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -46,11 +46,7 @@ jobs:
           path: 'build/distributions/besu*.zip'
           name: besu-${{ github.ref_name }}.zip
           compression-level: 0
-      - name: Artifactory Publish
-        env:
-          ARTIFACTORY_USER: ${{ secrets.BESU_ARTIFACTORY_USER }}
-          ARTIFACTORY_KEY: ${{ secrets.BESU_ARTIFACTORY_TOKEN }}
-        run: ./gradlew -Prelease.releaseVersion=${{ github.ref_name }} -Pversion=${{github.ref_name}} artifactoryPublish
+
   testWindows:
     runs-on: windows-2022
     needs: artifacts
@@ -95,3 +91,12 @@ jobs:
           body: |
             ${{steps.hashes.outputs.tarSha}}
             ${{steps.hashes.outputs.zipSha}}
+  arifactoryPublish:
+    runs-on: ubuntu-22.04
+    needs: artifacts
+    steps:
+      - name: Artifactory Publish
+        env:
+          ARTIFACTORY_USER: ${{ secrets.BESU_ARTIFACTORY_USER }}
+          ARTIFACTORY_KEY: ${{ secrets.BESU_ARTIFACTORY_TOKEN }}
+        run: ./gradlew -Prelease.releaseVersion=${{ github.ref_name }} -Pversion=${{github.ref_name}} artifactoryPublish

--- a/build.gradle
+++ b/build.gradle
@@ -499,6 +499,7 @@ subprojects {
           password = artifactoryKey
         }
         defaults {
+          publishBuildInfo = false //currently 404'ing still to be investigated
           publications('mavenJava')
           publishArtifacts = true
           publishPom = true


### PR DESCRIPTION
The 24.4.0 release deployed artifacts to artifactory as expected, but failed when updating the build-info, which was a surprise. This is a workaround which disables that publishing temporarily, and also defers jar publishing till the end of the workflow, to avoid derailing more important steps.


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

