### PR TITLE
[DRAFT] Implementing support for emptyBlockPeriodSeconds in QBFT (Issue #3810)

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -411,8 +411,9 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
     return block ->
         LOG.info(
             String.format(
-                "%s #%,d / %d tx / %d pending / %,d (%01.1f%%) gas / (%s)",
+                "%s %s #%,d / %d tx / %d pending / %,d (%01.1f%%) gas / (%s)",
                 block.getHeader().getCoinbase().equals(localAddress) ? "Produced" : "Imported",
+                block.getBody().getTransactions().size() == 0 ? "empty block" : "block",
                 block.getHeader().getNumber(),
                 block.getBody().getTransactions().size(),
                 transactionPool.count(),

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -139,15 +139,18 @@ public abstract class CommandTestAbstract {
   private static final Logger TEST_LOGGER = LoggerFactory.getLogger(CommandTestAbstract.class);
 
   protected static final int POA_BLOCK_PERIOD_SECONDS = 5;
+  protected static final int POA_EMPTY_BLOCK_PERIOD_SECONDS = 50;
   protected static final JsonObject VALID_GENESIS_QBFT_POST_LONDON =
       (new JsonObject())
           .put(
               "config",
               new JsonObject()
                   .put("londonBlock", 0)
+                  .put("qbft", new JsonObject().put("blockperiodseconds", POA_BLOCK_PERIOD_SECONDS))
                   .put(
                       "qbft",
-                      new JsonObject().put("blockperiodseconds", POA_BLOCK_PERIOD_SECONDS)));
+                      new JsonObject()
+                          .put("emptyblockperiodseconds", POA_EMPTY_BLOCK_PERIOD_SECONDS)));
   protected static final JsonObject VALID_GENESIS_IBFT2_POST_LONDON =
       (new JsonObject())
           .put(

--- a/config/src/main/java/org/hyperledger/besu/config/BftConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BftConfigOptions.java
@@ -38,6 +38,13 @@ public interface BftConfigOptions {
   int getBlockPeriodSeconds();
 
   /**
+   * Gets empty block period seconds.
+   *
+   * @return the empty block period seconds
+   */
+  int getEmptyBlockPeriodSeconds();
+
+  /**
    * Gets request timeout seconds.
    *
    * @return the request timeout seconds

--- a/config/src/main/java/org/hyperledger/besu/config/BftFork.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BftFork.java
@@ -40,6 +40,9 @@ public class BftFork implements Fork {
   /** The constant BLOCK_PERIOD_SECONDS_KEY. */
   public static final String BLOCK_PERIOD_SECONDS_KEY = "blockperiodseconds";
 
+  /** The constant EMPTY_BLOCK_PERIOD_SECONDS_KEY. */
+  public static final String EMPTY_BLOCK_PERIOD_SECONDS_KEY = "emptyblockperiodseconds";
+
   /** The constant BLOCK_REWARD_KEY. */
   public static final String BLOCK_REWARD_KEY = "blockreward";
 
@@ -80,6 +83,16 @@ public class BftFork implements Fork {
    */
   public OptionalInt getBlockPeriodSeconds() {
     return JsonUtil.getPositiveInt(forkConfigRoot, BLOCK_PERIOD_SECONDS_KEY);
+  }
+
+  /**
+   * Gets empty block period seconds.
+   *
+   * @return the empty block period seconds
+   */
+  public OptionalInt getEmptyBlockPeriodSeconds() {
+    // It can be 0 to disable custom empty block periods
+    return JsonUtil.getInt(forkConfigRoot, EMPTY_BLOCK_PERIOD_SECONDS_KEY);
   }
 
   /**

--- a/config/src/main/java/org/hyperledger/besu/config/JsonBftConfigOptions.java
+++ b/config/src/main/java/org/hyperledger/besu/config/JsonBftConfigOptions.java
@@ -34,6 +34,8 @@ public class JsonBftConfigOptions implements BftConfigOptions {
 
   private static final long DEFAULT_EPOCH_LENGTH = 30_000;
   private static final int DEFAULT_BLOCK_PERIOD_SECONDS = 1;
+  private static final int DEFAULT_EMPTY_BLOCK_PERIOD_SECONDS = 0;
+  // 0 keeps working as before, increase to activate it
   private static final int DEFAULT_ROUND_EXPIRY_SECONDS = 1;
   // In a healthy network this can be very small. This default limit will allow for suitable
   // protection for on a typical 20 node validator network with multiple rounds
@@ -64,6 +66,12 @@ public class JsonBftConfigOptions implements BftConfigOptions {
   public int getBlockPeriodSeconds() {
     return JsonUtil.getPositiveInt(
         bftConfigRoot, "blockperiodseconds", DEFAULT_BLOCK_PERIOD_SECONDS);
+  }
+
+  @Override
+  public int getEmptyBlockPeriodSeconds() {
+    return JsonUtil.getInt(
+            bftConfigRoot, "emptyblockperiodseconds", DEFAULT_EMPTY_BLOCK_PERIOD_SECONDS);
   }
 
   @Override
@@ -132,6 +140,9 @@ public class JsonBftConfigOptions implements BftConfigOptions {
     }
     if (bftConfigRoot.has("blockperiodseconds")) {
       builder.put("blockPeriodSeconds", getBlockPeriodSeconds());
+    }
+    if (bftConfigRoot.has("emptyblockperiodseconds")) {
+      builder.put("emptyblockperiodseconds", getEmptyBlockPeriodSeconds());
     }
     if (bftConfigRoot.has("requesttimeoutseconds")) {
       builder.put("requestTimeoutSeconds", getRequestTimeoutSeconds());

--- a/config/src/test/java/org/hyperledger/besu/config/JsonBftConfigOptionsTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/JsonBftConfigOptionsTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.config;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.hyperledger.besu.datatypes.Address;
@@ -30,6 +31,7 @@ public class JsonBftConfigOptionsTest {
 
   private static final int EXPECTED_DEFAULT_EPOCH_LENGTH = 30_000;
   private static final int EXPECTED_DEFAULT_BLOCK_PERIOD = 1;
+  private static final int EXPECTED_EMPTY_DEFAULT_BLOCK_PERIOD = 0;
   private static final int EXPECTED_DEFAULT_REQUEST_TIMEOUT = 1;
   private static final int EXPECTED_DEFAULT_GOSSIPED_HISTORY_LIMIT = 1000;
   private static final int EXPECTED_DEFAULT_MESSAGE_QUEUE_LIMIT = 1000;
@@ -62,9 +64,21 @@ public class JsonBftConfigOptionsTest {
   }
 
   @Test
+  public void shouldGetEmptyBlockPeriodFromConfig() {
+    final BftConfigOptions config = fromConfigOptions(singletonMap("emptyblockperiodseconds", 60));
+    assertThat(config.getEmptyBlockPeriodSeconds()).isEqualTo(60);
+  }
+
+  @Test
   public void shouldFallbackToDefaultBlockPeriod() {
     final BftConfigOptions config = fromConfigOptions(emptyMap());
     assertThat(config.getBlockPeriodSeconds()).isEqualTo(EXPECTED_DEFAULT_BLOCK_PERIOD);
+  }
+
+  @Test
+  public void shouldFallbackToEmptyDefaultBlockPeriod() {
+    final BftConfigOptions config = fromConfigOptions(emptyMap());
+    assertThat(config.getEmptyBlockPeriodSeconds()).isEqualTo(EXPECTED_EMPTY_DEFAULT_BLOCK_PERIOD);
   }
 
   @Test
@@ -74,10 +88,24 @@ public class JsonBftConfigOptionsTest {
   }
 
   @Test
+  public void shouldGetDefaultEmptyBlockPeriodFromDefaultConfig() {
+
+    assertThat(JsonBftConfigOptions.DEFAULT.getEmptyBlockPeriodSeconds())
+            .isEqualTo(EXPECTED_EMPTY_DEFAULT_BLOCK_PERIOD);
+  }
+
+  @Test
   public void shouldThrowOnNonPositiveBlockPeriod() {
     final BftConfigOptions config = fromConfigOptions(singletonMap("blockperiodseconds", -1));
     assertThatThrownBy(() -> config.getBlockPeriodSeconds())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldNotThrowOnNonPositiveEmptyBlockPeriod() {
+    // can be 0 to be compatible with older versions
+    final BftConfigOptions config = fromConfigOptions(singletonMap("emptyblockperiodseconds", 0));
+    assertThatCode(() -> config.getEmptyBlockPeriodSeconds()).doesNotThrowAnyException();
   }
 
   @Test

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/MutableBftConfigOptions.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/MutableBftConfigOptions.java
@@ -24,13 +24,19 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A mutable {@link BftConfigOptions} that is used for building config for transitions in the {@link
  * ForksSchedule}*.
  */
 public class MutableBftConfigOptions implements BftConfigOptions {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MutableBftConfigOptions.class);
   private long epochLength;
   private int blockPeriodSeconds;
+  private int emptyBlockPeriodSeconds;
   private int requestTimeoutSeconds;
   private int gossipedHistoryLimit;
   private int messageQueueLimit;
@@ -48,6 +54,7 @@ public class MutableBftConfigOptions implements BftConfigOptions {
   public MutableBftConfigOptions(final BftConfigOptions bftConfigOptions) {
     this.epochLength = bftConfigOptions.getEpochLength();
     this.blockPeriodSeconds = bftConfigOptions.getBlockPeriodSeconds();
+    this.emptyBlockPeriodSeconds = bftConfigOptions.getEmptyBlockPeriodSeconds();
     this.requestTimeoutSeconds = bftConfigOptions.getRequestTimeoutSeconds();
     this.gossipedHistoryLimit = bftConfigOptions.getGossipedHistoryLimit();
     this.messageQueueLimit = bftConfigOptions.getMessageQueueLimit();
@@ -65,7 +72,14 @@ public class MutableBftConfigOptions implements BftConfigOptions {
 
   @Override
   public int getBlockPeriodSeconds() {
+    LOG.debug("GET BLOCKPERIODSECONDS: " + blockPeriodSeconds);
     return blockPeriodSeconds;
+  }
+
+  @Override
+  public int getEmptyBlockPeriodSeconds() {
+    LOG.debug("GET EMPTYBLOCKPERIODSECONDS: " + emptyBlockPeriodSeconds);
+    return emptyBlockPeriodSeconds;
   }
 
   @Override
@@ -128,7 +142,18 @@ public class MutableBftConfigOptions implements BftConfigOptions {
    * @param blockPeriodSeconds the block period seconds
    */
   public void setBlockPeriodSeconds(final int blockPeriodSeconds) {
+    LOG.info("SET BLOCKPERIODSECONDS: " + blockPeriodSeconds);
     this.blockPeriodSeconds = blockPeriodSeconds;
+  }
+
+  /**
+   * Sets empty block period seconds.
+   *
+   * @param emptyBlockPeriodSeconds the empty block period seconds
+   */
+  public void setEmptyBlockPeriodSeconds(final int emptyBlockPeriodSeconds) {
+    LOG.info("SET EMPTYBLOCKPERIODSECONDS: " + emptyBlockPeriodSeconds);
+    this.emptyBlockPeriodSeconds = emptyBlockPeriodSeconds;
   }
 
   /**

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleFactoryTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/ForksScheduleFactoryTest.java
@@ -37,7 +37,7 @@ public class ForksScheduleFactoryTest {
   @SuppressWarnings("unchecked")
   public void throwsErrorIfHasForkForGenesisBlock() {
     final BftConfigOptions genesisConfigOptions = JsonBftConfigOptions.DEFAULT;
-    final BftFork fork = createFork(0, 10);
+    final BftFork fork = createFork(0, 10, 30);
     final SpecCreator<BftConfigOptions, BftFork> specCreator = Mockito.mock(SpecCreator.class);
 
     assertThatThrownBy(
@@ -49,9 +49,9 @@ public class ForksScheduleFactoryTest {
   @SuppressWarnings("unchecked")
   public void throwsErrorIfHasForksWithDuplicateBlock() {
     final BftConfigOptions genesisConfigOptions = JsonBftConfigOptions.DEFAULT;
-    final BftFork fork1 = createFork(1, 10);
-    final BftFork fork2 = createFork(1, 20);
-    final BftFork fork3 = createFork(2, 30);
+    final BftFork fork1 = createFork(1, 10, 30);
+    final BftFork fork2 = createFork(1, 20, 60);
+    final BftFork fork3 = createFork(2, 30, 90);
     final SpecCreator<BftConfigOptions, BftFork> specCreator = Mockito.mock(SpecCreator.class);
 
     assertThatThrownBy(
@@ -82,18 +82,20 @@ public class ForksScheduleFactoryTest {
     assertThat(schedule.getFork(2)).isEqualTo(new ForkSpec<>(2, configOptions2));
   }
 
-  private MutableBftConfigOptions createBftConfigOptions(final int blockPeriodSeconds) {
+  private MutableBftConfigOptions createBftConfigOptions(final int blockPeriodSeconds, final int emptyBlockPeriodSeconds) {
     final MutableBftConfigOptions bftConfigOptions =
         new MutableBftConfigOptions(JsonBftConfigOptions.DEFAULT);
     bftConfigOptions.setBlockPeriodSeconds(blockPeriodSeconds);
+    bftConfigOptions.setEmptyBlockPeriodSeconds(emptyBlockPeriodSeconds);
     return bftConfigOptions;
   }
 
-  private BftFork createFork(final long block, final long blockPeriodSeconds) {
+  private BftFork createFork(final long block, final long blockPeriodSeconds, final long emptyBlockPeriodSeconds) {
     return new BftFork(
         JsonUtil.objectNodeFromMap(
             Map.of(
                 BftFork.FORK_BLOCK_KEY, block,
-                BftFork.BLOCK_PERIOD_SECONDS_KEY, blockPeriodSeconds)));
+                    BftFork.BLOCK_PERIOD_SECONDS_KEY, blockPeriodSeconds,
+                    BftFork.EMPTY_BLOCK_PERIOD_SECONDS_KEY, emptyBlockPeriodSeconds)));
   }
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BlockTimerTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/BlockTimerTest.java
@@ -63,6 +63,13 @@ public class BlockTimerTest {
 
   @Test
   public void cancelTimerCancelsWhenNoTimer() {
+    final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
+
+    when(mockForksSchedule.getFork(anyLong()))
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
+
+
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
     // Starts with nothing running
     assertThat(timer.isRunning()).isFalse();
@@ -75,12 +82,13 @@ public class BlockTimerTest {
   @Test
   public void startTimerSchedulesCorrectlyWhenExpiryIsInTheFuture() {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
     final long NOW_MILLIS = 505_000L;
     final long BLOCK_TIME_STAMP = 500L;
     final long EXPECTED_DELAY = 10_000L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -104,12 +112,13 @@ public class BlockTimerTest {
   @Test
   public void aBlockTimerExpiryEventIsAddedToTheQueueOnExpiry() throws InterruptedException {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 1;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 10;
     final long NOW_MILLIS = 300_500L;
     final long BLOCK_TIME_STAMP = 300;
     final long EXPECTED_DELAY = 500;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
     when(mockClock.millis()).thenReturn(NOW_MILLIS);
 
     final BlockHeader header =
@@ -149,11 +158,12 @@ public class BlockTimerTest {
   @Test
   public void eventIsImmediatelyAddedToTheQueueIfAbsoluteExpiryIsEqualToNow() {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
     final long NOW_MILLIS = 515_000L;
     final long BLOCK_TIME_STAMP = 500;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -179,11 +189,12 @@ public class BlockTimerTest {
   @Test
   public void eventIsImmediatelyAddedToTheQueueIfAbsoluteExpiryIsInThePast() {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
     final long NOW_MILLIS = 520_000L;
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -209,11 +220,12 @@ public class BlockTimerTest {
   @Test
   public void startTimerCancelsExistingTimer() {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
     final long NOW_MILLIS = 500_000L;
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -237,11 +249,12 @@ public class BlockTimerTest {
   @Test
   public void runningFollowsTheStateOfTheTimer() {
     final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
     final long NOW_MILLIS = 500_000L;
     final long BLOCK_TIME_STAMP = 500L;
 
     when(mockForksSchedule.getFork(anyLong()))
-        .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS)));
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
 
     final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
 
@@ -263,10 +276,25 @@ public class BlockTimerTest {
     assertThat(timer.isRunning()).isFalse();
   }
 
-  private BftConfigOptions createBftFork(final int blockPeriodSeconds) {
+  @Test
+  public void checkBlockTimerEmptyAndNonEmptyPeriodSecods() {
+    final int MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS = 15;
+    final int MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS = 60;
+
+    when(mockForksSchedule.getFork(anyLong()))
+            .thenReturn(new ForkSpec<>(0, createBftFork(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS, MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS)));
+
+    final BlockTimer timer = new BlockTimer(mockQueue, mockForksSchedule, bftExecutors, mockClock);
+
+    assertThat(timer.getBlockPeriodSeconds()).isEqualTo(MINIMAL_TIME_BETWEEN_BLOCKS_SECONDS);
+    assertThat(timer.getEmptyBlockPeriodSeconds()).isEqualTo(MINIMAL_TIME_BETWEEN_EMPTY_BLOCKS_SECONDS);
+  }
+
+  private BftConfigOptions createBftFork(final int blockPeriodSeconds, final int emptyBlockPeriodSeconds) {
     final MutableBftConfigOptions bftConfigOptions =
-        new MutableBftConfigOptions(JsonBftConfigOptions.DEFAULT);
+            new MutableBftConfigOptions(JsonBftConfigOptions.DEFAULT);
     bftConfigOptions.setBlockPeriodSeconds(blockPeriodSeconds);
+    bftConfigOptions.setEmptyBlockPeriodSeconds(emptyBlockPeriodSeconds);
     return bftConfigOptions;
   }
 }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftBlockHeaderValidationRulesetFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftBlockHeaderValidationRulesetFactory.java
@@ -29,7 +29,6 @@ import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.ConstantField
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasLimitRangeAndDeltaValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.GasUsageValidationRule;
 import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampBoundedByFutureParameter;
-import org.hyperledger.besu.ethereum.mainnet.headervalidationrules.TimestampMoreRecentThanParent;
 
 import java.util.Optional;
 
@@ -58,7 +57,8 @@ public class QbftBlockHeaderValidationRulesetFactory {
             new GasLimitRangeAndDeltaValidationRule(
                 DEFAULT_MIN_GAS_LIMIT, DEFAULT_MAX_GAS_LIMIT, baseFeeMarket))
         .addRule(new TimestampBoundedByFutureParameter(1))
-        .addRule(new TimestampMoreRecentThanParent(secondsBetweenBlocks))
+        //.addRule(new TimestampMoreRecentThanParent(secondsBetweenBlocks))
+        // removed because of conflict with emptyblockperiodseconds
         .addRule(
             new ConstantFieldValidationRule<>(
                 "MixHash", BlockHeader::getMixHash, BftHelpers.EXPECTED_MIX_HASH))

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftForksSchedulesFactory.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/QbftForksSchedulesFactory.java
@@ -47,6 +47,7 @@ public class QbftForksSchedulesFactory {
         new MutableQbftConfigOptions(lastSpec.getValue());
 
     fork.getBlockPeriodSeconds().ifPresent(bftConfigOptions::setBlockPeriodSeconds);
+    fork.getEmptyBlockPeriodSeconds().ifPresent(bftConfigOptions::setEmptyBlockPeriodSeconds);
     fork.getBlockRewardWei().ifPresent(bftConfigOptions::setBlockRewardWei);
 
     if (fork.isMiningBeneficiaryConfigured()) {

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.consensus.qbft.payload.MessageFactory;
 import org.hyperledger.besu.consensus.qbft.validation.FutureRoundProposalMessageValidator;
 import org.hyperledger.besu.consensus.qbft.validation.MessageValidatorFactory;
 import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.plugin.services.securitymodule.SecurityModuleException;
 
@@ -130,19 +131,48 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
 
     logValidatorChanges(qbftRound);
 
+    if (roundIdentifier.equals(qbftRound.getRoundIdentifier())) {
+      buildBlockAndMaybePropose(roundIdentifier, qbftRound);
+    } else {
+      LOG.trace(
+              "Block timer expired for a round ({}) other than current ({})",
+              roundIdentifier,
+              qbftRound.getRoundIdentifier());
+    }
+  }
+
+  private void buildBlockAndMaybePropose(
+          final ConsensusRoundIdentifier roundIdentifier, final QbftRound qbftRound) {
+
     // mining will be checked against round 0 as the current round is initialised to 0 above
     final boolean isProposer =
-        finalState.isLocalNodeProposerForRound(qbftRound.getRoundIdentifier());
+            finalState.isLocalNodeProposerForRound(qbftRound.getRoundIdentifier());
 
-    if (isProposer) {
-      if (roundIdentifier.equals(qbftRound.getRoundIdentifier())) {
-        final long headerTimeStampSeconds = Math.round(clock.millis() / 1000D);
-        qbftRound.createAndSendProposalMessage(headerTimeStampSeconds);
+    final long headerTimeStampSeconds = Math.round(clock.millis() / 1000D);
+    final Block block = qbftRound.createBlock(headerTimeStampSeconds);
+    final boolean blockHasTransactions = !block.getBody().getTransactions().isEmpty();
+    if (blockHasTransactions) {
+      if (isProposer) {
+        LOG.debug("Block has transactions and this node is a proposer so it will send a proposal");
+        qbftRound.sendProposalMessage(block);
+      }else{
+        LOG.debug("Block has transactions but this node is not a proposer so it will not send a proposal");
+      }
+    } else {
+      final long emptyBlockPeriodSeconds = finalState.getBlockTimer().getEmptyBlockPeriodSeconds();
+      final long emptyBlockPeriodExpiryTime = parentHeader.getTimestamp() + emptyBlockPeriodSeconds;
+      final long nowInSeconds = finalState.getClock().millis() / 1000;
+      if (nowInSeconds >= emptyBlockPeriodExpiryTime) {
+        if (isProposer) {
+          LOG.debug("Block has no transactions and this node is a proposer so it will send a proposal");
+          qbftRound.sendProposalMessage(block);
+        } else {
+          LOG.debug("Block has no transactions but this node is not a proposer so it will not send a proposal");
+        }
       } else {
-        LOG.trace(
-            "Block timer expired for a round ({}) other than current ({})",
-            roundIdentifier,
-            qbftRound.getRoundIdentifier());
+        finalState.getRoundTimer().cancelTimer();
+        finalState.getBlockTimer().startEmptyBlockTimer(roundIdentifier, parentHeader);
+        currentRound = Optional.empty();
       }
     }
   }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftController.java
@@ -48,7 +48,7 @@ public class QbftController extends BaseBftController {
    * @param gossiper the gossiper
    * @param duplicateMessageTracker the duplicate message tracker
    * @param futureMessageBuffer the future message buffer
-   * @param sychronizerUpdater the synchronizer updater
+   * @param sychronizerUpdater the sychronizer updater
    * @param bftExtraDataCodec the bft extra data codec
    */
   public QbftController(

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRound.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftRound.java
@@ -128,6 +128,30 @@ public class QbftRound {
   }
 
   /**
+   * Create a block
+   *
+   * @return a Block
+   */
+  public Block createBlock(final long headerTimeStampSeconds) {
+    LOG.debug(
+            "Creating proposed block. round={}",
+            roundState.getRoundIdentifier());
+    return blockCreator.createBlock(headerTimeStampSeconds).getBlock();
+  }
+
+  /**
+   * Send proposal message.
+   *
+   * @param block to send
+   */
+  public void sendProposalMessage(final Block block) {
+    LOG.debug(
+            "Creating proposed block blockHeader={}",
+            block.getHeader());
+    updateStateWithProposalAndTransmit(block, emptyList(), emptyList());
+  }
+
+  /**
    * Create and send proposal message.
    *
    * @param headerTimeStampSeconds the header time stamp seconds

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/MutableQbftConfigOptionsTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/MutableQbftConfigOptionsTest.java
@@ -41,4 +41,24 @@ public class MutableQbftConfigOptionsTest {
 
     assertThat(mutableQbftConfigOptions.getValidatorContractAddress()).hasValue("0xabc");
   }
+
+  @Test
+  public void checkBlockPeriodSeconds() {
+    when(qbftConfigOptions.getBlockPeriodSeconds()).thenReturn(2);
+
+    final MutableQbftConfigOptions mutableQbftConfigOptions =
+            new MutableQbftConfigOptions(qbftConfigOptions);
+
+    assertThat(mutableQbftConfigOptions.getBlockPeriodSeconds()).isEqualTo(2);
+  }
+
+  @Test
+  public void checkEmptyBlockPeriodSeconds() {
+    when(qbftConfigOptions.getEmptyBlockPeriodSeconds()).thenReturn(60);
+
+    final MutableQbftConfigOptions mutableQbftConfigOptions =
+            new MutableQbftConfigOptions(qbftConfigOptions);
+
+    assertThat(mutableQbftConfigOptions.getEmptyBlockPeriodSeconds()).isEqualTo(60);
+  }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManagerTest.java
@@ -157,6 +157,7 @@ public class QbftBlockHeightManagerTest {
     when(finalState.getBlockTimer()).thenReturn(blockTimer);
     when(finalState.getQuorum()).thenReturn(3);
     when(finalState.getValidatorMulticaster()).thenReturn(validatorMulticaster);
+    when(finalState. getClock()).thenReturn(clock);
     when(blockCreator.createBlock(anyLong()))
         .thenReturn(
             new BlockCreationResult(
@@ -570,5 +571,25 @@ public class QbftBlockHeightManagerTest {
 
     manager.handleProposalPayload(futureRoundProposal);
     verify(roundFactory, never()).createNewRound(any(), anyInt());
+  }
+
+  @Test
+  public void checkOnlyEmptyBlockPeriodSecondsIsInvokedForBlocksWithNoTransactions() {
+    when(finalState.isLocalNodeProposerForRound(roundIdentifier)).thenReturn(true);
+
+    final QbftBlockHeightManager manager =
+            new QbftBlockHeightManager(
+                    headerTestFixture.buildHeader(),
+                    finalState,
+                    roundChangeManager,
+                    roundFactory,
+                    clock,
+                    messageValidatorFactory,
+                    messageFactory);
+
+    manager.handleBlockTimerExpiry(roundIdentifier);
+
+    verify(blockTimer, atLeastOnce()).getEmptyBlockPeriodSeconds();
+    verify(blockTimer, times(0)).getBlockPeriodSeconds();
   }
 }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/QbftForksSchedulesFactoryTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/validator/QbftForksSchedulesFactoryTest.java
@@ -63,6 +63,8 @@ public class QbftForksSchedulesFactoryTest
                 List.of("1", "2", "3"),
                 BftFork.BLOCK_PERIOD_SECONDS_KEY,
                 10,
+                BftFork.EMPTY_BLOCK_PERIOD_SECONDS_KEY,
+                60,
                 BftFork.BLOCK_REWARD_KEY,
                 "5",
                 QbftFork.VALIDATOR_SELECTION_MODE_KEY,
@@ -78,6 +80,7 @@ public class QbftForksSchedulesFactoryTest
 
     final Map<String, Object> forkOptions = new HashMap<>(configOptions.asMap());
     forkOptions.put(BftFork.BLOCK_PERIOD_SECONDS_KEY, 10);
+    forkOptions.put(BftFork.EMPTY_BLOCK_PERIOD_SECONDS_KEY, 60);
     forkOptions.put(BftFork.BLOCK_REWARD_KEY, "5");
     forkOptions.put(QbftFork.VALIDATOR_SELECTION_MODE_KEY, "5");
     forkOptions.put(QbftFork.VALIDATOR_CONTRACT_ADDRESS_KEY, "10");


### PR DESCRIPTION
## PR description
Implementing emptyblockperiodseconds for producing empty blocks at a specific interval independently of the value of the existing blockperiodseconds setting

## Fixed Issue(s)
https://github.com/hyperledger/besu/issues/3810


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

