### PR TITLE
Revert "Update Dockerfile - reuse NO_PROXY_CACHE env (#7203)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,10 +5,13 @@ ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true
 
 # Update and install dependencies without using any cache
 RUN apt-get update $NO_PROXY_CACHE  && \
-  apt-get $NO_PROXY_CACHE --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3*  && \
+  # $NO_PROXY_CACHE must not be used here or otherwise will trigger a hadolint error
+  apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
+    --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21* libjemalloc-dev=5.* adduser=3*  && \
   # Clean apt cache
   apt-get clean  && \
-  rm -rf /var/cache/apt/archives/*  && rm -rf /var/lib/apt/lists/*  && \
+  rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*  && \
+  rm -rf /var/lib/apt/lists/*  && \
   # Ubuntu 23.10 comes with an "ubuntu" user with uid 1000. We need 1000 for besu.
   userdel ubuntu 2>/dev/null || true && rm -rf /home/ubuntu  && \
   # Ensure we use a stable UID for besu, as file permissions are tied to UIDs.


### PR DESCRIPTION
This reverts commit dfe256e6478a91122e40adda928a71e1353668f1.
Reverts https://github.com/hyperledger/besu/pull/7203

There's an issue running docker develop workflow

https://github.com/hyperledger/besu/actions/runs/9491467523

```
Run docker run --rm -i hadolint/hadolint < docker/Dockerfile
Unable to find image 'hadolint/hadolint:latest' locally
latest: Pulling from hadolint/hadolint
db4123164570: Pulling fs layer
db4123164570: Download complete
db4123164570: Pull complete
Digest: sha256:fff226bdf9ebcc08db47fb90ee144dd770120b35c2b1cbbb46e932a650cfe232
Status: Downloaded newer image for hadolint/hadolint:latest
-:7 DL3008 warning: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
Error: Process completed with exit code 1.
```


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

