### PR TITLE
Check for EOFCreate subcontainer rules

### DIFF
--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
@@ -87,6 +87,8 @@ public class EOFReferenceTestTools {
     // Orphan containers are no longer allowed
     params.ignore("efValidation/EOF1_returncontract_valid-Prague\\[EOF1_returncontract_valid_1\\]");
     params.ignore("efValidation/EOF1_returncontract_valid-Prague\\[EOF1_returncontract_valid_2\\]");
+    params.ignore("efValidation/EOF1_eofcreate_valid-Prague\\[EOF1_eofcreate_valid_1\\]");
+    params.ignore("efValidation/EOF1_eofcreate_valid-Prague\\[EOF1_eofcreate_valid_2\\]");
     params.ignore("efValidation/EOF1_section_order-Prague\\[EOF1_section_order_6\\]");
   }
 

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
@@ -72,6 +72,22 @@ public class EOFReferenceTestTools {
 
     // TXCREATE still in tests, but has been removed
     params.ignore("EOF1_undefined_opcodes_186");
+
+    // embedded containers rules changed
+    params.ignore("EOF1_embedded_container");
+
+    // truncated data is only allowed in embedded containers
+    params.ignore("ori/validInvalid-Prague\\[validInvalid_48\\]");
+    params.ignore("efExample/validInvalid-Prague\\[validInvalid_1\\]");
+    params.ignore("efValidation/EOF1_truncated_section-Prague\\[EOF1_truncated_section_3\\]");
+    params.ignore("efValidation/EOF1_truncated_section-Prague\\[EOF1_truncated_section_4\\]");
+    params.ignore("EIP3540/validInvalid-Prague\\[validInvalid_2\\]");
+    params.ignore("EIP3540/validInvalid-Prague\\[validInvalid_3\\]");
+
+    // Orphan containers are no longer allowed
+    params.ignore("efValidation/EOF1_returncontract_valid-Prague\\[EOF1_returncontract_valid_1\\]");
+    params.ignore("efValidation/EOF1_returncontract_valid-Prague\\[EOF1_returncontract_valid_2\\]");
+    params.ignore("efValidation/EOF1_section_order-Prague\\[EOF1_section_order_6\\]");
   }
 
   private EOFReferenceTestTools() {

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
@@ -406,6 +406,16 @@ public record EOFLayout(
   }
 
   /**
+   * Finds the first instance of the subcontainer in the list of container, or -1 if not present
+   *
+   * @param container the container to search for
+   * @return the index of the container, or -1 if not found.
+   */
+  public int indexOfSubcontainer(final EOFLayout container) {
+    return Arrays.asList(subContainers).indexOf(container);
+  }
+
+  /**
    * Is valid.
    *
    * @return the boolean

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
@@ -15,10 +15,10 @@
 package org.hyperledger.besu.evm.code;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.evm.EOFTestConstants.bytesFromPrettyPrint;
 
 import org.hyperledger.besu.evm.Code;
 
-import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
 
 class CodeFactoryTest {
@@ -178,13 +178,445 @@ class CodeFactoryTest {
     invalidCode("0xEF0001010002030004006000AABBCCDD");
   }
 
+  @Test
+  void invalidDataTruncated() {
+    invalidCode("EF0001 010004 0200010001 040003 00 00800000 FE BEEF", "Incomplete data section");
+  }
+
+  @Test
+  void validComboEOFCreateReturnContract() {
+    validCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              0011 # Code section 0 , 17 bytes
+            030001 # Total subcontainers ( 1 )
+              0032 # Sub container 0, 50 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0004 # max stack:  4
+                   # Code section 0 - in=0 out=non-returning height=4
+              6000 # [0] PUSH1(0)
+              6000 # [2] PUSH1(0)
+              6000 # [4] PUSH1(0)
+              6000 # [6] PUSH1(0)
+              ec00 # [8] EOFCREATE(0)
+            612015 # [10] PUSH2(0x2015)
+              6001 # [13] PUSH1(1)
+                55 # [15] SSTORE
+                00 # [16] STOP
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0006 # Code section 0 , 6 bytes
+                030001 # Total subcontainers ( 1 )
+                  0014 # Sub container 0, 20 byte
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                  ee00 # [4] RETURNCONTRACT(0)
+                           # Subcontainer 0.0 starts here
+                    ef0001 # Magic and Version ( 1 )
+                    010004 # Types length ( 4 )
+                    020001 # Total code sections ( 1 )
+                      0001 # Code section 0 , 1 bytes
+                    040000 # Data section length(  0 )       \s
+                        00 # Terminator (end of header)
+                           # Code section 0 types
+                        00 # 0 inputs\s
+                        80 # 0 outputs  (Non-returning function)
+                      0000 # max stack:  0
+                           # Code section 0 - in=0 out=non-returning height=0
+                        00 # [0] STOP
+                           # Data section (empty)
+                           # Subcontainer 0.0 ends
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """);
+  }
+
+  @Test
+  void validComboReturnContactStop() {
+    validCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              000c # Code section 0 , 12 bytes
+            030001 # Total subcontainers ( 1 )
+              0014 # Sub container 0, 20 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0002 # max stack:  2
+                   # Code section 0 - in=0 out=non-returning height=2
+            612015 # [0] PUSH2(0x2015)
+              6001 # [3] PUSH1(1)
+                55 # [5] SSTORE
+              6000 # [6] PUSH1(0)
+              6000 # [8] PUSH1(0)
+              ee00 # [10] RETURNCONTRACT(0)
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0001 # Code section 0 , 1 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0000 # max stack:  0
+                       # Code section 0 - in=0 out=non-returning height=0
+                    00 # [0] STOP
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """);
+  }
+
+  @Test
+  void validComboReturnContactReturn() {
+    validCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              000c # Code section 0 , 12 bytes
+            030001 # Total subcontainers ( 1 )
+              0018 # Sub container 0, 24 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0002 # max stack:  2
+                   # Code section 0 - in=0 out=non-returning height=2
+            612015 # [0] PUSH2(0x2015)
+              6001 # [3] PUSH1(1)
+                55 # [5] SSTORE
+              6000 # [6] PUSH1(0)
+              6000 # [8] PUSH1(0)
+              ee00 # [10] RETURNCONTRACT(0)
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0005 # Code section 0 , 5 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                    f3 # [4] RETURN
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """);
+  }
+
+  @Test
+  void validComboEOFCreateRevert() {
+    validCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              0011 # Code section 0 , 17 bytes
+            030001 # Total subcontainers ( 1 )
+              0018 # Sub container 0, 24 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0004 # max stack:  4
+                   # Code section 0 - in=0 out=non-returning height=4
+              6000 # [0] PUSH1(0)
+              6000 # [2] PUSH1(0)
+              6000 # [4] PUSH1(0)
+              6000 # [6] PUSH1(0)
+              ec00 # [8] EOFCREATE(0)
+            612015 # [10] PUSH2(0x2015)
+              6001 # [13] PUSH1(1)
+                55 # [15] SSTORE
+                00 # [16] STOP
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0005 # Code section 0 , 5 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                    fd # [4] REVERT
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """);
+  }
+
+  @Test
+  void validComboReturncontractRevert() {
+    validCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              000c # Code section 0 , 12 bytes
+            030001 # Total subcontainers ( 1 )
+              0018 # Sub container 0, 24 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0002 # max stack:  2
+                   # Code section 0 - in=0 out=non-returning height=2
+            612015 # [0] PUSH2(0x2015)
+              6001 # [3] PUSH1(1)
+                55 # [5] SSTORE
+              6000 # [6] PUSH1(0)
+              6000 # [8] PUSH1(0)
+              ee00 # [10] RETURNCONTRACT(0)
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0005 # Code section 0 , 5 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                    fd # [4] REVERT
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """);
+  }
+
+  @Test
+  void invalidComboEOFCreateStop() {
+    invalidCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              0011 # Code section 0 , 17 bytes
+            030001 # Total subcontainers ( 1 )
+              0014 # Sub container 0, 20 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0004 # max stack:  4
+                   # Code section 0 - in=0 out=non-returning height=4
+              6000 # [0] PUSH1(0)
+              6000 # [2] PUSH1(0)
+              6000 # [4] PUSH1(0)
+              6000 # [6] PUSH1(0)
+              ec00 # [8] EOFCREATE(0)
+            612015 # [10] PUSH2(0x2015)
+              6001 # [13] PUSH1(1)
+                55 # [15] SSTORE
+                00 # [16] STOP
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0001 # Code section 0 , 1 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0000 # max stack:  0
+                       # Code section 0 - in=0 out=non-returning height=0
+                    00 # [0] STOP
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """,
+        "STOP is only a valid opcode in containers used for runtime operations.");
+  }
+
+  @Test
+  void invalidComboEOFCretateReturn() {
+    invalidCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              0011 # Code section 0 , 17 bytes
+            030001 # Total subcontainers ( 1 )
+              0018 # Sub container 0, 24 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0004 # max stack:  4
+                   # Code section 0 - in=0 out=non-returning height=4
+              6000 # [0] PUSH1(0)
+              6000 # [2] PUSH1(0)
+              6000 # [4] PUSH1(0)
+              6000 # [6] PUSH1(0)
+              ec00 # [8] EOFCREATE(0)
+            612015 # [10] PUSH2(0x2015)
+              6001 # [13] PUSH1(1)
+                55 # [15] SSTORE
+                00 # [16] STOP
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0005 # Code section 0 , 5 bytes
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                    f3 # [4] RETURN
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """,
+        "RETURN is only a valid opcode in containers used for runtime operations.");
+  }
+
+  @Test
+  void invalidReturncontractReturncontract() {
+    invalidCode(
+        """
+            0x # EOF
+            ef0001 # Magic and Version ( 1 )
+            010004 # Types length ( 4 )
+            020001 # Total code sections ( 1 )
+              000c # Code section 0 , 12 bytes
+            030001 # Total subcontainers ( 1 )
+              0032 # Sub container 0, 50 byte
+            040000 # Data section length(  0 )
+                00 # Terminator (end of header)
+                   # Code section 0 types
+                00 # 0 inputs\s
+                80 # 0 outputs  (Non-returning function)
+              0002 # max stack:  2
+                   # Code section 0 - in=0 out=non-returning height=2
+            612015 # [0] PUSH2(0x2015)
+              6001 # [3] PUSH1(1)
+                55 # [5] SSTORE
+              6000 # [6] PUSH1(0)
+              6000 # [8] PUSH1(0)
+              ee00 # [10] RETURNCONTRACT(0)
+                       # Subcontainer 0 starts here
+                ef0001 # Magic and Version ( 1 )
+                010004 # Types length ( 4 )
+                020001 # Total code sections ( 1 )
+                  0006 # Code section 0 , 6 bytes
+                030001 # Total subcontainers ( 1 )
+                  0014 # Sub container 0, 20 byte
+                040000 # Data section length(  0 )   \s
+                    00 # Terminator (end of header)
+                       # Code section 0 types
+                    00 # 0 inputs\s
+                    80 # 0 outputs  (Non-returning function)
+                  0002 # max stack:  2
+                       # Code section 0 - in=0 out=non-returning height=2
+                  6000 # [0] PUSH1(0)
+                  6000 # [2] PUSH1(0)
+                  ee00 # [4] RETURNCONTRACT(0)
+                           # Subcontainer 0.0 starts here
+                    ef0001 # Magic and Version ( 1 )
+                    010004 # Types length ( 4 )
+                    020001 # Total code sections ( 1 )
+                      0001 # Code section 0 , 1 bytes
+                    040000 # Data section length(  0 )       \s
+                        00 # Terminator (end of header)
+                           # Code section 0 types
+                        00 # 0 inputs\s
+                        80 # 0 outputs  (Non-returning function)
+                      0000 # max stack:  0
+                           # Code section 0 - in=0 out=non-returning height=0
+                        00 # [0] STOP
+                           # Data section (empty)
+                           # Subcontainer 0.0 ends
+                       # Data section (empty)
+                       # Subcontainer 0 ends
+                   # Data section (empty)
+            """,
+        "RETURNCONTRACT is only a valid opcode in containers used for initcode");
+  }
+
+  //  // valid subcontainer references
+  //  // invalid subcontainer references
+  //
+  //  {
+  //    "EF0001 010004 0200010001 040003 00 00800000 FE BEEF",
+  //            "Incomplete data section",
+  //            "Incomplete data section",
+  //            1
+  //  },
+  //
+
+  private static void validCode(final String str) {
+    Code code = CodeFactory.createCode(bytesFromPrettyPrint(str), 1);
+    assertThat(code.isValid()).isTrue();
+  }
+
+  private static void invalidCode(final String str, final String error) {
+    Code code = CodeFactory.createCode(bytesFromPrettyPrint(str), 1);
+    assertThat(code.isValid()).isFalse();
+    assertThat(((CodeInvalid) code).getInvalidReason()).contains(error);
+  }
+
   private static void invalidCode(final String str) {
-    Code code = CodeFactory.createCode(Bytes.fromHexString(str), 1);
+    Code code = CodeFactory.createCode(bytesFromPrettyPrint(str), 1);
     assertThat(code.isValid()).isFalse();
   }
 
   private static void invalidCode(final String str, final boolean legacy) {
-    Code code = CodeFactory.createCode(Bytes.fromHexString(str), 1, legacy, false);
+    Code code = CodeFactory.createCode(bytesFromPrettyPrint(str), 1, legacy, false);
     assertThat(code.isValid()).isFalse();
   }
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/EOFLayoutTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/EOFLayoutTest.java
@@ -143,14 +143,8 @@ public class EOFLayoutTest {
           },
           {
             "EF0001 010004 0200010001 040003 00 00800000 FE DEADBEEF",
-            "Incomplete data section",
+            "Excess data section",
             "Dangling data after end of all sections",
-            1
-          },
-          {
-            "EF0001 010004 0200010001 040003 00 00800000 FE BEEF",
-            "Incomplete data section",
-            "Incomplete data section",
             1
           },
           {
@@ -343,9 +337,9 @@ public class EOFLayoutTest {
 
   @ParameterizedTest(name = "{1}")
   @MethodSource({
-    //    "correctContainers",
-    //    "containersWithFormatErrors",
-    //    "typeSectionTests",
+    "correctContainers",
+    "containersWithFormatErrors",
+    "typeSectionTests",
     "subContainers"
   })
   void test(
@@ -354,7 +348,7 @@ public class EOFLayoutTest {
       final String failureReason,
       final int expectedVersion) {
     final Bytes container = Bytes.fromHexString(containerString.replaceAll("[^a-fxA-F0-9]", ""));
-    final EOFLayout layout = EOFLayout.parseEOF(container);
+    final EOFLayout layout = EOFLayout.parseEOF(container, true);
 
     assertThat(layout.version()).isEqualTo(expectedVersion);
     assertThat(layout.invalidReason()).isEqualTo(failureReason);


### PR DESCRIPTION
## PR description

Check and test for the unused container rule, and only returncontract
targets can have truncated data rule.
Also test the other subcontainer rules in unit tests.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

