### PR TITLE
Count all exceptions as retries when getting the range headers

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/SyncTargetRangeSource.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/SyncTargetRangeSource.java
@@ -172,11 +172,11 @@ public class SyncTargetRangeSource implements Iterator<SyncTargetRange> {
       retryCount++;
       if (retryCount >= retriesPermitted) {
         LOG.atDebug()
-                .setMessage(
-                        "Disconnecting target peer for not providing useful range headers after {} retries: {}.")
-                .addArgument(retriesPermitted)
-                .addArgument(peer)
-                .log();
+            .setMessage(
+                "Disconnecting target peer for not providing useful range headers after {} retries: {}.")
+            .addArgument(retriesPermitted)
+            .addArgument(peer)
+            .log();
         peer.disconnect(DisconnectMessage.DisconnectReason.USELESS_PEER_USELESS_RESPONSES);
         retryCount = 0;
         throw new RuntimeException("Too many retries fetching range headers for chain download.");

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/SyncTargetRangeSource.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/range/SyncTargetRangeSource.java
@@ -173,16 +173,21 @@ public class SyncTargetRangeSource implements Iterator<SyncTargetRange> {
       LOG.trace("Interrupted while waiting for new range headers", e);
       return null;
     } catch (final ExecutionException e) {
-      LOG.atTrace().setMessage("Future completed exceptionally while waiting for new range headers, target peer {}").addArgument(peer::toString).setCause(e).log();
+      LOG.atTrace()
+          .setMessage(
+              "Future completed exceptionally while waiting for new range headers, target peer {}")
+          .addArgument(peer::toString)
+          .setCause(e)
+          .log();
       this.pendingRequests = Optional.empty();
       retryCount++;
       if (retryCount >= retriesPermitted) {
         LOG.atDebug()
-                .setMessage(
-                        "Disconnecting target peer for not providing useful range headers after {} retries: {}.")
-                .addArgument(retriesPermitted)
-                .addArgument(peer)
-                .log();
+            .setMessage(
+                "Disconnecting target peer for not providing useful range headers after {} retries: {}.")
+            .addArgument(retriesPermitted)
+            .addArgument(peer)
+            .log();
         peer.disconnect(DisconnectMessage.DisconnectReason.USELESS_PEER_USELESS_RESPONSES);
         retryCount = 0;
         throw new RuntimeException("Too many retries fetching range headers for chain download.");

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetRangeSourceTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/SyncTargetRangeSourceTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -101,14 +102,13 @@ public class SyncTargetRangeSourceTest {
     when(rangeHeaders.getNextRangeHeaders(peer, commonAncestor))
         .thenReturn(CompletableFuture.failedFuture(new TimeoutException()));
 
-    for (int i = 1; i <= CHECKPOINT_TIMEOUTS_PERMITTED; i++) {
+    for (int i = 1; i < CHECKPOINT_TIMEOUTS_PERMITTED; i++) {
       assertThat(source).hasNext();
       assertThat(source.next()).isNull();
       verify(rangeHeaders, times(i)).getNextRangeHeaders(peer, commonAncestor);
     }
 
-    // Too many timeouts, give up on this sync target.
-    assertThat(source).isExhausted();
+    assertThatThrownBy(source::next).isInstanceOf(RuntimeException.class);
   }
 
   @Test
@@ -117,14 +117,13 @@ public class SyncTargetRangeSourceTest {
     when(rangeHeaders.getNextRangeHeaders(peer, commonAncestor))
         .thenReturn(completedFuture(emptyList()));
 
-    for (int i = 1; i <= CHECKPOINT_TIMEOUTS_PERMITTED; i++) {
+    for (int i = 1; i < CHECKPOINT_TIMEOUTS_PERMITTED; i++) {
       assertThat(source).hasNext();
       assertThat(source.next()).isNull();
       verify(rangeHeaders, times(i)).getNextRangeHeaders(peer, commonAncestor);
     }
 
-    // Too many timeouts, give up on this sync target.
-    assertThat(source).isExhausted();
+    assertThatThrownBy(source::next).isInstanceOf(RuntimeException.class);
   }
 
   @Test


### PR DESCRIPTION
## PR description

In a previous PR we made the change to disconnect the peer that was selected to provide the range headers that we need as input for the chain downloading pipeline for useless responses after a number of retires. To make sure that these useless peers are disconnected this PR increments the retry count for any exception that happens while trying to get these headers.

In addition this PR throws an exception after disconnecting the useless peer so the pipeline is immediately  restarted with a new target peer.
