### PR TITLE
Update gradle wrapper validation

### DIFF
--- a/.github/workflows/pre-review.yml
+++ b/.github/workflows/pre-review.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4
+      - uses: gradle/wrapper-validation-action@27152f6fa06a6b8062ef7195c795692e51fc2c81
   spotless:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## PR description

Updates gradle wrapper validation to v2 aka https://github.com/gradle/wrapper-validation-action/commit/27152f6fa06a6b8062ef7195c795692e51fc2c81

## Fixed Issue(s)
the version we're on uses Node 16 which is deprecated 

This will fix this warning -
`
[Gradle Wrapper Validation](https://github.com/hyperledger/besu/actions/runs/9026583582/job/24804116556)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
`


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

