### PR TITLE
Use github arm64 runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,8 @@
-name: docker develop
-
+name: docker
 on:
-  push:
-    branches:
-      - main
+  release:
+    types:
+      - prereleased
 env:
   registry: docker.io
 
@@ -22,7 +21,6 @@ jobs:
         uses: gradle/actions/setup-gradle@9e899d11ad247ec76be7a60bc1cf9d3abbb9e7f1
         with:
           cache-disabled: true
-
       - name: hadoLint
         run: docker run --rm -i hadolint/hadolint < docker/Dockerfile
   buildDocker:
@@ -42,29 +40,21 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          platform=${{ matrix.platform }}
-          if [ "$platform" = 'ubuntu-22.04' ]; then 
-            echo "PLATFORM_PAIR=linux-amd64" >> $GITHUB_OUTPUT
-            echo "ARCH=amd64" >> $GITHUB_OUTPUT
-          else
-            sudo apt-get update
-            sudo apt-get -y install docker.io
-            echo "PLATFORM_PAIR=linux-arm64" >> $GITHUB_OUTPUT
-            echo "ARCH=arm64" >> $GITHUB_OUTPUT
-          fi
-
-          # Get the current date and time in the format YY.MM
-          DATE_TIME=$(date +"%y.%-m")
-          # Get the short SHA of the merge commit
-          SHORT_SHA=${GITHUB_SHA::7}
-          # Construct the build target name
-          BUILD_TARGET_NAME="${DATE_TIME}-develop-${SHORT_SHA}"
-          echo "Build Target Name: $BUILD_TARGET_NAME"
-          # Set the build target name as an environment variable
-          echo "BUILD_TARGET_NAME=${BUILD_TARGET_NAME}" >> $GITHUB_ENV
-
+            platform=${{ matrix.platform }}
+            if [ "$platform" = 'ubuntu-22.04' ]; then 
+              echo "PLATFORM_PAIR=linux-amd64" >> $GITHUB_OUTPUT
+              echo "ARCH=amd64" >> $GITHUB_OUTPUT
+            else
+              sudo apt-get update
+              sudo apt-get -y install docker.io
+              echo "PLATFORM_PAIR=linux-arm64" >> $GITHUB_OUTPUT
+              echo "ARCH=arm64" >> $GITHUB_OUTPUT
+            fi
       - name: Checkout Repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: short sha
+        id: shortSha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Set up Java
         uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93
         with:
@@ -90,11 +80,11 @@ jobs:
           architecture: ${{ steps.prep.outputs.ARCH }}
         with:
           cache-disabled: true
-          arguments: testDocker -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{ env.BUILD_TARGET_NAME}} -Prelease.releaseVersion=develop
+          arguments: testDocker -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{github.event.release.name}} -Prelease.releaseVersion=${{ github.event.release.name }}
       - name: publish
         env:
           architecture: ${{ steps.prep.outputs.ARCH }}
-        run: ./gradlew --no-daemon dockerUpload -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{ env.BUILD_TARGET_NAME }} -Prelease.releaseVersion=develop
+        run: ./gradlew --no-daemon dockerUpload -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{github.event.release.name}} -Prelease.releaseVersion=${{ github.event.release.name }}
   multiArch:
     needs: buildDocker
     runs-on: ubuntu-22.04
@@ -120,4 +110,16 @@ jobs:
           username: ${{ secrets.DOCKER_USER_RW }}
           password: ${{ secrets.DOCKER_PASSWORD_RW }}
       - name: multi-arch docker
-        run: ./gradlew manifestDocker -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{ env.BUILD_TARGET_NAME }} -Prelease.releaseVersion=develop
+        run: ./gradlew manifestDocker -PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }} -Pversion=${{github.event.release.name}} -Prelease.releaseVersion=${{ github.event.release.name }}
+  amendNotes:
+    needs: multiArch
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: add pull command to release notes
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          append_body: true
+          body: |
+            `docker pull ${{env.registry}}/${{secrets.DOCKER_ORG}}/besu:${{github.event.release.name}}`

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,8 +45,10 @@ jobs:
               echo "PLATFORM_PAIR=linux-amd64" >> $GITHUB_OUTPUT
               echo "ARCH=amd64" >> $GITHUB_OUTPUT
             else
+              sudo usermod -aG docker $USER
               sudo apt-get update
-              sudo apt-get -y install docker.io
+              sudo apt-get -y install docker.io acl
+              sudo setfacl --modify user:$USER:rw /var/run/docker.sock
               echo "PLATFORM_PAIR=linux-arm64" >> $GITHUB_OUTPUT
               echo "ARCH=arm64" >> $GITHUB_OUTPUT
             fi


### PR DESCRIPTION
## Fixed Issue(s)
fixes #7026

github now offer arm64 runners.

The arm64 image is a plain ubuntu 22.04 server with nothing installed (no docker).