### PR TITLE
do not use NO_PROXY_CACHE env variable with apt-get install to avoid a linting error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,9 @@ ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true
 
 # Update and install dependencies without using any cache
 RUN apt-get update $NO_PROXY_CACHE  && \
-  apt-get install $NO_PROXY_CACHE --no-install-recommends -q --assume-yes openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3*  && \
+  # $NO_PROXY_CACHE must not be used here or otherwise will trigger a hadolint error
+  apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
+    --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3*  && \
   # Clean apt cache
   apt-get clean  && \
   rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*  && \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -5,8 +5,11 @@ ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true
 
 # Update and install dependencies without using any cache
 RUN apt-get update $NO_PROXY_CACHE  && \
-  apt-get install $NO_PROXY_CACHE --no-install-recommends -q --assume-yes ca-certificates-java=20190909*  && \
-  apt-get install $NO_PROXY_CACHE --no-install-recommends -q --assume-yes openjdk-17-jre-headless=17*  && \
+  # $NO_PROXY_CACHE must not be used here or otherwise will trigger a hadolint error
+  apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
+    --no-install-recommends -q --assume-yes install ca-certificates-java=20190909*  && \
+  apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
+    --no-install-recommends -q --assume-yes install openjdk-17-jre-headless=17*  && \
   # Clean apt cache  \
   apt-get clean  && \
   rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*  && \


### PR DESCRIPTION
## PR description

A recent modification in the Dockerfiles triggers a linting error which fails the pipeline running on the `main` branch. Ignoring the rule seems a bad idea, because it is enforcing that all packages which are installed via apt-get have a defined version number, which is a best practice.

Instead I have opted for replacing the ENV variable which triggers the error with the respective string.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

