### PR TITLE
add log-file flag

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -798,6 +798,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private static Boolean colorEnabled = null;
 
   @Option(
+      names = {"--log-file"},
+      description = "Log file to output logs")
+  private static Path logFile = null;
+
+  @Option(
       names = {"--reorg-logging-threshold"},
       description =
           "How deep a chain reorganization must be in order for it to be logged (default: ${DEFAULT-VALUE})")
@@ -1438,6 +1443,15 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
    */
   public static Optional<Boolean> getColorEnabled() {
     return Optional.ofNullable(colorEnabled);
+  }
+
+  /**
+   * Logging file.
+   *
+   * @return Optional string representing logging file. If set, log to that file.
+   */
+  public static Optional<Path> getLogFile() {
+    return Optional.ofNullable(logFile);
   }
 
   private void configureNativeLibs() {


### PR DESCRIPTION
## PR description
This PR adds a new cli flag `--log-file` to configure the logs to be written to the provided file instead of the console. If this parameter is not specified, by default the logs are written to console.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

