### PR TITLE
fix: pin github actions in container security scan workflow

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
  
       # Shell parameter expansion does not support directly on a step
       # Adding a separate step to set the image tag. This allows running
@@ -31,7 +31,7 @@ jobs:
 
       - name: Vulnerability scanner
         id: trivy
-        uses: aquasecurity/trivy-action@0.22.0
+        uses: aquasecurity/trivy-action@595be6a0f6560a0a8fc419ddf630567fc623531d
         with:
           image-ref: hyperledger/besu:${{ steps.tag.outputs.TAG }}
           format: sarif
@@ -39,6 +39,6 @@ jobs:
 
       # Check the vulnerabilities via GitHub security tab
       - name: Upload results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@23acc5c183826b7a8a97bce3cecc52db901f8251
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## PR description
Repository follow standard to use git hash to pin the GitHub actions. Updated the container security scan workflow actions with their git hashes.

## Fixed Issue(s)
fix requested in [discord](https://discord.com/channels/905194001349627914/905205502940696607/1250837893040177175) message

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

