### PR TITLE
Update JUnit test reports on PR merged on main

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -45,14 +45,24 @@ jobs:
         run: ./gradlew acceptanceTestNotPrivacy --test-dry-run -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
       - name: Extract current test list
         run: mkdir tmp; find . -type f -name TEST-*.xml | xargs -I{} bash -c "xmlstarlet sel -t -v '/testsuite/@name' '{}'; echo ' acceptanceTestNotPrivacy'" | tee tmp/currentTests.list
-      - name: get acceptance test reports
+      - name: Get acceptance test reports (Support transition) # can be removed after PR is merged
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        continue-on-error: true
         with:
           branch: main
           name_is_regexp: true
-          name: 'acceptance-node-\d*\d-test-results'
+          name: 'acceptance-node-\d+-test-results'
           path: tmp/junit-xml-reports-downloaded
           if_no_artifact_found: true
+      - name: Get acceptance test reports
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        continue-on-error: true
+        with:
+          branch: main
+          workflow: update-test-reports.yml
+          name: acceptance-test-results
+          path: tmp/junit-xml-reports-downloaded
+          if_no_artifact_found: ignore
       - name: Split tests
         run: .github/workflows/splitTestsByTime.sh tmp/junit-xml-reports-downloaded "tmp/junit-xml-reports-downloaded/acceptance-node-.*-test-results" "TEST-" ${{env.total-runners}} ${{ matrix.runner_index }} > testList.txt
       - name: format gradle args

--- a/.github/workflows/pre-review.yml
+++ b/.github/workflows/pre-review.yml
@@ -104,14 +104,24 @@ jobs:
         run: ./gradlew test --test-dry-run -Dorg.gradle.parallel=true -Dorg.gradle.caching=true
       - name: Extract current test list
         run: mkdir tmp; find . -type f -name TEST-*.xml | xargs -I{} bash -c "xmlstarlet sel -t -v '/testsuite/@name' '{}'; echo '{}' | sed 's#\./\(.*\)/build/test-results/.*# \1#'" | tee tmp/currentTests.list
-      - name: get unit test reports
+      - name: Get unit test reports (Support transition) # can be removed after PR is merged
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        continue-on-error: true
         with:
           branch: main
           name_is_regexp: true
           name: 'unit-.*-test-results'
           path: tmp/junit-xml-reports-downloaded
           if_no_artifact_found: true
+      - name: Get unit test reports
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        continue-on-error: true
+        with:
+          branch: main
+          workflow: update-test-reports.yml
+          name: unit-test-results
+          path: tmp/junit-xml-reports-downloaded
+          if_no_artifact_found: ignore
       - name: Split tests
         run: .github/workflows/splitTestsByTime.sh tmp/junit-xml-reports-downloaded "tmp/junit-xml-reports-downloaded/unit-.*-test-results" "build/test-results" ${{env.total-runners}} ${{ matrix.runner_index }} > testList.txt
       - name: Upload Timing

--- a/.github/workflows/update-test-reports.yml
+++ b/.github/workflows/update-test-reports.yml
@@ -1,0 +1,51 @@
+name: update-test-reports
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  syncTestReports:
+    if: github.repository == 'hyperledger/besu'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get latest merge PR number
+        id: latest_merged_pr_number
+        run: echo "PULL_REQUEST_NUMBER=$(gh pr list --repo hyperledger/besu --base main --state merged --limit 1 --json number | jq '.[].number')" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get unit test reports from latest merged PR
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+          workflow: pre-review.yml
+          workflow_conclusion: success
+          pr: ${{ env.LATEST_MERGED_PR_NUMBER }}
+          name_is_regexp: true
+          name: 'unit-\d+-test-results'
+          path: unit-test-results
+          if_no_artifact_found: fail
+        env:
+          LATEST_MERGED_PR_NUMBER: ${{ steps.latest_merged_pr_number.outputs.PULL_REQUEST_NUMBER }}
+      - name: Upload unit test results
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+          name: unit-test-results
+          path: 'unit-test-results/**/test-results/**/TEST-*.xml'
+      - name: Get acceptance test reports from latest merged PR
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+          workflow: acceptance-tests.yml
+          workflow_conclusion: success
+          pr: ${{ env.LATEST_MERGED_PR_NUMBER }}
+          name_is_regexp: true
+          name: 'acceptance-node-\d+-test-results'
+          path: acceptance-test-results
+          if_no_artifact_found: fail
+        env:
+          LATEST_MERGED_PR_NUMBER: ${{ steps.latest_merged_pr_number.outputs.PULL_REQUEST_NUMBER }}
+      - name: Upload acceptance test results
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+          name: acceptance-test-results
+          path: 'acceptance-test-results/**/test-results/**/TEST-*.xml'


### PR DESCRIPTION
## PR description

JUnit test reports are used to split acceptance and unit tests by time, but since these reports are only downloaded from main branch, and we do not run tests on main, it is necessary to just copy the reports from the last merge PR to the main branch, as done in this PR.

Note: since this PR is referencing some artifacts that are still not present on main (they will be after this PR is merged), tests are just split in a round robin way as fallback, and some download actions will report error.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

