### PR TITLE
T8n support for isStateTest and empty accounts

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/T8nExecutor.java
@@ -51,6 +51,7 @@ import org.hyperledger.besu.ethereum.referencetests.ReferenceTestWorldState;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedAccount;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.log.Log;
@@ -265,9 +266,11 @@ public class T8nExecutor {
             .blobGasPricePerGas(calculateExcessBlobGasForParent(protocolSpec, blockHeader));
     long blobGasLimit = protocolSpec.getGasLimitCalculator().currentBlobGasLimit();
 
-    protocolSpec
-        .getBlockHashProcessor()
-        .processBlockHashes(blockchain, worldState, referenceTestEnv);
+    if (!referenceTestEnv.isStateTest()) {
+      protocolSpec
+          .getBlockHashProcessor()
+          .processBlockHashes(blockchain, worldState, referenceTestEnv);
+    }
 
     final WorldUpdater rootWorldStateUpdater = worldState.updater();
     List<TransactionReceipt> receipts = new ArrayList<>();
@@ -318,13 +321,12 @@ public class T8nExecutor {
       timer.stop();
 
       if (shouldClearEmptyAccounts(fork)) {
-        final Account coinbase = worldStateUpdater.getOrCreate(blockHeader.getCoinbase());
-        if (coinbase != null && coinbase.isEmpty()) {
-          worldStateUpdater.deleteAccount(coinbase.getAddress());
-        }
-        final Account txSender = worldStateUpdater.getAccount(transaction.getSender());
-        if (txSender != null && txSender.isEmpty()) {
-          worldStateUpdater.deleteAccount(txSender.getAddress());
+        var entries = new ArrayList<>(worldState.getAccumulator().getAccountsToUpdate().entrySet());
+        for (var entry : entries) {
+          DiffBasedAccount updated = entry.getValue().getUpdated();
+          if (updated != null && updated.isEmpty()) {
+            worldState.getAccumulator().deleteAccount(entry.getKey());
+          }
         }
       }
       if (result.isInvalid()) {
@@ -397,7 +399,9 @@ public class T8nExecutor {
 
     // block reward
     // The max production reward was 5 Eth, longs can hold over 18 Eth.
-    if (!validTransactions.isEmpty() && (rewardString == null || Long.decode(rewardString) > 0)) {
+    if (!referenceTestEnv.isStateTest()
+        && !validTransactions.isEmpty()
+        && (rewardString == null || Long.decode(rewardString) > 0)) {
       Wei reward =
           (rewardString == null)
               ? protocolSpec.getBlockReward()
@@ -408,15 +412,24 @@ public class T8nExecutor {
     }
 
     rootWorldStateUpdater.commit();
-    // Invoke the withdrawal processor to handle CL withdrawals.
-    if (!referenceTestEnv.getWithdrawals().isEmpty()) {
-      try {
-        protocolSpec
-            .getWithdrawalsProcessor()
-            .ifPresent(
-                p -> p.processWithdrawals(referenceTestEnv.getWithdrawals(), worldState.updater()));
-      } catch (RuntimeException re) {
-        resultObject.put("exception", re.getMessage());
+
+    if (referenceTestEnv.isStateTest()) {
+      if (!referenceTestEnv.getWithdrawals().isEmpty()) {
+        resultObject.put("exception", "withdrawals are not supported in state tests");
+      }
+    } else {
+      // Invoke the withdrawal processor to handle CL withdrawals.
+      if (!referenceTestEnv.getWithdrawals().isEmpty()) {
+        try {
+          protocolSpec
+              .getWithdrawalsProcessor()
+              .ifPresent(
+                  p ->
+                      p.processWithdrawals(
+                          referenceTestEnv.getWithdrawals(), worldState.updater()));
+        } catch (RuntimeException re) {
+          resultObject.put("exception", re.getMessage());
+        }
       }
     }
 

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/BlockchainReferenceTestCaseSpec.java
@@ -249,7 +249,8 @@ public class BlockchainReferenceTestCaseSpec {
         @JsonProperty("uncleHeaders") final Object uncleHeaders,
         @JsonProperty("withdrawals") final Object withdrawals,
         @JsonProperty("depositRequests") final Object depositRequests,
-        @JsonProperty("withdrawalRequests") final Object withdrawalRequests) {
+        @JsonProperty("withdrawalRequests") final Object withdrawalRequests,
+        @JsonProperty("consolidationRequests") final Object consolidationRequests) {
       boolean blockVaid = true;
       // The BLOCK__WrongCharAtRLP_0 test has an invalid character in its rlp string.
       Bytes rlpAttempt = null;

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
@@ -83,6 +83,8 @@ public class ReferenceTestEnv extends BlockHeader {
 
   private final Bytes32 beaconRoot;
 
+  private final boolean isStateTest;
+
   /**
    * Public constructor.
    *
@@ -120,7 +122,8 @@ public class ReferenceTestEnv extends BlockHeader {
       @JsonProperty("parentGasLimit") final String parentGasLimit,
       @JsonProperty("parentGasUsed") final String parentGasUsed,
       @JsonProperty("parentTimestamp") final String parentTimestamp,
-      @JsonProperty("parentUncleHash") final String _parentUncleHash) {
+      @JsonProperty("parentUncleHash") final String _parentUncleHash,
+      @JsonProperty("isStateTest") final String isStateTest) {
     super(
         generateTestBlockHash(previousHash, number),
         Hash.EMPTY_LIST_HASH, // ommersHash
@@ -164,10 +167,16 @@ public class ReferenceTestEnv extends BlockHeader {
                         Map.entry(
                             Long.decode(entry.getKey()), Hash.fromHexString(entry.getValue())))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    this.beaconRoot =
-        beaconRoot == null
-            ? (currentBeaconRoot == null ? null : Hash.fromHexString(currentBeaconRoot))
-            : Hash.fromHexString(beaconRoot);
+    if (beaconRoot == null) {
+      if (currentBeaconRoot == null) {
+        this.beaconRoot = null;
+      } else {
+        this.beaconRoot = Hash.fromHexString(currentBeaconRoot);
+      }
+    } else {
+      this.beaconRoot = Hash.fromHexString(beaconRoot);
+    }
+    this.isStateTest = Boolean.parseBoolean(isStateTest);
   }
 
   @Override
@@ -237,6 +246,10 @@ public class ReferenceTestEnv extends BlockHeader {
 
   public Map<Long, Hash> getBlockHashes() {
     return blockHashes;
+  }
+
+  public boolean isStateTest() {
+    return isStateTest;
   }
 
   @Override


### PR DESCRIPTION

## PR description

Update t8n executor to support new isStateTest env flag that will
disable extra-transactional processing such as block rewards and beacon
root. Also, make sure such extra-transactional commits don't create 
empty accounts.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

