### PR TITLE
Add metrics to DefaultBlockchain to get TPS and Mgas/s

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.util.InvalidConfigurationException;
 import org.hyperledger.besu.util.Subscribers;
 
@@ -83,6 +84,10 @@ public class DefaultBlockchain implements MutableBlockchain {
   private final Optional<Cache<Hash, List<TransactionReceipt>>> transactionReceiptsCache;
   private final Optional<Cache<Hash, Difficulty>> totalDifficultyCache;
 
+  private Counter gasUsedCounter;
+  private Counter numberOfTransactionsCounter;
+
+
   private DefaultBlockchain(
       final Optional<Block> genesisBlock,
       final BlockchainStorage blockchainStorage,
@@ -117,6 +122,7 @@ public class DefaultBlockchain implements MutableBlockchain {
         "blockchain_height",
         "The current height of the canonical chain",
         this::getChainHeadBlockNumber);
+
     metricsSystem.createGauge(
         BesuMetricCategory.BLOCKCHAIN,
         "difficulty_total",
@@ -135,6 +141,11 @@ public class DefaultBlockchain implements MutableBlockchain {
         "Gas used by the current chain head block",
         () -> getChainHeadHeader().getGasUsed());
 
+    gasUsedCounter = metricsSystem.createCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "chain_head_gas_used_counter",
+            "Counter for Gas used");
+
     metricsSystem.createLongGauge(
         BesuMetricCategory.BLOCKCHAIN,
         "chain_head_gas_limit",
@@ -146,6 +157,12 @@ public class DefaultBlockchain implements MutableBlockchain {
         "chain_head_transaction_count",
         "Number of transactions in the current chain head block",
         () -> chainHeadTransactionCount);
+
+    numberOfTransactionsCounter = metricsSystem.createCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "chain_head_transaction_count_counter",
+            "Counter for the number of transactions");
+
 
     metricsSystem.createIntegerGauge(
         BesuMetricCategory.BLOCKCHAIN,
@@ -523,6 +540,9 @@ public class DefaultBlockchain implements MutableBlockchain {
     updater.setChainHead(newBlockHash);
     indexTransactionForBlock(
         updater, newBlockHash, blockWithReceipts.getBlock().getBody().getTransactions());
+    gasUsedCounter.inc(blockWithReceipts.getHeader().getGasUsed());
+    numberOfTransactionsCounter.inc(blockWithReceipts.getBlock().getBody().getTransactions().size());
+
     return BlockAddedEvent.createForHeadAdvancement(
         blockWithReceipts.getBlock(),
         LogWithMetadata.generate(


### PR DESCRIPTION
## PR description
This PR creates two new prometheus counters gasUsedCounter and numberOfTransactionsCounter.
These new counters will help to create graphs on Transactions per second and Gas used per second.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

