### PR TITLE
Add debug logging to see why we stop downloading from peer

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
@@ -47,7 +47,12 @@ import org.hyperledger.besu.services.pipeline.PipelineBuilder;
 
 import java.util.concurrent.CompletionStage;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(FastSyncDownloadPipelineFactory.class);
+
   protected final SynchronizerConfiguration syncConfig;
   protected final ProtocolSchedule protocolSchedule;
   protected final ProtocolContext protocolContext;
@@ -172,6 +177,15 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
   protected boolean shouldContinueDownloadingFromPeer(
       final EthPeer peer, final BlockHeader lastRoundHeader) {
     final BlockHeader pivotBlockHeader = fastSyncState.getPivotBlockHeader().get();
-    return !peer.isDisconnected() && lastRoundHeader.getNumber() < pivotBlockHeader.getNumber();
+    final boolean shouldContinue =
+        !peer.isDisconnected() && lastRoundHeader.getNumber() < pivotBlockHeader.getNumber();
+    LOG.trace(
+        "shouldContinueDownloadingFromPeer = {} (!peer.isDisconnected() = {} && lastRoundHeader.getNumber() = {} < pivotBlockHeader.getNumber() = {}); peer = {}",
+        shouldContinue,
+        !peer.isDisconnected(),
+        lastRoundHeader.getNumber(),
+        pivotBlockHeader.getNumber(),
+        peer);
+    return shouldContinue;
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/FastSyncDownloadPipelineFactory.java
@@ -179,13 +179,16 @@ public class FastSyncDownloadPipelineFactory implements DownloadPipelineFactory 
     final BlockHeader pivotBlockHeader = fastSyncState.getPivotBlockHeader().get();
     final boolean shouldContinue =
         !peer.isDisconnected() && lastRoundHeader.getNumber() < pivotBlockHeader.getNumber();
-    LOG.trace(
-        "shouldContinueDownloadingFromPeer = {} (!peer.isDisconnected() = {} && lastRoundHeader.getNumber() = {} < pivotBlockHeader.getNumber() = {}); peer = {}",
-        shouldContinue,
-        !peer.isDisconnected(),
-        lastRoundHeader.getNumber(),
-        pivotBlockHeader.getNumber(),
-        peer);
+
+    if (!shouldContinue && peer.isDisconnected()) {
+      LOG.debug("Stopping chain download due to disconnected peer {}", peer);
+    } else if (!shouldContinue && lastRoundHeader.getNumber() >= pivotBlockHeader.getNumber()) {
+      LOG.debug(
+          "Stopping chain download as lastRoundHeader={} is not less than pivotBlockHeader={} for peer {}",
+          lastRoundHeader.getNumber(),
+          pivotBlockHeader.getNumber(),
+          peer);
+    }
     return shouldContinue;
   }
 }


### PR DESCRIPTION
Logging for debugging #6884 


Example when peer disconnected:
```
DEBUG | FastSyncDownloadPipelineFactory | Stopping chain download due to disconnected peer PeerId: 0x143e11fb766781d2... PeerReputation score: 150, timeouts: {}, useless: 4, validated? true, disconnected? true, client: Geth/v1.13.14-stable-2bd6bd01/linux-amd64/go1.21.7, [Connection with hashCode 68650968 inboundInitiated? false initAt 1712288750661], enode://143e11fb766781d22d92a2e33f8f104cddae4411a122295ed1fdb6638de96a6ce65f5b7c964ba3763bba27961738fef7d3ecc739268f3e5e771fb4c87b6234ba@146.190.1.103:30303
```

Example when lastRoundHeader >= pivotBlockHeader:
```
DEBUG | FastSyncDownloadPipelineFactory | Stopping chain download as lastRoundHeader=1283816 is not less than pivotBlockHeader=1283816 for peer PeerId: 0x7a52e545cdc62aea... PeerReputation score: 150, timeouts: {}, useless: 0, validated? true, disconnected? false, client: besu/v24.3.0/linux-x86_64/openjdk-java-17, [Connection with hashCode 1511026419 inboundInitiated? true initAt 1712291178516], enode://7a52e545cdc62aea505e6f8795b10741ba7a9ef4b7daba88af55c0bd5af74ebeefe1098faeb31fea320f2c00297cfc5ad5af6c94916ce6b5d4f05e2d8b1ad562@202.61.198.135:30303?discport=0
```

