### PR TITLE
build - Fix gradle build for Java 21

### DIFF
--- a/datatypes/build.gradle
+++ b/datatypes/build.gradle
@@ -30,14 +30,13 @@ jar {
 
 dependencies {
   compileOnly 'com.fasterxml.jackson.core:jackson-databind'
+  compileOnly 'io.vertx:vertx-core'
 
   implementation project(':crypto:algorithms')
   implementation project(':ethereum:rlp')
   implementation 'com.google.guava:guava'
   implementation 'io.tmio:tuweni-bytes'
   implementation 'io.tmio:tuweni-units'
-
-  compileOnly 'io.vertx:vertx-core'
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/datatypes/build.gradle
+++ b/datatypes/build.gradle
@@ -37,6 +37,8 @@ dependencies {
   implementation 'io.tmio:tuweni-bytes'
   implementation 'io.tmio:tuweni-units'
 
+  compileOnly 'io.vertx:vertx-core'
+
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/evm/build.gradle
+++ b/evm/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   implementation 'tech.pegasys:jc-kzg-4844'
 
   compileOnly 'com.fasterxml.jackson.core:jackson-databind'
+  compileOnly 'io.vertx:vertx-core'
 
   testImplementation 'com.fasterxml.jackson.core:jackson-databind'
   testImplementation 'info.picocli:picocli'

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   api 'io.tmio:tuweni-units'
   implementation 'com.google.guava:guava'
   implementation project(':evm')
+  compileOnly 'io.vertx:vertx-core'
 }
 
 configurations { testArtifacts }


### PR DESCRIPTION
## PR description
 build - Fix gradle build for Java 21. Add compileOnly dependencies to allow gradle build to run against Java 21
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

