### PR TITLE
Add bootnodes to the maintained peer list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Update Docker base image to Ubuntu 24.04 [#7251](https://github.com/hyperledger/besu/pull/7251)
 - Add LUKSO as predefined network name [#7223](https://github.com/hyperledger/besu/pull/7223)
 - Refactored how code, initcode, and max stack size are configured in forks. [#7245](https://github.com/hyperledger/besu/pull/7245)
+- Nodes in a permissioned chain maintain (and retry) connections to bootnodes [#7257](https://github.com/hyperledger/besu/pull/7257)
 
 ### Bug fixes
 - Validation errors ignored in accounts-allowlist and empty list [#7138](https://github.com/hyperledger/besu/issues/7138)

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningAcceptanceTest.java
@@ -37,9 +37,10 @@ public class NodeSmartContractPermissioningAcceptanceTest
     permissionedCluster.start(bootnode, forbiddenNode, allowedNode, permissionedNode);
 
     // updating permissioning smart contract with allowed nodes
-
+    permissionedNode.verify(nodeIsForbidden(bootnode));
     permissionedNode.execute(allowNode(bootnode));
     permissionedNode.verify(nodeIsAllowed(bootnode));
+    permissionedNode.verify(admin.hasPeer(bootnode));
 
     permissionedNode.execute(allowNode(allowedNode));
     permissionedNode.verify(nodeIsAllowed(allowedNode));
@@ -47,7 +48,6 @@ public class NodeSmartContractPermissioningAcceptanceTest
     permissionedNode.execute(allowNode(permissionedNode));
     permissionedNode.verify(nodeIsAllowed(permissionedNode));
 
-    permissionedNode.verify(admin.addPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
 
     allowedNode.verify(eth.syncingStatus(false));

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTest.java
@@ -60,6 +60,7 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissionedNodeShouldDisconnectFromNodeNotPermittedAnymore() {
+    permissionedNode.verify(admin.hasPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 
@@ -71,6 +72,7 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissionedNodeShouldConnectToNewlyPermittedNode() {
+    permissionedNode.verify(admin.hasPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 
@@ -85,6 +87,7 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissioningUpdatesPropagateThroughNetwork() {
+    permissionedNode.verify(admin.hasPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/permissioning/NodeSmartContractPermissioningV2AcceptanceTest.java
@@ -60,7 +60,6 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissionedNodeShouldDisconnectFromNodeNotPermittedAnymore() {
-    permissionedNode.verify(admin.addPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 
@@ -72,7 +71,6 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissionedNodeShouldConnectToNewlyPermittedNode() {
-    permissionedNode.verify(admin.addPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 
@@ -87,7 +85,6 @@ public class NodeSmartContractPermissioningV2AcceptanceTest
 
   @Test
   public void permissioningUpdatesPropagateThroughNetwork() {
-    permissionedNode.verify(admin.addPeer(bootnode));
     permissionedNode.verify(admin.addPeer(allowedNode));
     permissionedNode.verify(net.awaitPeerCount(2));
 

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -795,7 +795,10 @@ public class RunnerBuilder {
       // In a permissioned chain Besu should maintain connections to both static nodes and
       // bootnodes, which includes retries periodically
       maintainedPeers =
-          Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes));
+          sanitizePeers(
+              network,
+              Stream.concat(staticNodes.stream(), bootnodes.stream()).collect(Collectors.toList()));
+      LOG.debug("Added bootnodes to the maintained peer list");
     } else {
       // In a public chain only maintain connections to static nodes
       maintainedPeers = sanitizePeers(network, staticNodes);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -790,18 +790,19 @@ public class RunnerBuilder {
       LOG.debug("added ethash observer: {}", stratumServer.get());
     }
 
+    final Stream<EnodeURL> maintainedPeers;
     if (besuController.getGenesisConfigOptions().isPoa()) {
       // In a permissioned chain Besu should maintain connections to both static nodes and
       // bootnodes, which includes retries periodically
-      Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes))
-          .map(DefaultPeer::fromEnodeURL)
-          .forEach(peerNetwork::addMaintainedConnectionPeer);
+      maintainedPeers =
+          Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes));
     } else {
       // In a public chain only maintain connections to static nodes
-      sanitizePeers(network, staticNodes)
-          .map(DefaultPeer::fromEnodeURL)
-          .forEach(peerNetwork::addMaintainedConnectionPeer);
+      maintainedPeers = sanitizePeers(network, staticNodes);
     }
+    maintainedPeers
+        .map(DefaultPeer::fromEnodeURL)
+        .forEach(peerNetwork::addMaintainedConnectionPeer);
 
     final Optional<NodeLocalConfigPermissioningController> nodeLocalConfigPermissioningController =
         nodePermissioningController.flatMap(NodePermissioningController::localConfigController);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -790,10 +790,18 @@ public class RunnerBuilder {
       LOG.debug("added ethash observer: {}", stratumServer.get());
     }
 
-    // Make sure Besu maintains connections to static nodes and bootnodes, including retries periodically
-    Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes))
-        .map(DefaultPeer::fromEnodeURL)
-        .forEach(peerNetwork::addMaintainedConnectionPeer);
+    if (besuController.getGenesisConfigOptions().isPoa()) {
+      // In a permissioned chain Besu should maintain connections to both static nodes and
+      // bootnodes, which includes retries periodically
+      Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes))
+          .map(DefaultPeer::fromEnodeURL)
+          .forEach(peerNetwork::addMaintainedConnectionPeer);
+    } else {
+      // In a public chain only maintain connections to static nodes
+      sanitizePeers(network, staticNodes)
+          .map(DefaultPeer::fromEnodeURL)
+          .forEach(peerNetwork::addMaintainedConnectionPeer);
+    }
 
     final Optional<NodeLocalConfigPermissioningController> nodeLocalConfigPermissioningController =
         nodePermissioningController.flatMap(NodePermissioningController::localConfigController);

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -790,7 +790,8 @@ public class RunnerBuilder {
       LOG.debug("added ethash observer: {}", stratumServer.get());
     }
 
-    sanitizePeers(network, staticNodes)
+    // Make sure Besu maintains connections to static nodes and bootnodes, including retries periodically
+    Stream.concat(sanitizePeers(network, staticNodes), sanitizePeers(network, bootnodes))
         .map(DefaultPeer::fromEnodeURL)
         .forEach(peerNetwork::addMaintainedConnectionPeer);
 


### PR DESCRIPTION
## PR description
This PR adds the bootnodes to the maintained-peer list in a permissioned chain. Currently the maintained node list only contains static nodes and nodes added with `admin_addPeer`. Adding bootnodes to the maintained list ensures that if a bootnode is offline when the node starts, it will retry its connection once a minute rather than requiring a restart.

Bootnode connectivity in a public-chain node remains unchanged.

## Fixed issues
Fixes https://github.com/hyperledger/besu/issues/7261

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] ~For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests~

Based on the outcome of this PR, I plan to raise a docs PR to describe how connections are maintained to bootnodes and static nodes since there isn't much detail covering the behaviour today. I'll wait for the outcome of this PR before raising the docs changes though.

