### PR TITLE
[MINOR] add toString for handshake messages

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/InitiatorHandshakeMessageV4.java
@@ -120,4 +120,20 @@ public final class InitiatorHandshakeMessageV4 implements InitiatorHandshakeMess
   public Bytes32 getEphPubKeyHash() {
     return ephPubKeyHash;
   }
+
+  @Override
+  public String toString() {
+    return "InitiatorHandshakeMessageV4{"
+        + "pubKey="
+        + pubKey
+        + ", signature="
+        + signature
+        + ", ephPubKey="
+        + ephPubKey
+        + ", ephPubKeyHash="
+        + ephPubKeyHash
+        + ", nonce="
+        + nonce
+        + '}';
+  }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ResponderHandshakeMessageV4.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/handshake/ecies/ResponderHandshakeMessageV4.java
@@ -67,4 +67,14 @@ public class ResponderHandshakeMessageV4 implements ResponderHandshakeMessage {
     temp.endList();
     return temp.encoded();
   }
+
+  @Override
+  public String toString() {
+    return "ResponderHandshakeMessageV4{"
+        + "ephPublicKey="
+        + ephPublicKey
+        + ", nonce="
+        + nonce
+        + '}';
+  }
 }


### PR DESCRIPTION
## PR description
Before -
`
{"@timestamp":"2024-04-03T04:03:50,365","level":"TRACE","thread":"nioEventLoopGroup-3-10","class":"ECIESHandshaker","message":"First ECIES handshake message under INITIATOR role: org.hyperledger.besu.ethereum.p2p.rlpx.handshake.ecies.InitiatorHandshakeMessageV4@2a66bbb5","throwable":""}
`

After -
`
{"@timestamp":"2024-04-03T04:03:50,925","level":"TRACE","thread":"nioEventLoopGroup-3-1","class":"ECIESHandshaker","message":"Received responder's ECIES handshake message from node 0xb2aaeccb38b380e6663458bf7066f132...: ResponderHandshakeMessageV4{ephPublicKey=0xe8afcfe96360bb7e83a223d5b0b080a9b7157db5edfda2dfbadcb057c512dacd3718a538a64afa41e2e5fbcc929154bedd861619f72ca413ecabe8f8e0678bf6, nonce=0xb4235af56982f5f348bb762625da18a775a977053b0e4bfec9546e3b6abc9858}","throwable":""}
`
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

