### PR TITLE
Update status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Besu Ethereum Client
- [![CircleCI](https://circleci.com/gh/hyperledger/besu/tree/main.svg?style=svg)](https://circleci.com/gh/hyperledger/besu/tree/main)
- [![Documentation Status](https://readthedocs.org/projects/hyperledger-besu/badge/?version=latest)](https://besu.hyperledger.org/en/latest/?badge=latest)
+
+ [![Acceptance Tests](https://github.com/hyperledger/besu/actions/workflows/acceptance-tests.yml/badge.svg?branch=main)](https://github.com/hyperledger/besu/actions/workflows/acceptance-tests.yml/badge.svg?branch=main)
+ [![Integration Tests](https://github.com/hyperledger/besu/actions/workflows/integration-tests.yml/badge.svg?branch=main)](https://github.com/hyperledger/besu/actions/workflows/integration-tests.yml/badge.svg?branch=main)
+ [![Container Security](https://github.com/hyperledger/besu/actions/workflows/container-security-scan.yml/badge.svg)](https://github.com/hyperledger/besu/actions/workflows/container-security-scan.yml/badge.svg)
+
  [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3174/badge)](https://bestpractices.coreinfrastructure.org/projects/3174)
  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/hyperledger/besu/blob/main/LICENSE)
  [![Discord](https://img.shields.io/discord/905194001349627914?logo=Hyperledger&style=plastic)](https://discord.gg/hyperledger)


### PR DESCRIPTION
## PR description
Besu repository does not use CircleCI anymore and one of the status badges check the CircleCI jobs. Updated the README with badges from GitHub actions. Integration and acceptance test badges use the main branch to get the status badge. Status badge for documentation refers to incorrect url. Docs status badge has been removed and will be updated with correct link later

## Fixed Issue(s)


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

