### PR TITLE
Expose transaction count by type metrics for the layered txpool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Update Web3j dependencies [#6811](https://github.com/hyperledger/besu/pull/6811)
 - Add `tx-pool-blob-price-bump` option to configure the price bump percentage required to replace blob transactions (by default 100%) [#6874](https://github.com/hyperledger/besu/pull/6874)
 - Log detailed timing of block creation steps [#6880](https://github.com/hyperledger/besu/pull/6880)
+- Expose transaction count by type metrics for the layered txpool [#6903](https://github.com/hyperledger/besu/pull/6903)
 
 ### Bug fixes
 - Fix txpool dump/restore race condition [#6665](https://github.com/hyperledger/besu/pull/6665)


### PR DESCRIPTION
## PR description

Expose transaction count by type metrics for each layer of the layered txpool

The new metric name is `besu_transaction_pool_number_of_transactions_by_type` and has `layer` and `type` as labels.

Example panel 
![image](https://github.com/hyperledger/besu/assets/91944855/fc000f5c-690c-4071-87c1-d1c11f563b1c)

Besu Full Grafana dashboard will be updated to render this metrics once the PR will be merged.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

