### PR TITLE
check correctly the storage in ToyAccount

### DIFF
--- a/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyAccount.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyAccount.java
@@ -171,7 +171,10 @@ public class ToyAccount implements MutableAccount {
    */
   @Override
   public boolean isStorageEmpty() {
-    return storage.isEmpty();
+    if (storage.isEmpty()) {
+      return parent == null || parent.isStorageEmpty();
+    }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
## PR description

We are not correctly checking the storage in the ToyAccount for the isStorageEmpty method. It can create issue during the contract creation step when we check if an account exist or not (only a problem for the toy environment and not a problem for mainnet). 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

