### PR TITLE
javadoc - Adding default constructor and javadoc for :plugin-api

### DIFF
--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -70,7 +70,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'lRmKnDTcM8T+0wZqTBQYIK9SLnyxgUNQ9Cue93VMgwE='
+  knownHash = 'w+IKkNGNQSO4AECcQMEeYX0TriGTdBSFSx5e7e10yuk='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockTraceResult.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/BlockTraceResult.java
@@ -100,6 +100,9 @@ public class BlockTraceResult {
   public static class Builder {
     List<TransactionTraceResult> transactionTraceResults = new ArrayList<>();
 
+    /** Constructs a new builder instance. */
+    private Builder() {}
+
     /**
      * Adds a transaction trace result to the builder.
      *


### PR DESCRIPTION
## PR description
javadoc - Adding default constructor and javadoc for :plugin-api
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

