### PR TITLE
fix: workflow permission to upload trivy sarif report

### DIFF
--- a/.github/workflows/container-security-scan.yml
+++ b/.github/workflows/container-security-scan.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   scan-sarif:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## PR description
Trivy scan result upload to GitHub fails due to permission issue. Added permission security-events=write to the workflow file as a fix. Since workflow permission explicitly defined, it requires contents=read explicity set as well

## Fixed Issue(s)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

