### PR TITLE
build: Add default constructor and javadoc for metrics, nat, pki, plugins, services, testutil, util

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImpl.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImpl.java
@@ -25,6 +25,9 @@ public class MetricCategoryRegistryImpl implements MetricCategoryRegistry {
 
   private final List<MetricCategory> metricCategories = new ArrayList<>();
 
+  /** Default constructor */
+  public MetricCategoryRegistryImpl() {}
+
   /**
    * Gets metric categories.
    *

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsConfigurationModule.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsConfigurationModule.java
@@ -24,6 +24,9 @@ import dagger.Provides;
 /** Dagger module for providing the {@link MetricsConfiguration} instance. */
 @Module
 public class MetricsConfigurationModule {
+  /** Default constructor */
+  public MetricsConfigurationModule() {}
+
   @Provides
   @Singleton
   MetricsConfiguration provideMetricsConfiguration() {

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsSystemModule.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsSystemModule.java
@@ -28,6 +28,8 @@ import dagger.Provides;
  */
 @Module
 public class MetricsSystemModule {
+  /** Default constructor */
+  public MetricsSystemModule() {}
 
   @Provides
   @Singleton

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpMetricsSystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpMetricsSystem.java
@@ -73,6 +73,9 @@ public class NoOpMetricsSystem implements ObservableMetricsSystem {
   public static final LabelledGauge NO_OP_LABELLED_3_GAUGE =
       new LabelledGaugeNoOpMetric(3, NO_OP_GAUGE);
 
+  /** Default constructor */
+  public NoOpMetricsSystem() {}
+
   @Override
   public LabelledMetric<Counter> createLabelledCounter(
       final MetricCategory category,

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpValueCollector.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpValueCollector.java
@@ -24,6 +24,9 @@ import java.util.function.DoubleSupplier;
 public class NoOpValueCollector implements LabelledGauge {
   private final List<String> labelValuesCreated = new ArrayList<>();
 
+  /** Default constructor */
+  public NoOpValueCollector() {}
+
   @Override
   public synchronized void labels(final DoubleSupplier valueSupplier, final String... labelValues) {
     final String labelValuesString = String.join(",", labelValues);

--- a/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
+++ b/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
@@ -164,6 +164,9 @@ public class RocksDBStats {
     HistogramType.READ_NUM_MERGE_OPERANDS,
   };
 
+  /** Default constructor */
+  private RocksDBStats() {}
+
   /**
    * Register rocks db metrics.
    *

--- a/nat/src/main/java/org/hyperledger/besu/nat/docker/DockerDetector.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/docker/DockerDetector.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 
 /** The Docker detector. */
 public class DockerDetector implements NatMethodDetector {
+  /** Default constructor */
+  public DockerDetector() {}
 
   @Override
   public Optional<NatMethod> detect() {

--- a/nat/src/main/java/org/hyperledger/besu/nat/docker/HostBasedIpDetector.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/docker/HostBasedIpDetector.java
@@ -25,6 +25,9 @@ public class HostBasedIpDetector implements IpDetector {
 
   private static final String HOSTNAME = "HOST_IP";
 
+  /** Default constructor */
+  public HostBasedIpDetector() {}
+
   @Override
   @SuppressWarnings("AddressSelection")
   public Optional<String> detectAdvertisedIp() {

--- a/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesDetector.java
+++ b/nat/src/main/java/org/hyperledger/besu/nat/kubernetes/KubernetesDetector.java
@@ -32,6 +32,9 @@ public class KubernetesDetector implements NatMethodDetector {
       Optional.ofNullable(System.getenv("KUBERNETES_SERVICE_HOST"));
   private static final Path KUBERNETES_WATERMARK_FILE = Paths.get("var/run/secrets/kubernetes.io");
 
+  /** Default constructor */
+  public KubernetesDetector() {}
+
   @Override
   public Optional<NatMethod> detect() {
     return KUBERNETES_SERVICE_HOST

--- a/pki/src/main/java/org/hyperledger/besu/pki/crl/CRLUtil.java
+++ b/pki/src/main/java/org/hyperledger/besu/pki/crl/CRLUtil.java
@@ -27,6 +27,8 @@ import java.util.stream.Collectors;
 
 /** The CRL util. */
 public class CRLUtil {
+  /** Default constructor */
+  private CRLUtil() {}
 
   /**
    * Load CRLs cert store.

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/configuration/RocksDBConfigurationBuilder.java
@@ -31,6 +31,9 @@ public class RocksDBConfigurationBuilder {
   private int backgroundThreadCount = DEFAULT_BACKGROUND_THREAD_COUNT;
   private boolean isHighSpec = DEFAULT_IS_HIGH_SPEC;
 
+  /** Instantiates a new Rocks db configuration builder. */
+  public RocksDBConfigurationBuilder() {}
+
   /**
    * Database dir.
    *

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
@@ -40,6 +40,9 @@ public class InMemoryStoragePlugin implements BesuPlugin {
   private InMemoryKeyValueStorageFactory factory;
   private InMemoryKeyValueStorageFactory privacyFactory;
 
+  /** Default constructor */
+  public InMemoryStoragePlugin() {}
+
   @Override
   public void register(final BesuContext context) {
     LOG.debug("Registering plugin");

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
@@ -290,6 +290,9 @@ public class SegmentedInMemoryKeyValueStorage
     /** protected access to deletedValues set for the transaction. */
     protected Map<SegmentIdentifier, Set<Bytes>> removedKeys = new HashMap<>();
 
+    /** Default constructor */
+    public SegmentedInMemoryTransaction() {}
+
     @Override
     public void put(
         final SegmentIdentifier segmentIdentifier, final byte[] key, final byte[] value) {

--- a/testutil/src/main/java/org/hyperledger/besu/kvstore/AbstractKeyValueStorageTest.java
+++ b/testutil/src/main/java/org/hyperledger/besu/kvstore/AbstractKeyValueStorageTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 /** The Abstract key value storage test. */
 @Disabled
 public abstract class AbstractKeyValueStorageTest {
+  /** Default Constructor */
+  protected AbstractKeyValueStorageTest() {}
 
   /**
    * Create store key value storage.

--- a/testutil/src/main/java/org/hyperledger/besu/testutil/MockExecutorService.java
+++ b/testutil/src/main/java/org/hyperledger/besu/testutil/MockExecutorService.java
@@ -36,6 +36,14 @@ public class MockExecutorService implements ExecutorService {
 
   private final List<ExecutorTask<?>> tasks = new ArrayList<>();
 
+  /** Default constructor */
+  public MockExecutorService() {}
+
+  /**
+   * Gets tasks.
+   *
+   * @return the tasks
+   */
   /**
    * Gets futures.
    *

--- a/testutil/src/main/java/org/hyperledger/besu/testutil/MockScheduledExecutor.java
+++ b/testutil/src/main/java/org/hyperledger/besu/testutil/MockScheduledExecutor.java
@@ -25,6 +25,8 @@ import java.util.concurrent.TimeoutException;
 
 /** The mock scheduled executor */
 public class MockScheduledExecutor extends MockExecutorService implements ScheduledExecutorService {
+  /** Default constructor */
+  public MockScheduledExecutor() {}
 
   @Override
   public ScheduledFuture<?> schedule(

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/EnclaveKeyUtils.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/EnclaveKeyUtils.java
@@ -34,6 +34,9 @@ import org.slf4j.LoggerFactory;
 public class EnclaveKeyUtils {
   private static final Logger LOG = LoggerFactory.getLogger(EnclaveKeyUtils.class);
 
+  /** Default constructor */
+  private EnclaveKeyUtils() {}
+
   /**
    * Utility method to load the enclave public key. Possible input values are the names of the *.pub
    * files in the resources folder.

--- a/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarnessFactory.java
+++ b/testutil/src/main/java/org/hyperledger/enclave/testutil/TesseraTestHarnessFactory.java
@@ -30,6 +30,9 @@ import org.testcontainers.containers.Network;
 public class TesseraTestHarnessFactory {
   private static final String storage = "memory";
 
+  /** Default constructor */
+  private TesseraTestHarnessFactory() {}
+
   /**
    * Create tessera test harness.
    *


### PR DESCRIPTION
## PR description
build: Add default constructor and javadoc for metrics, nat, pki, plugins, services, testutil, util
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

