### PR TITLE
build: Remove incomplete artifactory task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -685,6 +685,16 @@ distZip {
   setVersion(archiveBuildVersion)
 }
 
+publishing {
+  publications {
+    distArtifactory(MavenPublication) {
+      groupId = '.'
+      version = project.version
+      artifactId = 'besu'
+    }
+  }
+}
+
 artifactoryPublish {
   dependsOn distTar
   dependsOn distZip

--- a/build.gradle
+++ b/build.gradle
@@ -499,7 +499,6 @@ subprojects {
           password = artifactoryKey
         }
         defaults {
-          publishBuildInfo = false //currently 404'ing still to be investigated
           publications('mavenJava')
           publishArtifacts = true
           publishPom = true
@@ -684,31 +683,6 @@ distZip {
     delete fileTree(dir: 'build/distributions', include: '*.zip')
   }
   setVersion(archiveBuildVersion)
-}
-
-publishing {
-  publications {
-    distArtifactory(MavenPublication) {
-      groupId = '.'
-      version = project.version
-      artifactId = 'besu'
-    }
-  }
-}
-
-def artifactoryUser = project.hasProperty('artifactoryUser') ? project.property('artifactoryUser') : System.getenv('ARTIFACTORY_USER')
-def artifactoryKey = project.hasProperty('artifactoryApiKey') ? project.property('artifactoryApiKey') : System.getenv('ARTIFACTORY_KEY')
-def artifactoryOrg = System.getenv('ARTIFACTORY_ORG') ?: 'hyperledger'
-
-artifactory {
-  contextUrl = "https://hyperledger.jfrog.io/${artifactoryOrg}"
-  publish {
-    defaults {
-      publications('distArtifactory')
-      publishArtifacts = true
-      publishPom = false
-    }
-  }
 }
 
 artifactoryPublish {


### PR DESCRIPTION
## PR description
build: Remove incomplete artifactory task. The top level artifactory task was used to upload dists to artifactory which has been moved to GH

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

