### PR TITLE
check for empty in disconnect reason bytes

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManager.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManager.java
@@ -52,7 +52,7 @@ public class PeerDenylistManager implements DisconnectCallback {
       final boolean initiatedByPeer) {
     // we have a number of reasons that use the same code, but with different message strings
     // so here we use the code of the reason param to ensure we get the no-message version
-    if (shouldBlock(DisconnectReason.forCode(reason.getValue().get(0)), initiatedByPeer)) {
+    if (shouldBlock(DisconnectReason.forCode(reason.getValue()), initiatedByPeer)) {
       if (maintainedPeers.contains(connection.getPeer())) {
         LOG.debug(
             "Skip adding maintained peer {} to peer denylist for reason {}",

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/messages/DisconnectMessage.java
@@ -174,6 +174,14 @@ public final class DisconnectMessage extends AbstractMessageData {
       return BY_ID[code];
     }
 
+    public static DisconnectReason forCode(final Bytes codeBytes) {
+      if (codeBytes == null || codeBytes.isEmpty()) {
+        return UNKNOWN;
+      } else {
+        return forCode(codeBytes.get(0));
+      }
+    }
+
     DisconnectReason(final Byte code) {
       this.code = Optional.ofNullable(code);
       this.message = Optional.empty();

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/network/PeerDenylistManagerTest.java
@@ -111,6 +111,15 @@ public class PeerDenylistManagerTest {
     checkPermissions(denylist, peer.getPeer(), false);
   }
 
+  @Test
+  public void disconnectReasonWithEmptyValue_doesNotAddToDenylist() {
+    final PeerConnection peer = generatePeerConnection();
+
+    checkPermissions(denylist, peer.getPeer(), true);
+    peerDenylistManager.onDisconnect(peer, DisconnectReason.UNKNOWN, false);
+    checkPermissions(denylist, peer.getPeer(), true);
+  }
+
   private void checkPermissions(
       final PeerPermissionsDenylist denylist, final Peer remotePeer, final boolean expectedResult) {
     for (PeerPermissions.Action action : PeerPermissions.Action.values()) {


### PR DESCRIPTION
## PR description
Fix bug introduced in #6925
UNKNOWN disconnect reason has null code

## Fixed Issue(s)
Fixes #6937


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

