### PR TITLE
Disable limit trie logs for trie log subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Bug fixes
 - Fix `eth_call` deserialization to correctly ignore unknown fields in the transaction object. [#7323](https://github.com/hyperledger/besu/pull/7323)
+- Avoid executing pruner preload during trie log subcommands [#7366](https://github.com/hyperledger/besu/pull/7366)
 
 ## 24.7.0
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2233,6 +2233,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     return miningParameters;
   }
 
+  /**
+   * Get the data storage configuration
+   *
+   * @return the data storage configuration
+   */
   public DataStorageConfiguration getDataStorageConfiguration() {
     if (dataStorageConfiguration == null) {
       dataStorageConfiguration = dataStorageOptions.toDomainObject();

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -2233,7 +2233,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     return miningParameters;
   }
 
-  private DataStorageConfiguration getDataStorageConfiguration() {
+  public DataStorageConfiguration getDataStorageConfiguration() {
     if (dataStorageConfiguration == null) {
       dataStorageConfiguration = dataStorageOptions.toDomainObject();
     }

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommand.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogPruner;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguration;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 
 import java.io.IOException;
@@ -82,7 +83,14 @@ public class TrieLogSubCommand implements Runnable {
   }
 
   private static BesuController createBesuController() {
-    return parentCommand.besuCommand.buildController();
+    final DataStorageConfiguration config = parentCommand.besuCommand.getDataStorageConfiguration();
+    // disable limit trie logs to avoid preloading during subcommand execution
+    return parentCommand
+        .besuCommand
+        .getControllerBuilder()
+        .dataStorageConfiguration(
+            ImmutableDataStorageConfiguration.copyOf(config).withBonsaiLimitTrieLogsEnabled(false))
+        .build();
   }
 
   @Command(

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/TrieLogSubCommandTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.subcommands.storage;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+import org.hyperledger.besu.cli.CommandTestAbstract;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class TrieLogSubCommandTest extends CommandTestAbstract {
+
+  @Test
+  void limitTrieLogsDefaultDisabledForAllSubcommands() {
+    assertTrieLogSubcommand("prune");
+    assertTrieLogSubcommand("count");
+    assertTrieLogSubcommand("import");
+    assertTrieLogSubcommand("export");
+  }
+
+  @Test
+  void limitTrieLogsDisabledForAllSubcommands() {
+    assertTrieLogSubcommandWithExplicitLimitEnabled("prune");
+    assertTrieLogSubcommandWithExplicitLimitEnabled("count");
+    assertTrieLogSubcommandWithExplicitLimitEnabled("import");
+    assertTrieLogSubcommandWithExplicitLimitEnabled("export");
+  }
+
+  private void assertTrieLogSubcommand(final String trieLogSubcommand) {
+    parseCommand("storage", "trie-log", trieLogSubcommand);
+    assertConfigurationIsDisabledBySubcommand();
+  }
+
+  private void assertTrieLogSubcommandWithExplicitLimitEnabled(final String trieLogSubcommand) {
+    parseCommand("--bonsai-limit-trie-logs-enabled=true", "storage", "trie-log", trieLogSubcommand);
+    assertConfigurationIsDisabledBySubcommand();
+  }
+
+  private void assertConfigurationIsDisabledBySubcommand() {
+    verify(mockControllerBuilder, atLeastOnce())
+        .dataStorageConfiguration(dataStorageConfigurationArgumentCaptor.capture());
+    final List<DataStorageConfiguration> configs =
+        dataStorageConfigurationArgumentCaptor.getAllValues();
+    assertThat(configs.get(0).getBonsaiLimitTrieLogsEnabled()).isTrue();
+    assertThat(configs.get(1).getBonsaiLimitTrieLogsEnabled()).isFalse();
+  }
+
+  @Test
+  void limitTrieLogsDefaultEnabledForBesuMainCommand() {
+    parseCommand();
+    verify(mockControllerBuilder, atLeastOnce())
+        .dataStorageConfiguration(dataStorageConfigurationArgumentCaptor.capture());
+    final List<DataStorageConfiguration> configs =
+        dataStorageConfigurationArgumentCaptor.getAllValues();
+    assertThat(configs).allMatch(DataStorageConfiguration::getBonsaiLimitTrieLogsEnabled);
+  }
+}


### PR DESCRIPTION
## PR description

This avoids executing TrieLogPruner.preload unnecessarily during execution of the various trie log subcommands.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests