### PR TITLE
optimize node startup speed and memory allocation

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/clique/CliqueConditions.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/condition/clique/CliqueConditions.java
@@ -89,7 +89,7 @@ public class CliqueConditions {
 
   private int cliqueBlockPeriod(final BesuNode node) {
     final String config = node.getGenesisConfigProvider().create(emptyList()).get();
-    final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfig(config);
+    final GenesisConfigFile genesisConfigFile = GenesisConfigFile.fromConfigWithoutAccounts(config);
     final CliqueConfigOptions cliqueConfigOptions =
         genesisConfigFile.getConfigOptions().getCliqueConfigOptions();
     return cliqueConfigOptions.getBlockPeriodSeconds();

--- a/besu/src/main/java/org/hyperledger/besu/cli/config/EthNetworkConfig.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/config/EthNetworkConfig.java
@@ -138,7 +138,7 @@ public class EthNetworkConfig {
   public static EthNetworkConfig getNetworkConfig(final NetworkName networkName) {
     final String genesisContent = jsonConfig(networkName.getGenesisFile());
     final GenesisConfigOptions genesisConfigOptions =
-        GenesisConfigFile.fromConfig(genesisContent).getConfigOptions();
+        GenesisConfigFile.fromConfigWithoutAccounts(genesisContent).getConfigOptions();
     final Optional<List<String>> rawBootNodes =
         genesisConfigOptions.getDiscoveryOptions().getBootNodes();
     final List<EnodeURL> bootNodes =

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateBlockchainConfig.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/GenerateBlockchainConfig.java
@@ -283,7 +283,9 @@ class GenerateBlockchainConfig implements Runnable {
 
   /** Sets the selected signature algorithm instance in SignatureAlgorithmFactory. */
   private void processEcCurve() {
-    GenesisConfigOptions options = GenesisConfigFile.fromConfig(genesisConfig).getConfigOptions();
+    GenesisConfigOptions options =
+        GenesisConfigFile.fromConfigWithoutAccounts(String.valueOf(genesisConfig))
+            .getConfigOptions();
     Optional<String> ecCurve = options.getEcCurve();
 
     if (ecCurve.isEmpty()) {

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuController.java
@@ -333,6 +333,25 @@ public class BesuController implements java.io.Closeable {
     }
 
     /**
+     * From eth network config without alloc besu controller builder.
+     *
+     * @param ethNetworkConfig the eth network config
+     * @param genesisConfigOverrides the genesis config overrides
+     * @param syncMode The sync mode
+     * @return the besu controller builder
+     */
+    public BesuControllerBuilder fromEthNetworkConfigWithoutAccounts(
+        final EthNetworkConfig ethNetworkConfig,
+        final Map<String, String> genesisConfigOverrides,
+        final SyncMode syncMode) {
+      return fromGenesisConfig(
+              GenesisConfigFile.fromConfigWithoutAccounts(ethNetworkConfig.getGenesisConfig()),
+              genesisConfigOverrides,
+              syncMode)
+          .networkId(ethNetworkConfig.getNetworkId());
+    }
+
+    /**
      * From genesis config besu controller builder.
      *
      * @param genesisConfig the genesis config
@@ -390,8 +409,9 @@ public class BesuController implements java.io.Closeable {
           return new TransitionBesuControllerBuilder(builder, new MergeBesuControllerBuilder())
               .genesisConfigFile(genesisConfig);
         }
-
-      } else return builder.genesisConfigFile(genesisConfig);
+      } else {
+        return builder.genesisConfigFile(genesisConfig);
+      }
     }
 
     private BesuControllerBuilder createConsensusScheduleBesuControllerBuilder(

--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -107,6 +107,16 @@ public class GenesisConfigFile {
   }
 
   /**
+   * From config without account genesis config file.
+   *
+   * @param jsonString the json string
+   * @return the genesis config file
+   */
+  public static GenesisConfigFile fromConfigWithoutAccounts(final String jsonString) {
+    return fromConfig(JsonUtil.objectNodeFromStringWithout(jsonString, false, "alloc"));
+  }
+
+  /**
    * From config genesis config file.
    *
    * @param config the config

--- a/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonUtilTest.java
@@ -16,7 +16,9 @@ package org.hyperledger.besu.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -780,5 +782,26 @@ public class JsonUtilTest {
     final ObjectNode rootNode = JsonUtil.objectNodeFromString(jsonStr);
 
     assertThat(JsonUtil.hasKey(rootNode, "target")).isTrue();
+  }
+
+  @Test
+  void objectNodeFromStringWithoutAllocField() {
+    String genesisSting =
+        "{\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"000d836201318ec6899a67540690382780743280\":{\"balance\":\"0xad78ebc5ac6200000\"}}}";
+
+    ObjectNode jsonNodes = JsonUtil.objectNodeFromStringWithout(genesisSting, false, "alloc");
+
+    assertThat(jsonNodes.get("coinbase").toString()).isNotEmpty();
+    assertThat(jsonNodes.get("alloc")).isNull();
+  }
+
+  @Test
+  void getJsonFromFileWithoutAllocField() {
+    String genesisStingWithoutAllocField =
+        "{\"config\":{\"chainId\":1337, \"londonBlock\":0, \"phillyBlock\":5, \"parisBlock\":10, \"contractSizeLimit\":2147483647, \"ethash\":{\"fixeddifficulty\":100}}, \"nonce\":\"0x42\", \"timestamp\":\"0x0\", \"extraData\":\"0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa\", \"gasLimit\":\"0x1fffffffffffff\", \"difficulty\":\"0x10000\", \"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\", \"coinbase\":\"0x0000000000000000000000000000000000000000\"}";
+    File genesisFile = new File("src/test/resources/preMerge.json");
+
+    String genesisStringFromFile = JsonUtil.getJsonFromFileWithout(genesisFile, "alloc");
+    assertEquals(genesisStingWithoutAllocField, genesisStringFromFile);
   }
 }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/BlockchainImporter.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/BlockchainImporter.java
@@ -44,7 +44,7 @@ public class BlockchainImporter {
   public BlockchainImporter(final URL blocksUrl, final String genesisJson) throws Exception {
     protocolSchedule =
         MainnetProtocolSchedule.fromConfig(
-            GenesisConfigFile.fromConfig(genesisJson).getConfigOptions(),
+            GenesisConfigFile.fromConfigWithoutAccounts(genesisJson).getConfigOptions(),
             MiningParameters.newDefault(),
             new BadBlockManager());
     final BlockHeaderFunctions blockHeaderFunctions =


### PR DESCRIPTION
## PR description

In summary, if a user employs a large genesis file and activates the `--genesis-state-hash-cache-enabled` parameter, their node can start in under **10 seconds**, requiring less than **2GB of memory**. This is the essence of what this PR accomplishes.

1. Regarding the process of serializing the string into a GenesisConfigFile, many parts of the code follow a similar logic pattern: `GenesisConfigFile.fromConfig(genesisContent).getConfigOptions()`, which means obtaining config options from the GenesisConfigFile. In fact, it does not care about the rest of the content, especially the accounts information, while large genesis files often have accounts occupying a large portion.

    Therefore, this PR introduces a new method, `fromConfigWithoutAccounts`, for all places where accounts are not needed. During the serialization of the string into a GenesisConfigFile, it ignores the accounts information. This change is should be safe because the only time accounts information is needed is during the calculation of the genesis state hash.

2. Based on the `-genesis-state-hash-cache-enabled` parameter added in https://github.com/hyperledger/besu/pull/6758, this PR further enhances the performance improvements that the parameter can offer.

    Originally, the parameter's purpose was to cache and skip the calculation of the genesis state hash value. Building upon the previous improvements, this PR determines that if this parameter is enabled and there is a cached genesis state hash in the database, then it will directly ignore the accounts content when reading the genesis file.

The table below outlines the comparison of node startup time and total memory reclaimed before and after the optimizations made in this PR. All tests utilized a genesis file of 1.1GB in size.

|  | Time Consuming - Before optimization | Memory Allocated - Before optimization | Time Consuming - Optimized (this PR) | Memory Allocated - Optimized (this PR) |
| --- | --- | --- | --- | --- |
| --genesis-state-hash-cache-enabled=false && block number=0 | 7min37s | 184.95GB | 7min24s | 158.83GB |
| --genesis-state-hash-cache-enabled=false && block number=1 | 2min53s | 125.47GB | 2min36s | 96.53GB |
| --genesis-state-hash-cache-enabled=true && block number=0 | 7min35s | 183.33GB | 7min34s | 154.68GB |
| --genesis-state-hash-cache-enabled=true && block number=1 | 0min50s | 66.75GB | 0min9s | 1.31GB |

Without the `--genesis-state-hash-cache-enabled` parameter enabled, the startup time reduced from **2 minutes and 53 seconds** to **2 minutes and 36 seconds**, and the total memory reclaimed decreased from **125.47GB** to **96.53GB**. The optimization effect here is modest.

With the `--genesis-state-hash-cache-enabled` parameter enabled, the startup time can be reduced from **50 seconds** to **9 seconds**, and the total memory reclaimed from **66.75GB** to **1.31GB**, marking a significant optimization effect.

This is the unit test coverage report for the PR: [Unit Test Coverage Report](https://lyfsn.github.io/besu-starter/pr2/).

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

