### PR TITLE
Peer subprotocol triggered logging

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -465,7 +465,8 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .setMessage("Post-merge disconnect: peer still PoW {}")
             .addArgument(() -> getPeerOrPeerId(peer))
             .log();
-        handleDisconnect(peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_POW, false);
+        handleDisconnect(
+            peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY, false);
       } else {
         LOG.atDebug()
             .setMessage("Received status message from {}: {} with connection {}")

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -315,7 +315,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .addArgument(ethPeer::toString)
             .log();
         handleDisconnect(
-            ethPeer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_GOSSIP_BLOCKS, false);
+            ethPeer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_POW_BLOCKS, false);
         return;
       }
     }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManager.java
@@ -314,7 +314,8 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .setMessage("Post-merge disconnect: peer still gossiping blocks {}")
             .addArgument(ethPeer::toString)
             .log();
-        handleDisconnect(ethPeer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED, false);
+        handleDisconnect(
+            ethPeer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_GOSSIP_BLOCKS, false);
         return;
       }
     }
@@ -441,7 +442,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .addArgument(status::networkId)
             .addArgument(() -> getPeerOrPeerId(peer))
             .log();
-        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK);
       } else if (!forkIdManager.peerCheck(forkId) && status.protocolVersion() > 63) {
         LOG.atDebug()
             .setMessage("{} has matching network id ({}), but non-matching fork id: {}")
@@ -449,7 +450,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .addArgument(networkId::toString)
             .addArgument(forkId)
             .log();
-        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_MISMATCHED_FORKID);
       } else if (forkIdManager.peerCheck(status.genesisHash())) {
         LOG.atDebug()
             .setMessage("{} has matching network id ({}), but non-matching genesis hash: {}")
@@ -457,14 +458,14 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
             .addArgument(networkId::toString)
             .addArgument(status::genesisHash)
             .log();
-        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_MISMATCHED_GENESIS_HASH);
       } else if (mergePeerFilter.isPresent()
           && mergePeerFilter.get().disconnectIfPoW(status, peer)) {
         LOG.atDebug()
             .setMessage("Post-merge disconnect: peer still PoW {}")
             .addArgument(() -> getPeerOrPeerId(peer))
             .log();
-        handleDisconnect(peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED, false);
+        handleDisconnect(peer.getConnection(), DisconnectReason.SUBPROTOCOL_TRIGGERED_POW, false);
       } else {
         LOG.atDebug()
             .setMessage("Received status message from {}: {} with connection {}")
@@ -486,7 +487,7 @@ public class EthProtocolManager implements ProtocolManager, MinedBlockObserver {
           .log();
       // Parsing errors can happen when clients broadcast network ids outside the int range,
       // So just disconnect with "subprotocol" error rather than "breach of protocol".
-      peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+      peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_UNPARSABLE_STATUS);
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MergePeerFilter.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MergePeerFilter.java
@@ -47,7 +47,7 @@ public class MergePeerFilter implements MergeStateHandler, UnverifiedForkchoiceL
         LOG.debug(
             "Disconnecting peer with difficulty {}, likely still on PoW chain",
             status.totalDifficulty());
-        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+        peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY);
         return true;
       } else {
         return false;
@@ -61,7 +61,7 @@ public class MergePeerFilter implements MergeStateHandler, UnverifiedForkchoiceL
     final int code = message.getData().getCode();
     if (isFinalized() && (code == EthPV62.NEW_BLOCK || code == EthPV62.NEW_BLOCK_HASHES)) {
       LOG.debug("disconnecting peer for sending new blocks after transition to PoS");
-      peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+      peer.disconnect(DisconnectReason.SUBPROTOCOL_TRIGGERED_POW_BLOCKS);
       return true;
     } else {
       return false;

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
@@ -124,7 +124,6 @@ public final class DisconnectMessage extends AbstractMessageData {
     SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK((byte) 0x10, "Mismatched network id"),
     SUBPROTOCOL_TRIGGERED_MISMATCHED_FORKID((byte) 0x10, "Mismatched fork id"),
     SUBPROTOCOL_TRIGGERED_MISMATCHED_GENESIS_HASH((byte) 0x10, "Mismatched genesis hash"),
-    SUBPROTOCOL_TRIGGERED_POW((byte) 0x10, "Peer still POW"),
     SUBPROTOCOL_TRIGGERED_UNPARSABLE_STATUS((byte) 0x10, "Unparsable status message"),
     SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY((byte) 0x10, "Difficulty greater than TTD"),
     SUBPROTOCOL_TRIGGERED_POW_BLOCKS((byte) 0x10, "Peer sent blocks after POS transition");
@@ -142,7 +141,7 @@ public final class DisconnectMessage extends AbstractMessageData {
               .getAsInt();
       BY_ID = new DisconnectReason[maxValue + 1];
       Stream.of(DisconnectReason.values())
-          .filter(r -> r.code.isPresent())
+          .filter(r -> r.code.isPresent() && r.reason.isEmpty())
           .forEach(r -> BY_ID[r.code.get()] = r);
     }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
@@ -118,10 +118,20 @@ public final class DisconnectMessage extends AbstractMessageData {
     UNEXPECTED_ID((byte) 0x09),
     LOCAL_IDENTITY((byte) 0x0a),
     TIMEOUT((byte) 0x0b),
-    SUBPROTOCOL_TRIGGERED((byte) 0x10);
+    SUBPROTOCOL_TRIGGERED((byte) 0x10),
+    SUBPROTOCOL_TRIGGERED_GOSSIP_BLOCKS(
+        (byte) 0x10, "Post-merge disconnect: peer still gossiping blocks"),
+    SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK((byte) 0x10, "Mismatched network id"),
+    SUBPROTOCOL_TRIGGERED_MISMATCHED_FORKID((byte) 0x10, "Mismatched fork id"),
+    SUBPROTOCOL_TRIGGERED_MISMATCHED_GENESIS_HASH((byte) 0x10, "Mismatched genesis hash"),
+    SUBPROTOCOL_TRIGGERED_POW((byte) 0x10, "Peer still POW"),
+    SUBPROTOCOL_TRIGGERED_UNPARSABLE_STATUS((byte) 0x10, "Unparsable status message"),
+    SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY((byte) 0x10, "Difficulty greater than TTD"),
+    SUBPROTOCOL_TRIGGERED_POW_BLOCKS((byte) 0x10, "Peer sent blocks after POS transition");
 
     private static final DisconnectReason[] BY_ID;
     private final Optional<Byte> code;
+    private final Optional<String> reason;
 
     static {
       final int maxValue =
@@ -146,15 +156,25 @@ public final class DisconnectMessage extends AbstractMessageData {
 
     DisconnectReason(final Byte code) {
       this.code = Optional.ofNullable(code);
+      this.reason = Optional.empty();
+    }
+
+    DisconnectReason(final Byte code, final String reason) {
+      this.code = Optional.ofNullable(code);
+      this.reason = Optional.of(reason);
     }
 
     public Bytes getValue() {
       return code.map(Bytes::of).orElse(Bytes.EMPTY);
     }
 
+    public String getReason() {
+      return reason.orElse("");
+    }
+
     @Override
     public String toString() {
-      return getValue().toString() + " " + name();
+      return getValue().toString() + " " + name() + " " + getReason();
     }
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
@@ -128,7 +128,7 @@ public final class DisconnectMessage extends AbstractMessageData {
 
     private static final DisconnectReason[] BY_ID;
     private final Optional<Byte> code;
-    private final Optional<String> reason;
+    private final Optional<String> message;
 
     static {
       final int maxValue =
@@ -139,7 +139,7 @@ public final class DisconnectMessage extends AbstractMessageData {
               .getAsInt();
       BY_ID = new DisconnectReason[maxValue + 1];
       Stream.of(DisconnectReason.values())
-          .filter(r -> r.code.isPresent() && r.reason.isEmpty())
+          .filter(r -> r.code.isPresent() && r.message.isEmpty())
           .forEach(r -> BY_ID[r.code.get()] = r);
     }
 
@@ -153,25 +153,25 @@ public final class DisconnectMessage extends AbstractMessageData {
 
     DisconnectReason(final Byte code) {
       this.code = Optional.ofNullable(code);
-      this.reason = Optional.empty();
+      this.message = Optional.empty();
     }
 
-    DisconnectReason(final Byte code, final String reason) {
+    DisconnectReason(final Byte code, final String message) {
       this.code = Optional.ofNullable(code);
-      this.reason = Optional.of(reason);
+      this.message = Optional.of(message);
     }
 
     public Bytes getValue() {
       return code.map(Bytes::of).orElse(Bytes.EMPTY);
     }
 
-    public String getReason() {
-      return reason.orElse("");
+    public String getMessage() {
+      return message.orElse("");
     }
 
     @Override
     public String toString() {
-      return getValue().toString() + " " + name() + " " + getReason();
+      return getValue().toString() + " " + name() + " " + getMessage();
     }
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
@@ -119,13 +119,11 @@ public final class DisconnectMessage extends AbstractMessageData {
     LOCAL_IDENTITY((byte) 0x0a),
     TIMEOUT((byte) 0x0b),
     SUBPROTOCOL_TRIGGERED((byte) 0x10),
-    SUBPROTOCOL_TRIGGERED_GOSSIP_BLOCKS(
-        (byte) 0x10, "Post-merge disconnect: peer still gossiping blocks"),
     SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK((byte) 0x10, "Mismatched network id"),
     SUBPROTOCOL_TRIGGERED_MISMATCHED_FORKID((byte) 0x10, "Mismatched fork id"),
     SUBPROTOCOL_TRIGGERED_MISMATCHED_GENESIS_HASH((byte) 0x10, "Mismatched genesis hash"),
     SUBPROTOCOL_TRIGGERED_UNPARSABLE_STATUS((byte) 0x10, "Unparsable status message"),
-    SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY((byte) 0x10, "Difficulty greater than TTD"),
+    SUBPROTOCOL_TRIGGERED_POW_DIFFICULTY((byte) 0x10, "Peer has difficulty greater than POS TTD"),
     SUBPROTOCOL_TRIGGERED_POW_BLOCKS((byte) 0x10, "Peer sent blocks after POS transition");
 
     private static final DisconnectReason[] BY_ID;

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
@@ -89,4 +89,14 @@ public class DisconnectMessageTest {
     assertThat(disconnectMessage.getReason()).isEqualTo(DisconnectReason.UNKNOWN);
     assertThat(disconnectMessage.getData().toString()).isEqualToIgnoringCase("0xC180");
   }
+
+  @Test
+  public void readFromWithSubprotocolTriggeredUsesGenericReason() {
+    MessageData messageData =
+            new RawMessage(WireMessageCodes.DISCONNECT, Bytes.fromHexString("0xC110"));
+    DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
+
+    DisconnectReason reason = disconnectMessage.getReason();
+    assertThat(reason).isEqualTo(DisconnectReason.SUBPROTOCOL_TRIGGERED);
+  }
 }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessageTest.java
@@ -93,7 +93,7 @@ public class DisconnectMessageTest {
   @Test
   public void readFromWithSubprotocolTriggeredUsesGenericReason() {
     MessageData messageData =
-            new RawMessage(WireMessageCodes.DISCONNECT, Bytes.fromHexString("0xC110"));
+        new RawMessage(WireMessageCodes.DISCONNECT, Bytes.fromHexString("0xC110"));
     DisconnectMessage disconnectMessage = DisconnectMessage.readFrom(messageData);
 
     DisconnectReason reason = disconnectMessage.getReason();


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Add additional detail when we disconnect with SUBPROTOCOL_TRIGGERED disconnect reason. I've extended the enum with additional SUBPROTOCOL_TRIGGERED values using the same code `0x10` and added a message to these extended `SUBPROTOCOL_TRIGGERED` reasons.

If we receive a `0x10` this is mapped back to the generic `SUBPROTOCOL_TRIGGERED` reason.

example with the changes
`Disconnecting connection 1859339149, peer 0x6b8a113cb2edfa5d... reason 0x10 SUBPROTOCOL_TRIGGERED_MISMATCHED_NETWORK Mismatched network id`

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

