### PR TITLE
Deeper tracing of self-destructed accounts

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/UpdateTrackingAccount.java
@@ -128,7 +128,6 @@ public class UpdateTrackingAccount<A extends Account> implements MutableAccount 
   public void setWrappedAccount(final A account) {
     if (this.account == null) {
       this.account = account;
-      storageWasCleared = false;
     } else {
       throw new IllegalStateException("Already tracking a wrapped account");
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
@@ -86,6 +86,12 @@ public interface WorldUpdater extends MutableWorldView {
     return account;
   }
 
+  /**
+   * Check this and parent updaters to see if an address has been deleted since the last persist
+   *
+   * @param address address to check
+   * @return true if any updaters have marked the address as deleted.
+   */
   default boolean isDeleted(final Address address) {
     if (getDeletedAccountAddresses().contains(address)) {
       return true;


### PR DESCRIPTION
## PR description

Consider previously self-destructed accounts when creating accounts.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

