### PR TITLE
Fix named network default disabled for downgrade protection

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2679,7 +2679,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private Boolean getDefaultVersionCompatibilityProtectionIfNotSet() {
     // Version compatibility protection is enabled by default for non-named networks
     return Optional.ofNullable(versionCompatibilityProtection)
-        .orElse(commandLine.getParseResult().hasMatchedOption("network") ? false : true);
+        // if we have a specific genesis file or custom network id, we are not using a named network
+        .orElse(genesisFile != null || networkId != null);
   }
 
   private String generateConfigurationOverview() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -158,8 +158,6 @@ public class VersionMetadata implements Comparable<VersionMetadata> {
 
   @Override
   public int compareTo(@Nonnull final VersionMetadata versionMetadata) {
-    // Check the runtime version against the most recent version as recorded in the version
-    // metadata file
     final String thisVersion = this.getBesuVersion().split("-", 2)[0];
     final String metadataVersion = versionMetadata.getBesuVersion().split("-", 2)[0];
     return new ComparableVersion(thisVersion).compareTo(new ComparableVersion(metadataVersion));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,7 +28,7 @@ import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class VersionMetadata {
+public class VersionMetadata implements Comparable<VersionMetadata> {
   private static final Logger LOG = LoggerFactory.getLogger(VersionMetadata.class);
 
   /** Represents an unknown Besu version in the version metadata file */
@@ -36,16 +37,22 @@ public class VersionMetadata {
   private static final String METADATA_FILENAME = "VERSION_METADATA.json";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private final String besuVersion;
+  private static final VersionMetadata RUNTIME_VERSION =
+      new VersionMetadata(getRuntimeVersionString());
 
   /**
    * Get the version of Besu that is running.
    *
    * @return the version of Besu
    */
-  public static String getRuntimeVersion() {
+  public static String getRuntimeVersionString() {
     return VersionMetadata.class.getPackage().getImplementationVersion() == null
         ? BESU_VERSION_UNKNOWN
         : VersionMetadata.class.getPackage().getImplementationVersion();
+  }
+
+  public static VersionMetadata getRuntimeVersion() {
+    return RUNTIME_VERSION;
   }
 
   @JsonCreator
@@ -103,52 +110,58 @@ public class VersionMetadata {
    */
   public static void versionCompatibilityChecks(
       final boolean enforceCompatibilityProtection, final Path dataDir) throws IOException {
-    final VersionMetadata versionMetaData = VersionMetadata.lookUpFrom(dataDir);
-    if (versionMetaData.getBesuVersion().equals(VersionMetadata.BESU_VERSION_UNKNOWN)) {
+    final VersionMetadata metadataVersion = VersionMetadata.lookUpFrom(dataDir);
+    if (metadataVersion.getBesuVersion().equals(VersionMetadata.BESU_VERSION_UNKNOWN)) {
       // The version isn't known, potentially because the file doesn't exist. Write the latest
       // version to the metadata file.
       LOG.info(
           "No version data detected. Writing Besu version {} to metadata file",
-          VersionMetadata.getRuntimeVersion());
-      new VersionMetadata(VersionMetadata.getRuntimeVersion()).writeToDirectory(dataDir);
+          RUNTIME_VERSION.getBesuVersion());
+      RUNTIME_VERSION.writeToDirectory(dataDir);
     } else {
       // Check the runtime version against the most recent version as recorded in the version
       // metadata file
-      final String installedVersion = VersionMetadata.getRuntimeVersion().split("-", 2)[0];
-      final String metadataVersion = versionMetaData.getBesuVersion().split("-", 2)[0];
-      final int versionComparison =
-          new ComparableVersion(installedVersion).compareTo(new ComparableVersion(metadataVersion));
+      final int versionComparison = RUNTIME_VERSION.compareTo(metadataVersion);
       if (versionComparison == 0) {
         // Versions match - no-op
       } else if (versionComparison < 0) {
         if (!enforceCompatibilityProtection) {
           LOG.warn(
               "Besu version {} is lower than version {} that last started. Allowing startup because --version-compatibility-protection has been disabled.",
-              installedVersion,
-              metadataVersion);
+              RUNTIME_VERSION.getBesuVersion(),
+              metadataVersion.getBesuVersion());
           // We've allowed startup at an older version of Besu. Since the version in the metadata
           // file records the latest version of
           // Besu to write to the database we'll update the metadata version to this
           // downgraded-version.
-          new VersionMetadata(VersionMetadata.getRuntimeVersion()).writeToDirectory(dataDir);
+          RUNTIME_VERSION.writeToDirectory(dataDir);
         } else {
           final String message =
               "Besu version "
-                  + installedVersion
+                  + RUNTIME_VERSION.getBesuVersion()
                   + " is lower than version "
-                  + metadataVersion
+                  + metadataVersion.getBesuVersion()
                   + " that last started. Remove --version-compatibility-protection option to allow Besu to start at "
                   + " the lower version (warning - this may have unrecoverable effects on the database).";
-          LOG.error(message, installedVersion, metadataVersion);
+          LOG.error(message);
           throw new IllegalStateException(message);
         }
       } else {
         LOG.info(
             "Besu version {} is higher than version {} that last started. Updating version metadata.",
-            installedVersion,
-            metadataVersion);
-        new VersionMetadata(VersionMetadata.getRuntimeVersion()).writeToDirectory(dataDir);
+            RUNTIME_VERSION.getBesuVersion(),
+            metadataVersion.getBesuVersion());
+        RUNTIME_VERSION.writeToDirectory(dataDir);
       }
     }
+  }
+
+  @Override
+  public int compareTo(@Nonnull final VersionMetadata versionMetadata) {
+    // Check the runtime version against the most recent version as recorded in the version
+    // metadata file
+    final String thisVersion = this.getBesuVersion().split("-", 2)[0];
+    final String metadataVersion = versionMetadata.getBesuVersion().split("-", 2)[0];
+    return new ComparableVersion(thisVersion).compareTo(new ComparableVersion(metadataVersion));
   }
 }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
@@ -22,10 +22,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -60,6 +64,33 @@ class VersionMetadataTest {
     assertThat(Files.exists(temporaryFolder)).isTrue();
   }
 
+  static Stream<Arguments> versionTestProvider() {
+    return Stream.of(
+        Arguments.of("24.4.0", "24.3.3", 1),
+        Arguments.of("24.3.3", "24.3.3", 0),
+        Arguments.of("24.2.0", "24.3.3", -1),
+        Arguments.of("24.3.3", "24.3-develop-59da092", 1),
+        Arguments.of("24.3.0", "24.3-develop-59da092", 0),
+        Arguments.of("24.3.3", "24.4-develop-59da092", -1),
+        Arguments.of("24.2-develop-59da092", "24.3-develop-9999999", -1),
+        Arguments.of("24.3-develop-59da092", "24.3-develop-9999999", 0),
+        Arguments.of("24.4-develop-59da092", "24.3-develop-9999999", 1),
+        Arguments.of("24.4-develop-59da092", "24.3.0", 1),
+        Arguments.of("24.4-develop-59da092", "24.4.0", 0),
+        Arguments.of("24.4-develop-59da092", "24.4.1", -1));
+  }
+
+  @ParameterizedTest
+  @MethodSource("versionTestProvider")
+  public void assertCompatibilityChecks(
+      final String runtimeVersion,
+      final String metadataVersion,
+      final int expectedComparisonResult) {
+    VersionMetadata runtime = new VersionMetadata(runtimeVersion);
+    VersionMetadata develop = new VersionMetadata(metadataVersion);
+    assertThat(runtime.compareTo(develop)).isEqualTo(expectedComparisonResult);
+  }
+
   @Test
   void compatibilityCheckShouldThrowExceptionIfEnabled() throws Exception {
     // The version file says the last version to start was 23.10.3
@@ -69,7 +100,7 @@ class VersionMetadataTest {
     // The runtime says the current version is 23.10.2 (i.e. a downgrade)
     try (MockedStatic<VersionMetadata> mocked =
         Mockito.mockStatic(VersionMetadata.class, Mockito.CALLS_REAL_METHODS)) {
-      mocked.when(VersionMetadata::getRuntimeVersion).thenReturn("23.10.2");
+      mocked.when(VersionMetadata::getRuntimeVersionString).thenReturn("23.10.2");
 
       final VersionMetadata versionMetadata = VersionMetadata.lookUpFrom(tempDataDir);
       assertThat(versionMetadata).isNotNull();
@@ -96,7 +127,7 @@ class VersionMetadataTest {
     // version-compatibility-protection = false so no exception should be thrown
     try (MockedStatic<VersionMetadata> mocked =
         Mockito.mockStatic(VersionMetadata.class, Mockito.CALLS_REAL_METHODS)) {
-      mocked.when(VersionMetadata::getRuntimeVersion).thenReturn("23.10.2");
+      mocked.when(VersionMetadata::getRuntimeVersionString).thenReturn("23.10.2");
 
       final VersionMetadata versionMetadata = VersionMetadata.lookUpFrom(tempDataDir);
       assertThat(versionMetadata).isNotNull();
@@ -122,7 +153,7 @@ class VersionMetadataTest {
     // The runtime says the current version is 23.10.2 (i.e. a downgrade)
     try (MockedStatic<VersionMetadata> mocked =
         Mockito.mockStatic(VersionMetadata.class, Mockito.CALLS_REAL_METHODS)) {
-      mocked.when(VersionMetadata::getRuntimeVersion).thenReturn("23.10.4");
+      mocked.when(VersionMetadata::getRuntimeVersionString).thenReturn("23.10.4");
 
       final VersionMetadata versionMetadata = VersionMetadata.lookUpFrom(tempDataDir);
       assertThat(versionMetadata).isNotNull();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/core/VersionMetadataTest.java
@@ -82,7 +82,7 @@ class VersionMetadataTest {
 
   @ParameterizedTest
   @MethodSource("versionTestProvider")
-  public void assertCompatibilityChecks(
+  public void assertComparableChecks(
       final String runtimeVersion,
       final String metadataVersion,
       final int expectedComparisonResult) {


### PR DESCRIPTION
## PR description
Address downgrade default for named networks.  Previously the check for named network was only considering command line params, and not toml config files.

Also implemented Comparable on VersionMetadata, and added explicit version test cases for a variety of build versions.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

