### PR TITLE
Optimise TrieLogPruner.preload

### DIFF
--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/segmented/RocksDBColumnarKeyValueStorage.java
@@ -394,7 +394,8 @@ public abstract class RocksDBColumnarKeyValueStorage implements SegmentedKeyValu
 
   @Override
   public Stream<byte[]> streamKeys(final SegmentIdentifier segmentIdentifier) {
-    final RocksIterator rocksIterator = getDB().newIterator(safeColumnHandle(segmentIdentifier));
+    final RocksIterator rocksIterator =
+        getDB().newIterator(safeColumnHandle(segmentIdentifier), readOptions);
     rocksIterator.seekToFirst();
     return RocksDbIterator.create(rocksIterator).toStreamKeys();
   }


### PR DESCRIPTION
These optimisations only seem to save <= 17% of the time.

Control node took ~6mins.
Test node took between 5 mins and 5 mins 30 seconds on a couple of runs.

---

The problem with https://github.com/hyperledger/besu/pull/7337 is that for the duration of the async load, block import time appears to be affected. This could lead to impaired attestation performance and a missed proposal (although admittedly better than the alternative of downtime).

Ultimately need another PR that used a reasonable timeout for this load+prune operation, maybe 30 seconds.
