### PR TITLE
Move unknown options check further in the startup

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigurationDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigurationDefaultProvider.java
@@ -50,7 +50,7 @@ public class TomlConfigurationDefaultProvider implements IDefaultValueProvider {
   private final CommandLine commandLine;
   private final InputStream configurationInputStream;
   private TomlParseResult result;
-  private boolean isOptionsValid;
+  private boolean isUnknownOptionsChecked;
 
   /**
    * Instantiates a new Toml config file default value provider.
@@ -232,9 +232,9 @@ public class TomlConfigurationDefaultProvider implements IDefaultValueProvider {
           commandLine,
           String.format("Unable to read TOML configuration file %s", configurationInputStream));
 
-    if (!isOptionsValid && !commandLine.isUnmatchedArgumentsAllowed()) {
+    if (!isUnknownOptionsChecked && !commandLine.isUnmatchedArgumentsAllowed()) {
       checkUnknownOptions(result);
-      isOptionsValid = true;
+      isUnknownOptionsChecked = true;
     }
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigurationDefaultProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/TomlConfigurationDefaultProvider.java
@@ -50,6 +50,7 @@ public class TomlConfigurationDefaultProvider implements IDefaultValueProvider {
   private final CommandLine commandLine;
   private final InputStream configurationInputStream;
   private TomlParseResult result;
+  private boolean isOptionsValid;
 
   /**
    * Instantiates a new Toml config file default value provider.
@@ -230,6 +231,11 @@ public class TomlConfigurationDefaultProvider implements IDefaultValueProvider {
       throw new ParameterException(
           commandLine,
           String.format("Unable to read TOML configuration file %s", configurationInputStream));
+
+    if (!isOptionsValid && !commandLine.isUnmatchedArgumentsAllowed()) {
+      checkUnknownOptions(result);
+      isOptionsValid = true;
+    }
   }
 
   /** Load configuration from file. */
@@ -248,8 +254,6 @@ public class TomlConfigurationDefaultProvider implements IDefaultValueProvider {
           throw new ParameterException(
               commandLine, String.format("Invalid TOML configuration: %s", errors));
         }
-
-        checkUnknownOptions(result);
 
         this.result = result;
 


### PR DESCRIPTION
## PR description

There is a bug introduced by [#6700](https://github.com/hyperledger/besu/pull/6700) that prevents plugin CLI options from being used in config files. 
Move `checkUnknownOptions` to happen after the plugins register their custom CLI options. 