### PR TITLE
Fix name of parameter for WithdrawalRequest

### DIFF
--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/06_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/06_prague_getPayloadV4.json
@@ -31,7 +31,7 @@
           {
             "sourceAddress": "0xa4664c40aacebd82a2db79f0ea36c06bc6a19adb",
             "amount" : "0x0",
-            "validatorPubKey": "0xb10a4a15bf67b328c9b101d09e5c6ee6672978fdad9ef0d9e2ceffaee99223555d8601f0cb3bcc4ce1af9864779a416e"
+            "validatorPublicKey": "0xb10a4a15bf67b328c9b101d09e5c6ee6672978fdad9ef0d9e2ceffaee99223555d8601f0cb3bcc4ce1af9864779a416e"
           }
         ],
         "blockNumber": "0x2",

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/09_prague_newPayloadV4.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/09_prague_newPayloadV4.json
@@ -32,7 +32,7 @@
           {
             "sourceAddress": "0xa4664c40aacebd82a2db79f0ea36c06bc6a19adb",
             "amount" : "0x0",
-            "validatorPubKey": "0xb10a4a15bf67b328c9b101d09e5c6ee6672978fdad9ef0d9e2ceffaee99223555d8601f0cb3bcc4ce1af9864779a416e"
+            "validatorPublicKey": "0xb10a4a15bf67b328c9b101d09e5c6ee6672978fdad9ef0d9e2ceffaee99223555d8601f0cb3bcc4ce1af9864779a416e"
           }
         ],
         "blockNumber": "0x2",

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/15_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/15_prague_getPayloadV4.json
@@ -33,7 +33,7 @@
           {
             "sourceAddress": "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f",
             "amount": "0x0",
-            "validatorPubKey": "0x8706d19a62f28a6a6549f96c5adaebac9124a61d44868ec94f6d2d707c6a2f82c9162071231dfeb40e24bfde4ffdf243"
+            "validatorPublicKey": "0x8706d19a62f28a6a6549f96c5adaebac9124a61d44868ec94f6d2d707c6a2f82c9162071231dfeb40e24bfde4ffdf243"
           }
         ],
         "blockNumber": "0x4",

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalRequestParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/WithdrawalRequestParameter.java
@@ -24,21 +24,20 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.vertx.core.json.JsonObject;
 
 public class WithdrawalRequestParameter {
 
   private final String sourceAddress;
-  private final String validatorPubKey;
+  private final String validatorPublicKey;
   private final String amount;
 
   @JsonCreator
   public WithdrawalRequestParameter(
       @JsonProperty("sourceAddress") final String sourceAddress,
-      @JsonProperty("validatorPublicKey") final String validatorPubKey,
+      @JsonProperty("validatorPublicKey") final String validatorPublicKey,
       @JsonProperty("amount") final String amount) {
     this.sourceAddress = sourceAddress;
-    this.validatorPubKey = validatorPubKey;
+    this.validatorPublicKey = validatorPublicKey;
     this.amount = amount;
   }
 
@@ -53,15 +52,8 @@ public class WithdrawalRequestParameter {
   public WithdrawalRequest toWithdrawalRequest() {
     return new WithdrawalRequest(
         Address.fromHexString(sourceAddress),
-        BLSPublicKey.fromHexString(validatorPubKey),
+        BLSPublicKey.fromHexString(validatorPublicKey),
         GWei.fromHexString(amount));
-  }
-
-  public JsonObject asJsonObject() {
-    return new JsonObject()
-        .put("sourceAddress", sourceAddress)
-        .put("validatorPubKey", validatorPubKey)
-        .put("amount", amount);
   }
 
   @JsonGetter
@@ -70,8 +62,8 @@ public class WithdrawalRequestParameter {
   }
 
   @JsonGetter
-  public String getValidatorPubKey() {
-    return validatorPubKey;
+  public String getValidatorPublicKey() {
+    return validatorPublicKey;
   }
 
   @JsonGetter
@@ -85,13 +77,13 @@ public class WithdrawalRequestParameter {
     if (o == null || getClass() != o.getClass()) return false;
     final WithdrawalRequestParameter that = (WithdrawalRequestParameter) o;
     return Objects.equals(sourceAddress, that.sourceAddress)
-        && Objects.equals(validatorPubKey, that.validatorPubKey)
+        && Objects.equals(validatorPublicKey, that.validatorPublicKey)
         && Objects.equals(amount, that.amount);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sourceAddress, validatorPubKey, amount);
+    return Objects.hash(sourceAddress, validatorPublicKey, amount);
   }
 
   @Override
@@ -101,7 +93,7 @@ public class WithdrawalRequestParameter {
         + sourceAddress
         + '\''
         + ", validatorPubKey='"
-        + validatorPubKey
+        + validatorPublicKey
         + '\''
         + ", amount='"
         + amount


### PR DESCRIPTION
## PR description

The name of the parameter should be `validatorPublicKey`. This change https://github.com/hyperledger/besu/pull/7121/commits/7e78da631a24a55f990a58dfdcb7f63ca95b0267 tried to fix it but only made the change in the @JsonProperty in the constructor, that is used for deserialization.

To fix this, we need to fix it on the getter method with the @JsonGetter annotation. This is what is used for serialization and infers the name of the field from the name of the getter method. So `getValidatorPublicKey` becomes `validatorPublicKey` when serializing to json.

I have also removed the method `asJsonObject` because it is not being used.

