### PR TITLE
javadoc - Adding default constructor and javadoc for :ethereum:api

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStart.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStart.java
@@ -24,10 +24,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.CoinbaseNotSetException;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
+/** The type Miner start. */
 public class MinerStart implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Miner start.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public MinerStart(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStop.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerStop.java
@@ -21,10 +21,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
+/** The type Miner stop. */
 public class MinerStop implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Miner stop.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public MinerStop(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToAllowlist.java
@@ -27,10 +27,16 @@ import org.hyperledger.besu.ethereum.permissioning.AllowlistOperationResult;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Perm add accounts to allowlist. */
 public class PermAddAccountsToAllowlist implements JsonRpcMethod {
 
   private final Optional<AccountLocalConfigPermissioningController> allowlistController;
 
+  /**
+   * Instantiates a new Perm add accounts to allowlist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermAddAccountsToAllowlist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     this.allowlistController = allowlistController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddAccountsToWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 
 import java.util.Optional;
 
+/** The type Perm add accounts to whitelist. */
 @Deprecated
 public class PermAddAccountsToWhitelist extends PermAddAccountsToAllowlist {
 
+  /**
+   * Instantiates a new Perm add accounts to whitelist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermAddAccountsToWhitelist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     super(allowlistController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToAllowlist.java
@@ -29,11 +29,17 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import java.util.List;
 import java.util.Optional;
 
+/** The type Perm add nodes to allowlist. */
 public class PermAddNodesToAllowlist implements JsonRpcMethod {
 
   private final Optional<NodeLocalConfigPermissioningController>
       nodeAllowlistPermissioningController;
 
+  /**
+   * Instantiates a new Perm add nodes to allowlist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermAddNodesToAllowlist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     this.nodeAllowlistPermissioningController = nodeAllowlistPermissioningController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermAddNodesToWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 
 import java.util.Optional;
 
+/** The type Perm add nodes to whitelist. */
 @Deprecated
 public class PermAddNodesToWhitelist extends PermAddNodesToAllowlist {
 
+  /**
+   * Instantiates a new Perm add nodes to whitelist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermAddNodesToWhitelist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     super(nodeAllowlistPermissioningController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsAllowlist.java
@@ -25,10 +25,16 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 
 import java.util.Optional;
 
+/** The type Perm get accounts allowlist. */
 public class PermGetAccountsAllowlist implements JsonRpcMethod {
 
   private final Optional<AccountLocalConfigPermissioningController> allowlistController;
 
+  /**
+   * Instantiates a new Perm get accounts allowlist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermGetAccountsAllowlist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     this.allowlistController = allowlistController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetAccountsWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 
 import java.util.Optional;
 
+/** The type Perm get accounts whitelist. */
 @Deprecated
 public class PermGetAccountsWhitelist extends PermGetAccountsAllowlist {
 
+  /**
+   * Instantiates a new Perm get accounts whitelist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermGetAccountsWhitelist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     super(allowlistController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesAllowlist.java
@@ -27,11 +27,17 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import java.util.List;
 import java.util.Optional;
 
+/** The type Perm get nodes allowlist. */
 public class PermGetNodesAllowlist implements JsonRpcMethod {
 
   private final Optional<NodeLocalConfigPermissioningController>
       nodeAllowlistPermissioningController;
 
+  /**
+   * Instantiates a new Perm get nodes allowlist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermGetNodesAllowlist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     this.nodeAllowlistPermissioningController = nodeAllowlistPermissioningController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermGetNodesWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 
 import java.util.Optional;
 
+/** The type Perm get nodes whitelist. */
 @Deprecated
 public class PermGetNodesWhitelist extends PermGetNodesAllowlist {
 
+  /**
+   * Instantiates a new Perm get nodes whitelist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermGetNodesWhitelist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     super(nodeAllowlistPermissioningController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermReloadPermissionsFromFile.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermReloadPermissionsFromFile.java
@@ -26,11 +26,18 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 
 import java.util.Optional;
 
+/** The type Perm reload permissions from file. */
 public class PermReloadPermissionsFromFile implements JsonRpcMethod {
 
   private final Optional<AccountLocalConfigPermissioningController> accountAllowlistController;
   private final Optional<NodeLocalConfigPermissioningController> nodesAllowlistController;
 
+  /**
+   * Instantiates a new Perm reload permissions from file.
+   *
+   * @param accountAllowlistController the account allowlist controller
+   * @param nodesAllowlistController the nodes allowlist controller
+   */
   public PermReloadPermissionsFromFile(
       final Optional<AccountLocalConfigPermissioningController> accountAllowlistController,
       final Optional<NodeLocalConfigPermissioningController> nodesAllowlistController) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromAllowlist.java
@@ -27,10 +27,16 @@ import org.hyperledger.besu.ethereum.permissioning.AllowlistOperationResult;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Perm remove accounts from allowlist. */
 public class PermRemoveAccountsFromAllowlist implements JsonRpcMethod {
 
   private final Optional<AccountLocalConfigPermissioningController> allowlistController;
 
+  /**
+   * Instantiates a new Perm remove accounts from allowlist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermRemoveAccountsFromAllowlist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     this.allowlistController = allowlistController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveAccountsFromWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioni
 
 import java.util.Optional;
 
+/** The type Perm remove accounts from whitelist. */
 @Deprecated
 public class PermRemoveAccountsFromWhitelist extends PermRemoveAccountsFromAllowlist {
 
+  /**
+   * Instantiates a new Perm remove accounts from whitelist.
+   *
+   * @param allowlistController the allowlist controller
+   */
   public PermRemoveAccountsFromWhitelist(
       final Optional<AccountLocalConfigPermissioningController> allowlistController) {
     super(allowlistController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromAllowlist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromAllowlist.java
@@ -29,11 +29,17 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import java.util.List;
 import java.util.Optional;
 
+/** The type Perm remove nodes from allowlist. */
 public class PermRemoveNodesFromAllowlist implements JsonRpcMethod {
 
   private final Optional<NodeLocalConfigPermissioningController>
       nodeAllowlistPermissioningController;
 
+  /**
+   * Instantiates a new Perm remove nodes from allowlist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermRemoveNodesFromAllowlist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     this.nodeAllowlistPermissioningController = nodeAllowlistPermissioningController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/permissioning/PermRemoveNodesFromWhitelist.java
@@ -19,9 +19,15 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 
 import java.util.Optional;
 
+/** The type Perm remove nodes from whitelist. */
 @Deprecated
 public class PermRemoveNodesFromWhitelist extends PermRemoveNodesFromAllowlist {
 
+  /**
+   * Instantiates a new Perm remove nodes from whitelist.
+   *
+   * @param nodeAllowlistPermissioningController the node allowlist permissioning controller
+   */
   public PermRemoveNodesFromWhitelist(
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistPermissioningController) {
     super(nodeAllowlistPermissioningController);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameter.java
@@ -28,6 +28,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt64;
 
+/** The type Deposit parameter. */
 public class DepositParameter {
 
   private final String pubkey;
@@ -38,6 +39,15 @@ public class DepositParameter {
   private final String signature;
   private final String index;
 
+  /**
+   * Instantiates a new Deposit parameter.
+   *
+   * @param pubkey the pubkey
+   * @param withdrawalCredentials the withdrawal credentials
+   * @param amount the amount
+   * @param signature the signature
+   * @param index the index
+   */
   @JsonCreator
   public DepositParameter(
       @JsonProperty("pubkey") final String pubkey,
@@ -52,6 +62,12 @@ public class DepositParameter {
     this.index = index;
   }
 
+  /**
+   * From deposit deposit parameter.
+   *
+   * @param deposit the deposit
+   * @return the deposit parameter
+   */
   public static DepositParameter fromDeposit(final Deposit deposit) {
     return new DepositParameter(
         deposit.getPubkey().toString(),
@@ -61,6 +77,11 @@ public class DepositParameter {
         deposit.getIndex().toBytes().toQuantityHexString());
   }
 
+  /**
+   * To deposit deposit.
+   *
+   * @return the deposit
+   */
   public Deposit toDeposit() {
     return new Deposit(
         BLSPublicKey.fromHexString(pubkey),
@@ -70,6 +91,11 @@ public class DepositParameter {
         UInt64.fromHexString(index));
   }
 
+  /**
+   * As json object json object.
+   *
+   * @return the json object
+   */
   public JsonObject asJsonObject() {
     return new JsonObject()
         .put("pubkey", pubkey)
@@ -79,26 +105,51 @@ public class DepositParameter {
         .put("index", index);
   }
 
+  /**
+   * Gets pubkey.
+   *
+   * @return the pubkey
+   */
   @JsonGetter
   public String getPubkey() {
     return pubkey;
   }
 
+  /**
+   * Gets withdrawal credentials.
+   *
+   * @return the withdrawal credentials
+   */
   @JsonGetter
   public String getWithdrawalCredentials() {
     return withdrawalCredentials;
   }
 
+  /**
+   * Gets amount.
+   *
+   * @return the amount
+   */
   @JsonGetter
   public String getAmount() {
     return amount;
   }
 
+  /**
+   * Gets signature.
+   *
+   * @return the signature
+   */
   @JsonGetter
   public String getSignature() {
     return signature;
   }
 
+  /**
+   * Gets index.
+   *
+   * @return the index
+   */
   @JsonGetter
   public String getIndex() {
     return index;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/DepositParameter.java
@@ -63,7 +63,7 @@ public class DepositParameter {
   }
 
   /**
-   * From deposit deposit parameter.
+   * Deposit parameter from deposit.
    *
    * @param deposit the deposit
    * @return the deposit parameter
@@ -78,7 +78,7 @@ public class DepositParameter {
   }
 
   /**
-   * To deposit deposit.
+   * To deposit.
    *
    * @return the deposit
    */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineExchangeTransitionConfigurationParameter.java
@@ -20,11 +20,19 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Engine exchange transition configuration parameter. */
 public class EngineExchangeTransitionConfigurationParameter {
   private final Difficulty terminalTotalDifficulty;
   private final Hash terminalBlockHash;
   private final long terminalBlockNumber;
 
+  /**
+   * Instantiates a new Engine exchange transition configuration parameter.
+   *
+   * @param terminalTotalDifficulty the terminal total difficulty
+   * @param terminalBlockHash the terminal block hash
+   * @param terminalBlockNumber the terminal block number
+   */
   @JsonCreator
   public EngineExchangeTransitionConfigurationParameter(
       @JsonProperty("terminalTotalDifficulty") final String terminalTotalDifficulty,
@@ -35,24 +43,49 @@ public class EngineExchangeTransitionConfigurationParameter {
     this.terminalBlockNumber = terminalBlockNumber.getValue();
   }
 
+  /**
+   * Gets terminal total difficulty.
+   *
+   * @return the terminal total difficulty
+   */
   public Difficulty getTerminalTotalDifficulty() {
     return terminalTotalDifficulty;
   }
 
+  /**
+   * Gets terminal total difficulty as hex string.
+   *
+   * @return the terminal total difficulty as hex string
+   */
   @JsonProperty("terminalTotalDifficulty")
   public String getTerminalTotalDifficultyAsHexString() {
     return terminalTotalDifficulty.toShortHexString();
   }
 
+  /**
+   * Gets terminal block hash.
+   *
+   * @return the terminal block hash
+   */
   public Hash getTerminalBlockHash() {
     return terminalBlockHash;
   }
 
+  /**
+   * Gets terminal block hash as hex string.
+   *
+   * @return the terminal block hash as hex string
+   */
   @JsonProperty("terminalBlockHash")
   public String getTerminalBlockHashAsHexString() {
     return terminalBlockHash.toShortHexString();
   }
 
+  /**
+   * Gets terminal block number.
+   *
+   * @return the terminal block number
+   */
   public long getTerminalBlockNumber() {
     return terminalBlockNumber;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineForkchoiceUpdatedParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EngineForkchoiceUpdatedParameter.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Engine forkchoice updated parameter. */
 public class EngineForkchoiceUpdatedParameter {
   private final Hash headBlockHash;
 
@@ -26,18 +27,40 @@ public class EngineForkchoiceUpdatedParameter {
 
   private final Hash finalizedBlockHash;
 
+  /**
+   * Gets head block hash.
+   *
+   * @return the head block hash
+   */
   public Hash getHeadBlockHash() {
     return headBlockHash;
   }
 
+  /**
+   * Gets finalized block hash.
+   *
+   * @return the finalized block hash
+   */
   public Hash getFinalizedBlockHash() {
     return finalizedBlockHash;
   }
 
+  /**
+   * Gets safe block hash.
+   *
+   * @return the safe block hash
+   */
   public Hash getSafeBlockHash() {
     return safeBlockHash;
   }
 
+  /**
+   * Instantiates a new Engine forkchoice updated parameter.
+   *
+   * @param headBlockHash the head block hash
+   * @param finalizedBlockHash the finalized block hash
+   * @param safeBlockHash the safe block hash
+   */
   @JsonCreator
   public EngineForkchoiceUpdatedParameter(
       @JsonProperty("headBlockHash") final Hash headBlockHash,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -24,14 +24,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine payload attributes parameter. */
 public class EnginePayloadAttributesParameter {
 
+  /** The Timestamp. */
   final Long timestamp;
+
+  /** The Prev randao. */
   final Bytes32 prevRandao;
+
+  /** The Suggested fee recipient. */
   final Address suggestedFeeRecipient;
+
+  /** The Withdrawals. */
   final List<WithdrawalParameter> withdrawals;
+
   private final Bytes32 parentBeaconBlockRoot;
 
+  /**
+   * Instantiates a new Engine payload attributes parameter.
+   *
+   * @param timestamp the timestamp
+   * @param prevRandao the prev randao
+   * @param suggestedFeeRecipient the suggested fee recipient
+   * @param withdrawals the withdrawals
+   * @param parentBeaconBlockRoot the parent beacon block root
+   */
   @JsonCreator
   public EnginePayloadAttributesParameter(
       @JsonProperty("timestamp") final String timestamp,
@@ -47,26 +65,56 @@ public class EnginePayloadAttributesParameter {
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   public Long getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Gets prev randao.
+   *
+   * @return the prev randao
+   */
   public Bytes32 getPrevRandao() {
     return prevRandao;
   }
 
+  /**
+   * Gets suggested fee recipient.
+   *
+   * @return the suggested fee recipient
+   */
   public Address getSuggestedFeeRecipient() {
     return suggestedFeeRecipient;
   }
 
+  /**
+   * Gets parent beacon block root.
+   *
+   * @return the parent beacon block root
+   */
   public Bytes32 getParentBeaconBlockRoot() {
     return parentBeaconBlockRoot;
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @return the withdrawals
+   */
   public List<WithdrawalParameter> getWithdrawals() {
     return withdrawals;
   }
 
+  /**
+   * Serialize string.
+   *
+   * @return the string
+   */
   public String serialize() {
     final JsonObject json =
         new JsonObject()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadParameter.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine payload parameter. */
 public class EnginePayloadParameter {
   private final Hash blockHash;
   private final Hash parentHash;
@@ -112,78 +113,173 @@ public class EnginePayloadParameter {
     this.withdrawalRequests = withdrawalRequestParameters;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   public Hash getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets parent hash.
+   *
+   * @return the parent hash
+   */
   public Hash getParentHash() {
     return parentHash;
   }
 
+  /**
+   * Gets fee recipient.
+   *
+   * @return the fee recipient
+   */
   public Address getFeeRecipient() {
     return feeRecipient;
   }
 
+  /**
+   * Gets state root.
+   *
+   * @return the state root
+   */
   public Hash getStateRoot() {
     return stateRoot;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   public long getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets base fee per gas.
+   *
+   * @return the base fee per gas
+   */
   public Wei getBaseFeePerGas() {
     return baseFeePerGas;
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @return the gas limit
+   */
   public long getGasLimit() {
     return gasLimit;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   public long getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   public long getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Gets extra data.
+   *
+   * @return the extra data
+   */
   public String getExtraData() {
     return extraData;
   }
 
+  /**
+   * Gets receipts root.
+   *
+   * @return the receipts root
+   */
   public Hash getReceiptsRoot() {
     return receiptsRoot;
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   public LogsBloomFilter getLogsBloom() {
     return logsBloom;
   }
 
+  /**
+   * Gets prev randao.
+   *
+   * @return the prev randao
+   */
   public Bytes32 getPrevRandao() {
     return prevRandao;
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   public List<String> getTransactions() {
     return transactions;
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @return the withdrawals
+   */
   public List<WithdrawalParameter> getWithdrawals() {
     return withdrawals;
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @return the blob gas used
+   */
   public Long getBlobGasUsed() {
     return blobGasUsed;
   }
 
+  /**
+   * Gets excess blob gas.
+   *
+   * @return the excess blob gas
+   */
   public String getExcessBlobGas() {
     return excessBlobGas;
   }
 
+  /**
+   * Gets deposits.
+   *
+   * @return the deposits
+   */
   public List<DepositParameter> getDeposits() {
     return deposits;
   }
 
+  /**
+   * Gets withdrawal requests.
+   *
+   * @return the withdrawal requests
+   */
   public List<WithdrawalRequestParameter> getWithdrawalRequests() {
     return withdrawalRequests;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -25,14 +25,28 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine prepare payload parameter. */
 public class EnginePreparePayloadParameter {
   private final Optional<Hash> parentHash;
   private final Address feeRecipient;
   private final Bytes32 prevRandao;
   private final Optional<Long> timestamp;
+
+  /** The Withdrawals. */
   final List<WithdrawalParameter> withdrawals;
+
   private final Optional<Bytes32> parentBeaconBlockRoot;
 
+  /**
+   * Instantiates a new Engine prepare payload parameter.
+   *
+   * @param parentHash the parent hash
+   * @param feeRecipient the fee recipient
+   * @param timestamp the timestamp
+   * @param prevRandao the prev randao
+   * @param withdrawals the withdrawals
+   * @param parentBeaconBlockRoot the parent beacon block root
+   */
   @JsonCreator
   public EnginePreparePayloadParameter(
       @JsonProperty("parentHash") final Optional<Hash> parentHash,
@@ -49,26 +63,56 @@ public class EnginePreparePayloadParameter {
     this.parentBeaconBlockRoot = parentBeaconBlockRoot;
   }
 
+  /**
+   * Gets parent hash.
+   *
+   * @return the parent hash
+   */
   public Optional<Hash> getParentHash() {
     return parentHash;
   }
 
+  /**
+   * Gets fee recipient.
+   *
+   * @return the fee recipient
+   */
   public Address getFeeRecipient() {
     return feeRecipient;
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   public Optional<Long> getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Gets prev randao.
+   *
+   * @return the prev randao
+   */
   public Bytes32 getPrevRandao() {
     return prevRandao;
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @return the withdrawals
+   */
   public List<WithdrawalParameter> getWithdrawals() {
     return withdrawals;
   }
 
+  /**
+   * Gets parent beacon block root.
+   *
+   * @return the parent beacon block root
+   */
   public Optional<Bytes32> getParentBeaconBlockRoot() {
     return parentBeaconBlockRoot;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/FilterParameter.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+/** The type Filter parameter. */
 public class FilterParameter {
 
   private final BlockParameter fromBlock;
@@ -44,6 +45,19 @@ public class FilterParameter {
   private final Optional<Integer> after, count;
   private final boolean isValid;
 
+  /**
+   * Instantiates a new Filter parameter.
+   *
+   * @param fromBlock the from block
+   * @param toBlock the to block
+   * @param fromAddress the from address
+   * @param toAddress the to address
+   * @param address the address
+   * @param topics the topics
+   * @param blockHash the block hash
+   * @param after the after
+   * @param count the count
+   */
   @JsonCreator
   public FilterParameter(
       @JsonProperty("fromBlock") final BlockParameter fromBlock,
@@ -73,42 +87,92 @@ public class FilterParameter {
     this.count = Optional.ofNullable(count);
   }
 
+  /**
+   * Gets from block.
+   *
+   * @return the from block
+   */
   public BlockParameter getFromBlock() {
     return fromBlock;
   }
 
+  /**
+   * Gets to block.
+   *
+   * @return the to block
+   */
   public BlockParameter getToBlock() {
     return toBlock;
   }
 
+  /**
+   * Gets from address.
+   *
+   * @return the from address
+   */
   public List<Address> getFromAddress() {
     return fromAddress;
   }
 
+  /**
+   * Gets to address.
+   *
+   * @return the to address
+   */
   public List<Address> getToAddress() {
     return toAddress;
   }
 
+  /**
+   * Gets addresses.
+   *
+   * @return the addresses
+   */
   public List<Address> getAddresses() {
     return addresses;
   }
 
+  /**
+   * Gets topics.
+   *
+   * @return the topics
+   */
   public List<List<LogTopic>> getTopics() {
     return topics;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   public Optional<Hash> getBlockHash() {
     return maybeBlockHash;
   }
 
+  /**
+   * Gets logs query.
+   *
+   * @return the logs query
+   */
   public LogsQuery getLogsQuery() {
     return logsQuery;
   }
 
+  /**
+   * Gets after.
+   *
+   * @return the after
+   */
   public Optional<Integer> getAfter() {
     return after;
   }
 
+  /**
+   * Gets count.
+   *
+   * @return the count
+   */
   public Optional<Integer> getCount() {
     return count;
   }
@@ -175,6 +239,11 @@ public class FilterParameter {
         + '}';
   }
 
+  /**
+   * Is valid boolean.
+   *
+   * @return the boolean
+   */
   public boolean isValid() {
     return isValid;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonCallParameter.java
@@ -34,6 +34,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json call parameter. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JsonCallParameter extends CallParameter {
 
@@ -41,6 +42,23 @@ public class JsonCallParameter extends CallParameter {
 
   private final Optional<Boolean> strict;
 
+  /**
+   * Instantiates a new Json call parameter.
+   *
+   * @param from the from
+   * @param to the to
+   * @param gasLimit the gas limit
+   * @param gasPrice the gas price
+   * @param maxPriorityFeePerGas the max priority fee per gas
+   * @param maxFeePerGas the max fee per gas
+   * @param value the value
+   * @param data the data
+   * @param input the input
+   * @param strict the strict
+   * @param accessList the access list
+   * @param maxFeePerBlobGas the max fee per blob gas
+   * @param blobVersionedHashes the blob versioned hashes
+   */
   @JsonCreator
   public JsonCallParameter(
       @JsonProperty("from") final Address from,
@@ -78,10 +96,21 @@ public class JsonCallParameter extends CallParameter {
     this.strict = Optional.ofNullable(strict);
   }
 
+  /**
+   * Is maybe strict optional.
+   *
+   * @return the optional
+   */
   public Optional<Boolean> isMaybeStrict() {
     return strict;
   }
 
+  /**
+   * Log unknown properties.
+   *
+   * @param key the key
+   * @param value the value
+   */
   @JsonAnySetter
   public void logUnknownProperties(final String key, final Object value) {
     LOG.debug(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonRpcParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/JsonRpcParameter.java
@@ -24,20 +24,24 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
+/** The type Json rpc parameter. */
 public class JsonRpcParameter {
 
   private static final ObjectMapper mapper =
       new ObjectMapper()
           .registerModule(new Jdk8Module()); // Handle JDK8 Optionals (de)serialization
 
+  /** Default constructor. */
+  public JsonRpcParameter() {}
+
   /**
    * Retrieves a required parameter at the given index interpreted as the given class. Throws
    * InvalidJsonRpcParameters if parameter is missing or of the wrong type.
    *
+   * @param <T> The type of parameter.
    * @param params the list of objects from which to extract a typed object.
    * @param index Which index of the params array to access.
    * @param paramClass What type is expected at this index.
-   * @param <T> The type of parameter.
    * @return Returns the parameter cast as T if available, otherwise throws exception.
    */
   public <T> T required(final Object[] params, final int index, final Class<T> paramClass) {
@@ -52,10 +56,10 @@ public class JsonRpcParameter {
    * Retrieves an optional parameter at the given index interpreted as the given class. Throws
    * InvalidJsonRpcParameters if parameter is of the wrong type.
    *
+   * @param <T> The type of parameter.
    * @param params the list of objects from which to extract a typed object.
    * @param index Which index of the params array to access.
    * @param paramClass What type is expected at this index.
-   * @param <T> The type of parameter.
    * @return Returns the parameter cast as T if available.
    */
   @SuppressWarnings("unchecked")
@@ -87,6 +91,15 @@ public class JsonRpcParameter {
     return Optional.of(param);
   }
 
+  /**
+   * Optional list optional.
+   *
+   * @param <T> the type parameter
+   * @param params the params
+   * @param index the index
+   * @param listClass the list class
+   * @return the optional
+   */
   public <T> Optional<List<T>> optionalList(
       final Object[] params, final int index, final Class<T> listClass) {
     if (params == null || params.length <= index || params[index] == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PendingTransactionsParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/PendingTransactionsParams.java
@@ -37,11 +37,22 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Pending transactions params. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PendingTransactionsParams {
 
   private final Map<String, String> from, to, gas, gasPrice, value, nonce;
 
+  /**
+   * Instantiates a new Pending transactions params.
+   *
+   * @param from the from
+   * @param to the to
+   * @param gas the gas
+   * @param gasPrice the gas price
+   * @param value the value
+   * @param nonce the nonce
+   */
   @JsonCreator()
   public PendingTransactionsParams(
       @JsonProperty(FROM_FIELD) final Map<String, String> from,
@@ -58,6 +69,12 @@ public class PendingTransactionsParams {
     this.nonce = nonce;
   }
 
+  /**
+   * Filters list.
+   *
+   * @return the list
+   * @throws IllegalArgumentException the illegal argument exception
+   */
   public List<Filter> filters() throws IllegalArgumentException {
     final List<Filter> createdFilters = new ArrayList<>();
     getFilter(FROM_FIELD, from).ifPresent(createdFilters::add);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StringListParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/StringListParameter.java
@@ -19,10 +19,16 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+/** The type String list parameter. */
 public class StringListParameter {
 
   private final List<String> stringList = new ArrayList<>();
 
+  /**
+   * Instantiates a new String list parameter.
+   *
+   * @param strings the strings
+   */
   @JsonCreator
   public StringListParameter(final List<String> strings) {
     if (strings != null) {
@@ -30,6 +36,11 @@ public class StringListParameter {
     }
   }
 
+  /**
+   * Gets string list.
+   *
+   * @return the string list
+   */
   public List<String> getStringList() {
     return stringList;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TopicsDeserializer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TopicsDeserializer.java
@@ -27,11 +27,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.google.common.collect.Lists;
 
+/** The type Topics deserializer. */
 public class TopicsDeserializer extends StdDeserializer<List<List<LogTopic>>> {
+  /** Instantiates a new Topics deserializer. */
   public TopicsDeserializer() {
     this(null);
   }
 
+  /**
+   * Instantiates a new Topics deserializer.
+   *
+   * @param vc the vc
+   */
   public TopicsDeserializer(final Class<?> vc) {
     super(vc);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceCallManyParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceCallManyParameter.java
@@ -24,9 +24,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
+/** The type Trace call many parameter. */
 public class TraceCallManyParameter {
+  /** The Params. */
   TraceCallParameterTuple params;
 
+  /**
+   * Instantiates a new Trace call many parameter.
+   *
+   * @param parameters the parameters
+   */
   @JsonCreator
   public TraceCallManyParameter(
       @JsonDeserialize(using = TraceCallParameterDeserializer.class)
@@ -34,17 +41,29 @@ public class TraceCallManyParameter {
     this.params = parameters;
   }
 
+  /**
+   * Gets tuple.
+   *
+   * @return the tuple
+   */
   public TraceCallParameterTuple getTuple() {
     return this.params;
   }
 }
 
+/** The type Trace call parameter deserializer. */
 class TraceCallParameterDeserializer extends StdDeserializer<TraceCallParameterTuple> {
 
+  /**
+   * Instantiates a new Trace call parameter deserializer.
+   *
+   * @param vc the vc
+   */
   public TraceCallParameterDeserializer(final Class<?> vc) {
     super(vc);
   }
 
+  /** Instantiates a new Trace call parameter deserializer. */
   public TraceCallParameterDeserializer() {
     this(null);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceCallParameterTuple.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceCallParameterTuple.java
@@ -14,20 +14,37 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 
+/** The type Trace call parameter tuple. */
 public class TraceCallParameterTuple {
   private final JsonCallParameter jsonCallParameter;
   private final TraceTypeParameter traceTypeParameter;
 
+  /**
+   * Instantiates a new Trace call parameter tuple.
+   *
+   * @param callParameter the call parameter
+   * @param traceTypeParameter the trace type parameter
+   */
   public TraceCallParameterTuple(
       final JsonCallParameter callParameter, final TraceTypeParameter traceTypeParameter) {
     this.jsonCallParameter = callParameter;
     this.traceTypeParameter = traceTypeParameter;
   }
 
+  /**
+   * Gets json call parameter.
+   *
+   * @return the json call parameter
+   */
   public JsonCallParameter getJsonCallParameter() {
     return jsonCallParameter;
   }
 
+  /**
+   * Gets trace type parameter.
+   *
+   * @return the trace type parameter
+   */
   public TraceTypeParameter getTraceTypeParameter() {
     return traceTypeParameter;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceTypeParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TraceTypeParameter.java
@@ -25,13 +25,24 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+/** The type Trace type parameter. */
 public class TraceTypeParameter {
 
+  /** The enum Trace type. */
   public enum TraceType {
+    /** Trace trace type. */
     TRACE,
+    /** Vm trace trace type. */
     VM_TRACE,
+    /** State diff trace type. */
     STATE_DIFF;
 
+    /**
+     * From string trace type.
+     *
+     * @param traceType the trace type
+     * @return the trace type
+     */
     @JsonCreator
     static TraceType fromString(final String traceType) {
       if (traceType.equalsIgnoreCase("trace")) {
@@ -49,6 +60,11 @@ public class TraceTypeParameter {
 
   private final Set<TraceType> traceTypes;
 
+  /**
+   * Instantiates a new Trace type parameter.
+   *
+   * @param traceTypesInput the trace types input
+   */
   @JsonCreator
   public TraceTypeParameter(final List<String> traceTypesInput) {
     validateTraceTypes(traceTypesInput);
@@ -60,6 +76,11 @@ public class TraceTypeParameter {
             .collect(Collectors.toSet());
   }
 
+  /**
+   * Gets trace types.
+   *
+   * @return the trace types
+   */
   public Set<TraceType> getTraceTypes() {
     return traceTypes;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/TransactionTraceParams.java
@@ -24,34 +24,60 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+/** The interface Transaction trace params. */
 @Value.Immutable
 @JsonSerialize(as = ImmutableTransactionTraceParams.class)
 @JsonDeserialize(as = ImmutableTransactionTraceParams.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface TransactionTraceParams {
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonProperty("txHash")
   @Nullable
   String getTransactionHash();
 
+  /**
+   * Disable storage boolean.
+   *
+   * @return the boolean
+   */
   @JsonProperty(value = "disableStorage")
   @Value.Default
   default boolean disableStorage() {
     return false;
   }
 
+  /**
+   * Disable memory boolean.
+   *
+   * @return the boolean
+   */
   @JsonProperty(value = "disableMemory")
   @Value.Default
   default boolean disableMemory() {
     return false;
   }
 
+  /**
+   * Disable stack boolean.
+   *
+   * @return the boolean
+   */
   @JsonProperty(value = "disableStack")
   @Value.Default
   default boolean disableStack() {
     return false;
   }
 
+  /**
+   * Trace options trace options.
+   *
+   * @return the trace options
+   */
   default TraceOptions traceOptions() {
     return new TraceOptions(!disableStorage(), !disableMemory(), !disableStack());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UInt256Parameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UInt256Parameter.java
@@ -17,15 +17,26 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type U int 256 parameter. */
 public class UInt256Parameter {
 
   private final UInt256 value;
 
+  /**
+   * Instantiates a new U int 256 parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public UInt256Parameter(final String value) {
     this.value = UInt256.fromHexString(value);
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   public UInt256 getValue() {
     return value;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedIntParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedIntParameter.java
@@ -18,22 +18,38 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+/** The type Unsigned int parameter. */
 public class UnsignedIntParameter {
 
   private final int value;
 
+  /**
+   * Instantiates a new Unsigned int parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public UnsignedIntParameter(final String value) {
     this.value = Integer.decode(value);
     checkArgument(this.value >= 0);
   }
 
+  /**
+   * Instantiates a new Unsigned int parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public UnsignedIntParameter(final int value) {
     this.value = value;
     checkArgument(this.value >= 0);
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   public int getValue() {
     return value;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/UnsignedLongParameter.java
@@ -19,10 +19,16 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import org.checkerframework.checker.signedness.qual.Unsigned;
 
+/** The type Unsigned long parameter. */
 public class UnsignedLongParameter {
 
   @Unsigned private final long value;
 
+  /**
+   * Instantiates a new Unsigned long parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public UnsignedLongParameter(final String value) {
     checkArgument(value != null);
@@ -33,11 +39,21 @@ public class UnsignedLongParameter {
     }
   }
 
+  /**
+   * Instantiates a new Unsigned long parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public UnsignedLongParameter(final @Unsigned long value) {
     this.value = value;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   public @Unsigned long getValue() {
     return value;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalParameter.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.units.bigints.UInt64;
 
+/** The type Withdrawal parameter. */
 public class WithdrawalParameter {
 
   private final String index;
@@ -33,6 +34,14 @@ public class WithdrawalParameter {
   private final String address;
   private final String amount;
 
+  /**
+   * Instantiates a new Withdrawal parameter.
+   *
+   * @param index the index
+   * @param validatorIndex the validator index
+   * @param address the address
+   * @param amount the amount
+   */
   @JsonCreator
   public WithdrawalParameter(
       @JsonProperty("index") final String index,
@@ -45,6 +54,12 @@ public class WithdrawalParameter {
     this.amount = amount;
   }
 
+  /**
+   * From withdrawal withdrawal parameter.
+   *
+   * @param withdrawal the withdrawal
+   * @return the withdrawal parameter
+   */
   public static WithdrawalParameter fromWithdrawal(final Withdrawal withdrawal) {
     return new WithdrawalParameter(
         withdrawal.getIndex().toBytes().toQuantityHexString(),
@@ -53,6 +68,11 @@ public class WithdrawalParameter {
         withdrawal.getAmount().toShortHexString());
   }
 
+  /**
+   * To withdrawal withdrawal.
+   *
+   * @return the withdrawal
+   */
   public Withdrawal toWithdrawal() {
     return new Withdrawal(
         UInt64.fromHexString(index),
@@ -61,6 +81,11 @@ public class WithdrawalParameter {
         GWei.fromHexString(amount));
   }
 
+  /**
+   * As json object json object.
+   *
+   * @return the json object
+   */
   public JsonObject asJsonObject() {
     return new JsonObject()
         .put("index", index)
@@ -69,21 +94,41 @@ public class WithdrawalParameter {
         .put("amount", amount);
   }
 
+  /**
+   * Gets index.
+   *
+   * @return the index
+   */
   @JsonGetter
   public String getIndex() {
     return index;
   }
 
+  /**
+   * Gets validator index.
+   *
+   * @return the validator index
+   */
   @JsonGetter
   public String getValidatorIndex() {
     return validatorIndex;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   @JsonGetter
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Gets amount.
+   *
+   * @return the amount
+   */
   @JsonGetter
   public String getAmount() {
     return amount;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalRequestParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalRequestParameter.java
@@ -26,12 +26,20 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 
+/** The type Withdrawal request parameter. */
 public class WithdrawalRequestParameter {
 
   private final String sourceAddress;
   private final String validatorPubKey;
   private final String amount;
 
+  /**
+   * Instantiates a new Withdrawal request parameter.
+   *
+   * @param sourceAddress the source address
+   * @param validatorPubKey the validator pub key
+   * @param amount the amount
+   */
   @JsonCreator
   public WithdrawalRequestParameter(
       @JsonProperty("sourceAddress") final String sourceAddress,
@@ -42,6 +50,12 @@ public class WithdrawalRequestParameter {
     this.amount = amount;
   }
 
+  /**
+   * From withdrawal request withdrawal request parameter.
+   *
+   * @param withdrawalRequest the withdrawal request
+   * @return the withdrawal request parameter
+   */
   public static WithdrawalRequestParameter fromWithdrawalRequest(
       final WithdrawalRequest withdrawalRequest) {
     return new WithdrawalRequestParameter(
@@ -50,6 +64,11 @@ public class WithdrawalRequestParameter {
         withdrawalRequest.getAmount().toShortHexString());
   }
 
+  /**
+   * To withdrawal request withdrawal request.
+   *
+   * @return the withdrawal request
+   */
   public WithdrawalRequest toWithdrawalRequest() {
     return new WithdrawalRequest(
         Address.fromHexString(sourceAddress),
@@ -57,6 +76,11 @@ public class WithdrawalRequestParameter {
         GWei.fromHexString(amount));
   }
 
+  /**
+   * As json object json object.
+   *
+   * @return the json object
+   */
   public JsonObject asJsonObject() {
     return new JsonObject()
         .put("sourceAddress", sourceAddress)
@@ -64,16 +88,31 @@ public class WithdrawalRequestParameter {
         .put("amount", amount);
   }
 
+  /**
+   * Gets source address.
+   *
+   * @return the source address
+   */
   @JsonGetter
   public String getSourceAddress() {
     return sourceAddress;
   }
 
+  /**
+   * Gets validator pub key.
+   *
+   * @return the validator pub key
+   */
   @JsonGetter
   public String getValidatorPubKey() {
     return validatorPubKey;
   }
 
+  /**
+   * Gets amount.
+   *
+   * @return the amount
+   */
   @JsonGetter
   public String getAmount() {
     return amount;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/DisabledPrivacyRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/DisabledPrivacyRpcMethod.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
+/** The type Disabled privacy rpc method. */
 public class DisabledPrivacyRpcMethod implements JsonRpcMethod {
 
   private final String methodName;
@@ -29,6 +30,11 @@ public class DisabledPrivacyRpcMethod implements JsonRpcMethod {
     return methodName;
   }
 
+  /**
+   * Instantiates a new Disabled privacy rpc method.
+   *
+   * @param methodName the method name
+   */
   public DisabledPrivacyRpcMethod(final String methodName) {
     this.methodName = methodName;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecorator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecorator.java
@@ -27,10 +27,16 @@ import io.vertx.ext.auth.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Multi tenancy rpc method decorator. */
 public class MultiTenancyRpcMethodDecorator implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(MultiTenancyRpcMethodDecorator.class);
   private final JsonRpcMethod rpcMethod;
 
+  /**
+   * Instantiates a new Multi tenancy rpc method decorator.
+   *
+   * @param rpcMethod the rpc method
+   */
   public MultiTenancyRpcMethodDecorator(final JsonRpcMethod rpcMethod) {
     this.rpcMethod = rpcMethod;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtil.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtil.java
@@ -18,10 +18,20 @@ import java.util.Optional;
 
 import io.vertx.ext.auth.User;
 
+/** The type Multi tenancy user util. */
 public class MultiTenancyUserUtil {
   private static final String PRIVACY_USER_ID_CLAIM = "privacyUserId";
   private static final String ENCLAVE_PRIVACY_PUBLIC_KEY_CLAIM = "privacyPublicKey";
 
+  /** Default constructor. */
+  private MultiTenancyUserUtil() {}
+
+  /**
+   * Privacy user id optional.
+   *
+   * @param user the user
+   * @return the optional
+   */
   public static Optional<String> privacyUserId(final Optional<User> user) {
     return user.map(
         u -> {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterChanges.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterChanges.java
@@ -29,12 +29,20 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.List;
 
+/** The type Priv get filter changes. */
 public class PrivGetFilterChanges implements JsonRpcMethod {
 
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Priv get filter changes.
+   *
+   * @param filterManager the filter manager
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetFilterChanges(
       final FilterManager filterManager,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterLogs.java
@@ -29,12 +29,20 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.List;
 
+/** The type Priv get filter logs. */
 public class PrivGetFilterLogs implements JsonRpcMethod {
 
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Priv get filter logs.
+   *
+   * @param filterManager the filter manager
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetFilterLogs(
       final FilterManager filterManager,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivUninstallFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivUninstallFilter.java
@@ -23,12 +23,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Priv uninstall filter. */
 public class PrivUninstallFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv uninstall filter.
+   *
+   * @param filterManager the filter manager
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivUninstallFilter(
       final FilterManager filterManager,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacyIdProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacyIdProvider.java
@@ -22,11 +22,24 @@ import java.util.Optional;
 
 import io.vertx.ext.auth.User;
 
+/** The interface Privacy id provider. */
 @FunctionalInterface
 public interface PrivacyIdProvider {
 
+  /**
+   * Gets privacy user id.
+   *
+   * @param user the user
+   * @return the privacy user id
+   */
   String getPrivacyUserId(Optional<User> user);
 
+  /**
+   * Build privacy id provider.
+   *
+   * @param privacyParameters the privacy parameters
+   * @return the privacy id provider
+   */
   static PrivacyIdProvider build(final PrivacyParameters privacyParameters) {
     if (privacyParameters.isMultiTenancyEnabled()) {
       return multiTenancyPrivacyUserIdProvider();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/JsonRpcErrorResponseException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/JsonRpcErrorResponseException.java
@@ -16,15 +16,27 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.eea;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
+/** The type Json rpc error response exception. */
 public class JsonRpcErrorResponseException extends RuntimeException {
 
+  /** The Json rpc error. */
   private final RpcErrorType jsonRpcError;
 
+  /**
+   * Instantiates a new Json rpc error response exception.
+   *
+   * @param error the error
+   */
   public JsonRpcErrorResponseException(final RpcErrorType error) {
     super();
     this.jsonRpcError = error;
   }
 
+  /**
+   * Gets json rpc error.
+   *
+   * @return the json rpc error
+   */
   public RpcErrorType getJsonRpcError() {
     return jsonRpcError;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransaction.java
@@ -33,11 +33,22 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Plugin eea send raw transaction. */
 public class PluginEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
   private final GasCalculator gasCalculator;
 
+  /**
+   * Instantiates a new Plugin eea send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   * @param privacyIdProvider the privacy id provider
+   * @param privateMarkerTransactionFactory the private marker transaction factory
+   * @param publicNonceProvider the public nonce provider
+   * @param privacyController the privacy controller
+   * @param gasCalculator the gas calculator
+   */
   public PluginEeaSendRawTransaction(
       final TransactionPool transactionPool,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransaction.java
@@ -37,11 +37,21 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Restricted flexible eea send raw transaction. */
 public class RestrictedFlexibleEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
 
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Restricted flexible eea send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   * @param privacyIdProvider the privacy id provider
+   * @param privateMarkerTransactionFactory the private marker transaction factory
+   * @param publicNonceProvider the public nonce provider
+   * @param privacyController the privacy controller
+   */
   public RestrictedFlexibleEeaSendRawTransaction(
       final TransactionPool transactionPool,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransaction.java
@@ -35,11 +35,23 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Restricted offchain eea send raw transaction. */
 public class RestrictedOffchainEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
 
+  /** The Privacy controller. */
   final PrivacyController privacyController;
+
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Restricted offchain eea send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   * @param privacyIdProvider the privacy id provider
+   * @param privateMarkerTransactionFactory the private marker transaction factory
+   * @param publicNonceProvider the public nonce provider
+   * @param privacyController the privacy controller
+   */
   public RestrictedOffchainEeaSendRawTransaction(
       final TransactionPool transactionPool,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
@@ -32,11 +32,19 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
+/** The type Priv call. */
 public class PrivCall extends AbstractBlockParameterMethod {
 
   private final PrivacyIdProvider privacyIdProvider;
   private final PrivacyController privacyController;
 
+  /**
+   * Instantiates a new Priv call.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivCall(
       final BlockchainQueries blockchainQueries,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
@@ -29,12 +29,19 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv create privacy group. */
 public class PrivCreatePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivCreatePrivacyGroup.class);
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv create privacy group.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivCreatePrivacyGroup(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRoot.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRoot.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv debug get state root. */
 public class PrivDebugGetStateRoot extends AbstractBlockParameterMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDebugGetStateRoot.class);
@@ -44,6 +45,13 @@ public class PrivDebugGetStateRoot extends AbstractBlockParameterMethod {
   private final PrivacyIdProvider privacyIdProvider;
   private final PrivacyController privacyController;
 
+  /**
+   * Instantiates a new Priv debug get state root.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param privacyIdProvider the privacy id provider
+   * @param privacyController the privacy controller
+   */
   public PrivDebugGetStateRoot(
       final BlockchainQueries blockchainQueries,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
@@ -29,12 +29,19 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv delete privacy group. */
 public class PrivDeletePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDeletePrivacyGroup.class);
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv delete privacy group.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivDeletePrivacyGroup(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
@@ -46,6 +46,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv distribute raw transaction. */
 public class PrivDistributeRawTransaction implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDistributeRawTransaction.class);
@@ -53,6 +54,13 @@ public class PrivDistributeRawTransaction implements JsonRpcMethod {
   private final PrivacyIdProvider privacyIdProvider;
   private final boolean flexiblePrivacyGroupsEnabled;
 
+  /**
+   * Instantiates a new Priv distribute raw transaction.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   * @param flexiblePrivacyGroupsEnabled the flexible privacy groups enabled
+   */
   public PrivDistributeRawTransaction(
       final PrivacyController privacyController,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv find privacy group. */
 @SuppressWarnings("MockNotUsedInProduction")
 public class PrivFindPrivacyGroup implements JsonRpcMethod {
 
@@ -40,6 +41,12 @@ public class PrivFindPrivacyGroup implements JsonRpcMethod {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv find privacy group.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivFindPrivacyGroup(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
@@ -25,11 +25,19 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Priv get code. */
 public class PrivGetCode extends AbstractBlockParameterMethod {
 
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get code.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetCode(
       final BlockchainQueries blockchainQueries,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
@@ -40,6 +40,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv get eea transaction count. */
 public class PrivGetEeaTransactionCount implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetEeaTransactionCount.class);
@@ -47,6 +48,12 @@ public class PrivGetEeaTransactionCount implements JsonRpcMethod {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get eea transaction count.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetEeaTransactionCount(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Priv get logs. */
 public class PrivGetLogs implements JsonRpcMethod {
 
   private final BlockchainQueries blockchainQueries;
@@ -43,6 +44,14 @@ public class PrivGetLogs implements JsonRpcMethod {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get logs.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param privacyQueries the privacy queries
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetLogs(
       final BlockchainQueries blockchainQueries,
       final PrivacyQueries privacyQueries,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
@@ -22,10 +22,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
+/** The type Priv get privacy precompile address. */
 public class PrivGetPrivacyPrecompileAddress implements JsonRpcMethod {
 
   private final Address privacyAddress;
 
+  /**
+   * Instantiates a new Priv get privacy precompile address.
+   *
+   * @param privacyParameters the privacy parameters
+   */
   public PrivGetPrivacyPrecompileAddress(final PrivacyParameters privacyParameters) {
     privacyAddress = privacyParameters.getPrivacyAddress();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv get private transaction. */
 public class PrivGetPrivateTransaction implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetPrivateTransaction.class);
@@ -42,6 +43,12 @@ public class PrivGetPrivateTransaction implements JsonRpcMethod {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get private transaction.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetPrivateTransaction(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
@@ -32,12 +32,19 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv get transaction count. */
 public class PrivGetTransactionCount implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetTransactionCount.class);
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get transaction count.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetTransactionCount(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -41,6 +41,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Priv get transaction receipt. */
 public class PrivGetTransactionReceipt implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetTransactionReceipt.class);
@@ -49,6 +50,13 @@ public class PrivGetTransactionReceipt implements JsonRpcMethod {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv get transaction receipt.
+   *
+   * @param privateStateStorage the private state storage
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivGetTransactionReceipt(
       final PrivateStateStorage privateStateStorage,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
@@ -27,12 +27,20 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Priv new filter. */
 public class PrivNewFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Priv new filter.
+   *
+   * @param filterManager the filter manager
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivNewFilter(
       final FilterManager filterManager,
       final PrivacyController privacyController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUtil.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUtil.java
@@ -20,8 +20,20 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.Optional;
 
+/** The type Priv util. */
 public class PrivUtil {
+  /** Default constructor. */
+  private PrivUtil() {}
 
+  /**
+   * Check membership for authenticated user.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   * @param request the request
+   * @param privacyGroupId the privacy group id
+   * @param blockNumber the block number
+   */
   public static void checkMembershipForAuthenticatedUser(
       final PrivacyController privacyController,
       final PrivacyIdProvider privacyIdProvider,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroup.java
@@ -33,12 +33,19 @@ import graphql.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Privx find flexible privacy group. */
 public class PrivxFindFlexiblePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivxFindFlexiblePrivacyGroup.class);
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Privx find flexible privacy group.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivxFindFlexiblePrivacyGroup(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     this.privacyController = privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindOnchainPrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindOnchainPrivacyGroup.java
@@ -18,10 +18,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacyIdProvider;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Privx find onchain privacy group. */
 // Use PrivxFindFlexiblePrivacyGroup instead
 @Deprecated
 public class PrivxFindOnchainPrivacyGroup extends PrivxFindFlexiblePrivacyGroup {
 
+  /**
+   * Instantiates a new Privx find onchain privacy group.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivxFindOnchainPrivacyGroup(
       final PrivacyController privacyController, final PrivacyIdProvider privacyIdProvider) {
     super(privacyController, privacyIdProvider);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/parameters/CreatePrivacyGroupParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/parameters/CreatePrivacyGroupParameter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Create privacy group parameter. */
 public class CreatePrivacyGroupParameter {
 
   private final List<String> addresses;
@@ -30,6 +31,13 @@ public class CreatePrivacyGroupParameter {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final String description;
 
+  /**
+   * Instantiates a new Create privacy group parameter.
+   *
+   * @param addresses the addresses
+   * @param name the name
+   * @param description the description
+   */
   @JsonCreator
   public CreatePrivacyGroupParameter(
       @JsonProperty(value = "addresses", required = true) final List<String> addresses,
@@ -40,14 +48,29 @@ public class CreatePrivacyGroupParameter {
     this.description = description;
   }
 
+  /**
+   * Gets addresses.
+   *
+   * @return the addresses
+   */
   public List<String> getAddresses() {
     return addresses;
   }
 
+  /**
+   * Gets name.
+   *
+   * @return the name
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * Gets description.
+   *
+   * @return the description
+   */
   public String getDescription() {
     return description;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/Tracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/Tracer.java
@@ -28,8 +28,20 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Tracer. */
 public class Tracer {
+  /** Default constructor. */
+  private Tracer() {}
 
+  /**
+   * Process tracing optional.
+   *
+   * @param <TRACE> the type parameter
+   * @param blockchainQueries the blockchain queries
+   * @param blockHash the block hash
+   * @param mapper the mapper
+   * @return the optional
+   */
   public static <TRACE> Optional<TRACE> processTracing(
       final BlockchainQueries blockchainQueries,
       final Hash blockHash,
@@ -38,6 +50,15 @@ public class Tracer {
         blockchainQueries, blockchainQueries.getBlockHeaderByHash(blockHash), mapper);
   }
 
+  /**
+   * Process tracing optional.
+   *
+   * @param <TRACE> the type parameter
+   * @param blockchainQueries the blockchain queries
+   * @param blockHeader the block header
+   * @param mapper the mapper
+   * @return the optional
+   */
   public static <TRACE> Optional<TRACE> processTracing(
       final BlockchainQueries blockchainQueries,
       final Optional<BlockHeader> blockHeader,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTrace.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Transaction trace. */
 public class TransactionTrace {
 
   private final Transaction transaction;
@@ -29,6 +30,11 @@ public class TransactionTrace {
   private final List<TraceFrame> traceFrames;
   private final Optional<Block> block;
 
+  /**
+   * Instantiates a new Transaction trace.
+   *
+   * @param block the block
+   */
   public TransactionTrace(final Optional<Block> block) {
     this.transaction = null;
     this.result = null;
@@ -36,6 +42,13 @@ public class TransactionTrace {
     this.block = block;
   }
 
+  /**
+   * Instantiates a new Transaction trace.
+   *
+   * @param transaction the transaction
+   * @param result the result
+   * @param traceFrames the trace frames
+   */
   public TransactionTrace(
       final Transaction transaction,
       final TransactionProcessingResult result,
@@ -46,6 +59,14 @@ public class TransactionTrace {
     this.block = Optional.empty();
   }
 
+  /**
+   * Instantiates a new Transaction trace.
+   *
+   * @param transaction the transaction
+   * @param result the result
+   * @param traceFrames the trace frames
+   * @param block the block
+   */
   public TransactionTrace(
       final Transaction transaction,
       final TransactionProcessingResult result,
@@ -57,6 +78,12 @@ public class TransactionTrace {
     this.block = block;
   }
 
+  /**
+   * Instantiates a new Transaction trace.
+   *
+   * @param transaction the transaction
+   * @param block the block
+   */
   public TransactionTrace(final Transaction transaction, final Optional<Block> block) {
     this.transaction = transaction;
     this.result = null;
@@ -64,26 +91,56 @@ public class TransactionTrace {
     this.block = block;
   }
 
+  /**
+   * Gets transaction.
+   *
+   * @return the transaction
+   */
   public Transaction getTransaction() {
     return transaction;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   public long getGas() {
     return transaction.getGasLimit() - result.getGasRemaining();
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @return the gas limit
+   */
   public long getGasLimit() {
     return transaction.getGasLimit();
   }
 
+  /**
+   * Gets result.
+   *
+   * @return the result
+   */
   public TransactionProcessingResult getResult() {
     return result;
   }
 
+  /**
+   * Gets trace frames.
+   *
+   * @return the trace frames
+   */
   public List<TraceFrame> getTraceFrames() {
     return traceFrames;
   }
 
+  /**
+   * Gets block.
+   *
+   * @return the block
+   */
   public Optional<Block> getBlock() {
     return block;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/TransactionTracer.java
@@ -54,15 +54,31 @@ import org.apache.tuweni.units.bigints.UInt256;
 /** Used to produce debug traces of transactions */
 public class TransactionTracer {
 
+  /** The constant TRACE_PATH. */
   public static final String TRACE_PATH = "traces";
+
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final BlockReplay blockReplay;
 
+  /**
+   * Instantiates a new Transaction tracer.
+   *
+   * @param blockReplay the block replay
+   */
   public TransactionTracer(final BlockReplay blockReplay) {
     this.blockReplay = blockReplay;
   }
 
+  /**
+   * Trace transaction optional.
+   *
+   * @param mutableWorldState the mutable world state
+   * @param blockHash the block hash
+   * @param transactionHash the transaction hash
+   * @param tracer the tracer
+   * @return the optional
+   */
   public Optional<TransactionTrace> traceTransaction(
       final Tracer.TraceableState mutableWorldState,
       final Hash blockHash,
@@ -86,6 +102,15 @@ public class TransactionTracer {
         });
   }
 
+  /**
+   * Trace transaction to file list.
+   *
+   * @param mutableWorldState the mutable world state
+   * @param blockHash the block hash
+   * @param transactionTraceParams the transaction trace params
+   * @param traceDir the trace dir
+   * @return the list
+   */
   public List<String> traceTransactionToFile(
       final MutableWorldState mutableWorldState,
       final Hash blockHash,
@@ -198,6 +223,14 @@ public class TransactionTracer {
         blobGasPrice);
   }
 
+  /**
+   * Summary trace string.
+   *
+   * @param transaction the transaction
+   * @param timer the timer
+   * @param result the result
+   * @return the string
+   */
   public static String summaryTrace(
       final Transaction transaction, final long timer, final TransactionProcessingResult result) {
     final ObjectNode summaryLine = OBJECT_MAPPER.createObjectNode();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcError.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Json rpc error. */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class JsonRpcError {
@@ -35,6 +36,13 @@ public class JsonRpcError {
   private final String data;
   private String reason;
 
+  /**
+   * Instantiates a new Json rpc error.
+   *
+   * @param code the code
+   * @param message the message
+   * @param data the data
+   */
   @JsonCreator
   public JsonRpcError(
       @JsonProperty("code") final int code,
@@ -45,6 +53,12 @@ public class JsonRpcError {
     this.data = data;
   }
 
+  /**
+   * Instantiates a new Json rpc error.
+   *
+   * @param errorType the error type
+   * @param data the data
+   */
   public JsonRpcError(final RpcMethodError errorType, final String data) {
     this(errorType.getCode(), errorType.getMessage(), data);
 
@@ -53,10 +67,21 @@ public class JsonRpcError {
     }
   }
 
+  /**
+   * Instantiates a new Json rpc error.
+   *
+   * @param errorType the error type
+   */
   public JsonRpcError(final RpcErrorType errorType) {
     this(errorType, null);
   }
 
+  /**
+   * From json rpc error.
+   *
+   * @param validationResult the validation result
+   * @return the json rpc error
+   */
   public static JsonRpcError from(
       final ValidationResult<TransactionInvalidReason> validationResult) {
     final var jsonRpcError =
@@ -67,16 +92,31 @@ public class JsonRpcError {
     return jsonRpcError;
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   @JsonGetter("code")
   public int getCode() {
     return code;
   }
 
+  /**
+   * Gets message.
+   *
+   * @return the message
+   */
   @JsonGetter("message")
   public String getMessage() {
     return (reason == null ? message : message + ": " + reason);
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   @JsonGetter("data")
   public String getData() {
     return data;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
@@ -33,6 +33,7 @@ import org.web3j.abi.datatypes.AbiTypes;
 import org.web3j.abi.datatypes.Type;
 import org.web3j.abi.datatypes.Utf8String;
 
+/** The type Json rpc error response. */
 @JsonPropertyOrder({"jsonrpc", "id", "error"})
 public class JsonRpcErrorResponse implements JsonRpcResponse {
 
@@ -40,19 +41,38 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
   private final JsonRpcError error;
   @JsonIgnore private final RpcErrorType errorType;
 
+  /** The constant errorMethodABI. */
   // Encoding of "Error(string)" to check for at the start of the revert reason
   static final String errorMethodABI = "0x08c379a0";
 
+  /**
+   * Instantiates a new Json rpc error response.
+   *
+   * @param id the id
+   * @param error the error
+   */
   public JsonRpcErrorResponse(final Object id, final JsonRpcError error) {
     this.id = id;
     this.error = error;
     this.errorType = findErrorType(error.getCode(), error.getMessage());
   }
 
+  /**
+   * Instantiates a new Json rpc error response.
+   *
+   * @param id the id
+   * @param error the error
+   */
   public JsonRpcErrorResponse(final Object id, final RpcErrorType error) {
     this(id, new JsonRpcError(error));
   }
 
+  /**
+   * Instantiates a new Json rpc error response.
+   *
+   * @param id the id
+   * @param validationResult the validation result
+   */
   public JsonRpcErrorResponse(
       final Object id, final ValidationResult<RpcErrorType> validationResult) {
     this(
@@ -60,11 +80,21 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
         new JsonRpcError(validationResult.getInvalidReason(), validationResult.getErrorMessage()));
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @JsonGetter("id")
   public Object getId() {
     return id;
   }
 
+  /**
+   * Gets error.
+   *
+   * @return the error
+   */
   @JsonGetter("error")
   public JsonRpcError getError() {
     return error;
@@ -98,6 +128,11 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
     return MoreObjects.toStringHelper(this).add("id", id).add("error", error).toString();
   }
 
+  /**
+   * Gets error type.
+   *
+   * @return the error type
+   */
   @JsonIgnore
   public RpcErrorType getErrorType() {
     return errorType;
@@ -110,6 +145,12 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
         .orElse(RpcErrorType.UNKNOWN);
   }
 
+  /**
+   * Decode revert reason optional.
+   *
+   * @param revertReason the revert reason
+   * @return the optional
+   */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static Optional<String> decodeRevertReason(final Bytes revertReason) {
     if (revertReason.toHexString().startsWith(errorMethodABI)) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcNoResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcNoResponse.java
@@ -14,7 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+/** The type Json rpc no response. */
 public class JsonRpcNoResponse implements JsonRpcResponse {
+  /** Default constructor. */
+  public JsonRpcNoResponse() {}
 
   @Override
   public JsonRpcResponseType getType() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponse.java
@@ -16,12 +16,23 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The interface Json rpc response. */
 public interface JsonRpcResponse {
 
+  /**
+   * Gets version.
+   *
+   * @return the version
+   */
   @JsonGetter("jsonrpc")
   default String getVersion() {
     return "2.0";
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   JsonRpcResponseType getType();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponseType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponseType.java
@@ -16,8 +16,12 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
 /** Various types of responses that the JSON-RPC component may produce. */
 public enum JsonRpcResponseType {
+  /** None json rpc response type. */
   NONE,
+  /** Success json rpc response type. */
   SUCCESS,
+  /** Error json rpc response type. */
   ERROR,
+  /** Unauthorized json rpc response type. */
   UNAUTHORIZED
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcSuccessResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcSuccessResponse.java
@@ -20,29 +20,52 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Json rpc success response. */
 @JsonPropertyOrder({"jsonrpc", "id", "result"})
 public class JsonRpcSuccessResponse implements JsonRpcResponse {
 
+  /** The constant SUCCESS_RESULT. */
   public static final String SUCCESS_RESULT = "Success";
 
   private final Object id;
   private final Object result;
 
+  /**
+   * Instantiates a new Json rpc success response.
+   *
+   * @param id the id
+   * @param result the result
+   */
   public JsonRpcSuccessResponse(final Object id, final Object result) {
     this.id = id;
     this.result = result;
   }
 
+  /**
+   * Instantiates a new Json rpc success response.
+   *
+   * @param id the id
+   */
   public JsonRpcSuccessResponse(final Object id) {
     this.id = id;
     this.result = SUCCESS_RESULT;
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @JsonGetter("id")
   public Object getId() {
     return id;
   }
 
+  /**
+   * Gets result.
+   *
+   * @return the result
+   */
   @JsonGetter("result")
   public Object getResult() {
     return result;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcUnauthorizedResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcUnauthorizedResponse.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Json rpc unauthorized response. */
 @JsonPropertyOrder({"jsonrpc", "id", "error"})
 public class JsonRpcUnauthorizedResponse implements JsonRpcResponse {
 
@@ -28,21 +29,43 @@ public class JsonRpcUnauthorizedResponse implements JsonRpcResponse {
   private final JsonRpcError error;
   @JsonIgnore private final RpcErrorType errorType;
 
+  /**
+   * Instantiates a new Json rpc unauthorized response.
+   *
+   * @param id the id
+   * @param error the error
+   */
   public JsonRpcUnauthorizedResponse(final Object id, final JsonRpcError error) {
     this.id = id;
     this.error = error;
     this.errorType = findErrorType(error.getCode(), error.getMessage());
   }
 
+  /**
+   * Instantiates a new Json rpc unauthorized response.
+   *
+   * @param id the id
+   * @param error the error
+   */
   public JsonRpcUnauthorizedResponse(final Object id, final RpcErrorType error) {
     this(id, new JsonRpcError(error));
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @JsonGetter("id")
   public Object getId() {
     return id;
   }
 
+  /**
+   * Gets error.
+   *
+   * @return the error
+   */
   @JsonGetter("error")
   public JsonRpcError getError() {
     return error;
@@ -71,6 +94,11 @@ public class JsonRpcUnauthorizedResponse implements JsonRpcResponse {
     return Objects.hash(id, error);
   }
 
+  /**
+   * Gets error type.
+   *
+   * @return the error type
+   */
   @JsonIgnore
   public RpcErrorType getErrorType() {
     return errorType;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -21,213 +21,345 @@ import java.util.function.Function;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The enum Rpc error type. */
 public enum RpcErrorType implements RpcMethodError {
+  /** The Parse error. */
   // Standard errors
   PARSE_ERROR(-32700, "Parse error"),
+  /** The Invalid request. */
   INVALID_REQUEST(-32600, "Invalid Request"),
+  /** The Method not found. */
   METHOD_NOT_FOUND(-32601, "Method not found"),
+  /** The Invalid params. */
   INVALID_PARAMS(-32602, "Invalid params"),
+  /** The Internal error. */
   INTERNAL_ERROR(-32603, "Internal error"),
+  /** The Timeout error. */
   TIMEOUT_ERROR(-32603, "Timeout expired"),
 
+  /** The Method not enabled. */
   METHOD_NOT_ENABLED(-32604, "Method not enabled"),
 
+  /** The Tx pool disabled. */
   // Resource unavailable error
   TX_POOL_DISABLED(-32002, "Transaction pool not enabled"),
 
+  /** The Unknown block. */
   // eth_getBlockByNumber specific error message
   UNKNOWN_BLOCK(-39001, "Unknown block"),
 
+  /** The Eth send tx not available. */
   // eth_sendTransaction specific error message
   ETH_SEND_TX_NOT_AVAILABLE(
       -32604,
       "The method eth_sendTransaction is not supported. Use eth_sendRawTransaction to send a signed transaction to Besu."),
+  /** The Eth send tx already known. */
   ETH_SEND_TX_ALREADY_KNOWN(-32000, "Known transaction"),
+  /** The Eth send tx replacement underpriced. */
   ETH_SEND_TX_REPLACEMENT_UNDERPRICED(-32000, "Replacement transaction underpriced"),
+  /** The P 2 p disabled. */
   // P2P related errors
   P2P_DISABLED(-32000, "P2P has been disabled. This functionality is not available"),
+  /** The P 2 p network not running. */
   P2P_NETWORK_NOT_RUNNING(-32000, "P2P network is not running"),
 
+  /** The Filter not found. */
   // Filter & Subscription Errors
   FILTER_NOT_FOUND(-32000, "Filter not found"),
+  /** The Logs filter not found. */
   LOGS_FILTER_NOT_FOUND(-32000, "Logs filter not found"),
+  /** The Subscription not found. */
   SUBSCRIPTION_NOT_FOUND(-32000, "Subscription not found"),
+  /** The No mining work found. */
   NO_MINING_WORK_FOUND(-32000, "No mining work available yet"),
 
+  /** The Nonce too low. */
   // Transaction validation failures
   NONCE_TOO_LOW(-32001, "Nonce too low"),
+  /** The Invalid transaction signature. */
   INVALID_TRANSACTION_SIGNATURE(-32002, "Invalid signature"),
+  /** The Invalid transaction type. */
   INVALID_TRANSACTION_TYPE(-32602, "Invalid transaction type"),
+  /** The Intrinsic gas exceeds limit. */
   INTRINSIC_GAS_EXCEEDS_LIMIT(-32003, "Intrinsic gas exceeds gas limit"),
+  /** The Transaction upfront cost exceeds balance. */
   TRANSACTION_UPFRONT_COST_EXCEEDS_BALANCE(-32004, "Upfront cost exceeds account balance"),
+  /** The Exceeds block gas limit. */
   EXCEEDS_BLOCK_GAS_LIMIT(-32005, "Transaction gas limit exceeds block gas limit"),
+  /** The Exceeds rpc max block range. */
   EXCEEDS_RPC_MAX_BLOCK_RANGE(-32005, "Requested range exceeds maximum RPC range limit"),
+  /** The Exceeds rpc max batch size. */
   EXCEEDS_RPC_MAX_BATCH_SIZE(-32005, "Number of requests exceeds max batch size"),
+  /** The Nonce too high. */
   NONCE_TOO_HIGH(-32006, "Nonce too high"),
+  /** The Tx sender not authorized. */
   TX_SENDER_NOT_AUTHORIZED(-32007, "Sender account not authorized to send transactions"),
+  /** The Chain head world state not available. */
   CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE(-32008, "Initial sync is still in progress"),
+  /** The Gas price too low. */
   GAS_PRICE_TOO_LOW(-32009, "Gas price below configured minimum gas price"),
+  /** The Gas price below current base fee. */
   GAS_PRICE_BELOW_CURRENT_BASE_FEE(-32009, "Gas price below current base fee"),
 
+  /** The Blob gas price below current blob base fee. */
   BLOB_GAS_PRICE_BELOW_CURRENT_BLOB_BASE_FEE(-32009, "blob gas price below current blob base fee"),
+  /** The Wrong chain id. */
   WRONG_CHAIN_ID(-32000, "Wrong chainId"),
+  /** The Replay protected signatures not supported. */
   REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED(-32000, "ChainId not supported"),
+  /** The Replay protected signature required. */
   REPLAY_PROTECTED_SIGNATURE_REQUIRED(-32000, "ChainId is required"),
+  /** The Tx feecap exceeded. */
   TX_FEECAP_EXCEEDED(-32000, "Transaction fee cap exceeded"),
+  /** The Revert error. */
   REVERT_ERROR(
       -32000,
       "Execution reverted",
       data -> JsonRpcErrorResponse.decodeRevertReason(Bytes.fromHexString(data))),
+  /** The Transaction not found. */
   TRANSACTION_NOT_FOUND(-32000, "Transaction not found"),
+  /** The Max priority fee per gas exceeds max fee per gas. */
   MAX_PRIORITY_FEE_PER_GAS_EXCEEDS_MAX_FEE_PER_GAS(
       -32000, "Max priority fee per gas exceeds max fee per gas"),
+  /** The Nonce too far in future for sender. */
   NONCE_TOO_FAR_IN_FUTURE_FOR_SENDER(
       -32000, "Transaction nonce is too distant from current sender nonce"),
+  /** The Lower nonce invalid transaction exists. */
   LOWER_NONCE_INVALID_TRANSACTION_EXISTS(
       -32000, "An invalid transaction with a lower nonce exists"),
+  /** The Total blob gas too high. */
   TOTAL_BLOB_GAS_TOO_HIGH(-32000, "Total blob gas too high"),
+  /** The Plugin tx validator. */
   PLUGIN_TX_VALIDATOR(-32000, "Plugin has marked the transaction as invalid"),
+  /** The Execution halted. */
   EXECUTION_HALTED(-32000, "Transaction processing could not be completed due to an exception"),
 
+  /** The Unknown payload. */
   // Execution engine failures
   UNKNOWN_PAYLOAD(-32001, "Payload does not exist / is not available"),
+  /** The Invalid terminal block. */
   INVALID_TERMINAL_BLOCK(-32002, "Terminal block doesn't satisfy terminal block conditions"),
+  /** The Invalid forkchoice state. */
   INVALID_FORKCHOICE_STATE(-38002, "Invalid forkchoice state"),
+  /** The Invalid payload attributes. */
   INVALID_PAYLOAD_ATTRIBUTES(-38003, "Invalid payload attributes"),
+  /** The Invalid range request too large. */
   INVALID_RANGE_REQUEST_TOO_LARGE(-38004, "Too large request"),
+  /** The Unsupported fork. */
   UNSUPPORTED_FORK(-38005, "Unsupported fork"),
+  /** The Coinbase not set. */
   // Miner failures
   COINBASE_NOT_SET(-32010, "Coinbase not set. Unable to start mining without a coinbase"),
+  /** The No hashes per second. */
   NO_HASHES_PER_SECOND(-32011, "No hashes being generated by the current node"),
+  /** The Target gas limit modification unsupported. */
   TARGET_GAS_LIMIT_MODIFICATION_UNSUPPORTED(
       -32011, "The node is not attempting to target a gas limit so the target can't be changed"),
 
+  /** The Coinbase not specified. */
   // Wallet errors
   COINBASE_NOT_SPECIFIED(-32000, "Coinbase must be explicitly specified"),
 
+  /** The No account found. */
   // Account errors
   NO_ACCOUNT_FOUND(-32000, "Account not found"),
 
+  /** The World state unavailable. */
   // Worldstate errors
   WORLD_STATE_UNAVAILABLE(-32000, "World state unavailable"),
 
+  /** The Block not found. */
   // Debug failures
   BLOCK_NOT_FOUND(-32000, "Block not found"),
+  /** The Parent block not found. */
   PARENT_BLOCK_NOT_FOUND(-32000, "Parent block not found"),
 
+  /** The Account allowlist not enabled. */
   // Permissioning/Account allowlist errors
   ACCOUNT_ALLOWLIST_NOT_ENABLED(-32000, "Account allowlist has not been enabled"),
+  /** The Account allowlist empty entry. */
   ACCOUNT_ALLOWLIST_EMPTY_ENTRY(-32000, "Request contains an empty list of accounts"),
+  /** The Account allowlist invalid entry. */
   ACCOUNT_ALLOWLIST_INVALID_ENTRY(-32000, "Request contains an invalid account"),
+  /** The Account allowlist duplicated entry. */
   ACCOUNT_ALLOWLIST_DUPLICATED_ENTRY(-32000, "Request contains duplicate accounts"),
+  /** The Account allowlist existing entry. */
   ACCOUNT_ALLOWLIST_EXISTING_ENTRY(-32000, "Cannot add an existing account to allowlist"),
+  /** The Account allowlist absent entry. */
   ACCOUNT_ALLOWLIST_ABSENT_ENTRY(-32000, "Cannot remove an absent account from allowlist"),
 
+  /** The Node allowlist not enabled. */
   // Permissioning/Node allowlist errors
   NODE_ALLOWLIST_NOT_ENABLED(-32000, "Node allowlist has not been enabled"),
+  /** The Node allowlist empty entry. */
   NODE_ALLOWLIST_EMPTY_ENTRY(-32000, "Request contains an empty list of nodes"),
+  /** The Node allowlist invalid entry. */
   NODE_ALLOWLIST_INVALID_ENTRY(-32000, "Request contains an invalid node"),
+  /** The Node allowlist duplicated entry. */
   NODE_ALLOWLIST_DUPLICATED_ENTRY(-32000, "Request contains duplicate nodes"),
+  /** The Node allowlist existing entry. */
   NODE_ALLOWLIST_EXISTING_ENTRY(-32000, "Cannot add an existing node to allowlist"),
+  /** The Node allowlist missing entry. */
   NODE_ALLOWLIST_MISSING_ENTRY(-32000, "Cannot remove an absent node from allowlist"),
+  /** The constant NODE_ALLOWLIST_FIXED_NODE_CANNOT_BE_REMOVED. */
   NODE_ALLOWLIST_FIXED_NODE_CANNOT_BE_REMOVED(
       -32000, "Cannot remove a fixed node (bootnode or static node) from allowlist"),
 
+  /** The Allowlist persist failure. */
   // Permissioning/persistence errors
   ALLOWLIST_PERSIST_FAILURE(
       -32000, "Unable to persist changes to allowlist configuration file. Changes reverted"),
+  /** The Allowlist file sync. */
   ALLOWLIST_FILE_SYNC(
       -32000,
       "The permissioning allowlist configuration file is out of sync.  The changes have been applied, but not persisted to disk"),
+  /** The Allowlist reload error. */
   ALLOWLIST_RELOAD_ERROR(
       -32000,
       "Error reloading permissions file. Please use perm_getAccountsAllowlist and perm_getNodesAllowlist to review the current state of the allowlists"),
+  /** The Permissioning not enabled. */
   PERMISSIONING_NOT_ENABLED(-32000, "Node/Account allowlist has not been enabled"),
+  /** The Non permitted node cannot be added as a peer. */
   NON_PERMITTED_NODE_CANNOT_BE_ADDED_AS_A_PEER(-32000, "Cannot add a non-permitted node as a peer"),
 
+  /** The Unauthorized. */
   // Permissioning/Authorization errors
   UNAUTHORIZED(-40100, "Unauthorized"),
 
+  /** The Enclave error. */
   // Private transaction errors
   ENCLAVE_ERROR(-50100, "Error communicating with enclave"),
+  /** The Unsupported private transaction type. */
   UNSUPPORTED_PRIVATE_TRANSACTION_TYPE(-50100, "Unsupported private transaction type"),
+  /** The Privacy not enabled. */
   PRIVACY_NOT_ENABLED(-50100, "Privacy is not enabled"),
+  /** The Create privacy group error. */
   CREATE_PRIVACY_GROUP_ERROR(-50100, "Error creating privacy group"),
+  /** The Decode error. */
   DECODE_ERROR(-50100, "Unable to decode the private signed raw transaction"),
+  /** The Delete privacy group error. */
   DELETE_PRIVACY_GROUP_ERROR(-50100, "Error deleting privacy group"),
+  /** The Find privacy group error. */
   FIND_PRIVACY_GROUP_ERROR(-50100, "Error finding privacy group"),
+  /** The Find flexible privacy group error. */
   FIND_FLEXIBLE_PRIVACY_GROUP_ERROR(-50100, "Error finding flexible privacy group"),
+  /** The Get private transaction nonce error. */
   GET_PRIVATE_TRANSACTION_NONCE_ERROR(-50100, "Unable to determine nonce for account in group."),
+  /** The Offchain privacy group does not exist. */
   OFFCHAIN_PRIVACY_GROUP_DOES_NOT_EXIST(-50100, "Offchain Privacy group does not exist."),
+  /** The Flexible privacy group does not exist. */
   FLEXIBLE_PRIVACY_GROUP_DOES_NOT_EXIST(-50100, "Flexible Privacy group does not exist."),
+  /** The Flexible privacy group not enabled. */
   FLEXIBLE_PRIVACY_GROUP_NOT_ENABLED(-50100, "Flexible privacy groups not enabled."),
+  /** The Offchain privacy group not enabled. */
   OFFCHAIN_PRIVACY_GROUP_NOT_ENABLED(
       -50100, "Offchain privacy group can't be used with Flexible privacy groups enabled."),
+  /** The Flexible privacy group id not available. */
   FLEXIBLE_PRIVACY_GROUP_ID_NOT_AVAILABLE(
       -50100, "Private transactions to flexible privacy groups must use privacyGroupId"),
+  /** The Pmt failed intrinsic gas exceeds limit. */
   PMT_FAILED_INTRINSIC_GAS_EXCEEDS_LIMIT(
       -50100,
       "Privacy Marker Transaction failed due to intrinsic gas exceeding the limit. Gas limit used from the Private Transaction."),
+  /** The Private from does not match enclave public key. */
   PRIVATE_FROM_DOES_NOT_MATCH_ENCLAVE_PUBLIC_KEY(
       -50100, "Private from does not match enclave public key"),
+  /** The Value not zero. */
   VALUE_NOT_ZERO(-50100, "We cannot transfer ether in a private transaction yet."),
+  /** The Private transaction invalid. */
   PRIVATE_TRANSACTION_INVALID(-50100, "Private transaction invalid"),
+  /** The Private transaction failed. */
   PRIVATE_TRANSACTION_FAILED(-50100, "Private transaction failed"),
 
+  /** The Cant connect to local peer. */
   CANT_CONNECT_TO_LOCAL_PEER(-32100, "Cannot add local node as peer."),
+  /** The Cant resolve peer enode dns. */
   CANT_RESOLVE_PEER_ENODE_DNS(-32100, "Cannot resolve enode DNS hostname"),
+  /** The Dns not enabled. */
   DNS_NOT_ENABLED(-32100, "Enode DNS support is disabled"),
 
+  /** The Enode id invalid. */
   // Invalid input errors
   ENODE_ID_INVALID(
       -32000,
       "Invalid node ID: node ID must have exactly 128 hexadecimal characters and should not include any '0x' hex prefix."),
+  /** The Json rpc not canonical error. */
   JSON_RPC_NOT_CANONICAL_ERROR(-32000, "Invalid input"),
 
+  /** The Node missing peer url. */
   // Enclave errors
   NODE_MISSING_PEER_URL(-50200, "NodeMissingPeerUrl"),
+  /** Node pushing to peer rpc error type. */
   NODE_PUSHING_TO_PEER(-50200, "NodePushingToPeer"),
+  /** Node propagating to all peers rpc error type. */
   NODE_PROPAGATING_TO_ALL_PEERS(-50200, "NodePropagatingToAllPeers"),
+  /** No sender key rpc error type. */
   NO_SENDER_KEY(-50200, "NoSenderKey"),
+  /** Invalid payload rpc error type. */
   INVALID_PAYLOAD(-50200, "InvalidPayload"),
+  /** Enclave create key pair rpc error type. */
   ENCLAVE_CREATE_KEY_PAIR(-50200, "EnclaveCreateKeyPair"),
+  /** Enclave decode public key rpc error type. */
   ENCLAVE_DECODE_PUBLIC_KEY(-50200, "EnclaveDecodePublicKey"),
+  /** Enclave decrypt wrong private key rpc error type. */
   ENCLAVE_DECRYPT_WRONG_PRIVATE_KEY(-50200, "EnclaveDecryptWrongPrivateKey"),
+  /** Enclave encrypt combine keys rpc error type. */
   ENCLAVE_ENCRYPT_COMBINE_KEYS(-50200, "EnclaveEncryptCombineKeys"),
+  /** Enclave missing private key password rpc error type. */
   ENCLAVE_MISSING_PRIVATE_KEY_PASSWORD(-50200, "EnclaveMissingPrivateKeyPasswords"),
+  /** Enclave no matching private key rpc error type. */
   ENCLAVE_NO_MATCHING_PRIVATE_KEY(-50200, "EnclaveNoMatchingPrivateKey"),
+  /** Enclave not payload owner rpc error type. */
   ENCLAVE_NOT_PAYLOAD_OWNER(-50200, "EnclaveNotPayloadOwner"),
+  /** Enclave unsupported private key type rpc error type. */
   ENCLAVE_UNSUPPORTED_PRIVATE_KEY_TYPE(-50200, "EnclaveUnsupportedPrivateKeyType"),
+  /** Enclave storage decrypt rpc error type. */
   ENCLAVE_STORAGE_DECRYPT(-50200, "EnclaveStorageDecrypt"),
+  /** Enclave privacy group creation rpc error type. */
   ENCLAVE_PRIVACY_GROUP_CREATION(-50200, "EnclavePrivacyGroupIdCreation"),
+  /** Enclave payload not found rpc error type. */
   ENCLAVE_PAYLOAD_NOT_FOUND(-50200, "EnclavePayloadNotFound"),
+  /** Create group include self rpc error type. */
   CREATE_GROUP_INCLUDE_SELF(-50200, "CreatePrivacyGroupShouldIncludeSelf"),
 
+  /** The Tessera node missing peer url. */
   // Tessera error codes
   TESSERA_NODE_MISSING_PEER_URL(-50200, "Recipient not found for key:"),
+  /** The Tessera create group include self. */
   TESSERA_CREATE_GROUP_INCLUDE_SELF(
       -50200, "The list of members in a privacy group should include self"),
 
   /** Storing privacy group issue */
   ENCLAVE_UNABLE_STORE_PRIVACY_GROUP(-50200, "PrivacyGroupNotStored"),
+  /** Enclave unable delete privacy group rpc error type. */
   ENCLAVE_UNABLE_DELETE_PRIVACY_GROUP(-50200, "PrivacyGroupNotDeleted"),
+  /** Enclave unable push delete privacy group rpc error type. */
   ENCLAVE_UNABLE_PUSH_DELETE_PRIVACY_GROUP(-50200, "PrivacyGroupNotPushed"),
+  /** Enclave privacy group missing rpc error type. */
   ENCLAVE_PRIVACY_GROUP_MISSING(-50200, "PrivacyGroupNotFound"),
+  /** Enclave privacy query error rpc error type. */
   ENCLAVE_PRIVACY_QUERY_ERROR(-50200, "PrivacyGroupQueryError"),
+  /** Enclave keys cannot decrypt payload rpc error type. */
   ENCLAVE_KEYS_CANNOT_DECRYPT_PAYLOAD(-50200, "EnclaveKeysCannotDecryptPayload"),
+  /** Method unimplemented rpc error type. */
   METHOD_UNIMPLEMENTED(-50200, "MethodUnimplemented"),
 
   /** Plugins error */
   PLUGIN_NOT_FOUND(-60000, "Plugin not found"),
+  /** The Plugin internal error. */
   PLUGIN_INTERNAL_ERROR(-32603, "Plugin internal error"),
 
   // Retesteth Errors
 
+  /** The Block rlp import error. */
   BLOCK_RLP_IMPORT_ERROR(-32000, "Could not decode RLP for Block"),
+  /** The Block import error. */
   BLOCK_IMPORT_ERROR(-32000, "Could not import Block"),
 
+  /** The Unknown. */
   UNKNOWN(-32603, "Unknown internal error"),
 
+  /** The Invalid blobs. */
   INVALID_BLOBS(-32603, "blobs failed kzg validation");
 
   private final int code;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -157,7 +157,7 @@ public enum RpcErrorType implements RpcMethodError {
       -32011, "The node is not attempting to target a gas limit so the target can't be changed"),
 
   /** The Coinbase not specified. */
-  // Wallet errors
+  // coinbase errors
   COINBASE_NOT_SPECIFIED(-32000, "Coinbase must be explicitly specified"),
 
   /** The No account found. */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/CreateAccessListResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/CreateAccessListResult.java
@@ -21,20 +21,40 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Create access list result. */
 public class CreateAccessListResult {
+  /** The Access list list. */
   List<AccessListEntry> accessListList;
+
+  /** The Gas used. */
   String gasUsed;
 
+  /**
+   * Instantiates a new Create access list result.
+   *
+   * @param accessListEntries the access list entries
+   * @param gasUsed the gas used
+   */
   public CreateAccessListResult(final List<AccessListEntry> accessListEntries, final long gasUsed) {
     this.accessListList = accessListEntries;
     this.gasUsed = Quantity.create(gasUsed);
   }
 
+  /**
+   * Gets access list.
+   *
+   * @return the access list
+   */
   @JsonGetter(value = "accessList")
   public Collection<AccessListEntry> getAccessList() {
     return accessListList;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   @JsonGetter(value = "gasUsed")
   public String getGasUsed() {
     return gasUsed;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugAccountAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugAccountAtResult.java
@@ -16,13 +16,37 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import org.immutables.value.Value;
 
+/** The type Debug account at result. */
 @Value.Immutable
 public abstract class DebugAccountAtResult implements JsonRpcResult {
+  /** Default Constructor */
+  public DebugAccountAtResult() {}
+
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   public abstract String getCode();
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   public abstract String getNonce();
 
+  /**
+   * Gets balance.
+   *
+   * @return the balance
+   */
   public abstract String getBalance();
 
+  /**
+   * Gets codehash.
+   *
+   * @return the codehash
+   */
   public abstract String getCodehash();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugAccountRangeAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugAccountRangeAtResult.java
@@ -18,21 +18,38 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Debug account range at result. */
 public class DebugAccountRangeAtResult implements JsonRpcResult {
 
   private final Map<String, String> addressMap;
   private final String nextKey;
 
+  /**
+   * Instantiates a new Debug account range at result.
+   *
+   * @param addressMap the address map
+   * @param nextKey the next key
+   */
   public DebugAccountRangeAtResult(final Map<String, String> addressMap, final String nextKey) {
     this.addressMap = addressMap;
     this.nextKey = nextKey;
   }
 
+  /**
+   * Gets address map.
+   *
+   * @return the address map
+   */
   @JsonGetter(value = "addressMap")
   public Map<String, String> getAddressMap() {
     return addressMap;
   }
 
+  /**
+   * Gets next key.
+   *
+   * @return the next key
+   */
   @JsonGetter(value = "nextKey")
   public String getNextKey() {
     return nextKey;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugStorageRangeAtResult.java
@@ -27,11 +27,19 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Debug storage range at result. */
 public class DebugStorageRangeAtResult implements JsonRpcResult {
 
   private final NavigableMap<String, StorageEntry> storage = new TreeMap<>();
   private final String nextKey;
 
+  /**
+   * Instantiates a new Debug storage range at result.
+   *
+   * @param entries the entries
+   * @param nextKey the next key
+   * @param shortValues the short values
+   */
   public DebugStorageRangeAtResult(
       final NavigableMap<Bytes32, AccountStorageEntry> entries,
       final Bytes32 nextKey,
@@ -66,26 +74,48 @@ public class DebugStorageRangeAtResult implements JsonRpcResult {
     return "0x" + hex.substring(i);
   }
 
+  /**
+   * Gets storage.
+   *
+   * @return the storage
+   */
   @JsonGetter(value = "storage")
   public NavigableMap<String, StorageEntry> getStorage() {
     return storage;
   }
 
+  /**
+   * Gets next key.
+   *
+   * @return the next key
+   */
   @JsonGetter(value = "nextKey")
   public String getNextKey() {
     return nextKey;
   }
 
+  /**
+   * Gets complete.
+   *
+   * @return the complete
+   */
   @JsonGetter(value = "complete")
   public boolean getComplete() {
     return nextKey == null;
   }
 
+  /** The type Storage entry. */
   @JsonPropertyOrder(value = {"key", "value"})
   public static class StorageEntry {
     private final String value;
     private final String key;
 
+    /**
+     * Instantiates a new Storage entry.
+     *
+     * @param entry the entry
+     * @param shortValues the short values
+     */
     public StorageEntry(final AccountStorageEntry entry, final boolean shortValues) {
       if (shortValues) {
         this.value = entry.getValue().toMinimalBytes().toHexString();
@@ -102,11 +132,21 @@ public class DebugStorageRangeAtResult implements JsonRpcResult {
       }
     }
 
+    /**
+     * Gets key.
+     *
+     * @return the key
+     */
     @JsonGetter(value = "key")
     public String getKey() {
       return key;
     }
 
+    /**
+     * Gets value.
+     *
+     * @return the value
+     */
     @JsonGetter(value = "value")
     public String getValue() {
       return value;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugTraceTransactionResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/DebugTraceTransactionResult.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Debug trace transaction result. */
 @JsonPropertyOrder({"gas", "failed", "returnValue", "structLogs"})
 public class DebugTraceTransactionResult {
 
@@ -32,6 +33,11 @@ public class DebugTraceTransactionResult {
   private final long gas;
   private final boolean failed;
 
+  /**
+   * Instantiates a new Debug trace transaction result.
+   *
+   * @param transactionTrace the transaction trace
+   */
   public DebugTraceTransactionResult(final TransactionTrace transactionTrace) {
     gas = transactionTrace.getGas();
     returnValue = transactionTrace.getResult().getOutput().toString().substring(2);
@@ -42,6 +48,12 @@ public class DebugTraceTransactionResult {
     failed = !transactionTrace.getResult().isSuccessful();
   }
 
+  /**
+   * Of collection.
+   *
+   * @param traces the traces
+   * @return the collection
+   */
   public static Collection<DebugTraceTransactionResult> of(
       final Collection<TransactionTrace> traces) {
     return traces.stream().map(DebugTraceTransactionResult::new).collect(Collectors.toList());
@@ -54,21 +66,41 @@ public class DebugTraceTransactionResult {
         .orElse(new StructLog(frame));
   }
 
+  /**
+   * Gets struct logs.
+   *
+   * @return the struct logs
+   */
   @JsonGetter(value = "structLogs")
   public List<StructLog> getStructLogs() {
     return structLogs;
   }
 
+  /**
+   * Gets return value.
+   *
+   * @return the return value
+   */
   @JsonGetter(value = "returnValue")
   public String getReturnValue() {
     return returnValue;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   @JsonGetter(value = "gas")
   public long getGas() {
     return gas;
   }
 
+  /**
+   * Failed boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "failed")
   public boolean failed() {
     return failed;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineExchangeTransitionConfigurationResult.java
@@ -20,12 +20,20 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Engine exchange transition configuration result. */
 @JsonPropertyOrder({"terminalTotalDifficulty", "terminalBlockHash", "terminalBlockNumber"})
 public class EngineExchangeTransitionConfigurationResult {
   private final Difficulty terminalTotalDifficulty;
   private final Hash terminalBlockHash;
   private final long terminalBlockNumber;
 
+  /**
+   * Instantiates a new Engine exchange transition configuration result.
+   *
+   * @param terminalTotalDifficulty the terminal total difficulty
+   * @param terminalBlockHash the terminal block hash
+   * @param terminalBlockNumber the terminal block number
+   */
   public EngineExchangeTransitionConfigurationResult(
       final Difficulty terminalTotalDifficulty,
       final Hash terminalBlockHash,
@@ -35,29 +43,59 @@ public class EngineExchangeTransitionConfigurationResult {
     this.terminalBlockNumber = terminalBlockNumber;
   }
 
+  /**
+   * Gets terminal total difficulty as string.
+   *
+   * @return the terminal total difficulty as string
+   */
   @JsonGetter(value = "terminalTotalDifficulty")
   public String getTerminalTotalDifficultyAsString() {
     return Quantity.create(this.terminalTotalDifficulty.getAsBigInteger());
   }
 
+  /**
+   * Gets terminal total difficulty.
+   *
+   * @return the terminal total difficulty
+   */
   public Difficulty getTerminalTotalDifficulty() {
     return terminalTotalDifficulty;
   }
 
+  /**
+   * Gets terminal block hash as string.
+   *
+   * @return the terminal block hash as string
+   */
   @JsonGetter(value = "terminalBlockHash")
   public String getTerminalBlockHashAsString() {
     return terminalBlockHash.toHexString();
   }
 
+  /**
+   * Gets terminal block hash.
+   *
+   * @return the terminal block hash
+   */
   public Hash getTerminalBlockHash() {
     return terminalBlockHash;
   }
 
+  /**
+   * Gets terminal block number as string.
+   *
+   * @return the terminal block number as string
+   */
   @JsonGetter(value = "terminalBlockNumber")
   public String getTerminalBlockNumberAsString() {
     return Quantity.create(this.terminalBlockNumber);
   }
 
+  /**
+   * Gets terminal block number.
+   *
+   * @return the terminal block number
+   */
   public Long getTerminalBlockNumber() {
     return terminalBlockNumber;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadBodiesResultV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadBodiesResultV1.java
@@ -28,19 +28,19 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.tuweni.bytes.Bytes;
 
-/** The type Engine get payload bodies result v 1. */
+/** The type Engine get payload bodies result v1. */
 @JsonPropertyOrder({"payloadBodies"})
 public class EngineGetPayloadBodiesResultV1 {
 
   private final List<PayloadBody> payloadBodies;
 
-  /** Instantiates a new Engine get payload bodies result v 1. */
+  /** Instantiates a new Engine get payload bodies result v1. */
   public EngineGetPayloadBodiesResultV1() {
     this.payloadBodies = Collections.<PayloadBody>emptyList();
   }
 
   /**
-   * Instantiates a new Engine get payload bodies result v 1.
+   * Instantiates a new Engine get payload bodies result v1.
    *
    * @param payloadBody the payload body
    */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadBodiesResultV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadBodiesResultV1.java
@@ -28,28 +28,46 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonValue;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Engine get payload bodies result v 1. */
 @JsonPropertyOrder({"payloadBodies"})
 public class EngineGetPayloadBodiesResultV1 {
 
   private final List<PayloadBody> payloadBodies;
 
+  /** Instantiates a new Engine get payload bodies result v 1. */
   public EngineGetPayloadBodiesResultV1() {
     this.payloadBodies = Collections.<PayloadBody>emptyList();
   }
 
+  /**
+   * Instantiates a new Engine get payload bodies result v 1.
+   *
+   * @param payloadBody the payload body
+   */
   public EngineGetPayloadBodiesResultV1(final List<PayloadBody> payloadBody) {
     this.payloadBodies = payloadBody;
   }
 
+  /**
+   * Gets payload bodies.
+   *
+   * @return the payload bodies
+   */
   @JsonValue
   public List<PayloadBody> getPayloadBodies() {
     return payloadBodies;
   }
 
+  /** The type Payload body. */
   public static class PayloadBody {
     private final List<String> transactions;
     private final List<WithdrawalParameter> withdrawals;
 
+    /**
+     * Instantiates a new Payload body.
+     *
+     * @param blockBody the block body
+     */
     public PayloadBody(final BlockBody blockBody) {
       this.transactions =
           blockBody.getTransactions().stream()
@@ -69,11 +87,21 @@ public class EngineGetPayloadBodiesResultV1 {
               .orElse(null);
     }
 
+    /**
+     * Gets transactions.
+     *
+     * @return the transactions
+     */
     @JsonGetter(value = "transactions")
     public List<String> getTransactions() {
       return transactions;
     }
 
+    /**
+     * Gets withdrawals.
+     *
+     * @return the withdrawals
+     */
     @JsonGetter(value = "withdrawals")
     public List<WithdrawalParameter> getWithdrawals() {
       return withdrawals;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV1.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine get payload result v1. */
 @JsonPropertyOrder({
   "parentHash",
   "feeRecipient",
@@ -40,7 +41,9 @@ import org.apache.tuweni.bytes.Bytes32;
   "transactions"
 })
 public class EngineGetPayloadResultV1 {
+  /** The Block hash. */
   protected final String blockHash;
+
   private final String parentHash;
   private final String feeRecipient;
   private final String stateRoot;
@@ -53,8 +56,16 @@ public class EngineGetPayloadResultV1 {
   private final String timestamp;
   private final String extraData;
   private final String baseFeePerGas;
+
+  /** The Transactions. */
   protected final List<String> transactions;
 
+  /**
+   * Instantiates a new Engine get payload result v1.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   */
   public EngineGetPayloadResultV1(final BlockHeader header, final List<String> transactions) {
     this.blockNumber = Quantity.create(header.getNumber());
     this.blockHash = header.getHash().toString();
@@ -72,71 +83,141 @@ public class EngineGetPayloadResultV1 {
     this.prevRandao = header.getPrevRandao().map(Bytes32::toHexString).orElse(null);
   }
 
+  /**
+   * Gets number.
+   *
+   * @return the number
+   */
   @JsonGetter(value = "blockNumber")
   public String getNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "blockHash")
   public String getHash() {
     return blockHash;
   }
 
+  /**
+   * Gets parent hash.
+   *
+   * @return the parent hash
+   */
   @JsonGetter(value = "parentHash")
   public String getParentHash() {
     return parentHash;
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   @JsonGetter(value = "logsBloom")
   public String getLogsBloom() {
     return logsBloom;
   }
 
+  /**
+   * Gets prev randao.
+   *
+   * @return the prev randao
+   */
   @JsonGetter(value = "prevRandao")
   public String getPrevRandao() {
     return prevRandao;
   }
 
+  /**
+   * Gets state root.
+   *
+   * @return the state root
+   */
   @JsonGetter(value = "stateRoot")
   public String getStateRoot() {
     return stateRoot;
   }
 
+  /**
+   * Gets receipt root.
+   *
+   * @return the receipt root
+   */
   @JsonGetter(value = "receiptsRoot")
   public String getReceiptRoot() {
     return receiptsRoot;
   }
 
+  /**
+   * Gets extra data.
+   *
+   * @return the extra data
+   */
   @JsonGetter(value = "extraData")
   public String getExtraData() {
     return extraData;
   }
 
+  /**
+   * Gets base fee per gas.
+   *
+   * @return the base fee per gas
+   */
   @JsonGetter(value = "baseFeePerGas")
   public String getBaseFeePerGas() {
     return baseFeePerGas;
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @return the gas limit
+   */
   @JsonGetter(value = "gasLimit")
   public String getGasLimit() {
     return gasLimit;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   @JsonGetter(value = "gasUsed")
   public String getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   @JsonGetter(value = "timestamp")
   public String getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   @JsonGetter(value = "transactions")
   public List<String> getTransactions() {
     return transactions;
   }
 
+  /**
+   * Gets fee recipient.
+   *
+   * @return the fee recipient
+   */
   @JsonGetter(value = "feeRecipient")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getFeeRecipient() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV2.java
@@ -27,14 +27,25 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine get payload result v2. */
 @JsonPropertyOrder({
   "executionPayload",
   "blockValue",
 })
 public class EngineGetPayloadResultV2 {
+  /** The Execution payload. */
   protected final PayloadResult executionPayload;
+
   private final String blockValue;
 
+  /**
+   * Instantiates a new Engine get payload result v2.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param withdrawals the withdrawals
+   * @param blockValue the block value
+   */
   public EngineGetPayloadResultV2(
       final BlockHeader header,
       final List<String> transactions,
@@ -44,19 +55,32 @@ public class EngineGetPayloadResultV2 {
     this.blockValue = blockValue;
   }
 
+  /**
+   * Gets execution payload.
+   *
+   * @return the execution payload
+   */
   @JsonGetter(value = "executionPayload")
   public PayloadResult getExecutionPayload() {
     return executionPayload;
   }
 
+  /**
+   * Gets block value.
+   *
+   * @return the block value
+   */
   @JsonGetter(value = "blockValue")
   public String getBlockValue() {
     return blockValue;
   }
 
+  /** The type Payload result. */
   public static class PayloadResult {
 
+    /** The Block hash. */
     protected final String blockHash;
+
     private final String parentHash;
     private final String feeRecipient;
     private final String stateRoot;
@@ -69,9 +93,19 @@ public class EngineGetPayloadResultV2 {
     private final String timestamp;
     private final String extraData;
     private final String baseFeePerGas;
+
+    /** The Transactions. */
     protected final List<String> transactions;
+
     private final List<WithdrawalParameter> withdrawals;
 
+    /**
+     * Instantiates a new Payload result.
+     *
+     * @param header the header
+     * @param transactions the transactions
+     * @param withdrawals the withdrawals
+     */
     public PayloadResult(
         final BlockHeader header,
         final List<String> transactions,
@@ -100,76 +134,151 @@ public class EngineGetPayloadResultV2 {
               .orElse(null);
     }
 
+    /**
+     * Gets number.
+     *
+     * @return the number
+     */
     @JsonGetter(value = "blockNumber")
     public String getNumber() {
       return blockNumber;
     }
 
+    /**
+     * Gets hash.
+     *
+     * @return the hash
+     */
     @JsonGetter(value = "blockHash")
     public String getHash() {
       return blockHash;
     }
 
+    /**
+     * Gets parent hash.
+     *
+     * @return the parent hash
+     */
     @JsonGetter(value = "parentHash")
     public String getParentHash() {
       return parentHash;
     }
 
+    /**
+     * Gets logs bloom.
+     *
+     * @return the logs bloom
+     */
     @JsonGetter(value = "logsBloom")
     public String getLogsBloom() {
       return logsBloom;
     }
 
+    /**
+     * Gets prev randao.
+     *
+     * @return the prev randao
+     */
     @JsonGetter(value = "prevRandao")
     public String getPrevRandao() {
       return prevRandao;
     }
 
+    /**
+     * Gets state root.
+     *
+     * @return the state root
+     */
     @JsonGetter(value = "stateRoot")
     public String getStateRoot() {
       return stateRoot;
     }
 
+    /**
+     * Gets receipt root.
+     *
+     * @return the receipt root
+     */
     @JsonGetter(value = "receiptsRoot")
     public String getReceiptRoot() {
       return receiptsRoot;
     }
 
+    /**
+     * Gets extra data.
+     *
+     * @return the extra data
+     */
     @JsonGetter(value = "extraData")
     public String getExtraData() {
       return extraData;
     }
 
+    /**
+     * Gets base fee per gas.
+     *
+     * @return the base fee per gas
+     */
     @JsonGetter(value = "baseFeePerGas")
     public String getBaseFeePerGas() {
       return baseFeePerGas;
     }
 
+    /**
+     * Gets gas limit.
+     *
+     * @return the gas limit
+     */
     @JsonGetter(value = "gasLimit")
     public String getGasLimit() {
       return gasLimit;
     }
 
+    /**
+     * Gets gas used.
+     *
+     * @return the gas used
+     */
     @JsonGetter(value = "gasUsed")
     public String getGasUsed() {
       return gasUsed;
     }
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     @JsonGetter(value = "timestamp")
     public String getTimestamp() {
       return timestamp;
     }
 
+    /**
+     * Gets transactions.
+     *
+     * @return the transactions
+     */
     @JsonGetter(value = "transactions")
     public List<String> getTransactions() {
       return transactions;
     }
 
+    /**
+     * Gets withdrawals.
+     *
+     * @return the withdrawals
+     */
     @JsonGetter(value = "withdrawals")
     public List<WithdrawalParameter> getWithdrawals() {
       return withdrawals;
     }
 
+    /**
+     * Gets fee recipient.
+     *
+     * @return the fee recipient
+     */
     @JsonGetter(value = "feeRecipient")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFeeRecipient() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
@@ -27,13 +27,25 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine get payload result v3. */
 @JsonPropertyOrder({"executionPayload", "blockValue", "blobsBundle", "shouldOverrideBuilder"})
 public class EngineGetPayloadResultV3 {
+  /** The Execution payload. */
   protected final PayloadResult executionPayload;
+
   private final String blockValue;
   private final BlobsBundleV1 blobsBundle;
   private final boolean shouldOverrideBuilder;
 
+  /**
+   * Instantiates a new Engine get payload result v3.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param withdrawals the withdrawals
+   * @param blockValue the block value
+   * @param blobsBundle the blobs bundle
+   */
   public EngineGetPayloadResultV3(
       final BlockHeader header,
       final List<String> transactions,
@@ -46,29 +58,52 @@ public class EngineGetPayloadResultV3 {
     this.shouldOverrideBuilder = false;
   }
 
+  /**
+   * Gets execution payload.
+   *
+   * @return the execution payload
+   */
   @JsonGetter(value = "executionPayload")
   public PayloadResult getExecutionPayload() {
     return executionPayload;
   }
 
+  /**
+   * Gets block value.
+   *
+   * @return the block value
+   */
   @JsonGetter(value = "blockValue")
   public String getBlockValue() {
     return blockValue;
   }
 
+  /**
+   * Gets blobs bundle.
+   *
+   * @return the blobs bundle
+   */
   @JsonGetter(value = "blobsBundle")
   public BlobsBundleV1 getBlobsBundle() {
     return blobsBundle;
   }
 
+  /**
+   * Should override builder boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "shouldOverrideBuilder")
   public boolean shouldOverrideBuilder() {
     return shouldOverrideBuilder;
   }
 
+  /** The type Payload result. */
   public static class PayloadResult {
 
+    /** The Block hash. */
     protected final String blockHash;
+
     private final String parentHash;
     private final String feeRecipient;
     private final String stateRoot;
@@ -85,9 +120,18 @@ public class EngineGetPayloadResultV3 {
     private final String blobGasUsed;
     private final String parentBeaconBlockRoot;
 
+    /** The Transactions. */
     protected final List<String> transactions;
+
     private final List<WithdrawalParameter> withdrawals;
 
+    /**
+     * Instantiates a new Payload result.
+     *
+     * @param header the header
+     * @param transactions the transactions
+     * @param withdrawals the withdrawals
+     */
     public PayloadResult(
         final BlockHeader header,
         final List<String> transactions,
@@ -121,92 +165,182 @@ public class EngineGetPayloadResultV3 {
           header.getParentBeaconBlockRoot().map(Bytes32::toHexString).orElse(null);
     }
 
+    /**
+     * Gets number.
+     *
+     * @return the number
+     */
     @JsonGetter(value = "blockNumber")
     public String getNumber() {
       return blockNumber;
     }
 
+    /**
+     * Gets hash.
+     *
+     * @return the hash
+     */
     @JsonGetter(value = "blockHash")
     public String getHash() {
       return blockHash;
     }
 
+    /**
+     * Gets parent hash.
+     *
+     * @return the parent hash
+     */
     @JsonGetter(value = "parentHash")
     public String getParentHash() {
       return parentHash;
     }
 
+    /**
+     * Gets logs bloom.
+     *
+     * @return the logs bloom
+     */
     @JsonGetter(value = "logsBloom")
     public String getLogsBloom() {
       return logsBloom;
     }
 
+    /**
+     * Gets prev randao.
+     *
+     * @return the prev randao
+     */
     @JsonGetter(value = "prevRandao")
     public String getPrevRandao() {
       return prevRandao;
     }
 
+    /**
+     * Gets state root.
+     *
+     * @return the state root
+     */
     @JsonGetter(value = "stateRoot")
     public String getStateRoot() {
       return stateRoot;
     }
 
+    /**
+     * Gets receipt root.
+     *
+     * @return the receipt root
+     */
     @JsonGetter(value = "receiptsRoot")
     public String getReceiptRoot() {
       return receiptsRoot;
     }
 
+    /**
+     * Gets extra data.
+     *
+     * @return the extra data
+     */
     @JsonGetter(value = "extraData")
     public String getExtraData() {
       return extraData;
     }
 
+    /**
+     * Gets base fee per gas.
+     *
+     * @return the base fee per gas
+     */
     @JsonGetter(value = "baseFeePerGas")
     public String getBaseFeePerGas() {
       return baseFeePerGas;
     }
 
+    /**
+     * Gets gas limit.
+     *
+     * @return the gas limit
+     */
     @JsonGetter(value = "gasLimit")
     public String getGasLimit() {
       return gasLimit;
     }
 
+    /**
+     * Gets gas used.
+     *
+     * @return the gas used
+     */
     @JsonGetter(value = "gasUsed")
     public String getGasUsed() {
       return gasUsed;
     }
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     @JsonGetter(value = "timestamp")
     public String getTimestamp() {
       return timestamp;
     }
 
+    /**
+     * Gets transactions.
+     *
+     * @return the transactions
+     */
     @JsonGetter(value = "transactions")
     public List<String> getTransactions() {
       return transactions;
     }
 
+    /**
+     * Gets withdrawals.
+     *
+     * @return the withdrawals
+     */
     @JsonGetter(value = "withdrawals")
     public List<WithdrawalParameter> getWithdrawals() {
       return withdrawals;
     }
 
+    /**
+     * Gets fee recipient.
+     *
+     * @return the fee recipient
+     */
     @JsonGetter(value = "feeRecipient")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFeeRecipient() {
       return feeRecipient;
     }
 
+    /**
+     * Gets excess blob gas.
+     *
+     * @return the excess blob gas
+     */
     @JsonGetter(value = "excessBlobGas")
     public String getExcessBlobGas() {
       return excessBlobGas;
     }
 
+    /**
+     * Gets blob gas useds.
+     *
+     * @return the blob gas useds
+     */
     @JsonGetter(value = "blobGasUsed")
     public String getBlobGasUseds() {
       return blobGasUsed;
     }
 
+    /**
+     * Gets parent beacon block root.
+     *
+     * @return the parent beacon block root
+     */
     @JsonGetter(value = "parentBeaconBlockRoot")
     public String getParentBeaconBlockRoot() {
       return parentBeaconBlockRoot;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
@@ -31,13 +31,27 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Engine get payload result v4. */
 @JsonPropertyOrder({"executionPayload", "blockValue", "blobsBundle", "shouldOverrideBuilder"})
 public class EngineGetPayloadResultV4 {
+  /** The Execution payload. */
   protected final PayloadResult executionPayload;
+
   private final String blockValue;
   private final BlobsBundleV1 blobsBundle;
   private final boolean shouldOverrideBuilder;
 
+  /**
+   * Instantiates a new Engine get payload result v4.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param withdrawals the withdrawals
+   * @param deposits the deposits
+   * @param withdrawalRequests the withdrawal requests
+   * @param blockValue the block value
+   * @param blobsBundle the blobs bundle
+   */
   public EngineGetPayloadResultV4(
       final BlockHeader header,
       final List<String> transactions,
@@ -53,29 +67,52 @@ public class EngineGetPayloadResultV4 {
     this.shouldOverrideBuilder = false;
   }
 
+  /**
+   * Gets execution payload.
+   *
+   * @return the execution payload
+   */
   @JsonGetter(value = "executionPayload")
   public PayloadResult getExecutionPayload() {
     return executionPayload;
   }
 
+  /**
+   * Gets block value.
+   *
+   * @return the block value
+   */
   @JsonGetter(value = "blockValue")
   public String getBlockValue() {
     return blockValue;
   }
 
+  /**
+   * Gets blobs bundle.
+   *
+   * @return the blobs bundle
+   */
   @JsonGetter(value = "blobsBundle")
   public BlobsBundleV1 getBlobsBundle() {
     return blobsBundle;
   }
 
+  /**
+   * Should override builder boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "shouldOverrideBuilder")
   public boolean shouldOverrideBuilder() {
     return shouldOverrideBuilder;
   }
 
+  /** The type Payload result. */
   public static class PayloadResult {
 
+    /** The Block hash. */
     protected final String blockHash;
+
     private final String parentHash;
     private final String feeRecipient;
     private final String stateRoot;
@@ -92,11 +129,22 @@ public class EngineGetPayloadResultV4 {
     private final String blobGasUsed;
     private final String parentBeaconBlockRoot;
 
+    /** The Transactions. */
     protected final List<String> transactions;
+
     private final List<WithdrawalParameter> withdrawals;
     private final List<DepositParameter> deposits;
     private final List<WithdrawalRequestParameter> withdrawalRequests;
 
+    /**
+     * Instantiates a new Payload result.
+     *
+     * @param header the header
+     * @param transactions the transactions
+     * @param withdrawals the withdrawals
+     * @param deposits the deposits
+     * @param withdrawalRequests the withdrawal requests
+     */
     public PayloadResult(
         final BlockHeader header,
         final List<String> transactions,
@@ -145,102 +193,202 @@ public class EngineGetPayloadResultV4 {
           header.getParentBeaconBlockRoot().map(Bytes32::toHexString).orElse(null);
     }
 
+    /**
+     * Gets number.
+     *
+     * @return the number
+     */
     @JsonGetter(value = "blockNumber")
     public String getNumber() {
       return blockNumber;
     }
 
+    /**
+     * Gets hash.
+     *
+     * @return the hash
+     */
     @JsonGetter(value = "blockHash")
     public String getHash() {
       return blockHash;
     }
 
+    /**
+     * Gets parent hash.
+     *
+     * @return the parent hash
+     */
     @JsonGetter(value = "parentHash")
     public String getParentHash() {
       return parentHash;
     }
 
+    /**
+     * Gets logs bloom.
+     *
+     * @return the logs bloom
+     */
     @JsonGetter(value = "logsBloom")
     public String getLogsBloom() {
       return logsBloom;
     }
 
+    /**
+     * Gets prev randao.
+     *
+     * @return the prev randao
+     */
     @JsonGetter(value = "prevRandao")
     public String getPrevRandao() {
       return prevRandao;
     }
 
+    /**
+     * Gets state root.
+     *
+     * @return the state root
+     */
     @JsonGetter(value = "stateRoot")
     public String getStateRoot() {
       return stateRoot;
     }
 
+    /**
+     * Gets receipt root.
+     *
+     * @return the receipt root
+     */
     @JsonGetter(value = "receiptsRoot")
     public String getReceiptRoot() {
       return receiptsRoot;
     }
 
+    /**
+     * Gets extra data.
+     *
+     * @return the extra data
+     */
     @JsonGetter(value = "extraData")
     public String getExtraData() {
       return extraData;
     }
 
+    /**
+     * Gets base fee per gas.
+     *
+     * @return the base fee per gas
+     */
     @JsonGetter(value = "baseFeePerGas")
     public String getBaseFeePerGas() {
       return baseFeePerGas;
     }
 
+    /**
+     * Gets gas limit.
+     *
+     * @return the gas limit
+     */
     @JsonGetter(value = "gasLimit")
     public String getGasLimit() {
       return gasLimit;
     }
 
+    /**
+     * Gets gas used.
+     *
+     * @return the gas used
+     */
     @JsonGetter(value = "gasUsed")
     public String getGasUsed() {
       return gasUsed;
     }
 
+    /**
+     * Gets timestamp.
+     *
+     * @return the timestamp
+     */
     @JsonGetter(value = "timestamp")
     public String getTimestamp() {
       return timestamp;
     }
 
+    /**
+     * Gets transactions.
+     *
+     * @return the transactions
+     */
     @JsonGetter(value = "transactions")
     public List<String> getTransactions() {
       return transactions;
     }
 
+    /**
+     * Gets withdrawals.
+     *
+     * @return the withdrawals
+     */
     @JsonGetter(value = "withdrawals")
     public List<WithdrawalParameter> getWithdrawals() {
       return withdrawals;
     }
 
+    /**
+     * Gets deposits.
+     *
+     * @return the deposits
+     */
     @JsonGetter(value = "depositReceipts")
     public List<DepositParameter> getDeposits() {
       return deposits;
     }
 
+    /**
+     * Gets withdrawal requests.
+     *
+     * @return the withdrawal requests
+     */
     @JsonGetter(value = "withdrawalRequests")
     public List<WithdrawalRequestParameter> getWithdrawalRequests() {
       return withdrawalRequests;
     }
 
+    /**
+     * Gets fee recipient.
+     *
+     * @return the fee recipient
+     */
     @JsonGetter(value = "feeRecipient")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getFeeRecipient() {
       return feeRecipient;
     }
 
+    /**
+     * Gets excess blob gas.
+     *
+     * @return the excess blob gas
+     */
     @JsonGetter(value = "excessBlobGas")
     public String getExcessBlobGas() {
       return excessBlobGas;
     }
 
+    /**
+     * Gets blob gas useds.
+     *
+     * @return the blob gas useds
+     */
     @JsonGetter(value = "blobGasUsed")
     public String getBlobGasUseds() {
       return blobGasUsed;
     }
 
+    /**
+     * Gets parent beacon block root.
+     *
+     * @return the parent beacon block root
+     */
     @JsonGetter(value = "parentBeaconBlockRoot")
     public String getParentBeaconBlockRoot() {
       return parentBeaconBlockRoot;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePayloadStatusResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePayloadStatusResult.java
@@ -22,12 +22,25 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Engine payload status result. */
 @JsonPropertyOrder({"status", "latestValidHash", "validationError"})
 public class EnginePayloadStatusResult {
+  /** The Status. */
   EngineStatus status;
+
+  /** The Latest valid hash. */
   Optional<Hash> latestValidHash;
+
+  /** The Validation error. */
   Optional<String> validationError;
 
+  /**
+   * Instantiates a new Engine payload status result.
+   *
+   * @param status the status
+   * @param latestValidHash the latest valid hash
+   * @param validationError the validation error
+   */
   public EnginePayloadStatusResult(
       final EngineStatus status,
       final Hash latestValidHash,
@@ -37,24 +50,49 @@ public class EnginePayloadStatusResult {
     this.validationError = validationError;
   }
 
+  /**
+   * Gets status as string.
+   *
+   * @return the status as string
+   */
   @JsonGetter(value = "status")
   public String getStatusAsString() {
     return status.name();
   }
 
+  /**
+   * Gets status.
+   *
+   * @return the status
+   */
   public EngineStatus getStatus() {
     return status;
   }
 
+  /**
+   * Gets latest valid hash as string.
+   *
+   * @return the latest valid hash as string
+   */
   @JsonGetter(value = "latestValidHash")
   public String getLatestValidHashAsString() {
     return latestValidHash.map(Hash::toHexString).orElse(null);
   }
 
+  /**
+   * Gets latest valid hash.
+   *
+   * @return the latest valid hash
+   */
   public Optional<Hash> getLatestValidHash() {
     return latestValidHash;
   }
 
+  /**
+   * Gets error.
+   *
+   * @return the error
+   */
   @JsonGetter(value = "validationError")
   public String getError() {
     return validationError.orElse(null);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EnginePreparePayloadResult.java
@@ -22,21 +22,38 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Engine prepare payload result. */
 @JsonPropertyOrder({"status", "payloadId"})
 public class EnginePreparePayloadResult {
   private final EngineStatus status;
   private final PayloadIdentifier payloadId;
 
+  /**
+   * Instantiates a new Engine prepare payload result.
+   *
+   * @param status the status
+   * @param payloadId the payload id
+   */
   public EnginePreparePayloadResult(final EngineStatus status, final PayloadIdentifier payloadId) {
     this.status = status;
     this.payloadId = payloadId;
   }
 
+  /**
+   * Gets status.
+   *
+   * @return the status
+   */
   @JsonGetter(value = "status")
   public String getStatus() {
     return status.name();
   }
 
+  /**
+   * Gets payload id.
+   *
+   * @return the payload id
+   */
   @JsonGetter(value = "payloadId")
   public String getPayloadId() {
     return Optional.ofNullable(payloadId).map(PayloadIdentifier::toShortHexString).orElse("");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineUpdateForkchoiceResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineUpdateForkchoiceResult.java
@@ -28,13 +28,24 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Engine update forkchoice result. */
 @JsonPropertyOrder({"payloadStatus", "payloadId"})
 public class EngineUpdateForkchoiceResult {
   private final EnginePayloadStatusResult payloadStatus;
   private final PayloadIdentifier payloadId;
+
+  /** The Fork choice engine status. */
   static final EnumSet<EngineStatus> FORK_CHOICE_ENGINE_STATUS =
       EnumSet.of(VALID, INVALID, SYNCING);
 
+  /**
+   * Instantiates a new Engine update forkchoice result.
+   *
+   * @param status the status
+   * @param latestValidHash the latest valid hash
+   * @param payloadId the payload id
+   * @param errorMessage the error message
+   */
   public EngineUpdateForkchoiceResult(
       final EngineStatus status,
       final Hash latestValidHash,
@@ -50,11 +61,21 @@ public class EngineUpdateForkchoiceResult {
     this.payloadId = payloadId;
   }
 
+  /**
+   * Gets payload status.
+   *
+   * @return the payload status
+   */
   @JsonGetter(value = "payloadStatus")
   public EnginePayloadStatusResult getPayloadStatus() {
     return payloadStatus;
   }
 
+  /**
+   * Gets payload id.
+   *
+   * @return the payload id
+   */
   @JsonGetter(value = "payloadId")
   public String getPayloadId() {
     return Optional.ofNullable(payloadId).map(PayloadIdentifier::toHexString).orElse(null);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/FeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/FeeHistory.java
@@ -26,44 +26,112 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.immutables.value.Value;
 
+/** The interface Fee history. */
 @Value.Immutable
 public interface FeeHistory {
 
+  /**
+   * Gets oldest block.
+   *
+   * @return the oldest block
+   */
   long getOldestBlock();
 
+  /**
+   * Gets base fee per gas.
+   *
+   * @return the base fee per gas
+   */
   List<Wei> getBaseFeePerGas();
 
+  /**
+   * Gets base fee per blob gas.
+   *
+   * @return the base fee per blob gas
+   */
   List<Wei> getBaseFeePerBlobGas();
 
+  /**
+   * Gets gas used ratio.
+   *
+   * @return the gas used ratio
+   */
   List<Double> getGasUsedRatio();
 
+  /**
+   * Gets blob gas used ratio.
+   *
+   * @return the blob gas used ratio
+   */
   List<Double> getBlobGasUsedRatio();
 
+  /**
+   * Gets reward.
+   *
+   * @return the reward
+   */
   Optional<List<List<Wei>>> getReward();
 
+  /** The interface Fee history result. */
   @Value.Immutable
   @Value.Style(allParameters = true)
   @JsonInclude(JsonInclude.Include.NON_NULL)
   interface FeeHistoryResult {
+    /**
+     * Gets oldest block.
+     *
+     * @return the oldest block
+     */
     @JsonProperty("oldestBlock")
     String getOldestBlock();
 
+    /**
+     * Gets base fee per gas.
+     *
+     * @return the base fee per gas
+     */
     @JsonProperty("baseFeePerGas")
     List<String> getBaseFeePerGas();
 
+    /**
+     * Gets base fee per blob gas.
+     *
+     * @return the base fee per blob gas
+     */
     @JsonProperty("baseFeePerBlobGas")
     List<String> getBaseFeePerBlobGas();
 
+    /**
+     * Gets gas used ratio.
+     *
+     * @return the gas used ratio
+     */
     @JsonProperty("gasUsedRatio")
     List<Double> getGasUsedRatio();
 
+    /**
+     * Gets blob gas used ratio.
+     *
+     * @return the blob gas used ratio
+     */
     @JsonProperty("blobGasUsedRatio")
     List<Double> getBlobGasUsedRatio();
 
+    /**
+     * Gets reward.
+     *
+     * @return the reward
+     */
     @Nullable
     @JsonProperty("reward")
     List<List<String>> getReward();
 
+    /**
+     * From fee history result.
+     *
+     * @param feeHistory the fee history
+     * @return the fee history result
+     */
     static FeeHistoryResult from(final FeeHistory feeHistory) {
       return ImmutableFeeHistoryResult.of(
           Quantity.create(feeHistory.getOldestBlock()),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/JsonRpcResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/JsonRpcResult.java
@@ -17,5 +17,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+/** The interface Json rpc result. */
 @JsonInclude(Include.NON_ABSENT)
 public interface JsonRpcResult {}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogResult.java
@@ -47,6 +47,11 @@ public class LogResult implements JsonRpcResult {
   private final List<String> topics;
   private final boolean removed;
 
+  /**
+   * Instantiates a new Log result.
+   *
+   * @param logWithMetadata the log with metadata
+   */
   public LogResult(final LogWithMetadata logWithMetadata) {
     this.logIndex = Quantity.create(logWithMetadata.getLogIndex());
     this.blockNumber = Quantity.create(logWithMetadata.getBlockNumber());
@@ -63,46 +68,91 @@ public class LogResult implements JsonRpcResult {
     }
   }
 
+  /**
+   * Gets log index.
+   *
+   * @return the log index
+   */
   @JsonGetter(value = "logIndex")
   public String getLogIndex() {
     return logIndex;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonGetter(value = "transactionHash")
   public String getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   @JsonGetter(value = "address")
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   @JsonGetter(value = "data")
   public String getData() {
     return data;
   }
 
+  /**
+   * Gets topics.
+   *
+   * @return the topics
+   */
   @JsonGetter(value = "topics")
   public List<String> getTopics() {
     return topics;
   }
 
+  /**
+   * Is removed boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "removed")
   public boolean isRemoved() {
     return removed;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogsResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/LogsResult.java
@@ -26,6 +26,11 @@ public class LogsResult {
 
   private final List<LogResult> results;
 
+  /**
+   * Instantiates a new Logs result.
+   *
+   * @param logs the logs
+   */
   public LogsResult(final List<LogWithMetadata> logs) {
     results = new ArrayList<>(logs.size());
 
@@ -34,6 +39,11 @@ public class LogsResult {
     }
   }
 
+  /**
+   * Gets results.
+   *
+   * @return the results
+   */
   @JsonValue
   public List<LogResult> getResults() {
     return results;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/MinerDataResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/MinerDataResult.java
@@ -18,30 +18,90 @@ import java.util.List;
 
 import org.immutables.value.Value;
 
+/** The type Miner data result. */
 @Value.Immutable
 public abstract class MinerDataResult implements JsonRpcResult {
+  /** Default constructor. */
+  public MinerDataResult() {}
+
+  /**
+   * Gets net block reward.
+   *
+   * @return the net block reward
+   */
   public abstract String getNetBlockReward();
 
+  /**
+   * Gets static block reward.
+   *
+   * @return the static block reward
+   */
   public abstract String getStaticBlockReward();
 
+  /**
+   * Gets transaction fee.
+   *
+   * @return the transaction fee
+   */
   public abstract String getTransactionFee();
 
+  /**
+   * Gets uncle inclusion reward.
+   *
+   * @return the uncle inclusion reward
+   */
   public abstract String getUncleInclusionReward();
 
+  /**
+   * Gets uncle rewards.
+   *
+   * @return the uncle rewards
+   */
   public abstract List<UncleRewardResult> getUncleRewards();
 
+  /**
+   * Gets coinbase.
+   *
+   * @return the coinbase
+   */
   public abstract String getCoinbase();
 
+  /**
+   * Gets extra data.
+   *
+   * @return the extra data
+   */
   public abstract String getExtraData();
 
+  /**
+   * Gets difficulty.
+   *
+   * @return the difficulty
+   */
   public abstract String getDifficulty();
 
+  /**
+   * Gets total difficulty.
+   *
+   * @return the total difficulty
+   */
   public abstract String getTotalDifficulty();
 
+  /** The interface Uncle reward result. */
   @Value.Immutable
   public interface UncleRewardResult {
+    /**
+     * Gets hash.
+     *
+     * @return the hash
+     */
     String getHash();
 
+    /**
+     * Gets coinbase.
+     *
+     * @return the coinbase
+     */
     String getCoinbase();
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/NetworkResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/NetworkResult.java
@@ -19,22 +19,39 @@ import java.net.SocketAddress;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Network result. */
 @JsonPropertyOrder({"localAddress", "remoteAddress"})
 public class NetworkResult {
 
   private final String localAddress;
   private final String remoteAddress;
 
+  /**
+   * Instantiates a new Network result.
+   *
+   * @param localAddress the local address
+   * @param remoteAddress the remote address
+   */
   public NetworkResult(final SocketAddress localAddress, final SocketAddress remoteAddress) {
     this.localAddress = removeTrailingSlash(localAddress.toString());
     this.remoteAddress = removeTrailingSlash(remoteAddress.toString());
   }
 
+  /**
+   * Gets local address.
+   *
+   * @return the local address
+   */
   @JsonGetter(value = "localAddress")
   public String getLocalAddress() {
     return localAddress;
   }
 
+  /**
+   * Gets remote address.
+   *
+   * @return the remote address
+   */
   @JsonGetter(value = "remoteAddress")
   public String getRemoteAddress() {
     return remoteAddress;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
@@ -29,11 +29,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.immutables.value.Value;
 
+/** The interface Peer result. */
 @JsonPropertyOrder({"version", "name", "caps", "network", "port", "id", "protocols", "enode"})
 @Value.Immutable
 @Value.Style(allParameters = true)
 public interface PeerResult {
 
+  /**
+   * From eth peer peer result.
+   *
+   * @param peer the peer
+   * @return the peer result
+   */
   static PeerResult fromEthPeer(final EthPeer peer) {
     final PeerConnection connection = peer.getConnection();
     final PeerInfo peerInfo = connection.getPeerInfo();
@@ -53,27 +60,67 @@ public interface PeerResult {
         .build();
   }
 
+  /**
+   * Gets version.
+   *
+   * @return the version
+   */
   @JsonGetter(value = "version")
   String getVersion();
 
+  /**
+   * Gets name.
+   *
+   * @return the name
+   */
   @JsonGetter(value = "name")
   String getName();
 
+  /**
+   * Gets caps.
+   *
+   * @return the caps
+   */
   @JsonGetter(value = "caps")
   List<JsonNode> getCaps();
 
+  /**
+   * Gets network.
+   *
+   * @return the network
+   */
   @JsonGetter(value = "network")
   NetworkResult getNetwork();
 
+  /**
+   * Gets port.
+   *
+   * @return the port
+   */
   @JsonGetter(value = "port")
   String getPort();
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @JsonGetter(value = "id")
   String getId();
 
+  /**
+   * Gets protocols.
+   *
+   * @return the protocols
+   */
   @JsonGetter(value = "protocols")
   Map<String, ProtocolsResult> getProtocols();
 
+  /**
+   * Gets enode.
+   *
+   * @return the enode
+   */
   @JsonGetter(value = "enode")
   String getEnode();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionResult.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Pending transaction result. */
 @JsonPropertyOrder({"hash", "isReceivedFromLocalSource"})
 public class PendingTransactionResult implements TransactionResult {
 
@@ -28,22 +29,42 @@ public class PendingTransactionResult implements TransactionResult {
   private final boolean isReceivedFromLocalSource;
   private final Instant addedToPoolAt;
 
+  /**
+   * Instantiates a new Pending transaction result.
+   *
+   * @param pendingTransaction the pending transaction
+   */
   public PendingTransactionResult(final PendingTransaction pendingTransaction) {
     hash = pendingTransaction.getHash().toString();
     isReceivedFromLocalSource = pendingTransaction.isReceivedFromLocalSource();
     addedToPoolAt = Instant.ofEpochMilli(pendingTransaction.getAddedAt());
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "hash")
   public String getHash() {
     return hash;
   }
 
+  /**
+   * Gets added to pool at.
+   *
+   * @return the added to pool at
+   */
   @JsonGetter(value = "addedToPoolAt")
   public String getAddedToPoolAt() {
     return addedToPoolAt.toString();
   }
 
+  /**
+   * Is received from local source boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "isReceivedFromLocalSource")
   public boolean isReceivedFromLocalSource() {
     return isReceivedFromLocalSource;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionsResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionsResult.java
@@ -21,15 +21,26 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/** The type Pending transactions result. */
 public class PendingTransactionsResult implements TransactionResult {
 
   private final List<PendingTransactionResult> pendingTransactionResults;
 
+  /**
+   * Instantiates a new Pending transactions result.
+   *
+   * @param pendingTransactionSet the pending transaction set
+   */
   public PendingTransactionsResult(final Collection<PendingTransaction> pendingTransactionSet) {
     pendingTransactionResults =
         pendingTransactionSet.stream().map(PendingTransactionResult::new).toList();
   }
 
+  /**
+   * Gets results.
+   *
+   * @return the results
+   */
   @JsonValue
   public List<PendingTransactionResult> getResults() {
     return pendingTransactionResults;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionsStatisticsResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PendingTransactionsStatisticsResult.java
@@ -16,12 +16,20 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Pending transactions statistics result. */
 public class PendingTransactionsStatisticsResult {
 
   private final long maxSize;
   private final long localCount;
   private final long remoteCount;
 
+  /**
+   * Instantiates a new Pending transactions statistics result.
+   *
+   * @param maxSize the max size
+   * @param localCount the local count
+   * @param remoteCount the remote count
+   */
   public PendingTransactionsStatisticsResult(
       final long maxSize, final long localCount, final long remoteCount) {
     this.maxSize = maxSize;
@@ -29,16 +37,31 @@ public class PendingTransactionsStatisticsResult {
     this.remoteCount = remoteCount;
   }
 
+  /**
+   * Gets max size.
+   *
+   * @return the max size
+   */
   @JsonGetter
   public long getMaxSize() {
     return maxSize;
   }
 
+  /**
+   * Gets local count.
+   *
+   * @return the local count
+   */
   @JsonGetter
   public long getLocalCount() {
     return localCount;
   }
 
+  /**
+   * Gets remote count.
+   *
+   * @return the remote count
+   */
   @JsonGetter
   public long getRemoteCount() {
     return remoteCount;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/ProtocolsResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/ProtocolsResult.java
@@ -23,11 +23,18 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 import org.immutables.value.Value;
 
+/** The interface Protocols result. */
 @JsonPropertyOrder({"difficulty", "head", "version"})
 @Value.Immutable
 @Value.Style(allParameters = true)
 public interface ProtocolsResult {
 
+  /**
+   * From eth peer protocols result.
+   *
+   * @param ethPeer the eth peer
+   * @return the protocols result
+   */
   static ProtocolsResult fromEthPeer(final EthPeer ethPeer) {
     final BestBlock bestBlock = ethPeer.chainState().getBestBlock();
     return ImmutableProtocolsResult.builder()
@@ -37,9 +44,24 @@ public interface ProtocolsResult {
         .build();
   }
 
+  /**
+   * Gets difficulty.
+   *
+   * @return the difficulty
+   */
   String getDifficulty();
 
+  /**
+   * Gets head.
+   *
+   * @return the head
+   */
   String getHead();
 
+  /**
+   * Gets version.
+   *
+   * @return the version
+   */
   int getVersion();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/Quantity.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/Quantity.java
@@ -31,38 +31,88 @@ import org.apache.tuweni.units.bigints.UInt64Value;
 public class Quantity {
 
   private static final String HEX_PREFIX = "0x";
+
+  /** The constant HEX_ZERO. */
   public static final String HEX_ZERO = "0x0";
 
   private Quantity() {}
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final UInt256Value<?> value) {
     return uint256ToHex(value);
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final UInt64Value<?> value) {
     return (value == null || value.isZero()) ? HEX_ZERO : value.toMinimalBytes().toShortHexString();
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final int value) {
     return uint256ToHex(UInt256.valueOf(value));
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final long value) {
     return uint256ToHex(UInt256.fromHexString(Long.toHexString(value)));
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final Bytes value) {
     return create(value.toArrayUnsafe());
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final byte[] value) {
     return uint256ToHex(UInt256.fromBytes(Bytes32.leftPad(Bytes.wrap(value))));
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final BigInteger value) {
     return uint256ToHex(UInt256.valueOf(value));
   }
 
+  /**
+   * Create string.
+   *
+   * @param value the value
+   * @return the string
+   */
   public static String create(final byte value) {
     return formatMinimalValue(Integer.toHexString(value));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/SignerMetricResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/SignerMetricResult.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Signer metric result. */
 @JsonPropertyOrder({"address", "proposedBlockCount", "lastProposedBlockNumber"})
 public class SignerMetricResult {
 
@@ -28,6 +29,11 @@ public class SignerMetricResult {
   private long proposedBlockCount;
   private long lastProposedBlockNumber;
 
+  /**
+   * Instantiates a new Signer metric result.
+   *
+   * @param address the address
+   */
   public SignerMetricResult(final Address address) {
     this.address = address.toString();
   }
@@ -51,25 +57,46 @@ public class SignerMetricResult {
     return Objects.hash(address, proposedBlockCount, lastProposedBlockNumber);
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   @JsonGetter(value = "address")
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Gets proposed block count.
+   *
+   * @return the proposed block count
+   */
   @JsonGetter(value = "proposedBlockCount")
   public String getProposedBlockCount() {
     return Quantity.create(proposedBlockCount);
   }
 
+  /**
+   * Gets last proposed block number.
+   *
+   * @return the last proposed block number
+   */
   @JsonGetter(value = "lastProposedBlockNumber")
   public String getLastProposedBlockNumber() {
     return Quantity.create(lastProposedBlockNumber);
   }
 
+  /** Incremente nb block. */
   public void incrementeNbBlock() {
     this.proposedBlockCount++;
   }
 
+  /**
+   * Sets last proposed block number.
+   *
+   * @param lastProposedBlockNumber the last proposed block number
+   */
   public void setLastProposedBlockNumber(final long lastProposedBlockNumber) {
     this.lastProposedBlockNumber = lastProposedBlockNumber;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLog.java
@@ -27,6 +27,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Struct log. */
 @JsonPropertyOrder({"pc", "op", "gas", "gasCost", "depth", "stack", "memory", "storage"})
 public class StructLog {
 
@@ -39,8 +40,15 @@ public class StructLog {
   private final String[] stack;
   private final Object storage;
   private final String reason;
+
+  /** The Bytes 32 zero string. */
   static final String bytes32ZeroString = Bytes32.ZERO.toUnprefixedHexString();
 
+  /**
+   * Instantiates a new Struct log.
+   *
+   * @param traceFrame the trace frame
+   */
   public StructLog(final TraceFrame traceFrame) {
     depth = traceFrame.getDepth() + 1;
     gas = traceFrame.getGasRemaining();
@@ -82,46 +90,91 @@ public class StructLog {
     return formattedStorage;
   }
 
+  /**
+   * Depth int.
+   *
+   * @return the int
+   */
   @JsonGetter("depth")
   public int depth() {
     return depth;
   }
 
+  /**
+   * Gas long.
+   *
+   * @return the long
+   */
   @JsonGetter("gas")
   public long gas() {
     return gas;
   }
 
+  /**
+   * Gas cost long.
+   *
+   * @return the long
+   */
   @JsonGetter("gasCost")
   public long gasCost() {
     return gasCost;
   }
 
+  /**
+   * Memory string [ ].
+   *
+   * @return the string [ ]
+   */
   @JsonGetter("memory")
   public String[] memory() {
     return memory;
   }
 
+  /**
+   * Op string.
+   *
+   * @return the string
+   */
   @JsonGetter("op")
   public String op() {
     return op;
   }
 
+  /**
+   * Pc int.
+   *
+   * @return the int
+   */
   @JsonGetter("pc")
   public int pc() {
     return pc;
   }
 
+  /**
+   * Stack string [ ].
+   *
+   * @return the string [ ]
+   */
   @JsonGetter("stack")
   public String[] stack() {
     return stack;
   }
 
+  /**
+   * Storage object.
+   *
+   * @return the object
+   */
   @JsonGetter("storage")
   public Object storage() {
     return storage;
   }
 
+  /**
+   * Reason string.
+   *
+   * @return the string
+   */
   @JsonGetter("reason")
   public String reason() {
     return reason;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogWithError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/StructLogWithError.java
@@ -18,16 +18,27 @@ import org.hyperledger.besu.ethereum.debug.TraceFrame;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Struct log with error. */
 public class StructLogWithError extends StructLog {
 
   private final String[] error;
 
+  /**
+   * Instantiates a new Struct log with error.
+   *
+   * @param traceFrame the trace frame
+   */
   StructLogWithError(final TraceFrame traceFrame) {
     super(traceFrame);
     error =
         traceFrame.getExceptionalHaltReason().map(ehr -> new String[] {ehr.name()}).orElse(null);
   }
 
+  /**
+   * Get error string [ ].
+   *
+   * @return the string [ ]
+   */
   @JsonGetter("error")
   public String[] getError() {
     return error;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/SyncingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/SyncingResult.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Syncing result. */
 @JsonPropertyOrder({"startingBlock", "currentBlock", "highestBlock"})
 public class SyncingResult implements JsonRpcResult {
 
@@ -32,6 +33,11 @@ public class SyncingResult implements JsonRpcResult {
   private final String pullStates;
   private final String knownStates;
 
+  /**
+   * Instantiates a new Syncing result.
+   *
+   * @param syncStatus the sync status
+   */
   public SyncingResult(final SyncStatus syncStatus) {
 
     this.startingBlock = Quantity.create(syncStatus.getStartingBlock());
@@ -41,27 +47,52 @@ public class SyncingResult implements JsonRpcResult {
     this.knownStates = syncStatus.getKnownStates().map(Quantity::create).orElse(null);
   }
 
+  /**
+   * Gets starting block.
+   *
+   * @return the starting block
+   */
   @JsonGetter(value = "startingBlock")
   public String getStartingBlock() {
     return startingBlock;
   }
 
+  /**
+   * Gets current block.
+   *
+   * @return the current block
+   */
   @JsonGetter(value = "currentBlock")
   public String getCurrentBlock() {
     return currentBlock;
   }
 
+  /**
+   * Gets highest block.
+   *
+   * @return the highest block
+   */
   @JsonGetter(value = "highestBlock")
   public String getHighestBlock() {
     return highestBlock;
   }
 
+  /**
+   * Gets pull states.
+   *
+   * @return the pull states
+   */
   @JsonInclude(value = Include.NON_NULL)
   @JsonGetter(value = "pulledStates")
   public String getPullStates() {
     return pullStates;
   }
 
+  /**
+   * Gets known states.
+   *
+   * @return the known states
+   */
   @JsonInclude(value = Include.NON_NULL)
   @JsonGetter(value = "knownStates")
   public String getKnownStates() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TraceCallResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TraceCallResult.java
@@ -24,6 +24,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Trace call result. */
 @JsonPropertyOrder({"output", "stateDiff", "trace", "vmTrace"})
 public class TraceCallResult {
   private final String output;
@@ -31,6 +32,14 @@ public class TraceCallResult {
   private final List<FlatTrace> traces;
   private final VmTrace vmTrace;
 
+  /**
+   * Instantiates a new Trace call result.
+   *
+   * @param output the output
+   * @param stateDiff the state diff
+   * @param traces the traces
+   * @param vmTrace the vm trace
+   */
   public TraceCallResult(
       final String output,
       final StateDiffTrace stateDiff,
@@ -42,52 +51,106 @@ public class TraceCallResult {
     this.vmTrace = vmTrace;
   }
 
+  /**
+   * Gets output.
+   *
+   * @return the output
+   */
   @JsonGetter(value = "output")
   public String getOutput() {
     return output;
   }
 
+  /**
+   * Gets state diff.
+   *
+   * @return the state diff
+   */
   @JsonGetter(value = "stateDiff")
   public StateDiffTrace getStateDiff() {
     return stateDiff;
   }
 
+  /**
+   * Gets traces.
+   *
+   * @return the traces
+   */
   @JsonGetter(value = "trace")
   public List<FlatTrace> getTraces() {
     return traces;
   }
 
+  /**
+   * Gets vm trace.
+   *
+   * @return the vm trace
+   */
   @JsonGetter(value = "vmTrace")
   public VmTrace getVmTrace() {
     return vmTrace;
   }
 
+  /**
+   * Builder builder.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** The type Builder. */
   public static class Builder {
     private String output;
     private StateDiffTrace stateDiff;
     private final List<FlatTrace> traces = new ArrayList<>();
     private VmTrace vmTrace;
 
+    /** Instantiates a new Builder. */
+    public Builder() {}
+
+    /**
+     * Build trace call result.
+     *
+     * @return the trace call result
+     */
     public TraceCallResult build() {
       return new TraceCallResult(output, stateDiff, traces, vmTrace);
     }
 
+    /**
+     * Output.
+     *
+     * @param output the output
+     */
     public void output(final String output) {
       this.output = output;
     }
 
+    /**
+     * State diff.
+     *
+     * @param stateDiff the state diff
+     */
     public void stateDiff(final StateDiffTrace stateDiff) {
       this.stateDiff = stateDiff;
     }
 
+    /**
+     * Add trace.
+     *
+     * @param trace the trace
+     */
     public void addTrace(final FlatTrace trace) {
       traces.add(trace);
     }
 
+    /**
+     * Vm trace.
+     *
+     * @param vmTrace the vm trace
+     */
     public void vmTrace(final VmTrace vmTrace) {
       this.vmTrace = vmTrace;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TraceReplayResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TraceReplayResult.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Trace replay result. */
 @JsonPropertyOrder({"output", "revertReason", "stateDiff", "trace", "transactionHash", "vmTrace"})
 public class TraceReplayResult {
   private final String output;
@@ -35,6 +36,16 @@ public class TraceReplayResult {
   private final VmTrace vmTrace;
   private final String transactionHash;
 
+  /**
+   * Instantiates a new Trace replay result.
+   *
+   * @param output the output
+   * @param revertReason the revert reason
+   * @param stateDiff the state diff
+   * @param traces the traces
+   * @param transactionHash the transaction hash
+   * @param vmTrace the vm trace
+   */
   public TraceReplayResult(
       final String output,
       final String revertReason,
@@ -50,41 +61,77 @@ public class TraceReplayResult {
     this.vmTrace = vmTrace;
   }
 
+  /**
+   * Gets output.
+   *
+   * @return the output
+   */
   @JsonGetter(value = "output")
   public String getOutput() {
     return output;
   }
 
+  /**
+   * Gets revert reason.
+   *
+   * @return the revert reason
+   */
   @JsonInclude(Include.NON_NULL)
   @JsonGetter(value = "revertReason")
   public String getRevertReason() {
     return revertReason;
   }
 
+  /**
+   * Gets state diff.
+   *
+   * @return the state diff
+   */
   @JsonGetter(value = "stateDiff")
   public StateDiffTrace getStateDiff() {
     return stateDiff;
   }
 
+  /**
+   * Gets traces.
+   *
+   * @return the traces
+   */
   @JsonGetter(value = "trace")
   public List<FlatTrace> getTraces() {
     return traces;
   }
 
+  /**
+   * Gets vm trace.
+   *
+   * @return the vm trace
+   */
   @JsonGetter(value = "vmTrace")
   public VmTrace getVmTrace() {
     return vmTrace;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonGetter(value = "transactionHash")
   public String getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Creates a new Builder instance.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** The type Builder. */
   public static class Builder {
     private String output;
     private String revertReason;
@@ -93,31 +140,69 @@ public class TraceReplayResult {
     private VmTrace vmTrace;
     private String transactionHash;
 
+    /** Instantiates a new Builder. */
+    private Builder() {}
+
+    /**
+     * Build trace replay result.
+     *
+     * @return the trace replay result
+     */
     public TraceReplayResult build() {
       return new TraceReplayResult(
           output, revertReason, stateDiff, traces, transactionHash, vmTrace);
     }
 
+    /**
+     * Output.
+     *
+     * @param output the output
+     */
     public void output(final String output) {
       this.output = output;
     }
 
+    /**
+     * Revert reason.
+     *
+     * @param revertReason the revert reason
+     */
     public void revertReason(final String revertReason) {
       this.revertReason = revertReason;
     }
 
+    /**
+     * State diff.
+     *
+     * @param stateDiff the state diff
+     */
     public void stateDiff(final StateDiffTrace stateDiff) {
       this.stateDiff = stateDiff;
     }
 
+    /**
+     * Transaction hash.
+     *
+     * @param transactionHash the transaction hash
+     */
     public void transactionHash(final String transactionHash) {
       this.transactionHash = transactionHash;
     }
 
+    /**
+     * Add trace.
+     *
+     * @param trace the trace
+     */
     public void addTrace(final FlatTrace trace) {
       traces.add(trace);
     }
 
+    /**
+     * Vm trace.
+     *
+     * @param vmTrace the vm trace
+     */
     public void vmTrace(final VmTrace vmTrace) {
       this.vmTrace = vmTrace;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionCompleteResult.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Transaction complete result. */
 @JsonPropertyOrder({
   "accessList",
   "blockHash",
@@ -91,6 +92,11 @@ public class TransactionCompleteResult implements TransactionResult {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final List<VersionedHash> versionedHashes;
 
+  /**
+   * Instantiates a new Transaction complete result.
+   *
+   * @param tx the tx
+   */
   public TransactionCompleteResult(final TransactionWithMetadata tx) {
     final Transaction transaction = tx.getTransaction();
     final TransactionType transactionType = transaction.getType();
@@ -135,113 +141,223 @@ public class TransactionCompleteResult implements TransactionResult {
     this.versionedHashes = transaction.getVersionedHashes().orElse(null);
   }
 
+  /**
+   * Gets access list.
+   *
+   * @return the access list
+   */
   @JsonGetter(value = "accessList")
   public List<AccessListEntry> getAccessList() {
     return accessList;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets chain id.
+   *
+   * @return the chain id
+   */
   @JsonGetter(value = "chainId")
   public String getChainId() {
     return chainId;
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   @JsonGetter(value = "gas")
   public String getGas() {
     return gas;
   }
 
+  /**
+   * Gets max priority fee per gas.
+   *
+   * @return the max priority fee per gas
+   */
   @JsonGetter(value = "maxPriorityFeePerGas")
   public String getMaxPriorityFeePerGas() {
     return maxPriorityFeePerGas;
   }
 
+  /**
+   * Gets max fee per gas.
+   *
+   * @return the max fee per gas
+   */
   @JsonGetter(value = "maxFeePerGas")
   public String getMaxFeePerGas() {
     return maxFeePerGas;
   }
 
+  /**
+   * Gets max fee per blob gas.
+   *
+   * @return the max fee per blob gas
+   */
   @JsonGetter(value = "maxFeePerBlobGas")
   public String getMaxFeePerBlobGas() {
     return maxFeePerBlobGas;
   }
 
+  /**
+   * Gets gas price.
+   *
+   * @return the gas price
+   */
   @JsonGetter(value = "gasPrice")
   public String getGasPrice() {
     return gasPrice;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "hash")
   public String getHash() {
     return hash;
   }
 
+  /**
+   * Gets input.
+   *
+   * @return the input
+   */
   @JsonGetter(value = "input")
   public String getInput() {
     return input;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   @JsonGetter(value = "type")
   public String getType() {
     return type;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonGetter(value = "value")
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets y parity.
+   *
+   * @return the y parity
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "yParity")
   public String getYParity() {
     return yParity;
   }
 
+  /**
+   * Gets v.
+   *
+   * @return the v
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "v")
   public String getV() {
     return v;
   }
 
+  /**
+   * Gets r.
+   *
+   * @return the r
+   */
   @JsonGetter(value = "r")
   public String getR() {
     return r;
   }
 
+  /**
+   * Gets s.
+   *
+   * @return the s
+   */
   @JsonGetter(value = "s")
   public String getS() {
     return s;
   }
 
+  /**
+   * Gets versioned hashes.
+   *
+   * @return the versioned hashes
+   */
   @JsonGetter(value = "blobVersionedHashes")
   public List<VersionedHash> getVersionedHashes() {
     return versionedHashes;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionHashResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionHashResult.java
@@ -16,14 +16,25 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/** The type Transaction hash result. */
 public class TransactionHashResult implements TransactionResult {
 
   private final String hash;
 
+  /**
+   * Instantiates a new Transaction hash result.
+   *
+   * @param hash the hash
+   */
   public TransactionHashResult(final String hash) {
     this.hash = hash;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonValue
   public String getHash() {
     return hash;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionPendingResult.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Transaction pending result. */
 @JsonPropertyOrder({
   "blockHash",
   "blockNumber",
@@ -86,6 +87,11 @@ public class TransactionPendingResult implements TransactionResult {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private final List<VersionedHash> versionedHashes;
 
+  /**
+   * Instantiates a new Transaction pending result.
+   *
+   * @param transaction the transaction
+   */
   public TransactionPendingResult(final Transaction transaction) {
     final TransactionType transactionType = transaction.getType();
     this.accessList = transaction.getAccessList().orElse(null);
@@ -125,123 +131,243 @@ public class TransactionPendingResult implements TransactionResult {
     this.versionedHashes = transaction.getVersionedHashes().orElse(null);
   }
 
+  /**
+   * Gets access list.
+   *
+   * @return the access list
+   */
   @JsonGetter(value = "accessList")
   public List<AccessListEntry> getAccessList() {
     return accessList;
   }
 
+  /**
+   * Gets chain id.
+   *
+   * @return the chain id
+   */
   @JsonGetter(value = "chainId")
   public String getChainId() {
     return chainId;
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   @JsonGetter(value = "gas")
   public String getGas() {
     return gas;
   }
 
+  /**
+   * Gets gas price.
+   *
+   * @return the gas price
+   */
   @JsonGetter(value = "gasPrice")
   public String getGasPrice() {
     return gasPrice;
   }
 
+  /**
+   * Gets max priority fee per gas.
+   *
+   * @return the max priority fee per gas
+   */
   @JsonGetter(value = "maxPriorityFeePerGas")
   public String getMaxPriorityFeePerGas() {
     return maxPriorityFeePerGas;
   }
 
+  /**
+   * Gets max fee per gas.
+   *
+   * @return the max fee per gas
+   */
   @JsonGetter(value = "maxFeePerGas")
   public String getMaxFeePerGas() {
     return maxFeePerGas;
   }
 
+  /**
+   * Gets max fee per blob gas.
+   *
+   * @return the max fee per blob gas
+   */
   @JsonGetter(value = "maxFeePerBlobGas")
   public String getMaxFeePerBlobGas() {
     return maxFeePerBlobGas;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "hash")
   public String getHash() {
     return hash;
   }
 
+  /**
+   * Gets input.
+   *
+   * @return the input
+   */
   @JsonGetter(value = "input")
   public String getInput() {
     return input;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets public key.
+   *
+   * @return the public key
+   */
   @JsonGetter(value = "publicKey")
   public String getPublicKey() {
     return publicKey;
   }
 
+  /**
+   * Gets raw.
+   *
+   * @return the raw
+   */
   @JsonGetter(value = "raw")
   public String getRaw() {
     return raw;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   @JsonGetter(value = "type")
   public String getType() {
     return type;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonGetter(value = "value")
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets y parity.
+   *
+   * @return the y parity
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "yParity")
   public String getYParity() {
     return yParity;
   }
 
+  /**
+   * Gets v.
+   *
+   * @return the v
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "v")
   public String getV() {
     return v;
   }
 
+  /**
+   * Gets r.
+   *
+   * @return the r
+   */
   @JsonGetter(value = "r")
   public String getR() {
     return r;
   }
 
+  /**
+   * Gets s.
+   *
+   * @return the s
+   */
   @JsonGetter(value = "s")
   public String getS() {
     return s;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return null;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return null;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return null;
   }
 
+  /**
+   * Gets versioned hashes.
+   *
+   * @return the versioned hashes
+   */
   @JsonGetter(value = "blobVersionedHashes")
   public List<VersionedHash> getVersionedHashes() {
     return versionedHashes;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptLogResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptLogResult.java
@@ -24,6 +24,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Transaction receipt log result. */
 @JsonPropertyOrder({
   "address",
   "topics",
@@ -47,6 +48,16 @@ public class TransactionReceiptLogResult {
   private final String logIndex;
   private final boolean removed;
 
+  /**
+   * Instantiates a new Transaction receipt log result.
+   *
+   * @param log the log
+   * @param blockNumber the block number
+   * @param transactionHash the transaction hash
+   * @param blockHash the block hash
+   * @param transactionIndex the transaction index
+   * @param logIndex the log index
+   */
   public TransactionReceiptLogResult(
       final Log log,
       final long blockNumber,
@@ -72,46 +83,91 @@ public class TransactionReceiptLogResult {
     this.removed = false;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   @JsonGetter(value = "address")
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Gets topics.
+   *
+   * @return the topics
+   */
   @JsonGetter(value = "topics")
   public List<String> getTopics() {
     return topics;
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   @JsonGetter(value = "data")
   public String getData() {
     return data;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonGetter(value = "transactionHash")
   public String getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets log index.
+   *
+   * @return the log index
+   */
   @JsonGetter(value = "logIndex")
   public String getLogIndex() {
     return logIndex;
   }
 
+  /**
+   * Is removed boolean.
+   *
+   * @return the boolean
+   */
   @JsonGetter(value = "removed")
   public boolean isRemoved() {
     return removed;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptResult.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Transaction receipt result. */
 @JsonPropertyOrder({
   "blockHash",
   "blockNumber",
@@ -66,12 +67,20 @@ public abstract class TransactionReceiptResult {
   private final String transactionIndex;
   private final String revertReason;
 
+  /** The Receipt. */
   protected final TransactionReceipt receipt;
+
+  /** The Type. */
   protected final String type;
 
   private final String blobGasUsed;
   private final String blobGasPrice;
 
+  /**
+   * Instantiates a new Transaction receipt result.
+   *
+   * @param receiptWithMetadata the receipt with metadata
+   */
   protected TransactionReceiptResult(final TransactionReceiptWithMetadata receiptWithMetadata) {
     final Transaction txn = receiptWithMetadata.getTransaction();
     this.receipt = receiptWithMetadata.getReceipt();
@@ -105,83 +114,163 @@ public abstract class TransactionReceiptResult {
             : Quantity.create(txn.getType().getSerializedType());
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets contract address.
+   *
+   * @return the contract address
+   */
   @JsonGetter(value = "contractAddress")
   public String getContractAddress() {
     return contractAddress;
   }
 
+  /**
+   * Gets cumulative gas used.
+   *
+   * @return the cumulative gas used
+   */
   @JsonGetter(value = "cumulativeGasUsed")
   public String getCumulativeGasUsed() {
     return cumulativeGasUsed;
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   @JsonGetter(value = "gasUsed")
   public String getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @return the blob gas used
+   */
   @JsonGetter(value = "blobGasUsed")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getBlobGasUsed() {
     return blobGasUsed;
   }
 
+  /**
+   * Gets blob gas price.
+   *
+   * @return the blob gas price
+   */
   @JsonGetter(value = "blobGasPrice")
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public String getBlobGasPrice() {
     return blobGasPrice;
   }
 
+  /**
+   * Gets effective gas price.
+   *
+   * @return the effective gas price
+   */
   @JsonGetter(value = "effectiveGasPrice")
   public String getEffectiveGasPrice() {
     return effectiveGasPrice;
   }
 
+  /**
+   * Gets logs.
+   *
+   * @return the logs
+   */
   @JsonGetter(value = "logs")
   public List<TransactionReceiptLogResult> getLogs() {
     return logs;
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   @JsonGetter(value = "logsBloom")
   public String getLogsBloom() {
     return logsBloom;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonGetter(value = "transactionHash")
   public String getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   @JsonGetter(value = "type")
   public String getType() {
     return type;
   }
 
+  /**
+   * Gets revert reason.
+   *
+   * @return the revert reason
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "revertReason")
   public String getRevertReason() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptRootResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptRootResult.java
@@ -18,15 +18,26 @@ import org.hyperledger.besu.ethereum.api.query.TransactionReceiptWithMetadata;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Transaction receipt root result. */
 public class TransactionReceiptRootResult extends TransactionReceiptResult {
 
   private final String root;
 
+  /**
+   * Instantiates a new Transaction receipt root result.
+   *
+   * @param receiptWithMetadata the receipt with metadata
+   */
   public TransactionReceiptRootResult(final TransactionReceiptWithMetadata receiptWithMetadata) {
     super(receiptWithMetadata);
     root = receipt.getStateRoot().toString();
   }
 
+  /**
+   * Gets root.
+   *
+   * @return the root
+   */
   @JsonGetter(value = "root")
   public String getRoot() {
     return root;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptStatusResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionReceiptStatusResult.java
@@ -18,15 +18,26 @@ import org.hyperledger.besu.ethereum.api.query.TransactionReceiptWithMetadata;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Transaction receipt status result. */
 public class TransactionReceiptStatusResult extends TransactionReceiptResult {
 
   private final String status;
 
+  /**
+   * Instantiates a new Transaction receipt status result.
+   *
+   * @param receiptWithMetadata the receipt with metadata
+   */
   public TransactionReceiptStatusResult(final TransactionReceiptWithMetadata receiptWithMetadata) {
     super(receiptWithMetadata);
     status = Quantity.create(receipt.getStatus());
   }
 
+  /**
+   * Gets status.
+   *
+   * @return the status
+   */
   @JsonGetter(value = "status")
   public String getStatus() {
     return status;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/TransactionResult.java
@@ -14,4 +14,5 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
+/** The interface Transaction result. */
 public interface TransactionResult {}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/UncleBlockResult.java
@@ -21,7 +21,10 @@ import org.hyperledger.besu.ethereum.core.Difficulty;
 
 import java.util.Collections;
 
+/** The type Uncle block result. */
 public class UncleBlockResult {
+  /** Default constructor. */
+  private UncleBlockResult() {}
 
   /**
    * Returns an uncle block, which doesn't include transactions or ommers.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionGroupResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionGroupResult.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Private transaction group result. */
 @JsonPropertyOrder({
   "from",
   "gas",
@@ -41,11 +42,21 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class PrivateTransactionGroupResult extends PrivateTransactionResult {
   private final String privacyGroupId;
 
+  /**
+   * Instantiates a new Private transaction group result.
+   *
+   * @param tx the tx
+   */
   public PrivateTransactionGroupResult(final PrivateTransaction tx) {
     super(tx);
     this.privacyGroupId = tx.getPrivacyGroupId().get().toBase64String();
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   @JsonGetter(value = "privacyGroupId")
   public String getPrivacyGroupId() {
     return privacyGroupId;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionLegacyResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionLegacyResult.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Private transaction legacy result. */
 @JsonPropertyOrder({
   "from",
   "gas",
@@ -46,12 +47,22 @@ import org.apache.tuweni.bytes.Bytes;
 public class PrivateTransactionLegacyResult extends PrivateTransactionResult {
   private final List<String> privateFor;
 
+  /**
+   * Instantiates a new Private transaction legacy result.
+   *
+   * @param tx the tx
+   */
   public PrivateTransactionLegacyResult(final PrivateTransaction tx) {
     super(tx);
     this.privateFor =
         tx.getPrivateFor().get().stream().map(Bytes::toBase64String).collect(Collectors.toList());
   }
 
+  /**
+   * Gets private for.
+   *
+   * @return the private for
+   */
   @JsonGetter(value = "privateFor")
   public List<String> getPrivateFor() {
     return privateFor;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionReceiptResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionReceiptResult.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Private transaction receipt result. */
 @JsonPropertyOrder({
   "contractAddress",
   "from",
@@ -67,6 +68,24 @@ public class PrivateTransactionReceiptResult {
   private final String privacyGroupId;
   private final String logsBloom;
 
+  /**
+   * Instantiates a new Private transaction receipt result.
+   *
+   * @param contractAddress the contract address
+   * @param from the from
+   * @param to the to
+   * @param logs the logs
+   * @param output the output
+   * @param blockHash the block hash
+   * @param blockNumber the block number
+   * @param txIndex the tx index
+   * @param commitmentHash the commitment hash
+   * @param privateFrom the private from
+   * @param privateFor the private for
+   * @param privacyGroupId the privacy group id
+   * @param revertReason the revert reason
+   * @param status the status
+   */
   public PrivateTransactionReceiptResult(
       final String contractAddress,
       final String from,
@@ -105,76 +124,151 @@ public class PrivateTransactionReceiptResult {
     this.transactionIndex = Quantity.create(txIndex);
   }
 
+  /**
+   * Gets contract address.
+   *
+   * @return the contract address
+   */
   @JsonGetter(value = "contractAddress")
   public String getContractAddress() {
     return contractAddress;
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets output.
+   *
+   * @return the output
+   */
   @JsonGetter(value = "output")
   public String getOutput() {
     return output;
   }
 
+  /**
+   * Gets logs.
+   *
+   * @return the logs
+   */
   @JsonGetter(value = "logs")
   public List<TransactionReceiptLogResult> getLogs() {
     return logs;
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   @JsonGetter(value = "logsBloom")
   public String getLogsBloom() {
     return logsBloom;
   }
 
+  /**
+   * Gets commitment hash.
+   *
+   * @return the commitment hash
+   */
   @JsonGetter("commitmentHash")
   public String getCommitmentHash() {
     return commitmentHash;
   }
 
+  /**
+   * Gets private from.
+   *
+   * @return the private from
+   */
   @JsonGetter("privateFrom")
   public String getPrivateFrom() {
     return privateFrom;
   }
 
+  /**
+   * Gets private for.
+   *
+   * @return the private for
+   */
   @JsonGetter("privateFor")
   public List<String> getPrivateFor() {
     return privateFor;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   @JsonGetter("privacyGroupId")
   public String getPrivacyGroupId() {
     return privacyGroupId;
   }
 
+  /**
+   * Gets revert reason.
+   *
+   * @return the revert reason
+   */
   @JsonGetter("revertReason")
   public String getRevertReason() {
     return revertReason;
   }
 
+  /**
+   * Gets status.
+   *
+   * @return the status
+   */
   @JsonGetter("status")
   public String getStatus() {
     return status;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   @JsonGetter(value = "transactionIndex")
   public String getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonGetter(value = "blockHash")
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonGetter(value = "blockNumber")
   public String getBlockNumber() {
     return blockNumber;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/privacy/PrivateTransactionResult.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivateTransaction;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Private transaction result. */
 public abstract class PrivateTransactionResult {
   private final String from;
   private final String gas;
@@ -36,6 +37,11 @@ public abstract class PrivateTransactionResult {
   private final String privateFrom;
   private final String restriction;
 
+  /**
+   * Instantiates a new Private transaction result.
+   *
+   * @param tx the tx
+   */
   protected PrivateTransactionResult(final PrivateTransaction tx) {
     this.from = tx.getSender().toString();
     this.gas = Quantity.create(tx.getGasLimit());
@@ -51,61 +57,121 @@ public abstract class PrivateTransactionResult {
     this.restriction = new String(tx.getRestriction().getBytes().toArrayUnsafe(), UTF_8);
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   @JsonGetter(value = "gas")
   public String getGas() {
     return gas;
   }
 
+  /**
+   * Gets gas price.
+   *
+   * @return the gas price
+   */
   @JsonGetter(value = "gasPrice")
   public String getGasPrice() {
     return gasPrice;
   }
 
+  /**
+   * Gets input.
+   *
+   * @return the input
+   */
   @JsonGetter(value = "input")
   public String getInput() {
     return input;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonGetter(value = "value")
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets v.
+   *
+   * @return the v
+   */
   @JsonGetter(value = "v")
   public String getV() {
     return v;
   }
 
+  /**
+   * Gets r.
+   *
+   * @return the r
+   */
   @JsonGetter(value = "r")
   public String getR() {
     return r;
   }
 
+  /**
+   * Gets s.
+   *
+   * @return the s
+   */
   @JsonGetter(value = "s")
   public String getS() {
     return s;
   }
 
+  /**
+   * Gets private from.
+   *
+   * @return the private from
+   */
   @JsonGetter(value = "privateFrom")
   public String getPrivateFrom() {
     return privateFrom;
   }
 
+  /**
+   * Gets restriction.
+   *
+   * @return the restriction
+   */
   @JsonGetter(value = "restriction")
   public String getRestriction() {
     return restriction;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/GetProofResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/GetProofResult.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Get proof result. */
 public class GetProofResult {
 
   private final List<Bytes> accountProof;
@@ -44,6 +45,17 @@ public class GetProofResult {
 
   private final List<StorageEntryProof> storageEntries;
 
+  /**
+   * Instantiates a new Get proof result.
+   *
+   * @param address the address
+   * @param balance the balance
+   * @param codeHash the code hash
+   * @param nonce the nonce
+   * @param storageHash the storage hash
+   * @param accountProof the account proof
+   * @param storageEntries the storage entries
+   */
   public GetProofResult(
       final Address address,
       final Wei balance,
@@ -61,6 +73,13 @@ public class GetProofResult {
     this.storageEntries = storageEntries;
   }
 
+  /**
+   * Build get proof result get proof result.
+   *
+   * @param address the address
+   * @param worldStateProof the world state proof
+   * @return the get proof result
+   */
   public static GetProofResult buildGetProofResult(
       final Address address, final WorldStateProof worldStateProof) {
 
@@ -87,36 +106,71 @@ public class GetProofResult {
         storageEntries);
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   @JsonGetter(value = "address")
   public String getAddress() {
     return address.toString();
   }
 
+  /**
+   * Gets balance.
+   *
+   * @return the balance
+   */
   @JsonGetter(value = "balance")
   public String getBalance() {
     return Quantity.create(balance);
   }
 
+  /**
+   * Gets code hash.
+   *
+   * @return the code hash
+   */
   @JsonGetter(value = "codeHash")
   public String getCodeHash() {
     return codeHash.toString();
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return Quantity.create(nonce);
   }
 
+  /**
+   * Gets storage hash.
+   *
+   * @return the storage hash
+   */
   @JsonGetter(value = "storageHash")
   public String getStorageHash() {
     return storageHash.toString();
   }
 
+  /**
+   * Gets account proof.
+   *
+   * @return the account proof
+   */
   @JsonGetter(value = "accountProof")
   public List<String> getAccountProof() {
     return accountProof.stream().map(Bytes::toString).collect(Collectors.toList());
   }
 
+  /**
+   * Gets storage proof.
+   *
+   * @return the storage proof
+   */
   @JsonGetter(value = "storageProof")
   public List<StorageEntryProof> getStorageProof() {
     return storageEntries;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/StorageEntryProof.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/StorageEntryProof.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Storage entry proof. */
 public class StorageEntryProof {
 
   private final UInt256 key;
@@ -31,22 +32,44 @@ public class StorageEntryProof {
 
   private final List<Bytes> storageProof;
 
+  /**
+   * Instantiates a new Storage entry proof.
+   *
+   * @param key the key
+   * @param value the value
+   * @param storageProof the storage proof
+   */
   public StorageEntryProof(final UInt256 key, final UInt256 value, final List<Bytes> storageProof) {
     this.key = key;
     this.value = value;
     this.storageProof = storageProof;
   }
 
+  /**
+   * Gets key.
+   *
+   * @return the key
+   */
   @JsonGetter(value = "key")
   public String getKey() {
     return key.trimLeadingZeros().toHexString();
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonGetter(value = "value")
   public String getValue() {
     return Quantity.create(value);
   }
 
+  /**
+   * Gets storage proof.
+   *
+   * @return the storage proof
+   */
   @JsonGetter(value = "proof")
   public List<String> getStorageProof() {
     return storageProof.stream().map(Bytes::toString).collect(Collectors.toList());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/Trace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/Trace.java
@@ -21,9 +21,9 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing;
  *
  * <ul>
  *   <li>trace: {@link
- *       org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace}
+ *       org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTrace}*
  *   <li>vmTrace: {@link
- *       org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm.VmTrace}
+ *       org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm.VmTrace}*
  *   <li>stateDiff:
  * </ul>
  */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TraceFormatter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TraceFormatter.java
@@ -21,9 +21,19 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+/** The interface Trace formatter. */
 @FunctionalInterface
 public interface TraceFormatter {
 
+  /**
+   * Format stream.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param transactionTrace the transaction trace
+   * @param block the block
+   * @param traceCounter the trace counter
+   * @return the stream
+   */
   Stream<Trace> format(
       ProtocolSchedule protocolSchedule,
       TransactionTrace transactionTrace,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TraceWriter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TraceWriter.java
@@ -14,7 +14,13 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing;
 
+/** The interface Trace writer. */
 @FunctionalInterface
 public interface TraceWriter {
+  /**
+   * Write.
+   *
+   * @param trace the trace
+   */
   void write(Trace trace);
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TracingUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/TracingUtils.java
@@ -23,8 +23,17 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Tracing utils. */
 public class TracingUtils {
+  /** Default constructor. */
+  private TracingUtils() {}
 
+  /**
+   * Dump memory string.
+   *
+   * @param maybeMemory the maybe memory
+   * @return the string
+   */
   public static String dumpMemory(final Optional<Bytes32[]> maybeMemory) {
     return maybeMemory.map(TracingUtils::dumpMemory).orElse("");
   }
@@ -37,6 +46,12 @@ public class TracingUtils {
     return Arrays.stream(memory).map(Bytes::toUnprefixedHexString).collect(Collectors.joining());
   }
 
+  /**
+   * Dump memory and trim trailing zeros string.
+   *
+   * @param memory the memory
+   * @return the string
+   */
   public static String dumpMemoryAndTrimTrailingZeros(final Bytes32[] memory) {
     final String memoryString = dumpMemoryUnprefixed(memory);
     final Bytes value = Bytes.fromHexString(memoryString);
@@ -57,6 +72,12 @@ public class TracingUtils {
     return bytes.size();
   }
 
+  /**
+   * Wei as hex string.
+   *
+   * @param balance the balance
+   * @return the string
+   */
   public static String weiAsHex(final Wei balance) {
     return balance.isZero() ? "0x0" : balance.toShortHexString();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/DiffNode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/DiffNode.java
@@ -22,32 +22,57 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
+/** The type Diff node. */
 @JsonSerialize(using = DiffNode.Serializer.class)
 public final class DiffNode {
 
   private final Optional<String> from;
   private final Optional<String> to;
 
+  /**
+   * Instantiates a new Diff node.
+   *
+   * @param from the from
+   * @param to the to
+   */
   DiffNode(final String from, final String to) {
     this.from = Optional.ofNullable(from);
     this.to = Optional.ofNullable(to);
   }
 
+  /**
+   * Instantiates a new Diff node.
+   *
+   * @param from the from
+   * @param to the to
+   */
   DiffNode(final Optional<String> from, final Optional<String> to) {
     this.from = from;
     this.to = to;
   }
 
+  /**
+   * Has difference boolean.
+   *
+   * @return the boolean
+   */
   boolean hasDifference() {
     return from.map(it -> !it.equals(to.get())).orElse(to.isPresent());
   }
 
+  /** The type Serializer. */
   public static class Serializer extends StdSerializer<DiffNode> {
 
+    /** Instantiates a new Serializer. */
     public Serializer() {
       this(null);
     }
 
+    /**
+     * Instantiates a new Serializer.
+     *
+     * @param t the t
+     */
     protected Serializer(final Class<DiffNode> t) {
       super(t);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
@@ -33,8 +33,17 @@ import java.util.stream.Stream;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type State diff generator. */
 public class StateDiffGenerator {
+  /** Default constructor. */
+  public StateDiffGenerator() {}
 
+  /**
+   * Generate state diff stream.
+   *
+   * @param transactionTrace the transaction trace
+   * @return the stream
+   */
   public Stream<Trace> generateStateDiff(final TransactionTrace transactionTrace) {
     final List<TraceFrame> traceFrames = transactionTrace.getTraceFrames();
     if (traceFrames.isEmpty()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffTrace.java
@@ -18,4 +18,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.Trace;
 
 import java.util.TreeMap;
 
-public class StateDiffTrace extends TreeMap<String, AccountDiff> implements Trace {}
+/** The type State diff trace. */
+public class StateDiffTrace extends TreeMap<String, AccountDiff> implements Trace {
+  /** Default constructor. */
+  public StateDiffTrace() {}
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTrace.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Flat trace. */
 @JsonPropertyOrder({
   "action",
   "blockHash",
@@ -53,6 +54,20 @@ public class FlatTrace implements Trace {
   private final List<Integer> traceAddress;
   private final String type;
 
+  /**
+   * Instantiates a new Flat trace.
+   *
+   * @param actionBuilder the action builder
+   * @param resultBuilder the result builder
+   * @param subtraces the subtraces
+   * @param traceAddress the trace address
+   * @param type the type
+   * @param blockNumber the block number
+   * @param blockHash the block hash
+   * @param transactionPosition the transaction position
+   * @param transactionHash the transaction hash
+   * @param error the error
+   */
   protected FlatTrace(
       final Action.Builder actionBuilder,
       final Result.Builder resultBuilder,
@@ -78,6 +93,21 @@ public class FlatTrace implements Trace {
         null);
   }
 
+  /**
+   * Instantiates a new Flat trace.
+   *
+   * @param actionBuilder the action builder
+   * @param resultBuilder the result builder
+   * @param subtraces the subtraces
+   * @param traceAddress the trace address
+   * @param type the type
+   * @param blockNumber the block number
+   * @param blockHash the block hash
+   * @param transactionPosition the transaction position
+   * @param transactionHash the transaction hash
+   * @param error the error
+   * @param revertReason the revert reason
+   */
   protected FlatTrace(
       final Action.Builder actionBuilder,
       final Result.Builder resultBuilder,
@@ -104,6 +134,21 @@ public class FlatTrace implements Trace {
         revertReason);
   }
 
+  /**
+   * Instantiates a new Flat trace.
+   *
+   * @param action the action
+   * @param result the result
+   * @param subtraces the subtraces
+   * @param traceAddress the trace address
+   * @param type the type
+   * @param blockNumber the block number
+   * @param blockHash the block hash
+   * @param transactionPosition the transaction position
+   * @param transactionHash the transaction hash
+   * @param error the error
+   * @param revertReason the revert reason
+   */
   protected FlatTrace(
       final Action action,
       final Result result,
@@ -129,41 +174,82 @@ public class FlatTrace implements Trace {
     this.revertReason = revertReason;
   }
 
+  /**
+   * Fresh builder builder.
+   *
+   * @param transactionTrace the transaction trace
+   * @return the builder
+   */
   static Builder freshBuilder(final TransactionTrace transactionTrace) {
     return FlatTrace.builder()
         .resultBuilder(Result.builder())
         .actionBuilder(Action.Builder.from(transactionTrace));
   }
 
+  /**
+   * Gets action.
+   *
+   * @return the action
+   */
   public Action getAction() {
     return action;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   @JsonInclude(NON_NULL)
   public Long getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   @JsonInclude(NON_NULL)
   public String getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   @JsonInclude(NON_NULL)
   public String getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Gets transaction position.
+   *
+   * @return the transaction position
+   */
   @JsonInclude(NON_NULL)
   public Integer getTransactionPosition() {
     return transactionPosition;
   }
 
+  /**
+   * Gets error.
+   *
+   * @return the error
+   */
   @JsonInclude(NON_NULL)
   public String getError() {
     return error.orElse(null);
   }
 
+  /**
+   * Gets revert reason.
+   *
+   * @return the revert reason
+   */
   @JsonInclude(NON_NULL)
   public String getRevertReason() {
     return revertReason;
@@ -185,62 +271,124 @@ public class FlatTrace implements Trace {
     return (error.isPresent()) ? null : new AtomicReference<>(result);
   }
 
+  /**
+   * Gets subtraces.
+   *
+   * @return the subtraces
+   */
   public int getSubtraces() {
     return subtraces;
   }
 
+  /**
+   * Gets trace address.
+   *
+   * @return the trace address
+   */
   public List<Integer> getTraceAddress() {
     return traceAddress;
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public String getType() {
     return type;
   }
 
+  /**
+   * Builder builder.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** The type Context. */
   public static class Context {
 
     private final Builder builder;
     private long gasUsed = 0;
     private boolean createOp;
 
+    /**
+     * Instantiates a new Context.
+     *
+     * @param builder the builder
+     */
     Context(final Builder builder) {
       this.builder = builder;
     }
 
+    /**
+     * Gets builder.
+     *
+     * @return the builder
+     */
     public Builder getBuilder() {
       return builder;
     }
 
+    /**
+     * Inc gas used.
+     *
+     * @param gas the gas
+     */
     void incGasUsed(final long gas) {
       setGasUsed(gasUsed + gas);
     }
 
+    /**
+     * Dec gas used.
+     *
+     * @param gas the gas
+     */
     void decGasUsed(final long gas) {
       setGasUsed(gasUsed - gas);
     }
 
+    /**
+     * Gets gas used.
+     *
+     * @return the gas used
+     */
     public long getGasUsed() {
       return gasUsed;
     }
 
+    /**
+     * Sets gas used.
+     *
+     * @param gasUsed the gas used
+     */
     public void setGasUsed(final long gasUsed) {
       this.gasUsed = gasUsed;
       builder.getResultBuilder().gasUsed("0x" + Long.toHexString(gasUsed));
     }
 
+    /**
+     * Is create op boolean.
+     *
+     * @return the boolean
+     */
     boolean isCreateOp() {
       return createOp;
     }
 
+    /**
+     * Sets create op.
+     *
+     * @param createOp the create op
+     */
     void setCreateOp(final boolean createOp) {
       this.createOp = createOp;
     }
   }
 
+  /** The type Builder. */
   public static class Builder {
 
     private Action.Builder actionBuilder;
@@ -255,98 +403,210 @@ public class FlatTrace implements Trace {
     private Optional<String> error = Optional.empty();
     private String revertReason;
 
+    /** Instantiates a new Builder. */
     protected Builder() {}
 
+    /**
+     * Result builder builder.
+     *
+     * @param resultBuilder the result builder
+     * @return the builder
+     */
     Builder resultBuilder(final Result.Builder resultBuilder) {
       this.resultBuilder = resultBuilder;
       return this;
     }
 
+    /**
+     * Action builder builder.
+     *
+     * @param actionBuilder the action builder
+     * @return the builder
+     */
     Builder actionBuilder(final Action.Builder actionBuilder) {
       this.actionBuilder = actionBuilder;
       return this;
     }
 
+    /**
+     * Trace address builder.
+     *
+     * @param traceAddress the trace address
+     * @return the builder
+     */
     public Builder traceAddress(final List<Integer> traceAddress) {
       this.traceAddress = traceAddress;
       return this;
     }
 
+    /**
+     * Type builder.
+     *
+     * @param type the type
+     * @return the builder
+     */
     public Builder type(final String type) {
       this.type = type;
       return this;
     }
 
+    /**
+     * Block number builder.
+     *
+     * @param blockNumber the block number
+     * @return the builder
+     */
     public Builder blockNumber(final Long blockNumber) {
       this.blockNumber = blockNumber;
       return this;
     }
 
+    /**
+     * Block hash builder.
+     *
+     * @param blockHash the block hash
+     * @return the builder
+     */
     public Builder blockHash(final String blockHash) {
       this.blockHash = blockHash;
       return this;
     }
 
+    /**
+     * Transaction hash builder.
+     *
+     * @param transactionHash the transaction hash
+     * @return the builder
+     */
     public Builder transactionHash(final String transactionHash) {
       this.transactionHash = transactionHash;
       return this;
     }
 
+    /**
+     * Transaction position builder.
+     *
+     * @param transactionPosition the transaction position
+     * @return the builder
+     */
     public Builder transactionPosition(final Integer transactionPosition) {
       this.transactionPosition = transactionPosition;
       return this;
     }
 
+    /**
+     * Error builder.
+     *
+     * @param error the error
+     * @return the builder
+     */
     public Builder error(final Optional<String> error) {
       this.error = error;
       return this;
     }
 
+    /**
+     * Revert reason builder.
+     *
+     * @param revertReason the revert reason
+     * @return the builder
+     */
     public Builder revertReason(final String revertReason) {
       this.revertReason = revertReason;
       return this;
     }
 
+    /**
+     * Gets type.
+     *
+     * @return the type
+     */
     public String getType() {
       return type;
     }
 
+    /**
+     * Gets subtraces.
+     *
+     * @return the subtraces
+     */
     public int getSubtraces() {
       return subtraces;
     }
 
+    /**
+     * Gets trace address.
+     *
+     * @return the trace address
+     */
     public List<Integer> getTraceAddress() {
       return traceAddress;
     }
 
+    /**
+     * Gets block number.
+     *
+     * @return the block number
+     */
     public Long getBlockNumber() {
       return blockNumber;
     }
 
+    /**
+     * Gets block hash.
+     *
+     * @return the block hash
+     */
     public String getBlockHash() {
       return blockHash;
     }
 
+    /**
+     * Gets transaction hash.
+     *
+     * @return the transaction hash
+     */
     public String getTransactionHash() {
       return transactionHash;
     }
 
+    /**
+     * Gets transaction position.
+     *
+     * @return the transaction position
+     */
     public Integer getTransactionPosition() {
       return transactionPosition;
     }
 
+    /**
+     * Gets error.
+     *
+     * @return the error
+     */
     public Optional<String> getError() {
       return error;
     }
 
+    /**
+     * Gets revert reason.
+     *
+     * @return the revert reason
+     */
     public String getRevertReason() {
       return revertReason;
     }
 
+    /** Inc sub traces. */
     void incSubTraces() {
       this.subtraces++;
     }
 
+    /**
+     * Build flat trace.
+     *
+     * @return the flat trace
+     */
     public FlatTrace build() {
       return new FlatTrace(
           actionBuilder,
@@ -362,10 +622,20 @@ public class FlatTrace implements Trace {
           revertReason);
     }
 
+    /**
+     * Gets result builder.
+     *
+     * @return the result builder
+     */
     public Result.Builder getResultBuilder() {
       return resultBuilder;
     }
 
+    /**
+     * Gets action builder.
+     *
+     * @return the action builder
+     */
     public Action.Builder getActionBuilder() {
       return actionBuilder;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/FlatTraceGenerator.java
@@ -49,11 +49,15 @@ import com.google.common.collect.Streams;
 import com.google.common.util.concurrent.Atomics;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Flat trace generator. */
 public class FlatTraceGenerator {
 
   private static final String ZERO_ADDRESS_STRING = Address.ZERO.toHexString();
 
   private static final int EIP_150_DIVISOR = 64;
+
+  /** Default constructor. */
+  private FlatTraceGenerator() {}
 
   /**
    * Generates a stream of {@link Trace} from the passed {@link TransactionTrace} data.
@@ -229,6 +233,16 @@ public class FlatTraceGenerator {
         protocolSchedule, transactionTrace, block, traceCounter, true);
   }
 
+  /**
+   * Generate from transaction trace stream.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param transactionTrace the transaction trace
+   * @param block the block
+   * @param traceCounter the trace counter
+   * @param includeCreationMethod the include creation method
+   * @return the stream
+   */
   public static Stream<Trace> generateFromTransactionTrace(
       final ProtocolSchedule protocolSchedule,
       final TransactionTrace transactionTrace,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/MixInIgnoreRevertReason.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/MixInIgnoreRevertReason.java
@@ -16,5 +16,6 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/** The type Mix in ignore revert reason. */
 @JsonIgnoreProperties({"revertReason"})
 public class MixInIgnoreRevertReason {}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/Result.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/Result.java
@@ -19,6 +19,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Result. */
 @JsonInclude(NON_NULL)
 @JsonPropertyOrder({"address", "code", "gasUsed", "output"})
 public class Result {
@@ -26,6 +27,14 @@ public class Result {
   private final String output;
   private final String code;
 
+  /**
+   * Instantiates a new Result.
+   *
+   * @param gasUsed the gas used
+   * @param output the output
+   * @param code the code
+   * @param address the address
+   */
   public Result(
       final String gasUsed, final String output, final String code, final String address) {
     this.gasUsed = gasUsed;
@@ -36,26 +45,52 @@ public class Result {
 
   private final String address;
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   public String getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets output.
+   *
+   * @return the output
+   */
   public String getOutput() {
     return output;
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   public String getCode() {
     return code;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Builder builder.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** The type Builder. */
   public static final class Builder {
 
     private static final String GAS_USED_EMPTY = "0x0";
@@ -67,39 +102,84 @@ public class Result {
 
     private Builder() {}
 
+    /**
+     * Gas used builder.
+     *
+     * @param gasUsed the gas used
+     * @return the builder
+     */
     public Builder gasUsed(final String gasUsed) {
       this.gasUsed = gasUsed;
       return this;
     }
 
+    /**
+     * Is gas used empty boolean.
+     *
+     * @return the boolean
+     */
     public boolean isGasUsedEmpty() {
       return GAS_USED_EMPTY.equals(gasUsed);
     }
 
+    /**
+     * Output builder.
+     *
+     * @param output the output
+     * @return the builder
+     */
     public Builder output(final String output) {
       this.output = output;
       return this;
     }
 
+    /**
+     * Code builder.
+     *
+     * @param code the code
+     * @return the builder
+     */
     public Builder code(final String code) {
       this.code = code;
       this.output = null;
       return this;
     }
 
+    /**
+     * Gets code.
+     *
+     * @return the code
+     */
     public String getCode() {
       return code;
     }
 
+    /**
+     * Address builder.
+     *
+     * @param address the address
+     * @return the builder
+     */
     public Builder address(final String address) {
       this.address = address;
       return this;
     }
 
+    /**
+     * Gets address.
+     *
+     * @return the address
+     */
     public String getAddress() {
       return address;
     }
 
+    /**
+     * Of builder.
+     *
+     * @param result the result
+     * @return the builder
+     */
     public static Builder of(final Result result) {
       final Builder builder = new Builder();
       if (result != null) {
@@ -111,6 +191,11 @@ public class Result {
       return builder;
     }
 
+    /**
+     * Build result.
+     *
+     * @return the result
+     */
     public Result build() {
       return new Result(gasUsed, output, code, address);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTrace.java
@@ -21,8 +21,23 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+/** The type Reward trace. */
 public class RewardTrace extends FlatTrace {
 
+  /**
+   * Instantiates a new Reward trace.
+   *
+   * @param actionBuilder the action builder
+   * @param resultBuilder the result builder
+   * @param subtraces the subtraces
+   * @param traceAddress the trace address
+   * @param type the type
+   * @param blockNumber the block number
+   * @param blockHash the block hash
+   * @param transactionPosition the transaction position
+   * @param transactionHash the transaction hash
+   * @param error the error
+   */
   protected RewardTrace(
       final Action.Builder actionBuilder,
       final Result.Builder resultBuilder,
@@ -71,12 +86,19 @@ public class RewardTrace extends FlatTrace {
     return super.getTransactionPosition();
   }
 
+  /**
+   * Builder builder.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /** The type Builder. */
   public static final class Builder extends FlatTrace.Builder {
 
+    /** Instantiates a new Builder. */
     public Builder() {
       super();
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/RewardTraceGenerator.java
@@ -26,11 +26,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+/** The type Reward trace generator. */
 public class RewardTraceGenerator {
 
   private static final String REWARD_LABEL = "reward";
   private static final String BLOCK_LABEL = "block";
   private static final String UNCLE_LABEL = "uncle";
+
+  /** Default constructor. */
+  private RewardTraceGenerator() {}
 
   /**
    * Generates a stream of reward {@link Trace} from the passed {@link Block} data.

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/Mem.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/Mem.java
@@ -14,20 +14,37 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm;
 
+/** The type Mem. */
 public class Mem {
 
   private final String data;
   private final long off;
 
+  /**
+   * Instantiates a new Mem.
+   *
+   * @param data the data
+   * @param off the off
+   */
   public Mem(final String data, final long off) {
     this.data = data;
     this.off = off;
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   public String getData() {
     return data;
   }
 
+  /**
+   * Gets off.
+   *
+   * @return the off
+   */
   public long getOff() {
     return off;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/Store.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/Store.java
@@ -14,21 +14,38 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.vm;
 
+/** The type Store. */
 public class Store {
 
   private final String key;
 
   private final String val;
 
+  /**
+   * Instantiates a new Store.
+   *
+   * @param key the key
+   * @param val the val
+   */
   Store(final String key, final String val) {
     this.key = key;
     this.val = val;
   }
 
+  /**
+   * Gets key.
+   *
+   * @return the key
+   */
   public String getKey() {
     return key;
   }
 
+  /**
+   * Gets val.
+   *
+   * @return the val
+   */
   public String getVal() {
     return val;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperation.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperation.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Vm operation. */
 @JsonPropertyOrder({"cost", "operation", "ex", "pc", "sub"})
 public class VmOperation {
   private long cost;
@@ -31,46 +32,97 @@ public class VmOperation {
   private long pc;
   private VmTrace sub;
 
+  /** Instantiates a new Vm operation. */
   VmOperation() {}
 
+  /**
+   * Gets cost.
+   *
+   * @return the cost
+   */
   public long getCost() {
     return cost;
   }
 
+  /**
+   * Gets vm operation execution report.
+   *
+   * @return the vm operation execution report
+   */
   @JsonGetter("ex")
   public VmOperationExecutionReport getVmOperationExecutionReport() {
     return vmOperationExecutionReport;
   }
 
+  /**
+   * Gets pc.
+   *
+   * @return the pc
+   */
   public long getPc() {
     return pc;
   }
 
+  /**
+   * Gets sub.
+   *
+   * @return the sub
+   */
   public VmTrace getSub() {
     return sub;
   }
 
+  /**
+   * Sets cost.
+   *
+   * @param cost the cost
+   */
   public void setCost(final long cost) {
     this.cost = cost;
   }
 
+  /**
+   * Sets vm operation execution report.
+   *
+   * @param vmOperationExecutionReport the vm operation execution report
+   */
   void setVmOperationExecutionReport(final VmOperationExecutionReport vmOperationExecutionReport) {
     this.vmOperationExecutionReport = vmOperationExecutionReport;
   }
 
+  /**
+   * Sets pc.
+   *
+   * @param pc the pc
+   */
   public void setPc(final long pc) {
     this.pc = pc;
   }
 
+  /**
+   * Sets sub.
+   *
+   * @param sub the sub
+   */
   public void setSub(final VmTrace sub) {
     this.sub = sub;
   }
 
+  /**
+   * Gets operation.
+   *
+   * @return the operation
+   */
   @JsonInclude(NON_NULL)
   public String getOperation() {
     return operation;
   }
 
+  /**
+   * Sets operation.
+   *
+   * @param operation the operation
+   */
   public void setOperation(final String operation) {
     this.operation = operation;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperationExecutionReport.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperationExecutionReport.java
@@ -24,7 +24,7 @@ public class VmOperationExecutionReport {
   private Store store;
   private long used;
 
-  /** Instantiates a new Vm operation execution report. */
+  /** Instantiates a new VM operation execution report. */
   public VmOperationExecutionReport() {
     push = new ArrayList<>();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperationExecutionReport.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmOperationExecutionReport.java
@@ -24,43 +24,89 @@ public class VmOperationExecutionReport {
   private Store store;
   private long used;
 
+  /** Instantiates a new Vm operation execution report. */
   public VmOperationExecutionReport() {
     push = new ArrayList<>();
   }
 
+  /**
+   * Gets mem.
+   *
+   * @return the mem
+   */
   public Mem getMem() {
     return mem;
   }
 
+  /**
+   * Gets push.
+   *
+   * @return the push
+   */
   public List<String> getPush() {
     return push;
   }
 
+  /**
+   * Add push.
+   *
+   * @param value the value
+   */
   public void addPush(final String value) {
     push.add(0, value);
   }
 
+  /**
+   * Single push.
+   *
+   * @param value the value
+   */
   public void singlePush(final String value) {
     push.clear();
     push.add(value);
   }
 
+  /**
+   * Gets store.
+   *
+   * @return the store
+   */
   public Store getStore() {
     return store;
   }
 
+  /**
+   * Gets used.
+   *
+   * @return the used
+   */
   public long getUsed() {
     return used;
   }
 
+  /**
+   * Sets mem.
+   *
+   * @param mem the mem
+   */
   public void setMem(final Mem mem) {
     this.mem = mem;
   }
 
+  /**
+   * Sets store.
+   *
+   * @param store the store
+   */
   public void setStore(final Store store) {
     this.store = store;
   }
 
+  /**
+   * Sets used.
+   *
+   * @param used the used
+   */
   public void setUsed(final long used) {
     this.used = used;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTrace.java
@@ -22,15 +22,22 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The type Vm trace. */
 public class VmTrace implements Trace {
 
   private String code;
   private final List<VmOperation> vmOperations;
 
+  /** Instantiates a new Vm trace. */
   public VmTrace() {
     this("0x");
   }
 
+  /**
+   * Instantiates a new Vm trace.
+   *
+   * @param code the code
+   */
   public VmTrace(final String code) {
     this(code, new ArrayList<>());
   }
@@ -40,18 +47,38 @@ public class VmTrace implements Trace {
     this.vmOperations = vmOperations;
   }
 
+  /**
+   * Add.
+   *
+   * @param vmOperation the vm operation
+   */
   public void add(final VmOperation vmOperation) {
     vmOperations.add(vmOperation);
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   public String getCode() {
     return code;
   }
 
+  /**
+   * Sets code.
+   *
+   * @param code the code
+   */
   public void setCode(final String code) {
     this.code = code;
   }
 
+  /**
+   * Gets vm operations.
+   *
+   * @return the vm operations
+   */
   @JsonGetter("ops")
   public List<VmOperation> getVmOperations() {
     return vmOperations;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTraceGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/vm/VmTraceGenerator.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Vm trace generator. */
 public class VmTraceGenerator {
 
   private int currentIndex = 0;
@@ -43,6 +44,11 @@ public class VmTraceGenerator {
   private final Deque<VmTrace> parentTraces = new ArrayDeque<>();
   private int lastDepth = 0;
 
+  /**
+   * Instantiates a new Vm trace generator.
+   *
+   * @param transactionTrace the transaction trace
+   */
   public VmTraceGenerator(final TransactionTrace transactionTrace) {
     this.transactionTrace = transactionTrace;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/PendingTransactionFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/PendingTransactionFilter.java
@@ -34,14 +34,36 @@ import java.util.Optional;
  * value, nonce
  */
 public class PendingTransactionFilter {
-
+  /** The constant FROM_FIELD. */
   public static final String FROM_FIELD = "from";
+
+  /** The constant TO_FIELD. */
   public static final String TO_FIELD = "to";
+
+  /** The constant GAS_FIELD. */
   public static final String GAS_FIELD = "gas";
+
+  /** The constant GAS_PRICE_FIELD. */
   public static final String GAS_PRICE_FIELD = "gasPrice";
+
+  /** The constant VALUE_FIELD. */
   public static final String VALUE_FIELD = "value";
+
+  /** The constant NONCE_FIELD. */
   public static final String NONCE_FIELD = "nonce";
 
+  /** Default constructor. */
+  public PendingTransactionFilter() {}
+
+  /**
+   * Reduce collection.
+   *
+   * @param pendingTransactions the pending transactions
+   * @param filters the filters
+   * @param limit the limit
+   * @return the collection
+   * @throws InvalidJsonRpcParameters the invalid json rpc parameters
+   */
   public Collection<Transaction> reduce(
       final Collection<PendingTransaction> pendingTransactions,
       final List<Filter> filters,
@@ -126,26 +148,49 @@ public class PendingTransactionFilter {
     return predicate.getOperator().apply(transactionWei, Wei.fromHexString(value));
   }
 
+  /** The type Filter. */
   public static class Filter {
 
     private final String fieldName;
     private final String fieldValue;
     private final Predicate predicate;
 
+    /**
+     * Instantiates a new Filter.
+     *
+     * @param fieldName the field name
+     * @param fieldValue the field value
+     * @param predicate the predicate
+     */
     public Filter(final String fieldName, final String fieldValue, final Predicate predicate) {
       this.fieldName = fieldName;
       this.fieldValue = fieldValue;
       this.predicate = predicate;
     }
 
+    /**
+     * Gets field name.
+     *
+     * @return the field name
+     */
     public String getFieldName() {
       return fieldName;
     }
 
+    /**
+     * Gets field value.
+     *
+     * @return the field value
+     */
     public String getFieldValue() {
       return fieldValue;
     }
 
+    /**
+     * Gets predicate.
+     *
+     * @return the predicate
+     */
     public Predicate getPredicate() {
       return predicate;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/Predicate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/transaction/pool/Predicate.java
@@ -22,9 +22,13 @@ import java.util.stream.Stream;
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 public enum Predicate {
+  /** Eq predicate. */
   EQ((left, right) -> left.compareTo(right) == 0),
+  /** Lt predicate. */
   LT((left, right) -> left.compareTo(right) < 0),
+  /** Gt predicate. */
   GT((left, right) -> left.compareTo(right) > 0),
+  /** Action predicate. */
   ACTION((left, right) -> false);
 
   private final Operator operator;
@@ -33,15 +37,34 @@ public enum Predicate {
     this.operator = predicate;
   }
 
+  /**
+   * Gets operator.
+   *
+   * @return the operator
+   */
   public Operator getOperator() {
     return operator;
   }
 
+  /** The interface Operator. */
   @FunctionalInterface
   public interface Operator {
+    /**
+     * Apply boolean.
+     *
+     * @param left the left
+     * @param right the right
+     * @return the boolean
+     */
     boolean apply(final Comparable left, final Comparable right);
   }
 
+  /**
+   * From value optional.
+   *
+   * @param value the value
+   * @return the optional
+   */
   public static Optional<Predicate> fromValue(final String value) {
     return Stream.of(values()).filter(predicate -> predicate.name().equals(value)).findFirst();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcConfiguration.java
@@ -18,18 +18,27 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 
+/** The type Json rpc ipc configuration. */
 public class JsonRpcIpcConfiguration {
 
   private final boolean enabled;
   private final Path ipcPath;
   private final Collection<String> enabledApis;
 
+  /** Instantiates a new Json rpc ipc configuration. */
   public JsonRpcIpcConfiguration() {
     enabled = false;
     ipcPath = null;
     enabledApis = Collections.emptyList();
   }
 
+  /**
+   * Instantiates a new Json rpc ipc configuration.
+   *
+   * @param enabled the enabled
+   * @param ipcPath the ipc path
+   * @param enabledApis the enabled apis
+   */
   public JsonRpcIpcConfiguration(
       final boolean enabled, final Path ipcPath, final Collection<String> enabledApis) {
     this.enabled = enabled;
@@ -37,14 +46,29 @@ public class JsonRpcIpcConfiguration {
     this.enabledApis = enabledApis;
   }
 
+  /**
+   * Is enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEnabled() {
     return enabled;
   }
 
+  /**
+   * Gets path.
+   *
+   * @return the path
+   */
   public Path getPath() {
     return ipcPath;
   }
 
+  /**
+   * Gets enabled apis.
+   *
+   * @return the enabled apis
+   */
   public Collection<String> getEnabledApis() {
     return enabledApis;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcService.java
@@ -50,6 +50,7 @@ import io.vertx.core.net.SocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json rpc ipc service. */
 public class JsonRpcIpcService {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonRpcIpcService.class);
@@ -65,12 +66,24 @@ public class JsonRpcIpcService {
   private final JsonRpcExecutor jsonRpcExecutor;
   private NetServer netServer;
 
+  /**
+   * Instantiates a new Json rpc ipc service.
+   *
+   * @param vertx the vertx
+   * @param path the path
+   * @param rpcExecutor the rpc executor
+   */
   public JsonRpcIpcService(final Vertx vertx, final Path path, final JsonRpcExecutor rpcExecutor) {
     this.vertx = vertx;
     this.path = path;
     this.jsonRpcExecutor = rpcExecutor;
   }
 
+  /**
+   * Start future.
+   *
+   * @return the future
+   */
   public Future<NetServer> start() {
     netServer = vertx.createNetServer(buildNetServerOptions());
     netServer.connectHandler(
@@ -182,6 +195,11 @@ public class JsonRpcIpcService {
         .onFailure(throwable -> LOG.error("Unable to open IPC endpoint", throwable));
   }
 
+  /**
+   * Stop future.
+   *
+   * @return the future
+   */
   public Future<Void> stop() {
     if (netServer == null) {
       return Future.succeededFuture();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugJsonRpcMethods.java
@@ -53,6 +53,7 @@ import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import java.nio.file.Path;
 import java.util.Map;
 
+/** The type Debug json rpc methods. */
 public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockResultFactory blockResult = new BlockResultFactory();
@@ -66,6 +67,18 @@ public class DebugJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final Path dataDir;
   private final ApiConfiguration apiConfiguration;
 
+  /**
+   * Instantiates a new Debug json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolContext the protocol context
+   * @param protocolSchedule the protocol schedule
+   * @param metricsSystem the metrics system
+   * @param transactionPool the transaction pool
+   * @param synchronizer the synchronizer
+   * @param dataDir the data dir
+   * @param apiConfiguration the api configuration
+   */
   DebugJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EeaJsonRpcMethods.java
@@ -32,12 +32,21 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
 
 import java.util.Map;
 
+/** The type Eea json rpc methods. */
 public class EeaJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
 
   private final TransactionPool transactionPool;
   private final PrivacyParameters privacyParameters;
   private final NonceProvider nonceProvider;
 
+  /**
+   * Instantiates a new Eea json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param privacyParameters the privacy parameters
+   */
   public EeaJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -76,6 +76,7 @@ import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import java.util.Map;
 import java.util.Set;
 
+/** The type Eth json rpc methods. */
 public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockResultFactory blockResult = new BlockResultFactory();
@@ -89,6 +90,18 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final Set<Capability> supportedCapabilities;
   private final ApiConfiguration apiConfiguration;
 
+  /**
+   * Instantiates a new Eth json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param synchronizer the synchronizer
+   * @param protocolSchedule the protocol schedule
+   * @param filterManager the filter manager
+   * @param transactionPool the transaction pool
+   * @param miningCoordinator the mining coordinator
+   * @param supportedCapabilities the supported capabilities
+   * @param apiConfiguration the api configuration
+   */
   public EthJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final Synchronizer synchronizer,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Execution engine json rpc methods. */
 public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockResultFactory blockResultFactory = new BlockResultFactory();
@@ -58,6 +59,15 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final EthPeers ethPeers;
   private final Vertx consensusEngineServer;
 
+  /**
+   * Instantiates a new Execution engine json rpc methods.
+   *
+   * @param miningCoordinator the mining coordinator
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param ethPeers the eth peers
+   * @param consensusEngineServer the consensus engine server
+   */
   ExecutionEngineJsonRpcMethods(
       final MiningCoordinator miningCoordinator,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -51,8 +51,44 @@ import java.util.Set;
 
 import io.vertx.core.Vertx;
 
+/** The type Json rpc methods factory. */
 public class JsonRpcMethodsFactory {
+  /** Default constructor. */
+  public JsonRpcMethodsFactory() {}
 
+  /**
+   * Methods map.
+   *
+   * @param clientVersion the client version
+   * @param networkId the network id
+   * @param genesisConfigOptions the genesis config options
+   * @param p2pNetwork the p 2 p network
+   * @param blockchainQueries the blockchain queries
+   * @param synchronizer the synchronizer
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param filterManager the filter manager
+   * @param transactionPool the transaction pool
+   * @param miningParameters the mining parameters
+   * @param miningCoordinator the mining coordinator
+   * @param metricsSystem the metrics system
+   * @param supportedCapabilities the supported capabilities
+   * @param accountsAllowlistController the accounts allowlist controller
+   * @param nodeAllowlistController the node allowlist controller
+   * @param rpcApis the rpc apis
+   * @param privacyParameters the privacy parameters
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @param webSocketConfiguration the web socket configuration
+   * @param metricsConfiguration the metrics configuration
+   * @param natService the nat service
+   * @param namedPlugins the named plugins
+   * @param dataDir the data dir
+   * @param ethPeers the eth peers
+   * @param consensusEngineServer the consensus engine server
+   * @param apiConfiguration the api configuration
+   * @param enodeDnsConfiguration the enode dns configuration
+   * @return the map
+   */
   public Map<String, JsonRpcMethod> methods(
       final String clientVersion,
       final BigInteger networkId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/MinerJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/MinerJsonRpcMethods.java
@@ -30,11 +30,18 @@ import org.hyperledger.besu.ethereum.core.MiningParameters;
 
 import java.util.Map;
 
+/** The type Miner json rpc methods. */
 public class MinerJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final MiningCoordinator miningCoordinator;
   private final MiningParameters miningParameters;
 
+  /**
+   * Instantiates a new Miner json rpc methods.
+   *
+   * @param miningParameters the mining parameters
+   * @param miningCoordinator the mining coordinator
+   */
   public MinerJsonRpcMethods(
       final MiningParameters miningParameters, final MiningCoordinator miningCoordinator) {
     this.miningParameters = miningParameters;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/NetJsonRpcMethods.java
@@ -30,6 +30,7 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 
+/** The type Net json rpc methods. */
 public class NetJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final P2PNetwork p2pNetwork;
@@ -38,6 +39,15 @@ public class NetJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final WebSocketConfiguration webSocketConfiguration;
   private final MetricsConfiguration metricsConfiguration;
 
+  /**
+   * Instantiates a new Net json rpc methods.
+   *
+   * @param p2pNetwork the p 2 p network
+   * @param networkId the network id
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @param webSocketConfiguration the web socket configuration
+   * @param metricsConfiguration the metrics configuration
+   */
   public NetJsonRpcMethods(
       final P2PNetwork p2pNetwork,
       final BigInteger networkId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PermJsonRpcMethods.java
@@ -35,11 +35,18 @@ import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningC
 import java.util.Map;
 import java.util.Optional;
 
+/** The type Perm json rpc methods. */
 public class PermJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final Optional<AccountLocalConfigPermissioningController> accountsAllowlistController;
   private final Optional<NodeLocalConfigPermissioningController> nodeAllowlistController;
 
+  /**
+   * Instantiates a new Perm json rpc methods.
+   *
+   * @param accountsAllowlistController the accounts allowlist controller
+   * @param nodeAllowlistController the node allowlist controller
+   */
   public PermJsonRpcMethods(
       final Optional<AccountLocalConfigPermissioningController> accountsAllowlistController,
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistController) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PluginsJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PluginsJsonRpcMethods.java
@@ -21,10 +21,16 @@ import org.hyperledger.besu.plugin.BesuPlugin;
 
 import java.util.Map;
 
+/** The type Plugins json rpc methods. */
 public class PluginsJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final Map<String, BesuPlugin> namedPlugins;
 
+  /**
+   * Instantiates a new Plugins json rpc methods.
+   *
+   * @param namedPlugins the named plugins
+   */
   public PluginsJsonRpcMethods(final Map<String, BesuPlugin> namedPlugins) {
     this.namedPlugins = namedPlugins;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -43,10 +43,20 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
 
 import java.util.Map;
 
+/** The type Priv json rpc methods. */
 public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Priv json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param privacyParameters the privacy parameters
+   * @param filterManager the filter manager
+   */
   public PrivJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+/** The type Privacy api group json rpc methods. */
 public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockchainQueries blockchainQueries;
@@ -51,6 +52,14 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
   private final PrivateNonceProvider privateNonceProvider;
   private final PrivacyQueries privacyQueries;
 
+  /**
+   * Instantiates a new Privacy api group json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param privacyParameters the privacy parameters
+   */
   protected PrivacyApiGroupJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
@@ -71,22 +80,47 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
         new PrivacyQueries(blockchainQueries, privacyParameters.getPrivateWorldStateReader());
   }
 
+  /**
+   * Gets blockchain queries.
+   *
+   * @return the blockchain queries
+   */
   public BlockchainQueries getBlockchainQueries() {
     return blockchainQueries;
   }
 
+  /**
+   * Gets protocol schedule.
+   *
+   * @return the protocol schedule
+   */
   public ProtocolSchedule getProtocolSchedule() {
     return protocolSchedule;
   }
 
+  /**
+   * Gets transaction pool.
+   *
+   * @return the transaction pool
+   */
   public TransactionPool getTransactionPool() {
     return transactionPool;
   }
 
+  /**
+   * Gets privacy parameters.
+   *
+   * @return the privacy parameters
+   */
   public PrivacyParameters getPrivacyParameters() {
     return privacyParameters;
   }
 
+  /**
+   * Gets gas calculator.
+   *
+   * @return the gas calculator
+   */
   public GasCalculator getGasCalculator() {
     return protocolSchedule
         .getByBlockHeader(blockchainQueries.headBlockHeader())
@@ -108,6 +142,14 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
                 entry -> createPrivacyMethod(privacyParameters, entry.getValue())));
   }
 
+  /**
+   * Create map.
+   *
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   * @param markerTransactionFactory the marker transaction factory
+   * @return the map
+   */
   protected abstract Map<String, JsonRpcMethod> create(
       final PrivacyController privacyController,
       final PrivacyIdProvider privacyIdProvider,
@@ -162,6 +204,11 @@ public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMetho
     }
   }
 
+  /**
+   * Gets privacy queries.
+   *
+   * @return the privacy queries
+   */
   PrivacyQueries getPrivacyQueries() {
     return privacyQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivxJsonRpcMethods.java
@@ -28,8 +28,17 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
 
 import java.util.Map;
 
+/** The type Privx json rpc methods. */
 public class PrivxJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
 
+  /**
+   * Instantiates a new Privx json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param privacyParameters the privacy parameters
+   */
   public PrivxJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -34,6 +34,7 @@ import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 
 import java.util.Map;
 
+/** The type Trace json rpc methods. */
 public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockchainQueries blockchainQueries;
@@ -42,6 +43,14 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ApiConfiguration apiConfiguration;
   private final ProtocolContext protocolContext;
 
+  /**
+   * Instantiates a new Trace json rpc methods.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param apiConfiguration the api configuration
+   */
   TraceJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TxPoolJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TxPoolJsonRpcMethods.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.Map;
 
+/** The type Tx pool json rpc methods. */
 public class TxPoolJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Tx pool json rpc methods.
+   *
+   * @param transactionPool the transaction pool
+   */
   public TxPoolJsonRpcMethods(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/Web3JsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/Web3JsonRpcMethods.java
@@ -27,7 +27,7 @@ public class Web3JsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final String clientVersion;
 
   /**
-   * Instantiates a new Web 3 json rpc methods.
+   * Instantiates a new Web3 json rpc methods.
    *
    * @param clientVersion the client version
    */

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/Web3JsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/Web3JsonRpcMethods.java
@@ -21,10 +21,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Web3Sha3;
 
 import java.util.Map;
 
+/** The type Web 3 json rpc methods. */
 public class Web3JsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final String clientVersion;
 
+  /**
+   * Instantiates a new Web 3 json rpc methods.
+   *
+   * @param clientVersion the client version
+   */
   public Web3JsonRpcMethods(final String clientVersion) {
     this.clientVersion = clientVersion;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonResponseStreamer.java
@@ -24,6 +24,7 @@ import io.vertx.core.http.WebSocketFrame;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json response streamer. */
 class JsonResponseStreamer extends OutputStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonResponseStreamer.class);
@@ -36,6 +37,11 @@ class JsonResponseStreamer extends OutputStream {
   private Buffer buffer = EMPTY_BUFFER;
   private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
+  /**
+   * Instantiates a new Json response streamer.
+   *
+   * @param response the response
+   */
   public JsonResponseStreamer(final ServerWebSocket response) {
     this.response = response;
     this.response.exceptionHandler(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketConfiguration.java
@@ -28,11 +28,21 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+/** The type Web socket configuration. */
 public class WebSocketConfiguration {
+  /** The constant DEFAULT_WEBSOCKET_HOST. */
   public static final String DEFAULT_WEBSOCKET_HOST = "127.0.0.1";
+
+  /** The constant DEFAULT_WEBSOCKET_PORT. */
   public static final int DEFAULT_WEBSOCKET_PORT = 8546;
+
+  /** The constant DEFAULT_WEBSOCKET_ENGINE_PORT. */
   public static final int DEFAULT_WEBSOCKET_ENGINE_PORT = 8551;
+
+  /** The constant DEFAULT_WEBSOCKET_MAX_FRAME_SIZE. */
   public static final int DEFAULT_WEBSOCKET_MAX_FRAME_SIZE = 1024 * 1024;
+
+  /** The constant DEFAULT_MAX_ACTIVE_CONNECTIONS. */
   public static final int DEFAULT_MAX_ACTIVE_CONNECTIONS = 80;
 
   private boolean enabled;
@@ -49,6 +59,11 @@ public class WebSocketConfiguration {
   private int maxActiveConnections;
   private int maxFrameSize;
 
+  /**
+   * Create default web socket configuration.
+   *
+   * @return the web socket configuration
+   */
   public static WebSocketConfiguration createDefault() {
     final WebSocketConfiguration config = new WebSocketConfiguration();
     config.setEnabled(false);
@@ -61,6 +76,11 @@ public class WebSocketConfiguration {
     return config;
   }
 
+  /**
+   * Create engine default web socket configuration.
+   *
+   * @return the web socket configuration
+   */
   public static WebSocketConfiguration createEngineDefault() {
     final WebSocketConfiguration config = createDefault();
     config.setPort(DEFAULT_WEBSOCKET_ENGINE_PORT);
@@ -71,90 +91,200 @@ public class WebSocketConfiguration {
 
   private WebSocketConfiguration() {}
 
+  /**
+   * Is enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEnabled() {
     return enabled;
   }
 
+  /**
+   * Sets enabled.
+   *
+   * @param enabled the enabled
+   */
   public void setEnabled(final boolean enabled) {
     this.enabled = enabled;
   }
 
+  /**
+   * Sets host.
+   *
+   * @param host the host
+   */
   public void setHost(final String host) {
     this.host = host;
   }
 
+  /**
+   * Gets host.
+   *
+   * @return the host
+   */
   public String getHost() {
     return host;
   }
 
+  /**
+   * Sets port.
+   *
+   * @param port the port
+   */
   public void setPort(final int port) {
     this.port = port;
   }
 
+  /**
+   * Gets port.
+   *
+   * @return the port
+   */
   public int getPort() {
     return port;
   }
 
+  /**
+   * Gets rpc apis.
+   *
+   * @return the rpc apis
+   */
   public Collection<String> getRpcApis() {
     return rpcApis;
   }
 
+  /**
+   * Sets rpc apis.
+   *
+   * @param rpcApis the rpc apis
+   */
   public void setRpcApis(final List<String> rpcApis) {
     this.rpcApis = rpcApis;
   }
 
+  /**
+   * Gets rpc apis no auth.
+   *
+   * @return the rpc apis no auth
+   */
   public Collection<String> getRpcApisNoAuth() {
     return rpcApisNoAuth;
   }
 
+  /**
+   * Sets rpc apis no auth.
+   *
+   * @param rpcApis the rpc apis
+   */
   public void setRpcApisNoAuth(final List<String> rpcApis) {
     this.rpcApisNoAuth = rpcApis;
   }
 
+  /**
+   * Is authentication enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isAuthenticationEnabled() {
     return authenticationEnabled;
   }
 
+  /**
+   * Sets authentication enabled.
+   *
+   * @param authenticationEnabled the authentication enabled
+   */
   public void setAuthenticationEnabled(final boolean authenticationEnabled) {
     this.authenticationEnabled = authenticationEnabled;
   }
 
+  /**
+   * Sets authentication credentials file.
+   *
+   * @param authenticationCredentialsFile the authentication credentials file
+   */
   public void setAuthenticationCredentialsFile(final String authenticationCredentialsFile) {
     this.authenticationCredentialsFile = authenticationCredentialsFile;
   }
 
+  /**
+   * Gets authentication credentials file.
+   *
+   * @return the authentication credentials file
+   */
   public String getAuthenticationCredentialsFile() {
     return authenticationCredentialsFile;
   }
 
+  /**
+   * Sets hosts allowlist.
+   *
+   * @param hostsAllowlist the hosts allowlist
+   */
   public void setHostsAllowlist(final List<String> hostsAllowlist) {
     this.hostsAllowlist = hostsAllowlist;
   }
 
+  /**
+   * Gets hosts allowlist.
+   *
+   * @return the hosts allowlist
+   */
   public Collection<String> getHostsAllowlist() {
     return Collections.unmodifiableCollection(this.hostsAllowlist);
   }
 
+  /**
+   * Gets authentication public key file.
+   *
+   * @return the authentication public key file
+   */
   public File getAuthenticationPublicKeyFile() {
     return authenticationPublicKeyFile;
   }
 
+  /**
+   * Sets authentication public key file.
+   *
+   * @param authenticationPublicKeyFile the authentication public key file
+   */
   public void setAuthenticationPublicKeyFile(final File authenticationPublicKeyFile) {
     this.authenticationPublicKeyFile = authenticationPublicKeyFile;
   }
 
+  /**
+   * Gets authentication algorithm.
+   *
+   * @return the authentication algorithm
+   */
   public JwtAlgorithm getAuthenticationAlgorithm() {
     return authenticationAlgorithm;
   }
 
+  /**
+   * Sets authentication algorithm.
+   *
+   * @param algorithm the algorithm
+   */
   public void setAuthenticationAlgorithm(final JwtAlgorithm algorithm) {
     authenticationAlgorithm = algorithm;
   }
 
+  /**
+   * Gets timeout sec.
+   *
+   * @return the timeout sec
+   */
   public long getTimeoutSec() {
     return timeoutSec;
   }
 
+  /**
+   * Sets timeout sec.
+   *
+   * @param timeoutSec the timeout sec
+   */
   public void setTimeoutSec(final long timeoutSec) {
     this.timeoutSec = timeoutSec;
   }
@@ -208,18 +338,38 @@ public class WebSocketConfiguration {
         .toString();
   }
 
+  /**
+   * Gets max active connections.
+   *
+   * @return the max active connections
+   */
   public int getMaxActiveConnections() {
     return maxActiveConnections;
   }
 
+  /**
+   * Sets max active connections.
+   *
+   * @param maxActiveConnections the max active connections
+   */
   public void setMaxActiveConnections(final int maxActiveConnections) {
     this.maxActiveConnections = maxActiveConnections;
   }
 
+  /**
+   * Sets max frame size.
+   *
+   * @param maxFrameSize the max frame size
+   */
   public void setMaxFrameSize(final int maxFrameSize) {
     this.maxFrameSize = maxFrameSize;
   }
 
+  /**
+   * Gets max frame size.
+   *
+   * @return the max frame size
+   */
   public Integer getMaxFrameSize() {
     return maxFrameSize;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandler.java
@@ -45,6 +45,7 @@ import io.vertx.ext.auth.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Web socket message handler. */
 public class WebSocketMessageHandler {
 
   private static final ObjectMapper jsonObjectMapper =
@@ -61,9 +62,20 @@ public class WebSocketMessageHandler {
 
   private final Vertx vertx;
   private final JsonRpcExecutor jsonRpcExecutor;
+
+  /** The Eth scheduler. */
   final EthScheduler ethScheduler;
+
   private final long timeoutSec;
 
+  /**
+   * Instantiates a new Web socket message handler.
+   *
+   * @param vertx the vertx
+   * @param jsonRpcExecutor the json rpc executor
+   * @param ethScheduler the eth scheduler
+   * @param timeoutSec the timeout sec
+   */
   public WebSocketMessageHandler(
       final Vertx vertx,
       final JsonRpcExecutor jsonRpcExecutor,
@@ -75,6 +87,13 @@ public class WebSocketMessageHandler {
     this.timeoutSec = timeoutSec;
   }
 
+  /**
+   * Handle.
+   *
+   * @param websocket the websocket
+   * @param buffer the buffer
+   * @param user the user
+   */
   public void handle(
       final ServerWebSocket websocket, final Buffer buffer, final Optional<User> user) {
     if (buffer.length() == 0) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketService.java
@@ -48,6 +48,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Web socket service. */
 public class WebSocketService {
 
   private static final Logger LOG = LoggerFactory.getLogger(WebSocketService.class);
@@ -64,8 +65,17 @@ public class WebSocketService {
 
   private HttpServer httpServer;
 
+  /** The Authentication service. */
   @VisibleForTesting public final Optional<AuthenticationService> authenticationService;
 
+  /**
+   * Instantiates a new Web socket service.
+   *
+   * @param vertx the vertx
+   * @param configuration the configuration
+   * @param websocketMessageHandler the websocket message handler
+   * @param metricsSystem the metrics system
+   */
   public WebSocketService(
       final Vertx vertx,
       final WebSocketConfiguration configuration,
@@ -79,6 +89,15 @@ public class WebSocketService {
         metricsSystem);
   }
 
+  /**
+   * Instantiates a new Web socket service.
+   *
+   * @param vertx the vertx
+   * @param configuration the configuration
+   * @param websocketMessageHandler the websocket message handler
+   * @param authenticationService the authentication service
+   * @param metricsSystem the metrics system
+   */
   public WebSocketService(
       final Vertx vertx,
       final WebSocketConfiguration configuration,
@@ -98,6 +117,11 @@ public class WebSocketService {
         activeConnectionsCount::intValue);
   }
 
+  /**
+   * Start completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> start() {
     LOG.info(
         "Starting Websocket service on {}:{}", configuration.getHost(), configuration.getPort());
@@ -255,6 +279,11 @@ public class WebSocketService {
     };
   }
 
+  /**
+   * Stop completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> stop() {
     if (httpServer == null) {
       return CompletableFuture.completedFuture(null);
@@ -275,6 +304,11 @@ public class WebSocketService {
     return resultFuture;
   }
 
+  /**
+   * Socket address inet socket address.
+   *
+   * @return the inet socket address
+   */
   public InetSocketAddress socketAddress() {
     if (httpServer == null) {
       return EMPTY_SOCKET_ADDRESS;
@@ -308,6 +342,12 @@ public class WebSocketService {
     };
   }
 
+  /**
+   * Check host in allowlist boolean.
+   *
+   * @param host the host
+   * @return the boolean
+   */
   @VisibleForTesting
   boolean checkHostInAllowlist(final Optional<String> host) {
     return configuration.getHostsAllowlist().contains("*")

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/AbstractPrivateSubscriptionMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/AbstractPrivateSubscriptionMethod.java
@@ -20,11 +20,23 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscrip
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionRequestMapper;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Abstract private subscription method. */
 abstract class AbstractPrivateSubscriptionMethod extends AbstractSubscriptionMethod {
 
+  /** The Privacy controller. */
   final PrivacyController privacyController;
+
+  /** The Privacy id provider. */
   protected final PrivacyIdProvider privacyIdProvider;
 
+  /**
+   * Instantiates a new Abstract private subscription method.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   AbstractPrivateSubscriptionMethod(
       final SubscriptionManager subscriptionManager,
       final SubscriptionRequestMapper mapper,
@@ -35,6 +47,12 @@ abstract class AbstractPrivateSubscriptionMethod extends AbstractSubscriptionMet
     this.privacyIdProvider = privacyIdProvider;
   }
 
+  /**
+   * Check if privacy group matches authenticated privacy user id.
+   *
+   * @param request the request
+   * @param privacyGroupId the privacy group id
+   */
   void checkIfPrivacyGroupMatchesAuthenticatedPrivacyUserId(
       final JsonRpcRequestContext request, final String privacyGroupId) {
     final String privacyUserId = privacyIdProvider.getPrivacyUserId(request.getUser());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/AbstractSubscriptionMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/AbstractSubscriptionMethod.java
@@ -18,21 +18,38 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionRequestMapper;
 
+/** The type Abstract subscription method. */
 abstract class AbstractSubscriptionMethod implements JsonRpcMethod {
 
   private final SubscriptionManager subscriptionManager;
   private final SubscriptionRequestMapper mapper;
 
+  /**
+   * Instantiates a new Abstract subscription method.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   */
   AbstractSubscriptionMethod(
       final SubscriptionManager subscriptionManager, final SubscriptionRequestMapper mapper) {
     this.subscriptionManager = subscriptionManager;
     this.mapper = mapper;
   }
 
+  /**
+   * Subscription manager subscription manager.
+   *
+   * @return the subscription manager
+   */
   SubscriptionManager subscriptionManager() {
     return subscriptionManager;
   }
 
+  /**
+   * Gets mapper.
+   *
+   * @return the mapper
+   */
   public SubscriptionRequestMapper getMapper() {
     return mapper;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthSubscribe.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthSubscribe.java
@@ -26,8 +26,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscribeRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionRequestMapper;
 
+/** The type Eth subscribe. */
 public class EthSubscribe extends AbstractSubscriptionMethod {
 
+  /**
+   * Instantiates a new Eth subscribe.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   */
   EthSubscribe(
       final SubscriptionManager subscriptionManager, final SubscriptionRequestMapper mapper) {
     super(subscriptionManager, mapper);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribe.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/EthUnsubscribe.java
@@ -26,8 +26,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionRequestMapper;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.UnsubscribeRequest;
 
+/** The type Eth unsubscribe. */
 public class EthUnsubscribe extends AbstractSubscriptionMethod {
 
+  /**
+   * Instantiates a new Eth unsubscribe.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   */
   EthUnsubscribe(
       final SubscriptionManager subscriptionManager, final SubscriptionRequestMapper mapper) {
     super(subscriptionManager, mapper);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivSubscribe.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivSubscribe.java
@@ -29,8 +29,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Priv subscribe. */
 public class PrivSubscribe extends AbstractPrivateSubscriptionMethod {
 
+  /**
+   * Instantiates a new Priv subscribe.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivSubscribe(
       final SubscriptionManager subscriptionManager,
       final SubscriptionRequestMapper mapper,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivUnsubscribe.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivUnsubscribe.java
@@ -29,8 +29,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
+/** The type Priv unsubscribe. */
 public class PrivUnsubscribe extends AbstractPrivateSubscriptionMethod {
 
+  /**
+   * Instantiates a new Priv unsubscribe.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param mapper the mapper
+   * @param privacyController the privacy controller
+   * @param privacyIdProvider the privacy id provider
+   */
   public PrivUnsubscribe(
       final SubscriptionManager subscriptionManager,
       final SubscriptionRequestMapper mapper,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivateWebSocketMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/PrivateWebSocketMethodsFactory.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 
+/** The type Private web socket methods factory. */
 public class PrivateWebSocketMethodsFactory {
 
   private final PrivacyParameters privacyParameters;
@@ -42,6 +43,14 @@ public class PrivateWebSocketMethodsFactory {
   private final ProtocolSchedule protocolSchedule;
   private final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Private web socket methods factory.
+   *
+   * @param privacyParameters the privacy parameters
+   * @param subscriptionManager the subscription manager
+   * @param protocolSchedule the protocol schedule
+   * @param blockchainQueries the blockchain queries
+   */
   public PrivateWebSocketMethodsFactory(
       final PrivacyParameters privacyParameters,
       final SubscriptionManager subscriptionManager,
@@ -53,6 +62,11 @@ public class PrivateWebSocketMethodsFactory {
     this.blockchainQueries = blockchainQueries;
   }
 
+  /**
+   * Methods collection.
+   *
+   * @return the collection
+   */
   public Collection<JsonRpcMethod> methods() {
     final SubscriptionRequestMapper subscriptionRequestMapper = new SubscriptionRequestMapper();
     final PrivacyIdProvider privacyIdProvider = PrivacyIdProvider.build(privacyParameters);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketMethodsFactory.java
@@ -21,10 +21,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import java.util.HashMap;
 import java.util.Map;
 
+/** The type Web socket methods factory. */
 public class WebSocketMethodsFactory {
 
   private final Map<String, JsonRpcMethod> methods = new HashMap<>();
 
+  /**
+   * Instantiates a new Web socket methods factory.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param jsonRpcMethods the json rpc methods
+   */
   public WebSocketMethodsFactory(
       final SubscriptionManager subscriptionManager,
       final Map<String, JsonRpcMethod> jsonRpcMethods) {
@@ -38,10 +45,20 @@ public class WebSocketMethodsFactory {
         new EthUnsubscribe(subscriptionManager, new SubscriptionRequestMapper()));
   }
 
+  /**
+   * Methods map.
+   *
+   * @return the map
+   */
   public Map<String, JsonRpcMethod> methods() {
     return methods;
   }
 
+  /**
+   * Add methods.
+   *
+   * @param rpcMethods the rpc methods
+   */
   public void addMethods(final JsonRpcMethod... rpcMethods) {
     for (final JsonRpcMethod rpcMethod : rpcMethods) {
       methods.put(rpcMethod.getName(), rpcMethod);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketRpcRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/methods/WebSocketRpcRequest.java
@@ -21,10 +21,19 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+/** The type Web socket rpc request. */
 public class WebSocketRpcRequest extends JsonRpcRequest {
 
   private String connectionId;
 
+  /**
+   * Instantiates a new Web socket rpc request.
+   *
+   * @param version the version
+   * @param method the method
+   * @param params the params
+   * @param connectionId the connection id
+   */
   @JsonCreator
   public WebSocketRpcRequest(
       @JsonProperty("jsonrpc") final String version,
@@ -35,11 +44,21 @@ public class WebSocketRpcRequest extends JsonRpcRequest {
     this.connectionId = connectionId;
   }
 
+  /**
+   * Sets connection id.
+   *
+   * @param connectionId the connection id
+   */
   @JsonSetter("connectionId")
   public void setConnectionId(final String connectionId) {
     this.connectionId = connectionId;
   }
 
+  /**
+   * Gets connection id.
+   *
+   * @return the connection id
+   */
   @JsonGetter("connectionId")
   public String getConnectionId() {
     return this.connectionId;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/Subscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/Subscription.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+/** The type Subscription. */
 public class Subscription {
 
   private final Long subscriptionId;
@@ -27,6 +28,14 @@ public class Subscription {
   private final SubscriptionType subscriptionType;
   private final Boolean includeTransaction;
 
+  /**
+   * Instantiates a new Subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param subscriptionType the subscription type
+   * @param includeTransaction the include transaction
+   */
   public Subscription(
       final Long subscriptionId,
       final String connectionId,
@@ -38,18 +47,38 @@ public class Subscription {
     this.includeTransaction = includeTransaction;
   }
 
+  /**
+   * Gets subscription type.
+   *
+   * @return the subscription type
+   */
   public SubscriptionType getSubscriptionType() {
     return subscriptionType;
   }
 
+  /**
+   * Gets subscription id.
+   *
+   * @return the subscription id
+   */
   public Long getSubscriptionId() {
     return subscriptionId;
   }
 
+  /**
+   * Gets connection id.
+   *
+   * @return the connection id
+   */
   public String getConnectionId() {
     return connectionId;
   }
 
+  /**
+   * Gets include transaction.
+   *
+   * @return the include transaction
+   */
   public Boolean getIncludeTransaction() {
     return includeTransaction;
   }
@@ -64,6 +93,12 @@ public class Subscription {
         .toString();
   }
 
+  /**
+   * Is type boolean.
+   *
+   * @param type the type
+   * @return the boolean
+   */
   public boolean isType(final SubscriptionType type) {
     return this.subscriptionType == type;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilder.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionBuilder.java
@@ -24,8 +24,19 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing.
 
 import java.util.function.Function;
 
+/** The type Subscription builder. */
 public class SubscriptionBuilder {
+  /** Default constructor. */
+  public SubscriptionBuilder() {}
 
+  /**
+   * Build subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param request the request
+   * @return the subscription
+   */
   public Subscription build(
       final long subscriptionId, final String connectionId, final SubscribeRequest request) {
     final SubscriptionType subscriptionType = request.getSubscriptionType();
@@ -65,6 +76,13 @@ public class SubscriptionBuilder {
     }
   }
 
+  /**
+   * Map to subscription class function.
+   *
+   * @param <T> the type parameter
+   * @param clazz the clazz
+   * @return the function
+   */
   @SuppressWarnings("unchecked")
   public <T> Function<Subscription, T> mapToSubscriptionClass(final Class<T> clazz) {
     return subscription -> {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionNotFoundException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/SubscriptionNotFoundException.java
@@ -14,15 +14,27 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription;
 
+/** The type Subscription not found exception. */
 public class SubscriptionNotFoundException extends RuntimeException {
 
+  /** The Subscription id. */
   private final Long subscriptionId;
 
+  /**
+   * Instantiates a new Subscription not found exception.
+   *
+   * @param subscriptionId the subscription id
+   */
   public SubscriptionNotFoundException(final Long subscriptionId) {
     super(String.format("Subscription not found (id=%s)", subscriptionId));
     this.subscriptionId = subscriptionId;
   }
 
+  /**
+   * Gets subscription id.
+   *
+   * @return the subscription id
+   */
   public Long getSubscriptionId() {
     return subscriptionId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscription.java
@@ -17,16 +17,29 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.blockhe
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 
+/** The type New block headers subscription. */
 public class NewBlockHeadersSubscription extends Subscription {
 
   private final boolean includeTransactions;
 
+  /**
+   * Instantiates a new New block headers subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param includeTransactions the include transactions
+   */
   public NewBlockHeadersSubscription(
       final Long subscriptionId, final String connectionId, final boolean includeTransactions) {
     super(subscriptionId, connectionId, SubscriptionType.NEW_BLOCK_HEADERS, Boolean.FALSE);
     this.includeTransactions = includeTransactions;
   }
 
+  /**
+   * Gets include transactions.
+   *
+   * @return the include transactions
+   */
   public boolean getIncludeTransactions() {
     return includeTransactions;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionService.java
@@ -31,12 +31,19 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type New block headers subscription service. */
 public class NewBlockHeadersSubscriptionService implements BlockAddedObserver {
 
   private final SubscriptionManager subscriptionManager;
   private final BlockchainQueries blockchainQueries;
   private final BlockResultFactory blockResult = new BlockResultFactory();
 
+  /**
+   * Instantiates a new New block headers subscription service.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param blockchainQueries the blockchain queries
+   */
   public NewBlockHeadersSubscriptionService(
       final SubscriptionManager subscriptionManager, final BlockchainQueries blockchainQueries) {
     this.subscriptionManager = subscriptionManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscription.java
@@ -18,16 +18,29 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParam
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 
+/** The type Logs subscription. */
 public class LogsSubscription extends Subscription {
 
   private final FilterParameter filterParameter;
 
+  /**
+   * Instantiates a new Logs subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param filterParameter the filter parameter
+   */
   public LogsSubscription(
       final Long subscriptionId, final String connectionId, final FilterParameter filterParameter) {
     super(subscriptionId, connectionId, SubscriptionType.LOGS, Boolean.FALSE);
     this.filterParameter = filterParameter;
   }
 
+  /**
+   * Gets filter parameter.
+   *
+   * @return the filter parameter
+   */
   public FilterParameter getFilterParameter() {
     return filterParameter;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/LogsSubscriptionService.java
@@ -27,11 +27,18 @@ import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+/** The type Logs subscription service. */
 public class LogsSubscriptionService implements Consumer<LogWithMetadata> {
 
   private final SubscriptionManager subscriptionManager;
   private final Optional<PrivacyQueries> privacyQueries;
 
+  /**
+   * Instantiates a new Logs subscription service.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param privacyQueries the privacy queries
+   */
   public LogsSubscriptionService(
       final SubscriptionManager subscriptionManager,
       final Optional<PrivacyQueries> privacyQueries) {
@@ -57,6 +64,11 @@ public class LogsSubscriptionService implements Consumer<LogWithMetadata> {
         .forEach(logsSubscription -> sendLogToSubscription(logWithMetadata, logsSubscription));
   }
 
+  /**
+   * Check private logs.
+   *
+   * @param event the event
+   */
   public void checkPrivateLogs(final BlockAddedEvent event) {
     privacyQueries.ifPresent(
         pq ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/PrivateLogsSubscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/logs/PrivateLogsSubscription.java
@@ -16,11 +16,21 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.logs;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParameter;
 
+/** The type Private logs subscription. */
 public class PrivateLogsSubscription extends LogsSubscription {
 
   private final String privacyGroupId;
   private final String privacyUserId;
 
+  /**
+   * Instantiates a new Private logs subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param filterParameter the filter parameter
+   * @param privacyGroupId the privacy group id
+   * @param privacyUserId the privacy user id
+   */
   public PrivateLogsSubscription(
       final Long subscriptionId,
       final String connectionId,
@@ -32,10 +42,20 @@ public class PrivateLogsSubscription extends LogsSubscription {
     this.privacyUserId = privacyUserId;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   public String getPrivacyGroupId() {
     return privacyGroupId;
   }
 
+  /**
+   * Gets privacy user id.
+   *
+   * @return the privacy user id
+   */
   public String getPrivacyUserId() {
     return privacyUserId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDetailResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDetailResult.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Pending transaction detail result. */
 @JsonPropertyOrder({
   "from",
   "gas",
@@ -54,6 +55,11 @@ public class PendingTransactionDetailResult implements JsonRpcResult {
   private final String r;
   private final String s;
 
+  /**
+   * Instantiates a new Pending transaction detail result.
+   *
+   * @param tx the tx
+   */
   public PendingTransactionDetailResult(final Transaction tx) {
     TransactionType transactionType = tx.getType();
     this.from = tx.getSender().toString();
@@ -81,68 +87,133 @@ public class PendingTransactionDetailResult implements JsonRpcResult {
     this.s = Quantity.create(tx.getS());
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   @JsonGetter(value = "from")
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   @JsonGetter(value = "gas")
   public String getGas() {
     return gas;
   }
 
+  /**
+   * Gets gas price.
+   *
+   * @return the gas price
+   */
   @JsonGetter(value = "gasPrice")
   public String getGasPrice() {
     return gasPrice;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "hash")
   public String getHash() {
     return hash;
   }
 
+  /**
+   * Gets input.
+   *
+   * @return the input
+   */
   @JsonGetter(value = "input")
   public String getInput() {
     return input;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   @JsonGetter(value = "to")
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   @JsonGetter(value = "type")
   public String getType() {
     return type;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonGetter(value = "value")
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets parity.
+   *
+   * @return the parity
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "yParity")
   public String getyParity() {
     return yParity;
   }
 
+  /**
+   * Gets v.
+   *
+   * @return the v
+   */
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @JsonGetter(value = "v")
   public String getV() {
     return v;
   }
 
+  /**
+   * Gets r.
+   *
+   * @return the r
+   */
   @JsonGetter(value = "r")
   public String getR() {
     return r;
   }
 
+  /**
+   * Gets s.
+   *
+   * @return the s
+   */
   @JsonGetter(value = "s")
   public String getS() {
     return s;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionService.java
@@ -23,11 +23,17 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedL
 
 import java.util.List;
 
+/** The type Pending transaction dropped subscription service. */
 public class PendingTransactionDroppedSubscriptionService
     implements PendingTransactionDroppedListener {
 
   private final SubscriptionManager subscriptionManager;
 
+  /**
+   * Instantiates a new Pending transaction dropped subscription service.
+   *
+   * @param subscriptionManager the subscription manager
+   */
   public PendingTransactionDroppedSubscriptionService(
       final SubscriptionManager subscriptionManager) {
     this.subscriptionManager = subscriptionManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionResult.java
@@ -19,14 +19,25 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.JsonRpcResult;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/** The type Pending transaction result. */
 public class PendingTransactionResult implements JsonRpcResult {
 
   private final String hash;
 
+  /**
+   * Instantiates a new Pending transaction result.
+   *
+   * @param hash the hash
+   */
   public PendingTransactionResult(final Hash hash) {
     this.hash = hash.toString();
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonValue
   public String getHash() {
     return hash;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionSubscriptionService.java
@@ -22,10 +22,16 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedLis
 
 import java.util.List;
 
+/** The type Pending transaction subscription service. */
 public class PendingTransactionSubscriptionService implements PendingTransactionAddedListener {
 
   private final SubscriptionManager subscriptionManager;
 
+  /**
+   * Instantiates a new Pending transaction subscription service.
+   *
+   * @param subscriptionManager the subscription manager
+   */
   public PendingTransactionSubscriptionService(final SubscriptionManager subscriptionManager) {
     this.subscriptionManager = subscriptionManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/InvalidRequestException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/InvalidRequestException.java
@@ -14,8 +14,14 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request;
 
+/** The type Invalid request exception. */
 public class InvalidRequestException extends RuntimeException {
 
+  /**
+   * Instantiates a new Invalid request exception.
+   *
+   * @param message the message
+   */
   public InvalidRequestException(final String message) {
     super(message);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/InvalidSubscriptionRequestException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/InvalidSubscriptionRequestException.java
@@ -14,16 +14,29 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request;
 
+/** The type Invalid subscription request exception. */
 public class InvalidSubscriptionRequestException extends RuntimeException {
 
+  /** Instantiates a new Invalid subscription request exception. */
   public InvalidSubscriptionRequestException() {
     super();
   }
 
+  /**
+   * Instantiates a new Invalid subscription request exception.
+   *
+   * @param message the message
+   */
   public InvalidSubscriptionRequestException(final String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Invalid subscription request exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public InvalidSubscriptionRequestException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/PrivateSubscribeRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/PrivateSubscribeRequest.java
@@ -18,11 +18,22 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParam
 
 import java.util.Objects;
 
+/** The type Private subscribe request. */
 public class PrivateSubscribeRequest extends SubscribeRequest {
 
   private final String privacyGroupId;
   private final String privacyUserId;
 
+  /**
+   * Instantiates a new Private subscribe request.
+   *
+   * @param subscriptionType the subscription type
+   * @param filterParameter the filter parameter
+   * @param includeTransaction the include transaction
+   * @param connectionId the connection id
+   * @param privacyGroupId the privacy group id
+   * @param privacyUserId the privacy user id
+   */
   public PrivateSubscribeRequest(
       final SubscriptionType subscriptionType,
       final FilterParameter filterParameter,
@@ -35,10 +46,20 @@ public class PrivateSubscribeRequest extends SubscribeRequest {
     this.privacyUserId = privacyUserId;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   public String getPrivacyGroupId() {
     return privacyGroupId;
   }
 
+  /**
+   * Gets privacy user id.
+   *
+   * @return the privacy user id
+   */
   public String getPrivacyUserId() {
     return privacyUserId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/PrivateUnsubscribeRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/PrivateUnsubscribeRequest.java
@@ -16,16 +16,29 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request
 
 import java.util.Objects;
 
+/** The type Private unsubscribe request. */
 public class PrivateUnsubscribeRequest extends UnsubscribeRequest {
 
   private final String privacyGroupId;
 
+  /**
+   * Instantiates a new Private unsubscribe request.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param privacyGroupId the privacy group id
+   */
   public PrivateUnsubscribeRequest(
       final Long subscriptionId, final String connectionId, final String privacyGroupId) {
     super(subscriptionId, connectionId);
     this.privacyGroupId = privacyGroupId;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   public String getPrivacyGroupId() {
     return privacyGroupId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscribeRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscribeRequest.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.FilterParam
 
 import java.util.Objects;
 
+/** The type Subscribe request. */
 public class SubscribeRequest {
 
   private final SubscriptionType subscriptionType;
@@ -25,6 +26,14 @@ public class SubscribeRequest {
   private final FilterParameter filterParameter;
   private final String connectionId;
 
+  /**
+   * Instantiates a new Subscribe request.
+   *
+   * @param subscriptionType the subscription type
+   * @param filterParameter the filter parameter
+   * @param includeTransaction the include transaction
+   * @param connectionId the connection id
+   */
   public SubscribeRequest(
       final SubscriptionType subscriptionType,
       final FilterParameter filterParameter,
@@ -36,18 +45,38 @@ public class SubscribeRequest {
     this.connectionId = connectionId;
   }
 
+  /**
+   * Gets subscription type.
+   *
+   * @return the subscription type
+   */
   public SubscriptionType getSubscriptionType() {
     return subscriptionType;
   }
 
+  /**
+   * Gets filter parameter.
+   *
+   * @return the filter parameter
+   */
   public FilterParameter getFilterParameter() {
     return filterParameter;
   }
 
+  /**
+   * Gets include transaction.
+   *
+   * @return the include transaction
+   */
   public Boolean getIncludeTransaction() {
     return includeTransaction;
   }
 
+  /**
+   * Gets connection id.
+   *
+   * @return the connection id
+   */
   public String getConnectionId() {
     return this.connectionId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionParam.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionParam.java
@@ -17,15 +17,26 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The type Subscription param. */
 class SubscriptionParam {
 
   private final boolean includeTransaction;
 
+  /**
+   * Instantiates a new Subscription param.
+   *
+   * @param includeTransaction the include transaction
+   */
   @JsonCreator
   SubscriptionParam(@JsonProperty("includeTransactions") final boolean includeTransaction) {
     this.includeTransaction = includeTransaction;
   }
 
+  /**
+   * Include transaction boolean.
+   *
+   * @return the boolean
+   */
   boolean includeTransaction() {
     return includeTransaction;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionRequestMapper.java
@@ -21,10 +21,19 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcR
 
 import java.util.Optional;
 
+/** The type Subscription request mapper. */
 public class SubscriptionRequestMapper {
 
+  /** Instantiates a new Subscription request mapper. */
   public SubscriptionRequestMapper() {}
 
+  /**
+   * Map subscribe request subscribe request.
+   *
+   * @param jsonRpcRequestContext the json rpc request context
+   * @return the subscribe request
+   * @throws InvalidSubscriptionRequestException the invalid subscription request exception
+   */
   public SubscribeRequest mapSubscribeRequest(final JsonRpcRequestContext jsonRpcRequestContext)
       throws InvalidSubscriptionRequestException {
     try {
@@ -75,6 +84,13 @@ public class SubscriptionRequestMapper {
         SubscriptionType.LOGS, filterParameter, null, request.getConnectionId());
   }
 
+  /**
+   * Map unsubscribe request unsubscribe request.
+   *
+   * @param jsonRpcRequestContext the json rpc request context
+   * @return the unsubscribe request
+   * @throws InvalidSubscriptionRequestException the invalid subscription request exception
+   */
   public UnsubscribeRequest mapUnsubscribeRequest(final JsonRpcRequestContext jsonRpcRequestContext)
       throws InvalidSubscriptionRequestException {
     try {
@@ -88,6 +104,14 @@ public class SubscriptionRequestMapper {
     }
   }
 
+  /**
+   * Map private subscribe request private subscribe request.
+   *
+   * @param jsonRpcRequestContext the json rpc request context
+   * @param privacyUserId the privacy user id
+   * @return the private subscribe request
+   * @throws InvalidSubscriptionRequestException the invalid subscription request exception
+   */
   public PrivateSubscribeRequest mapPrivateSubscribeRequest(
       final JsonRpcRequestContext jsonRpcRequestContext, final String privacyUserId)
       throws InvalidSubscriptionRequestException {
@@ -122,6 +146,13 @@ public class SubscriptionRequestMapper {
     }
   }
 
+  /**
+   * Map private unsubscribe request private unsubscribe request.
+   *
+   * @param jsonRpcRequestContext the json rpc request context
+   * @return the private unsubscribe request
+   * @throws InvalidSubscriptionRequestException the invalid subscription request exception
+   */
   public PrivateUnsubscribeRequest mapPrivateUnsubscribeRequest(
       final JsonRpcRequestContext jsonRpcRequestContext)
       throws InvalidSubscriptionRequestException {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/SubscriptionType.java
@@ -16,19 +16,25 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** The enum Subscription type. */
 public enum SubscriptionType {
+  /** New block headers subscription type. */
   @JsonProperty("newHeads")
   NEW_BLOCK_HEADERS("newHeads"),
 
+  /** Logs subscription type. */
   @JsonProperty("logs")
   LOGS("logs"),
 
+  /** New pending transactions subscription type. */
   @JsonProperty("newPendingTransactions")
   NEW_PENDING_TRANSACTIONS("newPendingTransactions"),
 
+  /** Dropped pending transactions subscription type. */
   @JsonProperty("droppedPendingTransactions")
   DROPPED_PENDING_TRANSACTIONS("droppedPendingTransactions"),
 
+  /** Syncing subscription type. */
   @JsonProperty("syncing")
   SYNCING("syncing");
 
@@ -38,10 +44,21 @@ public enum SubscriptionType {
     this.code = code;
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   public String getCode() {
     return code;
   }
 
+  /**
+   * From code subscription type.
+   *
+   * @param code the code
+   * @return the subscription type
+   */
   public static SubscriptionType fromCode(final String code) {
     for (final SubscriptionType subscriptionType : SubscriptionType.values()) {
       if (code.equals(subscriptionType.getCode())) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/UnsubscribeRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/request/UnsubscribeRequest.java
@@ -16,20 +16,37 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request
 
 import java.util.Objects;
 
+/** The type Unsubscribe request. */
 public class UnsubscribeRequest {
 
   private final Long subscriptionId;
   private final String connectionId;
 
+  /**
+   * Instantiates a new Unsubscribe request.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   */
   public UnsubscribeRequest(final Long subscriptionId, final String connectionId) {
     this.subscriptionId = subscriptionId;
     this.connectionId = connectionId;
   }
 
+  /**
+   * Gets subscription id.
+   *
+   * @return the subscription id
+   */
   public Long getSubscriptionId() {
     return subscriptionId;
   }
 
+  /**
+   * Gets connection id.
+   *
+   * @return the connection id
+   */
   public String getConnectionId() {
     return connectionId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/response/SubscriptionResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/response/SubscriptionResponse.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.logs.Pri
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Subscription response. */
 @JsonPropertyOrder({"jsonrpc", "method", "params"})
 public class SubscriptionResponse {
 
@@ -32,6 +33,12 @@ public class SubscriptionResponse {
   private final String methodName;
   private final SubscriptionResponseResult params;
 
+  /**
+   * Instantiates a new Subscription response.
+   *
+   * @param subscription the subscription
+   * @param result the result
+   */
   public SubscriptionResponse(final Subscription subscription, final JsonRpcResult result) {
     if (subscription instanceof PrivateLogsSubscription) {
       final String privacyGroupId = ((PrivateLogsSubscription) subscription).getPrivacyGroupId();
@@ -46,16 +53,31 @@ public class SubscriptionResponse {
     }
   }
 
+  /**
+   * Gets jsonrpc.
+   *
+   * @return the jsonrpc
+   */
   @JsonGetter("jsonrpc")
   public String getJsonrpc() {
     return JSON_RPC_VERSION;
   }
 
+  /**
+   * Gets method.
+   *
+   * @return the method
+   */
   @JsonGetter("method")
   public String getMethod() {
     return methodName;
   }
 
+  /**
+   * Gets params.
+   *
+   * @return the params
+   */
   @JsonGetter("params")
   public SubscriptionResponseResult getParams() {
     return params;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/response/SubscriptionResponseResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/response/SubscriptionResponseResult.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Subscription response result. */
 @JsonPropertyOrder({"subscription", "privacyGroupId", "result"})
 public class SubscriptionResponseResult {
 
@@ -30,10 +31,23 @@ public class SubscriptionResponseResult {
   @JsonInclude(Include.NON_NULL)
   private final String privacyGroupId;
 
+  /**
+   * Instantiates a new Subscription response result.
+   *
+   * @param subscription the subscription
+   * @param result the result
+   */
   SubscriptionResponseResult(final String subscription, final JsonRpcResult result) {
     this(subscription, result, null);
   }
 
+  /**
+   * Instantiates a new Subscription response result.
+   *
+   * @param subscription the subscription
+   * @param result the result
+   * @param privacyGroupId the privacy group id
+   */
   SubscriptionResponseResult(
       final String subscription, final JsonRpcResult result, final String privacyGroupId) {
     this.subscription = subscription;
@@ -41,16 +55,31 @@ public class SubscriptionResponseResult {
     this.privacyGroupId = privacyGroupId;
   }
 
+  /**
+   * Gets subscription.
+   *
+   * @return the subscription
+   */
   @JsonGetter("subscription")
   public String getSubscription() {
     return subscription;
   }
 
+  /**
+   * Gets result.
+   *
+   * @return the result
+   */
   @JsonGetter("result")
   public JsonRpcResult getResult() {
     return result;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   @JsonGetter("privacyGroupId")
   public String getPrivacyGroupId() {
     return privacyGroupId;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/NotSynchronisingResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/NotSynchronisingResult.java
@@ -18,8 +18,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.JsonRpcResult;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/** The type Not synchronising result. */
 public class NotSynchronisingResult implements JsonRpcResult {
+  /** Default constructor. */
+  public NotSynchronisingResult() {}
 
+  /**
+   * Gets result.
+   *
+   * @return the result
+   */
   @JsonValue
   public boolean getResult() {
     return false;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscription.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscription.java
@@ -17,9 +17,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.syncing
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscription;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 
+/** The type Syncing subscription. */
 public class SyncingSubscription extends Subscription {
   private boolean firstMessageHasBeenSent = false;
 
+  /**
+   * Instantiates a new Syncing subscription.
+   *
+   * @param subscriptionId the subscription id
+   * @param connectionId the connection id
+   * @param subscriptionType the subscription type
+   */
   public SyncingSubscription(
       final Long subscriptionId,
       final String connectionId,
@@ -27,10 +35,20 @@ public class SyncingSubscription extends Subscription {
     super(subscriptionId, connectionId, subscriptionType, Boolean.FALSE);
   }
 
+  /**
+   * Sets first message has been sent.
+   *
+   * @param firstMessageHasBeenSent the first message has been sent
+   */
   public void setFirstMessageHasBeenSent(final boolean firstMessageHasBeenSent) {
     this.firstMessageHasBeenSent = firstMessageHasBeenSent;
   }
 
+  /**
+   * Is first message has been sent boolean.
+   *
+   * @return the boolean
+   */
   public boolean isFirstMessageHasBeenSent() {
     return firstMessageHasBeenSent;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/syncing/SyncingSubscriptionService.java
@@ -24,10 +24,17 @@ import org.hyperledger.besu.plugin.data.SyncStatus;
 
 import java.util.Optional;
 
+/** The type Syncing subscription service. */
 public class SyncingSubscriptionService {
 
   private final SubscriptionManager subscriptionManager;
 
+  /**
+   * Instantiates a new Syncing subscription service.
+   *
+   * @param subscriptionManager the subscription manager
+   * @param synchronizer the synchronizer
+   */
   public SyncingSubscriptionService(
       final SubscriptionManager subscriptionManager, final Synchronizer synchronizer) {
     this.subscriptionManager = subscriptionManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/LogsQuery.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/LogsQuery.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.Lists;
 
+/** The type Logs query. */
 public class LogsQuery {
 
   private final List<Address> addresses;
@@ -43,6 +44,12 @@ public class LogsQuery {
   private final List<LogsBloomFilter> addressBlooms;
   private final List<List<LogsBloomFilter>> topicsBlooms;
 
+  /**
+   * Instantiates a new Logs query.
+   *
+   * @param addresses the addresses
+   * @param topics the topics
+   */
   @JsonCreator
   public LogsQuery(
       @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("address")
@@ -75,6 +82,12 @@ public class LogsQuery {
             .collect(toUnmodifiableList());
   }
 
+  /**
+   * Could match boolean.
+   *
+   * @param bloom the bloom
+   * @return the boolean
+   */
   public boolean couldMatch(final LogsBloomFilter bloom) {
     return (addressBlooms.isEmpty() || addressBlooms.stream().anyMatch(bloom::couldContain))
         && (topicsBlooms.isEmpty()
@@ -83,6 +96,12 @@ public class LogsQuery {
                     topics -> topics.isEmpty() || topics.stream().anyMatch(bloom::couldContain)));
   }
 
+  /**
+   * Matches boolean.
+   *
+   * @param log the log
+   * @return the boolean
+   */
   public boolean matches(final Log log) {
     return matchesAddresses(log.getLogger()) && matchesTopics(log.getTopics());
   }
@@ -122,10 +141,20 @@ public class LogsQuery {
     return Objects.hash(addresses, topics);
   }
 
+  /** The type Builder. */
   public static class Builder {
     private final List<Address> queryAddresses = Lists.newArrayList();
     private final List<List<LogTopic>> queryTopics = Lists.newArrayList();
 
+    /** Default constructor. */
+    public Builder() {}
+
+    /**
+     * Address builder.
+     *
+     * @param address the address
+     * @return the builder
+     */
     public Builder address(final Address address) {
       if (address != null) {
         queryAddresses.add(address);
@@ -133,6 +162,12 @@ public class LogsQuery {
       return this;
     }
 
+    /**
+     * Addresses builder.
+     *
+     * @param addresses the addresses
+     * @return the builder
+     */
     public Builder addresses(final Address... addresses) {
       if (addresses != null && addresses.length > 0) {
         queryAddresses.addAll(Arrays.asList(addresses));
@@ -140,6 +175,12 @@ public class LogsQuery {
       return this;
     }
 
+    /**
+     * Addresses builder.
+     *
+     * @param addresses the addresses
+     * @return the builder
+     */
     public Builder addresses(final List<Address> addresses) {
       if (addresses != null && !addresses.isEmpty()) {
         queryAddresses.addAll(addresses);
@@ -147,6 +188,12 @@ public class LogsQuery {
       return this;
     }
 
+    /**
+     * Topics builder.
+     *
+     * @param topics the topics
+     * @return the builder
+     */
     public Builder topics(final List<List<LogTopic>> topics) {
       if (topics != null && !topics.isEmpty()) {
         queryTopics.addAll(topics);
@@ -154,6 +201,11 @@ public class LogsQuery {
       return this;
     }
 
+    /**
+     * Build logs query.
+     *
+     * @return the logs query
+     */
     public LogsQuery build() {
       return new LogsQuery(queryAddresses, queryTopics);
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/PrivacyQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/PrivacyQueries.java
@@ -31,11 +31,18 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
+/** The type Privacy queries. */
 public class PrivacyQueries {
 
   private final BlockchainQueries blockchainQueries;
   private final PrivateWorldStateReader privateWorldStateReader;
 
+  /**
+   * Instantiates a new Privacy queries.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param privateWorldStateReader the private world state reader
+   */
   public PrivacyQueries(
       final BlockchainQueries blockchainQueries,
       final PrivateWorldStateReader privateWorldStateReader) {
@@ -43,6 +50,15 @@ public class PrivacyQueries {
     this.privateWorldStateReader = privateWorldStateReader;
   }
 
+  /**
+   * Matching logs list.
+   *
+   * @param privacyGroupId the privacy group id
+   * @param fromBlockNumber the from block number
+   * @param toBlockNumber the to block number
+   * @param query the query
+   * @return the list
+   */
   public List<LogWithMetadata> matchingLogs(
       final String privacyGroupId,
       final long fromBlockNumber,
@@ -58,6 +74,14 @@ public class PrivacyQueries {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Matching logs list.
+   *
+   * @param privacyGroupId the privacy group id
+   * @param blockHash the block hash
+   * @param query the query
+   * @return the list
+   */
   public List<LogWithMetadata> matchingLogs(
       final String privacyGroupId, final Hash blockHash, final LogsQuery query) {
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
@@ -55,6 +55,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type State backup service. */
 public class StateBackupService {
 
   private static final Logger LOG = LoggerFactory.getLogger(StateBackupService.class);
@@ -77,6 +78,15 @@ public class StateBackupService {
   private Path backupDir;
   private RollingFileWriter accountFileWriter;
 
+  /**
+   * Instantiates a new State backup service.
+   *
+   * @param besuVersion the besu version
+   * @param blockchain the blockchain
+   * @param backupDir the backup dir
+   * @param scheduler the scheduler
+   * @param worldStateKeyValueStorage the world state key value storage
+   */
   public StateBackupService(
       final String besuVersion,
       final Blockchain blockchain,
@@ -90,10 +100,23 @@ public class StateBackupService {
     this.worldStateKeyValueStorage = worldStateKeyValueStorage;
   }
 
+  /**
+   * Gets backup dir.
+   *
+   * @return the backup dir
+   */
   public Path getBackupDir() {
     return backupDir;
   }
 
+  /**
+   * Request backup backup status.
+   *
+   * @param block the block
+   * @param compress the compress
+   * @param backupDir the backup dir
+   * @return the backup status
+   */
   public BackupStatus requestBackup(
       final long block, final boolean compress, final Optional<Path> backupDir) {
     boolean requestAccepted = false;
@@ -128,10 +151,25 @@ public class StateBackupService {
     return backupStatus;
   }
 
+  /**
+   * Data file to index path.
+   *
+   * @param dataName the data name
+   * @return the path
+   */
   public static Path dataFileToIndex(final Path dataName) {
     return Path.of(dataName.toString().replaceAll("(.*)[-.]\\d\\d\\d\\d\\.(.)dat", "$1.$2idx"));
   }
 
+  /**
+   * Account file name path.
+   *
+   * @param backupDir the backup dir
+   * @param targetBlock the target block
+   * @param fileNumber the file number
+   * @param compressed the compressed
+   * @return the path
+   */
   public static Path accountFileName(
       final Path backupDir,
       final long targetBlock,
@@ -143,18 +181,42 @@ public class StateBackupService {
             targetBlock, fileNumber, compressed ? "c" : "r"));
   }
 
+  /**
+   * Header file name path.
+   *
+   * @param backupDir the backup dir
+   * @param fileNumber the file number
+   * @param compressed the compressed
+   * @return the path
+   */
   public static Path headerFileName(
       final Path backupDir, final int fileNumber, final boolean compressed) {
     return backupDir.resolve(
         String.format("besu-header-backup-%04d.%sdat", fileNumber, compressed ? "c" : "r"));
   }
 
+  /**
+   * Body file name path.
+   *
+   * @param backupDir the backup dir
+   * @param fileNumber the file number
+   * @param compressed the compressed
+   * @return the path
+   */
   public static Path bodyFileName(
       final Path backupDir, final int fileNumber, final boolean compressed) {
     return backupDir.resolve(
         String.format("besu-body-backup-%04d.%sdat", fileNumber, compressed ? "c" : "r"));
   }
 
+  /**
+   * Receipt file name path.
+   *
+   * @param backupDir the backup dir
+   * @param fileNumber the file number
+   * @param compressed the compressed
+   * @return the path
+   */
   public static Path receiptFileName(
       final Path backupDir, final int fileNumber, final boolean compressed) {
     return backupDir.resolve(
@@ -338,67 +400,143 @@ public class StateBackupService {
     return State.CONTINUE;
   }
 
+  /** The type Backup status. */
   public static final class BackupStatus {
+    /** The Target block. */
     long targetBlock;
+
+    /** The Stored block. */
     long storedBlock;
+
+    /** The Compressed. */
     boolean compressed;
+
+    /** The Current account. */
     Bytes32 currentAccount;
+
+    /** The Current storage. */
     Bytes32 currentStorage;
+
+    /** The Account count. */
     AtomicLong accountCount = new AtomicLong(0);
+
+    /** The Code size. */
     AtomicLong codeSize = new AtomicLong(0);
+
+    /** The Storage count. */
     AtomicLong storageCount = new AtomicLong(0);
+
+    /** The Request accepted. */
     boolean requestAccepted;
 
+    /** Default constructor. */
+    public BackupStatus() {}
+
+    /**
+     * Gets target block.
+     *
+     * @return the target block
+     */
     @JsonGetter
     public String getTargetBlock() {
       return "0x" + Long.toHexString(targetBlock);
     }
 
+    /**
+     * Gets stored block.
+     *
+     * @return the stored block
+     */
     @JsonGetter
     public String getStoredBlock() {
       return "0x" + Long.toHexString(storedBlock);
     }
 
+    /**
+     * Gets current account.
+     *
+     * @return the current account
+     */
     @JsonGetter
     public String getCurrentAccount() {
       return currentAccount.toHexString();
     }
 
+    /**
+     * Gets current storage.
+     *
+     * @return the current storage
+     */
     @JsonGetter
     public String getCurrentStorage() {
       return currentStorage.toHexString();
     }
 
+    /**
+     * Is backing up boolean.
+     *
+     * @return the boolean
+     */
     @JsonGetter
     public boolean isBackingUp() {
       return currentAccount != null;
     }
 
+    /**
+     * Gets account count.
+     *
+     * @return the account count
+     */
     @JsonIgnore
     public long getAccountCount() {
       return accountCount.get();
     }
 
+    /**
+     * Gets code size.
+     *
+     * @return the code size
+     */
     @JsonIgnore
     public long getCodeSize() {
       return codeSize.get();
     }
 
+    /**
+     * Gets storage count.
+     *
+     * @return the storage count
+     */
     @JsonIgnore
     public long getStorageCount() {
       return storageCount.get();
     }
 
+    /**
+     * Gets current account bytes.
+     *
+     * @return the current account bytes
+     */
     @JsonIgnore
     public Bytes getCurrentAccountBytes() {
       return currentAccount;
     }
 
+    /**
+     * Gets stored block num.
+     *
+     * @return the stored block num
+     */
     @JsonIgnore
     public long getStoredBlockNum() {
       return storedBlock;
     }
 
+    /**
+     * Gets target block num.
+     *
+     * @return the target block num
+     */
     @JsonIgnore
     public long getTargetBlockNum() {
       return targetBlock;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionReceiptWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionReceiptWithMetadata.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 
 import java.util.Optional;
 
+/** The type Transaction receipt with metadata. */
 public class TransactionReceiptWithMetadata {
   private final TransactionReceipt receipt;
   private final Hash transactionHash;
@@ -59,6 +60,22 @@ public class TransactionReceiptWithMetadata {
     this.logIndexOffset = logIndexOffset;
   }
 
+  /**
+   * Create transaction receipt with metadata.
+   *
+   * @param receipt the receipt
+   * @param transaction the transaction
+   * @param transactionHash the transaction hash
+   * @param transactionIndex the transaction index
+   * @param gasUsed the gas used
+   * @param baseFee the base fee
+   * @param blockHash the block hash
+   * @param blockNumber the block number
+   * @param blobGasUsed the blob gas used
+   * @param blobGasPrice the blob gas price
+   * @param logIndexOffset the log index offset
+   * @return the transaction receipt with metadata
+   */
   public static TransactionReceiptWithMetadata create(
       final TransactionReceipt receipt,
       final Transaction transaction,
@@ -85,48 +102,103 @@ public class TransactionReceiptWithMetadata {
         logIndexOffset);
   }
 
+  /**
+   * Gets receipt.
+   *
+   * @return the receipt
+   */
   public TransactionReceipt getReceipt() {
     return receipt;
   }
 
+  /**
+   * Gets transaction hash.
+   *
+   * @return the transaction hash
+   */
   public Hash getTransactionHash() {
     return transactionHash;
   }
 
+  /**
+   * Gets transaction.
+   *
+   * @return the transaction
+   */
   public Transaction getTransaction() {
     return transaction;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   public int getTransactionIndex() {
     return transactionIndex;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   public Hash getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   public long getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   // The gas used for this particular transaction (as opposed to cumulativeGas which is included in
   // the receipt itself)
   public long getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets base fee.
+   *
+   * @return the base fee
+   */
   public Optional<Wei> getBaseFee() {
     return baseFee;
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @return the blob gas used
+   */
   public Optional<Long> getBlobGasUsed() {
     return blobGasUsed;
   }
 
+  /**
+   * Gets blob gas price.
+   *
+   * @return the blob gas price
+   */
   public Optional<Wei> getBlobGasPrice() {
     return blobGasPrice;
   }
 
+  /**
+   * Gets log index offset.
+   *
+   * @return the log index offset
+   */
   public int getLogIndexOffset() {
     return logIndexOffset;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/TransactionWithMetadata.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.core.Transaction;
 
 import java.util.Optional;
 
+/** The type Transaction with metadata. */
 public class TransactionWithMetadata {
 
   private final Transaction transaction;
@@ -28,6 +29,11 @@ public class TransactionWithMetadata {
   private final Optional<Hash> blockHash;
   private final Optional<Integer> transactionIndex;
 
+  /**
+   * Instantiates a new Transaction with metadata.
+   *
+   * @param transaction the transaction
+   */
   public TransactionWithMetadata(final Transaction transaction) {
     this.transaction = transaction;
     this.blockNumber = Optional.empty();
@@ -36,6 +42,15 @@ public class TransactionWithMetadata {
     this.transactionIndex = Optional.empty();
   }
 
+  /**
+   * Instantiates a new Transaction with metadata.
+   *
+   * @param transaction the transaction
+   * @param blockNumber the block number
+   * @param baseFee the base fee
+   * @param blockHash the block hash
+   * @param transactionIndex the transaction index
+   */
   public TransactionWithMetadata(
       final Transaction transaction,
       final long blockNumber,
@@ -49,22 +64,47 @@ public class TransactionWithMetadata {
     this.transactionIndex = Optional.of(transactionIndex);
   }
 
+  /**
+   * Gets transaction.
+   *
+   * @return the transaction
+   */
   public Transaction getTransaction() {
     return transaction;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @return the block number
+   */
   public Optional<Long> getBlockNumber() {
     return blockNumber;
   }
 
+  /**
+   * Gets base fee.
+   *
+   * @return the base fee
+   */
   public Optional<Wei> getBaseFee() {
     return baseFee;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   public Optional<Hash> getBlockHash() {
     return blockHash;
   }
 
+  /**
+   * Gets transaction index.
+   *
+   * @return the transaction index
+   */
   public Optional<Integer> getTransactionIndex() {
     return transactionIndex;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/LogBloomCacheMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/LogBloomCacheMetadata.java
@@ -26,29 +26,54 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Log bloom cache metadata. */
 public class LogBloomCacheMetadata {
   private static final Logger LOG = LoggerFactory.getLogger(LogBloomCacheMetadata.class);
 
+  /** The constant DEFAULT_VERSION. */
   public static final int DEFAULT_VERSION = 3;
 
   private static final String METADATA_FILENAME = "CACHE_METADATA.json";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private final int version;
 
+  /**
+   * Instantiates a new Log bloom cache metadata.
+   *
+   * @param version the version
+   */
   @JsonCreator
   public LogBloomCacheMetadata(@JsonProperty("version") final int version) {
     this.version = version;
   }
 
+  /**
+   * Gets version.
+   *
+   * @return the version
+   */
   public int getVersion() {
     return version;
   }
 
+  /**
+   * Look up from log bloom cache metadata.
+   *
+   * @param dataDir the data dir
+   * @return the log bloom cache metadata
+   * @throws IOException the io exception
+   */
   public static LogBloomCacheMetadata lookUpFrom(final Path dataDir) throws IOException {
     LOG.info("Lookup cache metadata file in data directory: {}", dataDir.toString());
     return resolveDatabaseMetadata(getDefaultMetadataFile(dataDir));
   }
 
+  /**
+   * Write to directory.
+   *
+   * @param dataDir the data dir
+   * @throws IOException the io exception
+   */
   public void writeToDirectory(final Path dataDir) throws IOException {
     MAPPER.writeValue(getDefaultMetadataFile(dataDir), this);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/TransactionLogBloomCacher.java
@@ -44,15 +44,23 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Transaction log bloom cacher. */
 public class TransactionLogBloomCacher {
 
   private static final Logger LOG = LoggerFactory.getLogger(TransactionLogBloomCacher.class);
   private static final String NO_SPACE_LEFT_ON_DEVICE = "No space left on device";
 
+  /** The constant BLOCKS_PER_BLOOM_CACHE. */
   public static final int BLOCKS_PER_BLOOM_CACHE = 100_000;
+
+  /** The constant BLOOM_BITS_LENGTH. */
   public static final int BLOOM_BITS_LENGTH = 256;
+
   private static final int EXPECTED_BLOOM_FILE_SIZE = BLOCKS_PER_BLOOM_CACHE * BLOOM_BITS_LENGTH;
+
+  /** The constant CURRENT. */
   public static final String CURRENT = "current";
+
   private final Map<Long, Boolean> cachedSegments;
 
   private final Lock submissionLock = new ReentrantLock();
@@ -64,6 +72,13 @@ public class TransactionLogBloomCacher {
 
   private final CachingStatus cachingStatus = new CachingStatus();
 
+  /**
+   * Instantiates a new Transaction log bloom cacher.
+   *
+   * @param blockchain the blockchain
+   * @param cacheDir the cache dir
+   * @param scheduler the scheduler
+   */
   public TransactionLogBloomCacher(
       final Blockchain blockchain, final Path cacheDir, final EthScheduler scheduler) {
     this.blockchain = blockchain;
@@ -72,10 +87,16 @@ public class TransactionLogBloomCacher {
     this.cachedSegments = new TreeMap<>();
   }
 
+  /**
+   * Gets caching status.
+   *
+   * @return the caching status
+   */
   public CachingStatus getCachingStatus() {
     return cachingStatus;
   }
 
+  /** Cache all. */
   void cacheAll() {
     ensurePreviousSegmentsArePresent(blockchain.getChainHeadBlockNumber(), false);
   }
@@ -88,6 +109,13 @@ public class TransactionLogBloomCacher {
     return calculateCacheFileName(Long.toString(blockNumber / BLOCKS_PER_BLOOM_CACHE), cacheDir);
   }
 
+  /**
+   * Generate log bloom cache caching status.
+   *
+   * @param start the start
+   * @param stop the stop
+   * @return the caching status
+   */
   public CachingStatus generateLogBloomCache(final long start, final long stop) {
     checkArgument(
         start % BLOCKS_PER_BLOOM_CACHE == 0, "Start block must be at the beginning of a file");
@@ -148,6 +176,13 @@ public class TransactionLogBloomCacher {
     }
   }
 
+  /**
+   * Cache logs bloom for block header.
+   *
+   * @param blockHeader the block header
+   * @param commonAncestorBlockHeader the common ancestor block header
+   * @param reusedCacheFile the reused cache file
+   */
   void cacheLogsBloomForBlockHeader(
       final BlockHeader blockHeader,
       final Optional<BlockHeader> commonAncestorBlockHeader,
@@ -246,6 +281,12 @@ public class TransactionLogBloomCacher {
     return false;
   }
 
+  /**
+   * Remove segments.
+   *
+   * @param startBlock the start block
+   * @param stopBlock the stop block
+   */
   public void removeSegments(final Long startBlock, final Long stopBlock) {
     if (!cachingStatus.isCaching()) {
       LOG.info(
@@ -281,6 +322,12 @@ public class TransactionLogBloomCacher {
     }
   }
 
+  /**
+   * Ensure previous segments are present.
+   *
+   * @param blockNumber the block number
+   * @param overrideCacheCheck the override cache check
+   */
   public void ensurePreviousSegmentsArePresent(
       final long blockNumber, final boolean overrideCacheCheck) {
     if (!cachingStatus.isCaching()) {
@@ -323,6 +370,13 @@ public class TransactionLogBloomCacher {
     return logs;
   }
 
+  /**
+   * Request caching caching status.
+   *
+   * @param fromBlock the from block
+   * @param toBlock the to block
+   * @return the caching status
+   */
   public CachingStatus requestCaching(final long fromBlock, final long toBlock) {
     boolean requestAccepted = false;
     try {
@@ -348,46 +402,98 @@ public class TransactionLogBloomCacher {
     return cachingStatus;
   }
 
+  /**
+   * Gets scheduler.
+   *
+   * @return the scheduler
+   */
   EthScheduler getScheduler() {
     return scheduler;
   }
 
+  /**
+   * Gets cache dir.
+   *
+   * @return the cache dir
+   */
   Path getCacheDir() {
     return cacheDir;
   }
 
+  /** The type Caching status. */
   public static final class CachingStatus {
+    /** The Start block. */
     long startBlock;
+
+    /** The End block. */
     long endBlock;
+
+    /** The Current block. */
     volatile long currentBlock;
+
+    /** The Caching count. */
     AtomicInteger cachingCount = new AtomicInteger(0);
+
+    /** The Request accepted. */
     boolean requestAccepted;
 
+    /** Default constructor. */
+    public CachingStatus() {}
+
+    /**
+     * Gets start block.
+     *
+     * @return the start block
+     */
     @JsonGetter
     public String getStartBlock() {
       return "0x" + Long.toHexString(startBlock);
     }
 
+    /**
+     * Gets end block.
+     *
+     * @return the end block
+     */
     @JsonGetter
     public String getEndBlock() {
       return endBlock == Long.MAX_VALUE ? "latest" : "0x" + Long.toHexString(endBlock);
     }
 
+    /**
+     * Gets current block.
+     *
+     * @return the current block
+     */
     @JsonGetter
     public String getCurrentBlock() {
       return "0x" + Long.toHexString(currentBlock);
     }
 
+    /**
+     * Is caching boolean.
+     *
+     * @return the boolean
+     */
     @JsonGetter
     public boolean isCaching() {
       return cachingCount.get() > 0;
     }
 
+    /**
+     * Is request accepted boolean.
+     *
+     * @return the boolean
+     */
     @JsonGetter
     public boolean isRequestAccepted() {
       return requestAccepted;
     }
   }
 
-  public static class InvalidCacheException extends Exception {}
+  /** The type Invalid cache exception. */
+  public static class InvalidCacheException extends Exception {
+    /** Default constructor. */
+    public InvalidCacheException() {}
+  }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/FileBasedPasswordProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/FileBasedPasswordProvider.java
@@ -22,9 +22,15 @@ import java.nio.file.Path;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+/** The type File based password provider. */
 public class FileBasedPasswordProvider implements Supplier<String> {
   private final Path passwordFile;
 
+  /**
+   * Instantiates a new File based password provider.
+   *
+   * @param passwordFile the password file
+   */
   public FileBasedPasswordProvider(final Path passwordFile) {
     requireNonNull(passwordFile, "Password file path cannot be null");
     this.passwordFile = passwordFile;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsClientAuthConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsClientAuthConfiguration.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
 
+/** The type Tls client auth configuration. */
 public class TlsClientAuthConfiguration {
   private final Optional<Path> knownClientsFile;
   private final boolean caClientsEnabled;
@@ -28,34 +29,67 @@ public class TlsClientAuthConfiguration {
     this.caClientsEnabled = caClientsEnabled;
   }
 
+  /**
+   * Gets known clients file.
+   *
+   * @return the known clients file
+   */
   public Optional<Path> getKnownClientsFile() {
     return knownClientsFile;
   }
 
+  /**
+   * Is ca clients enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isCaClientsEnabled() {
     return caClientsEnabled;
   }
 
+  /** The type Builder. */
   public static final class Builder {
     private Path knownClientsFile;
     private boolean caClientsEnabled;
 
     private Builder() {}
 
+    /**
+     * A tls client auth configuration builder.
+     *
+     * @return the builder
+     */
     public static Builder aTlsClientAuthConfiguration() {
       return new Builder();
     }
 
+    /**
+     * With known clients file builder.
+     *
+     * @param knownClientsFile the known clients file
+     * @return the builder
+     */
     public Builder withKnownClientsFile(final Path knownClientsFile) {
       this.knownClientsFile = knownClientsFile;
       return this;
     }
 
+    /**
+     * With ca clients enabled builder.
+     *
+     * @param caClientsEnabled the ca clients enabled
+     * @return the builder
+     */
     public Builder withCaClientsEnabled(final boolean caClientsEnabled) {
       this.caClientsEnabled = caClientsEnabled;
       return this;
     }
 
+    /**
+     * Build tls client auth configuration.
+     *
+     * @return the tls client auth configuration
+     */
     public TlsClientAuthConfiguration build() {
       if (!caClientsEnabled) {
         Objects.requireNonNull(knownClientsFile, "Known Clients File is required");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
+/** The type Tls configuration. */
 public class TlsConfiguration {
 
   private final Path keyStorePath;
@@ -44,26 +45,52 @@ public class TlsConfiguration {
     this.cipherSuites = cipherSuites;
   }
 
+  /**
+   * Gets key store path.
+   *
+   * @return the key store path
+   */
   public Path getKeyStorePath() {
     return keyStorePath;
   }
 
+  /**
+   * Gets key store password.
+   *
+   * @return the key store password
+   */
   public String getKeyStorePassword() {
     return keyStorePasswordSupplier.get();
   }
 
+  /**
+   * Gets client auth configuration.
+   *
+   * @return the client auth configuration
+   */
   public Optional<TlsClientAuthConfiguration> getClientAuthConfiguration() {
     return clientAuthConfiguration;
   }
 
+  /**
+   * Gets secure transport protocols.
+   *
+   * @return the secure transport protocols
+   */
   public Optional<Set<String>> getSecureTransportProtocols() {
     return secureTransportProtocols;
   }
 
+  /**
+   * Gets cipher suites.
+   *
+   * @return the cipher suites
+   */
   public Optional<Set<String>> getCipherSuites() {
     return cipherSuites;
   }
 
+  /** The type Builder. */
   public static final class Builder {
     private Path keyStorePath;
     private Supplier<String> keyStorePasswordSupplier;
@@ -73,36 +100,76 @@ public class TlsConfiguration {
 
     private Builder() {}
 
+    /**
+     * A tls configuration builder.
+     *
+     * @return the builder
+     */
     public static Builder aTlsConfiguration() {
       return new Builder();
     }
 
+    /**
+     * With key store path builder.
+     *
+     * @param keyStorePath the key store path
+     * @return the builder
+     */
     public Builder withKeyStorePath(final Path keyStorePath) {
       this.keyStorePath = keyStorePath;
       return this;
     }
 
+    /**
+     * With key store password supplier builder.
+     *
+     * @param keyStorePasswordSupplier the key store password supplier
+     * @return the builder
+     */
     public Builder withKeyStorePasswordSupplier(final Supplier<String> keyStorePasswordSupplier) {
       this.keyStorePasswordSupplier = keyStorePasswordSupplier;
       return this;
     }
 
+    /**
+     * With client auth configuration builder.
+     *
+     * @param clientAuthConfiguration the client auth configuration
+     * @return the builder
+     */
     public Builder withClientAuthConfiguration(
         final TlsClientAuthConfiguration clientAuthConfiguration) {
       this.clientAuthConfiguration = clientAuthConfiguration;
       return this;
     }
 
+    /**
+     * With secure transport protocols builder.
+     *
+     * @param secureTransportProtocols the secure transport protocols
+     * @return the builder
+     */
     public Builder withSecureTransportProtocols(final List<String> secureTransportProtocols) {
       this.secureTransportProtocols = new HashSet<>(secureTransportProtocols);
       return this;
     }
 
+    /**
+     * With cipher suites builder.
+     *
+     * @param cipherSuites the cipher suites
+     * @return the builder
+     */
     public Builder withCipherSuites(final List<String> cipherSuites) {
       this.cipherSuites = new HashSet<>(cipherSuites);
       return this;
     }
 
+    /**
+     * Build tls configuration.
+     *
+     * @return the tls configuration
+     */
     public TlsConfiguration build() {
       requireNonNull(keyStorePath, "Key Store Path must not be null");
       requireNonNull(keyStorePasswordSupplier, "Key Store password supplier must not be null");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsConfigurationException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/tls/TlsConfigurationException.java
@@ -14,11 +14,23 @@
  */
 package org.hyperledger.besu.ethereum.api.tls;
 
+/** The type Tls configuration exception. */
 public class TlsConfigurationException extends RuntimeException {
+  /**
+   * Instantiates a new Tls configuration exception.
+   *
+   * @param message the message
+   */
   public TlsConfigurationException(final String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Tls configuration exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public TlsConfigurationException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/DomainObjectDecodeUtils.java
@@ -22,8 +22,17 @@ import org.hyperledger.besu.ethereum.rlp.RLPException;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Domain object decode utils. */
 public class DomainObjectDecodeUtils {
+  private DomainObjectDecodeUtils() {}
 
+  /**
+   * Decode raw transaction transaction.
+   *
+   * @param rawTransaction the raw transaction
+   * @return the transaction
+   * @throws InvalidJsonRpcRequestException the invalid json rpc request exception
+   */
   public static Transaction decodeRawTransaction(final String rawTransaction)
       throws InvalidJsonRpcRequestException {
     try {


### PR DESCRIPTION
## PR description
javadoc - Adding default constructor and javadoc for :ethereum:api (~200 files)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

