### PR TITLE
javadoc - Adding default constructor and javadoc for :ethereum:api

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -18,64 +18,126 @@ import java.util.function.LongSupplier;
 
 import org.immutables.value.Value;
 
+/** The type Api configuration. */
 @Value.Immutable
 @Value.Style(allParameters = true)
 public abstract class ApiConfiguration {
 
+  /** The constant DEFAULT_LOWER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT. */
   public static final long DEFAULT_LOWER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT = 0L;
+
+  /** The constant DEFAULT_UPPER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT. */
   public static final long DEFAULT_UPPER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT = Long.MAX_VALUE;
 
+  /** Default Constructor */
+  protected ApiConfiguration() {}
+
+  /**
+   * Gets gas price blocks.
+   *
+   * @return the gas price blocks
+   */
   @Value.Default
   public long getGasPriceBlocks() {
     return 100;
   }
 
+  /**
+   * Gets gas price percentile.
+   *
+   * @return the gas price percentile
+   */
   @Value.Default
   public double getGasPricePercentile() {
     return 50.0d;
   }
 
+  /**
+   * Gets gas price min supplier.
+   *
+   * @return the gas price min supplier
+   */
   @Value.Default
   @Value.Auxiliary
   public LongSupplier getGasPriceMinSupplier() {
     return () -> 1_000_000_000L; // 1 GWei
   }
 
+  /**
+   * Gets gas price max.
+   *
+   * @return the gas price max
+   */
   @Value.Default
   public long getGasPriceMax() {
     return 500_000_000_000L; // 500 GWei
   }
 
+  /**
+   * Gets gas price fraction.
+   *
+   * @return the gas price fraction
+   */
   @Value.Derived
   public double getGasPriceFraction() {
     return getGasPricePercentile() / 100.0;
   }
 
+  /**
+   * Gets max logs range.
+   *
+   * @return the max logs range
+   */
   @Value.Default
   public Long getMaxLogsRange() {
     return 5000L;
   }
 
+  /**
+   * Gets gas cap.
+   *
+   * @return the gas cap
+   */
   @Value.Default
   public Long getGasCap() {
     return 0L;
   }
 
+  /**
+   * Is gas and priority fee limiting enabled boolean.
+   *
+   * @return the boolean
+   */
   @Value.Default
   public boolean isGasAndPriorityFeeLimitingEnabled() {
     return false;
   }
 
+  /**
+   * Gets lower bound gas and priority fee coefficient.
+   *
+   * @return the lower bound gas and priority fee coefficient
+   */
   @Value.Default
   public Long getLowerBoundGasAndPriorityFeeCoefficient() {
     return DEFAULT_LOWER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT;
   }
 
+  /**
+   * Gets upper bound gas and priority fee coefficient.
+   *
+   * @return the upper bound gas and priority fee coefficient
+   */
   @Value.Default
   public Long getUpperBoundGasAndPriorityFeeCoefficient() {
     return DEFAULT_UPPER_BOUND_GAS_AND_PRIORITY_FEE_COEFFICIENT;
   }
 
+  /**
+   * Gets max trace filter range.
+   *
+   * @return the max trace filter range
+   */
   @Value.Default
   public Long getMaxTraceFilterRange() {
     return 1000L;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLConfiguration.java
@@ -26,8 +26,11 @@ import java.util.Objects;
 
 import com.google.common.base.MoreObjects;
 
+/** The type Graph ql configuration. */
 public class GraphQLConfiguration {
   private static final String DEFAULT_GRAPHQL_HTTP_HOST = "127.0.0.1";
+
+  /** The constant DEFAULT_GRAPHQL_HTTP_PORT. */
   public static final int DEFAULT_GRAPHQL_HTTP_PORT = 8547;
 
   private boolean enabled;
@@ -37,6 +40,11 @@ public class GraphQLConfiguration {
   private List<String> hostsAllowlist = Arrays.asList("localhost", "127.0.0.1");
   private long httpTimeoutSec = TimeoutOptions.defaultOptions().getTimeoutSeconds();
 
+  /**
+   * Create default graph ql configuration.
+   *
+   * @return the graph ql configuration
+   */
   public static GraphQLConfiguration createDefault() {
     final GraphQLConfiguration config = new GraphQLConfiguration();
     config.setEnabled(false);
@@ -48,52 +56,112 @@ public class GraphQLConfiguration {
 
   private GraphQLConfiguration() {}
 
+  /**
+   * Is enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEnabled() {
     return enabled;
   }
 
+  /**
+   * Sets enabled.
+   *
+   * @param enabled the enabled
+   */
   public void setEnabled(final boolean enabled) {
     this.enabled = enabled;
   }
 
+  /**
+   * Gets port.
+   *
+   * @return the port
+   */
   public int getPort() {
     return port;
   }
 
+  /**
+   * Sets port.
+   *
+   * @param port the port
+   */
   public void setPort(final int port) {
     this.port = port;
   }
 
+  /**
+   * Gets host.
+   *
+   * @return the host
+   */
   public String getHost() {
     return host;
   }
 
+  /**
+   * Sets host.
+   *
+   * @param host the host
+   */
   public void setHost(final String host) {
     this.host = host;
   }
 
+  /**
+   * Gets cors allowed domains.
+   *
+   * @return the cors allowed domains
+   */
   Collection<String> getCorsAllowedDomains() {
     return corsAllowedDomains;
   }
 
+  /**
+   * Sets cors allowed domains.
+   *
+   * @param corsAllowedDomains the cors allowed domains
+   */
   public void setCorsAllowedDomains(final List<String> corsAllowedDomains) {
     checkNotNull(corsAllowedDomains);
     this.corsAllowedDomains = corsAllowedDomains;
   }
 
+  /**
+   * Gets hosts allowlist.
+   *
+   * @return the hosts allowlist
+   */
   Collection<String> getHostsAllowlist() {
     return Collections.unmodifiableCollection(this.hostsAllowlist);
   }
 
+  /**
+   * Sets hosts allowlist.
+   *
+   * @param hostsAllowlist the hosts allowlist
+   */
   public void setHostsAllowlist(final List<String> hostsAllowlist) {
     checkNotNull(hostsAllowlist);
     this.hostsAllowlist = hostsAllowlist;
   }
 
+  /**
+   * Gets http timeout sec.
+   *
+   * @return the http timeout sec
+   */
   public Long getHttpTimeoutSec() {
     return httpTimeoutSec;
   }
 
+  /**
+   * Sets http timeout sec.
+   *
+   * @param httpTimeoutSec the http timeout sec
+   */
   public void setHttpTimeoutSec(final long httpTimeoutSec) {
     this.httpTimeoutSec = httpTimeoutSec;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLContextType.java
@@ -16,12 +16,20 @@ package org.hyperledger.besu.ethereum.api.graphql;
 
 /** Internal GraphQL Context */
 public enum GraphQLContextType {
+  /** Blockchain queries graph ql context type. */
   BLOCKCHAIN_QUERIES,
+  /** Protocol schedule graph ql context type. */
   PROTOCOL_SCHEDULE,
+  /** Transaction pool graph ql context type. */
   TRANSACTION_POOL,
+  /** Mining coordinator graph ql context type. */
   MINING_COORDINATOR,
+  /** Synchronizer graph ql context type. */
   SYNCHRONIZER,
+  /** Is alive handler graph ql context type. */
   IS_ALIVE_HANDLER,
+  /** Chain id graph ql context type. */
   CHAIN_ID,
+  /** Gas cap graph ql context type. */
   GAS_CAP
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetcherContext.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetcherContext.java
@@ -21,18 +21,49 @@ import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
+/** The interface Graph ql data fetcher context. */
 public interface GraphQLDataFetcherContext {
 
+  /**
+   * Gets transaction pool.
+   *
+   * @return the transaction pool
+   */
   TransactionPool getTransactionPool();
 
+  /**
+   * Gets blockchain queries.
+   *
+   * @return the blockchain queries
+   */
   BlockchainQueries getBlockchainQueries();
 
+  /**
+   * Gets mining coordinator.
+   *
+   * @return the mining coordinator
+   */
   MiningCoordinator getMiningCoordinator();
 
+  /**
+   * Gets synchronizer.
+   *
+   * @return the synchronizer
+   */
   Synchronizer getSynchronizer();
 
+  /**
+   * Gets protocol schedule.
+   *
+   * @return the protocol schedule
+   */
   ProtocolSchedule getProtocolSchedule();
 
+  /**
+   * Gets is alive handler.
+   *
+   * @return the is alive handler
+   */
   default IsAliveHandler getIsAliveHandler() {
     return new IsAliveHandler(true);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetcherContextImpl.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetcherContextImpl.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
+/** The type Graph ql data fetcher context. */
 public class GraphQLDataFetcherContextImpl implements GraphQLDataFetcherContext {
 
   private final BlockchainQueries blockchainQueries;
@@ -30,6 +31,12 @@ public class GraphQLDataFetcherContextImpl implements GraphQLDataFetcherContext 
   private final TransactionPool transactionPool;
   private final IsAliveHandler isAliveHandler;
 
+  /**
+   * Instantiates a new Graph ql data fetcher context.
+   *
+   * @param context the context
+   * @param isAliveHandler the is alive handler
+   */
   public GraphQLDataFetcherContextImpl(
       final GraphQLDataFetcherContext context, final IsAliveHandler isAliveHandler) {
     this(
@@ -41,6 +48,15 @@ public class GraphQLDataFetcherContextImpl implements GraphQLDataFetcherContext 
         isAliveHandler);
   }
 
+  /**
+   * Instantiates a new Graph ql data fetcher context.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param miningCoordinator the mining coordinator
+   * @param synchronizer the synchronizer
+   */
   public GraphQLDataFetcherContextImpl(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
@@ -56,6 +72,16 @@ public class GraphQLDataFetcherContextImpl implements GraphQLDataFetcherContext 
         new IsAliveHandler(true));
   }
 
+  /**
+   * Instantiates a new Graph ql data fetcher context.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionPool the transaction pool
+   * @param miningCoordinator the mining coordinator
+   * @param synchronizer the synchronizer
+   * @param isAliveHandler the is alive handler
+   */
   public GraphQLDataFetcherContextImpl(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
@@ -62,10 +62,16 @@ import graphql.schema.DataFetcher;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Graph ql data fetchers. */
 public class GraphQLDataFetchers {
 
   private final Integer highestEthVersion;
 
+  /**
+   * Instantiates a new Graph ql data fetchers.
+   *
+   * @param supportedCapabilities the supported capabilities
+   */
   public GraphQLDataFetchers(final Set<Capability> supportedCapabilities) {
     final OptionalInt version =
         supportedCapabilities.stream()
@@ -75,10 +81,20 @@ public class GraphQLDataFetchers {
     highestEthVersion = version.isPresent() ? version.getAsInt() : null;
   }
 
+  /**
+   * Gets protocol version data fetcher.
+   *
+   * @return the protocol version data fetcher
+   */
   DataFetcher<Optional<Integer>> getProtocolVersionDataFetcher() {
     return dataFetchingEnvironment -> Optional.of(highestEthVersion);
   }
 
+  /**
+   * Gets send raw transaction data fetcher.
+   *
+   * @return the send raw transaction data fetcher
+   */
   DataFetcher<Optional<Bytes32>> getSendRawTransactionDataFetcher() {
     return dataFetchingEnvironment -> {
       try {
@@ -100,6 +116,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets syncing data fetcher.
+   *
+   * @return the syncing data fetcher
+   */
   DataFetcher<Optional<SyncStateAdapter>> getSyncingDataFetcher() {
     return dataFetchingEnvironment -> {
       final Synchronizer synchronizer =
@@ -109,6 +130,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets pending state data fetcher.
+   *
+   * @return the pending state data fetcher
+   */
   DataFetcher<Optional<PendingStateAdapter>> getPendingStateDataFetcher() {
     return dataFetchingEnvironment -> {
       final TransactionPool txPool =
@@ -117,6 +143,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets gas price data fetcher.
+   *
+   * @return the gas price data fetcher
+   */
   DataFetcher<Optional<Wei>> getGasPriceDataFetcher() {
     return dataFetchingEnvironment -> {
       final GraphQLContext graphQLContext = dataFetchingEnvironment.getGraphQlContext();
@@ -131,6 +162,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets chain id data fetcher.
+   *
+   * @return the chain id data fetcher
+   */
   public DataFetcher<Optional<BigInteger>> getChainIdDataFetcher() {
     return dataFetchingEnvironment -> {
       final GraphQLContext graphQLContext = dataFetchingEnvironment.getGraphQlContext();
@@ -138,6 +174,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets max priority fee per gas data fetcher.
+   *
+   * @return the max priority fee per gas data fetcher
+   */
   public DataFetcher<Wei> getMaxPriorityFeePerGasDataFetcher() {
     return dataFetchingEnvironment -> {
       final BlockchainQueries blockchainQuery =
@@ -146,6 +187,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets range block data fetcher.
+   *
+   * @return the range block data fetcher
+   */
   DataFetcher<List<NormalBlockAdapter>> getRangeBlockDataFetcher() {
 
     return dataFetchingEnvironment -> {
@@ -173,6 +219,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets block data fetcher.
+   *
+   * @return the block data fetcher
+   */
   public DataFetcher<Optional<NormalBlockAdapter>> getBlockDataFetcher() {
 
     return dataFetchingEnvironment -> {
@@ -198,6 +249,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets account data fetcher.
+   *
+   * @return the account data fetcher
+   */
   DataFetcher<Optional<AccountAdapter>> getAccountDataFetcher() {
     return dataFetchingEnvironment -> {
       final BlockchainQueries blockchainQuery =
@@ -241,6 +297,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets logs data fetcher.
+   *
+   * @return the logs data fetcher
+   */
   DataFetcher<Optional<List<LogAdapter>>> getLogsDataFetcher() {
     return dataFetchingEnvironment -> {
       final BlockchainQueries blockchainQuery =
@@ -287,6 +348,11 @@ public class GraphQLDataFetchers {
     };
   }
 
+  /**
+   * Gets transaction data fetcher.
+   *
+   * @return the transaction data fetcher
+   */
   DataFetcher<Optional<TransactionAdapter>> getTransactionDataFetcher() {
     return dataFetchingEnvironment -> {
       final BlockchainQueries blockchain =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLException.java
@@ -23,9 +23,15 @@ import java.util.Map;
 import graphql.ErrorType;
 import graphql.language.SourceLocation;
 
+/** The type Graph ql exception. */
 class GraphQLException extends RuntimeException implements graphql.GraphQLError {
   private final GraphQLError error;
 
+  /**
+   * Instantiates a new Graph ql exception.
+   *
+   * @param error the error
+   */
   GraphQLException(final GraphQLError error) {
 
     super(error.getMessage());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpService.java
@@ -68,6 +68,7 @@ import io.vertx.ext.web.handler.TimeoutHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Graph ql http service. */
 public class GraphQLHttpService {
 
   private static final Logger LOG = LoggerFactory.getLogger(GraphQLHttpService.class);
@@ -126,6 +127,11 @@ public class GraphQLHttpService {
     checkArgument(config.getHost() != null, "Required host is not configured.");
   }
 
+  /**
+   * Start completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> start() {
     LOG.info("Starting GraphQL HTTP service on {}:{}", config.getHost(), config.getPort());
     // Create the HTTP server and a router object.
@@ -230,6 +236,11 @@ public class GraphQLHttpService {
     }
   }
 
+  /**
+   * Stop completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> stop() {
     if (httpServer == null) {
       return CompletableFuture.completedFuture(null);
@@ -248,6 +259,11 @@ public class GraphQLHttpService {
     return resultFuture;
   }
 
+  /**
+   * Socket address inet socket address.
+   *
+   * @return the inet socket address
+   */
   public InetSocketAddress socketAddress() {
     if (httpServer == null) {
       return EMPTY_SOCKET_ADDRESS;
@@ -255,6 +271,11 @@ public class GraphQLHttpService {
     return new InetSocketAddress(config.getHost(), httpServer.actualPort());
   }
 
+  /**
+   * Url string.
+   *
+   * @return the string
+   */
   @VisibleForTesting
   public String url() {
     if (httpServer == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLProvider.java
@@ -31,12 +31,21 @@ import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.schema.idl.TypeRuntimeWiring;
 
+/** The type Graph ql provider. */
 public class GraphQLProvider {
 
+  /** The constant MAX_COMPLEXITY. */
   public static final int MAX_COMPLEXITY = 200;
 
   private GraphQLProvider() {}
 
+  /**
+   * Build graph ql graph ql.
+   *
+   * @param graphQLDataFetchers the graph ql data fetchers
+   * @return the graph ql
+   * @throws IOException the io exception
+   */
   public static GraphQL buildGraphQL(final GraphQLDataFetchers graphQLDataFetchers)
       throws IOException {
     final URL url = Resources.getResource("schema.graphqls");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLServiceException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLServiceException.java
@@ -14,8 +14,14 @@
  */
 package org.hyperledger.besu.ethereum.api.graphql;
 
+/** The type Graph ql service exception. */
 class GraphQLServiceException extends RuntimeException {
 
+  /**
+   * Instantiates a new Graph ql service exception.
+   *
+   * @param message the message
+   */
   public GraphQLServiceException(final String message) {
     super(message);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/Scalars.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/Scalars.java
@@ -35,6 +35,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Scalars. */
 public class Scalars {
 
   private Scalars() {}
@@ -366,6 +367,11 @@ public class Scalars {
         }
       };
 
+  /**
+   * Address scalar graph ql scalar type.
+   *
+   * @return the graph ql scalar type
+   */
   public static GraphQLScalarType addressScalar() {
     return GraphQLScalarType.newScalar()
         .name("Address")
@@ -374,6 +380,11 @@ public class Scalars {
         .build();
   }
 
+  /**
+   * Big int scalar graph ql scalar type.
+   *
+   * @return the graph ql scalar type
+   */
   public static GraphQLScalarType bigIntScalar() {
     return GraphQLScalarType.newScalar()
         .name("BigInt")
@@ -382,6 +393,11 @@ public class Scalars {
         .build();
   }
 
+  /**
+   * Bytes scalar graph ql scalar type.
+   *
+   * @return the graph ql scalar type
+   */
   public static GraphQLScalarType bytesScalar() {
     return GraphQLScalarType.newScalar()
         .name("Bytes")
@@ -390,6 +406,11 @@ public class Scalars {
         .build();
   }
 
+  /**
+   * Bytes 32 scalar graph ql scalar type.
+   *
+   * @return the graph ql scalar type
+   */
   public static GraphQLScalarType bytes32Scalar() {
     return GraphQLScalarType.newScalar()
         .name("Bytes32")
@@ -398,6 +419,11 @@ public class Scalars {
         .build();
   }
 
+  /**
+   * Long scalar graph ql scalar type.
+   *
+   * @return the graph ql scalar type
+   */
   public static GraphQLScalarType longScalar() {
     return GraphQLScalarType.newScalar()
         .name("Long")

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AccessListEntryAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AccessListEntryAdapter.java
@@ -23,19 +23,35 @@ import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Access list entry adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class AccessListEntryAdapter extends AdapterBase {
   private final AccessListEntry accessListEntry;
 
+  /**
+   * Instantiates a new Access list entry adapter.
+   *
+   * @param accessListEntry the access list entry
+   */
   public AccessListEntryAdapter(final AccessListEntry accessListEntry) {
     this.accessListEntry = accessListEntry;
   }
 
+  /**
+   * Gets storage keys.
+   *
+   * @return the storage keys
+   */
   public List<Bytes32> getStorageKeys() {
     final var storage = accessListEntry.storageKeys();
     return new ArrayList<>(storage);
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   public Optional<Address> getAddress() {
     return Optional.of(accessListEntry.address());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AccountAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AccountAdapter.java
@@ -28,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Account adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class AccountAdapter extends AdapterBase {
 
@@ -35,18 +36,42 @@ public class AccountAdapter extends AdapterBase {
   private final Address address;
   private final Optional<Long> blockNumber;
 
+  /**
+   * Instantiates a new Account adapter.
+   *
+   * @param account the account
+   */
   public AccountAdapter(final Account account) {
     this(account == null ? null : account.getAddress(), account, Optional.empty());
   }
 
+  /**
+   * Instantiates a new Account adapter.
+   *
+   * @param account the account
+   * @param blockNumber the block number
+   */
   public AccountAdapter(final Account account, final Optional<Long> blockNumber) {
     this(account == null ? null : account.getAddress(), account, blockNumber);
   }
 
+  /**
+   * Instantiates a new Account adapter.
+   *
+   * @param address the address
+   * @param account the account
+   */
   public AccountAdapter(final Address address, final Account account) {
     this(address, account, Optional.empty());
   }
 
+  /**
+   * Instantiates a new Account adapter.
+   *
+   * @param address the address
+   * @param account the account
+   * @param blockNumber the block number
+   */
   public AccountAdapter(
       final Address address, final Account account, final Optional<Long> blockNumber) {
     this.account = Optional.ofNullable(account);
@@ -54,18 +79,39 @@ public class AccountAdapter extends AdapterBase {
     this.blockNumber = blockNumber;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   public Address getAddress() {
     return address;
   }
 
+  /**
+   * Gets balance.
+   *
+   * @return the balance
+   */
   public Wei getBalance() {
     return account.map(AccountState::getBalance).orElse(Wei.ZERO);
   }
 
+  /**
+   * Gets transaction count.
+   *
+   * @return the transaction count
+   */
   public Long getTransactionCount() {
     return account.map(AccountState::getNonce).orElse(0L);
   }
 
+  /**
+   * Gets code.
+   *
+   * @param environment the environment
+   * @return the code
+   */
   public Bytes getCode(final DataFetchingEnvironment environment) {
 
     if (account.get() instanceof BonsaiAccount) {
@@ -80,6 +126,12 @@ public class AccountAdapter extends AdapterBase {
     }
   }
 
+  /**
+   * Gets storage.
+   *
+   * @param environment the environment
+   * @return the storage
+   */
   public Bytes32 getStorage(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final Bytes32 slot = environment.getArgument("slot");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/AdapterBase.java
@@ -19,7 +19,14 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import graphql.schema.DataFetchingEnvironment;
 
+/** The type Adapter base. */
 abstract class AdapterBase {
+  /**
+   * Gets blockchain queries.
+   *
+   * @param environment the environment
+   * @return the blockchain queries
+   */
   BlockchainQueries getBlockchainQueries(final DataFetchingEnvironment environment) {
     return environment.getGraphQlContext().get(GraphQLContextType.BLOCKCHAIN_QUERIES);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/BlockAdapterBase.java
@@ -48,15 +48,27 @@ import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Block adapter base. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class BlockAdapterBase extends AdapterBase {
 
   private final BlockHeader header;
 
+  /**
+   * Instantiates a new Block adapter base.
+   *
+   * @param header the header
+   */
   BlockAdapterBase(final BlockHeader header) {
     this.header = header;
   }
 
+  /**
+   * Gets parent.
+   *
+   * @param environment the environment
+   * @return the parent
+   */
   public Optional<NormalBlockAdapter> getParent(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final Hash parentHash = header.getParentHash();
@@ -65,28 +77,59 @@ public class BlockAdapterBase extends AdapterBase {
     return block.map(NormalBlockAdapter::new);
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   public Bytes32 getHash() {
     return header.getHash();
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   public Bytes getNonce() {
     final long nonce = header.getNonce();
     final byte[] bytes = Longs.toByteArray(nonce);
     return Bytes.wrap(bytes);
   }
 
+  /**
+   * Gets transactions root.
+   *
+   * @return the transactions root
+   */
   public Bytes32 getTransactionsRoot() {
     return header.getTransactionsRoot();
   }
 
+  /**
+   * Gets state root.
+   *
+   * @return the state root
+   */
   public Bytes32 getStateRoot() {
     return header.getStateRoot();
   }
 
+  /**
+   * Gets receipts root.
+   *
+   * @return the receipts root
+   */
   public Bytes32 getReceiptsRoot() {
     return header.getReceiptsRoot();
   }
 
+  /**
+   * Gets miner.
+   *
+   * @param environment the environment
+   * @return the miner
+   */
   public AccountAdapter getMiner(final DataFetchingEnvironment environment) {
 
     final BlockchainQueries query = getBlockchainQueries(environment);
@@ -102,46 +145,102 @@ public class BlockAdapterBase extends AdapterBase {
         .orElseGet(() -> new EmptyAccountAdapter(header.getCoinbase()));
   }
 
+  /**
+   * Gets extra data.
+   *
+   * @return the extra data
+   */
   public Bytes getExtraData() {
     return header.getExtraData();
   }
 
+  /**
+   * Gets base fee per gas.
+   *
+   * @return the base fee per gas
+   */
   public Optional<Wei> getBaseFeePerGas() {
     return header.getBaseFee();
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @return the gas limit
+   */
   public Long getGasLimit() {
     return header.getGasLimit();
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   public Long getGasUsed() {
     return header.getGasUsed();
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   public Long getTimestamp() {
     return header.getTimestamp();
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   public Bytes getLogsBloom() {
     return header.getLogsBloom();
   }
 
+  /**
+   * Gets mix hash.
+   *
+   * @return the mix hash
+   */
   public Bytes32 getMixHash() {
     return header.getMixHash();
   }
 
+  /**
+   * Gets difficulty.
+   *
+   * @return the difficulty
+   */
   public Difficulty getDifficulty() {
     return header.getDifficulty();
   }
 
+  /**
+   * Gets ommer hash.
+   *
+   * @return the ommer hash
+   */
   public Bytes32 getOmmerHash() {
     return header.getOmmersHash();
   }
 
+  /**
+   * Gets number.
+   *
+   * @return the number
+   */
   public Long getNumber() {
     return header.getNumber();
   }
 
+  /**
+   * Gets account.
+   *
+   * @param environment the environment
+   * @return the account
+   */
   public AccountAdapter getAccount(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final long bn = header.getNumber();
@@ -152,6 +251,12 @@ public class BlockAdapterBase extends AdapterBase {
         .get();
   }
 
+  /**
+   * Gets logs.
+   *
+   * @param environment the environment
+   * @return the logs
+   */
   public List<LogAdapter> getLogs(final DataFetchingEnvironment environment) {
 
     final Map<String, Object> filter = environment.getArgument("filter");
@@ -183,11 +288,23 @@ public class BlockAdapterBase extends AdapterBase {
     return results;
   }
 
+  /**
+   * Gets estimate gas.
+   *
+   * @param environment the environment
+   * @return the estimate gas
+   */
   public Long getEstimateGas(final DataFetchingEnvironment environment) {
     final Optional<CallResult> result = executeCall(environment);
     return result.map(CallResult::getGasUsed).orElse(0L);
   }
 
+  /**
+   * Gets call.
+   *
+   * @param environment the environment
+   * @return the call
+   */
   public Optional<CallResult> getCall(final DataFetchingEnvironment environment) {
     return executeCall(environment);
   }
@@ -259,12 +376,23 @@ public class BlockAdapterBase extends AdapterBase {
         header);
   }
 
+  /**
+   * Gets raw header.
+   *
+   * @return the raw header
+   */
   Bytes getRawHeader() {
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
     header.writeTo(rlpOutput);
     return rlpOutput.encoded();
   }
 
+  /**
+   * Gets raw.
+   *
+   * @param environment the environment
+   * @return the raw
+   */
   Bytes getRaw(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     return query
@@ -279,10 +407,21 @@ public class BlockAdapterBase extends AdapterBase {
         .orElse(Bytes.EMPTY);
   }
 
+  /**
+   * Gets withdrawals root.
+   *
+   * @return the withdrawals root
+   */
   Optional<Bytes32> getWithdrawalsRoot() {
     return header.getWithdrawalsRoot().map(Function.identity());
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @param environment the environment
+   * @return the withdrawals
+   */
   Optional<List<WithdrawalAdapter>> getWithdrawals(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     return query
@@ -295,10 +434,20 @@ public class BlockAdapterBase extends AdapterBase {
                     .map(wl -> wl.stream().map(WithdrawalAdapter::new).toList()));
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @return the blob gas used
+   */
   public Optional<Long> getBlobGasUsed() {
     return header.getBlobGasUsed();
   }
 
+  /**
+   * Gets excess blob gas.
+   *
+   * @return the excess blob gas
+   */
   public Optional<Long> getExcessBlobGas() {
     return header.getExcessBlobGas().map(BlobGas::toLong);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/CallResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/CallResult.java
@@ -16,26 +16,49 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Call result. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class CallResult {
   private final Long status;
   private final Long gasUsed;
   private final Bytes data;
 
+  /**
+   * Instantiates a new Call result.
+   *
+   * @param status the status
+   * @param gasUsed the gas used
+   * @param data the data
+   */
   CallResult(final Long status, final Long gasUsed, final Bytes data) {
     this.status = status;
     this.gasUsed = gasUsed;
     this.data = data;
   }
 
+  /**
+   * Gets status.
+   *
+   * @return the status
+   */
   public Long getStatus() {
     return status;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   public Long getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   public Bytes getData() {
     return data;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/EmptyAccountAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/EmptyAccountAdapter.java
@@ -21,9 +21,15 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Empty account adapter. */
 public class EmptyAccountAdapter extends AccountAdapter {
   private final Address address;
 
+  /**
+   * Instantiates a new Empty account adapter.
+   *
+   * @param address the address
+   */
   public EmptyAccountAdapter(final Address address) {
     super(null);
     this.address = address;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/LogAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/LogAdapter.java
@@ -28,27 +28,54 @@ import java.util.Optional;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Log adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class LogAdapter extends AdapterBase {
   private final LogWithMetadata logWithMetadata;
 
+  /**
+   * Instantiates a new Log adapter.
+   *
+   * @param logWithMetadata the log with metadata
+   */
   public LogAdapter(final LogWithMetadata logWithMetadata) {
     this.logWithMetadata = logWithMetadata;
   }
 
+  /**
+   * Gets index.
+   *
+   * @return the index
+   */
   public Integer getIndex() {
     return logWithMetadata.getLogIndex();
   }
 
+  /**
+   * Gets topics.
+   *
+   * @return the topics
+   */
   public List<LogTopic> getTopics() {
     final List<LogTopic> topics = logWithMetadata.getTopics();
     return new ArrayList<>(topics);
   }
 
+  /**
+   * Gets data.
+   *
+   * @return the data
+   */
   public Bytes getData() {
     return logWithMetadata.getData();
   }
 
+  /**
+   * Gets transaction.
+   *
+   * @param environment the environment
+   * @return the transaction
+   */
   public TransactionAdapter getTransaction(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final Hash hash = logWithMetadata.getTransactionHash();
@@ -56,6 +83,12 @@ public class LogAdapter extends AdapterBase {
     return tran.map(TransactionAdapter::new).orElseThrow();
   }
 
+  /**
+   * Gets account.
+   *
+   * @param environment the environment
+   * @return the account
+   */
   public AccountAdapter getAccount(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     long blockNumber = logWithMetadata.getBlockNumber();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/NormalBlockAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/NormalBlockAdapter.java
@@ -27,9 +27,15 @@ import java.util.Optional;
 
 import graphql.schema.DataFetchingEnvironment;
 
+/** The type Normal block adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class NormalBlockAdapter extends BlockAdapterBase {
 
+  /**
+   * Instantiates a new Normal block adapter.
+   *
+   * @param blockWithMetaData the block with meta data
+   */
   public NormalBlockAdapter(
       final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetaData) {
     super(blockWithMetaData.getHeader());
@@ -38,18 +44,39 @@ public class NormalBlockAdapter extends BlockAdapterBase {
 
   private final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetaData;
 
+  /**
+   * Gets transaction count.
+   *
+   * @return the transaction count
+   */
   public Optional<Integer> getTransactionCount() {
     return Optional.of(blockWithMetaData.getTransactions().size());
   }
 
+  /**
+   * Gets total difficulty.
+   *
+   * @return the total difficulty
+   */
   public Difficulty getTotalDifficulty() {
     return blockWithMetaData.getTotalDifficulty();
   }
 
+  /**
+   * Gets ommer count.
+   *
+   * @return the ommer count
+   */
   public Optional<Integer> getOmmerCount() {
     return Optional.of(blockWithMetaData.getOmmers().size());
   }
 
+  /**
+   * Gets ommers.
+   *
+   * @param environment the environment
+   * @return the ommers
+   */
   public List<UncleBlockAdapter> getOmmers(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final List<Hash> ommers = blockWithMetaData.getOmmers();
@@ -63,6 +90,12 @@ public class NormalBlockAdapter extends BlockAdapterBase {
     return results;
   }
 
+  /**
+   * Gets ommer at.
+   *
+   * @param environment the environment
+   * @return the ommer at
+   */
   public Optional<UncleBlockAdapter> getOmmerAt(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final int index = ((Number) environment.getArgument("index")).intValue();
@@ -75,6 +108,11 @@ public class NormalBlockAdapter extends BlockAdapterBase {
     return Optional.empty();
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   public List<TransactionAdapter> getTransactions() {
     final List<TransactionWithMetadata> trans = blockWithMetaData.getTransactions();
     final List<TransactionAdapter> results = new ArrayList<>();
@@ -84,6 +122,12 @@ public class NormalBlockAdapter extends BlockAdapterBase {
     return results;
   }
 
+  /**
+   * Gets transaction at.
+   *
+   * @param environment the environment
+   * @return the transaction at
+   */
   public Optional<TransactionAdapter> getTransactionAt(final DataFetchingEnvironment environment) {
     final int index = ((Number) environment.getArgument("index")).intValue();
     final List<TransactionWithMetadata> trans = blockWithMetaData.getTransactions();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/PendingStateAdapter.java
@@ -36,19 +36,35 @@ import graphql.schema.DataFetchingEnvironment;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Pending state adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class PendingStateAdapter extends AdapterBase {
 
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Pending state adapter.
+   *
+   * @param transactionPool the transaction pool
+   */
   public PendingStateAdapter(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
   }
 
+  /**
+   * Gets transaction count.
+   *
+   * @return the transaction count
+   */
   public Integer getTransactionCount() {
     return transactionPool.count();
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   public List<TransactionAdapter> getTransactions() {
     return transactionPool.getPendingTransactions().stream()
         .map(PendingTransaction::getTransaction)
@@ -57,6 +73,12 @@ public class PendingStateAdapter extends AdapterBase {
         .toList();
   }
 
+  /**
+   * Gets account.
+   *
+   * @param dataFetchingEnvironment the data fetching environment
+   * @return the account
+   */
   // until the miner can expose the current "proposed block" we have no
   // speculative environment, so estimate against latest.
   public AccountAdapter getAccount(final DataFetchingEnvironment dataFetchingEnvironment) {
@@ -71,6 +93,12 @@ public class PendingStateAdapter extends AdapterBase {
         .orElseGet(() -> new AccountAdapter(null));
   }
 
+  /**
+   * Gets estimate gas.
+   *
+   * @param environment the environment
+   * @return the estimate gas
+   */
   // until the miner can expose the current "proposed block" we have no
   // speculative environment, so estimate against latest.
   public Optional<Long> getEstimateGas(final DataFetchingEnvironment environment) {
@@ -78,6 +106,12 @@ public class PendingStateAdapter extends AdapterBase {
     return result.map(CallResult::getGasUsed);
   }
 
+  /**
+   * Gets call.
+   *
+   * @param environment the environment
+   * @return the call
+   */
   // until the miner can expose the current "proposed block" we have no
   // speculative environment, so estimate against latest.
   public Optional<CallResult> getCall(final DataFetchingEnvironment environment) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/SyncStateAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/SyncStateAdapter.java
@@ -16,22 +16,43 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
 
 import org.hyperledger.besu.plugin.data.SyncStatus;
 
+/** The type Sync state adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class SyncStateAdapter {
   private final SyncStatus syncStatus;
 
+  /**
+   * Instantiates a new Sync state adapter.
+   *
+   * @param syncStatus the sync status
+   */
   public SyncStateAdapter(final SyncStatus syncStatus) {
     this.syncStatus = syncStatus;
   }
 
+  /**
+   * Gets starting block.
+   *
+   * @return the starting block
+   */
   public Long getStartingBlock() {
     return syncStatus.getStartingBlock();
   }
 
+  /**
+   * Gets current block.
+   *
+   * @return the current block
+   */
   public Long getCurrentBlock() {
     return syncStatus.getCurrentBlock();
   }
 
+  /**
+   * Gets highest block.
+   *
+   * @return the highest block
+   */
   public Long getHighestBlock() {
     return syncStatus.getHighestBlock();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/TransactionAdapter.java
@@ -37,11 +37,17 @@ import javax.annotation.Nonnull;
 import graphql.schema.DataFetchingEnvironment;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Transaction adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 public class TransactionAdapter extends AdapterBase {
   private final TransactionWithMetadata transactionWithMetadata;
   private Optional<TransactionReceiptWithMetadata> transactionReceiptWithMetadata;
 
+  /**
+   * Instantiates a new Transaction adapter.
+   *
+   * @param transactionWithMetadata the transaction with metadata
+   */
   public TransactionAdapter(final @Nonnull TransactionWithMetadata transactionWithMetadata) {
     this.transactionWithMetadata = transactionWithMetadata;
   }
@@ -64,22 +70,48 @@ public class TransactionAdapter extends AdapterBase {
     return transactionReceiptWithMetadata;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   public Hash getHash() {
     return transactionWithMetadata.getTransaction().getHash();
   }
 
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public Optional<Integer> getType() {
     return Optional.of(transactionWithMetadata.getTransaction().getType().ordinal());
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   public Long getNonce() {
     return transactionWithMetadata.getTransaction().getNonce();
   }
 
+  /**
+   * Gets index.
+   *
+   * @return the index
+   */
   public Optional<Integer> getIndex() {
     return transactionWithMetadata.getTransactionIndex();
   }
 
+  /**
+   * Gets from.
+   *
+   * @param environment the environment
+   * @return the from
+   */
   public AccountAdapter getFrom(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final Long blockNumber =
@@ -95,6 +127,12 @@ public class TransactionAdapter extends AdapterBase {
         .orElse(new EmptyAccountAdapter(addr));
   }
 
+  /**
+   * Gets to.
+   *
+   * @param environment the environment
+   * @return the to
+   */
   public Optional<AccountAdapter> getTo(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final Long blockNumber =
@@ -114,39 +152,86 @@ public class TransactionAdapter extends AdapterBase {
                     .or(() -> Optional.of(new EmptyAccountAdapter(address))));
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   public Wei getValue() {
     return transactionWithMetadata.getTransaction().getValue();
   }
 
+  /**
+   * Gets gas price.
+   *
+   * @return the gas price
+   */
   public Wei getGasPrice() {
     return transactionWithMetadata.getTransaction().getGasPrice().orElse(Wei.ZERO);
   }
 
+  /**
+   * Gets max fee per gas.
+   *
+   * @return the max fee per gas
+   */
   public Optional<Wei> getMaxFeePerGas() {
     return transactionWithMetadata.getTransaction().getMaxFeePerGas();
   }
 
+  /**
+   * Gets max priority fee per gas.
+   *
+   * @return the max priority fee per gas
+   */
   public Optional<Wei> getMaxPriorityFeePerGas() {
     return transactionWithMetadata.getTransaction().getMaxPriorityFeePerGas();
   }
 
+  /**
+   * Gets max fee per blob gas.
+   *
+   * @return the max fee per blob gas
+   */
   public Optional<Wei> getMaxFeePerBlobGas() {
     return transactionWithMetadata.getTransaction().getMaxFeePerBlobGas();
   }
 
+  /**
+   * Gets effective tip.
+   *
+   * @param environment the environment
+   * @return the effective tip
+   */
   public Optional<Wei> getEffectiveTip(final DataFetchingEnvironment environment) {
     return getReceipt(environment)
         .map(rwm -> rwm.getTransaction().getEffectivePriorityFeePerGas(rwm.getBaseFee()));
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   public Long getGas() {
     return transactionWithMetadata.getTransaction().getGasLimit();
   }
 
+  /**
+   * Gets input data.
+   *
+   * @return the input data
+   */
   public Bytes getInputData() {
     return transactionWithMetadata.getTransaction().getPayload();
   }
 
+  /**
+   * Gets block.
+   *
+   * @param environment the environment
+   * @return the block
+   */
   public Optional<NormalBlockAdapter> getBlock(final DataFetchingEnvironment environment) {
     return transactionWithMetadata
         .getBlockHash()
@@ -154,6 +239,12 @@ public class TransactionAdapter extends AdapterBase {
         .map(NormalBlockAdapter::new);
   }
 
+  /**
+   * Gets status.
+   *
+   * @param environment the environment
+   * @return the status
+   */
   public Optional<Long> getStatus(final DataFetchingEnvironment environment) {
     return getReceipt(environment)
         .map(TransactionReceiptWithMetadata::getReceipt)
@@ -164,27 +255,63 @@ public class TransactionAdapter extends AdapterBase {
                     : Optional.of((long) receipt.getStatus()));
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @param environment the environment
+   * @return the gas used
+   */
   public Optional<Long> getGasUsed(final DataFetchingEnvironment environment) {
     return getReceipt(environment).map(TransactionReceiptWithMetadata::getGasUsed);
   }
 
+  /**
+   * Gets cumulative gas used.
+   *
+   * @param environment the environment
+   * @return the cumulative gas used
+   */
   public Optional<Long> getCumulativeGasUsed(final DataFetchingEnvironment environment) {
     return getReceipt(environment).map(rpt -> rpt.getReceipt().getCumulativeGasUsed());
   }
 
+  /**
+   * Gets effective gas price.
+   *
+   * @param environment the environment
+   * @return the effective gas price
+   */
   public Optional<Wei> getEffectiveGasPrice(final DataFetchingEnvironment environment) {
     return getReceipt(environment)
         .map(rwm -> rwm.getTransaction().getEffectiveGasPrice(rwm.getBaseFee()));
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @param environment the environment
+   * @return the blob gas used
+   */
   public Optional<Long> getBlobGasUsed(final DataFetchingEnvironment environment) {
     return getReceipt(environment).flatMap(TransactionReceiptWithMetadata::getBlobGasUsed);
   }
 
+  /**
+   * Gets blob gas price.
+   *
+   * @param environment the environment
+   * @return the blob gas price
+   */
   public Optional<Wei> getBlobGasPrice(final DataFetchingEnvironment environment) {
     return getReceipt(environment).flatMap(TransactionReceiptWithMetadata::getBlobGasPrice);
   }
 
+  /**
+   * Gets created contract.
+   *
+   * @param environment the environment
+   * @return the created contract
+   */
   public Optional<AccountAdapter> getCreatedContract(final DataFetchingEnvironment environment) {
     final boolean contractCreated = transactionWithMetadata.getTransaction().isContractCreation();
     if (contractCreated) {
@@ -207,6 +334,12 @@ public class TransactionAdapter extends AdapterBase {
     return Optional.empty();
   }
 
+  /**
+   * Gets logs.
+   *
+   * @param environment the environment
+   * @return the logs
+   */
   public List<LogAdapter> getLogs(final DataFetchingEnvironment environment) {
     final BlockchainQueries query = getBlockchainQueries(environment);
     final ProtocolSchedule protocolSchedule =
@@ -239,22 +372,47 @@ public class TransactionAdapter extends AdapterBase {
     return results;
   }
 
+  /**
+   * Gets r.
+   *
+   * @return the r
+   */
   public BigInteger getR() {
     return transactionWithMetadata.getTransaction().getR();
   }
 
+  /**
+   * Gets s.
+   *
+   * @return the s
+   */
   public BigInteger getS() {
     return transactionWithMetadata.getTransaction().getS();
   }
 
+  /**
+   * Gets v.
+   *
+   * @return the v
+   */
   public Optional<BigInteger> getV() {
     return Optional.ofNullable(transactionWithMetadata.getTransaction().getV());
   }
 
+  /**
+   * Gets y parity.
+   *
+   * @return the y parity
+   */
   public Optional<BigInteger> getYParity() {
     return Optional.ofNullable(transactionWithMetadata.getTransaction().getYParity());
   }
 
+  /**
+   * Gets access list.
+   *
+   * @return the access list
+   */
   public List<AccessListEntryAdapter> getAccessList() {
     return transactionWithMetadata
         .getTransaction()
@@ -263,12 +421,23 @@ public class TransactionAdapter extends AdapterBase {
         .orElse(List.of());
   }
 
+  /**
+   * Gets raw.
+   *
+   * @return the raw
+   */
   public Optional<Bytes> getRaw() {
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
     transactionWithMetadata.getTransaction().writeTo(rlpOutput);
     return Optional.of(rlpOutput.encoded());
   }
 
+  /**
+   * Gets raw receipt.
+   *
+   * @param environment the environment
+   * @return the raw receipt
+   */
   public Optional<Bytes> getRawReceipt(final DataFetchingEnvironment environment) {
     return getReceipt(environment)
         .map(
@@ -279,6 +448,11 @@ public class TransactionAdapter extends AdapterBase {
             });
   }
 
+  /**
+   * Gets blob versioned hashes.
+   *
+   * @return the blob versioned hashes
+   */
   public List<VersionedHash> getBlobVersionedHashes() {
     return transactionWithMetadata.getTransaction().getVersionedHashes().orElse(List.of());
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/UncleBlockAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/UncleBlockAdapter.java
@@ -22,37 +22,78 @@ import java.util.Optional;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Uncle block adapter. */
 @SuppressWarnings("unused") // reflected by GraphQL
 class UncleBlockAdapter extends BlockAdapterBase {
 
+  /**
+   * Instantiates a new Uncle block adapter.
+   *
+   * @param uncleHeader the uncle header
+   */
   UncleBlockAdapter(final BlockHeader uncleHeader) {
     super(uncleHeader);
   }
 
+  /**
+   * Gets transaction count.
+   *
+   * @return the transaction count
+   */
   public Optional<Integer> getTransactionCount() {
     return Optional.of(0);
   }
 
+  /**
+   * Gets total difficulty.
+   *
+   * @return the total difficulty
+   */
   public UInt256 getTotalDifficulty() {
     return UInt256.ZERO;
   }
 
+  /**
+   * Gets ommer count.
+   *
+   * @return the ommer count
+   */
   public Optional<Integer> getOmmerCount() {
     return Optional.empty();
   }
 
+  /**
+   * Gets ommers.
+   *
+   * @return the ommers
+   */
   public List<NormalBlockAdapter> getOmmers() {
     return new ArrayList<>();
   }
 
+  /**
+   * Gets ommer at.
+   *
+   * @return the ommer at
+   */
   public Optional<NormalBlockAdapter> getOmmerAt() {
     return Optional.empty();
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   public List<TransactionAdapter> getTransactions() {
     return new ArrayList<>();
   }
 
+  /**
+   * Gets transaction at.
+   *
+   * @return the transaction at
+   */
   public Optional<TransactionAdapter> getTransactionAt() {
     return Optional.empty();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/WithdrawalAdapter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/pojoadapter/WithdrawalAdapter.java
@@ -17,26 +17,53 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.pojoadapter;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.plugin.data.Withdrawal;
 
+/** The type Withdrawal adapter. */
 public class WithdrawalAdapter {
 
+  /** The Withdrawal. */
   Withdrawal withdrawal;
 
+  /**
+   * Instantiates a new Withdrawal adapter.
+   *
+   * @param withdrawal the withdrawal
+   */
   public WithdrawalAdapter(final Withdrawal withdrawal) {
     this.withdrawal = withdrawal;
   }
 
+  /**
+   * Gets index.
+   *
+   * @return the index
+   */
   public Long getIndex() {
     return withdrawal.getIndex().toLong();
   }
 
+  /**
+   * Gets validator.
+   *
+   * @return the validator
+   */
   public Long getValidator() {
     return withdrawal.getValidatorIndex().toLong();
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   public Address getAddress() {
     return withdrawal.getAddress();
   }
 
+  /**
+   * Gets amount.
+   *
+   * @return the amount
+   */
   public Long getAmount() {
     return withdrawal.getAmount().getAsBigInteger().longValue();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLError.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLError.java
@@ -19,30 +19,48 @@ import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonGetter;
 
+/** The enum Graph ql error. */
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum GraphQLError {
+  /** The Invalid params. */
   // Standard errors
   INVALID_PARAMS(-32602, "Invalid params"),
+  /** The Internal error. */
   INTERNAL_ERROR(-32603, "Internal error"),
 
+  /** The Nonce too low. */
   // Transaction validation failures
   NONCE_TOO_LOW(-32001, "Nonce too low"),
+  /** The Invalid transaction signature. */
   INVALID_TRANSACTION_SIGNATURE(-32002, "Invalid signature"),
+  /** The Intrinsic gas exceeds limit. */
   INTRINSIC_GAS_EXCEEDS_LIMIT(-32003, "Intrinsic gas exceeds gas limit"),
+  /** The Transaction upfront cost exceeds balance. */
   TRANSACTION_UPFRONT_COST_EXCEEDS_BALANCE(-32004, "Upfront cost exceeds account balance"),
+  /** The Exceeds block gas limit. */
   EXCEEDS_BLOCK_GAS_LIMIT(-32005, "Transaction gas limit exceeds block gas limit"),
+  /** The Incorrect nonce. */
   INCORRECT_NONCE(-32006, "Nonce too high"),
+  /** The Tx sender not authorized. */
   TX_SENDER_NOT_AUTHORIZED(-32007, "Sender account not authorized to send transactions"),
+  /** The Chain head world state not available. */
   CHAIN_HEAD_WORLD_STATE_NOT_AVAILABLE(-32008, "Initial sync is still in progress"),
+  /** The Gas price too low. */
   GAS_PRICE_TOO_LOW(-32009, "Gas price below configured minimum gas price"),
+  /** The Wrong chain id. */
   WRONG_CHAIN_ID(-32000, "Wrong Chain ID in transaction signature"),
+  /** The Replay protected signatures not supported. */
   REPLAY_PROTECTED_SIGNATURES_NOT_SUPPORTED(
       -32000, "Signatures with replay protection are not supported"),
+  /** The Tx feecap exceeded. */
   TX_FEECAP_EXCEEDED(-32000, "Transaction fee cap exceeded"),
 
+  /** The Private transaction failed. */
   // Private Transaction Errors
   PRIVATE_TRANSACTION_FAILED(-32000, "Private transaction failed"),
+  /** The Private nonce too low. */
   PRIVATE_NONCE_TOO_LOW(-50100, "Private transaction nonce too low"),
+  /** The Incorrect private nonce. */
   INCORRECT_PRIVATE_NONCE(-50100, "Private transaction nonce is incorrect");
 
   private final int code;
@@ -53,16 +71,32 @@ public enum GraphQLError {
     this.message = message;
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   @JsonGetter("code")
   public int getCode() {
     return code;
   }
 
+  /**
+   * Gets message.
+   *
+   * @return the message
+   */
   @JsonGetter("message")
   public String getMessage() {
     return message;
   }
 
+  /**
+   * Of graph ql error.
+   *
+   * @param transactionInvalidReason the transaction invalid reason
+   * @return the graph ql error
+   */
   public static GraphQLError of(final TransactionInvalidReason transactionInvalidReason) {
     switch (transactionInvalidReason) {
       case WRONG_CHAIN_ID:

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLErrorResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLErrorResponse.java
@@ -16,8 +16,14 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/** The type Graph ql error response. */
 public class GraphQLErrorResponse extends GraphQLResponse {
 
+  /**
+   * Instantiates a new Graph ql error response.
+   *
+   * @param errors the errors
+   */
   public GraphQLErrorResponse(final Object errors) {
     super(errors);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLJsonRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLJsonRequest.java
@@ -19,36 +19,70 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+/** The type Graph ql json request. */
 public class GraphQLJsonRequest {
   private String query;
   private String operationName;
   private Map<String, Object> variables;
 
+  /** Default constructor. */
+  public GraphQLJsonRequest() {}
+
+  /**
+   * Gets query.
+   *
+   * @return the query
+   */
   @JsonGetter
   public String getQuery() {
     return query;
   }
 
+  /**
+   * Sets query.
+   *
+   * @param query the query
+   */
   @JsonSetter
   public void setQuery(final String query) {
     this.query = query;
   }
 
+  /**
+   * Gets operation name.
+   *
+   * @return the operation name
+   */
   @JsonGetter
   public String getOperationName() {
     return operationName;
   }
 
+  /**
+   * Sets operation name.
+   *
+   * @param operationName the operation name
+   */
   @JsonSetter
   public void setOperationName(final String operationName) {
     this.operationName = operationName;
   }
 
+  /**
+   * Gets variables.
+   *
+   * @return the variables
+   */
   @JsonGetter
   public Map<String, Object> getVariables() {
     return variables;
   }
 
+  /**
+   * Sets variables.
+   *
+   * @param variables the variables
+   */
   @JsonSetter
   public void setVariables(final Map<String, Object> variables) {
     this.variables = variables;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLNoResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLNoResponse.java
@@ -14,8 +14,10 @@
  */
 package org.hyperledger.besu.ethereum.api.graphql.internal.response;
 
+/** The type Graph ql no response. */
 public class GraphQLNoResponse extends GraphQLResponse {
 
+  /** Instantiates a new Graph ql no response. */
   public GraphQLNoResponse() {
     super(null);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLResponse.java
@@ -16,15 +16,31 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.response;
 
 import java.util.Objects;
 
+/** The type Graph ql response. */
 public abstract class GraphQLResponse {
+  /**
+   * Gets type.
+   *
+   * @return the type
+   */
   public abstract GraphQLResponseType getType();
 
   private final Object result;
 
+  /**
+   * Instantiates a new Graph ql response.
+   *
+   * @param result the result
+   */
   GraphQLResponse(final Object result) {
     this.result = result;
   }
 
+  /**
+   * Gets result.
+   *
+   * @return the result
+   */
   public Object getResult() {
     return result;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLResponseType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLResponseType.java
@@ -16,8 +16,12 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.response;
 
 /** Various types of responses that the JSON-RPC component may produce. */
 public enum GraphQLResponseType {
+  /** None graph ql response type. */
   NONE,
+  /** Success graph ql response type. */
   SUCCESS,
+  /** Error graph ql response type. */
   ERROR,
+  /** Unauthorized graph ql response type. */
   UNAUTHORIZED
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLSuccessResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/internal/response/GraphQLSuccessResponse.java
@@ -16,8 +16,14 @@ package org.hyperledger.besu.ethereum.api.graphql.internal.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+/** The type Graph ql success response. */
 public class GraphQLSuccessResponse extends GraphQLResponse {
 
+  /**
+   * Instantiates a new Graph ql success response.
+   *
+   * @param data the data
+   */
   public GraphQLSuccessResponse(final Object data) {
     super(data);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/AbstractJsonRpcExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/AbstractJsonRpcExecutor.java
@@ -40,13 +40,22 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Abstract json rpc executor. */
 public abstract class AbstractJsonRpcExecutor {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractJsonRpcExecutor.class);
 
   private static final String SPAN_CONTEXT = "span_context";
+
+  /** The Json rpc executor. */
   final JsonRpcExecutor jsonRpcExecutor;
+
+  /** The Tracer. */
   final Tracer tracer;
+
+  /** The Ctx. */
   final RoutingContext ctx;
+
+  /** The Json rpc configuration. */
   final JsonRpcConfiguration jsonRpcConfiguration;
 
   private static final ObjectMapper jsonObjectMapper =
@@ -73,10 +82,30 @@ public abstract class AbstractJsonRpcExecutor {
     this.jsonRpcConfiguration = jsonRpcConfiguration;
   }
 
+  /**
+   * Execute.
+   *
+   * @throws IOException the io exception
+   */
   abstract void execute() throws IOException;
 
+  /**
+   * Gets rpc method name.
+   *
+   * @param ctx the ctx
+   * @return the rpc method name
+   */
   abstract String getRpcMethodName(final RoutingContext ctx);
 
+  /**
+   * Execute request json rpc response.
+   *
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param jsonRequest the json request
+   * @param ctx the ctx
+   * @return the json rpc response
+   */
   protected static JsonRpcResponse executeRequest(
       final JsonRpcExecutor jsonRpcExecutor,
       final Tracer tracer,
@@ -93,6 +122,13 @@ public abstract class AbstractJsonRpcExecutor {
         req -> req.mapTo(JsonRpcRequest.class));
   }
 
+  /**
+   * Handle json rpc error.
+   *
+   * @param routingContext the routing context
+   * @param id the id
+   * @param error the error
+   */
   protected static void handleJsonRpcError(
       final RoutingContext routingContext, final Object id, final RpcErrorType error) {
     final HttpServerResponse response = routingContext.response();
@@ -110,21 +146,48 @@ public abstract class AbstractJsonRpcExecutor {
     };
   }
 
+  /**
+   * Prepare http response http server response.
+   *
+   * @param ctx the ctx
+   * @return the http server response
+   */
   protected HttpServerResponse prepareHttpResponse(final RoutingContext ctx) {
     HttpServerResponse response = ctx.response();
     response = response.putHeader("Content-Type", APPLICATION_JSON);
     return response;
   }
 
+  /**
+   * Gets json object mapper.
+   *
+   * @return the json object mapper
+   */
   protected static ObjectMapper getJsonObjectMapper() {
     return jsonObjectMapper;
   }
 
+  /**
+   * The interface Exception throwing supplier.
+   *
+   * @param <T> the type parameter
+   */
   @FunctionalInterface
   protected interface ExceptionThrowingSupplier<T> {
+    /**
+     * Get t.
+     *
+     * @return the t
+     * @throws Exception the exception
+     */
     T get() throws Exception;
   }
 
+  /**
+   * Lazy trace logger.
+   *
+   * @param logMessageSupplier the log message supplier
+   */
   protected static void lazyTraceLogger(
       final ExceptionThrowingSupplier<String> logMessageSupplier) {
     if (LOG.isTraceEnabled()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/AuthenticationHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/AuthenticationHandler.java
@@ -28,10 +28,18 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Authentication handler. */
 public class AuthenticationHandler {
 
   private AuthenticationHandler() {}
 
+  /**
+   * Handler handler.
+   *
+   * @param authenticationService the authentication service
+   * @param noAuthRpcApis the no auth rpc apis
+   * @return the handler
+   */
   public static Handler<RoutingContext> handler(
       final AuthenticationService authenticationService, final Collection<String> noAuthRpcApis) {
     return ctx -> {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/HandlerFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/HandlerFactory.java
@@ -29,8 +29,18 @@ import io.opentelemetry.api.trace.Tracer;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Handler factory. */
 public class HandlerFactory {
+  /** Default constructor. */
+  private HandlerFactory() {}
 
+  /**
+   * Timeout handler.
+   *
+   * @param globalOptions the global options
+   * @param methods the methods
+   * @return the handler
+   */
   public static Handler<RoutingContext> timeout(
       final TimeoutOptions globalOptions, final Map<String, JsonRpcMethod> methods) {
     assert methods != null && globalOptions != null;
@@ -40,15 +50,35 @@ public class HandlerFactory {
             .collect(Collectors.toMap(Function.identity(), ignored -> globalOptions)));
   }
 
+  /**
+   * Authentication handler.
+   *
+   * @param authenticationService the authentication service
+   * @param noAuthRpcApis the no auth rpc apis
+   * @return the handler
+   */
   public static Handler<RoutingContext> authentication(
       final AuthenticationService authenticationService, final Collection<String> noAuthRpcApis) {
     return AuthenticationHandler.handler(authenticationService, noAuthRpcApis);
   }
 
+  /**
+   * Json rpc parser handler.
+   *
+   * @return the handler
+   */
   public static Handler<RoutingContext> jsonRpcParser() {
     return JsonRpcParserHandler.handler();
   }
 
+  /**
+   * Json rpc executor handler.
+   *
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @return the handler
+   */
   public static Handler<RoutingContext> jsonRpcExecutor(
       final JsonRpcExecutor jsonRpcExecutor,
       final Tracer tracer,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/IsAliveHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/IsAliveHandler.java
@@ -20,22 +20,46 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
+/** The type Is alive handler. */
 public class IsAliveHandler implements Supplier<Boolean> {
 
   private final AtomicBoolean alive;
 
+  /**
+   * Instantiates a new Is alive handler.
+   *
+   * @param alive the alive
+   */
   public IsAliveHandler(final boolean alive) {
     this(new AtomicBoolean(alive));
   }
 
+  /**
+   * Instantiates a new Is alive handler.
+   *
+   * @param alive the alive
+   */
   public IsAliveHandler(final AtomicBoolean alive) {
     this.alive = alive;
   }
 
+  /**
+   * Instantiates a new Is alive handler.
+   *
+   * @param ethScheduler the eth scheduler
+   * @param timeoutSec the timeout sec
+   */
   public IsAliveHandler(final EthScheduler ethScheduler, final long timeoutSec) {
     this(ethScheduler, new AtomicBoolean(true), timeoutSec);
   }
 
+  /**
+   * Instantiates a new Is alive handler.
+   *
+   * @param ethScheduler the eth scheduler
+   * @param alive the alive
+   * @param timeoutSec the timeout sec
+   */
   public IsAliveHandler(
       final EthScheduler ethScheduler, final AtomicBoolean alive, final long timeoutSec) {
     this.alive = alive;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcArrayExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcArrayExecutor.java
@@ -34,7 +34,16 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Json rpc array executor. */
 public class JsonRpcArrayExecutor extends AbstractJsonRpcExecutor {
+  /**
+   * Instantiates a new Json rpc array executor.
+   *
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param ctx the ctx
+   * @param jsonRpcConfiguration the json rpc configuration
+   */
   public JsonRpcArrayExecutor(
       final JsonRpcExecutor jsonRpcExecutor,
       final Tracer tracer,
@@ -67,6 +76,7 @@ public class JsonRpcArrayExecutor extends AbstractJsonRpcExecutor {
    *
    * @param rpcRequestBatch the batch of RPC requests.
    * @param streamer the JsonResponseStreamer to use.
+   * @throws IOException the io exception
    */
   public void executeRpcRequestBatch(
       final JsonArray rpcRequestBatch, final JsonResponseStreamer streamer) throws IOException {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
@@ -31,11 +31,21 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json rpc executor handler. */
 public class JsonRpcExecutorHandler {
   private static final Logger LOG = LoggerFactory.getLogger(JsonRpcExecutorHandler.class);
 
   private JsonRpcExecutorHandler() {}
 
+  /**
+   * Handler handler.
+   *
+   * @param jsonObjectMapper the json object mapper
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @return the handler
+   */
   public static Handler<RoutingContext> handler(
       final ObjectMapper jsonObjectMapper,
       final JsonRpcExecutor jsonRpcExecutor,
@@ -44,6 +54,14 @@ public class JsonRpcExecutorHandler {
     return handler(jsonRpcExecutor, tracer, jsonRpcConfiguration);
   }
 
+  /**
+   * Handler handler.
+   *
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @return the handler
+   */
   public static Handler<RoutingContext> handler(
       final JsonRpcExecutor jsonRpcExecutor,
       final Tracer tracer,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcObjectExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcObjectExecutor.java
@@ -35,9 +35,18 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Json rpc object executor. */
 public class JsonRpcObjectExecutor extends AbstractJsonRpcExecutor {
   private final ObjectWriter jsonObjectWriter = createObjectWriter();
 
+  /**
+   * Instantiates a new Json rpc object executor.
+   *
+   * @param jsonRpcExecutor the json rpc executor
+   * @param tracer the tracer
+   * @param ctx the ctx
+   * @param jsonRpcConfiguration the json rpc configuration
+   */
   public JsonRpcObjectExecutor(
       final JsonRpcExecutor jsonRpcExecutor,
       final Tracer tracer,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcParserHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcParserHandler.java
@@ -26,10 +26,16 @@ import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Json rpc parser handler. */
 public class JsonRpcParserHandler {
 
   private JsonRpcParserHandler() {}
 
+  /**
+   * Handler handler.
+   *
+   * @return the handler
+   */
   public static Handler<RoutingContext> handler() {
     return ctx -> {
       final HttpServerResponse response = ctx.response();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/RpcMethodTimeoutException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/RpcMethodTimeoutException.java
@@ -14,7 +14,9 @@
  */
 package org.hyperledger.besu.ethereum.api.handlers;
 
+/** The type Rpc method timeout exception. */
 public class RpcMethodTimeoutException extends RuntimeException {
+  /** Instantiates a new Rpc method timeout exception. */
   public RpcMethodTimeoutException() {
     super("Timeout expired");
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutHandler.java
@@ -23,8 +23,18 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Timeout handler. */
 public class TimeoutHandler {
+  /** Default constructor. */
+  private TimeoutHandler() {}
 
+  /**
+   * Handler handler.
+   *
+   * @param globalOptions the global options
+   * @param timeoutOptionsByMethod the timeout options by method
+   * @return the handler
+   */
   public static Handler<RoutingContext> handler(
       final Optional<TimeoutOptions> globalOptions,
       final Map<String, TimeoutOptions> timeoutOptionsByMethod) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutOptions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutOptions.java
@@ -17,8 +17,10 @@ package org.hyperledger.besu.ethereum.api.handlers;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+/** The type Timeout options. */
 public class TimeoutOptions {
 
+  /** The constant DEFAULT_ERROR_CODE. */
   public static final int DEFAULT_ERROR_CODE = 504;
 
   private static final long DEFAULT_TIMEOUT_SECONDS = Duration.ofMinutes(5).toSeconds();
@@ -26,27 +28,58 @@ public class TimeoutOptions {
 
   private final int errorCode;
 
+  /**
+   * Instantiates a new Timeout options.
+   *
+   * @param timeoutSec the timeout sec
+   * @param errorCode the error code
+   */
   public TimeoutOptions(final long timeoutSec, final int errorCode) {
     this.timeoutSec = timeoutSec;
     this.errorCode = errorCode;
   }
 
+  /**
+   * Instantiates a new Timeout options.
+   *
+   * @param timeoutSec the timeout sec
+   */
   public TimeoutOptions(final long timeoutSec) {
     this(timeoutSec, DEFAULT_ERROR_CODE);
   }
 
+  /**
+   * Default options timeout options.
+   *
+   * @return the timeout options
+   */
   public static TimeoutOptions defaultOptions() {
     return new TimeoutOptions(DEFAULT_TIMEOUT_SECONDS, DEFAULT_ERROR_CODE);
   }
 
+  /**
+   * Gets timeout seconds.
+   *
+   * @return the timeout seconds
+   */
   public long getTimeoutSeconds() {
     return timeoutSec;
   }
 
+  /**
+   * Gets timeout millis.
+   *
+   * @return the timeout millis
+   */
   public long getTimeoutMillis() {
     return TimeUnit.SECONDS.toMillis(timeoutSec);
   }
 
+  /**
+   * Gets error code.
+   *
+   * @return the error code
+   */
   public int getErrorCode() {
     return errorCode;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/EngineJsonRpcService.java
@@ -98,6 +98,7 @@ import io.vertx.ext.web.handler.CorsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine json rpc service. */
 public class EngineJsonRpcService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineJsonRpcService.class);
@@ -143,6 +144,7 @@ public class EngineJsonRpcService {
   private final WebSocketConfiguration socketConfiguration;
   private final Optional<WebSocketMessageHandler> webSocketMessageHandler;
 
+  /** The Authentication service. */
   @VisibleForTesting public final Optional<AuthenticationService> authenticationService;
 
   private HttpServer httpServer;
@@ -219,6 +221,11 @@ public class EngineJsonRpcService {
     this.metricsSystem = metricsSystem;
   }
 
+  /**
+   * Start completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<Void> start() {
     LOG.info("Starting JSON-RPC service on {}:{}", config.getHost(), config.getPort());
     LOG.debug("max number of active connections {}", maxActiveConnections);
@@ -275,6 +282,11 @@ public class EngineJsonRpcService {
     return resultFuture;
   }
 
+  /**
+   * Stop completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<Void> stop() {
     if (httpServer == null) {
       return CompletableFuture.completedFuture(null);
@@ -633,6 +645,11 @@ public class EngineJsonRpcService {
     }
   }
 
+  /**
+   * Socket address inet socket address.
+   *
+   * @return the inet socket address
+   */
   public InetSocketAddress socketAddress() {
     if (httpServer == null) {
       return EMPTY_SOCKET_ADDRESS;
@@ -644,6 +661,11 @@ public class EngineJsonRpcService {
     return String.format("host=%s, port=%d", socketAddress.host(), socketAddress.port());
   }
 
+  /**
+   * Url string.
+   *
+   * @return the string
+   */
   @VisibleForTesting
   public String url() {
     if (httpServer == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonResponseStreamer.java
@@ -24,6 +24,7 @@ import io.vertx.core.net.SocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json response streamer. */
 public class JsonResponseStreamer extends OutputStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonResponseStreamer.class);
@@ -35,6 +36,12 @@ public class JsonResponseStreamer extends OutputStream {
   private boolean closed = false;
   private final AtomicReference<Throwable> failure = new AtomicReference<>();
 
+  /**
+   * Instantiates a new Json response streamer.
+   *
+   * @param response the response
+   * @param socketAddress the socket address
+   */
   public JsonResponseStreamer(
       final HttpServerResponse response, final SocketAddress socketAddress) {
     this.response = response;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcConfiguration.java
@@ -31,13 +31,26 @@ import java.util.Optional;
 
 import com.google.common.base.MoreObjects;
 
+/** The type Json rpc configuration. */
 public class JsonRpcConfiguration {
   private static final String DEFAULT_JSON_RPC_HOST = "127.0.0.1";
+
+  /** The constant DEFAULT_JSON_RPC_PORT. */
   public static final int DEFAULT_JSON_RPC_PORT = 8545;
+
+  /** The constant DEFAULT_ENGINE_JSON_RPC_PORT. */
   public static final int DEFAULT_ENGINE_JSON_RPC_PORT = 8551;
+
+  /** The constant DEFAULT_MAX_ACTIVE_CONNECTIONS. */
   public static final int DEFAULT_MAX_ACTIVE_CONNECTIONS = 80;
+
+  /** The constant DEFAULT_MAX_BATCH_SIZE. */
   public static final int DEFAULT_MAX_BATCH_SIZE = 1024;
+
+  /** The constant DEFAULT_MAX_REQUEST_CONTENT_LENGTH. */
   public static final long DEFAULT_MAX_REQUEST_CONTENT_LENGTH = 5 * 1024 * 1024; // 5MB
+
+  /** The constant DEFAULT_PRETTY_JSON_ENABLED. */
   public static final boolean DEFAULT_PRETTY_JSON_ENABLED = false;
 
   private boolean enabled;
@@ -58,6 +71,11 @@ public class JsonRpcConfiguration {
   private long maxRequestContentLength;
   private boolean prettyJsonEnabled;
 
+  /**
+   * Create default json rpc configuration.
+   *
+   * @return the json rpc configuration
+   */
   public static JsonRpcConfiguration createDefault() {
     final JsonRpcConfiguration config = new JsonRpcConfiguration();
     config.setEnabled(false);
@@ -72,6 +90,11 @@ public class JsonRpcConfiguration {
     return config;
   }
 
+  /**
+   * Create engine default json rpc configuration.
+   *
+   * @return the json rpc configuration
+   */
   public static JsonRpcConfiguration createEngineDefault() {
     final JsonRpcConfiguration config = createDefault();
     config.setEnabled(false);
@@ -88,121 +111,266 @@ public class JsonRpcConfiguration {
 
   private JsonRpcConfiguration() {}
 
+  /**
+   * Is enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEnabled() {
     return enabled;
   }
 
+  /**
+   * Sets enabled.
+   *
+   * @param enabled the enabled
+   */
   public void setEnabled(final boolean enabled) {
     this.enabled = enabled;
   }
 
+  /**
+   * Gets port.
+   *
+   * @return the port
+   */
   public int getPort() {
     return port;
   }
 
+  /**
+   * Sets port.
+   *
+   * @param port the port
+   */
   public void setPort(final int port) {
     this.port = port;
   }
 
+  /**
+   * Gets host.
+   *
+   * @return the host
+   */
   public String getHost() {
     return host;
   }
 
+  /**
+   * Sets host.
+   *
+   * @param host the host
+   */
   public void setHost(final String host) {
     this.host = host;
   }
 
+  /**
+   * Gets cors allowed domains.
+   *
+   * @return the cors allowed domains
+   */
   public Collection<String> getCorsAllowedDomains() {
     return corsAllowedDomains;
   }
 
+  /**
+   * Sets cors allowed domains.
+   *
+   * @param corsAllowedDomains the cors allowed domains
+   */
   public void setCorsAllowedDomains(final List<String> corsAllowedDomains) {
     if (corsAllowedDomains != null) {
       this.corsAllowedDomains = corsAllowedDomains;
     }
   }
 
+  /**
+   * Gets rpc apis.
+   *
+   * @return the rpc apis
+   */
   public Collection<String> getRpcApis() {
     return rpcApis;
   }
 
+  /**
+   * Sets rpc apis.
+   *
+   * @param rpcApis the rpc apis
+   */
   public void setRpcApis(final List<String> rpcApis) {
     this.rpcApis = rpcApis;
   }
 
+  /**
+   * Gets no auth rpc apis.
+   *
+   * @return the no auth rpc apis
+   */
   public Collection<String> getNoAuthRpcApis() {
     return this.noAuthRpcApis;
   }
 
+  /**
+   * Sets no auth rpc apis.
+   *
+   * @param rpcApis the rpc apis
+   */
   public void setNoAuthRpcApis(final List<String> rpcApis) {
     this.noAuthRpcApis = rpcApis;
   }
 
+  /**
+   * Add rpc api.
+   *
+   * @param rpcApi the rpc api
+   */
   public void addRpcApi(final String rpcApi) {
     this.rpcApis = new ArrayList<>(rpcApis);
     rpcApis.add(rpcApi);
   }
 
+  /**
+   * Gets hosts allowlist.
+   *
+   * @return the hosts allowlist
+   */
   public Collection<String> getHostsAllowlist() {
     return Collections.unmodifiableCollection(this.hostsAllowlist);
   }
 
+  /**
+   * Sets hosts allowlist.
+   *
+   * @param hostsAllowlist the hosts allowlist
+   */
   public void setHostsAllowlist(final List<String> hostsAllowlist) {
     this.hostsAllowlist = hostsAllowlist;
   }
 
+  /**
+   * Is authentication enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isAuthenticationEnabled() {
     return authenticationEnabled;
   }
 
+  /**
+   * Sets authentication enabled.
+   *
+   * @param authenticationEnabled the authentication enabled
+   */
   public void setAuthenticationEnabled(final boolean authenticationEnabled) {
     this.authenticationEnabled = authenticationEnabled;
   }
 
+  /**
+   * Sets authentication credentials file.
+   *
+   * @param authenticationCredentialsFile the authentication credentials file
+   */
   public void setAuthenticationCredentialsFile(final String authenticationCredentialsFile) {
     this.authenticationCredentialsFile = authenticationCredentialsFile;
   }
 
+  /**
+   * Gets authentication credentials file.
+   *
+   * @return the authentication credentials file
+   */
   public String getAuthenticationCredentialsFile() {
     return authenticationCredentialsFile;
   }
 
+  /**
+   * Gets authentication public key file.
+   *
+   * @return the authentication public key file
+   */
   public File getAuthenticationPublicKeyFile() {
     return authenticationPublicKeyFile;
   }
 
+  /**
+   * Sets authentication public key file.
+   *
+   * @param authenticationPublicKeyFile the authentication public key file
+   */
   public void setAuthenticationPublicKeyFile(final File authenticationPublicKeyFile) {
     this.authenticationPublicKeyFile = authenticationPublicKeyFile;
   }
 
+  /**
+   * Gets authentication algorithm.
+   *
+   * @return the authentication algorithm
+   */
   public JwtAlgorithm getAuthenticationAlgorithm() {
     return authenticationAlgorithm;
   }
 
+  /**
+   * Sets authentication algorithm.
+   *
+   * @param authenticationAlgorithm the authentication algorithm
+   */
   public void setAuthenticationAlgorithm(final JwtAlgorithm authenticationAlgorithm) {
     this.authenticationAlgorithm = authenticationAlgorithm;
   }
 
+  /**
+   * Gets tls configuration.
+   *
+   * @return the tls configuration
+   */
   public Optional<TlsConfiguration> getTlsConfiguration() {
     return tlsConfiguration;
   }
 
+  /**
+   * Sets tls configuration.
+   *
+   * @param tlsConfiguration the tls configuration
+   */
   public void setTlsConfiguration(final Optional<TlsConfiguration> tlsConfiguration) {
     this.tlsConfiguration = tlsConfiguration;
   }
 
+  /**
+   * Gets http timeout sec.
+   *
+   * @return the http timeout sec
+   */
   public long getHttpTimeoutSec() {
     return httpTimeoutSec;
   }
 
+  /**
+   * Sets http timeout sec.
+   *
+   * @param httpTimeoutSec the http timeout sec
+   */
   public void setHttpTimeoutSec(final long httpTimeoutSec) {
     this.httpTimeoutSec = httpTimeoutSec;
   }
 
+  /**
+   * Is pretty json enabled boolean.
+   *
+   * @return the boolean
+   */
   public boolean isPrettyJsonEnabled() {
     return prettyJsonEnabled;
   }
 
+  /**
+   * Sets pretty json enabled.
+   *
+   * @param prettyJsonEnabled the pretty json enabled
+   */
   public void setPrettyJsonEnabled(final boolean prettyJsonEnabled) {
     this.prettyJsonEnabled = prettyJsonEnabled;
   }
@@ -262,26 +430,56 @@ public class JsonRpcConfiguration {
         maxBatchSize);
   }
 
+  /**
+   * Gets max active connections.
+   *
+   * @return the max active connections
+   */
   public int getMaxActiveConnections() {
     return maxActiveConnections;
   }
 
+  /**
+   * Sets max active connections.
+   *
+   * @param maxActiveConnections the max active connections
+   */
   public void setMaxActiveConnections(final int maxActiveConnections) {
     this.maxActiveConnections = maxActiveConnections;
   }
 
+  /**
+   * Gets max batch size.
+   *
+   * @return the max batch size
+   */
   public int getMaxBatchSize() {
     return maxBatchSize;
   }
 
+  /**
+   * Sets max batch size.
+   *
+   * @param maxBatchSize the max batch size
+   */
   public void setMaxBatchSize(final int maxBatchSize) {
     this.maxBatchSize = maxBatchSize;
   }
 
+  /**
+   * Gets max request content length.
+   *
+   * @return the max request content length
+   */
   public long getMaxRequestContentLength() {
     return maxRequestContentLength;
   }
 
+  /**
+   * Sets max request content length.
+   *
+   * @param maxRequestContentLength the max request content length
+   */
   public void setMaxRequestContentLength(final long maxRequestContentLength) {
     this.maxRequestContentLength = maxRequestContentLength;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcEnclaveErrorConverter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcEnclaveErrorConverter.java
@@ -20,8 +20,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** The type Json rpc enclave error converter. */
 public class JsonRpcEnclaveErrorConverter {
+  /** Default constructor. */
+  private JsonRpcEnclaveErrorConverter() {}
 
+  /**
+   * Convert enclave invalid reason rpc error type.
+   *
+   * @param reason the reason
+   * @return the rpc error type
+   */
   public static RpcErrorType convertEnclaveInvalidReason(final String reason) {
 
     final List<RpcErrorType> err =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcErrorConverter.java
@@ -17,8 +17,17 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
+/** The type Json rpc error converter. */
 public class JsonRpcErrorConverter {
+  /** Default constructor. */
+  private JsonRpcErrorConverter() {}
 
+  /**
+   * Convert transaction invalid reason rpc error type.
+   *
+   * @param reason the reason
+   * @return the rpc error type
+   */
   public static RpcErrorType convertTransactionInvalidReason(
       final TransactionInvalidReason reason) {
     switch (reason) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpService.java
@@ -87,6 +87,7 @@ import io.vertx.ext.web.handler.CorsHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json rpc http service. */
 public class JsonRpcHttpService {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonRpcHttpService.class);
@@ -129,6 +130,7 @@ public class JsonRpcHttpService {
   private final int maxActiveConnections;
   private final AtomicInteger activeConnectionsCount = new AtomicInteger();
 
+  /** The Authentication service. */
   @VisibleForTesting public final Optional<AuthenticationService> authenticationService;
 
   private HttpServer httpServer;
@@ -169,6 +171,19 @@ public class JsonRpcHttpService {
         readinessService);
   }
 
+  /**
+   * Instantiates a new Json rpc http service.
+   *
+   * @param vertx the vertx
+   * @param dataDir the data dir
+   * @param config the config
+   * @param metricsSystem the metrics system
+   * @param natService the nat service
+   * @param methods the methods
+   * @param authenticationService the authentication service
+   * @param livenessService the liveness service
+   * @param readinessService the readiness service
+   */
   public JsonRpcHttpService(
       final Vertx vertx,
       final Path dataDir,
@@ -217,6 +232,11 @@ public class JsonRpcHttpService {
         config.getMaxActiveConnections() > 0, "Invalid max active connections configuration.");
   }
 
+  /**
+   * Start completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> start() {
     LOG.info("Starting JSON-RPC service on {}:{}", config.getHost(), config.getPort());
     LOG.debug("max number of active connections {}", maxActiveConnections);
@@ -523,6 +543,11 @@ public class JsonRpcHttpService {
     }
   }
 
+  /**
+   * Stop completable future.
+   *
+   * @return the completable future
+   */
   public CompletableFuture<?> stop() {
     if (httpServer == null) {
       return CompletableFuture.completedFuture(null);
@@ -541,6 +566,11 @@ public class JsonRpcHttpService {
     return resultFuture;
   }
 
+  /**
+   * Socket address inet socket address.
+   *
+   * @return the inet socket address
+   */
   public InetSocketAddress socketAddress() {
     if (httpServer == null) {
       return EMPTY_SOCKET_ADDRESS;
@@ -548,6 +578,11 @@ public class JsonRpcHttpService {
     return new InetSocketAddress(config.getHost(), httpServer.actualPort());
   }
 
+  /**
+   * Url string.
+   *
+   * @return the string
+   */
   @VisibleForTesting
   public String url() {
     if (httpServer == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcServiceException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcServiceException.java
@@ -14,8 +14,14 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc;
 
+/** The type Json rpc service exception. */
 public class JsonRpcServiceException extends RuntimeException {
 
+  /**
+   * Instantiates a new Json rpc service exception.
+   *
+   * @param message the message
+   */
   public JsonRpcServiceException(final String message) {
     super(message);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/LatestNonceProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/LatestNonceProvider.java
@@ -21,11 +21,18 @@ import org.hyperledger.besu.ethereum.util.NonceProvider;
 
 import java.util.OptionalLong;
 
+/** The type Latest nonce provider. */
 public class LatestNonceProvider implements NonceProvider {
 
   private final BlockchainQueries blockchainQueries;
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Latest nonce provider.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionPool the transaction pool
+   */
   public LatestNonceProvider(
       final BlockchainQueries blockchainQueries, final TransactionPool transactionPool) {
     this.blockchainQueries = blockchainQueries;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcApis.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcApis.java
@@ -19,30 +19,50 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/** The enum Rpc apis. */
 public enum RpcApis {
+  /** Eth rpc apis. */
   ETH,
+  /** Debug rpc apis. */
   DEBUG,
+  /** Miner rpc apis. */
   MINER,
+  /** Net rpc apis. */
   NET,
+  /** Perm rpc apis. */
   PERM,
+  /** Web 3 rpc apis. */
   WEB3,
+  /** Admin rpc apis. */
   ADMIN,
+  /** Eea rpc apis. */
   EEA,
+  /** Priv rpc apis. */
   PRIV,
+  /** Txpool rpc apis. */
   TXPOOL,
+  /** Trace rpc apis. */
   TRACE,
+  /** Plugins rpc apis. */
   PLUGINS,
+  /** Clique rpc apis. */
   CLIQUE,
+  /** Ibft rpc apis. */
   IBFT,
+  /** Engine rpc apis. */
   ENGINE,
+  /** Qbft rpc apis. */
   QBFT;
 
+  /** The constant DEFAULT_RPC_APIS. */
   public static final List<String> DEFAULT_RPC_APIS = Arrays.asList("ETH", "NET", "WEB3");
 
+  /** The constant ALL_JSON_RPC_APIS. */
   @SuppressWarnings("unused")
   public static final List<RpcApis> ALL_JSON_RPC_APIS =
       Arrays.asList(ETH, DEBUG, MINER, NET, PERM, WEB3, ADMIN, EEA, PRIV, TXPOOL, TRACE, PLUGINS);
 
+  /** The constant VALID_APIS. */
   public static final List<String> VALID_APIS =
       Stream.of(RpcApis.values()).map(RpcApis::name).collect(Collectors.toList());
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -17,186 +17,366 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import java.util.Collection;
 import java.util.HashSet;
 
+/** The enum Rpc method. */
 public enum RpcMethod {
+  /** Admin add peer rpc method. */
   ADMIN_ADD_PEER("admin_addPeer"),
+  /** Admin node info rpc method. */
   ADMIN_NODE_INFO("admin_nodeInfo"),
+  /** Admin peers rpc method. */
   ADMIN_PEERS("admin_peers"),
+  /** Admin remove peer rpc method. */
   ADMIN_REMOVE_PEER("admin_removePeer"),
+  /** Admin change log level rpc method. */
   ADMIN_CHANGE_LOG_LEVEL("admin_changeLogLevel"),
+  /** Admin generate log bloom cache rpc method. */
   ADMIN_GENERATE_LOG_BLOOM_CACHE("admin_generateLogBloomCache"),
+  /** Admin logs repair cache rpc method. */
   ADMIN_LOGS_REPAIR_CACHE("admin_logsRepairCache"),
+  /** Admin logs remove cache rpc method. */
   ADMIN_LOGS_REMOVE_CACHE("admin_logsRemoveCache"),
+  /** Clique discard rpc method. */
   CLIQUE_DISCARD("clique_discard"),
+  /** Clique get signers rpc method. */
   CLIQUE_GET_SIGNERS("clique_getSigners"),
+  /** Clique get signers at hash rpc method. */
   CLIQUE_GET_SIGNERS_AT_HASH("clique_getSignersAtHash"),
+  /** Clique get proposals rpc method. */
   CLIQUE_GET_PROPOSALS("clique_proposals"),
+  /** Clique propose rpc method. */
   CLIQUE_PROPOSE("clique_propose"),
+  /** Clique get signer metrics rpc method. */
   CLIQUE_GET_SIGNER_METRICS("clique_getSignerMetrics"),
+  /** Debug account at rpc method. */
   DEBUG_ACCOUNT_AT("debug_accountAt"),
+  /** Debug metrics rpc method. */
   DEBUG_METRICS("debug_metrics"),
+  /** Debug resync worldstate rpc method. */
   DEBUG_RESYNC_WORLDSTATE("debug_resyncWorldState"),
+  /** Debug set head rpc method. */
   DEBUG_SET_HEAD("debug_setHead"),
+  /** Debug replay block rpc method. */
   DEBUG_REPLAY_BLOCK("debug_replayBlock"),
+  /** Debug storage range at rpc method. */
   DEBUG_STORAGE_RANGE_AT("debug_storageRangeAt"),
+  /** Debug trace block rpc method. */
   DEBUG_TRACE_BLOCK("debug_traceBlock"),
+  /** Debug trace block by hash rpc method. */
   DEBUG_TRACE_BLOCK_BY_HASH("debug_traceBlockByHash"),
+  /** Debug trace block by number rpc method. */
   DEBUG_TRACE_BLOCK_BY_NUMBER("debug_traceBlockByNumber"),
+  /** Debug standard trace block to file rpc method. */
   DEBUG_STANDARD_TRACE_BLOCK_TO_FILE("debug_standardTraceBlockToFile"),
+  /** Debug standard trace bad block to file rpc method. */
   DEBUG_STANDARD_TRACE_BAD_BLOCK_TO_FILE("debug_standardTraceBadBlockToFile"),
+  /** Debug trace transaction rpc method. */
   DEBUG_TRACE_TRANSACTION("debug_traceTransaction"),
+  /** Debug trace call rpc method. */
   DEBUG_TRACE_CALL("debug_traceCall"),
+  /** Debug batch raw transaction rpc method. */
   DEBUG_BATCH_RAW_TRANSACTION("debug_batchSendRawTransaction"),
+  /** Debug get bad blocks rpc method. */
   DEBUG_GET_BAD_BLOCKS("debug_getBadBlocks"),
+  /** Debug get raw header rpc method. */
   DEBUG_GET_RAW_HEADER("debug_getRawHeader"),
+  /** Debug get raw block rpc method. */
   DEBUG_GET_RAW_BLOCK("debug_getRawBlock"),
+  /** Debug get raw receipts rpc method. */
   DEBUG_GET_RAW_RECEIPTS("debug_getRawReceipts"),
+  /** Debug get raw transaction rpc method. */
   DEBUG_GET_RAW_TRANSACTION("debug_getRawTransaction"),
+  /** Engine get payload v 1 rpc method. */
   ENGINE_GET_PAYLOAD_V1("engine_getPayloadV1"),
+  /** Engine get payload v 2 rpc method. */
   ENGINE_GET_PAYLOAD_V2("engine_getPayloadV2"),
+  /** Engine get payload v 3 rpc method. */
   ENGINE_GET_PAYLOAD_V3("engine_getPayloadV3"),
+  /** Engine get payload v 4 rpc method. */
   ENGINE_GET_PAYLOAD_V4("engine_getPayloadV4"),
+  /** Engine new payload v 1 rpc method. */
   ENGINE_NEW_PAYLOAD_V1("engine_newPayloadV1"),
+  /** Engine new payload v 2 rpc method. */
   ENGINE_NEW_PAYLOAD_V2("engine_newPayloadV2"),
+  /** Engine new payload v 3 rpc method. */
   ENGINE_NEW_PAYLOAD_V3("engine_newPayloadV3"),
+  /** Engine new payload v 4 rpc method. */
   ENGINE_NEW_PAYLOAD_V4("engine_newPayloadV4"),
+  /** Engine forkchoice updated v 1 rpc method. */
   ENGINE_FORKCHOICE_UPDATED_V1("engine_forkchoiceUpdatedV1"),
+  /** Engine forkchoice updated v 2 rpc method. */
   ENGINE_FORKCHOICE_UPDATED_V2("engine_forkchoiceUpdatedV2"),
+  /** Engine forkchoice updated v 3 rpc method. */
   ENGINE_FORKCHOICE_UPDATED_V3("engine_forkchoiceUpdatedV3"),
+  /** Engine exchange transition configuration rpc method. */
   ENGINE_EXCHANGE_TRANSITION_CONFIGURATION("engine_exchangeTransitionConfigurationV1"),
+  /** Engine get payload bodies by hash v 1 rpc method. */
   ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1("engine_getPayloadBodiesByHashV1"),
+  /** Engine get payload bodies by range v 1 rpc method. */
   ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1("engine_getPayloadBodiesByRangeV1"),
+  /** Engine exchange capabilities rpc method. */
   ENGINE_EXCHANGE_CAPABILITIES("engine_exchangeCapabilities"),
+  /** Engine prepare payload debug rpc method. */
   ENGINE_PREPARE_PAYLOAD_DEBUG("engine_preparePayload_debug"),
+  /** Priv call rpc method. */
   PRIV_CALL("priv_call"),
+  /** Priv get private transaction rpc method. */
   PRIV_GET_PRIVATE_TRANSACTION("priv_getPrivateTransaction"),
+  /** Priv get transaction count rpc method. */
   PRIV_GET_TRANSACTION_COUNT("priv_getTransactionCount"),
+  /** Priv get privacy precompile address rpc method. */
   PRIV_GET_PRIVACY_PRECOMPILE_ADDRESS("priv_getPrivacyPrecompileAddress"),
+  /** Priv get transaction receipt rpc method. */
   PRIV_GET_TRANSACTION_RECEIPT("priv_getTransactionReceipt"),
+  /** Priv create privacy group rpc method. */
   PRIV_CREATE_PRIVACY_GROUP("priv_createPrivacyGroup"),
+  /** Priv delete privacy group rpc method. */
   PRIV_DELETE_PRIVACY_GROUP("priv_deletePrivacyGroup"),
+  /** Priv find privacy group rpc method. */
   PRIV_FIND_PRIVACY_GROUP("priv_findPrivacyGroup"),
+  /** Priv debug get state root rpc method. */
   PRIV_DEBUG_GET_STATE_ROOT("priv_debugGetStateRoot"),
+  /** Priv distribute raw transaction rpc method. */
   PRIV_DISTRIBUTE_RAW_TRANSACTION("priv_distributeRawTransaction"),
+  /** Priv get eea transaction count rpc method. */
   PRIV_GET_EEA_TRANSACTION_COUNT("priv_getEeaTransactionCount"),
+  /** Priv get code rpc method. */
   PRIV_GET_CODE("priv_getCode"),
+  /** Priv get logs rpc method. */
   PRIV_GET_LOGS("priv_getLogs"),
+  /** Priv new filter rpc method. */
   PRIV_NEW_FILTER("priv_newFilter"),
+  /** Priv uninstall filter rpc method. */
   PRIV_UNINSTALL_FILTER("priv_uninstallFilter"),
+  /** Priv get filter changes rpc method. */
   PRIV_GET_FILTER_CHANGES("priv_getFilterChanges"),
+  /** Priv get filter logs rpc method. */
   PRIV_GET_FILTER_LOGS("priv_getFilterLogs"),
+  /** Priv subscribe rpc method. */
   PRIV_SUBSCRIBE("priv_subscribe"),
+  /** Priv unsubscribe rpc method. */
   PRIV_UNSUBSCRIBE("priv_unsubscribe"),
+  /** Privx find privacy group old rpc method. */
   PRIVX_FIND_PRIVACY_GROUP_OLD("privx_findOnchainPrivacyGroup"),
+  /** Privx find privacy group rpc method. */
   PRIVX_FIND_PRIVACY_GROUP("privx_findFlexiblePrivacyGroup"),
+  /** Eea send raw transaction rpc method. */
   EEA_SEND_RAW_TRANSACTION("eea_sendRawTransaction"),
+  /** Eth accounts rpc method. */
   ETH_ACCOUNTS("eth_accounts"),
+  /** Eth block number rpc method. */
   ETH_BLOCK_NUMBER("eth_blockNumber"),
+  /** Eth call rpc method. */
   ETH_CALL("eth_call"),
+  /** Eth chain id rpc method. */
   ETH_CHAIN_ID("eth_chainId"),
+  /** Eth coinbase rpc method. */
   ETH_COINBASE("eth_coinbase"),
+  /** Eth estimate gas rpc method. */
   ETH_ESTIMATE_GAS("eth_estimateGas"),
+  /** Eth create access list rpc method. */
   ETH_CREATE_ACCESS_LIST("eth_createAccessList"),
+  /** Eth fee history rpc method. */
   ETH_FEE_HISTORY("eth_feeHistory"),
+  /** Eth gas price rpc method. */
   ETH_GAS_PRICE("eth_gasPrice"),
+  /** Eth blob base fee rpc method. */
   ETH_BLOB_BASE_FEE("eth_blobBaseFee"),
+  /** Eth get balance rpc method. */
   ETH_GET_BALANCE("eth_getBalance"),
+  /** Eth get block by hash rpc method. */
   ETH_GET_BLOCK_BY_HASH("eth_getBlockByHash"),
+  /** Eth get block by number rpc method. */
   ETH_GET_BLOCK_BY_NUMBER("eth_getBlockByNumber"),
+  /** Eth get block receipts rpc method. */
   ETH_GET_BLOCK_RECEIPTS("eth_getBlockReceipts"),
+  /** Eth get block transaction count by hash rpc method. */
   ETH_GET_BLOCK_TRANSACTION_COUNT_BY_HASH("eth_getBlockTransactionCountByHash"),
+  /** Eth get block transaction count by number rpc method. */
   ETH_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER("eth_getBlockTransactionCountByNumber"),
+  /** Eth get code rpc method. */
   ETH_GET_CODE("eth_getCode"),
+  /** Eth get filter changes rpc method. */
   ETH_GET_FILTER_CHANGES("eth_getFilterChanges"),
+  /** Eth get filter logs rpc method. */
   ETH_GET_FILTER_LOGS("eth_getFilterLogs"),
+  /** Eth get logs rpc method. */
   ETH_GET_LOGS("eth_getLogs"),
+  /** Eth get miner data by block hash rpc method. */
   ETH_GET_MINER_DATA_BY_BLOCK_HASH("eth_getMinerDataByBlockHash"),
+  /** Eth get miner data by block number rpc method. */
   ETH_GET_MINER_DATA_BY_BLOCK_NUMBER("eth_getMinerDataByBlockNumber"),
+  /** Eth get proof rpc method. */
   ETH_GET_PROOF("eth_getProof"),
+  /** Eth get storage at rpc method. */
   ETH_GET_STORAGE_AT("eth_getStorageAt"),
+  /** Eth get transaction by block hash and index rpc method. */
   ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX("eth_getTransactionByBlockHashAndIndex"),
+  /** Eth get transaction by block number and index rpc method. */
   ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX("eth_getTransactionByBlockNumberAndIndex"),
+  /** Eth get transaction by hash rpc method. */
   ETH_GET_TRANSACTION_BY_HASH("eth_getTransactionByHash"),
+  /** Eth get transaction count rpc method. */
   ETH_GET_TRANSACTION_COUNT("eth_getTransactionCount"),
+  /** Eth get transaction receipt rpc method. */
   ETH_GET_TRANSACTION_RECEIPT("eth_getTransactionReceipt"),
+  /** Eth get uncle by block hash and index rpc method. */
   ETH_GET_UNCLE_BY_BLOCK_HASH_AND_INDEX("eth_getUncleByBlockHashAndIndex"),
+  /** Eth get uncle by block number and index rpc method. */
   ETH_GET_UNCLE_BY_BLOCK_NUMBER_AND_INDEX("eth_getUncleByBlockNumberAndIndex"),
+  /** Eth get uncle count by block hash rpc method. */
   ETH_GET_UNCLE_COUNT_BY_BLOCK_HASH("eth_getUncleCountByBlockHash"),
+  /** Eth get uncle count by block number rpc method. */
   ETH_GET_UNCLE_COUNT_BY_BLOCK_NUMBER("eth_getUncleCountByBlockNumber"),
+  /** Eth get work rpc method. */
   ETH_GET_WORK("eth_getWork"),
+  /** Eth hashrate rpc method. */
   ETH_HASHRATE("eth_hashrate"),
+  /** Eth mining rpc method. */
   ETH_MINING("eth_mining"),
+  /** Eth new block filter rpc method. */
   ETH_NEW_BLOCK_FILTER("eth_newBlockFilter"),
+  /** Eth new filter rpc method. */
   ETH_NEW_FILTER("eth_newFilter"),
+  /** Eth new pending transaction filter rpc method. */
   ETH_NEW_PENDING_TRANSACTION_FILTER("eth_newPendingTransactionFilter"),
+  /** Eth protocol version rpc method. */
   ETH_PROTOCOL_VERSION("eth_protocolVersion"),
+  /** Eth send raw private transaction rpc method. */
   ETH_SEND_RAW_PRIVATE_TRANSACTION("eth_sendRawPrivateTransaction"),
+  /** Eth send raw transaction rpc method. */
   ETH_SEND_RAW_TRANSACTION("eth_sendRawTransaction"),
+  /** Eth send transaction rpc method. */
   ETH_SEND_TRANSACTION("eth_sendTransaction"),
+  /** Eth submit hashrate rpc method. */
   ETH_SUBMIT_HASHRATE("eth_submitHashrate"),
+  /** Eth submit work rpc method. */
   ETH_SUBMIT_WORK("eth_submitWork"),
+  /** Eth subscribe rpc method. */
   ETH_SUBSCRIBE("eth_subscribe"),
+  /** Eth syncing rpc method. */
   ETH_SYNCING("eth_syncing"),
+  /** Eth uninstall filter rpc method. */
   ETH_UNINSTALL_FILTER("eth_uninstallFilter"),
+  /** Eth unsubscribe rpc method. */
   ETH_UNSUBSCRIBE("eth_unsubscribe"),
+  /** Ibft discard validator vote rpc method. */
   IBFT_DISCARD_VALIDATOR_VOTE("ibft_discardValidatorVote"),
+  /** Ibft get pending votes rpc method. */
   IBFT_GET_PENDING_VOTES("ibft_getPendingVotes"),
+  /** Ibft get validators by block hash rpc method. */
   IBFT_GET_VALIDATORS_BY_BLOCK_HASH("ibft_getValidatorsByBlockHash"),
+  /** Ibft get validators by block number rpc method. */
   IBFT_GET_VALIDATORS_BY_BLOCK_NUMBER("ibft_getValidatorsByBlockNumber"),
+  /** Ibft propose validator vote rpc method. */
   IBFT_PROPOSE_VALIDATOR_VOTE("ibft_proposeValidatorVote"),
+  /** Ibft get signer metrics rpc method. */
   IBFT_GET_SIGNER_METRICS("ibft_getSignerMetrics"),
+  /** Qbft discard validator vote rpc method. */
   QBFT_DISCARD_VALIDATOR_VOTE("qbft_discardValidatorVote"),
+  /** Qbft get pending votes rpc method. */
   QBFT_GET_PENDING_VOTES("qbft_getPendingVotes"),
+  /** Qbft get validators by block hash rpc method. */
   QBFT_GET_VALIDATORS_BY_BLOCK_HASH("qbft_getValidatorsByBlockHash"),
+  /** Qbft get validators by block number rpc method. */
   QBFT_GET_VALIDATORS_BY_BLOCK_NUMBER("qbft_getValidatorsByBlockNumber"),
+  /** Qbft propose validator vote rpc method. */
   QBFT_PROPOSE_VALIDATOR_VOTE("qbft_proposeValidatorVote"),
+  /** Qbft get signer metrics rpc method. */
   QBFT_GET_SIGNER_METRICS("qbft_getSignerMetrics"),
+  /** Miner change target gas limit rpc method. */
   MINER_CHANGE_TARGET_GAS_LIMIT("miner_changeTargetGasLimit"),
+  /** Miner set coinbase rpc method. */
   MINER_SET_COINBASE("miner_setCoinbase"),
+  /** Miner set etherbase rpc method. */
   MINER_SET_ETHERBASE("miner_setEtherbase"),
+  /** Miner start rpc method. */
   MINER_START("miner_start"),
+  /** Miner stop rpc method. */
   MINER_STOP("miner_stop"),
+  /** Miner get min priority fee rpc method. */
   MINER_GET_MIN_PRIORITY_FEE("miner_getMinPriorityFee"),
+  /** Miner set min priority fee rpc method. */
   MINER_SET_MIN_PRIORITY_FEE("miner_setMinPriorityFee"),
+  /** Miner get min gas price rpc method. */
   MINER_GET_MIN_GAS_PRICE("miner_getMinGasPrice"),
+  /** Miner set min gas price rpc method. */
   MINER_SET_MIN_GAS_PRICE("miner_setMinGasPrice"),
+  /** Net enode rpc method. */
   NET_ENODE("net_enode"),
+  /** Net listening rpc method. */
   NET_LISTENING("net_listening"),
+  /** Net peer count rpc method. */
   NET_PEER_COUNT("net_peerCount"),
+  /** Net services rpc method. */
   NET_SERVICES("net_services"),
+  /** Net version rpc method. */
   NET_VERSION("net_version"),
+  /** Perm add accounts to whitelist rpc method. */
   PERM_ADD_ACCOUNTS_TO_WHITELIST("perm_addAccountsToWhitelist"),
+  /** Perm add accounts to allowlist rpc method. */
   PERM_ADD_ACCOUNTS_TO_ALLOWLIST("perm_addAccountsToAllowlist"),
+  /** Perm add nodes to whitelist rpc method. */
   PERM_ADD_NODES_TO_WHITELIST("perm_addNodesToWhitelist"),
+  /** Perm add nodes to allowlist rpc method. */
   PERM_ADD_NODES_TO_ALLOWLIST("perm_addNodesToAllowlist"),
+  /** Perm get accounts whitelist rpc method. */
   PERM_GET_ACCOUNTS_WHITELIST("perm_getAccountsWhitelist"),
+  /** Perm get accounts allowlist rpc method. */
   PERM_GET_ACCOUNTS_ALLOWLIST("perm_getAccountsAllowlist"),
+  /** Perm get nodes whitelist rpc method. */
   PERM_GET_NODES_WHITELIST("perm_getNodesWhitelist"),
+  /** Perm get nodes allowlist rpc method. */
   PERM_GET_NODES_ALLOWLIST("perm_getNodesAllowlist"),
+  /** Perm reload permissions from file rpc method. */
   PERM_RELOAD_PERMISSIONS_FROM_FILE("perm_reloadPermissionsFromFile"),
+  /** Perm remove accounts from whitelist rpc method. */
   PERM_REMOVE_ACCOUNTS_FROM_WHITELIST("perm_removeAccountsFromWhitelist"),
+  /** Perm remove accounts from allowlist rpc method. */
   PERM_REMOVE_ACCOUNTS_FROM_ALLOWLIST("perm_removeAccountsFromAllowlist"),
+  /** Perm remove nodes from whitelist rpc method. */
   PERM_REMOVE_NODES_FROM_WHITELIST("perm_removeNodesFromWhitelist"),
+  /** Perm remove nodes from allowlist rpc method. */
   PERM_REMOVE_NODES_FROM_ALLOWLIST("perm_removeNodesFromAllowlist"),
+  /** Rpc modules rpc method. */
   RPC_MODULES("rpc_modules"),
+  /** Trace block rpc method. */
   TRACE_BLOCK("trace_block"),
+  /** Trace call rpc method. */
   TRACE_CALL("trace_call"),
+  /** Trace call many rpc method. */
   TRACE_CALL_MANY("trace_callMany"),
+  /** Trace get rpc method. */
   TRACE_GET("trace_get"),
+  /** Trace filter rpc method. */
   TRACE_FILTER("trace_filter"),
+  /** Trace raw transaction rpc method. */
   TRACE_RAW_TRANSACTION("trace_rawTransaction"),
+  /** Trace replay block transactions rpc method. */
   TRACE_REPLAY_BLOCK_TRANSACTIONS("trace_replayBlockTransactions"),
+  /** Trace transaction rpc method. */
   TRACE_TRANSACTION("trace_transaction"),
+  /** Tx pool besu statistics rpc method. */
   TX_POOL_BESU_STATISTICS("txpool_besuStatistics"),
+  /** Tx pool besu transactions rpc method. */
   TX_POOL_BESU_TRANSACTIONS("txpool_besuTransactions"),
+  /** Tx pool besu pending transactions rpc method. */
   TX_POOL_BESU_PENDING_TRANSACTIONS("txpool_besuPendingTransactions"),
+  /** Web 3 client version rpc method. */
   WEB3_CLIENT_VERSION("web3_clientVersion"),
+  /** Web 3 sha 3 rpc method. */
   WEB3_SHA3("web3_sha3"),
+  /** Plugins reload config rpc method. */
   PLUGINS_RELOAD_CONFIG("plugins_reloadPluginConfig");
 
   private final String methodName;
 
   private static final Collection<String> allMethodNames;
 
+  /**
+   * Gets method name.
+   *
+   * @return the method name
+   */
   public String getMethodName() {
     return methodName;
   }
@@ -212,6 +392,12 @@ public enum RpcMethod {
     this.methodName = methodName;
   }
 
+  /**
+   * Rpc method exists boolean.
+   *
+   * @param rpcMethodName the rpc method name
+   * @return the boolean
+   */
   public static boolean rpcMethodExists(final String rpcMethodName) {
     return allMethodNames.contains(rpcMethodName);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationService.java
@@ -24,13 +24,38 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.jwt.JWTAuth;
 import io.vertx.ext.web.RoutingContext;
 
+/** The interface Authentication service. */
 public interface AuthenticationService {
+  /**
+   * Handle login.
+   *
+   * @param routingContext the routing context
+   */
   void handleLogin(RoutingContext routingContext);
 
+  /**
+   * Gets jwt auth provider.
+   *
+   * @return the jwt auth provider
+   */
   JWTAuth getJwtAuthProvider();
 
+  /**
+   * Authenticate.
+   *
+   * @param token the token
+   * @param handler the handler
+   */
   void authenticate(String token, Handler<Optional<User>> handler);
 
+  /**
+   * Is permitted boolean.
+   *
+   * @param optionalUser the optional user
+   * @param jsonRpcMethod the json rpc method
+   * @param noAuthMethods the no auth methods
+   * @return the boolean
+   */
   boolean isPermitted(
       final Optional<User> optionalUser,
       final JsonRpcMethod jsonRpcMethod,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/AuthenticationUtils.java
@@ -16,8 +16,16 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
 import java.util.Optional;
 
+/** The type Authentication utils. */
 public class AuthenticationUtils {
+  private AuthenticationUtils() {}
 
+  /**
+   * Gets jwt token from authorization header value.
+   *
+   * @param value the value
+   * @return the jwt token from authorization header value
+   */
   public static String getJwtTokenFromAuthorizationHeaderValue(final String value) {
     if (value != null) {
       final String bearerSchemaName = "Bearer ";
@@ -28,6 +36,12 @@ public class AuthenticationUtils {
     return null;
   }
 
+  /**
+   * Trunc token string.
+   *
+   * @param jwtToken the jwt token
+   * @return the string
+   */
   public static String truncToken(final String jwtToken) {
     return Optional.ofNullable(jwtToken)
         .map(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/DefaultAuthenticationService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/DefaultAuthenticationService.java
@@ -45,14 +45,28 @@ import org.slf4j.LoggerFactory;
 /** Provides authentication handlers for use in the http and websocket services */
 public class DefaultAuthenticationService implements AuthenticationService {
 
+  /** The constant USERNAME. */
   public static final String USERNAME = "username";
+
+  /** The constant PASSWORD. */
   public static final String PASSWORD = "password";
+
   private final JWTAuth jwtAuthProvider;
+
+  /** The Jwt auth options. */
   @VisibleForTesting public final JWTAuthOptions jwtAuthOptions;
+
   private final Optional<AuthenticationProvider> credentialAuthProvider;
   private static final JWTAuthOptionsFactory jwtAuthOptionsFactory = new JWTAuthOptionsFactory();
   private static final Logger LOG = LoggerFactory.getLogger(DefaultAuthenticationService.class);
 
+  /**
+   * Instantiates a new Default authentication service.
+   *
+   * @param jwtAuthProvider the jwt auth provider
+   * @param jwtAuthOptions the jwt auth options
+   * @param credentialAuthProvider the credential auth provider
+   */
   public DefaultAuthenticationService(
       final JWTAuth jwtAuthProvider,
       final JWTAuthOptions jwtAuthOptions,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/EngineAuthService.java
@@ -39,21 +39,35 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine auth service. */
 public class EngineAuthService implements AuthenticationService {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineAuthService.class);
   private static final int JWT_EXPIRATION_TIME_IN_SECONDS = 60;
 
+  /** The constant EPHEMERAL_JWT_FILE. */
   public static final String EPHEMERAL_JWT_FILE = "jwt.hex";
 
   private final JWTAuth jwtAuthProvider;
 
+  /**
+   * Instantiates a new Engine auth service.
+   *
+   * @param vertx the vertx
+   * @param signingKey the signing key
+   * @param datadir the datadir
+   */
   public EngineAuthService(final Vertx vertx, final Optional<File> signingKey, final Path datadir) {
     final JWTAuthOptions jwtAuthOptions =
         engineApiJWTOptions(JwtAlgorithm.HS256, signingKey, datadir);
     this.jwtAuthProvider = JWTAuth.create(vertx, jwtAuthOptions);
   }
 
+  /**
+   * Create token string.
+   *
+   * @return the string
+   */
   public String createToken() {
     JsonObject claims = new JsonObject();
     claims.put("iat", System.currentTimeMillis() / 1000);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JWTAuthOptionsFactory.java
@@ -33,14 +33,31 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
 
+/** The type Jwt auth options factory. */
 public class JWTAuthOptionsFactory {
 
   private static final JwtAlgorithm DEFAULT = JwtAlgorithm.RS256;
 
+  /** Default constructor. */
+  public JWTAuthOptionsFactory() {}
+
+  /**
+   * Create for external public key jwt auth options.
+   *
+   * @param externalPublicKeyFile the external public key file
+   * @return the jwt auth options
+   */
   public JWTAuthOptions createForExternalPublicKey(final File externalPublicKeyFile) {
     return createForExternalPublicKeyWithAlgorithm(externalPublicKeyFile, DEFAULT);
   }
 
+  /**
+   * Create for external public key with algorithm jwt auth options.
+   *
+   * @param externalPublicKeyFile the external public key file
+   * @param algorithm the algorithm
+   * @return the jwt auth options
+   */
   public JWTAuthOptions createForExternalPublicKeyWithAlgorithm(
       final File externalPublicKeyFile, final JwtAlgorithm algorithm) {
     final byte[] externalJwtPublicKey = readPublicKey(externalPublicKeyFile);
@@ -51,6 +68,12 @@ public class JWTAuthOptionsFactory {
                 .setBuffer(keyPairToPublicPemString(externalJwtPublicKey)));
   }
 
+  /**
+   * Create with generated key pair jwt auth options.
+   *
+   * @param jwtAlgorithm the jwt algorithm
+   * @return the jwt auth options
+   */
   public JWTAuthOptions createWithGeneratedKeyPair(final JwtAlgorithm jwtAlgorithm) {
     if (jwtAlgorithm.toString().startsWith("H")) {
       throw new IllegalArgumentException(
@@ -68,6 +91,12 @@ public class JWTAuthOptionsFactory {
                 .setBuffer(keyPairToPrivatePemString(keypair)));
   }
 
+  /**
+   * Engine api jwt options jwt auth options.
+   *
+   * @param jwtAlgorithm the jwt algorithm
+   * @return the jwt auth options
+   */
   public JWTAuthOptions engineApiJWTOptions(final JwtAlgorithm jwtAlgorithm) {
     byte[] ephemeralKey = Bytes32.random().toArray();
     return new JWTAuthOptions()
@@ -78,6 +107,11 @@ public class JWTAuthOptionsFactory {
                 .setBuffer(Buffer.buffer(ephemeralKey)));
   }
 
+  /**
+   * Create with generated key pair jwt auth options.
+   *
+   * @return the jwt auth options
+   */
   public JWTAuthOptions createWithGeneratedKeyPair() {
     return createWithGeneratedKeyPair(JwtAlgorithm.RS256);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JwtAlgorithm.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/JwtAlgorithm.java
@@ -14,15 +14,29 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
+/** The enum Jwt algorithm. */
 public enum JwtAlgorithm {
+  /** Rs 256 jwt algorithm. */
   RS256,
+  /** Rs 384 jwt algorithm. */
   RS384,
+  /** Rs 512 jwt algorithm. */
   RS512,
+  /** Es 256 jwt algorithm. */
   ES256,
+  /** Es 384 jwt algorithm. */
   ES384,
+  /** Hs 256 jwt algorithm. */
   HS256,
+  /** Es 512 jwt algorithm. */
   ES512;
 
+  /**
+   * From string jwt algorithm.
+   *
+   * @param str the str
+   * @return the jwt algorithm
+   */
   public static JwtAlgorithm fromString(final String str) {
     for (final JwtAlgorithm alg : JwtAlgorithm.values()) {
       if (alg.name().equalsIgnoreCase(str)) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuth.java
@@ -31,12 +31,21 @@ import org.apache.tuweni.toml.TomlParseResult;
 import org.apache.tuweni.toml.TomlTable;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
+/** The type Toml auth. */
 public class TomlAuth implements AuthenticationProvider {
 
+  /** The constant PRIVACY_PUBLIC_KEY. */
   public static final String PRIVACY_PUBLIC_KEY = "privacyPublicKey";
+
   private final Vertx vertx;
   private final TomlAuthOptions options;
 
+  /**
+   * Instantiates a new Toml auth.
+   *
+   * @param vertx the vertx
+   * @param options the options
+   */
   public TomlAuth(final Vertx vertx, final TomlAuthOptions options) {
     this.vertx = vertx;
     this.options = options;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuthOptions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlAuthOptions.java
@@ -19,25 +19,49 @@ import java.nio.file.Paths;
 
 import io.vertx.core.Vertx;
 
+/** The type Toml auth options. */
 public class TomlAuthOptions {
 
   private Path tomlPath;
 
+  /** Instantiates a new Toml auth options. */
   public TomlAuthOptions() {}
 
+  /**
+   * Instantiates a new Toml auth options.
+   *
+   * @param that the that
+   */
   public TomlAuthOptions(final TomlAuthOptions that) {
     tomlPath = that.tomlPath;
   }
 
+  /**
+   * Create provider toml auth.
+   *
+   * @param vertx the vertx
+   * @return the toml auth
+   */
   public TomlAuth createProvider(final Vertx vertx) {
     return new TomlAuth(vertx, this);
   }
 
+  /**
+   * Sets toml path.
+   *
+   * @param tomlPath the toml path
+   * @return the toml path
+   */
   public TomlAuthOptions setTomlPath(final String tomlPath) {
     this.tomlPath = Paths.get(tomlPath);
     return this;
   }
 
+  /**
+   * Gets toml path.
+   *
+   * @return the toml path
+   */
   public Path getTomlPath() {
     return tomlPath;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/TomlUser.java
@@ -25,6 +25,7 @@ import io.vertx.ext.auth.User;
 import io.vertx.ext.auth.authorization.Authorization;
 import io.vertx.ext.auth.authorization.Authorizations;
 
+/** The type Toml user. */
 public class TomlUser implements User {
 
   private final String username;
@@ -34,6 +35,16 @@ public class TomlUser implements User {
   private final List<String> roles;
   private final Optional<String> privacyPublicKey;
 
+  /**
+   * Instantiates a new Toml user.
+   *
+   * @param username the username
+   * @param password the password
+   * @param groups the groups
+   * @param permissions the permissions
+   * @param roles the roles
+   * @param privacyPublicKey the privacy public key
+   */
   TomlUser(
       final String username,
       final String password,
@@ -104,32 +115,68 @@ public class TomlUser implements User {
     throw new UnsupportedOperationException("Not implemented");
   }
 
+  /**
+   * Do is permitted.
+   *
+   * @param permission the permission
+   * @param resultHandler the result handler
+   */
   protected void doIsPermitted(
       final String permission, final Handler<AsyncResult<Boolean>> resultHandler) {
     // we only use Toml for authentication
     throw new UnsupportedOperationException("Not implemented");
   }
 
+  /**
+   * Gets username.
+   *
+   * @return the username
+   */
   public String getUsername() {
     return username;
   }
 
+  /**
+   * Gets password.
+   *
+   * @return the password
+   */
   public String getPassword() {
     return password;
   }
 
+  /**
+   * Gets groups.
+   *
+   * @return the groups
+   */
   public List<String> getGroups() {
     return groups;
   }
 
+  /**
+   * Gets permissions.
+   *
+   * @return the permissions
+   */
   public List<String> getPermissions() {
     return permissions;
   }
 
+  /**
+   * Gets roles.
+   *
+   * @return the roles
+   */
   public List<String> getRoles() {
     return roles;
   }
 
+  /**
+   * Gets privacy public key.
+   *
+   * @return the privacy public key
+   */
   public Optional<String> getPrivacyPublicKey() {
     return privacyPublicKey;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/UnsecurableEngineApiException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/authentication/UnsecurableEngineApiException.java
@@ -14,10 +14,16 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.authentication;
 
+/** The type Unsecurable engine api exception. */
 /*
  * Thrown when config options are insufficient to secure the Engine API
  */
 public class UnsecurableEngineApiException extends RuntimeException {
+  /**
+   * Instantiates a new Unsecurable engine api exception.
+   *
+   * @param reason the reason
+   */
   public UnsecurableEngineApiException(final String reason) {
     super(reason);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/context/ContextKey.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/context/ContextKey.java
@@ -18,11 +18,23 @@ import java.util.function.Supplier;
 
 import io.vertx.ext.web.RoutingContext;
 
+/** The enum Context key. */
 public enum ContextKey {
+  /** Request body as json object context key. */
   REQUEST_BODY_AS_JSON_OBJECT,
+  /** Request body as json array context key. */
   REQUEST_BODY_AS_JSON_ARRAY,
+  /** Authenticated user context key. */
   AUTHENTICATED_USER;
 
+  /**
+   * Extract from t.
+   *
+   * @param <T> the type parameter
+   * @param ctx the ctx
+   * @param defaultSupplier the default supplier
+   * @return the t
+   */
   public <T> T extractFrom(final RoutingContext ctx, final Supplier<T> defaultSupplier) {
     final T value = ctx.get(this.name());
     return value != null ? value : defaultSupplier.get();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/AuthenticatedJsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/AuthenticatedJsonRpcProcessor.java
@@ -26,12 +26,20 @@ import java.util.Collection;
 
 import io.opentelemetry.api.trace.Span;
 
+/** The type Authenticated json rpc processor. */
 public class AuthenticatedJsonRpcProcessor implements JsonRpcProcessor {
 
   private final JsonRpcProcessor rpcProcessor;
   private final AuthenticationService authenticationService;
   private final Collection<String> noAuthRpcApis;
 
+  /**
+   * Instantiates a new Authenticated json rpc processor.
+   *
+   * @param rpcProcessor the rpc processor
+   * @param authenticationService the authentication service
+   * @param noAuthRpcApis the no auth rpc apis
+   */
   public AuthenticatedJsonRpcProcessor(
       final JsonRpcProcessor rpcProcessor,
       final AuthenticationService authenticationService,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/BaseJsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/BaseJsonRpcProcessor.java
@@ -30,9 +30,13 @@ import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Base json rpc processor. */
 public class BaseJsonRpcProcessor implements JsonRpcProcessor {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseJsonRpcProcessor.class);
+
+  /** Default constructor */
+  public BaseJsonRpcProcessor() {}
 
   @Override
   public JsonRpcResponse process(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/JsonRpcExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/JsonRpcExecutor.java
@@ -42,6 +42,7 @@ import io.vertx.ext.auth.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Json rpc executor. */
 public class JsonRpcExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(JsonRpcExecutor.class);
@@ -49,12 +50,29 @@ public class JsonRpcExecutor {
   private final JsonRpcProcessor rpcProcessor;
   private final Map<String, JsonRpcMethod> rpcMethods;
 
+  /**
+   * Instantiates a new Json rpc executor.
+   *
+   * @param rpcProcessor the rpc processor
+   * @param rpcMethods the rpc methods
+   */
   public JsonRpcExecutor(
       final JsonRpcProcessor rpcProcessor, final Map<String, JsonRpcMethod> rpcMethods) {
     this.rpcProcessor = rpcProcessor;
     this.rpcMethods = rpcMethods;
   }
 
+  /**
+   * Execute json rpc response.
+   *
+   * @param optionalUser the optional user
+   * @param tracer the tracer
+   * @param spanContext the span context
+   * @param alive the alive
+   * @param jsonRpcRequest the json rpc request
+   * @param requestBodyProvider the request body provider
+   * @return the json rpc response
+   */
   public JsonRpcResponse execute(
       final Optional<User> optionalUser,
       final Tracer tracer,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/JsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/JsonRpcProcessor.java
@@ -21,7 +21,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 
 import io.opentelemetry.api.trace.Span;
 
+/** The interface Json rpc processor. */
 public interface JsonRpcProcessor {
+  /**
+   * Process json rpc response.
+   *
+   * @param id the id
+   * @param method the method
+   * @param metricSpan the metric span
+   * @param request the request
+   * @return the json rpc response
+   */
   JsonRpcResponse process(
       final JsonRpcRequestId id,
       final JsonRpcMethod method,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TimedJsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TimedJsonRpcProcessor.java
@@ -23,11 +23,18 @@ import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import io.opentelemetry.api.trace.Span;
 
+/** The type Timed json rpc processor. */
 public class TimedJsonRpcProcessor implements JsonRpcProcessor {
 
   private final JsonRpcProcessor rpcProcessor;
   private final LabelledMetric<OperationTimer> requestTimer;
 
+  /**
+   * Instantiates a new Timed json rpc processor.
+   *
+   * @param rpcProcessor the rpc processor
+   * @param requestTimer the request timer
+   */
   public TimedJsonRpcProcessor(
       final JsonRpcProcessor rpcProcessor, final LabelledMetric<OperationTimer> requestTimer) {
     this.rpcProcessor = rpcProcessor;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TracedJsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TracedJsonRpcProcessor.java
@@ -28,11 +28,20 @@ import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 
+/** The type Traced json rpc processor. */
 public class TracedJsonRpcProcessor implements JsonRpcProcessor {
 
   private final JsonRpcProcessor rpcProcessor;
+
+  /** The Rpc errors counter. */
   protected final LabelledMetric<Counter> rpcErrorsCounter;
 
+  /**
+   * Instantiates a new Traced json rpc processor.
+   *
+   * @param rpcProcessor the rpc processor
+   * @param metricsSystem the metrics system
+   */
   public TracedJsonRpcProcessor(
       final JsonRpcProcessor rpcProcessor, final MetricsSystem metricsSystem) {
     this.rpcProcessor = rpcProcessor;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/HealthService.java
@@ -21,11 +21,16 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
+/** The type Health service. */
 public final class HealthService {
 
+  /** The constant ALWAYS_HEALTHY. */
   public static final HealthService ALWAYS_HEALTHY = new HealthService(params -> true);
 
+  /** The constant LIVENESS_PATH. */
   public static final String LIVENESS_PATH = "/liveness";
+
+  /** The constant READINESS_PATH. */
   public static final String READINESS_PATH = "/readiness";
 
   private static final int HEALTHY_STATUS_CODE = HttpResponseStatus.OK.code();
@@ -35,10 +40,20 @@ public final class HealthService {
 
   private final HealthCheck healthCheck;
 
+  /**
+   * Instantiates a new Health service.
+   *
+   * @param healthCheck the health check
+   */
   public HealthService(final HealthCheck healthCheck) {
     this.healthCheck = healthCheck;
   }
 
+  /**
+   * Handle request.
+   *
+   * @param routingContext the routing context
+   */
   public void handleRequest(final RoutingContext routingContext) {
     final int statusCode;
     final String statusText;
@@ -57,13 +72,27 @@ public final class HealthService {
     }
   }
 
+  /** The interface Health check. */
   @FunctionalInterface
   public interface HealthCheck {
+    /**
+     * Is healthy boolean.
+     *
+     * @param paramSource the param source
+     * @return the boolean
+     */
     boolean isHealthy(ParamSource paramSource);
   }
 
+  /** The interface Param source. */
   @FunctionalInterface
   public interface ParamSource {
+    /**
+     * Gets param.
+     *
+     * @param name the name
+     * @return the param
+     */
     String getParam(String name);
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/LivenessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/LivenessCheck.java
@@ -17,8 +17,12 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.health;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Liveness check. */
 public class LivenessCheck implements HealthService.HealthCheck {
   private static final Logger LOG = LoggerFactory.getLogger(LivenessCheck.class);
+
+  /** Default constructor. */
+  public LivenessCheck() {}
 
   @Override
   public boolean isHealthy(final HealthService.ParamSource params) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/health/ReadinessCheck.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.plugin.data.SyncStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Readiness check. */
 public class ReadinessCheck implements HealthService.HealthCheck {
   private static final Logger LOG = LoggerFactory.getLogger(ReadinessCheck.class);
   private static final int DEFAULT_MINIMUM_PEERS = 1;
@@ -28,6 +29,12 @@ public class ReadinessCheck implements HealthService.HealthCheck {
   private final P2PNetwork p2pNetwork;
   private final Synchronizer synchronizer;
 
+  /**
+   * Instantiates a new Readiness check.
+   *
+   * @param p2pNetwork the p 2 p network
+   * @param synchronizer the synchronizer
+   */
   public ReadinessCheck(final P2PNetwork p2pNetwork, final Synchronizer synchronizer) {
     this.p2pNetwork = p2pNetwork;
     this.synchronizer = synchronizer;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/DebugReplayBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/DebugReplayBlock.java
@@ -33,12 +33,20 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Debug replay block. */
 public class DebugReplayBlock extends AbstractBlockParameterMethod {
   private static final Logger LOG = LoggerFactory.getLogger(DebugReplayBlock.class);
 
   private final ProtocolContext protocolContext;
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Debug replay block.
+   *
+   * @param blockchain the blockchain
+   * @param protocolContext the protocol context
+   * @param protocolSchedule the protocol schedule
+   */
   public DebugReplayBlock(
       final BlockchainQueries blockchain,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 
+/** The type Json rpc request. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class JsonRpcRequest {
 
@@ -42,6 +43,13 @@ public class JsonRpcRequest {
   private final String version;
   private boolean isNotification = true;
 
+  /**
+   * Instantiates a new Json rpc request.
+   *
+   * @param version the version
+   * @param method the method
+   * @param params the params
+   */
   @JsonCreator
   public JsonRpcRequest(
       @JsonProperty("jsonrpc") final String version,
@@ -55,37 +63,72 @@ public class JsonRpcRequest {
     }
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   @JsonGetter("id")
   public Object getId() {
     return id == null ? null : id.getValue();
   }
 
+  /**
+   * Gets method.
+   *
+   * @return the method
+   */
   @JsonGetter("method")
   public String getMethod() {
     return method;
   }
 
+  /**
+   * Gets version.
+   *
+   * @return the version
+   */
   @JsonGetter("jsonrpc")
   public String getVersion() {
     return version;
   }
 
+  /**
+   * Get params object [ ].
+   *
+   * @return the object [ ]
+   */
   @JsonInclude(Include.NON_NULL)
   @JsonGetter("params")
   public Object[] getParams() {
     return params;
   }
 
+  /**
+   * Is notification boolean.
+   *
+   * @return the boolean
+   */
   @JsonIgnore
   public boolean isNotification() {
     return isNotification;
   }
 
+  /**
+   * Gets param length.
+   *
+   * @return the param length
+   */
   @JsonIgnore
   public int getParamLength() {
     return hasParams() ? params.length : 0;
   }
 
+  /**
+   * Has params boolean.
+   *
+   * @return the boolean
+   */
   @JsonIgnore
   public boolean hasParams() {
 
@@ -102,6 +145,11 @@ public class JsonRpcRequest {
     return true;
   }
 
+  /**
+   * Sets id.
+   *
+   * @param id the id
+   */
   @JsonSetter("id")
   protected void setId(final JsonRpcRequestId id) {
     // If an id is explicitly set, it is not a notification
@@ -130,14 +178,38 @@ public class JsonRpcRequest {
     return Objects.hash(id, method, Arrays.hashCode(params), version, isNotification);
   }
 
+  /**
+   * Gets required parameter.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param paramClass the param class
+   * @return the required parameter
+   */
   public <T> T getRequiredParameter(final int index, final Class<T> paramClass) {
     return parameterAccessor.required(params, index, paramClass);
   }
 
+  /**
+   * Gets optional parameter.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param paramClass the param class
+   * @return the optional parameter
+   */
   public <T> Optional<T> getOptionalParameter(final int index, final Class<T> paramClass) {
     return parameterAccessor.optional(params, index, paramClass);
   }
 
+  /**
+   * Gets optional list.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param paramClass the param class
+   * @return the optional list
+   */
   public <T> Optional<List<T>> getOptionalList(final int index, final Class<T> paramClass) {
     return parameterAccessor.optionalList(params, index, paramClass);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequestContext.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequestContext.java
@@ -21,29 +21,61 @@ import java.util.function.Supplier;
 
 import io.vertx.ext.auth.User;
 
+/** The type Json rpc request context. */
 public class JsonRpcRequestContext {
 
   private final JsonRpcRequest jsonRpcRequest;
   private final Optional<User> user;
   private final Supplier<Boolean> alive;
 
+  /**
+   * Instantiates a new Json rpc request context.
+   *
+   * @param jsonRpcRequest the json rpc request
+   */
   public JsonRpcRequestContext(final JsonRpcRequest jsonRpcRequest) {
     this(jsonRpcRequest, () -> true);
   }
 
+  /**
+   * Instantiates a new Json rpc request context.
+   *
+   * @param jsonRpcRequest the json rpc request
+   * @param alive the alive
+   */
   public JsonRpcRequestContext(final JsonRpcRequest jsonRpcRequest, final Supplier<Boolean> alive) {
     this(jsonRpcRequest, Optional.empty(), alive);
   }
 
+  /**
+   * Instantiates a new Json rpc request context.
+   *
+   * @param jsonRpcRequest the json rpc request
+   * @param user the user
+   */
   public JsonRpcRequestContext(final JsonRpcRequest jsonRpcRequest, final User user) {
     this(jsonRpcRequest, Optional.of(user), () -> true);
   }
 
+  /**
+   * Instantiates a new Json rpc request context.
+   *
+   * @param jsonRpcRequest the json rpc request
+   * @param user the user
+   * @param alive the alive
+   */
   public JsonRpcRequestContext(
       final JsonRpcRequest jsonRpcRequest, final User user, final Supplier<Boolean> alive) {
     this(jsonRpcRequest, Optional.of(user), alive);
   }
 
+  /**
+   * Instantiates a new Json rpc request context.
+   *
+   * @param jsonRpcRequest the json rpc request
+   * @param user the user
+   * @param alive the alive
+   */
   public JsonRpcRequestContext(
       final JsonRpcRequest jsonRpcRequest,
       final Optional<User> user,
@@ -53,22 +85,56 @@ public class JsonRpcRequestContext {
     this.alive = alive;
   }
 
+  /**
+   * Gets request.
+   *
+   * @return the request
+   */
   public JsonRpcRequest getRequest() {
     return jsonRpcRequest;
   }
 
+  /**
+   * Gets user.
+   *
+   * @return the user
+   */
   public Optional<User> getUser() {
     return user;
   }
 
+  /**
+   * Gets required parameter.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param paramClass the param class
+   * @return the required parameter
+   */
   public <T> T getRequiredParameter(final int index, final Class<T> paramClass) {
     return jsonRpcRequest.getRequiredParameter(index, paramClass);
   }
 
+  /**
+   * Gets optional parameter.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param paramClass the param class
+   * @return the optional parameter
+   */
   public <T> Optional<T> getOptionalParameter(final int index, final Class<T> paramClass) {
     return jsonRpcRequest.getOptionalParameter(index, paramClass);
   }
 
+  /**
+   * Gets optional list.
+   *
+   * @param <T> the type parameter
+   * @param index the index
+   * @param listOf the list of
+   * @return the optional list
+   */
   public <T> Optional<List<T>> getOptionalList(final int index, final Class<T> listOf) {
     return jsonRpcRequest.getOptionalList(index, listOf);
   }
@@ -90,6 +156,11 @@ public class JsonRpcRequestContext {
     return Objects.hash(jsonRpcRequest, user);
   }
 
+  /**
+   * Is alive boolean.
+   *
+   * @return the boolean
+   */
   public boolean isAlive() {
     return alive.get();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequestId.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/JsonRpcRequestId.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/** The type Json rpc request id. */
 public class JsonRpcRequestId {
 
   private static final Class<?>[] VALID_ID_TYPES =
@@ -31,6 +32,11 @@ public class JsonRpcRequestId {
 
   private final Object id;
 
+  /**
+   * Instantiates a new Json rpc request id.
+   *
+   * @param id the id
+   */
   @JsonCreator
   public JsonRpcRequestId(final Object id) {
     if (isRequestTypeInvalid(id)) {
@@ -39,6 +45,11 @@ public class JsonRpcRequestId {
     this.id = id;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   @JsonValue
   public Object getValue() {
     return id;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/QosTimer.java
@@ -20,6 +20,7 @@ import java.util.function.Consumer;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
+/** The type Qos timer. */
 public class QosTimer {
 
   private final Vertx timerVertx;
@@ -29,6 +30,13 @@ public class QosTimer {
   private final long periodMillis;
   private final Consumer<Long> consumerTask;
 
+  /**
+   * Instantiates a new Qos timer.
+   *
+   * @param timerVertx the timer vertx
+   * @param periodMillis the period millis
+   * @param consumerTask the consumer task
+   */
   public QosTimer(
       final Vertx timerVertx, final long periodMillis, final Consumer<Long> consumerTask) {
     this.timerVertx = timerVertx;
@@ -37,16 +45,27 @@ public class QosTimer {
     resetTimer();
   }
 
+  /** Reset timer. */
   public void resetTimer() {
     lastReset.set(System.currentTimeMillis());
     resetTimerHandler(timerHandler());
   }
 
+  /**
+   * Reset timer handler.
+   *
+   * @param timerHandler the timer handler
+   */
   void resetTimerHandler(final Handler<Long> timerHandler) {
     timerVertx.cancelTimer(timerId.get());
     timerId.set(timerVertx.setTimer(periodMillis, timerHandler));
   }
 
+  /**
+   * Timer handler handler.
+   *
+   * @return the handler
+   */
   Handler<Long> timerHandler() {
     return z -> {
       var lastCall = getLastCallMillis();
@@ -58,6 +77,11 @@ public class QosTimer {
     };
   }
 
+  /**
+   * Gets last call millis.
+   *
+   * @return the last call millis
+   */
   long getLastCallMillis() {
     return lastReset.get();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/InvalidJsonRpcParameters.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/InvalidJsonRpcParameters.java
@@ -14,12 +14,24 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception;
 
+/** The type Invalid json rpc parameters. */
 public class InvalidJsonRpcParameters extends InvalidJsonRpcRequestException {
 
+  /**
+   * Instantiates a new Invalid json rpc parameters.
+   *
+   * @param s the s
+   */
   public InvalidJsonRpcParameters(final String s) {
     super(s);
   }
 
+  /**
+   * Instantiates a new Invalid json rpc parameters.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public InvalidJsonRpcParameters(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/InvalidJsonRpcRequestException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/InvalidJsonRpcRequestException.java
@@ -14,11 +14,23 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception;
 
+/** The type Invalid json rpc request exception. */
 public class InvalidJsonRpcRequestException extends IllegalArgumentException {
+  /**
+   * Instantiates a new Invalid json rpc request exception.
+   *
+   * @param message the message
+   */
   public InvalidJsonRpcRequestException(final String message) {
     super(message);
   }
 
+  /**
+   * Instantiates a new Invalid json rpc request exception.
+   *
+   * @param message the message
+   * @param cause the cause
+   */
   public InvalidJsonRpcRequestException(final String message, final Throwable cause) {
     super(message, cause);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/exception/Logging403ErrorHandler.java
@@ -20,9 +20,13 @@ import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Logging 403 error handler. */
 public class Logging403ErrorHandler implements Handler<RoutingContext> {
 
   private static final Logger LOG = LoggerFactory.getLogger(Logging403ErrorHandler.class);
+
+  /** Default constructor. */
+  public Logging403ErrorHandler() {}
 
   @Override
   public void handle(final RoutingContext event) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/BlockFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/BlockFilter.java
@@ -24,18 +24,34 @@ class BlockFilter extends Filter {
 
   private final List<Hash> blockHashes = new ArrayList<>();
 
+  /**
+   * Instantiates a new Block filter.
+   *
+   * @param id the id
+   */
   BlockFilter(final String id) {
     super(id);
   }
 
+  /**
+   * Add block hash.
+   *
+   * @param hash the hash
+   */
   void addBlockHash(final Hash hash) {
     blockHashes.add(hash);
   }
 
+  /**
+   * Block hashes list.
+   *
+   * @return the list
+   */
   List<Hash> blockHashes() {
     return blockHashes;
   }
 
+  /** Clear block hashes. */
   void clearBlockHashes() {
     blockHashes.clear();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/Filter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/Filter.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 
 import com.google.common.annotations.VisibleForTesting;
 
+/** The type Filter. */
 abstract class Filter {
 
   private static final Duration DEFAULT_EXPIRE_DURATION = Duration.ofMinutes(10);
@@ -26,28 +27,54 @@ abstract class Filter {
   private final String id;
   private Instant expireTime;
 
+  /**
+   * Instantiates a new Filter.
+   *
+   * @param id the id
+   */
   Filter(final String id) {
     this.id = id;
     resetExpireTime();
   }
 
+  /**
+   * Gets id.
+   *
+   * @return the id
+   */
   String getId() {
     return id;
   }
 
+  /** Reset expire time. */
   void resetExpireTime() {
     this.expireTime = Instant.now().plus(DEFAULT_EXPIRE_DURATION);
   }
 
+  /**
+   * Is expired boolean.
+   *
+   * @return the boolean
+   */
   boolean isExpired() {
     return Instant.now().isAfter(expireTime);
   }
 
+  /**
+   * Sets expire time.
+   *
+   * @param expireTime the expire time
+   */
   @VisibleForTesting
   void setExpireTime(final Instant expireTime) {
     this.expireTime = expireTime;
   }
 
+  /**
+   * Gets expire time.
+   *
+   * @return the expire time
+   */
   @VisibleForTesting
   Instant getExpireTime() {
     return expireTime;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterIdGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterIdGenerator.java
@@ -19,10 +19,19 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 
 import java.security.SecureRandom;
 
+/** The type Filter id generator. */
 public class FilterIdGenerator {
 
   private final SecureRandom secureRandom = SecureRandomProvider.createSecureRandom();
 
+  /** Default constructor. */
+  public FilterIdGenerator() {}
+
+  /**
+   * Next id string.
+   *
+   * @return the string
+   */
   public String nextId() {
     final byte[] randomBytes = new byte[16];
     secureRandom.nextBytes(randomBytes);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManager.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManager.java
@@ -49,6 +49,15 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
   private final Optional<PrivacyQueries> privacyQueries;
   private final List<PrivateTransactionEvent> removalEvents;
 
+  /**
+   * Instantiates a new Filter manager.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionPool the transaction pool
+   * @param privacyQueries the privacy queries
+   * @param filterIdGenerator the filter id generator
+   * @param filterRepository the filter repository
+   */
   FilterManager(
       final BlockchainQueries blockchainQueries,
       final TransactionPool transactionPool,
@@ -158,6 +167,11 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
     }
   }
 
+  /**
+   * Record block event.
+   *
+   * @param event the event
+   */
   public void recordBlockEvent(final BlockAddedEvent event) {
     final Hash blockHash = event.getBlock().getHash();
     final Collection<BlockFilter> blockFilters =
@@ -208,6 +222,11 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
     removalEvents.add(event);
   }
 
+  /**
+   * Record pending transaction event.
+   *
+   * @param transaction the transaction
+   */
   @VisibleForTesting
   void recordPendingTransactionEvent(final Transaction transaction) {
     final Collection<PendingTransactionFilter> pendingTransactionFilters =
@@ -224,6 +243,11 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
         });
   }
 
+  /**
+   * Process removal event.
+   *
+   * @param event the event
+   */
   @VisibleForTesting
   void processRemovalEvent(final PrivateTransactionEvent event) {
     // when user removed from privacy group, remove all filters created by that user in that group
@@ -281,6 +305,12 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
     return hashes;
   }
 
+  /**
+   * Logs changes list.
+   *
+   * @param filterId the filter id
+   * @return the list
+   */
   public List<LogWithMetadata> logsChanges(final String filterId) {
     final LogFilter filter = filterRepository.getFilter(filterId, LogFilter.class).orElse(null);
     if (filter == null) {
@@ -296,6 +326,12 @@ public class FilterManager extends AbstractVerticle implements PrivateTransactio
     return logs;
   }
 
+  /**
+   * Logs list.
+   *
+   * @param filterId the filter id
+   * @return the list
+   */
   public List<LogWithMetadata> logs(final String filterId) {
     final LogFilter filter = filterRepository.getFilter(filterId, LogFilter.class).orElse(null);
     if (filter == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerBuilder.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterManagerBuilder.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
 
+/** The type Filter manager builder. */
 public class FilterManagerBuilder {
 
   private BlockchainQueries blockchainQueries;
@@ -32,37 +33,81 @@ public class FilterManagerBuilder {
   private Optional<PrivacyParameters> privacyParameters = Optional.empty();
   private Optional<PrivacyQueries> privacyQueries = Optional.empty();
 
+  /** Default constructor. */
+  public FilterManagerBuilder() {}
+
+  /**
+   * Filter id generator filter manager builder.
+   *
+   * @param filterIdGenerator the filter id generator
+   * @return the filter manager builder
+   */
   public FilterManagerBuilder filterIdGenerator(final FilterIdGenerator filterIdGenerator) {
     this.filterIdGenerator = filterIdGenerator;
     return this;
   }
 
+  /**
+   * Filter repository filter manager builder.
+   *
+   * @param filterRepository the filter repository
+   * @return the filter manager builder
+   */
   public FilterManagerBuilder filterRepository(final FilterRepository filterRepository) {
     this.filterRepository = filterRepository;
     return this;
   }
 
+  /**
+   * Blockchain queries filter manager builder.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @return the filter manager builder
+   */
   public FilterManagerBuilder blockchainQueries(final BlockchainQueries blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
     return this;
   }
 
+  /**
+   * Transaction pool filter manager builder.
+   *
+   * @param transactionPool the transaction pool
+   * @return the filter manager builder
+   */
   public FilterManagerBuilder transactionPool(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
     return this;
   }
 
+  /**
+   * Privacy parameters filter manager builder.
+   *
+   * @param privacyParameters the privacy parameters
+   * @return the filter manager builder
+   */
   public FilterManagerBuilder privacyParameters(final PrivacyParameters privacyParameters) {
     this.privacyParameters = Optional.ofNullable(privacyParameters);
     return this;
   }
 
+  /**
+   * Privacy queries filter manager builder.
+   *
+   * @param privacyQueries the privacy queries
+   * @return the filter manager builder
+   */
   @VisibleForTesting
   FilterManagerBuilder privacyQueries(final PrivacyQueries privacyQueries) {
     this.privacyQueries = Optional.ofNullable(privacyQueries);
     return this;
   }
 
+  /**
+   * Build filter manager.
+   *
+   * @return the filter manager
+   */
   public FilterManager build() {
     if (blockchainQueries == null) {
       throw new IllegalStateException("BlockchainQueries is required to build FilterManager");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterRepository.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterRepository.java
@@ -22,22 +22,44 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/** The type Filter repository. */
 public class FilterRepository {
 
   private final Map<String, Filter> filters = new ConcurrentHashMap<>();
 
+  /** Instantiates a new Filter repository. */
   public FilterRepository() {}
 
+  /**
+   * Gets filters.
+   *
+   * @return the filters
+   */
   Collection<Filter> getFilters() {
     return new ArrayList<>(filters.values());
   }
 
+  /**
+   * Gets filters of type.
+   *
+   * @param <T> the type parameter
+   * @param filterClass the filter class
+   * @return the filters of type
+   */
   <T extends Filter> Collection<T> getFiltersOfType(final Class<T> filterClass) {
     return filters.values().stream()
         .flatMap(f -> getIfTypeMatches(f, filterClass).map(Stream::of).orElseGet(Stream::empty))
         .collect(Collectors.toList());
   }
 
+  /**
+   * Gets filter.
+   *
+   * @param <T> the type parameter
+   * @param filterId the filter id
+   * @param filterClass the filter class
+   * @return the filter
+   */
   <T extends Filter> Optional<T> getFilter(final String filterId, final Class<T> filterClass) {
     final Filter filter = filters.get(filterId);
     return getIfTypeMatches(filter, filterClass);
@@ -57,10 +79,21 @@ public class FilterRepository {
     return Optional.of((T) filter);
   }
 
+  /**
+   * Exists boolean.
+   *
+   * @param id the id
+   * @return the boolean
+   */
   boolean exists(final String id) {
     return filters.containsKey(id);
   }
 
+  /**
+   * Save.
+   *
+   * @param filter the filter
+   */
   void save(final Filter filter) {
     if (filter == null) {
       throw new IllegalArgumentException("Can't save null filter");
@@ -74,10 +107,16 @@ public class FilterRepository {
     filters.put(filter.getId(), filter);
   }
 
+  /**
+   * Delete.
+   *
+   * @param id the id
+   */
   void delete(final String id) {
     filters.remove(id);
   }
 
+  /** Delete all. */
   void deleteAll() {
     filters.clear();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTimeoutMonitor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/FilterTimeoutMonitor.java
@@ -14,14 +14,21 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter;
 
+/** The type Filter timeout monitor. */
 class FilterTimeoutMonitor {
 
   private final FilterRepository filterRepository;
 
+  /**
+   * Instantiates a new Filter timeout monitor.
+   *
+   * @param filterRepository the filter repository
+   */
   FilterTimeoutMonitor(final FilterRepository filterRepository) {
     this.filterRepository = filterRepository;
   }
 
+  /** Check filters. */
   void checkFilters() {
     filterRepository
         .getFilters()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/LogFilter.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import java.util.ArrayList;
 import java.util.List;
 
+/** The type Log filter. */
 class LogFilter extends Filter {
 
   private final BlockParameter fromBlock;
@@ -29,6 +30,14 @@ class LogFilter extends Filter {
 
   private final List<LogWithMetadata> logs = new ArrayList<>();
 
+  /**
+   * Instantiates a new Log filter.
+   *
+   * @param id the id
+   * @param fromBlock the from block
+   * @param toBlock the to block
+   * @param logsQuery the logs query
+   */
   LogFilter(
       final String id,
       final BlockParameter fromBlock,
@@ -40,26 +49,52 @@ class LogFilter extends Filter {
     this.logsQuery = logsQuery;
   }
 
+  /**
+   * Gets from block.
+   *
+   * @return the from block
+   */
   public BlockParameter getFromBlock() {
     return fromBlock;
   }
 
+  /**
+   * Gets to block.
+   *
+   * @return the to block
+   */
   public BlockParameter getToBlock() {
     return toBlock;
   }
 
+  /**
+   * Gets logs query.
+   *
+   * @return the logs query
+   */
   public LogsQuery getLogsQuery() {
     return logsQuery;
   }
 
+  /**
+   * Add logs.
+   *
+   * @param logs the logs
+   */
   void addLogs(final List<LogWithMetadata> logs) {
     this.logs.addAll(logs);
   }
 
+  /**
+   * Logs list.
+   *
+   * @return the list
+   */
   List<LogWithMetadata> logs() {
     return logs;
   }
 
+  /** Clear logs. */
   void clearLogs() {
     logs.clear();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/PendingTransactionFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/PendingTransactionFilter.java
@@ -24,18 +24,34 @@ class PendingTransactionFilter extends Filter {
 
   private final List<Hash> transactionHashes = new ArrayList<>();
 
+  /**
+   * Instantiates a new Pending transaction filter.
+   *
+   * @param id the id
+   */
   PendingTransactionFilter(final String id) {
     super(id);
   }
 
+  /**
+   * Add transaction hash.
+   *
+   * @param hash the hash
+   */
   void addTransactionHash(final Hash hash) {
     transactionHashes.add(hash);
   }
 
+  /**
+   * Transaction hashes list.
+   *
+   * @return the list
+   */
   List<Hash> transactionHashes() {
     return transactionHashes;
   }
 
+  /** Clear transaction hashes. */
   void clearTransactionHashes() {
     transactionHashes.clear();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/PrivateLogFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/filter/PrivateLogFilter.java
@@ -17,11 +17,22 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 
+/** The type Private log filter. */
 public class PrivateLogFilter extends LogFilter {
 
   private final String privacyGroupId;
   private final String privacyUserId;
 
+  /**
+   * Instantiates a new Private log filter.
+   *
+   * @param id the id
+   * @param privacyGroupId the privacy group id
+   * @param privacyUserId the privacy user id
+   * @param fromBlock the from block
+   * @param toBlock the to block
+   * @param logsQuery the logs query
+   */
   PrivateLogFilter(
       final String id,
       final String privacyGroupId,
@@ -34,10 +45,20 @@ public class PrivateLogFilter extends LogFilter {
     this.privacyUserId = privacyUserId;
   }
 
+  /**
+   * Gets privacy group id.
+   *
+   * @return the privacy group id
+   */
   public String getPrivacyGroupId() {
     return privacyGroupId;
   }
 
+  /**
+   * Gets privacy user id.
+   *
+   * @return the privacy user id
+   */
   public String getPrivacyUserId() {
     return privacyUserId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterMethod.java
@@ -29,41 +29,95 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Abstract block parameter method. */
 public abstract class AbstractBlockParameterMethod implements JsonRpcMethod {
 
+  /** The Blockchain queries supplier. */
   protected final Supplier<BlockchainQueries> blockchainQueriesSupplier;
 
+  /**
+   * Instantiates a new Abstract block parameter method.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   protected AbstractBlockParameterMethod(final BlockchainQueries blockchainQueries) {
     this(Suppliers.ofInstance(blockchainQueries));
   }
 
+  /**
+   * Instantiates a new Abstract block parameter method.
+   *
+   * @param blockchainQueriesSupplier the blockchain queries supplier
+   */
   protected AbstractBlockParameterMethod(
       final Supplier<BlockchainQueries> blockchainQueriesSupplier) {
     this.blockchainQueriesSupplier = blockchainQueriesSupplier;
   }
 
+  /**
+   * Block parameter block parameter.
+   *
+   * @param request the request
+   * @return the block parameter
+   */
   protected abstract BlockParameter blockParameter(JsonRpcRequestContext request);
 
+  /**
+   * Result by block number object.
+   *
+   * @param request the request
+   * @param blockNumber the block number
+   * @return the object
+   */
   protected abstract Object resultByBlockNumber(JsonRpcRequestContext request, long blockNumber);
 
+  /**
+   * Gets blockchain queries.
+   *
+   * @return the blockchain queries
+   */
   protected BlockchainQueries getBlockchainQueries() {
     return blockchainQueriesSupplier.get();
   }
 
+  /**
+   * Pending result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object pendingResult(final JsonRpcRequestContext request) {
     // TODO: Update once we mine and better understand pending semantics.
     // For now act like we are not mining and just return latest.
     return latestResult(request);
   }
 
+  /**
+   * Latest result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object latestResult(final JsonRpcRequestContext request) {
     return resultByBlockNumber(request, blockchainQueriesSupplier.get().headBlockNumber());
   }
 
+  /**
+   * Finalized result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object finalizedResult(final JsonRpcRequestContext request) {
     return posRelatedResult(request, BlockchainQueries::finalizedBlockHeader);
   }
 
+  /**
+   * Safe result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object safeResult(final JsonRpcRequestContext request) {
     return posRelatedResult(request, BlockchainQueries::safeBlockHeader);
   }
@@ -80,6 +134,12 @@ public abstract class AbstractBlockParameterMethod implements JsonRpcMethod {
                 new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.UNKNOWN_BLOCK));
   }
 
+  /**
+   * Find result by param type object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object findResultByParamType(final JsonRpcRequestContext request) {
     final BlockParameter blockParam = blockParameter(request);
     final Optional<Long> blockNumber = blockParam.getNumber();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterOrBlockHashMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractBlockParameterOrBlockHashMethod.java
@@ -31,48 +31,109 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Abstract block parameter or block hash method. */
 public abstract class AbstractBlockParameterOrBlockHashMethod implements JsonRpcMethod {
 
+  /** The Blockchain queries. */
   protected final Supplier<BlockchainQueries> blockchainQueries;
 
+  /**
+   * Instantiates a new Abstract block parameter or block hash method.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   protected AbstractBlockParameterOrBlockHashMethod(final BlockchainQueries blockchainQueries) {
     this(Suppliers.ofInstance(blockchainQueries));
   }
 
+  /**
+   * Instantiates a new Abstract block parameter or block hash method.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   protected AbstractBlockParameterOrBlockHashMethod(
       final Supplier<BlockchainQueries> blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }
 
+  /**
+   * Block parameter or block hash block parameter or block hash.
+   *
+   * @param request the request
+   * @return the block parameter or block hash
+   */
   protected abstract BlockParameterOrBlockHash blockParameterOrBlockHash(
       JsonRpcRequestContext request);
 
+  /**
+   * Result by block hash object.
+   *
+   * @param request the request
+   * @param blockHash the block hash
+   * @return the object
+   */
   protected abstract Object resultByBlockHash(JsonRpcRequestContext request, Hash blockHash);
 
+  /**
+   * Result by block header object.
+   *
+   * @param request the request
+   * @param blockHeader the block header
+   * @return the object
+   */
   protected Object resultByBlockHeader(
       final JsonRpcRequestContext request, final BlockHeader blockHeader) {
     return resultByBlockHash(request, blockHeader.getBlockHash());
   }
 
+  /**
+   * Gets blockchain queries.
+   *
+   * @return the blockchain queries
+   */
   protected BlockchainQueries getBlockchainQueries() {
     return blockchainQueries.get();
   }
 
+  /**
+   * Pending result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object pendingResult(final JsonRpcRequestContext request) {
     // TODO: Update once we mine and better understand pending semantics.
     // For now act like we are not mining and just return latest.
     return latestResult(request);
   }
 
+  /**
+   * Latest result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object latestResult(final JsonRpcRequestContext request) {
     return resultByBlockHeader(
         request, getBlockchainQueries().getBlockchain().getChainHead().getBlockHeader());
   }
 
+  /**
+   * Finalized result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object finalizedResult(final JsonRpcRequestContext request) {
     return posRelatedResult(request, BlockchainQueries::finalizedBlockHeader);
   }
 
+  /**
+   * Safe result object.
+   *
+   * @param request the request
+   * @return the object
+   */
   protected Object safeResult(final JsonRpcRequestContext request) {
     return posRelatedResult(request, BlockchainQueries::safeBlockHeader);
   }
@@ -89,6 +150,12 @@ public abstract class AbstractBlockParameterOrBlockHashMethod implements JsonRpc
                 new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.UNKNOWN_BLOCK));
   }
 
+  /**
+   * Handle param types object.
+   *
+   * @param requestContext the request context
+   * @return the object
+   */
   protected Object handleParamTypes(final JsonRpcRequestContext requestContext) {
     final BlockParameterOrBlockHash blockParameterOrBlockHash =
         blockParameterOrBlockHash(requestContext);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractEstimateGas.java
@@ -35,19 +35,34 @@ import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
 
 import java.util.Optional;
 
+/** The type Abstract estimate gas. */
 public abstract class AbstractEstimateGas implements JsonRpcMethod {
 
   private static final double SUB_CALL_REMAINING_GAS_RATIO = 65D / 64D;
 
+  /** The Blockchain queries. */
   protected final BlockchainQueries blockchainQueries;
+
+  /** The Transaction simulator. */
   protected final TransactionSimulator transactionSimulator;
 
+  /**
+   * Instantiates a new Abstract estimate gas.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionSimulator the transaction simulator
+   */
   public AbstractEstimateGas(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     this.blockchainQueries = blockchainQueries;
     this.transactionSimulator = transactionSimulator;
   }
 
+  /**
+   * Block header block header.
+   *
+   * @return the block header
+   */
   protected BlockHeader blockHeader() {
     final Blockchain theChain = blockchainQueries.getBlockchain();
 
@@ -61,6 +76,13 @@ public abstract class AbstractEstimateGas implements JsonRpcMethod {
         .orElse(null);
   }
 
+  /**
+   * Override gas limit and price call parameter.
+   *
+   * @param callParams the call params
+   * @param gasLimit the gas limit
+   * @return the call parameter
+   */
   protected CallParameter overrideGasLimitAndPrice(
       final JsonCallParameter callParams, final long gasLimit) {
     return new CallParameter(
@@ -94,6 +116,12 @@ public abstract class AbstractEstimateGas implements JsonRpcMethod {
     return ((long) ((gasUsedByTransaction + gasStipend) * subCallMultiplier));
   }
 
+  /**
+   * Validate and get call params json call parameter.
+   *
+   * @param request the request
+   * @return the json call parameter
+   */
   protected JsonCallParameter validateAndGetCallParams(final JsonRpcRequestContext request) {
     final JsonCallParameter callParams = request.getRequiredParameter(0, JsonCallParameter.class);
     if (callParams.getGasPrice() != null
@@ -104,6 +132,13 @@ public abstract class AbstractEstimateGas implements JsonRpcMethod {
     return callParams;
   }
 
+  /**
+   * Error response json rpc error response.
+   *
+   * @param request the request
+   * @param result the result
+   * @return the json rpc error response
+   */
   protected JsonRpcErrorResponse errorResponse(
       final JsonRpcRequestContext request, final TransactionSimulatorResult result) {
 
@@ -129,11 +164,25 @@ public abstract class AbstractEstimateGas implements JsonRpcMethod {
     }
   }
 
+  /**
+   * Error response json rpc error response.
+   *
+   * @param request the request
+   * @param rpcErrorType the rpc error type
+   * @return the json rpc error response
+   */
   protected JsonRpcErrorResponse errorResponse(
       final JsonRpcRequestContext request, final RpcErrorType rpcErrorType) {
     return errorResponse(request, new JsonRpcError(rpcErrorType));
   }
 
+  /**
+   * Error response json rpc error response.
+   *
+   * @param request the request
+   * @param jsonRpcError the json rpc error
+   * @return the json rpc error response
+   */
   protected JsonRpcErrorResponse errorResponse(
       final JsonRpcRequestContext request, final JsonRpcError jsonRpcError) {
     return new JsonRpcErrorResponse(request.getRequest().getId(), jsonRpcError);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByBlock.java
@@ -43,13 +43,25 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/** The type Abstract trace by block. */
 public abstract class AbstractTraceByBlock extends AbstractBlockParameterMethod
     implements JsonRpcMethod {
+  /** The Protocol schedule. */
   protected final ProtocolSchedule protocolSchedule;
+
+  /** The Transaction simulator. */
   protected final TransactionSimulator transactionSimulator;
 
+  /** The constant mapper. */
   protected static final ObjectMapper mapper = new ObjectMapper();
 
+  /**
+   * Instantiates a new Abstract trace by block.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionSimulator the transaction simulator
+   */
   protected AbstractTraceByBlock(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
@@ -72,6 +84,16 @@ public abstract class AbstractTraceByBlock extends AbstractBlockParameterMethod
     return BlockParameter.LATEST;
   }
 
+  /**
+   * Gets trace call result.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param traceTypes the trace types
+   * @param simulatorResult the simulator result
+   * @param transactionTrace the transaction trace
+   * @param block the block
+   * @return the trace call result
+   */
   protected JsonNode getTraceCallResult(
       final ProtocolSchedule protocolSchedule,
       final Set<TraceTypeParameter.TraceType> traceTypes,
@@ -108,12 +130,23 @@ public abstract class AbstractTraceByBlock extends AbstractBlockParameterMethod
     return mapper.valueToTree(builder.build());
   }
 
+  /**
+   * Build transaction validation params transaction validation params.
+   *
+   * @return the transaction validation params
+   */
   protected TransactionValidationParams buildTransactionValidationParams() {
     return ImmutableTransactionValidationParams.builder()
         .from(TransactionValidationParams.transactionSimulator())
         .build();
   }
 
+  /**
+   * Build trace options trace options.
+   *
+   * @param traceTypes the trace types
+   * @return the trace options
+   */
   protected TraceOptions buildTraceOptions(final Set<TraceTypeParameter.TraceType> traceTypes) {
     return new TraceOptions(
         traceTypes.contains(TraceType.STATE_DIFF),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceByHash.java
@@ -37,11 +37,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+/** The type Abstract trace by hash. */
 public abstract class AbstractTraceByHash implements JsonRpcMethod {
+  /** The Block tracer supplier. */
   protected final Supplier<BlockTracer> blockTracerSupplier;
+
+  /** The Blockchain queries. */
   protected final BlockchainQueries blockchainQueries;
+
+  /** The Protocol schedule. */
   protected final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Abstract trace by hash.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   */
   protected AbstractTraceByHash(
       final Supplier<BlockTracer> blockTracerSupplier,
       final BlockchainQueries blockchainQueries,
@@ -51,6 +64,12 @@ public abstract class AbstractTraceByHash implements JsonRpcMethod {
     this.protocolSchedule = protocolSchedule;
   }
 
+  /**
+   * Result by transaction hash stream.
+   *
+   * @param transactionHash the transaction hash
+   * @return the stream
+   */
   public Stream<FlatTrace> resultByTransactionHash(final Hash transactionHash) {
     return blockchainQueries
         .transactionByHash(transactionHash)
@@ -100,6 +119,12 @@ public abstract class AbstractTraceByHash implements JsonRpcMethod {
         .map(FlatTrace.class::cast);
   }
 
+  /**
+   * Array node from trace stream json node.
+   *
+   * @param traceStream the trace stream
+   * @return the json node
+   */
   protected JsonNode arrayNodeFromTraceStream(final Stream<FlatTrace> traceStream) {
     final ObjectMapper mapper = new ObjectMapper();
     final ArrayNode resultArrayNode = mapper.createArrayNode();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractTraceCall.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Abstract trace call. */
 public abstract class AbstractTraceCall extends AbstractTraceByBlock {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractTraceCall.class);
 
@@ -43,6 +44,14 @@ public abstract class AbstractTraceCall extends AbstractTraceByBlock {
    */
   private final boolean recordChildCallGas;
 
+  /**
+   * Instantiates a new Abstract trace call.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionSimulator the transaction simulator
+   * @param recordChildCallGas the record child call gas
+   */
   protected AbstractTraceCall(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
@@ -86,8 +95,21 @@ public abstract class AbstractTraceCall extends AbstractTraceByBlock {
             () -> new JsonRpcErrorResponse(requestContext.getRequest().getId(), INTERNAL_ERROR));
   }
 
+  /**
+   * Gets trace options.
+   *
+   * @param requestContext the request context
+   * @return the trace options
+   */
   protected abstract TraceOptions getTraceOptions(final JsonRpcRequestContext requestContext);
 
+  /**
+   * Gets simulator result handler.
+   *
+   * @param requestContext the request context
+   * @param tracer the tracer
+   * @return the simulator result handler
+   */
   protected abstract PreCloseStateHandler<Object> getSimulatorResultHandler(
       final JsonRpcRequestContext requestContext, final DebugOperationTracer tracer);
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminAddPeer.java
@@ -29,10 +29,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Admin add peer. */
 public class AdminAddPeer extends AdminModifyPeer {
 
   private static final Logger LOG = LoggerFactory.getLogger(AdminAddPeer.class);
 
+  /**
+   * Instantiates a new Admin add peer.
+   *
+   * @param peerNetwork the peer network
+   * @param enodeDnsConfiguration the enode dns configuration
+   */
   public AdminAddPeer(
       final P2PNetwork peerNetwork, final Optional<EnodeDnsConfiguration> enodeDnsConfiguration) {
     super(peerNetwork, enodeDnsConfiguration);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevel.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminChangeLogLevel.java
@@ -30,11 +30,15 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Admin change log level. */
 public class AdminChangeLogLevel implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(AdminChangeLogLevel.class);
   private static final Set<String> VALID_PARAMS =
       Set.of("OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL");
+
+  /** Default constructor */
+  public AdminChangeLogLevel() {}
 
   @Override
   public String getName() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCache.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminGenerateLogBloomCache.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import java.util.Optional;
 
+/** The type Admin generate log bloom cache. */
 public class AdminGenerateLogBloomCache implements JsonRpcMethod {
 
   private final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Admin generate log bloom cache.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public AdminGenerateLogBloomCache(final BlockchainQueries blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRemoveCache.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRemoveCache.java
@@ -28,9 +28,15 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import java.util.Map;
 import java.util.Optional;
 
+/** The type Admin logs remove cache. */
 public class AdminLogsRemoveCache implements JsonRpcMethod {
   private final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Admin logs remove cache.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public AdminLogsRemoveCache(final BlockchainQueries blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRepairCache.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminLogsRepairCache.java
@@ -24,9 +24,15 @@ import org.hyperledger.besu.ethereum.api.query.cache.TransactionLogBloomCacher;
 import java.util.Map;
 import java.util.Optional;
 
+/** The type Admin logs repair cache. */
 public class AdminLogsRepairCache implements JsonRpcMethod {
   private final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Admin logs repair cache.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public AdminLogsRepairCache(final BlockchainQueries blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminModifyPeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminModifyPeer.java
@@ -25,11 +25,21 @@ import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
 
 import java.util.Optional;
 
+/** The type Admin modify peer. */
 public abstract class AdminModifyPeer implements JsonRpcMethod {
 
+  /** The Peer network. */
   protected final P2PNetwork peerNetwork;
+
+  /** The Enode dns configuration. */
   protected final Optional<EnodeDnsConfiguration> enodeDnsConfiguration;
 
+  /**
+   * Instantiates a new Admin modify peer.
+   *
+   * @param peerNetwork the peer network
+   * @param enodeDnsConfiguration the enode dns configuration
+   */
   protected AdminModifyPeer(
       final P2PNetwork peerNetwork, final Optional<EnodeDnsConfiguration> enodeDnsConfiguration) {
     this.peerNetwork = peerNetwork;
@@ -72,5 +82,12 @@ public abstract class AdminModifyPeer implements JsonRpcMethod {
     }
   }
 
+  /**
+   * Perform operation json rpc response.
+   *
+   * @param id the id
+   * @param enode the enode
+   * @return the json rpc response
+   */
   protected abstract JsonRpcResponse performOperation(final Object id, final String enode);
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminNodeInfo.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import com.google.common.collect.ImmutableMap;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Admin node info. */
 public class AdminNodeInfo implements JsonRpcMethod {
 
   private final String clientVersion;
@@ -48,6 +49,16 @@ public class AdminNodeInfo implements JsonRpcMethod {
   private final BlockchainQueries blockchainQueries;
   private final NatService natService;
 
+  /**
+   * Instantiates a new Admin node info.
+   *
+   * @param clientVersion the client version
+   * @param networkId the network id
+   * @param genesisConfigOptions the genesis config options
+   * @param peerNetwork the peer network
+   * @param blockchainQueries the blockchain queries
+   * @param natService the nat service
+   */
   public AdminNodeInfo(
       final String clientVersion,
       final BigInteger networkId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeers.java
@@ -26,9 +26,15 @@ import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException
 
 import java.util.stream.Collectors;
 
+/** The type Admin peers. */
 public class AdminPeers implements JsonRpcMethod {
   private final EthPeers ethPeers;
 
+  /**
+   * Instantiates a new Admin peers.
+   *
+   * @param ethPeers the eth peers
+   */
   public AdminPeers(final EthPeers ethPeers) {
     this.ethPeers = ethPeers;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminRemovePeer.java
@@ -28,10 +28,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Admin remove peer. */
 public class AdminRemovePeer extends AdminModifyPeer {
 
   private static final Logger LOG = LoggerFactory.getLogger(AdminRemovePeer.class);
 
+  /**
+   * Instantiates a new Admin remove peer.
+   *
+   * @param peerNetwork the peer network
+   * @param enodeDnsConfiguration the enode dns configuration
+   */
   public AdminRemovePeer(
       final P2PNetwork peerNetwork, final Optional<EnodeDnsConfiguration> enodeDnsConfiguration) {
     super(peerNetwork, enodeDnsConfiguration);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/BuildArrayNodeCompleterStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/BuildArrayNodeCompleterStep.java
@@ -18,10 +18,16 @@ import org.hyperledger.besu.ethereum.api.util.ArrayNodeWrapper;
 
 import java.util.function.Consumer;
 
+/** The type Build array node completer step. */
 public class BuildArrayNodeCompleterStep implements Consumer<Object> {
 
   private final ArrayNodeWrapper resultArrayNode;
 
+  /**
+   * Instantiates a new Build array node completer step.
+   *
+   * @param resultArrayNode the result array node
+   */
   public BuildArrayNodeCompleterStep(final ArrayNodeWrapper resultArrayNode) {
     this.resultArrayNode = resultArrayNode;
   }
@@ -31,6 +37,11 @@ public class BuildArrayNodeCompleterStep implements Consumer<Object> {
     resultArrayNode.addPOJO(object);
   }
 
+  /**
+   * Gets result array node.
+   *
+   * @return the result array node
+   */
   public ArrayNodeWrapper getResultArrayNode() {
     return this.resultArrayNode;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountAt.java
@@ -42,15 +42,28 @@ import java.util.function.Supplier;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Debug account at. */
 public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
   private final Supplier<BlockTracer> blockTracerSupplier;
 
+  /**
+   * Instantiates a new Debug account at.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param blockTracerSupplier the block tracer supplier
+   */
   public DebugAccountAt(
       final BlockchainQueries blockchainQueries, final Supplier<BlockTracer> blockTracerSupplier) {
     super(blockchainQueries);
     this.blockTracerSupplier = blockTracerSupplier;
   }
 
+  /**
+   * Instantiates a new Debug account at.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param blockTracerSupplier the block tracer supplier
+   */
   public DebugAccountAt(
       final Supplier<BlockchainQueries> blockchainQueries,
       final Supplier<BlockTracer> blockTracerSupplier) {
@@ -140,6 +153,15 @@ public class DebugAccountAt extends AbstractBlockParameterOrBlockHashMethod {
                 requestContext.getRequest().getId(), RpcErrorType.WORLD_STATE_UNAVAILABLE));
   }
 
+  /**
+   * Debug account at result immutable debug account at result.
+   *
+   * @param code the code
+   * @param nonce the nonce
+   * @param balance the balance
+   * @param codeHash the code hash
+   * @return the immutable debug account at result
+   */
   protected ImmutableDebugAccountAtResult debugAccountAtResult(
       final Bytes code, final String nonce, final String balance, final String codeHash) {
     return ImmutableDebugAccountAtResult.builder()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountRange.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugAccountRange.java
@@ -35,14 +35,25 @@ import java.util.stream.Collectors;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Debug account range. */
 public class DebugAccountRange implements JsonRpcMethod {
 
   private final Supplier<BlockchainQueries> blockchainQueries;
 
+  /**
+   * Instantiates a new Debug account range.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public DebugAccountRange(final BlockchainQueries blockchainQueries) {
     this(Suppliers.ofInstance(blockchainQueries));
   }
 
+  /**
+   * Instantiates a new Debug account range.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public DebugAccountRange(final Supplier<BlockchainQueries> blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugBatchSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugBatchSendRawTransaction.java
@@ -35,13 +35,24 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.google.common.base.Suppliers;
 
+/** The type Debug batch send raw transaction. */
 public class DebugBatchSendRawTransaction implements JsonRpcMethod {
   private final Supplier<TransactionPool> transactionPool;
 
+  /**
+   * Instantiates a new Debug batch send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   */
   public DebugBatchSendRawTransaction(final TransactionPool transactionPool) {
     this(Suppliers.ofInstance(transactionPool));
   }
 
+  /**
+   * Instantiates a new Debug batch send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   */
   public DebugBatchSendRawTransaction(final Supplier<TransactionPool> transactionPool) {
     this.transactionPool = transactionPool;
   }
@@ -77,32 +88,60 @@ public class DebugBatchSendRawTransaction implements JsonRpcMethod {
     }
   }
 
+  /** The type Execution status. */
   @JsonPropertyOrder({"index", "success", "errorMessage"})
   static class ExecutionStatus {
     private final int index;
     private final boolean success;
     private final String errorMessage;
 
+    /**
+     * Instantiates a new Execution status.
+     *
+     * @param index the index
+     */
     ExecutionStatus(final int index) {
       this(index, true, null);
     }
 
+    /**
+     * Instantiates a new Execution status.
+     *
+     * @param index the index
+     * @param success the success
+     * @param errorMessage the error message
+     */
     ExecutionStatus(final int index, final boolean success, final String errorMessage) {
       this.index = index;
       this.success = success;
       this.errorMessage = errorMessage;
     }
 
+    /**
+     * Gets index.
+     *
+     * @return the index
+     */
     @JsonGetter(value = "index")
     public int getIndex() {
       return index;
     }
 
+    /**
+     * Is success boolean.
+     *
+     * @return the boolean
+     */
     @JsonGetter(value = "success")
     public boolean isSuccess() {
       return success;
     }
 
+    /**
+     * Gets error message.
+     *
+     * @return the error message
+     */
     @JsonGetter(value = "errorMessage")
     @JsonInclude(Include.NON_NULL)
     public String getErrorMessage() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetBadBlocks.java
@@ -25,11 +25,18 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFac
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** The type Debug get bad blocks. */
 public class DebugGetBadBlocks implements JsonRpcMethod {
 
   private final ProtocolContext protocolContext;
   private final BlockResultFactory blockResultFactory;
 
+  /**
+   * Instantiates a new Debug get bad blocks.
+   *
+   * @param protocolContext the protocol context
+   * @param blockResultFactory the block result factory
+   */
   public DebugGetBadBlocks(
       final ProtocolContext protocolContext, final BlockResultFactory blockResultFactory) {
     this.protocolContext = protocolContext;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawBlock.java
@@ -24,8 +24,14 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import com.google.common.base.Suppliers;
 
+/** The type Debug get raw block. */
 public class DebugGetRawBlock extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Debug get raw block.
+   *
+   * @param blockchain the blockchain
+   */
   public DebugGetRawBlock(final BlockchainQueries blockchain) {
     super(Suppliers.ofInstance(blockchain));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawHeader.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawHeader.java
@@ -24,8 +24,14 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 
 import com.google.common.base.Suppliers;
 
+/** The type Debug get raw header. */
 public class DebugGetRawHeader extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Debug get raw header.
+   *
+   * @param blockchain the blockchain
+   */
   public DebugGetRawHeader(final BlockchainQueries blockchain) {
     super(Suppliers.ofInstance(blockchain));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawReceipts.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawReceipts.java
@@ -26,8 +26,14 @@ import java.util.List;
 
 import com.google.common.base.Suppliers;
 
+/** The type Debug get raw receipts. */
 public class DebugGetRawReceipts extends AbstractBlockParameterOrBlockHashMethod {
 
+  /**
+   * Instantiates a new Debug get raw receipts.
+   *
+   * @param blockchain the blockchain
+   */
   public DebugGetRawReceipts(final BlockchainQueries blockchain) {
     super(Suppliers.ofInstance(blockchain));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugGetRawTransaction.java
@@ -23,10 +23,17 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 
+/** The type Debug get raw transaction. */
 public class DebugGetRawTransaction implements JsonRpcMethod {
 
+  /** The Blockchain queries. */
   protected final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Debug get raw transaction.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public DebugGetRawTransaction(final BlockchainQueries blockchainQueries) {
     this.blockchainQueries = blockchainQueries;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugMetrics.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugMetrics.java
@@ -25,10 +25,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/** The type Debug metrics. */
 public class DebugMetrics implements JsonRpcMethod {
 
   private final ObservableMetricsSystem metricsSystem;
 
+  /**
+   * Instantiates a new Debug metrics.
+   *
+   * @param metricsSystem the metrics system
+   */
   public DebugMetrics(final ObservableMetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugResyncWorldstate.java
@@ -22,10 +22,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 
+/** The type Debug resync worldstate. */
 public class DebugResyncWorldstate implements JsonRpcMethod {
   private final Synchronizer synchronizer;
   private final BadBlockManager badBlockManager;
 
+  /**
+   * Instantiates a new Debug resync worldstate.
+   *
+   * @param protocolContext the protocol context
+   * @param synchronizer the synchronizer
+   */
   public DebugResyncWorldstate(
       final ProtocolContext protocolContext, final Synchronizer synchronizer) {
     this.synchronizer = synchronizer;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -27,9 +27,16 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import java.util.Optional;
 
+/** The type Debug set head. */
 public class DebugSetHead extends AbstractBlockParameterMethod {
   private final ProtocolContext protocolContext;
 
+  /**
+   * Instantiates a new Debug set head.
+   *
+   * @param blockchain the blockchain
+   * @param protocolContext the protocol context
+   */
   public DebugSetHead(final BlockchainQueries blockchain, final ProtocolContext protocolContext) {
     super(blockchain);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFile.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBadBlockToFile.java
@@ -31,11 +31,20 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+/** The type Debug standard trace bad block to file. */
 public class DebugStandardTraceBadBlockToFile extends DebugStandardTraceBlockToFile
     implements JsonRpcMethod {
 
   private final ProtocolContext protocolContext;
 
+  /**
+   * Instantiates a new Debug standard trace bad block to file.
+   *
+   * @param transactionTracerSupplier the transaction tracer supplier
+   * @param blockchainQueries the blockchain queries
+   * @param protocolContext the protocol context
+   * @param dataDir the data dir
+   */
   public DebugStandardTraceBadBlockToFile(
       final Supplier<TransactionTracer> transactionTracerSupplier,
       final BlockchainQueries blockchainQueries,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFile.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStandardTraceBlockToFile.java
@@ -37,12 +37,22 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Debug standard trace block to file. */
 public class DebugStandardTraceBlockToFile implements JsonRpcMethod {
 
+  /** The Blockchain queries. */
   protected final Supplier<BlockchainQueries> blockchainQueries;
+
   private final Supplier<TransactionTracer> transactionTracerSupplier;
   private final Path dataDir;
 
+  /**
+   * Instantiates a new Debug standard trace block to file.
+   *
+   * @param transactionTracerSupplier the transaction tracer supplier
+   * @param blockchainQueries the blockchain queries
+   * @param dataDir the data dir
+   */
   public DebugStandardTraceBlockToFile(
       final Supplier<TransactionTracer> transactionTracerSupplier,
       final BlockchainQueries blockchainQueries,
@@ -78,6 +88,13 @@ public class DebugStandardTraceBlockToFile implements JsonRpcMethod {
                 requestContext.getRequest().getId(), RpcErrorType.BLOCK_NOT_FOUND));
   }
 
+  /**
+   * Trace block list.
+   *
+   * @param block the block
+   * @param transactionTraceParams the transaction trace params
+   * @return the list
+   */
   protected List<String> traceBlock(
       final Block block, final Optional<TransactionTraceParams> transactionTraceParams) {
     return Tracer.processTracing(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugStorageRangeAt.java
@@ -40,17 +40,31 @@ import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Debug storage range at. */
 public class DebugStorageRangeAt implements JsonRpcMethod {
 
   private final Supplier<BlockchainQueries> blockchainQueries;
   private final Supplier<BlockReplay> blockReplay;
   private final boolean shortValues;
 
+  /**
+   * Instantiates a new Debug storage range at.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param blockReplay the block replay
+   */
   public DebugStorageRangeAt(
       final BlockchainQueries blockchainQueries, final BlockReplay blockReplay) {
     this(Suppliers.ofInstance(blockchainQueries), Suppliers.ofInstance(blockReplay), false);
   }
 
+  /**
+   * Instantiates a new Debug storage range at.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param blockReplay the block replay
+   * @param shortValues the short values
+   */
   public DebugStorageRangeAt(
       final Supplier<BlockchainQueries> blockchainQueries,
       final Supplier<BlockReplay> blockReplay,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlock.java
@@ -41,6 +41,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Debug trace block. */
 public class DebugTraceBlock implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(DebugTraceBlock.class);
@@ -48,6 +49,13 @@ public class DebugTraceBlock implements JsonRpcMethod {
   private final BlockHeaderFunctions blockHeaderFunctions;
   private final BlockchainQueries blockchainQueries;
 
+  /**
+   * Instantiates a new Debug trace block.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param blockHeaderFunctions the block header functions
+   * @param blockchainQueries the blockchain queries
+   */
   public DebugTraceBlock(
       final Supplier<BlockTracer> blockTracerSupplier,
       final BlockHeaderFunctions blockHeaderFunctions,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByHash.java
@@ -31,11 +31,18 @@ import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 import java.util.Collection;
 import java.util.function.Supplier;
 
+/** The type Debug trace block by hash. */
 public class DebugTraceBlockByHash implements JsonRpcMethod {
 
   private final Supplier<BlockTracer> blockTracerSupplier;
   private final Supplier<BlockchainQueries> blockchainQueries;
 
+  /**
+   * Instantiates a new Debug trace block by hash.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param blockchainQueriesSupplier the blockchain queries supplier
+   */
   public DebugTraceBlockByHash(
       final Supplier<BlockTracer> blockTracerSupplier,
       final Supplier<BlockchainQueries> blockchainQueriesSupplier) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockByNumber.java
@@ -30,10 +30,17 @@ import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+/** The type Debug trace block by number. */
 public class DebugTraceBlockByNumber extends AbstractBlockParameterMethod {
 
   private final Supplier<BlockTracer> blockTracerSupplier;
 
+  /**
+   * Instantiates a new Debug trace block by number.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param blockchain the blockchain
+   */
   public DebugTraceBlockByNumber(
       final Supplier<BlockTracer> blockTracerSupplier, final BlockchainQueries blockchain) {
     super(blockchain);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceCall.java
@@ -36,9 +36,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Debug trace call. */
 public class DebugTraceCall extends AbstractTraceCall {
   private static final Logger LOG = LoggerFactory.getLogger(DebugTraceCall.class);
 
+  /**
+   * Instantiates a new Debug trace call.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionSimulator the transaction simulator
+   */
   public DebugTraceCall(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceTransaction.java
@@ -30,11 +30,18 @@ import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 
 import java.util.Optional;
 
+/** The type Debug trace transaction. */
 public class DebugTraceTransaction implements JsonRpcMethod {
 
   private final TransactionTracer transactionTracer;
   private final BlockchainQueries blockchain;
 
+  /**
+   * Instantiates a new Debug trace transaction.
+   *
+   * @param blockchain the blockchain
+   * @param transactionTracer the transaction tracer
+   */
   public DebugTraceTransaction(
       final BlockchainQueries blockchain, final TransactionTracer transactionTracer) {
     this.blockchain = blockchain;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthAccounts.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthAccounts.java
@@ -19,7 +19,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
+/** The type Eth accounts. */
 public class EthAccounts implements JsonRpcMethod {
+  /** Default constructor. */
+  public EthAccounts() {}
 
   @Override
   public String getName() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlobBaseFee.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlobBaseFee.java
@@ -27,12 +27,20 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
+/** The type Eth blob base fee. */
 public class EthBlobBaseFee implements JsonRpcMethod {
 
+  /** The Blockchain. */
   final Blockchain blockchain;
 
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Eth blob base fee.
+   *
+   * @param blockchain the blockchain
+   * @param protocolSchedule the protocol schedule
+   */
   public EthBlobBaseFee(final Blockchain blockchain, final ProtocolSchedule protocolSchedule) {
     this.blockchain = blockchain;
     this.protocolSchedule = protocolSchedule;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlockNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthBlockNumber.java
@@ -25,15 +25,27 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Eth block number. */
 public class EthBlockNumber implements JsonRpcMethod {
 
   private final Supplier<BlockchainQueries> blockchain;
   private final boolean resultAsInteger;
 
+  /**
+   * Instantiates a new Eth block number.
+   *
+   * @param blockchain the blockchain
+   */
   public EthBlockNumber(final BlockchainQueries blockchain) {
     this(Suppliers.ofInstance(blockchain), false);
   }
 
+  /**
+   * Instantiates a new Eth block number.
+   *
+   * @param blockchain the blockchain
+   * @param resultAsInteger the result as integer
+   */
   public EthBlockNumber(
       final Supplier<BlockchainQueries> blockchain, final boolean resultAsInteger) {
     this.blockchain = blockchain;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCall.java
@@ -40,9 +40,16 @@ import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulatorResult;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
+/** The type Eth call. */
 public class EthCall extends AbstractBlockParameterOrBlockHashMethod {
   private final TransactionSimulator transactionSimulator;
 
+  /**
+   * Instantiates a new Eth call.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionSimulator the transaction simulator
+   */
   public EthCall(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     super(blockchainQueries);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthChainId.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthChainId.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import java.math.BigInteger;
 import java.util.Optional;
 
+/** The type Eth chain id. */
 public class EthChainId implements JsonRpcMethod {
 
   private final Optional<BigInteger> chainId;
 
+  /**
+   * Instantiates a new Eth chain id.
+   *
+   * @param chainId the chain id
+   */
   public EthChainId(final Optional<BigInteger> chainId) {
     this.chainId = chainId;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCoinbase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCoinbase.java
@@ -25,10 +25,16 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
 import java.util.Optional;
 
+/** The type Eth coinbase. */
 public class EthCoinbase implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Eth coinbase.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public EthCoinbase(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
@@ -37,8 +37,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
+/** The type Eth create access list. */
 public class EthCreateAccessList extends AbstractEstimateGas {
 
+  /**
+   * Instantiates a new Eth create access list.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionSimulator the transaction simulator
+   */
   public EthCreateAccessList(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     super(blockchainQueries, transactionSimulator);
@@ -158,6 +165,14 @@ public class EthCreateAccessList extends AbstractEstimateGas {
     return new AccessListSimulatorResult(result, tracer);
   }
 
+  /**
+   * Override access list call parameter.
+   *
+   * @param callParams the call params
+   * @param gasLimit the gas limit
+   * @param accessListEntries the access list entries
+   * @return the call parameter
+   */
   protected CallParameter overrideAccessList(
       final JsonCallParameter callParams,
       final long gasLimit,
@@ -175,19 +190,38 @@ public class EthCreateAccessList extends AbstractEstimateGas {
   }
 
   private static class AccessListSimulatorResult {
+    /** The Result. */
     final Optional<TransactionSimulatorResult> result;
+
+    /** The Tracer. */
     final AccessListOperationTracer tracer;
 
+    /**
+     * Instantiates a new Access list simulator result.
+     *
+     * @param result the result
+     * @param tracer the tracer
+     */
     public AccessListSimulatorResult(
         final Optional<TransactionSimulatorResult> result, final AccessListOperationTracer tracer) {
       this.result = result;
       this.tracer = tracer;
     }
 
+    /**
+     * Gets result.
+     *
+     * @return the result
+     */
     public Optional<TransactionSimulatorResult> getResult() {
       return result;
     }
 
+    /**
+     * Gets tracer.
+     *
+     * @return the tracer
+     */
     public AccessListOperationTracer getTracer() {
       return tracer;
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -35,10 +35,17 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth estimate gas. */
 public class EthEstimateGas extends AbstractEstimateGas {
 
   private static final Logger LOG = LoggerFactory.getLogger(EthEstimateGas.class);
 
+  /**
+   * Instantiates a new Eth estimate gas.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param transactionSimulator the transaction simulator
+   */
   public EthEstimateGas(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     super(blockchainQueries, transactionSimulator);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthFeeHistory.java
@@ -56,6 +56,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Streams;
 
+/** The type Eth fee history. */
 public class EthFeeHistory implements JsonRpcMethod {
   private final ProtocolSchedule protocolSchedule;
   private final Blockchain blockchain;
@@ -64,8 +65,17 @@ public class EthFeeHistory implements JsonRpcMethod {
   private final Cache<RewardCacheKey, List<Wei>> cache;
   private static final int MAXIMUM_CACHE_SIZE = 100_000;
 
+  /** The type Reward cache key. */
   record RewardCacheKey(Hash blockHash, List<Double> rewardPercentiles) {}
 
+  /**
+   * Instantiates a new Eth fee history.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param blockchain the blockchain
+   * @param miningCoordinator the mining coordinator
+   * @param apiConfiguration the api configuration
+   */
   public EthFeeHistory(
       final ProtocolSchedule protocolSchedule,
       final Blockchain blockchain,
@@ -212,8 +222,16 @@ public class EthFeeHistory implements JsonRpcMethod {
             });
   }
 
+  /** The type Transaction info. */
   record TransactionInfo(Transaction transaction, Long gasUsed, Wei effectivePriorityFeePerGas) {}
 
+  /**
+   * Compute rewards list.
+   *
+   * @param rewardPercentiles the reward percentiles
+   * @param block the block
+   * @return the list
+   */
   @VisibleForTesting
   public List<Wei> computeRewards(final List<Double> rewardPercentiles, final Block block) {
     final List<Transaction> transactions = block.getBody().getTransactions();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPrice.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPrice.java
@@ -27,12 +27,20 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+/** The type Eth gas price. */
 public class EthGasPrice implements JsonRpcMethod {
 
   private final Supplier<BlockchainQueries> blockchain;
   private final MiningCoordinator miningCoordinator;
   private final ApiConfiguration apiConfiguration;
 
+  /**
+   * Instantiates a new Eth gas price.
+   *
+   * @param blockchain the blockchain
+   * @param miningCoordinator the mining coordinator
+   * @param apiConfiguration the api configuration
+   */
   public EthGasPrice(
       final BlockchainQueries blockchain,
       final MiningCoordinator miningCoordinator,
@@ -40,6 +48,13 @@ public class EthGasPrice implements JsonRpcMethod {
     this(() -> blockchain, miningCoordinator, apiConfiguration);
   }
 
+  /**
+   * Instantiates a new Eth gas price.
+   *
+   * @param blockchain the blockchain
+   * @param miningCoordinator the mining coordinator
+   * @param apiConfiguration the api configuration
+   */
   public EthGasPrice(
       final Supplier<BlockchainQueries> blockchain,
       final MiningCoordinator miningCoordinator,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBalance.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBalance.java
@@ -24,11 +24,22 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import java.util.function.Supplier;
 
+/** The type Eth get balance. */
 public class EthGetBalance extends AbstractBlockParameterOrBlockHashMethod {
+  /**
+   * Instantiates a new Eth get balance.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public EthGetBalance(final BlockchainQueries blockchainQueries) {
     super(blockchainQueries);
   }
 
+  /**
+   * Instantiates a new Eth get balance.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public EthGetBalance(final Supplier<BlockchainQueries> blockchainQueries) {
     super(blockchainQueries);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByHash.java
@@ -27,17 +27,31 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Eth get block by hash. */
 public class EthGetBlockByHash implements JsonRpcMethod {
 
   private final BlockResultFactory blockResult;
   private final Supplier<BlockchainQueries> blockchain;
   private final boolean includeCoinbase;
 
+  /**
+   * Instantiates a new Eth get block by hash.
+   *
+   * @param blockchain the blockchain
+   * @param blockResult the block result
+   */
   public EthGetBlockByHash(
       final BlockchainQueries blockchain, final BlockResultFactory blockResult) {
     this(Suppliers.ofInstance(blockchain), blockResult, false);
   }
 
+  /**
+   * Instantiates a new Eth get block by hash.
+   *
+   * @param blockchain the blockchain
+   * @param blockResult the block result
+   * @param includeCoinbase the include coinbase
+   */
   public EthGetBlockByHash(
       final Supplier<BlockchainQueries> blockchain,
       final BlockResultFactory blockResult,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -30,6 +30,7 @@ import com.google.common.base.Suppliers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth get block by number. */
 public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
 
   private final BlockResultFactory blockResult;
@@ -37,6 +38,13 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
   private static final Logger LOGGER = LoggerFactory.getLogger(EthGetBlockByNumber.class);
   private final Synchronizer synchronizer;
 
+  /**
+   * Instantiates a new Eth get block by number.
+   *
+   * @param blockchain the blockchain
+   * @param blockResult the block result
+   * @param synchronizer the synchronizer
+   */
   public EthGetBlockByNumber(
       final BlockchainQueries blockchain,
       final BlockResultFactory blockResult,
@@ -44,6 +52,14 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
     this(Suppliers.ofInstance(blockchain), blockResult, synchronizer, false);
   }
 
+  /**
+   * Instantiates a new Eth get block by number.
+   *
+   * @param blockchain the blockchain
+   * @param blockResult the block result
+   * @param synchronizer the synchronizer
+   * @param includeCoinbase the include coinbase
+   */
   public EthGetBlockByNumber(
       final Supplier<BlockchainQueries> blockchain,
       final BlockResultFactory blockResult,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceipts.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceipts.java
@@ -35,10 +35,17 @@ import java.util.stream.Collectors;
 
 import com.google.common.base.Suppliers;
 
+/** The type Eth get block receipts. */
 public class EthGetBlockReceipts extends AbstractBlockParameterOrBlockHashMethod {
 
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Eth get block receipts.
+   *
+   * @param blockchain the blockchain
+   * @param protocolSchedule the protocol schedule
+   */
   public EthGetBlockReceipts(
       final BlockchainQueries blockchain, final ProtocolSchedule protocolSchedule) {
     super(Suppliers.ofInstance(blockchain));

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByHash.java
@@ -22,10 +22,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get block transaction count by hash. */
 public class EthGetBlockTransactionCountByHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
 
+  /**
+   * Instantiates a new Eth get block transaction count by hash.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetBlockTransactionCountByHash(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockTransactionCountByNumber.java
@@ -20,8 +20,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get block transaction count by number. */
 public class EthGetBlockTransactionCountByNumber extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Eth get block transaction count by number.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetBlockTransactionCountByNumber(final BlockchainQueries blockchain) {
     super(blockchain);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetCode.java
@@ -25,12 +25,23 @@ import java.util.function.Supplier;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Eth get code. */
 public class EthGetCode extends AbstractBlockParameterOrBlockHashMethod {
 
+  /**
+   * Instantiates a new Eth get code.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public EthGetCode(final BlockchainQueries blockchainQueries) {
     super(blockchainQueries);
   }
 
+  /**
+   * Instantiates a new Eth get code.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public EthGetCode(final Supplier<BlockchainQueries> blockchainQueries) {
     super(blockchainQueries);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChanges.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterChanges.java
@@ -28,10 +28,16 @@ import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** The type Eth get filter changes. */
 public class EthGetFilterChanges implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth get filter changes.
+   *
+   * @param filterManager the filter manager
+   */
   public EthGetFilterChanges(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetFilterLogs.java
@@ -26,10 +26,16 @@ import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 
 import java.util.List;
 
+/** The type Eth get filter logs. */
 public class EthGetFilterLogs implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth get filter logs.
+   *
+   * @param filterManager the filter manager
+   */
   public EthGetFilterLogs(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetLogs.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth get logs. */
 public class EthGetLogs implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(EthGetLogs.class);
@@ -39,6 +40,12 @@ public class EthGetLogs implements JsonRpcMethod {
   private final BlockchainQueries blockchain;
   private final long maxLogRange;
 
+  /**
+   * Instantiates a new Eth get logs.
+   *
+   * @param blockchain the blockchain
+   * @param maxLogRange the max log range
+   */
   public EthGetLogs(final BlockchainQueries blockchain, final long maxLogRange) {
     this.blockchain = blockchain;
     this.maxLogRange = maxLogRange;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockHash.java
@@ -38,15 +38,28 @@ import java.util.function.Supplier;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.units.bigints.BaseUInt256Value;
 
+/** The type Eth get miner data by block hash. */
 public class EthGetMinerDataByBlockHash implements JsonRpcMethod {
   private final Supplier<BlockchainQueries> blockchain;
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Eth get miner data by block hash.
+   *
+   * @param blockchain the blockchain
+   * @param protocolSchedule the protocol schedule
+   */
   public EthGetMinerDataByBlockHash(
       final BlockchainQueries blockchain, final ProtocolSchedule protocolSchedule) {
     this(Suppliers.ofInstance(blockchain), protocolSchedule);
   }
 
+  /**
+   * Instantiates a new Eth get miner data by block hash.
+   *
+   * @param blockchain the blockchain
+   * @param protocolSchedule the protocol schedule
+   */
   public EthGetMinerDataByBlockHash(
       final Supplier<BlockchainQueries> blockchain, final ProtocolSchedule protocolSchedule) {
     this.blockchain = blockchain;
@@ -73,6 +86,14 @@ public class EthGetMinerDataByBlockHash implements JsonRpcMethod {
     return new JsonRpcSuccessResponse(requestContext.getRequest().getId(), minerDataResult);
   }
 
+  /**
+   * Create miner data result miner data result.
+   *
+   * @param block the block
+   * @param protocolSchedule the protocol schedule
+   * @param blockchainQueries the blockchain queries
+   * @return the miner data result
+   */
   public static MinerDataResult createMinerDataResult(
       final BlockWithMetadata<TransactionWithMetadata, Hash> block,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetMinerDataByBlockNumber.java
@@ -24,9 +24,16 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
+/** The type Eth get miner data by block number. */
 public class EthGetMinerDataByBlockNumber extends AbstractBlockParameterMethod {
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Eth get miner data by block number.
+   *
+   * @param blockchain the blockchain
+   * @param protocolSchedule the protocol schedule
+   */
   public EthGetMinerDataByBlockNumber(
       final BlockchainQueries blockchain, final ProtocolSchedule protocolSchedule) {
     super(blockchain);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProof.java
@@ -35,7 +35,13 @@ import java.util.stream.Collectors;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Eth get proof. */
 public class EthGetProof extends AbstractBlockParameterOrBlockHashMethod {
+  /**
+   * Instantiates a new Eth get proof.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetProof(final BlockchainQueries blockchain) {
     super(blockchain);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetStorageAt.java
@@ -24,7 +24,13 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
+/** The type Eth get storage at. */
 public class EthGetStorageAt extends AbstractBlockParameterOrBlockHashMethod {
+  /**
+   * Instantiates a new Eth get storage at.
+   *
+   * @param blockchainQueries the blockchain queries
+   */
   public EthGetStorageAt(final BlockchainQueries blockchainQueries) {
     super(blockchainQueries);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockHashAndIndex.java
@@ -27,10 +27,16 @@ import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 
 import java.util.Optional;
 
+/** The type Eth get transaction by block hash and index. */
 public class EthGetTransactionByBlockHashAndIndex implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
 
+  /**
+   * Instantiates a new Eth get transaction by block hash and index.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetTransactionByBlockHashAndIndex(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockNumberAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByBlockNumberAndIndex.java
@@ -24,8 +24,14 @@ import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
 
 import java.util.Optional;
 
+/** The type Eth get transaction by block number and index. */
 public class EthGetTransactionByBlockNumberAndIndex extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Eth get transaction by block number and index.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetTransactionByBlockNumberAndIndex(final BlockchainQueries blockchain) {
     super(blockchain);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionByHash.java
@@ -28,11 +28,18 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.Optional;
 
+/** The type Eth get transaction by hash. */
 public class EthGetTransactionByHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Eth get transaction by hash.
+   *
+   * @param blockchain the blockchain
+   * @param transactionPool the transaction pool
+   */
   public EthGetTransactionByHash(
       final BlockchainQueries blockchain, final TransactionPool transactionPool) {
     this.blockchain = blockchain;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionCount.java
@@ -27,14 +27,27 @@ import java.util.function.Supplier;
 
 import com.google.common.base.Suppliers;
 
+/** The type Eth get transaction count. */
 public class EthGetTransactionCount extends AbstractBlockParameterOrBlockHashMethod {
   private final Supplier<TransactionPool> transactionPoolSupplier;
 
+  /**
+   * Instantiates a new Eth get transaction count.
+   *
+   * @param blockchain the blockchain
+   * @param transactionPoolSupplier the transaction pool supplier
+   */
   public EthGetTransactionCount(
       final BlockchainQueries blockchain, final TransactionPool transactionPoolSupplier) {
     this(Suppliers.ofInstance(blockchain), Suppliers.ofInstance(transactionPoolSupplier));
   }
 
+  /**
+   * Instantiates a new Eth get transaction count.
+   *
+   * @param blockchain the blockchain
+   * @param transactionPoolSupplier the transaction pool supplier
+   */
   public EthGetTransactionCount(
       final Supplier<BlockchainQueries> blockchain,
       final Supplier<TransactionPool> transactionPoolSupplier) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceipt.java
@@ -27,12 +27,19 @@ import org.hyperledger.besu.ethereum.api.query.TransactionReceiptWithMetadata;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.TransactionReceiptType;
 
+/** The type Eth get transaction receipt. */
 public class EthGetTransactionReceipt implements JsonRpcMethod {
 
   private final BlockchainQueries blockchainQueries;
 
   private final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Eth get transaction receipt.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   */
   public EthGetTransactionReceipt(
       final BlockchainQueries blockchainQueries, final ProtocolSchedule protocolSchedule) {
     this.blockchainQueries = blockchainQueries;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockHashAndIndex.java
@@ -24,10 +24,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.UncleBlockResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get uncle by block hash and index. */
 public class EthGetUncleByBlockHashAndIndex implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
 
+  /**
+   * Instantiates a new Eth get uncle by block hash and index.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetUncleByBlockHashAndIndex(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndex.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleByBlockNumberAndIndex.java
@@ -22,8 +22,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.UncleBlockResult;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get uncle by block number and index. */
 public class EthGetUncleByBlockNumberAndIndex extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Eth get uncle by block number and index.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetUncleByBlockNumberAndIndex(final BlockchainQueries blockchain) {
     super(blockchain);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockHash.java
@@ -22,10 +22,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get uncle count by block hash. */
 public class EthGetUncleCountByBlockHash implements JsonRpcMethod {
 
   private final BlockchainQueries blockchain;
 
+  /**
+   * Instantiates a new Eth get uncle count by block hash.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetUncleCountByBlockHash(final BlockchainQueries blockchain) {
     this.blockchain = blockchain;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetUncleCountByBlockNumber.java
@@ -20,8 +20,14 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 
+/** The type Eth get uncle count by block number. */
 public class EthGetUncleCountByBlockNumber extends AbstractBlockParameterMethod {
 
+  /**
+   * Instantiates a new Eth get uncle count by block number.
+   *
+   * @param blockchain the blockchain
+   */
   public EthGetUncleCountByBlockNumber(final BlockchainQueries blockchain) {
     super(blockchain);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWork.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetWork.java
@@ -35,12 +35,18 @@ import com.google.common.io.BaseEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth get work. */
 public class EthGetWork implements JsonRpcMethod {
 
   private final MiningCoordinator miner;
   private static final Logger LOG = LoggerFactory.getLogger(EthGetWork.class);
   private final EpochCalculator epochCalculator;
 
+  /**
+   * Instantiates a new Eth get work.
+   *
+   * @param miner the miner
+   */
   public EthGetWork(final MiningCoordinator miner) {
     this.miner = miner;
     if (miner instanceof PoWMiningCoordinator) {
@@ -70,6 +76,12 @@ public class EthGetWork implements JsonRpcMethod {
     }
   }
 
+  /**
+   * Raw response list.
+   *
+   * @param rawResult the raw result
+   * @return the list
+   */
   public List<String> rawResponse(final PoWSolverInputs rawResult) {
     final byte[] dagSeed =
         DirectAcyclicGraphSeed.dagSeed(rawResult.getBlockNumber(), epochCalculator);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthHashrate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthHashrate.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
 import java.util.Optional;
 
+/** The type Eth hashrate. */
 public class EthHashrate implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Eth hashrate.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public EthHashrate(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthMining.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthMining.java
@@ -20,10 +20,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
+/** The type Eth mining. */
 public class EthMining implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Eth mining.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public EthMining(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewBlockFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewBlockFilter.java
@@ -20,10 +20,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
+/** The type Eth new block filter. */
 public class EthNewBlockFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth new block filter.
+   *
+   * @param filterManager the filter manager
+   */
   public EthNewBlockFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
+/** The type Eth new filter. */
 public class EthNewFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth new filter.
+   *
+   * @param filterManager the filter manager
+   */
   public EthNewFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewPendingTransactionFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewPendingTransactionFilter.java
@@ -20,10 +20,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
+/** The type Eth new pending transaction filter. */
 public class EthNewPendingTransactionFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth new pending transaction filter.
+   *
+   * @param filterManager the filter manager
+   */
   public EthNewPendingTransactionFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthProtocolVersion.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthProtocolVersion.java
@@ -25,10 +25,16 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import java.util.OptionalInt;
 import java.util.Set;
 
+/** The type Eth protocol version. */
 public class EthProtocolVersion implements JsonRpcMethod {
 
   private final Integer highestEthVersion;
 
+  /**
+   * Instantiates a new Eth protocol version.
+   *
+   * @param supportedCapabilities the supported capabilities
+   */
   public EthProtocolVersion(final Set<Capability> supportedCapabilities) {
     final OptionalInt version =
         supportedCapabilities.stream()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendRawTransaction.java
@@ -38,6 +38,7 @@ import com.google.common.base.Suppliers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth send raw transaction. */
 public class EthSendRawTransaction implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(EthSendRawTransaction.class);
 
@@ -45,10 +46,21 @@ public class EthSendRawTransaction implements JsonRpcMethod {
 
   private final Supplier<TransactionPool> transactionPool;
 
+  /**
+   * Instantiates a new Eth send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   */
   public EthSendRawTransaction(final TransactionPool transactionPool) {
     this(Suppliers.ofInstance(transactionPool), false);
   }
 
+  /**
+   * Instantiates a new Eth send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   * @param sendEmptyHashOnInvalidBlock the send empty hash on invalid block
+   */
   public EthSendRawTransaction(
       final Supplier<TransactionPool> transactionPool, final boolean sendEmptyHashOnInvalidBlock) {
     this.transactionPool = transactionPool;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSendTransaction.java
@@ -20,7 +20,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
+/** The type Eth send transaction. */
 public class EthSendTransaction implements JsonRpcMethod {
+  /** Default constructor. */
+  public EthSendTransaction() {}
 
   @Override
   public String getName() {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitHashRate.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitHashRate.java
@@ -22,10 +22,16 @@ import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Eth submit hash rate. */
 public class EthSubmitHashRate implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Eth submit hash rate.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public EthSubmitHashRate(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWork.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSubmitWork.java
@@ -31,11 +31,17 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Eth submit work. */
 public class EthSubmitWork implements JsonRpcMethod {
 
   private final MiningCoordinator miner;
   private static final Logger LOG = LoggerFactory.getLogger(EthSubmitWork.class);
 
+  /**
+   * Instantiates a new Eth submit work.
+   *
+   * @param miner the miner
+   */
   public EthSubmitWork(final MiningCoordinator miner) {
     this.miner = miner;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncing.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthSyncing.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.SyncingResult;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 
+/** The type Eth syncing. */
 /*
  * SyncProgress retrieves the current progress of the syncing algorithm. If there's no sync
  * currently running, it returns false.
@@ -29,6 +30,11 @@ public class EthSyncing implements JsonRpcMethod {
 
   private final Synchronizer synchronizer;
 
+  /**
+   * Instantiates a new Eth syncing.
+   *
+   * @param synchronizer the synchronizer
+   */
   public EthSyncing(final Synchronizer synchronizer) {
     this.synchronizer = synchronizer;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthUninstallFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthUninstallFilter.java
@@ -20,10 +20,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
+/** The type Eth uninstall filter. */
 public class EthUninstallFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;
 
+  /**
+   * Instantiates a new Eth uninstall filter.
+   *
+   * @param filterManager the filter manager
+   */
   public EthUninstallFilter(final FilterManager filterManager) {
     this.filterManager = filterManager;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecuteTransactionStep.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
+/** The type Execute transaction step. */
 public class ExecuteTransactionStep implements Function<TransactionTrace, TransactionTrace> {
 
   private final TraceBlock.ChainUpdater chainUpdater;
@@ -43,6 +44,16 @@ public class ExecuteTransactionStep implements Function<TransactionTrace, Transa
   private final ProtocolSpec protocolSpec;
   private final Block block;
 
+  /**
+   * Instantiates a new Execute transaction step.
+   *
+   * @param chainUpdater the chain updater
+   * @param transactionProcessor the transaction processor
+   * @param blockchain the blockchain
+   * @param tracer the tracer
+   * @param protocolSpec the protocol spec
+   * @param block the block
+   */
   public ExecuteTransactionStep(
       final TraceBlock.ChainUpdater chainUpdater,
       final MainnetTransactionProcessor transactionProcessor,
@@ -58,6 +69,15 @@ public class ExecuteTransactionStep implements Function<TransactionTrace, Transa
     this.block = block;
   }
 
+  /**
+   * Instantiates a new Execute transaction step.
+   *
+   * @param chainUpdater the chain updater
+   * @param transactionProcessor the transaction processor
+   * @param blockchain the blockchain
+   * @param tracer the tracer
+   * @param protocolSpec the protocol spec
+   */
   public ExecuteTransactionStep(
       final TraceBlock.ChainUpdater chainUpdater,
       final MainnetTransactionProcessor transactionProcessor,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/ExecutionEngineJsonRpcMethod.java
@@ -33,24 +33,51 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Execution engine json rpc method. */
 public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
+  /** The enum Engine status. */
   public enum EngineStatus {
+    /** Valid engine status. */
     VALID,
+    /** Invalid engine status. */
     INVALID,
+    /** Syncing engine status. */
     SYNCING,
+    /** Accepted engine status. */
     ACCEPTED,
+    /** Invalid block hash engine status. */
     INVALID_BLOCK_HASH;
   }
 
+  /** The constant ENGINE_API_LOGGING_THRESHOLD. */
   public static final long ENGINE_API_LOGGING_THRESHOLD = 60000L;
+
   private final Vertx syncVertx;
   private static final Logger LOG = LoggerFactory.getLogger(ExecutionEngineJsonRpcMethod.class);
+
+  /** The Merge context optional. */
   protected final Optional<MergeContext> mergeContextOptional;
+
+  /** The Merge context. */
   protected final Supplier<MergeContext> mergeContext;
+
+  /** The Protocol schedule. */
   protected final Optional<ProtocolSchedule> protocolSchedule;
+
+  /** The Protocol context. */
   protected final ProtocolContext protocolContext;
+
+  /** The Engine call listener. */
   protected final EngineCallListener engineCallListener;
 
+  /**
+   * Instantiates a new Execution engine json rpc method.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param engineCallListener the engine call listener
+   */
   protected ExecutionEngineJsonRpcMethod(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,
@@ -64,6 +91,13 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     this.engineCallListener = engineCallListener;
   }
 
+  /**
+   * Instantiates a new Execution engine json rpc method.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param engineCallListener the engine call listener
+   */
   protected ExecutionEngineJsonRpcMethod(
       final Vertx vertx,
       final ProtocolContext protocolContext,
@@ -122,8 +156,20 @@ public abstract class ExecutionEngineJsonRpcMethod implements JsonRpcMethod {
     }
   }
 
+  /**
+   * Sync response json rpc response.
+   *
+   * @param request the request
+   * @return the json rpc response
+   */
   public abstract JsonRpcResponse syncResponse(final JsonRpcRequestContext request);
 
+  /**
+   * Validate fork supported validation result.
+   *
+   * @param blockTimestamp the block timestamp
+   * @return the validation result
+   */
   protected ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {
     return ValidationResult.valid();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/JsonCallParameterUtil.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/JsonCallParameterUtil.java
@@ -18,10 +18,17 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonCallParameter;
 
+/** The type Json call parameter util. */
 public class JsonCallParameterUtil {
 
   private JsonCallParameterUtil() {}
 
+  /**
+   * Validate and get call params json call parameter.
+   *
+   * @param request the request
+   * @return the json call parameter
+   */
   public static JsonCallParameter validateAndGetCallParams(final JsonRpcRequestContext request) {
     final JsonCallParameter callParams = request.getRequiredParameter(0, JsonCallParameter.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/JsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/JsonRpcMethod.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import java.util.ArrayList;
 import java.util.List;
 
+/** The interface Json rpc method. */
 public interface JsonRpcMethod {
 
   /**

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetEnode.java
@@ -25,10 +25,16 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import java.util.Optional;
 
+/** The type Net enode. */
 public class NetEnode implements JsonRpcMethod {
 
   private final P2PNetwork p2pNetwork;
 
+  /**
+   * Instantiates a new Net enode.
+   *
+   * @param p2pNetwork the p 2 p network
+   */
   public NetEnode(final P2PNetwork p2pNetwork) {
     this.p2pNetwork = p2pNetwork;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetListening.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetListening.java
@@ -20,10 +20,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 
+/** The type Net listening. */
 public class NetListening implements JsonRpcMethod {
 
   private final P2PNetwork p2pNetwork;
 
+  /**
+   * Instantiates a new Net listening.
+   *
+   * @param p2pNetwork the p 2 p network
+   */
   public NetListening(final P2PNetwork p2pNetwork) {
     this.p2pNetwork = p2pNetwork;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetPeerCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetPeerCount.java
@@ -24,9 +24,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.p2p.network.exceptions.P2PDisabledException;
 
+/** The type Net peer count. */
 public class NetPeerCount implements JsonRpcMethod {
   private final P2PNetwork p2pNetwork;
 
+  /**
+   * Instantiates a new Net peer count.
+   *
+   * @param p2pNetwork the p 2 p network
+   */
   public NetPeerCount(final P2PNetwork p2pNetwork) {
     this.p2pNetwork = p2pNetwork;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetServices.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetServices.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 
 import com.google.common.collect.ImmutableMap;
 
+/** The type Net services. */
 public class NetServices implements JsonRpcMethod {
 
   private final JsonRpcConfiguration jsonRpcConfiguration;
@@ -33,6 +34,14 @@ public class NetServices implements JsonRpcMethod {
   private final P2PNetwork p2pNetwork;
   private final MetricsConfiguration metricsConfiguration;
 
+  /**
+   * Instantiates a new Net services.
+   *
+   * @param jsonRpcConfiguration the json rpc configuration
+   * @param webSocketConfiguration the web socket configuration
+   * @param p2pNetwork the p 2 p network
+   * @param metricsConfiguration the metrics configuration
+   */
   public NetServices(
       final JsonRpcConfiguration jsonRpcConfiguration,
       final WebSocketConfiguration webSocketConfiguration,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersion.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/NetVersion.java
@@ -31,6 +31,11 @@ import java.util.Optional;
 public class NetVersion implements JsonRpcMethod {
   private final String networkId;
 
+  /**
+   * Instantiates a new Net version.
+   *
+   * @param netId the net id
+   */
   public NetVersion(final Optional<BigInteger> netId) {
     this.networkId = String.valueOf(netId.orElse(null));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginJsonRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginJsonRpcMethod.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Plugin json rpc method. */
 public class PluginJsonRpcMethod implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PluginJsonRpcMethod.class);
@@ -34,6 +35,12 @@ public class PluginJsonRpcMethod implements JsonRpcMethod {
   private final String name;
   private final Function<PluginRpcRequest, ?> function;
 
+  /**
+   * Instantiates a new Plugin json rpc method.
+   *
+   * @param name the name
+   * @param function the function
+   */
   public PluginJsonRpcMethod(final String name, final Function<PluginRpcRequest, ?> function) {
     this.name = name;
     this.function = function;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginsReloadConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/PluginsReloadConfiguration.java
@@ -29,11 +29,17 @@ import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Plugins reload configuration. */
 public class PluginsReloadConfiguration implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PluginsReloadConfiguration.class);
   private final Map<String, BesuPlugin> namedPlugins;
 
+  /**
+   * Instantiates a new Plugins reload configuration.
+   *
+   * @param namedPlugins the named plugins
+   */
   public PluginsReloadConfiguration(final Map<String, BesuPlugin> namedPlugins) {
     this.namedPlugins = namedPlugins;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/RpcModules.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/RpcModules.java
@@ -24,10 +24,16 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+/** The type Rpc modules. */
 public class RpcModules implements JsonRpcMethod {
 
   private final Map<String, String> moduleVersions;
 
+  /**
+   * Instantiates a new Rpc modules.
+   *
+   * @param modulesList the modules list
+   */
   public RpcModules(final Collection<String> modulesList) {
     this.moduleVersions =
         modulesList.stream()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
@@ -51,11 +51,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace block. */
 public class TraceBlock extends AbstractBlockParameterMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceBlock.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** The Protocol schedule. */
   protected final ProtocolSchedule protocolSchedule;
 
+  /**
+   * Instantiates a new Trace block.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param queries the queries
+   */
   public TraceBlock(final ProtocolSchedule protocolSchedule, final BlockchainQueries queries) {
     super(queries);
     this.protocolSchedule = protocolSchedule;
@@ -88,6 +97,13 @@ public class TraceBlock extends AbstractBlockParameterMethod {
         .orElse(null);
   }
 
+  /**
+   * Trace block array node wrapper.
+   *
+   * @param block the block
+   * @param filterParameter the filter parameter
+   * @return the array node wrapper
+   */
   protected ArrayNodeWrapper traceBlock(
       final Block block, final Optional<FilterParameter> filterParameter) {
 
@@ -165,6 +181,14 @@ public class TraceBlock extends AbstractBlockParameterMethod {
         .orElse(emptyResult());
   }
 
+  /**
+   * Generate traces from transaction trace and block.
+   *
+   * @param filterParameter the filter parameter
+   * @param transactionTraces the transaction traces
+   * @param block the block
+   * @param resultArrayNode the result array node
+   */
   protected void generateTracesFromTransactionTraceAndBlock(
       final Optional<FilterParameter> filterParameter,
       final List<TransactionTrace> transactionTraces,
@@ -177,6 +201,13 @@ public class TraceBlock extends AbstractBlockParameterMethod {
                 .forEachOrdered(resultArrayNode::addPOJO));
   }
 
+  /**
+   * Generate rewards from block.
+   *
+   * @param maybeFilterParameter the maybe filter parameter
+   * @param block the block
+   * @param resultArrayNode the result array node
+   */
   protected void generateRewardsFromBlock(
       final Optional<FilterParameter> maybeFilterParameter,
       final Block block,
@@ -185,24 +216,46 @@ public class TraceBlock extends AbstractBlockParameterMethod {
         .forEachOrdered(resultArrayNode::addPOJO);
   }
 
+  /**
+   * Empty result array node wrapper.
+   *
+   * @return the array node wrapper
+   */
   ArrayNodeWrapper emptyResult() {
     return new ArrayNodeWrapper(MAPPER.createArrayNode());
   }
 
+  /** The type Chain updater. */
   public static class ChainUpdater {
 
     private final MutableWorldState worldState;
     private WorldUpdater updater;
 
+    /**
+     * Instantiates a new Chain updater.
+     *
+     * @param worldState the world state
+     */
     public ChainUpdater(final MutableWorldState worldState) {
       this.worldState = worldState;
     }
 
+    /**
+     * Instantiates a new Chain updater.
+     *
+     * @param worldState the world state
+     * @param updater the updater
+     */
     public ChainUpdater(final MutableWorldState worldState, final WorldUpdater updater) {
       this.worldState = worldState;
       this.updater = updater;
     }
 
+    /**
+     * Gets next updater.
+     *
+     * @return the next updater
+     */
     public WorldUpdater getNextUpdater() {
       // if we have no prior updater, it must be the first TX, so use the block's initial state
       if (updater == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCall.java
@@ -34,9 +34,17 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace call. */
 public class TraceCall extends AbstractTraceCall {
   private static final Logger LOG = LoggerFactory.getLogger(TraceCall.class);
 
+  /**
+   * Instantiates a new Trace call.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionSimulator the transaction simulator
+   */
   public TraceCall(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceCallMany.java
@@ -45,10 +45,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace call many. */
 public class TraceCallMany extends TraceCall implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(TraceCallMany.class);
 
+  /**
+   * Instantiates a new Trace call many.
+   *
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   * @param transactionSimulator the transaction simulator
+   */
   public TraceCallMany(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
@@ -175,12 +183,14 @@ public class TraceCallMany extends TraceCall implements JsonRpcMethod {
   }
 
   private static class TransactionInvalidException extends RuntimeException {
+    /** Instantiates a new Transaction invalid exception. */
     TransactionInvalidException() {
       super();
     }
   }
 
   private static class EmptySimulatorResultException extends RuntimeException {
+    /** Instantiates a new Empty simulator result exception. */
     EmptySimulatorResultException() {
       super();
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilter.java
@@ -65,11 +65,20 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace filter. */
 public class TraceFilter extends TraceBlock {
 
   private static final Logger LOG = LoggerFactory.getLogger(TraceFilter.class);
   private final Long maxRange;
 
+  /**
+   * Instantiates a new Trace filter.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param protocolSchedule the protocol schedule
+   * @param blockchainQueries the blockchain queries
+   * @param maxRange the max range
+   */
   public TraceFilter(
       final Supplier<BlockTracer> blockTracerSupplier,
       final ProtocolSchedule protocolSchedule,
@@ -227,6 +236,12 @@ public class TraceFilter extends TraceBlock {
     return blockList;
   }
 
+  /**
+   * Create transaction block map map.
+   *
+   * @param blockList the block list
+   * @return the map
+   */
   public Map<Transaction, Block> createTransactionBlockMap(final List<Block> blockList) {
     Map<Transaction, Block> transactionBlockMap = new HashMap<>();
     for (Block block : blockList) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterSource.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterSource.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Trace filter source. */
 public class TraceFilterSource implements Iterator<TransactionTrace> {
 
   private final ArrayNodeWrapper resultArrayNode;
@@ -31,6 +32,12 @@ public class TraceFilterSource implements Iterator<TransactionTrace> {
   private Iterator<TransactionTrace> transactionTraceIterator;
   private Block currentBlock;
 
+  /**
+   * Instantiates a new Trace filter source.
+   *
+   * @param blockList the block list
+   * @param resultArrayNode the result array node
+   */
   public TraceFilterSource(final List<Block> blockList, final ArrayNodeWrapper resultArrayNode) {
     this.resultArrayNode = resultArrayNode;
     this.blockIterator = blockList.iterator();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFlatTransactionStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFlatTransactionStep.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+/** The type Trace flat transaction step. */
 public class TraceFlatTransactionStep
     implements Function<TransactionTrace, CompletableFuture<Stream<FlatTrace>>> {
 
@@ -37,6 +38,13 @@ public class TraceFlatTransactionStep
   private final Block block;
   private final Optional<FilterParameter> filterParameter;
 
+  /**
+   * Instantiates a new Trace flat transaction step.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param block the block
+   * @param filterParameter the filter parameter
+   */
   public TraceFlatTransactionStep(
       final ProtocolSchedule protocolSchedule,
       final Block block,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceGet.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceGet.java
@@ -32,9 +32,17 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace get. */
 public class TraceGet extends AbstractTraceByHash implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceGet.class);
 
+  /**
+   * Instantiates a new Trace get.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param blockchainQueries the blockchain queries
+   * @param protocolSchedule the protocol schedule
+   */
   public TraceGet(
       final Supplier<BlockTracer> blockTracerSupplier,
       final BlockchainQueries blockchainQueries,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceRawTransaction.java
@@ -41,9 +41,17 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace raw transaction. */
 public class TraceRawTransaction extends AbstractTraceByBlock implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceRawTransaction.class);
 
+  /**
+   * Instantiates a new Trace raw transaction.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param blockchainQueries the blockchain queries
+   * @param transactionSimulator the transaction simulator
+   */
   public TraceRawTransaction(
       final ProtocolSchedule protocolSchedule,
       final BlockchainQueries blockchainQueries,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayBlockTransactions.java
@@ -52,11 +52,18 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace replay block transactions. */
 public class TraceReplayBlockTransactions extends AbstractBlockParameterMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceReplayBlockTransactions.class);
   private final ProtocolSchedule protocolSchedule;
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
+  /**
+   * Instantiates a new Trace replay block transactions.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param queries the queries
+   */
   public TraceReplayBlockTransactions(
       final ProtocolSchedule protocolSchedule, final BlockchainQueries queries) {
     super(queries);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayTransactionStep.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceReplayTransactionStep.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+/** The type Trace replay transaction step. */
 public class TraceReplayTransactionStep
     implements Function<TransactionTrace, CompletableFuture<TraceReplayResult>> {
 
@@ -38,6 +39,13 @@ public class TraceReplayTransactionStep
   private final Block block;
   private final Set<TraceType> traceTypes;
 
+  /**
+   * Instantiates a new Trace replay transaction step.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param block the block
+   * @param traceTypes the trace types
+   */
   public TraceReplayTransactionStep(
       final ProtocolSchedule protocolSchedule, final Block block, final Set<TraceType> traceTypes) {
     this.protocolSchedule = protocolSchedule;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceTransaction.java
@@ -28,9 +28,17 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Trace transaction. */
 public class TraceTransaction extends AbstractTraceByHash implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceTransaction.class);
 
+  /**
+   * Instantiates a new Trace transaction.
+   *
+   * @param blockTracerSupplier the block tracer supplier
+   * @param protocolSchedule the protocol schedule
+   * @param blockchainQueries the blockchain queries
+   */
   public TraceTransaction(
       final Supplier<BlockTracer> blockTracerSupplier,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TransactionSource.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TransactionSource.java
@@ -23,12 +23,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+/** The type Transaction source. */
 public class TransactionSource implements Iterator<TransactionTrace> {
 
   private final List<Transaction> transactions;
   private final AtomicInteger currentIndex = new AtomicInteger(0);
   private final Block block;
 
+  /**
+   * Instantiates a new Transaction source.
+   *
+   * @param block the block
+   */
   public TransactionSource(final Block block) {
     this.block = block;
     this.transactions = block.getBody().getTransactions();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuPendingTransactions.java
@@ -31,12 +31,19 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/** The type Tx pool besu pending transactions. */
 public class TxPoolBesuPendingTransactions implements JsonRpcMethod {
 
+  /** The Pending transaction filter. */
   final PendingTransactionFilter pendingTransactionFilter;
 
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Tx pool besu pending transactions.
+   *
+   * @param transactionPool the transaction pool
+   */
   public TxPoolBesuPendingTransactions(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
     this.pendingTransactionFilter = new PendingTransactionFilter();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatistics.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuStatistics.java
@@ -24,10 +24,16 @@ import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
 import java.util.Collection;
 
+/** The type Tx pool besu statistics. */
 public class TxPoolBesuStatistics implements JsonRpcMethod {
 
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Tx pool besu statistics.
+   *
+   * @param transactionPool the transaction pool
+   */
   public TxPoolBesuStatistics(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuTransactions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TxPoolBesuTransactions.java
@@ -21,10 +21,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.PendingTransactionsResult;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
 
+/** The type Tx pool besu transactions. */
 public class TxPoolBesuTransactions implements JsonRpcMethod {
 
   private final TransactionPool transactionPool;
 
+  /**
+   * Instantiates a new Tx pool besu transactions.
+   *
+   * @param transactionPool the transaction pool
+   */
   public TxPoolBesuTransactions(final TransactionPool transactionPool) {
     this.transactionPool = transactionPool;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3ClientVersion.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3ClientVersion.java
@@ -19,10 +19,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 
+/** The type Web 3 client version. */
 public class Web3ClientVersion implements JsonRpcMethod {
 
   private final String clientVersion;
 
+  /**
+   * Instantiates a new Web 3 client version.
+   *
+   * @param clientVersion the client version
+   */
   public Web3ClientVersion(final String clientVersion) {
     this.clientVersion = clientVersion;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/Web3Sha3.java
@@ -24,8 +24,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Web 3 sha 3. */
 public class Web3Sha3 implements JsonRpcMethod {
 
+  /** Instantiates a new Web 3 sha 3. */
   public Web3Sha3() {}
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -51,11 +51,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.spi.LoggingEventBuilder;
 
+/** The type Abstract engine forkchoice updated. */
 public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractEngineForkchoiceUpdated.class);
   private final MergeMiningCoordinator mergeCoordinator;
+
+  /** The Cancun timestamp. */
   protected final Long cancunTimestamp;
 
+  /**
+   * Instantiates a new Abstract engine forkchoice updated.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param engineCallListener the engine call listener
+   */
   public AbstractEngineForkchoiceUpdated(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,
@@ -70,6 +82,13 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
     cancunTimestamp = cancun.map(ScheduledProtocolSpec.Hardfork::milestone).orElse(Long.MAX_VALUE);
   }
 
+  /**
+   * Validate parameter validation result.
+   *
+   * @param forkchoiceUpdatedParameter the forkchoice updated parameter
+   * @param maybePayloadAttributes the maybe payload attributes
+   * @return the validation result
+   */
   protected ValidationResult<RpcErrorType> validateParameter(
       final EngineForkchoiceUpdatedParameter forkchoiceUpdatedParameter,
       final Optional<EnginePayloadAttributesParameter> maybePayloadAttributes) {
@@ -230,9 +249,24 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
             Optional.empty()));
   }
 
+  /**
+   * Is payload attributes valid optional.
+   *
+   * @param requestId the request id
+   * @param payloadAttribute the payload attribute
+   * @return the optional
+   */
   protected abstract Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
       final Object requestId, final EnginePayloadAttributesParameter payloadAttribute);
 
+  /**
+   * Is payload attribute relevant to new head optional.
+   *
+   * @param requestId the request id
+   * @param payloadAttributes the payload attributes
+   * @param headBlockHeader the head block header
+   * @return the optional
+   */
   protected Optional<JsonRpcErrorResponse> isPayloadAttributeRelevantToNewHead(
       final Object requestId,
       final EnginePayloadAttributesParameter payloadAttributes,
@@ -360,14 +394,29 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
         requestId, new EngineUpdateForkchoiceResult(SYNCING, null, null, Optional.empty()));
   }
 
+  /**
+   * Require terminal po w block validation boolean.
+   *
+   * @return the boolean
+   */
   protected boolean requireTerminalPoWBlockValidation() {
     return false;
   }
 
+  /**
+   * Gets invalid parameters error.
+   *
+   * @return the invalid parameters error
+   */
   protected RpcErrorType getInvalidParametersError() {
     return RpcErrorType.INVALID_PARAMS;
   }
 
+  /**
+   * Gets invalid payload attributes error.
+   *
+   * @return the invalid payload attributes error
+   */
   protected RpcErrorType getInvalidPayloadAttributesError() {
     return RpcErrorType.INVALID_PAYLOAD_ATTRIBUTES;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayload.java
@@ -35,12 +35,26 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Abstract engine get payload. */
 public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMethod {
 
   private final MergeMiningCoordinator mergeMiningCoordinator;
+
+  /** The Block result factory. */
   protected final BlockResultFactory blockResultFactory;
+
   private static final Logger LOG = LoggerFactory.getLogger(AbstractEngineGetPayload.class);
 
+  /**
+   * Instantiates a new Abstract engine get payload.
+   *
+   * @param vertx the vertx
+   * @param schedule the schedule
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   */
   public AbstractEngineGetPayload(
       final Vertx vertx,
       final ProtocolSchedule schedule,
@@ -53,6 +67,15 @@ public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMet
     this.blockResultFactory = blockResultFactory;
   }
 
+  /**
+   * Instantiates a new Abstract engine get payload.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   */
   public AbstractEngineGetPayload(
       final Vertx vertx,
       final ProtocolContext protocolContext,
@@ -90,6 +113,13 @@ public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMet
     return new JsonRpcErrorResponse(request.getRequest().getId(), RpcErrorType.UNKNOWN_PAYLOAD);
   }
 
+  /**
+   * Log proposal.
+   *
+   * @param payloadId the payload id
+   * @param proposal the proposal
+   * @param maybeReward the maybe reward
+   */
   protected void logProposal(
       final PayloadIdentifier payloadId,
       final BlockWithReceipts proposal,
@@ -114,6 +144,14 @@ public abstract class AbstractEngineGetPayload extends ExecutionEngineJsonRpcMet
         .log();
   }
 
+  /**
+   * Create response json rpc response.
+   *
+   * @param request the request
+   * @param payloadId the payload id
+   * @param blockWithReceipts the block with receipts
+   * @return the json rpc response
+   */
   protected abstract JsonRpcResponse createResponse(
       final JsonRpcRequestContext request,
       final PayloadIdentifier payloadId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -81,6 +81,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Abstract engine new payload. */
 public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMethod {
 
   private static final Hash OMMERS_HASH_CONSTANT = Hash.EMPTY_LIST_HASH;
@@ -89,6 +90,16 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
   private final MergeMiningCoordinator mergeCoordinator;
   private final EthPeers ethPeers;
 
+  /**
+   * Instantiates a new Abstract engine new payload.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param ethPeers the eth peers
+   * @param engineCallListener the engine call listener
+   */
   public AbstractEngineNewPayload(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,
@@ -370,6 +381,15 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
   }
 
+  /**
+   * Respond with json rpc response.
+   *
+   * @param requestId the request id
+   * @param param the param
+   * @param latestValidHash the latest valid hash
+   * @param status the status
+   * @return the json rpc response
+   */
   JsonRpcResponse respondWith(
       final Object requestId,
       final EnginePayloadParameter param,
@@ -395,6 +415,16 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
   // engine api calls are synchronous, no need for volatile
   private long lastInvalidWarn = 0;
 
+  /**
+   * Respond with invalid json rpc response.
+   *
+   * @param requestId the request id
+   * @param param the param
+   * @param latestValidHash the latest valid hash
+   * @param invalidStatus the invalid status
+   * @param validationError the validation error
+   * @return the json rpc response
+   */
   JsonRpcResponse respondWithInvalid(
       final Object requestId,
       final EnginePayloadParameter param,
@@ -427,10 +457,23 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             invalidStatus, latestValidHash, Optional.of(validationError)));
   }
 
+  /**
+   * Gets invalid block hash status.
+   *
+   * @return the invalid block hash status
+   */
   protected EngineStatus getInvalidBlockHashStatus() {
     return INVALID;
   }
 
+  /**
+   * Validate parameters validation result.
+   *
+   * @param parameter the parameter
+   * @param maybeVersionedHashParam the maybe versioned hash param
+   * @param maybeBeaconBlockRootParam the maybe beacon block root param
+   * @return the validation result
+   */
   protected ValidationResult<RpcErrorType> validateParameters(
       final EnginePayloadParameter parameter,
       final Optional<List<String>> maybeVersionedHashParam,
@@ -438,6 +481,16 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     return ValidationResult.valid();
   }
 
+  /**
+   * Validate blobs validation result.
+   *
+   * @param blobTransactions the blob transactions
+   * @param header the header
+   * @param maybeParentHeader the maybe parent header
+   * @param maybeVersionedHashes the maybe versioned hashes
+   * @param protocolSpec the protocol spec
+   * @return the validation result
+   */
   protected ValidationResult<RpcErrorType> validateBlobs(
       final List<Transaction> blobTransactions,
       final BlockHeader header,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/DepositsValidatorProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/DepositsValidatorProvider.java
@@ -22,8 +22,18 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 
 import java.util.Optional;
 
+/** The type Deposits validator provider. */
 public class DepositsValidatorProvider {
+  private DepositsValidatorProvider() {}
 
+  /**
+   * Gets deposits validator.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param blockTimestamp the block timestamp
+   * @param blockNumber the block number
+   * @return the deposits validator
+   */
   static DepositsValidator getDepositsValidator(
       final ProtocolSchedule protocolSchedule, final long blockTimestamp, final long blockNumber) {
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineCallListener.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineCallListener.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
 
+/** The interface Engine call listener. */
 public interface EngineCallListener {
+  /** Execution engine called. */
   void executionEngineCalled();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilities.java
@@ -32,9 +32,17 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine exchange capabilities. */
 public class EngineExchangeCapabilities extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(EngineExchangeCapabilities.class);
 
+  /**
+   * Instantiates a new Engine exchange capabilities.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param engineCallListener the engine call listener
+   */
   public EngineExchangeCapabilities(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfiguration.java
@@ -38,10 +38,12 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine exchange transition configuration. */
 public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG =
       LoggerFactory.getLogger(EngineExchangeTransitionConfiguration.class);
 
+  /** The constant FALLBACK_TTD_DEFAULT. */
   // use (2^256 - 2^10) if engine is enabled in the absence of a TTD configuration
   static final Difficulty FALLBACK_TTD_DEFAULT =
       Difficulty.fromHexString(
@@ -49,6 +51,13 @@ public class EngineExchangeTransitionConfiguration extends ExecutionEngineJsonRp
 
   private static final Supplier<ObjectMapper> mapperSupplier = Suppliers.memoize(ObjectMapper::new);
 
+  /**
+   * Instantiates a new Engine exchange transition configuration.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param engineCallListener the engine call listener
+   */
   public EngineExchangeTransitionConfiguration(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV1.java
@@ -26,8 +26,18 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine forkchoice updated v1. */
 public class EngineForkchoiceUpdatedV1 extends AbstractEngineForkchoiceUpdated {
 
+  /**
+   * Instantiates a new Engine forkchoice updated v1.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param engineCallListener the engine call listener
+   */
   public EngineForkchoiceUpdatedV1(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2.java
@@ -28,12 +28,22 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine forkchoice updated v2. */
 // TODO Withdrawals use composition instead? Want to make it more obvious that there is no
 // difference between V1/V2 code other than the method name
 public class EngineForkchoiceUpdatedV2 extends AbstractEngineForkchoiceUpdated {
 
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV2.class);
 
+  /**
+   * Instantiates a new Engine forkchoice updated 2.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param engineCallListener the engine call listener
+   */
   public EngineForkchoiceUpdatedV2(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV3.java
@@ -31,11 +31,21 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine forkchoice updated v3. */
 public class EngineForkchoiceUpdatedV3 extends AbstractEngineForkchoiceUpdated {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> cancun;
   private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV3.class);
 
+  /**
+   * Instantiates a new Engine forkchoice updated v3.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param engineCallListener the engine call listener
+   */
   public EngineForkchoiceUpdatedV3(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1.java
@@ -34,12 +34,21 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine get payload bodies by hash v1. */
 public class EngineGetPayloadBodiesByHashV1 extends ExecutionEngineJsonRpcMethod {
 
   private static final int MAX_REQUEST_BLOCKS = 1024;
   private static final Logger LOG = LoggerFactory.getLogger(EngineGetPayloadBodiesByHashV1.class);
   private final BlockResultFactory blockResultFactory;
 
+  /**
+   * Instantiates a new Engine get payload bodies by hash v1.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   */
   public EngineGetPayloadBodiesByHashV1(
       final Vertx vertx,
       final ProtocolContext protocolContext,
@@ -81,6 +90,11 @@ public class EngineGetPayloadBodiesByHashV1 extends ExecutionEngineJsonRpcMethod
     return new JsonRpcSuccessResponse(reqId, engineGetPayloadBodiesResultV1);
   }
 
+  /**
+   * Gets max request blocks.
+   *
+   * @return the max request blocks
+   */
   protected int getMaxRequestBlocks() {
     return MAX_REQUEST_BLOCKS;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1.java
@@ -34,11 +34,20 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine get payload bodies by range v1. */
 public class EngineGetPayloadBodiesByRangeV1 extends ExecutionEngineJsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(EngineGetPayloadBodiesByRangeV1.class);
   private static final int MAX_REQUEST_BLOCKS = 1024;
   private final BlockResultFactory blockResultFactory;
 
+  /**
+   * Instantiates a new Engine get payload bodies by range v1.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   */
   public EngineGetPayloadBodiesByRangeV1(
       final Vertx vertx,
       final ProtocolContext protocolContext,
@@ -105,6 +114,11 @@ public class EngineGetPayloadBodiesByRangeV1 extends ExecutionEngineJsonRpcMetho
     return new JsonRpcSuccessResponse(reqId, engineGetPayloadBodiesResultV1);
   }
 
+  /**
+   * Gets max request blocks.
+   *
+   * @return the max request blocks
+   */
   protected int getMaxRequestBlocks() {
     return MAX_REQUEST_BLOCKS;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV1.java
@@ -28,8 +28,18 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine get payload v1. */
 public class EngineGetPayloadV1 extends AbstractEngineGetPayload {
 
+  /**
+   * Instantiates a new Engine get payload v1.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   */
   public EngineGetPayloadV1(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV2.java
@@ -33,10 +33,21 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine get payload v2. */
 public class EngineGetPayloadV2 extends AbstractEngineGetPayload {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> cancun;
 
+  /**
+   * Instantiates a new Engine get payload v2.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   * @param schedule the schedule
+   */
   public EngineGetPayloadV2(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3.java
@@ -32,10 +32,21 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine get payload v3. */
 public class EngineGetPayloadV3 extends AbstractEngineGetPayload {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> cancun;
 
+  /**
+   * Instantiates a new Engine get payload v3.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   * @param schedule the schedule
+   */
   public EngineGetPayloadV3(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4.java
@@ -32,10 +32,21 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine get payload v4. */
 public class EngineGetPayloadV4 extends AbstractEngineGetPayload {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> prague;
 
+  /**
+   * Instantiates a new Engine get payload v4.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param mergeMiningCoordinator the merge mining coordinator
+   * @param blockResultFactory the block result factory
+   * @param engineCallListener the engine call listener
+   * @param schedule the schedule
+   */
   public EngineGetPayloadV4(
       final Vertx vertx,
       final ProtocolContext protocolContext,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV1.java
@@ -33,8 +33,19 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine new payload v1. */
 public class EngineNewPayloadV1 extends AbstractEngineNewPayload {
 
+  /**
+   * Instantiates a new Engine new payload v1.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param ethPeers the eth peers
+   * @param engineCallListener the engine call listener
+   */
   public EngineNewPayloadV1(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
@@ -32,8 +32,19 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine new payload v2. */
 public class EngineNewPayloadV2 extends AbstractEngineNewPayload {
 
+  /**
+   * Instantiates a new Engine new payload v2.
+   *
+   * @param vertx the vertx
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param ethPeers the eth peers
+   * @param engineCallListener the engine call listener
+   */
   public EngineNewPayloadV2(
       final Vertx vertx,
       final ProtocolSchedule protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
@@ -29,10 +29,21 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine new payload v3. */
 public class EngineNewPayloadV3 extends AbstractEngineNewPayload {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> cancun;
 
+  /**
+   * Instantiates a new Engine new payload v3.
+   *
+   * @param vertx the vertx
+   * @param timestampSchedule the timestamp schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param ethPeers the eth peers
+   * @param engineCallListener the engine call listener
+   */
   public EngineNewPayloadV3(
       final Vertx vertx,
       final ProtocolSchedule timestampSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -29,10 +29,21 @@ import java.util.Optional;
 
 import io.vertx.core.Vertx;
 
+/** The type Engine new payload v4. */
 public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
 
   private final Optional<ScheduledProtocolSpec.Hardfork> prague;
 
+  /**
+   * Instantiates a new Engine new payload v4.
+   *
+   * @param vertx the vertx
+   * @param timestampSchedule the timestamp schedule
+   * @param protocolContext the protocol context
+   * @param mergeCoordinator the merge coordinator
+   * @param ethPeers the eth peers
+   * @param engineCallListener the engine call listener
+   */
   public EngineNewPayloadV4(
       final Vertx vertx,
       final ProtocolSchedule timestampSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -39,9 +39,18 @@ import java.util.Optional;
 import graphql.VisibleForTesting;
 import io.vertx.core.Vertx;
 
+/** The type Engine prepare payload debug. */
 public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
   private final MergeMiningCoordinator mergeCoordinator;
 
+  /**
+   * Instantiates a new Engine prepare payload debug.
+   *
+   * @param vertx the vertx
+   * @param protocolContext the protocol context
+   * @param engineCallListener the engine call listener
+   * @param mergeCoordinator the merge coordinator
+   */
   public EnginePreparePayloadDebug(
       final Vertx vertx,
       final ProtocolContext protocolContext,
@@ -84,6 +93,12 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
         .orElseGet(() -> new JsonRpcErrorResponse(requestId, RpcErrorType.INVALID_PARAMS));
   }
 
+  /**
+   * Generate payload optional.
+   *
+   * @param param the param
+   * @return the optional
+   */
   @VisibleForTesting
   Optional<PayloadIdentifier> generatePayload(final EnginePreparePayloadParameter param) {
     final List<Withdrawal> withdrawals =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineQosTimer.java
@@ -21,12 +21,20 @@ import io.vertx.core.Vertx;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Engine qos timer. */
 public class EngineQosTimer implements EngineCallListener {
+  /** The Qos timeout millis. */
   static final long QOS_TIMEOUT_MILLIS = 120000L;
+
   private static final Logger LOG = LoggerFactory.getLogger(EngineQosTimer.class);
 
   private final QosTimer qosTimer;
 
+  /**
+   * Instantiates a new Engine qos timer.
+   *
+   * @param vertx the vertx
+   */
   public EngineQosTimer(final Vertx vertx) {
     qosTimer = new QosTimer(vertx, QOS_TIMEOUT_MILLIS, lastCall -> logTimeoutWarning());
     qosTimer.resetTimer();
@@ -37,12 +45,18 @@ public class EngineQosTimer implements EngineCallListener {
     getQosTimer().resetTimer();
   }
 
+  /** Log timeout warning. */
   public void logTimeoutWarning() {
     LOG.warn(
         "Execution engine not called in {} seconds, consensus client may not be connected",
         QOS_TIMEOUT_MILLIS / 1000L);
   }
 
+  /**
+   * Gets qos timer.
+   *
+   * @return the qos timer
+   */
   @VisibleForTesting
   public QosTimer getQosTimer() {
     return qosTimer;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/WithdrawalRequestValidatorProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/WithdrawalRequestValidatorProvider.java
@@ -23,8 +23,19 @@ import org.hyperledger.besu.ethereum.mainnet.WithdrawalRequestValidator.Prohibit
 
 import java.util.Optional;
 
+/** The type Withdrawal request validator provider. */
 public class WithdrawalRequestValidatorProvider {
+  /** Default constructor. */
+  private WithdrawalRequestValidatorProvider() {}
 
+  /**
+   * Gets withdrawal request validator.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param blockTimestamp the block timestamp
+   * @param blockNumber the block number
+   * @return the withdrawal request validator
+   */
   static WithdrawalRequestValidator getWithdrawalRequestValidator(
       final ProtocolSchedule protocolSchedule, final long blockTimestamp, final long blockNumber) {
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/WithdrawalsValidatorProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/WithdrawalsValidatorProvider.java
@@ -22,8 +22,19 @@ import org.hyperledger.besu.ethereum.mainnet.WithdrawalsValidator;
 
 import java.util.Optional;
 
+/** The type Withdrawals validator provider. */
 public class WithdrawalsValidatorProvider {
+  /** Default constructor. */
+  private WithdrawalsValidatorProvider() {}
 
+  /**
+   * Gets withdrawals validator.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param blockTimestamp the block timestamp
+   * @param blockNumber the block number
+   * @return the withdrawals validator
+   */
   static WithdrawalsValidator getWithdrawalsValidator(
       final ProtocolSchedule protocolSchedule, final long blockTimestamp, final long blockNumber) {
 
@@ -35,6 +46,14 @@ public class WithdrawalsValidatorProvider {
     return getWithdrawalsValidator(protocolSchedule.getByBlockHeader(blockHeader));
   }
 
+  /**
+   * Gets withdrawals validator.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param parentBlockHeader the parent block header
+   * @param timestampForNextBlock the timestamp for next block
+   * @return the withdrawals validator
+   */
   static WithdrawalsValidator getWithdrawalsValidator(
       final ProtocolSchedule protocolSchedule,
       final BlockHeader parentBlockHeader,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerChangeTargetGasLimit.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerChangeTargetGasLimit.java
@@ -23,10 +23,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
+/** The type Miner change target gas limit. */
 public class MinerChangeTargetGasLimit implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Miner change target gas limit.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public MinerChangeTargetGasLimit(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerGetMinGasPrice.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerGetMinGasPrice.java
@@ -22,9 +22,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 
+/** The type Miner get min gas price. */
 public class MinerGetMinGasPrice implements JsonRpcMethod {
   private final MiningParameters miningParameters;
 
+  /**
+   * Instantiates a new Miner get min gas price.
+   *
+   * @param miningParameters the mining parameters
+   */
   public MinerGetMinGasPrice(final MiningParameters miningParameters) {
     this.miningParameters = miningParameters;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerGetMinPriorityFee.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerGetMinPriorityFee.java
@@ -22,9 +22,15 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 
+/** The type Miner get min priority fee. */
 public class MinerGetMinPriorityFee implements JsonRpcMethod {
   private final MiningParameters miningParameters;
 
+  /**
+   * Instantiates a new Miner get min priority fee.
+   *
+   * @param miningParameters the mining parameters
+   */
   public MinerGetMinPriorityFee(final MiningParameters miningParameters) {
     this.miningParameters = miningParameters;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetCoinbase.java
@@ -24,10 +24,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSucces
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 
+/** The type Miner set coinbase. */
 public class MinerSetCoinbase implements JsonRpcMethod {
 
   private final MiningCoordinator miningCoordinator;
 
+  /**
+   * Instantiates a new Miner set coinbase.
+   *
+   * @param miningCoordinator the mining coordinator
+   */
   public MinerSetCoinbase(final MiningCoordinator miningCoordinator) {
     this.miningCoordinator = miningCoordinator;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetEtherbase.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetEtherbase.java
@@ -19,10 +19,16 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 
+/** The type Miner set etherbase. */
 public class MinerSetEtherbase implements JsonRpcMethod {
 
   private final MinerSetCoinbase minerSetCoinbaseMethod;
 
+  /**
+   * Instantiates a new Miner set etherbase.
+   *
+   * @param minerSetCoinbaseMethod the miner set coinbase method
+   */
   public MinerSetEtherbase(final MinerSetCoinbase minerSetCoinbaseMethod) {
 
     this.minerSetCoinbaseMethod = minerSetCoinbaseMethod;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetMinGasPrice.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetMinGasPrice.java
@@ -28,11 +28,17 @@ import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Miner set min gas price. */
 public class MinerSetMinGasPrice implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(MinerSetMinGasPrice.class);
 
   private final MiningParameters miningParameters;
 
+  /**
+   * Instantiates a new Miner set min gas price.
+   *
+   * @param miningParameters the mining parameters
+   */
   public MinerSetMinGasPrice(final MiningParameters miningParameters) {
     this.miningParameters = miningParameters;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetMinPriorityFee.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/miner/MinerSetMinPriorityFee.java
@@ -28,11 +28,17 @@ import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Miner set min priority fee. */
 public class MinerSetMinPriorityFee implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(MinerSetMinPriorityFee.class);
 
   private final MiningParameters miningParameters;
 
+  /**
+   * Instantiates a new Miner set min priority fee.
+   *
+   * @param miningParameters the mining parameters
+   */
   public MinerSetMinPriorityFee(final MiningParameters miningParameters) {
     this.miningParameters = miningParameters;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameter.java
@@ -24,19 +24,36 @@ import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-// Represents a block parameter that can be a special value ("pending", "earliest", "latest",
-// "finalized", "safe") or a number formatted as a hex string.
+/**
+ * Represents a block parameter that can be a special value ("pending", "earliest", "latest",
+ * "finalized", "safe") or a number formatted as a hex string.
+ */
 // See: https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter
 public class BlockParameter {
 
   private final BlockParameterType type;
   private final Optional<Long> number;
+
+  /** The constant EARLIEST. */
   public static final BlockParameter EARLIEST = new BlockParameter("earliest");
+
+  /** The constant LATEST. */
   public static final BlockParameter LATEST = new BlockParameter("latest");
+
+  /** The constant PENDING. */
   public static final BlockParameter PENDING = new BlockParameter("pending");
+
+  /** The constant FINALIZED. */
   public static final BlockParameter FINALIZED = new BlockParameter("finalized");
+
+  /** The constant SAFE. */
   public static final BlockParameter SAFE = new BlockParameter("safe");
 
+  /**
+   * Instantiates a new Block parameter.
+   *
+   * @param value the value
+   */
   @JsonCreator
   public BlockParameter(final String value) {
     final String normalizedValue = value.toLowerCase(Locale.ROOT);
@@ -69,39 +86,85 @@ public class BlockParameter {
     }
   }
 
+  /**
+   * Instantiates a new Block parameter.
+   *
+   * @param value the value
+   */
   public BlockParameter(final long value) {
     type = BlockParameterType.NUMERIC;
     number = Optional.of(value);
   }
 
+  /**
+   * Gets number.
+   *
+   * @return the number
+   */
   public Optional<Long> getNumber() {
     return number;
   }
 
+  /**
+   * Is pending boolean.
+   *
+   * @return the boolean
+   */
   public boolean isPending() {
     return this.type == BlockParameterType.PENDING;
   }
 
+  /**
+   * Is latest boolean.
+   *
+   * @return the boolean
+   */
   public boolean isLatest() {
     return this.type == BlockParameterType.LATEST;
   }
 
+  /**
+   * Is earliest boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEarliest() {
     return this.type == BlockParameterType.EARLIEST;
   }
 
+  /**
+   * Is finalized boolean.
+   *
+   * @return the boolean
+   */
   public boolean isFinalized() {
     return this.type == BlockParameterType.FINALIZED;
   }
 
+  /**
+   * Is safe boolean.
+   *
+   * @return the boolean
+   */
   public boolean isSafe() {
     return this.type == BlockParameterType.SAFE;
   }
 
+  /**
+   * Is numeric boolean.
+   *
+   * @return the boolean
+   */
   public boolean isNumeric() {
     return this.type == BlockParameterType.NUMERIC;
   }
 
+  /**
+   * Gets block number.
+   *
+   * @param blockchain the blockchain
+   * @return the block number
+   */
   public Optional<Long> getBlockNumber(final BlockchainQueries blockchain) {
     if (this.isFinalized()) {
       return blockchain.finalizedBlockHeader().map(ProcessableBlockHeader::getNumber);
@@ -137,11 +200,17 @@ public class BlockParameter {
   }
 
   private enum BlockParameterType {
+    /** Earliest block parameter type. */
     EARLIEST,
+    /** Latest block parameter type. */
     LATEST,
+    /** Pending block parameter type. */
     PENDING,
+    /** Numeric block parameter type. */
     NUMERIC,
+    /** Finalized block parameter type. */
     FINALIZED,
+    /** Safe block parameter type. */
     SAFE
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterOrBlockHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/BlockParameterOrBlockHash.java
@@ -42,6 +42,12 @@ public class BlockParameterOrBlockHash {
   private final Optional<Hash> blockHash;
   private final boolean requireCanonical;
 
+  /**
+   * Instantiates a new Block parameter or block hash.
+   *
+   * @param value the value
+   * @throws JsonProcessingException the json processing exception
+   */
   @JsonCreator
   public BlockParameterOrBlockHash(final Object value) throws JsonProcessingException {
     if (value instanceof String) {
@@ -105,53 +111,110 @@ public class BlockParameterOrBlockHash {
     }
   }
 
+  /**
+   * Gets number.
+   *
+   * @return the number
+   */
   public OptionalLong getNumber() {
     return number;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   public Optional<Hash> getHash() {
     return blockHash;
   }
 
+  /**
+   * Gets require canonical.
+   *
+   * @return the require canonical
+   */
   public boolean getRequireCanonical() {
     return requireCanonical;
   }
 
+  /**
+   * Is pending boolean.
+   *
+   * @return the boolean
+   */
   public boolean isPending() {
     return this.type == BlockParameterType.PENDING;
   }
 
+  /**
+   * Is latest boolean.
+   *
+   * @return the boolean
+   */
   public boolean isLatest() {
     return this.type == BlockParameterType.LATEST;
   }
 
+  /**
+   * Is safe boolean.
+   *
+   * @return the boolean
+   */
   public boolean isSafe() {
     return this.type == BlockParameterType.SAFE;
   }
 
+  /**
+   * Is finalized boolean.
+   *
+   * @return the boolean
+   */
   public boolean isFinalized() {
     return this.type == BlockParameterType.FINALIZED;
   }
 
+  /**
+   * Is earliest boolean.
+   *
+   * @return the boolean
+   */
   public boolean isEarliest() {
     return this.type == BlockParameterType.EARLIEST;
   }
 
+  /**
+   * Is numeric boolean.
+   *
+   * @return the boolean
+   */
   public boolean isNumeric() {
     return this.type == BlockParameterType.NUMERIC;
   }
 
+  /**
+   * Gets block hash.
+   *
+   * @return the block hash
+   */
   public boolean getBlockHash() {
     return this.type == BlockParameterType.HASH;
   }
 
   private enum BlockParameterType {
+    /** Earliest block parameter type. */
     EARLIEST,
+    /** Latest block parameter type. */
     LATEST,
+    /** Pending block parameter type. */
     PENDING,
+    /** Safe block parameter type. */
     SAFE,
+    /** Finalized block parameter type. */
     FINALIZED,
+    /** Numeric block parameter type. */
     NUMERIC,
+    /** Hash block parameter type. */
     HASH
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/AbstractEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/AbstractEeaSendRawTransaction.java
@@ -46,6 +46,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Abstract eea send raw transaction. */
 public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractEeaSendRawTransaction.class);
   private final TransactionPool transactionPool;
@@ -53,6 +54,14 @@ public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
   private final PrivateMarkerTransactionFactory privateMarkerTransactionFactory;
   private final NonceProvider publicNonceProvider;
 
+  /**
+   * Instantiates a new Abstract eea send raw transaction.
+   *
+   * @param transactionPool the transaction pool
+   * @param privacyIdProvider the privacy id provider
+   * @param privateMarkerTransactionFactory the private marker transaction factory
+   * @param publicNonceProvider the public nonce provider
+   */
   protected AbstractEeaSendRawTransaction(
       final TransactionPool transactionPool,
       final PrivacyIdProvider privacyIdProvider,
@@ -109,6 +118,13 @@ public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
     }
   }
 
+  /**
+   * Gets json rpc error response.
+   *
+   * @param id the id
+   * @param errorReason the error reason
+   * @return the json rpc error response
+   */
   JsonRpcErrorResponse getJsonRpcErrorResponse(
       final Object id, final TransactionInvalidReason errorReason) {
     if (errorReason.equals(TransactionInvalidReason.INTRINSIC_GAS_EXCEEDS_GAS_LIMIT)) {
@@ -117,12 +133,37 @@ public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
     return new JsonRpcErrorResponse(id, convertTransactionInvalidReason(errorReason));
   }
 
+  /**
+   * Validate private transaction validation result.
+   *
+   * @param privateTransaction the private transaction
+   * @param user the user
+   * @return the validation result
+   */
   protected abstract ValidationResult<TransactionInvalidReason> validatePrivateTransaction(
       final PrivateTransaction privateTransaction, final Optional<User> user);
 
+  /**
+   * Create private marker transaction transaction.
+   *
+   * @param sender the sender
+   * @param privateTransaction the private transaction
+   * @param user the user
+   * @return the transaction
+   */
   protected abstract Transaction createPrivateMarkerTransaction(
       final Address sender, final PrivateTransaction privateTransaction, final Optional<User> user);
 
+  /**
+   * Create private marker transaction transaction.
+   *
+   * @param sender the sender
+   * @param privacyPrecompileAddress the privacy precompile address
+   * @param pmtPayload the pmt payload
+   * @param privateTransaction the private transaction
+   * @param privacyUserId the privacy user id
+   * @return the transaction
+   */
   protected Transaction createPrivateMarkerTransaction(
       final Address sender,
       final Address privacyPrecompileAddress,
@@ -150,5 +191,12 @@ public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
     return Transaction.readFrom(rlpBytes);
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @param privateTransaction the private transaction
+   * @param pmtPayload the pmt payload
+   * @return the gas limit
+   */
   protected abstract long getGasLimit(PrivateTransaction privateTransaction, String pmtPayload);
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockReplay.java
@@ -36,12 +36,20 @@ import org.hyperledger.besu.ethereum.vm.CachingBlockHashLookup;
 import java.util.List;
 import java.util.Optional;
 
+/** The type Block replay. */
 public class BlockReplay {
 
   private final ProtocolSchedule protocolSchedule;
   private final Blockchain blockchain;
   private final ProtocolContext protocolContext;
 
+  /**
+   * Instantiates a new Block replay.
+   *
+   * @param protocolSchedule the protocol schedule
+   * @param protocolContext the protocol context
+   * @param blockchain the blockchain
+   */
   public BlockReplay(
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
@@ -51,6 +59,13 @@ public class BlockReplay {
     this.blockchain = blockchain;
   }
 
+  /**
+   * Block optional.
+   *
+   * @param block the block
+   * @param action the action
+   * @return the optional
+   */
   public Optional<BlockTrace> block(
       final Block block, final TransactionAction<TransactionTrace> action) {
     return performActionWithBlock(
@@ -77,11 +92,28 @@ public class BlockReplay {
         });
   }
 
+  /**
+   * Block optional.
+   *
+   * @param blockHash the block hash
+   * @param action the action
+   * @return the optional
+   */
   public Optional<BlockTrace> block(
       final Hash blockHash, final TransactionAction<TransactionTrace> action) {
     return getBlock(blockHash).flatMap(block -> block(block, action));
   }
 
+  /**
+   * Before transaction in block optional.
+   *
+   * @param <T> the type parameter
+   * @param mutableWorldState the mutable world state
+   * @param blockHash the block hash
+   * @param transactionHash the transaction hash
+   * @param action the action
+   * @return the optional
+   */
   public <T> Optional<T> beforeTransactionInBlock(
       final TraceableState mutableWorldState,
       final Hash blockHash,
@@ -121,6 +153,16 @@ public class BlockReplay {
         });
   }
 
+  /**
+   * After transaction in block optional.
+   *
+   * @param <T> the type parameter
+   * @param mutableWorldState the mutable world state
+   * @param blockHash the block hash
+   * @param transactionHash the transaction hash
+   * @param action the action
+   * @return the optional
+   */
   public <T> Optional<T> afterTransactionInBlock(
       final TraceableState mutableWorldState,
       final Hash blockHash,
@@ -146,6 +188,14 @@ public class BlockReplay {
         });
   }
 
+  /**
+   * Perform action with block optional.
+   *
+   * @param <T> the type parameter
+   * @param blockHash the block hash
+   * @param action the action
+   * @return the optional
+   */
   public <T> Optional<T> performActionWithBlock(final Hash blockHash, final BlockAction<T> action) {
     Optional<Block> maybeBlock = getBlock(blockHash);
     if (maybeBlock.isEmpty()) {
@@ -180,8 +230,23 @@ public class BlockReplay {
     return Optional.empty();
   }
 
+  /**
+   * The interface Block action.
+   *
+   * @param <T> the type parameter
+   */
   @FunctionalInterface
   public interface BlockAction<T> {
+    /**
+     * Perform optional.
+     *
+     * @param body the body
+     * @param blockHeader the block header
+     * @param blockchain the blockchain
+     * @param transactionProcessor the transaction processor
+     * @param protocolSpec the protocol spec
+     * @return the optional
+     */
     Optional<T> perform(
         BlockBody body,
         BlockHeader blockHeader,
@@ -190,8 +255,23 @@ public class BlockReplay {
         ProtocolSpec protocolSpec);
   }
 
+  /**
+   * The interface Transaction action.
+   *
+   * @param <T> the type parameter
+   */
   @FunctionalInterface
   public interface TransactionAction<T> {
+    /**
+     * Perform action t.
+     *
+     * @param transaction the transaction
+     * @param blockHeader the block header
+     * @param blockchain the blockchain
+     * @param transactionProcessor the transaction processor
+     * @param blobGasPrice the blob gas price
+     * @return the t
+     */
     T performAction(
         Transaction transaction,
         BlockHeader blockHeader,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTrace.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTrace.java
@@ -16,14 +16,25 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor;
 
 import java.util.List;
 
+/** The type Block trace. */
 public class BlockTrace {
 
   private final List<TransactionTrace> transactionTraces;
 
+  /**
+   * Instantiates a new Block trace.
+   *
+   * @param transactionTraces the transaction traces
+   */
   public BlockTrace(final List<TransactionTrace> transactionTraces) {
     this.transactionTraces = transactionTraces;
   }
 
+  /**
+   * Gets transaction traces.
+   *
+   * @return the transaction traces
+   */
   public List<TransactionTrace> getTransactionTraces() {
     return transactionTraces;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTracer.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/BlockTracer.java
@@ -33,10 +33,23 @@ public class BlockTracer {
   // Either the initial block state or the state of the prior TX, including miner rewards.
   private WorldUpdater chainedUpdater;
 
+  /**
+   * Instantiates a new Block tracer.
+   *
+   * @param blockReplay the block replay
+   */
   public BlockTracer(final BlockReplay blockReplay) {
     this.blockReplay = blockReplay;
   }
 
+  /**
+   * Trace optional.
+   *
+   * @param mutableWorldState the mutable world state
+   * @param blockHash the block hash
+   * @param tracer the tracer
+   * @return the optional
+   */
   public Optional<BlockTrace> trace(
       final Tracer.TraceableState mutableWorldState,
       final Hash blockHash,
@@ -44,6 +57,14 @@ public class BlockTracer {
     return blockReplay.block(blockHash, prepareReplayAction(mutableWorldState, tracer));
   }
 
+  /**
+   * Trace optional.
+   *
+   * @param mutableWorldState the mutable world state
+   * @param block the block
+   * @param tracer the tracer
+   * @return the optional
+   */
   public Optional<BlockTrace> trace(
       final Tracer.TraceableState mutableWorldState,
       final Block block,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BadBlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BadBlockResult.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
+/** The interface Bad block result. */
 @Value.Immutable
 @Value.Style(allParameters = true)
 @JsonSerialize(as = ImmutableBadBlockResult.class)
@@ -29,15 +30,37 @@ import org.immutables.value.Value;
 @JsonPropertyOrder({"block", "hash", "rlp"})
 public interface BadBlockResult {
 
+  /**
+   * Gets block result.
+   *
+   * @return the block result
+   */
   @JsonProperty("block")
   BlockResult getBlockResult();
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonProperty("hash")
   String getHash();
 
+  /**
+   * Gets rlp.
+   *
+   * @return the rlp
+   */
   @JsonProperty("rlp")
   String getRlp();
 
+  /**
+   * From bad block result.
+   *
+   * @param blockResult the block result
+   * @param block the block
+   * @return the bad block result
+   */
   static BadBlockResult from(final BlockResult blockResult, final Block block) {
     return ImmutableBadBlockResult.of(
         blockResult, block.getHash().toHexString(), block.toRlp().toHexString());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobsBundleV1.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlobsBundleV1.java
@@ -31,6 +31,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Blobs bundle v1. */
 @JsonPropertyOrder({"commitments", "proofs", "blobs"})
 public class BlobsBundleV1 {
 
@@ -41,6 +42,11 @@ public class BlobsBundleV1 {
 
   private final List<String> blobs;
 
+  /**
+   * Instantiates a new Blobs bundle v1.
+   *
+   * @param transactions the transactions
+   */
   public BlobsBundleV1(final List<Transaction> transactions) {
     final List<BlobsWithCommitments> blobsWithCommitments =
         transactions.stream()
@@ -79,6 +85,13 @@ public class BlobsBundleV1 {
         blobs.size());
   }
 
+  /**
+   * Instantiates a new Blobs bundle v1.
+   *
+   * @param commitments the commitments
+   * @param proofs the proofs
+   * @param blobs the blobs
+   */
   public BlobsBundleV1(
       final List<String> commitments, final List<String> proofs, final List<String> blobs) {
     if (blobs.size() != commitments.size() || blobs.size() != proofs.size()) {
@@ -90,16 +103,31 @@ public class BlobsBundleV1 {
     this.blobs = blobs;
   }
 
+  /**
+   * Gets commitments.
+   *
+   * @return the commitments
+   */
   @JsonGetter("commitments")
   public List<String> getCommitments() {
     return commitments;
   }
 
+  /**
+   * Gets proofs.
+   *
+   * @return the proofs
+   */
   @JsonGetter("proofs")
   public List<String> getProofs() {
     return proofs;
   }
 
+  /**
+   * Gets blobs.
+   *
+   * @return the blobs
+   */
   @JsonGetter("blobs")
   public List<String> getBlobs() {
     return blobs;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockReceiptsResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockReceiptsResult.java
@@ -23,10 +23,20 @@ public class BlockReceiptsResult {
 
   private final List<TransactionReceiptResult> results;
 
+  /**
+   * Instantiates a new Block receipts result.
+   *
+   * @param receipts the receipts
+   */
   public BlockReceiptsResult(final List<TransactionReceiptResult> receipts) {
     results = receipts;
   }
 
+  /**
+   * Gets results.
+   *
+   * @return the results
+   */
   @JsonValue
   public List<TransactionReceiptResult> getResults() {
     return results;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResult.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.tuweni.bytes.Bytes32;
 
+/** The type Block result. */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
   "number",
@@ -61,7 +62,10 @@ import org.apache.tuweni.bytes.Bytes32;
 public class BlockResult implements JsonRpcResult {
 
   private final String number;
+
+  /** The Hash. */
   protected final String hash;
+
   private final String mixHash;
   private final String parentHash;
   private final String nonce;
@@ -79,7 +83,10 @@ public class BlockResult implements JsonRpcResult {
   private final String gasLimit;
   private final String gasUsed;
   private final String timestamp;
+
+  /** The Transactions. */
   protected final List<TransactionResult> transactions;
+
   private final List<JsonNode> ommers;
   private final String coinbase;
   private final String withdrawalsRoot;
@@ -89,6 +96,15 @@ public class BlockResult implements JsonRpcResult {
   private final String excessBlobGas;
   private final String parentBeaconBlockRoot;
 
+  /**
+   * Instantiates a new Block result.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param ommers the ommers
+   * @param totalDifficulty the total difficulty
+   * @param size the size
+   */
   public BlockResult(
       final BlockHeader header,
       final List<TransactionResult> transactions,
@@ -98,6 +114,17 @@ public class BlockResult implements JsonRpcResult {
     this(header, transactions, ommers, totalDifficulty, size, false, Optional.empty());
   }
 
+  /**
+   * Instantiates a new Block result.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param ommers the ommers
+   * @param totalDifficulty the total difficulty
+   * @param size the size
+   * @param includeCoinbase the include coinbase
+   * @param withdrawals the withdrawals
+   */
   public BlockResult(
       final BlockHeader header,
       final List<TransactionResult> transactions,
@@ -140,137 +167,272 @@ public class BlockResult implements JsonRpcResult {
         header.getParentBeaconBlockRoot().map(Bytes32::toHexString).orElse(null);
   }
 
+  /**
+   * Gets number.
+   *
+   * @return the number
+   */
   @JsonGetter(value = "number")
   public String getNumber() {
     return number;
   }
 
+  /**
+   * Gets hash.
+   *
+   * @return the hash
+   */
   @JsonGetter(value = "hash")
   public String getHash() {
     return hash;
   }
 
+  /**
+   * Gets mix hash.
+   *
+   * @return the mix hash
+   */
   @JsonGetter(value = "mixHash")
   public String getMixHash() {
     return mixHash;
   }
 
+  /**
+   * Gets parent hash.
+   *
+   * @return the parent hash
+   */
   @JsonGetter(value = "parentHash")
   public String getParentHash() {
     return parentHash;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   @JsonGetter(value = "nonce")
   public String getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets sha 3 uncles.
+   *
+   * @return the sha 3 uncles
+   */
   @JsonGetter(value = "sha3Uncles")
   public String getSha3Uncles() {
     return sha3Uncles;
   }
 
+  /**
+   * Gets logs bloom.
+   *
+   * @return the logs bloom
+   */
   @JsonGetter(value = "logsBloom")
   public String getLogsBloom() {
     return logsBloom;
   }
 
+  /**
+   * Gets transactions root.
+   *
+   * @return the transactions root
+   */
   @JsonGetter(value = "transactionsRoot")
   public String getTransactionsRoot() {
     return transactionsRoot;
   }
 
+  /**
+   * Gets state root.
+   *
+   * @return the state root
+   */
   @JsonGetter(value = "stateRoot")
   public String getStateRoot() {
     return stateRoot;
   }
 
+  /**
+   * Gets receipts root.
+   *
+   * @return the receipts root
+   */
   @JsonGetter(value = "receiptsRoot")
   public String getReceiptsRoot() {
     return receiptsRoot;
   }
 
+  /**
+   * Gets miner.
+   *
+   * @return the miner
+   */
   @JsonGetter(value = "miner")
   public String getMiner() {
     return miner;
   }
 
+  /**
+   * Gets difficulty.
+   *
+   * @return the difficulty
+   */
   @JsonGetter(value = "difficulty")
   public String getDifficulty() {
     return difficulty;
   }
 
+  /**
+   * Gets total difficulty.
+   *
+   * @return the total difficulty
+   */
   @JsonGetter(value = "totalDifficulty")
   public String getTotalDifficulty() {
     return totalDifficulty;
   }
 
+  /**
+   * Gets extra data.
+   *
+   * @return the extra data
+   */
   @JsonGetter(value = "extraData")
   public String getExtraData() {
     return extraData;
   }
 
+  /**
+   * Gets base fee per gas.
+   *
+   * @return the base fee per gas
+   */
   @JsonGetter(value = "baseFeePerGas")
   public String getBaseFeePerGas() {
     return baseFeePerGas;
   }
 
+  /**
+   * Gets size.
+   *
+   * @return the size
+   */
   @JsonGetter(value = "size")
   public String getSize() {
     return size;
   }
 
+  /**
+   * Gets gas limit.
+   *
+   * @return the gas limit
+   */
   @JsonGetter(value = "gasLimit")
   public String getGasLimit() {
     return gasLimit;
   }
 
+  /**
+   * Gets gas used.
+   *
+   * @return the gas used
+   */
   @JsonGetter(value = "gasUsed")
   public String getGasUsed() {
     return gasUsed;
   }
 
+  /**
+   * Gets timestamp.
+   *
+   * @return the timestamp
+   */
   @JsonGetter(value = "timestamp")
   public String getTimestamp() {
     return timestamp;
   }
 
+  /**
+   * Gets ommers.
+   *
+   * @return the ommers
+   */
   @JsonGetter(value = "uncles")
   public List<JsonNode> getOmmers() {
     return ommers;
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   @JsonGetter(value = "transactions")
   public List<TransactionResult> getTransactions() {
     return transactions;
   }
 
+  /**
+   * Gets coinbase.
+   *
+   * @return the coinbase
+   */
   @JsonGetter(value = "author")
   @JsonInclude(Include.NON_NULL)
   public String getCoinbase() {
     return coinbase;
   }
 
+  /**
+   * Gets withdrawals root.
+   *
+   * @return the withdrawals root
+   */
   @JsonGetter(value = "withdrawalsRoot")
   public String getWithdrawalsRoot() {
     return withdrawalsRoot;
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @return the withdrawals
+   */
   @JsonGetter(value = "withdrawals")
   public List<WithdrawalParameter> getWithdrawals() {
     return withdrawals;
   }
 
+  /**
+   * Gets blob gas used.
+   *
+   * @return the blob gas used
+   */
   @JsonGetter(value = "blobGasUsed")
   public String getBlobGasUsed() {
     return blobGasUsed;
   }
 
+  /**
+   * Gets excess blob gas.
+   *
+   * @return the excess blob gas
+   */
   @JsonGetter(value = "excessBlobGas")
   public String getExcessBlobGas() {
     return excessBlobGas;
   }
 
+  /**
+   * Gets parent beacon block root.
+   *
+   * @return the parent beacon block root
+   */
   @JsonGetter(value = "parentBeaconBlockRoot")
   public String getParentBeaconBlockRoot() {
     return parentBeaconBlockRoot;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/BlockResultFactory.java
@@ -36,13 +36,29 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.tuweni.bytes.Bytes;
 
+/** The type Block result factory. */
 public class BlockResultFactory {
+  /** Default constructor. */
+  public BlockResultFactory() {}
 
+  /**
+   * Transaction complete block result.
+   *
+   * @param blockWithMetadata the block with metadata
+   * @return the block result
+   */
   public BlockResult transactionComplete(
       final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetadata) {
     return transactionComplete(blockWithMetadata, false);
   }
 
+  /**
+   * Transaction complete block result.
+   *
+   * @param blockWithMetadata the block with metadata
+   * @param includeCoinbase the include coinbase
+   * @return the block result
+   */
   public BlockResult transactionComplete(
       final BlockWithMetadata<TransactionWithMetadata, Hash> blockWithMetadata,
       final boolean includeCoinbase) {
@@ -65,6 +81,12 @@ public class BlockResultFactory {
         blockWithMetadata.getWithdrawals());
   }
 
+  /**
+   * Transaction complete block result.
+   *
+   * @param block the block
+   * @return the block result
+   */
   public BlockResult transactionComplete(final Block block) {
 
     final int count = block.getBody().getTransactions().size();
@@ -93,6 +115,12 @@ public class BlockResultFactory {
         block.getHeader(), txs, ommers, block.getHeader().getDifficulty(), block.calculateSize());
   }
 
+  /**
+   * Payload transaction complete v 1 engine get payload result v 1.
+   *
+   * @param block the block
+   * @return the engine get payload result v 1
+   */
   public EngineGetPayloadResultV1 payloadTransactionCompleteV1(final Block block) {
     final List<String> txs =
         block.getBody().getTransactions().stream()
@@ -105,6 +133,12 @@ public class BlockResultFactory {
     return new EngineGetPayloadResultV1(block.getHeader(), txs);
   }
 
+  /**
+   * Payload transaction complete v 2 engine get payload result v 2.
+   *
+   * @param blockWithReceipts the block with receipts
+   * @return the engine get payload result v 2
+   */
   public EngineGetPayloadResultV2 payloadTransactionCompleteV2(
       final BlockWithReceipts blockWithReceipts) {
     final List<String> txs =
@@ -123,6 +157,12 @@ public class BlockResultFactory {
         Quantity.create(blockValue));
   }
 
+  /**
+   * Payload bodies complete v 1 engine get payload bodies result v 1.
+   *
+   * @param blockBodies the block bodies
+   * @return the engine get payload bodies result v 1
+   */
   public EngineGetPayloadBodiesResultV1 payloadBodiesCompleteV1(
       final List<Optional<BlockBody>> blockBodies) {
     final List<PayloadBody> payloadBodies =
@@ -132,6 +172,12 @@ public class BlockResultFactory {
     return new EngineGetPayloadBodiesResultV1(payloadBodies);
   }
 
+  /**
+   * Payload transaction complete v 3 engine get payload result v 3.
+   *
+   * @param blockWithReceipts the block with receipts
+   * @return the engine get payload result v 3
+   */
   public EngineGetPayloadResultV3 payloadTransactionCompleteV3(
       final BlockWithReceipts blockWithReceipts) {
     final List<String> txs =
@@ -154,6 +200,12 @@ public class BlockResultFactory {
         blobsBundleV1);
   }
 
+  /**
+   * Payload transaction complete v 4 engine get payload result v 4.
+   *
+   * @param blockWithReceipts the block with receipts
+   * @return the engine get payload result v 4
+   */
   public EngineGetPayloadResultV4 payloadTransactionCompleteV4(
       final BlockWithReceipts blockWithReceipts) {
     final List<String> txs =
@@ -178,10 +230,23 @@ public class BlockResultFactory {
         blobsBundleV1);
   }
 
+  /**
+   * Transaction hash block result.
+   *
+   * @param blockWithMetadata the block with metadata
+   * @return the block result
+   */
   public BlockResult transactionHash(final BlockWithMetadata<Hash, Hash> blockWithMetadata) {
     return transactionHash(blockWithMetadata, false);
   }
 
+  /**
+   * Transaction hash block result.
+   *
+   * @param blockWithMetadata the block with metadata
+   * @param includeCoinbase the include coinbase
+   * @return the block result
+   */
   public BlockResult transactionHash(
       final BlockWithMetadata<Hash, Hash> blockWithMetadata, final boolean includeCoinbase) {
     final List<TransactionResult> txs =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/AccountDiff.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/AccountDiff.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.diff;
 
 import java.util.Map;
 
+/** The type Account diff. */
 public final class AccountDiff {
 
   private final DiffNode balance;
@@ -23,6 +24,14 @@ public final class AccountDiff {
   private final DiffNode nonce;
   private final Map<String, DiffNode> storage;
 
+  /**
+   * Instantiates a new Account diff.
+   *
+   * @param balance the balance
+   * @param code the code
+   * @param nonce the nonce
+   * @param storage the storage
+   */
   AccountDiff(
       final DiffNode balance,
       final DiffNode code,
@@ -34,22 +43,47 @@ public final class AccountDiff {
     this.storage = storage;
   }
 
+  /**
+   * Gets balance.
+   *
+   * @return the balance
+   */
   public DiffNode getBalance() {
     return balance;
   }
 
+  /**
+   * Gets code.
+   *
+   * @return the code
+   */
   public DiffNode getCode() {
     return code;
   }
 
+  /**
+   * Gets nonce.
+   *
+   * @return the nonce
+   */
   public DiffNode getNonce() {
     return nonce;
   }
 
+  /**
+   * Gets storage.
+   *
+   * @return the storage
+   */
   public Map<String, DiffNode> getStorage() {
     return storage;
   }
 
+  /**
+   * Has difference boolean.
+   *
+   * @return the boolean
+   */
   boolean hasDifference() {
     return balance.hasDifference()
         || code.hasDifference()

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/Action.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/flat/Action.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.debug.TraceFrame;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+/** The type Action. */
 @JsonInclude(NON_NULL)
 @JsonPropertyOrder({
   "creationMethod",
@@ -84,62 +85,133 @@ public class Action {
     this.rewardType = rewardType;
   }
 
+  /**
+   * Instantiates new Builder.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }
 
+  /**
+   * Gets creation method.
+   *
+   * @return the creation method
+   */
   public String getCreationMethod() {
     return creationMethod;
   }
 
+  /**
+   * Gets call type.
+   *
+   * @return the call type
+   */
   public String getCallType() {
     return callType;
   }
 
+  /**
+   * Gets from.
+   *
+   * @return the from
+   */
   public String getFrom() {
     return from;
   }
 
+  /**
+   * Gets gas.
+   *
+   * @return the gas
+   */
   public String getGas() {
     return gas;
   }
 
+  /**
+   * Gets input.
+   *
+   * @return the input
+   */
   public String getInput() {
     return input;
   }
 
+  /**
+   * Gets to.
+   *
+   * @return the to
+   */
   public String getTo() {
     return to;
   }
 
+  /**
+   * Gets value.
+   *
+   * @return the value
+   */
   public String getValue() {
     return value;
   }
 
+  /**
+   * Gets init.
+   *
+   * @return the init
+   */
   public String getInit() {
     return init;
   }
 
+  /**
+   * Gets address.
+   *
+   * @return the address
+   */
   public String getAddress() {
     return address;
   }
 
+  /**
+   * Gets balance.
+   *
+   * @return the balance
+   */
   public String getBalance() {
     return balance;
   }
 
+  /**
+   * Gets refund address.
+   *
+   * @return the refund address
+   */
   public String getRefundAddress() {
     return refundAddress;
   }
 
+  /**
+   * Gets author.
+   *
+   * @return the author
+   */
   public String getAuthor() {
     return author;
   }
 
+  /**
+   * Gets reward type.
+   *
+   * @return the reward type
+   */
   public String getRewardType() {
     return rewardType;
   }
 
+  /** The type Builder. */
   public static final class Builder {
     private String creationMethod;
     private String callType;
@@ -157,6 +229,12 @@ public class Action {
 
     private Builder() {}
 
+    /**
+     * Of builder.
+     *
+     * @param action the action
+     * @return the builder
+     */
     public static Builder of(final Action action) {
       final Builder builder = new Builder();
       builder.creationMethod = action.creationMethod;
@@ -175,6 +253,12 @@ public class Action {
       return builder;
     }
 
+    /**
+     * From builder.
+     *
+     * @param trace the trace
+     * @return the builder
+     */
     public static Builder from(final TransactionTrace trace) {
       final Builder builder =
           new Builder()
@@ -191,87 +275,190 @@ public class Action {
       return builder;
     }
 
+    /**
+     * Creation method builder.
+     *
+     * @param creationMethod the creation method
+     * @return the builder
+     */
     public Builder creationMethod(final String creationMethod) {
       this.creationMethod = creationMethod;
       return this;
     }
 
+    /**
+     * Call type builder.
+     *
+     * @param callType the call type
+     * @return the builder
+     */
     public Builder callType(final String callType) {
       this.callType = callType;
       return this;
     }
 
+    /**
+     * Gets call type.
+     *
+     * @return the call type
+     */
     public String getCallType() {
       return callType;
     }
 
+    /**
+     * From builder.
+     *
+     * @param from the from
+     * @return the builder
+     */
     public Builder from(final String from) {
       this.from = from;
       return this;
     }
 
+    /**
+     * Gets from.
+     *
+     * @return the from
+     */
     public String getFrom() {
       return from;
     }
 
+    /**
+     * Gas builder.
+     *
+     * @param gas the gas
+     * @return the builder
+     */
     public Builder gas(final String gas) {
       this.gas = gas;
       return this;
     }
 
+    /**
+     * Input builder.
+     *
+     * @param input the input
+     * @return the builder
+     */
     public Builder input(final String input) {
       this.input = input;
       return this;
     }
 
+    /**
+     * To builder.
+     *
+     * @param to the to
+     * @return the builder
+     */
     public Builder to(final String to) {
       this.to = to;
       return this;
     }
 
+    /**
+     * Author builder.
+     *
+     * @param author the author
+     * @return the builder
+     */
     public Builder author(final String author) {
       this.author = author;
       return this;
     }
 
+    /**
+     * Reward type builder.
+     *
+     * @param rewardType the reward type
+     * @return the builder
+     */
     public Builder rewardType(final String rewardType) {
       this.rewardType = rewardType;
       return this;
     }
 
+    /**
+     * Gets to.
+     *
+     * @return the to
+     */
     public String getTo() {
       return to;
     }
 
+    /**
+     * Init builder.
+     *
+     * @param init the init
+     * @return the builder
+     */
     public Builder init(final String init) {
       this.init = init;
       return this;
     }
 
+    /**
+     * Value builder.
+     *
+     * @param value the value
+     * @return the builder
+     */
     public Builder value(final String value) {
       this.value = value;
       return this;
     }
 
+    /**
+     * Address builder.
+     *
+     * @param address the address
+     * @return the builder
+     */
     public Builder address(final String address) {
       this.address = address;
       return this;
     }
 
+    /**
+     * Balance builder.
+     *
+     * @param balance the balance
+     * @return the builder
+     */
     public Builder balance(final String balance) {
       this.balance = balance;
       return this;
     }
 
+    /**
+     * Refund address builder.
+     *
+     * @param refundAddress the refund address
+     * @return the builder
+     */
     Builder refundAddress(final String refundAddress) {
       this.refundAddress = refundAddress;
       return this;
     }
 
+    /**
+     * Gets gas.
+     *
+     * @return the gas
+     */
     public String getGas() {
       return gas;
     }
 
+    /**
+     * Build action.
+     *
+     * @return the action
+     */
     public Action build() {
       return new Action(
           creationMethod,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/AdminJsonRpcMethods.java
@@ -37,6 +37,7 @@ import java.math.BigInteger;
 import java.util.Map;
 import java.util.Optional;
 
+/** The type Admin json rpc methods. */
 public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final String clientVersion;
@@ -49,6 +50,19 @@ public class AdminJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final EthPeers ethPeers;
   private final Optional<EnodeDnsConfiguration> enodeDnsConfiguration;
 
+  /**
+   * Instantiates a new Admin json rpc methods.
+   *
+   * @param clientVersion the client version
+   * @param networkId the network id
+   * @param genesisConfigOptions the genesis config options
+   * @param p2pNetwork the p 2 p network
+   * @param blockchainQueries the blockchain queries
+   * @param namedPlugins the named plugins
+   * @param natService the nat service
+   * @param ethPeers the eth peers
+   * @param enodeDnsConfiguration the enode dns configuration
+   */
   public AdminJsonRpcMethods(
       final String clientVersion,
       final BigInteger networkId,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ApiGroupJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ApiGroupJsonRpcMethods.java
@@ -23,22 +23,47 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/** The type Api group json rpc methods. */
 public abstract class ApiGroupJsonRpcMethods implements JsonRpcMethods {
+  /** Instantiates a new Api group json rpc methods. */
+  protected ApiGroupJsonRpcMethods() {}
 
   @Override
   public Map<String, JsonRpcMethod> create(final Collection<String> apis) {
     return apis.contains(getApiGroup()) ? create() : Collections.emptyMap();
   }
 
+  /**
+   * Gets api group.
+   *
+   * @return the api group
+   */
   protected abstract String getApiGroup();
 
+  /**
+   * Create map.
+   *
+   * @return the map
+   */
   protected abstract Map<String, JsonRpcMethod> create();
 
+  /**
+   * Map of map.
+   *
+   * @param methods the methods
+   * @return the map
+   */
   protected Map<String, JsonRpcMethod> mapOf(final JsonRpcMethod... methods) {
     return Arrays.stream(methods)
         .collect(Collectors.toMap(JsonRpcMethod::getName, method -> method));
   }
 
+  /**
+   * Map of map.
+   *
+   * @param methods the methods
+   * @return the map
+   */
   protected Map<String, JsonRpcMethod> mapOf(final List<JsonRpcMethod> methods) {
     return methods.stream().collect(Collectors.toMap(JsonRpcMethod::getName, method -> method));
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethods.java
@@ -19,6 +19,13 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import java.util.Collection;
 import java.util.Map;
 
+/** The interface Json rpc methods. */
 public interface JsonRpcMethods {
+  /**
+   * Create map.
+   *
+   * @param enabledRpcApis the enabled rpc apis
+   * @return the map
+   */
   Map<String, JsonRpcMethod> create(Collection<String> enabledRpcApis);
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BackendQuery.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BackendQuery.java
@@ -23,20 +23,53 @@ import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Backend query. */
 public class BackendQuery {
   private static final Logger LOG = LoggerFactory.getLogger(BackendQuery.class);
 
+  /** Default constructor */
+  private BackendQuery() {}
+
+  /**
+   * Run if task is alive.
+   *
+   * @param <T> the task type parameter
+   * @param task the task
+   * @param alive the alive boolean supplier
+   * @return the task with type T
+   * @throws Exception the exception
+   */
   public static <T> T runIfAlive(final Callable<T> task, final Supplier<Boolean> alive)
       throws Exception {
     return runIfAlive(Optional.empty(), task, alive);
   }
 
+  /**
+   * Run if alive t.
+   *
+   * @param <T> the type parameter
+   * @param taskName the task name
+   * @param task the task
+   * @param alive the alive
+   * @return the t
+   * @throws Exception the exception
+   */
   public static <T> T runIfAlive(
       final String taskName, final Callable<T> task, final Supplier<Boolean> alive)
       throws Exception {
     return runIfAlive(Optional.ofNullable(taskName), task, alive);
   }
 
+  /**
+   * Run if alive t.
+   *
+   * @param <T> the type parameter
+   * @param taskName the task name
+   * @param task the task
+   * @param alive the alive
+   * @return the t
+   * @throws Exception the exception
+   */
   public static <T> T runIfAlive(
       final Optional<String> taskName, final Callable<T> task, final Supplier<Boolean> alive)
       throws Exception {
@@ -48,6 +81,12 @@ public class BackendQuery {
     return task.call();
   }
 
+  /**
+   * Stop if expired.
+   *
+   * @param alive the alive
+   * @throws Exception the exception
+   */
   public static void stopIfExpired(final Supplier<Boolean> alive) throws Exception {
     runIfAlive(() -> null, alive);
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockWithMetadata.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockWithMetadata.java
@@ -21,6 +21,12 @@ import org.hyperledger.besu.ethereum.core.Withdrawal;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * The type Block with metadata.
+ *
+ * @param <T> the type parameter
+ * @param <O> the type parameter
+ */
 public class BlockWithMetadata<T, O> {
 
   private final BlockHeader header;
@@ -31,6 +37,8 @@ public class BlockWithMetadata<T, O> {
   private final Optional<List<Withdrawal>> withdrawals;
 
   /**
+   * Instantiates a new Block with metadata.
+   *
    * @param header The block header
    * @param transactions Block transactions in generic format
    * @param ommers Block ommers in generic format
@@ -46,6 +54,16 @@ public class BlockWithMetadata<T, O> {
     this(header, transactions, ommers, totalDifficulty, size, Optional.empty());
   }
 
+  /**
+   * Instantiates a new Block with metadata.
+   *
+   * @param header the header
+   * @param transactions the transactions
+   * @param ommers the ommers
+   * @param totalDifficulty the total difficulty
+   * @param size the size
+   * @param withdrawals the withdrawals
+   */
   public BlockWithMetadata(
       final BlockHeader header,
       final List<T> transactions,
@@ -61,26 +79,56 @@ public class BlockWithMetadata<T, O> {
     this.withdrawals = withdrawals;
   }
 
+  /**
+   * Gets header.
+   *
+   * @return the header
+   */
   public BlockHeader getHeader() {
     return header;
   }
 
+  /**
+   * Gets ommers.
+   *
+   * @return the ommers
+   */
   public List<O> getOmmers() {
     return ommers;
   }
 
+  /**
+   * Gets transactions.
+   *
+   * @return the transactions
+   */
   public List<T> getTransactions() {
     return transactions;
   }
 
+  /**
+   * Gets total difficulty.
+   *
+   * @return the total difficulty
+   */
   public Difficulty getTotalDifficulty() {
     return totalDifficulty;
   }
 
+  /**
+   * Gets size.
+   *
+   * @return the size
+   */
   public int getSize() {
     return size;
   }
 
+  /**
+   * Gets withdrawals.
+   *
+   * @return the withdrawals
+   */
   public Optional<List<Withdrawal>> getWithdrawals() {
     return withdrawals;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -63,6 +63,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Blockchain queries. */
 public class BlockchainQueries {
   private static final Logger LOG = LoggerFactory.getLogger(BlockchainQueries.class);
 
@@ -73,10 +74,23 @@ public class BlockchainQueries {
   private final Optional<EthScheduler> ethScheduler;
   private final ApiConfiguration apiConfig;
 
+  /**
+   * Instantiates a new Blockchain queries.
+   *
+   * @param blockchain the blockchain
+   * @param worldStateArchive the world state archive
+   */
   public BlockchainQueries(final Blockchain blockchain, final WorldStateArchive worldStateArchive) {
     this(blockchain, worldStateArchive, Optional.empty(), Optional.empty());
   }
 
+  /**
+   * Instantiates a new Blockchain queries.
+   *
+   * @param blockchain the blockchain
+   * @param worldStateArchive the world state archive
+   * @param scheduler the scheduler
+   */
   public BlockchainQueries(
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
@@ -84,6 +98,14 @@ public class BlockchainQueries {
     this(blockchain, worldStateArchive, Optional.empty(), Optional.ofNullable(scheduler));
   }
 
+  /**
+   * Instantiates a new Blockchain queries.
+   *
+   * @param blockchain the blockchain
+   * @param worldStateArchive the world state archive
+   * @param cachePath the cache path
+   * @param scheduler the scheduler
+   */
   public BlockchainQueries(
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
@@ -97,6 +119,15 @@ public class BlockchainQueries {
         ImmutableApiConfiguration.builder().build());
   }
 
+  /**
+   * Instantiates a new Blockchain queries.
+   *
+   * @param blockchain the blockchain
+   * @param worldStateArchive the world state archive
+   * @param cachePath the cache path
+   * @param scheduler the scheduler
+   * @param apiConfig the api config
+   */
   public BlockchainQueries(
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
@@ -115,14 +146,29 @@ public class BlockchainQueries {
     this.apiConfig = apiConfig;
   }
 
+  /**
+   * Gets blockchain.
+   *
+   * @return the blockchain
+   */
   public Blockchain getBlockchain() {
     return blockchain;
   }
 
+  /**
+   * Gets world state archive.
+   *
+   * @return the world state archive
+   */
   public WorldStateArchive getWorldStateArchive() {
     return worldStateArchive;
   }
 
+  /**
+   * Gets transaction log bloom cacher.
+   *
+   * @return the transaction log bloom cacher
+   */
   public Optional<TransactionLogBloomCacher> getTransactionLogBloomCacher() {
     return transactionLogBloomCacher;
   }
@@ -495,14 +541,32 @@ public class BlockchainQueries {
     return blockchain.getBlockHashByNumber(blockNumber).flatMap(this::blockByHashWithTxHashes);
   }
 
+  /**
+   * Gets block header by hash.
+   *
+   * @param hash the hash
+   * @return the block header by hash
+   */
   public Optional<BlockHeader> getBlockHeaderByHash(final Hash hash) {
     return blockchain.getBlockHeader(hash);
   }
 
+  /**
+   * Gets block header by number.
+   *
+   * @param number the number
+   * @return the block header by number
+   */
   public Optional<BlockHeader> getBlockHeaderByNumber(final long number) {
     return blockchain.getBlockHeader(number);
   }
 
+  /**
+   * Block is on canonical chain boolean.
+   *
+   * @param hash the hash
+   * @return the boolean
+   */
   public boolean blockIsOnCanonicalChain(final Hash hash) {
     return blockchain.blockIsOnCanonicalChain(hash);
   }
@@ -595,6 +659,12 @@ public class BlockchainQueries {
         txs.get(txIndex), header.getNumber(), header.getBaseFee(), blockHeaderHash, txIndex);
   }
 
+  /**
+   * Transaction location by hash optional.
+   *
+   * @param transactionHash the transaction hash
+   * @return the optional
+   */
   public Optional<TransactionLocation> transactionLocationByHash(final Hash transactionHash) {
     return blockchain.getTransactionLocation(transactionHash);
   }
@@ -603,6 +673,7 @@ public class BlockchainQueries {
    * Returns the transaction receipt associated with the given transaction hash.
    *
    * @param transactionHash The hash of the transaction that corresponds to the receipt to retrieve.
+   * @param protocolSchedule the protocol schedule
    * @return The transaction receipt associated with the referenced transaction.
    */
   public Optional<TransactionReceiptWithMetadata> transactionReceiptByTransactionHash(
@@ -813,6 +884,14 @@ public class BlockchainQueries {
     return results;
   }
 
+  /**
+   * Matching logs list.
+   *
+   * @param blockHash the block hash
+   * @param query the query
+   * @param isQueryAlive the is query alive
+   * @return the list
+   */
   public List<LogWithMetadata> matchingLogs(
       final Hash blockHash, final LogsQuery query, final Supplier<Boolean> isQueryAlive) {
     try {
@@ -855,6 +934,14 @@ public class BlockchainQueries {
     }
   }
 
+  /**
+   * Matching logs list.
+   *
+   * @param blockHash the block hash
+   * @param transactionWithMetaData the transaction with meta data
+   * @param isQueryAlive the is query alive
+   * @return the list
+   */
   public List<LogWithMetadata> matchingLogs(
       final Hash blockHash,
       final TransactionWithMetadata transactionWithMetaData,
@@ -943,6 +1030,11 @@ public class BlockchainQueries {
     return getAndMapWorldState(blockHash, mapper);
   }
 
+  /**
+   * Gas price optional.
+   *
+   * @return the optional
+   */
   public Optional<Long> gasPrice() {
     final long blockHeight = headBlockNumber();
     final long[] gasCollection =
@@ -973,6 +1065,11 @@ public class BlockchainQueries {
                             (int) ((gasCollection.length) * apiConfig.getGasPriceFraction()))])));
   }
 
+  /**
+   * Gas priority fee optional.
+   *
+   * @return the optional
+   */
   public Optional<Wei> gasPriorityFee() {
     final long blockHeight = headBlockNumber();
     final BigInteger[] gasCollection =
@@ -1076,6 +1173,11 @@ public class BlockchainQueries {
     return logIndexOffset;
   }
 
+  /**
+   * Gets eth scheduler.
+   *
+   * @return the eth scheduler
+   */
   public Optional<EthScheduler> getEthScheduler() {
     return ethScheduler;
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/cache/AutoTransactionLogBloomCachingService.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/** The type Auto transaction log bloom caching service. */
 public class AutoTransactionLogBloomCachingService {
   private static final Logger LOG =
       LoggerFactory.getLogger(AutoTransactionLogBloomCachingService.class);
@@ -38,12 +39,19 @@ public class AutoTransactionLogBloomCachingService {
   private final TransactionLogBloomCacher transactionLogBloomCacher;
   private OptionalLong blockAddedSubscriptionId = OptionalLong.empty();
 
+  /**
+   * Instantiates a new Auto transaction log bloom caching service.
+   *
+   * @param blockchain the blockchain
+   * @param transactionLogBloomCacher the transaction log bloom cacher
+   */
   public AutoTransactionLogBloomCachingService(
       final Blockchain blockchain, final TransactionLogBloomCacher transactionLogBloomCacher) {
     this.blockchain = blockchain;
     this.transactionLogBloomCacher = transactionLogBloomCacher;
   }
 
+  /** Start. */
   public void start() {
     try {
       LOG.info("Starting auto transaction log bloom caching service.");
@@ -93,6 +101,7 @@ public class AutoTransactionLogBloomCachingService {
     }
   }
 
+  /** Stop. */
   public void stop() {
     LOG.info("Shutting down Auto transaction logs caching service.");
     blockAddedSubscriptionId.ifPresent(blockchain::removeObserver);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/ArrayNodeWrapper.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/util/ArrayNodeWrapper.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+/** The type Array node wrapper. */
 public class ArrayNodeWrapper {
 
   private final ArrayNode arrayNode;
@@ -27,10 +28,22 @@ public class ArrayNodeWrapper {
   private final Optional<Integer> maybeCount;
   private int currentOffset;
 
+  /**
+   * Instantiates a new Array node wrapper.
+   *
+   * @param arrayNode the array node
+   */
   public ArrayNodeWrapper(final ArrayNode arrayNode) {
     this(arrayNode, Optional.empty(), Optional.empty());
   }
 
+  /**
+   * Instantiates a new Array node wrapper.
+   *
+   * @param arrayNode the array node
+   * @param maybeAfter the maybe after
+   * @param maybeCount the maybe count
+   */
   public ArrayNodeWrapper(
       final ArrayNode arrayNode,
       final Optional<Integer> maybeAfter,
@@ -41,6 +54,11 @@ public class ArrayNodeWrapper {
     this.maybeCount = maybeCount;
   }
 
+  /**
+   * Add pojo.
+   *
+   * @param object the object
+   */
   public void addPOJO(final Object object) {
     final boolean isValidOffset = maybeAfter.map(after -> currentOffset >= after).orElse(true);
     final boolean isValidSize = maybeCount.map(count -> count > arrayNode.size()).orElse(true);
@@ -50,6 +68,11 @@ public class ArrayNodeWrapper {
     currentOffset++;
   }
 
+  /**
+   * Add all.
+   *
+   * @param wrapper the wrapper
+   */
   public void addAll(final ArrayNodeWrapper wrapper) {
     final Iterator<JsonNode> elements = wrapper.arrayNode.elements();
     while (!isFull() && elements.hasNext()) {
@@ -57,10 +80,20 @@ public class ArrayNodeWrapper {
     }
   }
 
+  /**
+   * Is full boolean.
+   *
+   * @return the boolean
+   */
   public boolean isFull() {
     return maybeCount.map(count -> count <= arrayNode.size()).orElse(false);
   }
 
+  /**
+   * Gets array node.
+   *
+   * @return the array node
+   */
   public ArrayNode getArrayNode() {
     return arrayNode;
   }


### PR DESCRIPTION
## PR description
javadoc - Adding default constructor and javadoc for :ethereum:api (~200 files)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

