### PR TITLE
Add metrics for trie log pruner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next release
 
+### Upcoming Breaking Changes
+- Receipt compaction will be enabled by default in a future version of Besu. After this change it will not be possible to downgrade to the previous Besu version.
+- --Xbonsai-limit-trie-logs-enabled is deprecated, use --bonsai-limit-trie-logs-enabled instead
+- --Xbonsai-trie-logs-pruning-window-size is deprecated, use --bonsai-trie-logs-pruning-window-size instead
+- `besu storage x-trie-log` subcommand is deprecated, use `besu storage trie-log` instead
+
 ### Breaking Changes
 - Remove deprecated sync modes (X_SNAP and X_CHECKPOINT). Use SNAP and CHECKPOINT instead [#7309](https://github.com/hyperledger/besu/pull/7309)
 - Remove PKI-backed QBFT (deprecated in 24.5.1) Other forms of QBFT remain unchanged. [#7293](https://github.com/hyperledger/besu/pull/7293)
@@ -15,7 +21,8 @@
 - Implement gnark-crypto for eip-2537 [#7316](https://github.com/hyperledger/besu/pull/7316)
 - Improve blob size transaction selector [#7312](https://github.com/hyperledger/besu/pull/7312)
 - Added EIP-7702 [#7237](https://github.com/hyperledger/besu/pull/7237)
-- implement gnark-crypto for eip-196 [#7262](https://github.com/hyperledger/besu/pull/7262)
+- Implement gnark-crypto for eip-196 [#7262](https://github.com/hyperledger/besu/pull/7262)
+- Add trie log pruner metrics [#7352](https://github.com/hyperledger/besu/pull/7352)
 
 ### Bug fixes
 - Fix `eth_call` deserialization to correctly ignore unknown fields in the transaction object. [#7323](https://github.com/hyperledger/besu/pull/7323)

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -793,7 +793,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             scheduler::executeServiceTask,
             dataStorageConfiguration.getBonsaiMaxLayersToLoad(),
             dataStorageConfiguration.getBonsaiTrieLogPruningWindowSize(),
-            isProofOfStake);
+            isProofOfStake,
+            metricsSystem);
     trieLogPruner.initialize();
 
     return trieLogPruner;

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogPrunerTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldSt
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogAddedEvent;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogPruner;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -72,7 +73,8 @@ public class TrieLogPrunerTest {
 
     // When
     TrieLogPruner trieLogPruner =
-        new TrieLogPruner(worldState, blockchain, executeAsync, 3, loadingLimit, false);
+        new TrieLogPruner(
+            worldState, blockchain, executeAsync, 3, loadingLimit, false, new NoOpMetricsSystem());
     trieLogPruner.initialize();
 
     // Then
@@ -92,7 +94,13 @@ public class TrieLogPrunerTest {
     // requireFinalizedBlock = false means this is not a PoS chain
     TrieLogPruner trieLogPruner =
         new TrieLogPruner(
-            worldState, blockchain, executeAsync, blocksToRetain, pruningWindowSize, false);
+            worldState,
+            blockchain,
+            executeAsync,
+            blocksToRetain,
+            pruningWindowSize,
+            false,
+            new NoOpMetricsSystem());
 
     trieLogPruner.addToPruneQueue(0, key(0)); // older block outside prune window
     trieLogPruner.addToPruneQueue(1, key(1)); // block inside the prune window
@@ -201,7 +209,13 @@ public class TrieLogPrunerTest {
     when(blockchain.getChainHeadBlockNumber()).thenReturn(chainHeight);
     TrieLogPruner trieLogPruner =
         new TrieLogPruner(
-            worldState, blockchain, executeAsync, blocksToRetain, pruningWindowSize, true);
+            worldState,
+            blockchain,
+            executeAsync,
+            blocksToRetain,
+            pruningWindowSize,
+            true,
+            new NoOpMetricsSystem());
 
     trieLogPruner.addToPruneQueue(1, key(1));
     trieLogPruner.addToPruneQueue(2, key(2));
@@ -240,7 +254,8 @@ public class TrieLogPrunerTest {
     // Given
     final TriggerableConsumer triggerableConsumer = new TriggerableConsumer();
     TrieLogPruner trieLogPruner =
-        new TrieLogPruner(worldState, blockchain, triggerableConsumer, 0, 1, false);
+        new TrieLogPruner(
+            worldState, blockchain, triggerableConsumer, 0, 1, false, new NoOpMetricsSystem());
     assertThat(trieLogPruner.pruneFromQueue()).isEqualTo(0);
 
     final TrieLogLayer layer = new TrieLogLayer();
@@ -261,7 +276,8 @@ public class TrieLogPrunerTest {
   public void onTrieLogAdded_should_not_prune_when_no_blockNumber() {
     // Given
     TrieLogPruner trieLogPruner =
-        new TrieLogPruner(worldState, blockchain, executeAsync, 0, 1, false);
+        new TrieLogPruner(
+            worldState, blockchain, executeAsync, 0, 1, false, new NoOpMetricsSystem());
     assertThat(trieLogPruner.pruneFromQueue()).isEqualTo(0);
 
     final TrieLogLayer layer = new TrieLogLayer();
@@ -289,7 +305,13 @@ public class TrieLogPrunerTest {
     when(blockchain.getChainHeadBlockNumber()).thenReturn(chainHeight);
     TrieLogPruner trieLogPruner =
         new TrieLogPruner(
-            worldState, blockchain, executeAsync, blocksToRetain, pruningWindowSize, true);
+            worldState,
+            blockchain,
+            executeAsync,
+            blocksToRetain,
+            pruningWindowSize,
+            true,
+            new NoOpMetricsSystem());
 
     trieLogPruner.addToPruneQueue(1, key(1));
     trieLogPruner.addToPruneQueue(2, key(2));


### PR DESCRIPTION
## PR description

Add 3 counters, can be referenced in grafana with:
besu_pruner_trie_log_added_to_prune_queue_total
besu_pruner_trie_log_pruned_from_queue_total
besu_pruner_trie_log_pruned_trie_log_pruned_orphan_total

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

