### PR TITLE
Make `eth_gasPrice` aware of the base fee market

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 - Fix parsing `gasLimit` parameter when its value is > `Long.MAX_VALUE` [#7116](https://github.com/hyperledger/besu/pull/7116)
+- Make `eth_gasPrice` aware of the base fee market [#7102](https://github.com/hyperledger/besu/pull/7102)
 
 ## 24.5.1
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -327,6 +327,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       Suppliers.memoize(this::readGenesisConfigFile);
   private final Supplier<GenesisConfigOptions> genesisConfigOptionsSupplier =
       Suppliers.memoize(this::readGenesisConfigOptions);
+  private final Supplier<MiningParameters> miningParametersSupplier =
+      Suppliers.memoize(this::getMiningParameters);
 
   private RocksDBPlugin rocksDBPlugin;
 
@@ -898,7 +900,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private Collection<EnodeURL> staticNodes;
   private BesuController besuController;
   private BesuConfigurationImpl pluginCommonConfiguration;
-  private MiningParameters miningParameters;
 
   private BesuComponent besuComponent;
   private final Supplier<ObservableMetricsSystem> metricsSystem =
@@ -1354,7 +1355,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
                 besuController.getProtocolSchedule(),
                 besuController.getProtocolContext().getBlockchain(),
                 besuController.getProtocolContext().getWorldStateArchive(),
-                getMiningParameters()),
+                miningParametersSupplier.get()),
             besuController.getProtocolSchedule()));
 
     besuController.getAdditionalPluginServices().appendPluginServices(besuPluginContext);
@@ -1376,7 +1377,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             "--privacy-marker-transaction-signing-key-file can not be used in conjunction with a plugin that specifies a PrivateMarkerTransactionFactory");
       }
 
-      if (Wei.ZERO.compareTo(getMiningParameters().getMinTransactionGasPrice()) < 0
+      if (Wei.ZERO.compareTo(miningParametersSupplier.get().getMinTransactionGasPrice()) < 0
           && (privacyOptionGroup.privateMarkerTransactionSigningKeyPath == null
               && (privacyPluginService == null
                   || privacyPluginService.getPrivateMarkerTransactionFactory() == null))) {
@@ -1846,7 +1847,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         dataDir(),
         dataDir().resolve(DATABASE_PATH),
         getDataStorageConfiguration(),
-        getMiningParameters());
+        miningParametersSupplier.get());
     final KeyValueStorageProvider storageProvider = keyValueStorageProvider(keyValueStorageName);
     return controllerBuilderFactory
         .fromEthNetworkConfig(updateNetworkConfig(network), getDefaultSyncModeIfNotSet())
@@ -1855,7 +1856,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .networkConfiguration(unstableNetworkingOptions.toDomainObject())
         .dataDirectory(dataDir())
         .dataStorageConfiguration(getDataStorageConfiguration())
-        .miningParameters(getMiningParameters())
+        .miningParameters(miningParametersSupplier.get())
         .transactionPoolConfiguration(buildTransactionPoolConfiguration())
         .nodeKey(new NodeKey(securityModule()))
         .metricsSystem(metricsSystem.get())
@@ -1866,7 +1867,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .isRevertReasonEnabled(isRevertReasonEnabled)
         .storageProvider(storageProvider)
         .gasLimitCalculator(
-            getMiningParameters().getTargetGasLimit().isPresent()
+            miningParametersSupplier.get().getTargetGasLimit().isPresent()
                 ? new FrontierTargetingGasLimitCalculator()
                 : GasLimitCalculator.constant())
         .requiredBlocks(requiredBlocks)
@@ -2159,14 +2160,17 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       txPoolConfBuilder.priceBump(Percentage.ZERO);
     }
 
-    if (getMiningParameters().getMinTransactionGasPrice().equals(Wei.ZERO)
+    if (miningParametersSupplier.get().getMinTransactionGasPrice().equals(Wei.ZERO)
         && !transactionPoolOptions.isPriceBumpSet(commandLine)) {
       logger.info(
           "Forcing price bump for transaction replacement to 0, since min-gas-price is set to 0");
       txPoolConfBuilder.priceBump(Percentage.ZERO);
     }
 
-    if (getMiningParameters().getMinTransactionGasPrice().lessThan(txPoolConf.getMinGasPrice())) {
+    if (miningParametersSupplier
+        .get()
+        .getMinTransactionGasPrice()
+        .lessThan(txPoolConf.getMinGasPrice())) {
       if (transactionPoolOptions.isMinGasPriceSet(commandLine)) {
         throw new ParameterException(
             commandLine, "tx-pool-min-gas-price cannot be greater than the value of min-gas-price");
@@ -2177,9 +2181,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         // the user of the change
         logger.warn(
             "Forcing tx-pool-min-gas-price="
-                + getMiningParameters().getMinTransactionGasPrice().toDecimalString()
+                + miningParametersSupplier.get().getMinTransactionGasPrice().toDecimalString()
                 + ", since it cannot be greater than the value of min-gas-price");
-        txPoolConfBuilder.minGasPrice(getMiningParameters().getMinTransactionGasPrice());
+        txPoolConfBuilder.minGasPrice(miningParametersSupplier.get().getMinTransactionGasPrice());
       }
     }
 
@@ -2187,13 +2191,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   }
 
   private MiningParameters getMiningParameters() {
-    if (miningParameters == null) {
-      miningOptions.setTransactionSelectionService(transactionSelectionServiceImpl);
-      miningParameters = miningOptions.toDomainObject();
-      getGenesisBlockPeriodSeconds(genesisConfigOptionsSupplier.get())
-          .ifPresent(miningParameters::setBlockPeriodSeconds);
-      initMiningParametersMetrics(miningParameters);
-    }
+    miningOptions.setTransactionSelectionService(transactionSelectionServiceImpl);
+    final var miningParameters = miningOptions.toDomainObject();
+    getGenesisBlockPeriodSeconds(genesisConfigOptionsSupplier.get())
+        .ifPresent(miningParameters::setBlockPeriodSeconds);
+    initMiningParametersMetrics(miningParameters);
     return miningParameters;
   }
 
@@ -2569,8 +2571,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         effectivePorts, metricsOptionGroup.metricsPort, metricsOptionGroup.isMetricsEnabled);
     addPortIfEnabled(
         effectivePorts,
-        getMiningParameters().getStratumPort(),
-        getMiningParameters().isStratumMiningEnabled());
+        miningParametersSupplier.get().getStratumPort(),
+        miningParametersSupplier.get().isStratumMiningEnabled());
     return effectivePorts;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1351,8 +1351,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         TraceService.class,
         new TraceServiceImpl(
             new BlockchainQueries(
+                besuController.getProtocolSchedule(),
                 besuController.getProtocolContext().getBlockchain(),
-                besuController.getProtocolContext().getWorldStateArchive()),
+                besuController.getProtocolContext().getWorldStateArchive(),
+                getMiningParameters()),
             besuController.getProtocolSchedule()));
 
     besuController.getAdditionalPluginServices().appendPluginServices(besuPluginContext);
@@ -1755,7 +1757,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             unstableIpcOptions.isEnabled(),
             unstableIpcOptions.getIpcPath(),
             unstableIpcOptions.getRpcIpcApis());
-    apiConfiguration = apiConfigurationOptions.apiConfiguration(getMiningParameters());
+    apiConfiguration = apiConfigurationOptions.apiConfiguration();
     dataStorageConfiguration = getDataStorageConfiguration();
     // hostsWhitelist is a hidden option. If it is specified, add the list to hostAllowlist
     if (!hostsWhitelist.isEmpty()) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/ApiConfigurationOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/ApiConfigurationOptions.java
@@ -17,9 +17,9 @@ package org.hyperledger.besu.cli.options.stable;
 import static java.util.Arrays.asList;
 
 import org.hyperledger.besu.cli.util.CommandLineUtils;
+import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.ApiConfiguration;
 import org.hyperledger.besu.ethereum.api.ImmutableApiConfiguration;
-import org.hyperledger.besu.ethereum.core.MiningParameters;
 
 import org.slf4j.Logger;
 import picocli.CommandLine;
@@ -119,17 +119,14 @@ public class ApiConfigurationOptions {
   /**
    * Creates an ApiConfiguration based on the provided options.
    *
-   * @param miningParameters The mining parameters
    * @return An ApiConfiguration instance
    */
-  public ApiConfiguration apiConfiguration(final MiningParameters miningParameters) {
+  public ApiConfiguration apiConfiguration() {
     var builder =
         ImmutableApiConfiguration.builder()
             .gasPriceBlocks(apiGasPriceBlocks)
             .gasPricePercentile(apiGasPricePercentile)
-            .gasPriceMinSupplier(
-                miningParameters.getMinTransactionGasPrice().getAsBigInteger()::longValueExact)
-            .gasPriceMax(apiGasPriceMax)
+            .gasPriceMax(Wei.of(apiGasPriceMax))
             .maxLogsRange(rpcMaxLogsRange)
             .gasCap(rpcGasCap)
             .isGasAndPriorityFeeLimitingEnabled(apiGasAndPriorityFeeLimitingEnabled)

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -731,7 +731,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
         createSubProtocolConfiguration(ethProtocolManager, maybeSnapProtocolManager);
 
     final JsonRpcMethods additionalJsonRpcMethodFactory =
-        createAdditionalJsonRpcMethodFactory(protocolContext);
+        createAdditionalJsonRpcMethodFactory(protocolContext, protocolSchedule, miningParameters);
 
     if (dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled()
         && DataStorageFormat.BONSAI.equals(dataStorageConfiguration.getDataStorageFormat())) {
@@ -884,10 +884,14 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
    * Create additional json rpc method factory json rpc methods.
    *
    * @param protocolContext the protocol context
+   * @param protocolSchedule the protocol schedule
+   * @param miningParameters the mining parameters
    * @return the json rpc methods
    */
   protected JsonRpcMethods createAdditionalJsonRpcMethodFactory(
-      final ProtocolContext protocolContext) {
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
     return apis -> Collections.emptyMap();
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -72,8 +72,10 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder {
 
   @Override
   protected JsonRpcMethods createAdditionalJsonRpcMethodFactory(
-      final ProtocolContext protocolContext) {
-    return new CliqueJsonRpcMethods(protocolContext);
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
+    return new CliqueJsonRpcMethods(protocolContext, protocolSchedule, miningParameters);
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/ConsensusScheduleBesuControllerBuilder.java
@@ -204,10 +204,12 @@ public class ConsensusScheduleBesuControllerBuilder extends BesuControllerBuilde
 
   @Override
   protected JsonRpcMethods createAdditionalJsonRpcMethodFactory(
-      final ProtocolContext protocolContext) {
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
     return besuControllerBuilderSchedule
         .get(0L)
-        .createAdditionalJsonRpcMethodFactory(protocolContext);
+        .createAdditionalJsonRpcMethodFactory(protocolContext, protocolSchedule, miningParameters);
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -111,8 +111,10 @@ public class IbftBesuControllerBuilder extends BftBesuControllerBuilder {
 
   @Override
   protected JsonRpcMethods createAdditionalJsonRpcMethodFactory(
-      final ProtocolContext protocolContext) {
-    return new IbftJsonRpcMethods(protocolContext);
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
+    return new IbftJsonRpcMethods(protocolContext, protocolSchedule, miningParameters);
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -130,10 +130,15 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
 
   @Override
   protected JsonRpcMethods createAdditionalJsonRpcMethodFactory(
-      final ProtocolContext protocolContext) {
+      final ProtocolContext protocolContext,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
 
     return new QbftJsonRpcMethods(
-        protocolContext, createReadOnlyValidatorProvider(protocolContext.getBlockchain()));
+        protocolContext,
+        protocolSchedule,
+        miningParameters,
+        createReadOnlyValidatorProvider(protocolContext.getBlockchain()));
   }
 
   private ValidatorProvider createReadOnlyValidatorProvider(final Blockchain blockchain) {

--- a/besu/src/test/java/org/hyperledger/besu/controller/QbftBesuControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/QbftBesuControllerBuilderTest.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.List;
 
@@ -99,10 +101,13 @@ public class QbftBesuControllerBuilderTest extends AbstractBftBesuControllerBuil
   @Test
   public void missingTransactionValidatorProviderThrowsError() {
     final ProtocolContext protocolContext = mock(ProtocolContext.class);
+    final ProtocolSchedule protocolSchedule = mock(ProtocolSchedule.class);
     when(protocolContext.getBlockchain()).thenReturn(mock(MutableBlockchain.class));
 
     assertThatThrownBy(
-            () -> bftBesuControllerBuilder.createAdditionalJsonRpcMethodFactory(protocolContext))
+            () ->
+                bftBesuControllerBuilder.createAdditionalJsonRpcMethodFactory(
+                    protocolContext, protocolSchedule, MiningParameters.newDefault()))
         .isInstanceOf(NullPointerException.class)
         .hasMessage("transactionValidatorProvider should have been initialised");
   }

--- a/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.worldstate.WorldView;
@@ -74,7 +75,12 @@ class TraceServiceImplTest {
     blockchainSetupUtil.importAllBlocks();
     blockchain = blockchainSetupUtil.getBlockchain();
     worldStateArchive = blockchainSetupUtil.getWorldArchive();
-    blockchainQueries = new BlockchainQueries(blockchain, worldStateArchive);
+    blockchainQueries =
+        new BlockchainQueries(
+            blockchainSetupUtil.getProtocolSchedule(),
+            blockchain,
+            worldStateArchive,
+            MiningParameters.newDefault());
     traceService =
         new TraceServiceImpl(blockchainQueries, blockchainSetupUtil.getProtocolSchedule());
   }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/jsonrpc/CliqueJsonRpcMethods.java
@@ -31,6 +31,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
 import java.util.Map;
@@ -38,14 +40,23 @@ import java.util.Map;
 /** The Clique json rpc methods. */
 public class CliqueJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ProtocolContext context;
+  private final ProtocolSchedule protocolSchedule;
+  private final MiningParameters miningParameters;
 
   /**
    * Instantiates a new Clique json rpc methods.
    *
-   * @param context the context
+   * @param context the protocol context
+   * @param protocolSchedule the protocol schedule
+   * @param miningParameters the mining parameters
    */
-  public CliqueJsonRpcMethods(final ProtocolContext context) {
+  public CliqueJsonRpcMethods(
+      final ProtocolContext context,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
     this.context = context;
+    this.protocolSchedule = protocolSchedule;
+    this.miningParameters = miningParameters;
   }
 
   @Override
@@ -58,7 +69,7 @@ public class CliqueJsonRpcMethods extends ApiGroupJsonRpcMethods {
     final MutableBlockchain blockchain = context.getBlockchain();
     final WorldStateArchive worldStateArchive = context.getWorldStateArchive();
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(blockchain, worldStateArchive);
+        new BlockchainQueries(protocolSchedule, blockchain, worldStateArchive, miningParameters);
     final ValidatorProvider validatorProvider =
         context.getConsensusContext(CliqueContext.class).getValidatorProvider();
 

--- a/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/IbftJsonRpcMethods.java
+++ b/consensus/ibft/src/main/java/org/hyperledger/besu/consensus/ibft/jsonrpc/IbftJsonRpcMethods.java
@@ -32,6 +32,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Map;
 
@@ -39,14 +41,23 @@ import java.util.Map;
 public class IbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final ProtocolContext context;
+  private final ProtocolSchedule protocolSchedule;
+  private final MiningParameters miningParameters;
 
   /**
    * Instantiates a new Ibft json rpc methods.
    *
-   * @param context the context
+   * @param context the protocol context
+   * @param protocolSchedule the protocol schedule
+   * @param miningParameters the mining parameters
    */
-  public IbftJsonRpcMethods(final ProtocolContext context) {
+  public IbftJsonRpcMethods(
+      final ProtocolContext context,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters) {
     this.context = context;
+    this.protocolSchedule = protocolSchedule;
+    this.miningParameters = miningParameters;
   }
 
   @Override
@@ -58,7 +69,8 @@ public class IbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
   protected Map<String, JsonRpcMethod> create() {
     final MutableBlockchain blockchain = context.getBlockchain();
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(blockchain, context.getWorldStateArchive());
+        new BlockchainQueries(
+            protocolSchedule, blockchain, context.getWorldStateArchive(), miningParameters);
     final BftContext bftContext = context.getConsensusContext(BftContext.class);
     final BlockInterface blockInterface = bftContext.getBlockInterface();
     final ValidatorProvider validatorProvider =

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/jsonrpc/QbftJsonRpcMethods.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/jsonrpc/QbftJsonRpcMethods.java
@@ -28,6 +28,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.RpcApis;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.ApiGroupJsonRpcMethods;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 
 import java.util.Map;
 
@@ -36,17 +38,26 @@ public class QbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final ProtocolContext context;
   private final ValidatorProvider readOnlyValidatorProvider;
+  private final ProtocolSchedule protocolSchedule;
+  private final MiningParameters miningParameters;
 
   /**
    * Instantiates a new Qbft json rpc methods.
    *
-   * @param context the context
+   * @param context the protocol context
+   * @param protocolSchedule the protocol schedule
+   * @param miningParameters the mining parameters
    * @param readOnlyValidatorProvider the read only validator provider
    */
   public QbftJsonRpcMethods(
-      final ProtocolContext context, final ValidatorProvider readOnlyValidatorProvider) {
+      final ProtocolContext context,
+      final ProtocolSchedule protocolSchedule,
+      final MiningParameters miningParameters,
+      final ValidatorProvider readOnlyValidatorProvider) {
     this.context = context;
     this.readOnlyValidatorProvider = readOnlyValidatorProvider;
+    this.protocolSchedule = protocolSchedule;
+    this.miningParameters = miningParameters;
   }
 
   @Override
@@ -57,7 +68,11 @@ public class QbftJsonRpcMethods extends ApiGroupJsonRpcMethods {
   @Override
   protected Map<String, JsonRpcMethod> create() {
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(context.getBlockchain(), context.getWorldStateArchive());
+        new BlockchainQueries(
+            protocolSchedule,
+            context.getBlockchain(),
+            context.getWorldStateArchive(),
+            miningParameters);
     final BftContext bftContext = context.getConsensusContext(BftContext.class);
     final BlockInterface blockInterface = bftContext.getBlockInterface();
     final ValidatorProvider validatorProvider = bftContext.getValidatorProvider();

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -89,7 +89,9 @@ public class JsonRpcTestMethodsFactory {
       final BlockImporter blockImporter = protocolSpec.getBlockImporter();
       blockImporter.importBlock(context, block, HeaderValidationMode.FULL);
     }
-    this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
+    this.blockchainQueries =
+        new BlockchainQueries(
+            protocolSchedule, blockchain, stateArchive, MiningParameters.newDefault());
   }
 
   public JsonRpcTestMethodsFactory(
@@ -101,7 +103,12 @@ public class JsonRpcTestMethodsFactory {
     this.blockchain = blockchain;
     this.stateArchive = stateArchive;
     this.context = context;
-    this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
+    this.blockchainQueries =
+        new BlockchainQueries(
+            importer.getProtocolSchedule(),
+            blockchain,
+            stateArchive,
+            MiningParameters.newDefault());
     this.synchronizer = mock(Synchronizer.class);
   }
 
@@ -116,7 +123,12 @@ public class JsonRpcTestMethodsFactory {
     this.stateArchive = stateArchive;
     this.context = context;
     this.synchronizer = synchronizer;
-    this.blockchainQueries = new BlockchainQueries(blockchain, stateArchive);
+    this.blockchainQueries =
+        new BlockchainQueries(
+            importer.getProtocolSchedule(),
+            blockchain,
+            stateArchive,
+            MiningParameters.newDefault());
   }
 
   public BlockchainQueries getBlockchainQueries() {

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/frontier/EthGetFilterChangesIntegrationTest.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -123,7 +124,11 @@ public class EthGetFilterChangesIntegrationTest {
             TransactionPoolConfiguration.DEFAULT);
     transactionPool.setEnabled();
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(blockchain, protocolContext.getWorldStateArchive());
+        new BlockchainQueries(
+            executionContext.getProtocolSchedule(),
+            blockchain,
+            protocolContext.getWorldStateArchive(),
+            MiningParameters.newDefault());
     filterManager =
         new FilterManagerBuilder()
             .blockchainQueries(blockchainQueries)

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/fork/london/EthGetFilterChangesIntegrationTest.java
@@ -45,6 +45,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
@@ -123,7 +124,11 @@ public class EthGetFilterChangesIntegrationTest {
             TransactionPoolConfiguration.DEFAULT);
     transactionPool.setEnabled();
     final BlockchainQueries blockchainQueries =
-        new BlockchainQueries(blockchain, protocolContext.getWorldStateArchive());
+        new BlockchainQueries(
+            executionContext.getProtocolSchedule(),
+            blockchain,
+            protocolContext.getWorldStateArchive(),
+            MiningParameters.newDefault());
     filterManager =
         new FilterManagerBuilder()
             .blockchainQueries(blockchainQueries)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/ApiConfiguration.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api;
 
-import java.util.function.LongSupplier;
+import org.hyperledger.besu.datatypes.Wei;
 
 import org.immutables.value.Value;
 
@@ -36,14 +36,8 @@ public abstract class ApiConfiguration {
   }
 
   @Value.Default
-  @Value.Auxiliary
-  public LongSupplier getGasPriceMinSupplier() {
-    return () -> 1_000_000_000L; // 1 GWei
-  }
-
-  @Value.Default
-  public long getGasPriceMax() {
-    return 500_000_000_000L; // 500 GWei
+  public Wei getGasPriceMax() {
+    return Wei.of(500_000_000_000L); // 500 GWei
   }
 
   @Value.Derived

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLDataFetchers.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.api.query.BlockWithMetadata;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.query.LogsQuery;
 import org.hyperledger.besu.ethereum.api.query.TransactionWithMetadata;
-import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.Transaction;
@@ -117,17 +116,12 @@ public class GraphQLDataFetchers {
     };
   }
 
-  DataFetcher<Optional<Wei>> getGasPriceDataFetcher() {
+  DataFetcher<Wei> getGasPriceDataFetcher() {
     return dataFetchingEnvironment -> {
       final GraphQLContext graphQLContext = dataFetchingEnvironment.getGraphQlContext();
       final BlockchainQueries blockchainQueries =
           graphQLContext.get(GraphQLContextType.BLOCKCHAIN_QUERIES);
-      final MiningCoordinator miningCoordinator =
-          graphQLContext.get(GraphQLContextType.MINING_COORDINATOR);
-      return blockchainQueries
-          .gasPrice()
-          .map(Wei::of)
-          .or(() -> Optional.of(miningCoordinator.getMinTransactionGasPrice()));
+      return blockchainQueries.gasPrice();
     };
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/EthJsonRpcMethods.java
@@ -175,7 +175,7 @@ public class EthJsonRpcMethods extends ApiGroupJsonRpcMethods {
         new EthMining(miningCoordinator),
         new EthCoinbase(miningCoordinator),
         new EthProtocolVersion(supportedCapabilities),
-        new EthGasPrice(blockchainQueries, miningCoordinator, apiConfiguration),
+        new EthGasPrice(blockchainQueries, apiConfiguration),
         new EthGetWork(miningCoordinator),
         new EthSubmitWork(miningCoordinator),
         new EthHashrate(miningCoordinator),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -30,12 +30,15 @@ import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.BaseFeeMarket;
+import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
@@ -60,49 +63,77 @@ import java.util.stream.LongStream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.apache.tuweni.units.bigints.UInt256s;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BlockchainQueries {
   private static final Logger LOG = LoggerFactory.getLogger(BlockchainQueries.class);
 
+  private final ProtocolSchedule protocolSchedule;
   private final WorldStateArchive worldStateArchive;
   private final Blockchain blockchain;
   private final Optional<Path> cachePath;
   private final Optional<TransactionLogBloomCacher> transactionLogBloomCacher;
   private final Optional<EthScheduler> ethScheduler;
   private final ApiConfiguration apiConfig;
-
-  public BlockchainQueries(final Blockchain blockchain, final WorldStateArchive worldStateArchive) {
-    this(blockchain, worldStateArchive, Optional.empty(), Optional.empty());
-  }
+  private final MiningParameters miningParameters;
 
   public BlockchainQueries(
+      final ProtocolSchedule protocolSchedule,
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
-      final EthScheduler scheduler) {
-    this(blockchain, worldStateArchive, Optional.empty(), Optional.ofNullable(scheduler));
-  }
-
-  public BlockchainQueries(
-      final Blockchain blockchain,
-      final WorldStateArchive worldStateArchive,
-      final Optional<Path> cachePath,
-      final Optional<EthScheduler> scheduler) {
+      final MiningParameters miningParameters) {
     this(
+        protocolSchedule,
         blockchain,
         worldStateArchive,
-        cachePath,
-        scheduler,
-        ImmutableApiConfiguration.builder().build());
+        Optional.empty(),
+        Optional.empty(),
+        miningParameters);
   }
 
   public BlockchainQueries(
+      final ProtocolSchedule protocolSchedule,
+      final Blockchain blockchain,
+      final WorldStateArchive worldStateArchive,
+      final EthScheduler scheduler,
+      final MiningParameters miningParameters) {
+    this(
+        protocolSchedule,
+        blockchain,
+        worldStateArchive,
+        Optional.empty(),
+        Optional.ofNullable(scheduler),
+        miningParameters);
+  }
+
+  public BlockchainQueries(
+      final ProtocolSchedule protocolSchedule,
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
       final Optional<Path> cachePath,
       final Optional<EthScheduler> scheduler,
-      final ApiConfiguration apiConfig) {
+      final MiningParameters miningParameters) {
+    this(
+        protocolSchedule,
+        blockchain,
+        worldStateArchive,
+        cachePath,
+        scheduler,
+        ImmutableApiConfiguration.builder().build(),
+        miningParameters);
+  }
+
+  public BlockchainQueries(
+      final ProtocolSchedule protocolSchedule,
+      final Blockchain blockchain,
+      final WorldStateArchive worldStateArchive,
+      final Optional<Path> cachePath,
+      final Optional<EthScheduler> scheduler,
+      final ApiConfiguration apiConfig,
+      final MiningParameters miningParameters) {
+    this.protocolSchedule = protocolSchedule;
     this.blockchain = blockchain;
     this.worldStateArchive = worldStateArchive;
     this.cachePath = cachePath;
@@ -113,6 +144,7 @@ public class BlockchainQueries {
                 new TransactionLogBloomCacher(blockchain, cachePath.get(), scheduler.get()))
             : Optional.empty();
     this.apiConfig = apiConfig;
+    this.miningParameters = miningParameters;
   }
 
   public Blockchain getBlockchain() {
@@ -943,9 +975,13 @@ public class BlockchainQueries {
     return getAndMapWorldState(blockHash, mapper);
   }
 
-  public Optional<Long> gasPrice() {
+  public Wei gasPrice() {
     final long blockHeight = headBlockNumber();
-    final long[] gasCollection =
+    final var chainHeadHeader = blockchain.getChainHeadHeader();
+    final var nextBlockProtocolSpec =
+        protocolSchedule.getForNextBlockHeader(chainHeadHeader, System.currentTimeMillis());
+    final var nextBlockFeeMarket = nextBlockProtocolSpec.getFeeMarket();
+    final Wei[] gasCollection =
         LongStream.range(Math.max(0, blockHeight - apiConfig.getGasPriceBlocks()), blockHeight)
             .mapToObj(
                 l ->
@@ -957,20 +993,48 @@ public class BlockchainQueries {
                             () -> new IllegalStateException("Could not retrieve block #" + l)))
             .flatMap(Collection::stream)
             .filter(t -> t.getGasPrice().isPresent())
-            .mapToLong(t -> t.getGasPrice().get().toLong())
+            .map(t -> t.getGasPrice().get())
             .sorted()
-            .toArray();
+            .toArray(Wei[]::new);
     return (gasCollection == null || gasCollection.length == 0)
-        ? Optional.empty()
-        : Optional.of(
-            Math.max(
-                apiConfig.getGasPriceMinSupplier().getAsLong(),
-                Math.min(
-                    apiConfig.getGasPriceMax(),
-                    gasCollection[
-                        Math.min(
-                            gasCollection.length - 1,
-                            (int) ((gasCollection.length) * apiConfig.getGasPriceFraction()))])));
+        ? gasPriceLowerBound(chainHeadHeader, nextBlockFeeMarket)
+        : UInt256s.max(
+            gasPriceLowerBound(chainHeadHeader, nextBlockFeeMarket),
+            UInt256s.min(
+                apiConfig.getGasPriceMax(),
+                gasCollection[
+                    Math.min(
+                        gasCollection.length - 1,
+                        (int) ((gasCollection.length) * apiConfig.getGasPriceFraction()))]));
+  }
+
+  /**
+   * Return the min gas required for a tx to be mineable. On networks with gas price fee market it
+   * is just the minGasPrice, while on networks with base fee market it is the max between the
+   * minGasPrice and the baseFee for the next block + minPriorityFeePerGas.
+   *
+   * @return the min gas required for a tx to be mineable.
+   */
+  public Wei gasPriceLowerBound() {
+    final var chainHeadHeader = blockchain.getChainHeadHeader();
+    final var nextBlockProtocolSpec =
+        protocolSchedule.getForNextBlockHeader(chainHeadHeader, System.currentTimeMillis());
+    final var nextBlockFeeMarket = nextBlockProtocolSpec.getFeeMarket();
+    return gasPriceLowerBound(chainHeadHeader, nextBlockFeeMarket);
+  }
+
+  private Wei gasPriceLowerBound(
+      final BlockHeader chainHeadHeader, final FeeMarket nextBlockFeeMarket) {
+    final var minGasPrice = miningParameters.getMinTransactionGasPrice();
+
+    if (nextBlockFeeMarket.implementsBaseFee()) {
+      return UInt256s.max(
+          getNextBlockBaseFee(chainHeadHeader, (BaseFeeMarket) nextBlockFeeMarket)
+              .add(miningParameters.getMinPriorityFeePerGas()),
+          minGasPrice);
+    }
+
+    return minGasPrice;
   }
 
   public Optional<Wei> gasPriorityFee() {
@@ -998,6 +1062,31 @@ public class BlockchainQueries {
                     Math.min(
                         gasCollection.length - 1,
                         (int) ((gasCollection.length) * apiConfig.getGasPriceFraction()))]));
+  }
+
+  /**
+   * Calculate and return the value of the base fee for the next block, if the network has a base
+   * fee market, otherwise return empty.
+   *
+   * @return the optional base fee
+   */
+  public Optional<Wei> getNextBlockBaseFee() {
+    final var chainHeadHeader = blockchain.getChainHeadHeader();
+    final var nextBlockProtocolSpec =
+        protocolSchedule.getForNextBlockHeader(chainHeadHeader, System.currentTimeMillis());
+    final var nextBlockFeeMarket = nextBlockProtocolSpec.getFeeMarket();
+    return nextBlockFeeMarket.implementsBaseFee()
+        ? Optional.of(getNextBlockBaseFee(chainHeadHeader, (BaseFeeMarket) nextBlockFeeMarket))
+        : Optional.empty();
+  }
+
+  private Wei getNextBlockBaseFee(
+      final BlockHeader chainHeadHeader, final BaseFeeMarket nextBlockFeeMarket) {
+    return nextBlockFeeMarket.computeBaseFee(
+        chainHeadHeader.getNumber() + 1,
+        chainHeadHeader.getBaseFee().orElse(Wei.ZERO),
+        chainHeadHeader.getGasUsed(),
+        nextBlockFeeMarket.targetGasUsed(chainHeadHeader));
   }
 
   private <T> Optional<T> fromAccount(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueries.java
@@ -982,7 +982,8 @@ public class BlockchainQueries {
         protocolSchedule.getForNextBlockHeader(chainHeadHeader, System.currentTimeMillis());
     final var nextBlockFeeMarket = nextBlockProtocolSpec.getFeeMarket();
     final Wei[] gasCollection =
-        LongStream.range(Math.max(0, blockHeight - apiConfig.getGasPriceBlocks()), blockHeight)
+        LongStream.rangeClosed(
+                Math.max(0, blockHeight - apiConfig.getGasPriceBlocks() + 1), blockHeight)
             .mapToObj(
                 l ->
                     blockchain
@@ -1011,7 +1012,7 @@ public class BlockchainQueries {
   /**
    * Return the min gas required for a tx to be mineable. On networks with gas price fee market it
    * is just the minGasPrice, while on networks with base fee market it is the max between the
-   * minGasPrice and the baseFee for the next block + minPriorityFeePerGas.
+   * minGasPrice and the baseFee for the next block.
    *
    * @return the min gas required for a tx to be mineable.
    */
@@ -1029,9 +1030,7 @@ public class BlockchainQueries {
 
     if (nextBlockFeeMarket.implementsBaseFee()) {
       return UInt256s.max(
-          getNextBlockBaseFee(chainHeadHeader, (BaseFeeMarket) nextBlockFeeMarket)
-              .add(miningParameters.getMinPriorityFeePerGas()),
-          minGasPrice);
+          getNextBlockBaseFee(chainHeadHeader, (BaseFeeMarket) nextBlockFeeMarket), minGasPrice);
     }
 
     return minGasPrice;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/graphql/GraphQLHttpServiceTest.java
@@ -216,7 +216,7 @@ public class GraphQLHttpServiceTest {
   @Test
   public void query_get() throws Exception {
     final Wei price = Wei.of(16);
-    Mockito.when(blockchainQueries.gasPrice()).thenReturn(Optional.of(price.toLong()));
+    Mockito.when(blockchainQueries.gasPrice()).thenReturn(price);
     Mockito.when(miningCoordinatorMock.getMinTransactionGasPrice()).thenReturn(price);
 
     try (final Response resp = client.newCall(buildGetRequest("?query={gasPrice}")).execute()) {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -145,7 +145,10 @@ public abstract class AbstractJsonRpcHttpServiceTest {
 
     final BlockchainQueries blockchainQueries =
         new BlockchainQueries(
-            blockchainSetupUtil.getBlockchain(), blockchainSetupUtil.getWorldArchive());
+            blockchainSetupUtil.getProtocolSchedule(),
+            blockchainSetupUtil.getBlockchain(),
+            blockchainSetupUtil.getWorldArchive(),
+            miningParameters);
     final FilterIdGenerator filterIdGenerator = mock(FilterIdGenerator.class);
     final FilterRepository filterRepository = new FilterRepository();
     when(filterIdGenerator.nextId()).thenReturn("0x1");

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
@@ -36,8 +36,10 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
 import java.util.List;
@@ -66,6 +68,7 @@ public class EthGetBlockByNumberTest {
   private EthGetBlockByNumber method;
   @Mock private Synchronizer synchronizer;
   @Mock private WorldStateArchive worldStateArchive;
+  @Mock private ProtocolSchedule protocolSchedule;
 
   @BeforeEach
   public void setUp() {
@@ -87,7 +90,10 @@ public class EthGetBlockByNumberTest {
             latestHeader.getStateRoot(), latestHeader.getHash()))
         .thenReturn(Boolean.TRUE);
 
-    blockchainQueries = spy(new BlockchainQueries(blockchain, worldStateArchive));
+    blockchainQueries =
+        spy(
+            new BlockchainQueries(
+                protocolSchedule, blockchain, worldStateArchive, MiningParameters.newDefault()));
 
     method = new EthGetBlockByNumber(blockchainQueries, blockResult, synchronizer);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceiptsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockReceiptsTest.java
@@ -35,6 +35,7 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -82,7 +83,10 @@ public class EthGetBlockReceiptsTest {
       blockchain.appendBlock(block, receipts);
     }
 
-    blockchainQueries = spy(new BlockchainQueries(blockchain, worldStateArchive));
+    blockchainQueries =
+        spy(
+            new BlockchainQueries(
+                protocolSchedule, blockchain, worldStateArchive, MiningParameters.newDefault()));
     protocolSchedule = mock(ProtocolSchedule.class);
     method = new EthGetBlockReceipts(blockchainQueries, protocolSchedule);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
@@ -39,6 +39,8 @@ import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.ChainHead;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.proof.WorldStateProof;
 import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
@@ -63,6 +65,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class EthGetProofTest {
   @Mock private Blockchain blockchain;
+  @Mock private ProtocolSchedule protocolSchedule;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private WorldStateArchive archive;
@@ -83,7 +86,10 @@ class EthGetProofTest {
 
   @BeforeEach
   public void setUp() {
-    blockchainQueries = spy(new BlockchainQueries(blockchain, archive));
+    blockchainQueries =
+        spy(
+            new BlockchainQueries(
+                protocolSchedule, blockchain, archive, MiningParameters.newDefault()));
     when(blockchainQueries.getBlockchain()).thenReturn(blockchain);
     when(blockchainQueries.headBlockNumber()).thenReturn(14L);
     when(blockchain.getChainHead()).thenReturn(chainHead);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetTransactionReceiptTest.java
@@ -42,6 +42,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.PoWHasher;
@@ -189,7 +190,12 @@ public class EthGetTransactionReceiptTest {
   private final Blockchain blockchain = mock(Blockchain.class);
 
   private final BlockchainQueries blockchainQueries =
-      spy(new BlockchainQueries(blockchain, mock(WorldStateArchive.class)));
+      spy(
+          new BlockchainQueries(
+              protocolSchedule,
+              blockchain,
+              mock(WorldStateArchive.class),
+              MiningParameters.newDefault()));
   private final EthGetTransactionReceipt ethGetTransactionReceipt =
       new EthGetTransactionReceipt(blockchainQueries, protocolSchedule);
   private final String receiptString =

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/blockheaders/NewBlockHeadersSubscriptionServiceTest.java
@@ -32,8 +32,10 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStoragePrefixedKeyBlockchainStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -47,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -73,9 +76,16 @@ public class NewBlockHeadersSubscriptionServiceTest {
   private final SubscriptionManager subscriptionManagerSpy =
       new SubscriptionManager(new NoOpMetricsSystem());
 
+  @Mock ProtocolSchedule protocolSchedule;
+
   @Spy
   private final BlockchainQueries blockchainQueriesSpy =
-      Mockito.spy(new BlockchainQueries(blockchain, createInMemoryWorldStateArchive()));
+      Mockito.spy(
+          new BlockchainQueries(
+              protocolSchedule,
+              blockchain,
+              createInMemoryWorldStateArchive(),
+              MiningParameters.newDefault()));
 
   @BeforeEach
   public void before() {

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesLogCacheTest.java
@@ -28,8 +28,10 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Difficulty;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockHeaderFunctions;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
@@ -63,6 +65,7 @@ public class BlockchainQueriesLogCacheTest {
   private Hash testHash;
   private static LogsBloomFilter testLogsBloomFilter;
 
+  @Mock ProtocolSchedule protocolSchedule;
   @Mock MutableBlockchain blockchain;
   @Mock WorldStateArchive worldStateArchive;
   @Mock EthScheduler scheduler;
@@ -127,7 +130,12 @@ public class BlockchainQueriesLogCacheTest {
     when(blockchain.getBlockBody(any())).thenReturn(Optional.of(fakeBody));
     blockchainQueries =
         new BlockchainQueries(
-            blockchain, worldStateArchive, Optional.of(cacheDir), Optional.of(scheduler));
+            protocolSchedule,
+            blockchain,
+            worldStateArchive,
+            Optional.of(cacheDir),
+            Optional.of(scheduler),
+            MiningParameters.newDefault());
   }
 
   /**

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -28,9 +28,11 @@ import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator.BlockOptions;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.LogWithMetadata;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.worldstate.WorldState;
@@ -46,6 +48,7 @@ import java.util.stream.Collectors;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class BlockchainQueriesTest {
   private BlockDataGenerator gen;
@@ -587,7 +590,13 @@ public class BlockchainQueriesTest {
       this.blockchain = blockchain;
       this.blockData = blockData;
       this.worldStateArchive = worldStateArchive;
-      this.blockchainQueries = new BlockchainQueries(blockchain, worldStateArchive, scheduler);
+      this.blockchainQueries =
+          new BlockchainQueries(
+              Mockito.mock(ProtocolSchedule.class),
+              blockchain,
+              worldStateArchive,
+              scheduler,
+              MiningParameters.newDefault());
     }
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/query/BlockchainQueriesTest.java
@@ -507,6 +507,9 @@ public class BlockchainQueriesTest {
     assertThat(retrievedOmmerBlockHeader).isEqualTo(ommerBlockHeader);
   }
 
+  @Test
+  public void getGasPriceLowerBound() {}
+
   private void assertBlockMatchesResult(
       final Block targetBlock, final BlockWithMetadata<TransactionWithMetadata, Hash> result) {
     assertThat(result.getHeader()).isEqualTo(targetBlock.getHeader());
@@ -600,13 +603,5 @@ public class BlockchainQueriesTest {
     }
   }
 
-  private static class BlockData {
-    final Block block;
-    final List<TransactionReceipt> receipts;
-
-    private BlockData(final Block block, final List<TransactionReceipt> receipts) {
-      this.block = block;
-      this.receipts = receipts;
-    }
-  }
+  private record BlockData(Block block, List<TransactionReceipt> receipts) {}
 }

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/graphql/eth_gasPrice.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/graphql/eth_gasPrice.json
@@ -2,7 +2,7 @@
   "request": "{ gasPrice maxPriorityFeePerGas }",
   "response": {
     "data": {
-      "gasPrice": "0x1",
+      "gasPrice": "0x2dbc88c1",
       "maxPriorityFeePerGas": "0x3b9aca00"
     }
   },

--- a/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
+++ b/ethereum/retesteth/src/main/java/org/hyperledger/besu/ethereum/retesteth/RetestethContext.java
@@ -181,7 +181,9 @@ public class RetestethContext {
     blockchain = createInMemoryBlockchain(genesisState.getBlock());
     protocolContext = new ProtocolContext(blockchain, worldStateArchive, null, badBlockManager);
 
-    blockchainQueries = new BlockchainQueries(blockchain, worldStateArchive, ethScheduler);
+    blockchainQueries =
+        new BlockchainQueries(
+            protocolSchedule, blockchain, worldStateArchive, ethScheduler, miningParameters);
 
     final String sealengine = JsonUtil.getString(genesisConfig, "sealengine", "");
     headerValidationMode =


### PR DESCRIPTION
## PR description

The `eth_gasPrice` is not taking in account the base fee market values, when the network supports them, so it is possible that it returns values that are not good for pricing a tx for inclusion in the next block.
Specifically the calculation of gas price lower bound only rely on the runtime value of `minGasPrice`, but on base fee market networks, it could be that `baseFee` for the next block is higher than the `minGasPrice`, for example for devnets using the default, the `minGasPrice=1kwei` and the genesis sets `baseFee=1gwei` and the result is that senders thinks the can just price the gas at 1kwei to the the tx included, which is not the case.

This PR takes in consideration the baseFee value when calculating the lower bound, along with the fix I did some refactoring to move the gas price calculation into `BlockchainQueries` and continue to directly use `MiningParameters` to get the gas market info.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

