### PR TITLE
[MINOR] nuke those extra ellipses

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -211,7 +211,7 @@ public class EthPeer implements Comparable<EthPeer> {
 
   public void recordRequestTimeout(final int requestCode) {
     LOG.atDebug()
-        .setMessage("Timed out while waiting for response from peer {}...")
+        .setMessage("Timed out while waiting for response from peer {}")
         .addArgument(this::getLoggableId)
         .log();
     LOG.trace("Timed out while waiting for response from peer {}", this);
@@ -220,7 +220,7 @@ public class EthPeer implements Comparable<EthPeer> {
 
   public void recordUselessResponse(final String requestType) {
     LOG.atTrace()
-        .setMessage("Received useless response for request type {} from peer {}...")
+        .setMessage("Received useless response for request type {} from peer {}")
         .addArgument(requestType)
         .addArgument(this::getLoggableId)
         .log();
@@ -262,7 +262,7 @@ public class EthPeer implements Comparable<EthPeer> {
     if (connectionToUse.getAgreedCapabilities().stream()
         .noneMatch(capability -> capability.getName().equalsIgnoreCase(protocolName))) {
       LOG.atDebug()
-          .setMessage("Protocol {} unavailable for this peer {}...")
+          .setMessage("Protocol {} unavailable for this peer {}")
           .addArgument(protocolName)
           .addArgument(this.getLoggableId())
           .log();
@@ -272,7 +272,7 @@ public class EthPeer implements Comparable<EthPeer> {
         .anyMatch(
             p -> !p.isMessagePermitted(connectionToUse.getRemoteEnode(), messageData.getCode()))) {
       LOG.info(
-          "Permissioning blocked sending of message code {} to {}...",
+          "Permissioning blocked sending of message code {} to {}",
           messageData.getCode(),
           this.getLoggableId());
       if (LOG.isDebugEnabled()) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeer.java
@@ -437,7 +437,7 @@ public class EthPeer implements Comparable<EthPeer> {
         localRequestManager -> localRequestManager.dispatchResponse(ethMessage),
         () -> {
           LOG.trace(
-              "Message {} not expected has just been received for protocol {}, peer {} ",
+              "Message {} not expected has just been received for protocol {}, {} ",
               messageCode,
               protocolName,
               this);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -480,7 +480,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
       }
     } catch (final RLPException e) {
       LOG.atDebug()
-          .setMessage("Unable to parse status message from peer {}... {}")
+          .setMessage("Unable to parse status message from peer {} {}")
           .addArgument(peer::getLoggableId)
           .addArgument(e)
           .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -126,7 +126,7 @@ public abstract class AbstractGetHeadersFromPeerTask
     }
 
     LOG.atTrace()
-        .setMessage("Received {} of {} headers requested from peer {}...")
+        .setMessage("Received {} of {} headers requested from peer {}")
         .addArgument(headersList::size)
         .addArgument(count)
         .addArgument(peer::getLoggableId)
@@ -137,7 +137,7 @@ public abstract class AbstractGetHeadersFromPeerTask
   private void updatePeerChainState(final EthPeer peer, final BlockHeader blockHeader) {
     if (blockHeader.getNumber() > peer.chainState().getEstimatedHeight()) {
       LOG.atTrace()
-          .setMessage("Updating chain state for peer {}... to block header {}")
+          .setMessage("Updating chain state for peer {} to block header {}")
           .addArgument(peer::getLoggableId)
           .addArgument(blockHeader::toLogString)
           .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcher.java
@@ -89,7 +89,7 @@ public class BufferedGetPooledTransactionsFromPeerFetcher {
                 transactionTracker.markTransactionsAsSeen(peer, retrievedTransactions);
 
                 LOG.atTrace()
-                    .setMessage("Got {} transactions of {} hashes requested from peer {}...")
+                    .setMessage("Got {} transactions of {} hashes requested from peer {}")
                     .addArgument(retrievedTransactions::size)
                     .addArgument(task.getTransactionHashes()::size)
                     .addArgument(peer::getLoggableId)
@@ -120,7 +120,7 @@ public class BufferedGetPooledTransactionsFromPeerFetcher {
     metrics.incrementAlreadySeenTransactions(metricLabel, alreadySeenCount);
     LOG.atTrace()
         .setMessage(
-            "Transaction hashes to request from peer {}... fresh count {}, already seen count {}")
+            "Transaction hashes to request from peer {} fresh count {}, already seen count {}")
         .addArgument(peer::getLoggableId)
         .addArgument(toRetrieve::size)
         .addArgument(alreadySeenCount)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetHeadersFromPeerByHashTask.java
@@ -120,7 +120,7 @@ public class GetHeadersFromPeerByHashTask extends AbstractGetHeadersFromPeerTask
     return sendRequestToPeer(
         peer -> {
           LOG.atTrace()
-              .setMessage("Requesting {} headers (hash {}...) from peer {}...")
+              .setMessage("Requesting {} headers (hash {}...) from peer {}")
               .addArgument(count)
               .addArgument(referenceHash.slice(0, 6))
               .addArgument(peer::getLoggableId)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetNodeDataFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetNodeDataFromPeerTask.java
@@ -67,7 +67,7 @@ public class GetNodeDataFromPeerTask extends AbstractPeerRequestTask<Map<Hash, B
     return sendRequestToPeer(
         peer -> {
           LOG.atTrace()
-              .setMessage("Requesting {} node data entries from peer {}...")
+              .setMessage("Requesting {} node data entries from peer {}")
               .addArgument(hashes::size)
               .addArgument(peer::getLoggableId)
               .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
@@ -62,7 +62,7 @@ public class GetPooledTransactionsFromPeerTask extends AbstractPeerRequestTask<L
     return sendRequestToPeer(
         peer -> {
           LOG.atTrace()
-              .setMessage("Requesting {} transaction pool entries from peer {}...")
+              .setMessage("Requesting {} transaction pool entries from peer {}")
               .addArgument(hashes::size)
               .addArgument(peer::getLoggableId)
               .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetReceiptsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetReceiptsFromPeerTask.java
@@ -84,7 +84,7 @@ public class GetReceiptsFromPeerTask
     return sendRequestToPeer(
         peer -> {
           LOG.atTrace()
-              .setMessage("Requesting {} receipts from peer {}...")
+              .setMessage("Requesting {} receipts from peer {}")
               .addArgument(blockHeaders::size)
               .addArgument(peer::getLoggableId)
               .log();

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/PivotBlockConfirmer.java
@@ -210,8 +210,7 @@ class PivotBlockConfirmer {
       }
     }
 
-    LOG.debug(
-        "Query peer {}... for block {}.", peer.nodeId().toString().substring(0, 8), blockNumber);
+    LOG.debug("Query peer {} for block {}.", peer.getLoggableId(), blockNumber);
     return Optional.of(task);
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/DefaultP2PNetwork.java
@@ -425,7 +425,6 @@ public class DefaultP2PNetwork implements P2PNetwork {
   public void subscribeConnectRequest(final ShouldConnectCallback callback) {
     rlpxAgent.subscribeConnectRequest(callback);
   }
-  ;
 
   @Override
   public void subscribeDisconnect(final DisconnectCallback callback) {


### PR DESCRIPTION
## PR description

Similar to #6849 - ellipsis is now included in loggableId. There were a few more places where this was duplicated.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

