### PR TITLE
container verify GitHub workflow

### DIFF
--- a/.github/workflows/BesuContainerVerify.sh
+++ b/.github/workflows/BesuContainerVerify.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+##
+## Copyright contributors to Hyperledger Besu.
+##
+## Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+## the License. You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+## an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+## specific language governing permissions and limitations under the License.
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+
+CONTAINER_NAME=${CONTAINER_NAME:-besu}
+VERSION=${VERSION}
+TAG=${TAG}
+CHECK_LATEST=${CHECK_LATEST}
+RETRY=${RETRY:-10}
+SLEEP=${SLEEP:-5}
+
+# Helper function to throw error
+log_error() {
+  echo "::error $1"
+  exit 1
+}
+
+# Check container is in running state
+_RUN_STATE=$(docker inspect --type=container -f={{.State.Status}} ${CONTAINER_NAME})
+if [[ "${_RUN_STATE}" != "running" ]]
+then
+  log_error "container is not running"
+fi
+
+# Check for specific log message in container logs to verify besu started
+_SUCCESS=false
+while [[ ${_SUCCESS} != "true" && $RETRY -gt 0 ]]
+do
+  docker logs ${CONTAINER_NAME} | grep -q "Ethereum main loop is up" && {
+    _SUCCESS=true
+    continue
+  }
+  echo "Waiting for the besu to start. Remaining retries $RETRY ..."
+  RETRY=$(expr $RETRY - 1)
+  sleep $SLEEP
+done
+
+# Log entry does not present after all retries, fail the script with a message
+if [[ ${_SUCCESS} != "true" ]]
+then
+  docker logs --tail=100 ${CONTAINER_NAME}
+  log_error "could not find the log message 'Ethereum main loop is up'"
+else
+  echo "Besu container started and entered main loop"
+fi
+
+# For the latest tag check the version match
+if [[ ${TAG} == "latest" && ${CHECK_LATEST} == "true" ]]
+then
+  _VERSION_IN_LOG=$(docker logs ${CONTAINER_NAME} | grep "#" | grep "Besu version" | cut -d " " -f 4 | sed 's/\s//g')
+  echo "Extracted version from logs [$_VERSION_IN_LOG]"
+  if [[ "$_VERSION_IN_LOG" != "${VERSION}" ]]
+  then
+    log_error "version [$_VERSION_IN_LOG] extracted from container logs does not match the expected version [${VERSION}]"
+  else
+    echo "Latest Besu container version matches"
+  fi
+fi

--- a/.github/workflows/container-verify.yml
+++ b/.github/workflows/container-verify.yml
@@ -1,0 +1,57 @@
+name: container verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Besu version'
+        required: true
+      verify-latest-version:
+        description: 'Check latest container version'
+        required: false
+        type: choice
+        default: "true"
+        options:
+          - "true"
+          - "false"
+
+jobs:
+  verify:
+    timeout-minutes: 4
+    strategy:
+      matrix:
+        combination:
+          - tag: ${{ inputs.version }}
+            platform: ''
+            runner: ubuntu-latest
+          - tag: ${{ inputs.version }}-amd64
+            platform: 'linux/amd64'
+            runner: ubuntu-latest
+          - tag: latest
+            platform: ''
+            runner: ubuntu-latest
+          - tag: ${{ inputs.version }}-arm64
+            platform: ''
+            runner: besu-arm64
+    runs-on: ${{ matrix.combination.runner }}
+    env:
+      CONTAINER_NAME: besu-check
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+
+      - name: Start container
+        run: |
+          PLATFORM_OPT=""
+          [[ x${{ matrix.combination.platform }} != 'x' ]] && PLATFORM_OPT="--platform ${{ matrix.combination.platform }}"
+          docker run -d $PLATFORM_OPT --name ${{ env.CONTAINER_NAME }} hyperledger/besu:${{ matrix.combination.tag }}
+
+      - name: Verify besu container
+        run: bash .github/workflows/BesuContainerVerify.sh
+        env:
+          TAG: ${{ matrix.combination.tag }}
+          VERSION: ${{ inputs.version }}
+          CHECK_LATEST: ${{ inputs.verify-latest-version }}
+
+      - name: Stop container
+        run: docker stop ${{ env.CONTAINER_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,3 +265,17 @@ jobs:
         run: ./gradlew "-Prelease.releaseVersion=${{ github.event.release.name }}" "-PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }}" dockerUploadRelease
       - name: Docker manifest
         run: ./gradlew "-Prelease.releaseVersion=${{ github.event.release.name }}" "-PdockerOrgName=${{ env.registry }}/${{ secrets.DOCKER_ORG }}" manifestDockerRelease
+
+  verifyContainer:
+    needs: dockerPromoteX64
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Trigger container verify
+        run: echo '{"version":"${{ github.event.release.name }}","verify-latest-version":"true"}' | gh workflow run container-verify.yml --json
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## PR description
Container verification step in release process automated with the container verify GitHub workflow. New workflow is triggered at the end of the release workflow which will check the released container images starts successfully. Verification test only checks container starts and reach the Ethereum main loop.

## Fixed Issue(s)
fixes #7176

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

