### PR TITLE
feat: Refactor Node DNS Resolver to use vertx virtual threads

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemon.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemon.java
@@ -88,7 +88,6 @@ public class DNSDaemon extends AbstractVerticle {
   public void stop() {
     LOG.info("Stopping DNSDaemon for {}", enrLink);
     periodicTaskId.ifPresent(vertx::cancelTimer);
-    dnsResolver.close();
   }
 
   /**

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
@@ -24,12 +24,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.base.Splitter;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.dns.DnsClient;
 import io.vertx.core.dns.DnsClientOptions;
@@ -42,9 +39,8 @@ import org.slf4j.LoggerFactory;
 
 // Adapted from https://github.com/tmio/tuweni and licensed under Apache 2.0
 /** Resolves a set of ENR nodes from a host name. */
-public class DNSResolver implements AutoCloseable {
+public class DNSResolver {
   private static final Logger LOG = LoggerFactory.getLogger(DNSResolver.class);
-  private final ExecutorService rawTxtRecordsExecutor = Executors.newSingleThreadExecutor();
   private final String enrLink;
   private long seq;
   private final DnsClient dnsClient;
@@ -151,21 +147,22 @@ public class DNSResolver implements AutoCloseable {
     }
 
     final DNSEntry entry = optionalDNSEntry.get();
-    if (entry instanceof ENRNode node) {
-      // TODO: this always return true because the visitor is reference to list.add
-      return visitor.visit(node.nodeRecord());
-    } else if (entry instanceof DNSEntry.ENRTree tree) {
-      for (String e : tree.entries()) {
-        // TODO: When would this ever return false?
-        boolean keepGoing = internalVisit(e, domainName, visitor);
-        if (!keepGoing) {
-          return false;
+    switch (entry) {
+      case ENRNode node -> {
+        // TODO: this always return true because the visitor is reference to list.add
+        return visitor.visit(node.nodeRecord());
+      }
+      case DNSEntry.ENRTree tree -> {
+        for (String e : tree.entries()) {
+          // TODO: When would this ever return false?
+          boolean keepGoing = internalVisit(e, domainName, visitor);
+          if (!keepGoing) {
+            return false;
+          }
         }
       }
-    } else if (entry instanceof ENRTreeLink link) {
-      visitTree(link, visitor);
-    } else {
-      LOG.debug("Unsupported type of node {}", entry);
+      case ENRTreeLink link -> visitTree(link, visitor);
+      default -> LOG.debug("Unsupported type of node {}", entry);
     }
     return true;
   }
@@ -187,40 +184,15 @@ public class DNSResolver implements AutoCloseable {
    * @return the first TXT entry of the DNS record. Empty if no record is found.
    */
   Optional<String> resolveRawRecord(final String domainName) {
-    // vertx-dns is async, kotlin coroutines allows us to await, similarly Java 21 new thread
-    // model would also allow us to await. For now, we will use CountDownLatch to block the
-    // current thread until the DNS resolution is complete.
-    LOG.debug("Resolving TXT records on domain: {}", domainName);
-    final CountDownLatch latch = new CountDownLatch(1);
-    final AtomicReference<Optional<String>> record = new AtomicReference<>(Optional.empty());
-    rawTxtRecordsExecutor.submit(
-        () -> {
-          dnsClient
-              .resolveTXT(domainName)
-              .onComplete(
-                  ar -> {
-                    if (ar.succeeded()) {
-                      LOG.trace(
-                          "TXT record resolved on domain {}. Result: {}", domainName, ar.result());
-                      record.set(ar.result().stream().findFirst());
-                    } else {
-                      LOG.trace(
-                          "TXT record not resolved on domain {}, because: {}",
-                          domainName,
-                          ar.cause().getMessage());
-                    }
-                    latch.countDown();
-                  });
-        });
-
+    LOG.trace("Resolving TXT records on domain: {}", domainName);
     try {
-      // causes the worker thread to wait. Once we move to Java 21, this can be simplified.
-      latch.await();
-    } catch (InterruptedException e) {
-      LOG.debug("Interrupted while waiting for DNS resolution");
+      // Future.await parks current virtual thread and waits for the result. Any failure is
+      // thrown as a Throwable.
+      return Future.await(dnsClient.resolveTXT(domainName)).stream().findFirst();
+    } catch (final Throwable e) {
+      LOG.trace("Error while resolving TXT records on domain: {}", domainName, e);
+      return Optional.empty();
     }
-
-    return record.get();
   }
 
   private boolean checkSignature(
@@ -228,10 +200,5 @@ public class DNSResolver implements AutoCloseable {
     Bytes32 hash =
         Hash.keccak256(Bytes.wrap(root.signedContent().getBytes(StandardCharsets.UTF_8)));
     return SECP256K1.verifyHashed(hash, sig, pubKey);
-  }
-
-  @Override
-  public void close() {
-    rawTxtRecordsExecutor.shutdown();
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSResolver.java
@@ -114,7 +114,7 @@ public class DNSResolver {
   private void visitTree(final ENRTreeLink link, final DNSVisitor visitor) {
     Optional<DNSEntry> optionalEntry = resolveRecord(link.domainName());
     if (optionalEntry.isEmpty()) {
-      LOG.debug("No DNS record found for {}", link.domainName());
+      LOG.trace("No DNS record found for {}", link.domainName());
       return;
     }
 
@@ -142,19 +142,16 @@ public class DNSResolver {
       final String entryName, final String domainName, final DNSVisitor visitor) {
     final Optional<DNSEntry> optionalDNSEntry = resolveRecord(entryName + "." + domainName);
     if (optionalDNSEntry.isEmpty()) {
-      LOG.debug("No DNS record found for {}", entryName + "." + domainName);
       return true;
     }
 
     final DNSEntry entry = optionalDNSEntry.get();
     switch (entry) {
       case ENRNode node -> {
-        // TODO: this always return true because the visitor is reference to list.add
         return visitor.visit(node.nodeRecord());
       }
       case DNSEntry.ENRTree tree -> {
         for (String e : tree.entries()) {
-          // TODO: When would this ever return false?
           boolean keepGoing = internalVisit(e, domainName, visitor);
           if (!keepGoing) {
             return false;
@@ -168,7 +165,7 @@ public class DNSResolver {
   }
 
   /**
-   * Resolves one DNS record associated with the given domain name.
+   * Maps TXT DNS record to DNSEntry.
    *
    * @param domainName the domain name to query
    * @return the DNS entry read from the domain. Empty if no record is found.
@@ -197,7 +194,7 @@ public class DNSResolver {
 
   private boolean checkSignature(
       final ENRTreeRoot root, final SECP256K1.PublicKey pubKey, final SECP256K1.Signature sig) {
-    Bytes32 hash =
+    final Bytes32 hash =
         Hash.keccak256(Bytes.wrap(root.signedContent().getBytes(StandardCharsets.UTF_8)));
     return SECP256K1.verifyHashed(hash, sig, pubKey);
   }

--- a/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
+++ b/ethereum/p2p/src/test/java/org/hyperledger/besu/ethereum/p2p/discovery/dns/DNSDaemonTest.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.ethereum.p2p.discovery.dns;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.security.Security;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -38,12 +37,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class DNSDaemonTest {
   private static final String holeskyEnr =
       "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.holesky.ethdisco.net";
-  // private static MockDNSServer mockDNSServer;
   private final MockDnsServerVerticle mockDnsServerVerticle = new MockDnsServerVerticle();
   private DNSDaemon dnsDaemon;
 
   @BeforeAll
-  static void setup() throws IOException {
+  static void setup() {
     Security.addProvider(new BouncyCastleProvider());
   }
 
@@ -68,7 +66,9 @@ class DNSDaemonTest {
             "localhost:" + mockDnsServerVerticle.port());
 
     final DeploymentOptions options =
-        new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER).setWorkerPoolSize(1);
+        new DeploymentOptions()
+            .setThreadingModel(ThreadingModel.VIRTUAL_THREAD)
+            .setWorkerPoolSize(1);
     vertx.deployVerticle(dnsDaemon, options);
   }
 
@@ -109,7 +109,9 @@ class DNSDaemonTest {
             "localhost:" + mockDnsServerVerticle.port());
 
     final DeploymentOptions options =
-        new DeploymentOptions().setThreadingModel(ThreadingModel.WORKER).setWorkerPoolSize(1);
+        new DeploymentOptions()
+            .setThreadingModel(ThreadingModel.VIRTUAL_THREAD)
+            .setWorkerPoolSize(1);
     vertx.deployVerticle(dnsDaemon, options);
   }
 


### PR DESCRIPTION
## PR description
Refactor Node DNS Resolver to use vertx virtual threads (Java 21).
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

