### PR TITLE
Fix docker goss test

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -20,7 +20,7 @@ if [[ $i != 0 ]]; then exit $i; fi
 # we test that things listen on the right interface/port, not what interface the advertise
 # hence we dont set p2p-host=0.0.0.0 because this sets what its advertising to devp2p; the important piece is that it defaults to listening on all interfaces
 GOSS_FILES_PATH=$TEST_PATH/01 \
-bash $TEST_PATH/dgoss run $DOCKER_IMAGE \
+bash $TEST_PATH/dgoss run -p 8545:8545 -p 8546:8546 -p 8547:8547 -p 30303:30303 $DOCKER_IMAGE \
 --network=dev \
 --rpc-http-enabled \
 --rpc-ws-enabled \

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -20,7 +20,7 @@ if [[ $i != 0 ]]; then exit $i; fi
 # we test that things listen on the right interface/port, not what interface the advertise
 # hence we dont set p2p-host=0.0.0.0 because this sets what its advertising to devp2p; the important piece is that it defaults to listening on all interfaces
 GOSS_FILES_PATH=$TEST_PATH/01 \
-bash $TEST_PATH/dgoss run -p 8545:8545 -p 8546:8546 -p 8547:8547 -p 30303:30303 $DOCKER_IMAGE \
+bash $TEST_PATH/dgoss run --sysctl net.ipv6.conf.all.disable_ipv6=1 $DOCKER_IMAGE \
 --network=dev \
 --rpc-http-enabled \
 --rpc-ws-enabled \


### PR DESCRIPTION
Fixes docker.yml github workflow on self-hosted runner version 2.315.0 (docker ~25.0.4+~ 26.0.0?)

Since docker 26.0.0, IPv6 is used by default but our goss_wait test is expecting ports to be exposed on IPv4.
Disabling IPv6 should work for all docker versions, at least while the runners are on various versions of docker.

Once all runners are on 26+ then we could probably change goss_wait.yml to:

```
# runtime docker tests for interfaces & ports
port:
  tcp6:30303:
    listening: true
    ip:
    - '::'
  udp6:30303:
    listening: true
    ip:
    - '::'
  tcp6:8545:
    listening: true
    ip:
    - '::'
  tcp6:8546:
    listening: true
    ip:
    - '::'
  tcp6:8547:
    listening: true
    ip:
    - '::'
```

and reenable IPv6

Fixes #6929 