### PR TITLE
Promote --bonsai-limit-trie-logs-enabled to stable

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2792,11 +2792,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     }
 
     if (DataStorageFormat.BONSAI.equals(getDataStorageConfiguration().getDataStorageFormat())
-        && getDataStorageConfiguration().getUnstable().getBonsaiLimitTrieLogsEnabled()) {
+        && getDataStorageConfiguration().getBonsaiLimitTrieLogsEnabled()) {
       builder.setLimitTrieLogsEnabled();
       builder.setTrieLogRetentionLimit(getDataStorageConfiguration().getBonsaiMaxLayersToLoad());
       builder.setTrieLogsPruningWindowSize(
-          getDataStorageConfiguration().getUnstable().getBonsaiTrieLogPruningWindowSize());
+          getDataStorageConfiguration().getBonsaiTrieLogPruningWindowSize());
     }
 
     builder.setSnapServerEnabled(this.unstableSynchronizerOptions.isSnapsyncServerEnabled());

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/stable/DataStorageOptions.java
@@ -14,13 +14,13 @@
  */
 package org.hyperledger.besu.cli.options.stable;
 
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
 import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_RECEIPT_COMPACTION_ENABLED;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT;
 import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_CODE_USING_CODE_HASH_ENABLED;
 import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_FULL_FLAT_DB_ENABLED;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT;
 
 import org.hyperledger.besu.cli.options.CLIOptions;
 import org.hyperledger.besu.cli.util.CommandLineUtils;
@@ -58,10 +58,34 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
       paramLabel = "<LONG>",
       description =
           "Limit of historical layers that can be loaded with BONSAI (default: ${DEFAULT-VALUE}). When using "
-              + Unstable.BONSAI_LIMIT_TRIE_LOGS_ENABLED
+              + BONSAI_LIMIT_TRIE_LOGS_ENABLED
               + " it will also be used as the number of layers of trie logs to retain.",
       arity = "1")
   private Long bonsaiMaxLayersToLoad = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
+
+  private static final String BONSAI_LIMIT_TRIE_LOGS_ENABLED = "--bonsai-limit-trie-logs-enabled";
+
+  /** The bonsai trie logs pruning window size. */
+  public static final String BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE =
+      "--bonsai-trie-logs-pruning-window-size";
+
+  @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
+  @CommandLine.Option(
+      names = {
+        BONSAI_LIMIT_TRIE_LOGS_ENABLED,
+        "--Xbonsai-limit-trie-logs-enabled",
+        "--Xbonsai-trie-log-pruning-enabled"
+      },
+      fallbackValue = "true",
+      description = "Limit the number of trie logs that are retained. (default: ${DEFAULT-VALUE})")
+  private Boolean bonsaiLimitTrieLogsEnabled = DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
+
+  @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
+  @CommandLine.Option(
+      names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE, "--Xbonsai-trie-logs-pruning-window-size"},
+      description =
+          "The max number of blocks to load and prune trie logs for at startup. (default: ${DEFAULT-VALUE})")
+  private Integer bonsaiTrieLogPruningWindowSize = DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 
   @Option(
       names = "--receipt-compaction-enabled",
@@ -77,30 +101,6 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
 
   /** The unstable options for data storage. */
   public static class Unstable {
-    private static final String BONSAI_LIMIT_TRIE_LOGS_ENABLED = "--bonsai-limit-trie-logs-enabled";
-
-    /** The bonsai trie logs pruning window size. */
-    public static final String BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE =
-        "--bonsai-trie-logs-pruning-window-size";
-
-    @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
-    @CommandLine.Option(
-        names = {
-          BONSAI_LIMIT_TRIE_LOGS_ENABLED,
-          "--Xbonsai-limit-trie-logs-enabled",
-          "--Xbonsai-trie-log-pruning-enabled"
-        },
-        fallbackValue = "true",
-        description =
-            "Limit the number of trie logs that are retained. (default: ${DEFAULT-VALUE})")
-    private Boolean bonsaiLimitTrieLogsEnabled = DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
-
-    @SuppressWarnings("ExperimentalCliOptionMustBeCorrectlyDisplayed")
-    @CommandLine.Option(
-        names = {BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE, "--Xbonsai-trie-logs-pruning-window-size"},
-        description =
-            "The max number of blocks to load and prune trie logs for at startup. (default: ${DEFAULT-VALUE})")
-    private Integer bonsaiTrieLogPruningWindowSize = DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 
     // TODO: --Xsnapsync-synchronizer-flat-db-healing-enabled is deprecated, remove it in a future
     // release
@@ -142,13 +142,12 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
    * @param syncMode the sync mode
    */
   public void validate(final CommandLine commandLine, final SyncMode syncMode) {
-    if (DataStorageFormat.BONSAI == dataStorageFormat
-        && unstableOptions.bonsaiLimitTrieLogsEnabled) {
+    if (DataStorageFormat.BONSAI == dataStorageFormat && bonsaiLimitTrieLogsEnabled) {
       if (SyncMode.FULL == syncMode) {
         throw new CommandLine.ParameterException(
             commandLine,
             String.format(
-                "Cannot enable " + Unstable.BONSAI_LIMIT_TRIE_LOGS_ENABLED + " with sync-mode %s",
+                "Cannot enable " + BONSAI_LIMIT_TRIE_LOGS_ENABLED + " with sync-mode %s",
                 syncMode));
       }
       if (bonsaiMaxLayersToLoad < MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT) {
@@ -158,22 +157,22 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
                 BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD + " minimum value is %d",
                 MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT));
       }
-      if (unstableOptions.bonsaiTrieLogPruningWindowSize <= 0) {
+      if (bonsaiTrieLogPruningWindowSize <= 0) {
         throw new CommandLine.ParameterException(
             commandLine,
             String.format(
-                Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE + "=%d must be greater than 0",
-                unstableOptions.bonsaiTrieLogPruningWindowSize));
+                BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE + "=%d must be greater than 0",
+                bonsaiTrieLogPruningWindowSize));
       }
-      if (unstableOptions.bonsaiTrieLogPruningWindowSize <= bonsaiMaxLayersToLoad) {
+      if (bonsaiTrieLogPruningWindowSize <= bonsaiMaxLayersToLoad) {
         throw new CommandLine.ParameterException(
             commandLine,
             String.format(
-                Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
+                BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
                     + "=%d must be greater than "
                     + BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD
                     + "=%d",
-                unstableOptions.bonsaiTrieLogPruningWindowSize,
+                bonsaiTrieLogPruningWindowSize,
                 bonsaiMaxLayersToLoad));
       }
     }
@@ -190,10 +189,9 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
     dataStorageOptions.dataStorageFormat = domainObject.getDataStorageFormat();
     dataStorageOptions.bonsaiMaxLayersToLoad = domainObject.getBonsaiMaxLayersToLoad();
     dataStorageOptions.receiptCompactionEnabled = domainObject.getReceiptCompactionEnabled();
-    dataStorageOptions.unstableOptions.bonsaiLimitTrieLogsEnabled =
-        domainObject.getUnstable().getBonsaiLimitTrieLogsEnabled();
-    dataStorageOptions.unstableOptions.bonsaiTrieLogPruningWindowSize =
-        domainObject.getUnstable().getBonsaiTrieLogPruningWindowSize();
+    dataStorageOptions.bonsaiLimitTrieLogsEnabled = domainObject.getBonsaiLimitTrieLogsEnabled();
+    dataStorageOptions.bonsaiTrieLogPruningWindowSize =
+        domainObject.getBonsaiTrieLogPruningWindowSize();
     dataStorageOptions.unstableOptions.bonsaiFullFlatDbEnabled =
         domainObject.getUnstable().getBonsaiFullFlatDbEnabled();
     dataStorageOptions.unstableOptions.bonsaiCodeUsingCodeHashEnabled =
@@ -208,10 +206,10 @@ public class DataStorageOptions implements CLIOptions<DataStorageConfiguration> 
         .dataStorageFormat(dataStorageFormat)
         .bonsaiMaxLayersToLoad(bonsaiMaxLayersToLoad)
         .receiptCompactionEnabled(receiptCompactionEnabled)
+        .bonsaiLimitTrieLogsEnabled(bonsaiLimitTrieLogsEnabled)
+        .bonsaiTrieLogPruningWindowSize(bonsaiTrieLogPruningWindowSize)
         .unstable(
             ImmutableDataStorageConfiguration.Unstable.builder()
-                .bonsaiLimitTrieLogsEnabled(unstableOptions.bonsaiLimitTrieLogsEnabled)
-                .bonsaiTrieLogPruningWindowSize(unstableOptions.bonsaiTrieLogPruningWindowSize)
                 .bonsaiFullFlatDbEnabled(unstableOptions.bonsaiFullFlatDbEnabled)
                 .bonsaiCodeStoredByCodeHashEnabled(unstableOptions.bonsaiCodeUsingCodeHashEnabled)
                 .build())

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelper.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli.subcommands.storage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.cli.options.stable.DataStorageOptions.BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 
 import org.hyperledger.besu.cli.options.stable.DataStorageOptions;
 import org.hyperledger.besu.datatypes.Hash;
@@ -296,25 +296,23 @@ public class TrieLogHelper {
   void validatePruneConfiguration(final DataStorageConfiguration config) {
     checkArgument(
         config.getBonsaiMaxLayersToLoad()
-            >= DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT,
+            >= DataStorageConfiguration.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT,
         String.format(
             BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD + " minimum value is %d",
-            DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT));
+            DataStorageConfiguration.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT));
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogPruningWindowSize() > 0,
+        config.getBonsaiTrieLogPruningWindowSize() > 0,
         String.format(
-            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
-                + "=%d must be greater than 0",
-            config.getUnstable().getBonsaiTrieLogPruningWindowSize()));
+            DataStorageOptions.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE + "=%d must be greater than 0",
+            config.getBonsaiTrieLogPruningWindowSize()));
     checkArgument(
-        config.getUnstable().getBonsaiTrieLogPruningWindowSize()
-            > config.getBonsaiMaxLayersToLoad(),
+        config.getBonsaiTrieLogPruningWindowSize() > config.getBonsaiMaxLayersToLoad(),
         String.format(
-            DataStorageOptions.Unstable.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
+            DataStorageOptions.BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE
                 + "=%d must be greater than "
                 + BONSAI_STORAGE_FORMAT_MAX_LAYERS_TO_LOAD
                 + "=%d",
-            config.getUnstable().getBonsaiTrieLogPruningWindowSize(),
+            config.getBonsaiTrieLogPruningWindowSize(),
             config.getBonsaiMaxLayersToLoad()));
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -733,7 +733,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
     final JsonRpcMethods additionalJsonRpcMethodFactory =
         createAdditionalJsonRpcMethodFactory(protocolContext, protocolSchedule, miningParameters);
 
-    if (dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled()
+    if (dataStorageConfiguration.getBonsaiLimitTrieLogsEnabled()
         && DataStorageFormat.BONSAI.equals(dataStorageConfiguration.getDataStorageFormat())) {
       final TrieLogManager trieLogManager =
           ((BonsaiWorldStateProvider) worldStateArchive).getTrieLogManager();
@@ -784,7 +784,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             blockchain,
             scheduler::executeServiceTask,
             dataStorageConfiguration.getBonsaiMaxLayersToLoad(),
-            dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize(),
+            dataStorageConfiguration.getBonsaiTrieLogPruningWindowSize(),
             isProofOfStake);
     trieLogPruner.initialize();
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -1252,7 +1252,7 @@ public class BesuCommandTest extends CommandTestAbstract {
     final DataStorageConfiguration dataStorageConfiguration =
         dataStorageConfigurationArgumentCaptor.getValue();
     assertThat(dataStorageConfiguration.getDataStorageFormat()).isEqualTo(BONSAI);
-    assertThat(dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled()).isTrue();
+    assertThat(dataStorageConfiguration.getBonsaiLimitTrieLogsEnabled()).isTrue();
     assertThat(commandOutput.toString(UTF_8)).isEmpty();
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/stable/DataStorageOptionsTest.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.cli.options.stable;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT;
 
 import org.hyperledger.besu.cli.options.AbstractCLIOptionsTest;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
@@ -31,8 +31,7 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogPruningLimitOption() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize())
-                .isEqualTo(600),
+            assertThat(dataStorageConfiguration.getBonsaiTrieLogPruningWindowSize()).isEqualTo(600),
         "--bonsai-limit-trie-logs-enabled",
         "--bonsai-trie-logs-pruning-window-size",
         "600");
@@ -42,8 +41,7 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogPruningLimitLegacyOption() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiTrieLogPruningWindowSize())
-                .isEqualTo(600),
+            assertThat(dataStorageConfiguration.getBonsaiTrieLogPruningWindowSize()).isEqualTo(600),
         "--Xbonsai-limit-trie-logs-enabled",
         "--Xbonsai-trie-logs-pruning-window-size",
         "600");
@@ -53,8 +51,7 @@ public class DataStorageOptionsTest
   public void bonsaiTrieLogsEnabled_explicitlySetToFalse() {
     internalTestSuccess(
         dataStorageConfiguration ->
-            assertThat(dataStorageConfiguration.getUnstable().getBonsaiLimitTrieLogsEnabled())
-                .isEqualTo(false),
+            assertThat(dataStorageConfiguration.getBonsaiLimitTrieLogsEnabled()).isEqualTo(false),
         "--bonsai-limit-trie-logs-enabled=false");
   }
 
@@ -157,11 +154,8 @@ public class DataStorageOptionsTest
     return ImmutableDataStorageConfiguration.builder()
         .dataStorageFormat(DataStorageFormat.BONSAI)
         .bonsaiMaxLayersToLoad(513L)
-        .unstable(
-            ImmutableDataStorageConfiguration.Unstable.builder()
-                .bonsaiLimitTrieLogsEnabled(true)
-                .bonsaiTrieLogPruningWindowSize(514)
-                .build())
+        .bonsaiLimitTrieLogsEnabled(true)
+        .bonsaiTrieLogPruningWindowSize(514)
         .build();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelperTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogHelperTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli.subcommands.storage;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.Unstable.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
+import static org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration.DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
 import static org.hyperledger.besu.plugin.services.storage.DataStorageFormat.BONSAI;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
@@ -135,10 +135,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(3L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     mockBlockchainBase();
@@ -176,10 +173,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(2L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     when(blockchain.getChainHeadBlockNumber()).thenReturn(5L);
@@ -199,10 +193,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(10L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     when(blockchain.getChainHeadBlockNumber()).thenReturn(5L);
@@ -222,10 +213,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(2L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     mockBlockchainBase();
@@ -246,10 +234,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(6L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     when(blockchain.getChainHeadBlockNumber()).thenReturn(5L);
@@ -271,10 +256,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(3L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     mockBlockchainBase();
@@ -303,10 +285,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(511L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     TrieLogHelper helper = new TrieLogHelper();
@@ -324,11 +303,8 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(512L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .bonsaiTrieLogPruningWindowSize(0)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
+            .bonsaiTrieLogPruningWindowSize(0)
             .build();
 
     TrieLogHelper helper = new TrieLogHelper();
@@ -345,11 +321,8 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(512L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .bonsaiTrieLogPruningWindowSize(512)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
+            .bonsaiTrieLogPruningWindowSize(512)
             .build();
 
     TrieLogHelper helper = new TrieLogHelper();
@@ -368,10 +341,7 @@ class TrieLogHelperTest {
         ImmutableDataStorageConfiguration.builder()
             .dataStorageFormat(BONSAI)
             .bonsaiMaxLayersToLoad(3L)
-            .unstable(
-                ImmutableDataStorageConfiguration.Unstable.builder()
-                    .bonsaiLimitTrieLogsEnabled(true)
-                    .build())
+            .bonsaiLimitTrieLogsEnabled(true)
             .build();
 
     mockBlockchainBase();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/DataStorageConfiguration.java
@@ -23,6 +23,9 @@ import org.immutables.value.Value;
 public interface DataStorageConfiguration {
 
   long DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD = 512;
+  boolean DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED = true;
+  long MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
+  int DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE = 30_000;
   boolean DEFAULT_RECEIPT_COMPACTION_ENABLED = false;
 
   DataStorageConfiguration DEFAULT_CONFIG =
@@ -57,6 +60,16 @@ public interface DataStorageConfiguration {
   Long getBonsaiMaxLayersToLoad();
 
   @Value.Default
+  default boolean getBonsaiLimitTrieLogsEnabled() {
+    return DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
+  }
+
+  @Value.Default
+  default int getBonsaiTrieLogPruningWindowSize() {
+    return DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
+  }
+
+  @Value.Default
   default boolean getReceiptCompactionEnabled() {
     return DEFAULT_RECEIPT_COMPACTION_ENABLED;
   }
@@ -69,9 +82,6 @@ public interface DataStorageConfiguration {
   @Value.Immutable
   interface Unstable {
 
-    boolean DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED = true;
-    long MINIMUM_BONSAI_TRIE_LOG_RETENTION_LIMIT = DEFAULT_BONSAI_MAX_LAYERS_TO_LOAD;
-    int DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE = 30_000;
     boolean DEFAULT_BONSAI_FULL_FLAT_DB_ENABLED = true;
     boolean DEFAULT_BONSAI_CODE_USING_CODE_HASH_ENABLED = true;
 
@@ -80,16 +90,6 @@ public interface DataStorageConfiguration {
 
     DataStorageConfiguration.Unstable DEFAULT_PARTIAL =
         ImmutableDataStorageConfiguration.Unstable.builder().bonsaiFullFlatDbEnabled(false).build();
-
-    @Value.Default
-    default boolean getBonsaiLimitTrieLogsEnabled() {
-      return DEFAULT_BONSAI_LIMIT_TRIE_LOGS_ENABLED;
-    }
-
-    @Value.Default
-    default int getBonsaiTrieLogPruningWindowSize() {
-      return DEFAULT_BONSAI_TRIE_LOG_PRUNING_WINDOW_SIZE;
-    }
 
     @Value.Default
     default boolean getBonsaiFullFlatDbEnabled() {


### PR DESCRIPTION
Also --bonsai-trie-logs-pruning-window-size

Following https://github.com/hyperledger/besu/pull/7181 and https://github.com/hyperledger/besu/pull/7192

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests