### PR TITLE
Implementing Issue #7047 - Optionally load jemalloc

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -402,12 +402,12 @@ public class ConfigurationOverviewBuilder {
             t -> {
               try {
                 String jemallocEnabled = environment.get("BESU_USING_JEMALLOC");
-                if(jemallocEnabled.equals("true")) {
+                if (jemallocEnabled.equals("true")) {
                   final String version = PlatformDetector.getJemalloc();
                   lines.add("jemalloc: " + version);
-                }else{
+                } else {
                   logger.info(
-                          "BESU_USING_JEMALLOC is present but is not set to true, jemalloc library not loaded");
+                      "BESU_USING_JEMALLOC is present but is not set to true, jemalloc library not loaded");
                 }
 
               } catch (final Throwable throwable) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -401,12 +401,18 @@ public class ConfigurationOverviewBuilder {
         .ifPresentOrElse(
             t -> {
               try {
-                final String version = PlatformDetector.getJemalloc();
-                lines.add("jemalloc: " + version);
+                String jemallocEnabled = environment.get("BESU_USING_JEMALLOC");
+                if(jemallocEnabled.equals("true")) {
+                  final String version = PlatformDetector.getJemalloc();
+                  lines.add("jemalloc: " + version);
+                }else{
+                  logger.info(
+                          "BESU_USING_JEMALLOC is present but is not set to true, jemalloc library not loaded");
+                }
+
               } catch (final Throwable throwable) {
                 logger.warn(
-                    "BESU_USING_JEMALLOC is present but we failed to load jemalloc library to get the version",
-                    throwable);
+                    "BESU_USING_JEMALLOC is present but we failed to load jemalloc library to get the version");
               }
             },
             () -> {

--- a/besu/src/main/scripts/unixStartScript.txt
+++ b/besu/src/main/scripts/unixStartScript.txt
@@ -182,7 +182,7 @@ APP_ARGS=`save "\$@"`
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" <% if ( mainClassName.startsWith('--module ') ) { %>--module-path "\"\$MODULE_PATH\"" <% } %>${mainClassName} "\$APP_ARGS"
 
-unset BESU_USING_JEMALLOC
+#unset BESU_USING_JEMALLOC
 if [ "\$darwin" = "false" -a "\$msys" = "false" ]; then
   # check if jemalloc is available
   TEST_JEMALLOC=\$(LD_PRELOAD=libjemalloc.so sh -c true 2>&1)
@@ -190,7 +190,7 @@ if [ "\$darwin" = "false" -a "\$msys" = "false" ]; then
   # if jemalloc is available the output is empty, otherwise the output has an error line
   if [ -z "\$TEST_JEMALLOC" ]; then
     export LD_PRELOAD=libjemalloc.so
-    export BESU_USING_JEMALLOC=true
+#    export BESU_USING_JEMALLOC=true
   else
     # jemalloc not available, as fallback limit malloc to 2 arenas
     export MALLOC_ARENA_MAX=2


### PR DESCRIPTION
## PR description
Implementing a optional configuration via the existing environment variable `BESU_USING_JEMALLOC `to enable/disable the loading of jemalloc when starting Besu.

If set, `BESU_USING_JEMALLOC=true` will load jemalloc, if set to anything else it won't. If `BESU_USING_JEMALLOC` is not set at all it'll load jemalloc too (that is the existing behavior).

Please note the installation of jemalloc itself must be done using symlinks, otherwise the initial besu script must be changed to provide the name of the installed libjemalloc.so.

In Ubunto, for instance, I used

` sudo apt-get install -y libjemalloc-dev`


## Fixed Issue(s)
Optionally load jemalloc #7047->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

