### PR TITLE
Promote option - bonsai-limit-trie-logs-enabled and bonsai-trie-logs-pruning-window-size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 - In profile=ENTERPRISE, use sync-mode=FULL (instead of FAST) and data-storage-format=FOREST (instead of BONSAI) [#7186](https://github.com/hyperledger/besu/pull/7186)
   - If this breaks your node, you can reset sync-mode=FAST and data-storage-format=BONSAI
 
+### Upcoming Breaking Changes
+- Receipt compaction will be enabled by default in a future version of Besu. After this change it will not be possible to downgrade to the previous Besu version.
+- PKI-backed QBFT will be removed in a future version of Besu. Other forms of QBFT will remain unchanged.
+- --Xbonsai-limit-trie-logs-enabled is deprecated, use --bonsai-limit-trie-logs-enabled instead
+- --Xbonsai-trie-logs-pruning-window-size is deprecated, use --bonsai-trie-logs-pruning-window-size instead
+
 ### Additions and Improvements
 - Add two counters to DefaultBlockchain in order to be able to calculate TPS and Mgas/s [#7105](https://github.com/hyperledger/besu/pull/7105)
 - Enable --Xbonsai-limit-trie-logs-enabled by default, unless sync-mode=FULL [#7181](https://github.com/hyperledger/besu/pull/7181)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Breaking Changes
 - Java 21 has been enforced as minimum version to build and run Besu.
-- With --Xbonsai-limit-trie-logs-enabled by default in this release, historic trie log data will be removed from the database unless sync-mode=FULL. It respects the --bonsai-historical-block-limit setting so shouldn't break any RPCs, but may be breaking if you are accessing this data from the database directly. Can be disabled with --Xbonsai-limit-trie-logs-enabled=false
+- With --Xbonsai-limit-trie-logs-enabled by default in this release, historic trie log data will be removed from the database unless sync-mode=FULL. It respects the --bonsai-historical-block-limit setting so shouldn't break any RPCs, but may be breaking if you are accessing this data from the database directly. Can be disabled with --bonsai-limit-trie-logs-enabled=false
 - In profile=ENTERPRISE, use sync-mode=FULL (instead of FAST) and data-storage-format=FOREST (instead of BONSAI) [#7186](https://github.com/hyperledger/besu/pull/7186)
   - If this breaks your node, you can reset sync-mode=FAST and data-storage-format=BONSAI
 
 ### Additions and Improvements
 - Add two counters to DefaultBlockchain in order to be able to calculate TPS and Mgas/s [#7105](https://github.com/hyperledger/besu/pull/7105)
 - Enable --Xbonsai-limit-trie-logs-enabled by default, unless sync-mode=FULL [#7181](https://github.com/hyperledger/besu/pull/7181)
+- Promote experimental --Xbonsai-limit-trie-logs-enabled to production-ready, --bonsai-limit-trie-logs-enabled [#7192](https://github.com/hyperledger/besu/pull/7192)
+- Promote experimental --Xbonsai-trie-logs-pruning-window-size to production-ready, --bonsai-trie-logs-pruning-window-size [#7192](https://github.com/hyperledger/besu/pull/7192)
 - `admin_nodeInfo` JSON/RPC call returns the currently active EVM version [#7127](https://github.com/hyperledger/besu/pull/7127)
 
 ### Bug fixes

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
@@ -83,8 +83,8 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
     public static final String BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE =
         "--bonsai-trie-logs-pruning-window-size";
 
+    @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
     @CommandLine.Option(
-        hidden = true,
         names = {
           BONSAI_LIMIT_TRIE_LOGS_ENABLED,
           "--Xbonsai-limit-trie-logs-enabled",
@@ -95,8 +95,8 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
             "Limit the number of trie logs that are retained. (default: ${DEFAULT-VALUE})")
     private boolean bonsaiLimitTrieLogsEnabled = DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
 
+    @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
     @CommandLine.Option(
-        hidden = true,
         names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE, "--Xbonsai-trie-logs-pruning-window-size"},
         description =
             "The max number of blocks to load and prune trie logs for at startup. (default: ${DEFAULT-VALUE})")

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
@@ -93,14 +93,14 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
         fallbackValue = "true",
         description =
             "Limit the number of trie logs that are retained. (default: ${DEFAULT-VALUE})")
-    private boolean bonsaiLimitTrieLogsEnabled = DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
+    private Boolean bonsaiLimitTrieLogsEnabled = DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
 
     @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
     @CommandLine.Option(
         names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE, "--Xbonsai-trie-logs-pruning-window-size"},
         description =
             "The max number of blocks to load and prune trie logs for at startup. (default: ${DEFAULT-VALUE})")
-    private int bonsaiTrieLogPruningWindowSize = DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
+    private Integer bonsaiTrieLogPruningWindowSize = DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 
     // TODO: --Xsnapsync-synchronizer-flat-db-healing-enabled is deprecated, remove it in a future
     // release

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
@@ -77,16 +77,19 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
 
   /** The unstable options for data storage. */
   public static class Unstable {
-    private static final String BONSAI_LIMIT_TRIE_LOGS_ENABLED =
-        "--Xbonsai-limit-trie-logs-enabled";
+    private static final String BONSAI_LIMIT_TRIE_LOGS_ENABLED = "--bonsai-limit-trie-logs-enabled";
 
     /** The bonsai trie logs pruning window size. */
     public static final String BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE =
-        "--Xbonsai-trie-logs-pruning-window-size";
+        "--bonsai-trie-logs-pruning-window-size";
 
     @CommandLine.Option(
         hidden = true,
-        names = {BONSAI_LIMIT_TRIE_LOGS_ENABLED, "--Xbonsai-trie-log-pruning-enabled"},
+        names = {
+          BONSAI_LIMIT_TRIE_LOGS_ENABLED,
+          "--Xbonsai-limit-trie-logs-enabled",
+          "--Xbonsai-trie-log-pruning-enabled"
+        },
         fallbackValue = "true",
         description =
             "Limit the number of trie logs that are retained. (default: ${DEFAULT-VALUE})")
@@ -94,7 +97,7 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
 
     @CommandLine.Option(
         hidden = true,
-        names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE},
+        names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE, "--Xbonsai-trie-logs-pruning-window-size"},
         description =
             "The max number of blocks to load and prune trie logs for at startup. (default: ${DEFAULT-VALUE})")
     private int bonsaiTrieLogPruningWindowSize = DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1088,7 +1088,7 @@ public class BesuCommandTest extends CommandTestAbstract {
 
   @Test
   public void syncMode_full_requires_bonsaiLimitTrieLogsToBeDisabled() {
-    parseCommand("--sync-mode", "FULL", "--Xbonsai-limit-trie-logs-enabled=false");
+    parseCommand("--sync-mode", "FULL", "--bonsai-limit-trie-logs-enabled=false");
     verify(mockControllerBuilder).synchronizerConfiguration(syncConfigurationCaptor.capture());
 
     final SynchronizerConfiguration syncConfig = syncConfigurationCaptor.getValue();
@@ -1264,13 +1264,13 @@ public class BesuCommandTest extends CommandTestAbstract {
     Mockito.verifyNoInteractions(mockRunnerBuilder);
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8))
-        .contains("Cannot enable --Xbonsai-limit-trie-logs-enabled with sync-mode FULL");
+        .contains("Cannot enable --bonsai-limit-trie-logs-enabled with sync-mode FULL");
   }
 
   @Test
   public void parsesValidBonsaiHistoricalBlockLimitOption() {
     parseCommand(
-        "--Xbonsai-limit-trie-logs-enabled=false",
+        "--bonsai-limit-trie-logs-enabled=false",
         "--data-storage-format",
         "BONSAI",
         "--bonsai-historical-block-limit",

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
@@ -33,6 +33,17 @@ public class DataStorageOptionsTest
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize())
                 .isEqualTo(600),
+        "--bonsai-limit-trie-logs-enabled",
+        "--bonsai-trie-logs-pruning-window-size",
+        "600");
+  }
+
+  @Test
+  public void bonsaiTrieLogPruningLimitLegacyOption() {
+    internalTestSuccess(
+        dataStorageConfiguration ->
+            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize())
+                .isEqualTo(600),
         "--Xbonsai-limit-trie-logs-enabled",
         "--Xbonsai-trie-logs-pruning-window-size",
         "600");
@@ -44,24 +55,24 @@ public class DataStorageOptionsTest
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled())
                 .isEqualTo(false),
-        "--Xbonsai-limit-trie-logs-enabled=false");
+        "--bonsai-limit-trie-logs-enabled=false");
   }
 
   @Test
   public void bonsaiTrieLogPruningWindowSizeShouldBePositive() {
     internalTestFailure(
-        "--Xbonsai-trie-logs-pruning-window-size=0 must be greater than 0",
-        "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-pruning-window-size",
+        "--bonsai-trie-logs-pruning-window-size=0 must be greater than 0",
+        "--bonsai-limit-trie-logs-enabled",
+        "--bonsai-trie-logs-pruning-window-size",
         "0");
   }
 
   @Test
   public void bonsaiTrieLogPruningWindowSizeShouldBeAboveRetentionLimit() {
     internalTestFailure(
-        "--Xbonsai-trie-logs-pruning-window-size=512 must be greater than --bonsai-historical-block-limit=512",
-        "--Xbonsai-limit-trie-logs-enabled",
-        "--Xbonsai-trie-logs-pruning-window-size",
+        "--bonsai-trie-logs-pruning-window-size=512 must be greater than --bonsai-historical-block-limit=512",
+        "--bonsai-limit-trie-logs-enabled",
+        "--bonsai-trie-logs-pruning-window-size",
         "512");
   }
 
@@ -71,7 +82,7 @@ public class DataStorageOptionsTest
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
                 .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT + 1),
-        "--Xbonsai-limit-trie-logs-enabled",
+        "--bonsai-limit-trie-logs-enabled",
         "--bonsai-historical-block-limit",
         "513");
   }
@@ -82,7 +93,7 @@ public class DataStorageOptionsTest
         dataStorageConfiguration ->
             assertThat(dataStorageConfiguration.getBonsaiMaxLayersToLoad())
                 .isEqualTo(MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT),
-        "--Xbonsai-limit-trie-logs-enabled",
+        "--bonsai-limit-trie-logs-enabled",
         "--bonsai-historical-block-limit",
         "512");
   }
@@ -91,7 +102,7 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogRetentionLimitShouldBeAboveMinimum() {
     internalTestFailure(
         "--bonsai-historical-block-limit minimum value is 512",
-        "--Xbonsai-limit-trie-logs-enabled",
+        "--bonsai-limit-trie-logs-enabled",
         "--bonsai-historical-block-limit",
         "511");
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelperTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelperTest.java
@@ -336,7 +336,7 @@ class TrieLogHelperTest {
             () ->
                 helper.prune(dataStorageConfiguration, inMemoryWorldState, blockchain, Path.of("")))
         .isInstanceOf(RuntimeException.class)
-        .hasMessage("--Xbonsai-trie-logs-pruning-window-size=0 must be greater than 0");
+        .hasMessage("--bonsai-trie-logs-pruning-window-size=0 must be greater than 0");
   }
 
   @Test
@@ -358,7 +358,7 @@ class TrieLogHelperTest {
                 helper.prune(dataStorageConfiguration, inMemoryWorldState, blockchain, Path.of("")))
         .isInstanceOf(RuntimeException.class)
         .hasMessage(
-            "--Xbonsai-trie-logs-pruning-window-size=512 must be greater than --bonsai-historical-block-limit=512");
+            "--bonsai-trie-logs-pruning-window-size=512 must be greater than --bonsai-historical-block-limit=512");
   }
 
   @Test

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -213,6 +213,8 @@ ethstats-cacert-file="./root.cert"
 # Data storage
 data-storage-format="BONSAI"
 bonsai-historical-block-limit=512
+bonsai-limit-trie-logs-enabled=true
+bonsai-trie-logs-pruning-window-size=100_000
 receipt-compaction-enabled=true
 
 # feature flags

--- a/config/src/main/resources/profiles/enterprise-private.toml
+++ b/config/src/main/resources/profiles/enterprise-private.toml
@@ -7,4 +7,4 @@ tx-pool-no-local-priority=true
 tx-pool-limit-by-account-percentage=0.15
 rpc-http-max-active-connections=300
 min-gas-price=0
-Xbonsai-limit-trie-logs-enabled=false
+bonsai-limit-trie-logs-enabled=false

--- a/config/src/main/resources/profiles/minimalist-staker.toml
+++ b/config/src/main/resources/profiles/minimalist-staker.toml
@@ -1,4 +1,3 @@
 sync-mode="CHECKPOINT"
 data-storage-format="BONSAI"
-bonsai-historical-block-limit=512
 max-peers=25


### PR DESCRIPTION
Create --bonsai-limit-trie-logs-enabled as alias of --Xbonsai-limit-trie-logs-enabled and unhide option
Same for bonsai-trie-logs-pruning-window-size

Remove --bonsai-historical-block-limit=512 from minimalist_staker profile so it inherits the default which is the same value

Follow on from #7181 
Will restructure code from Unstable -> Stable in next PR.

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests
