### PR TITLE
Update GeneralStateTestCaseEipSpec for use in linea-arithmetization

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -232,7 +232,7 @@ public class StateTestSubCommand implements Runnable {
       }
 
       final BlockHeader blockHeader = spec.getBlockHeader();
-      final Transaction transaction = spec.getTransaction();
+      final Transaction transaction = spec.getTransaction(0);
       final ObjectNode summaryLine = objectMapper.createObjectNode();
       if (transaction == null) {
         if (parentCommand.showJsonAlloc || parentCommand.showJsonResults) {

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseEipSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseEipSpec.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 public class GeneralStateTestCaseEipSpec {
@@ -33,7 +34,7 @@ public class GeneralStateTestCaseEipSpec {
   // anything
   // is run, which isn't friendly and 2) this makes it harder to parallelize this step. Anyway, this
   // is why this is a supplier: calling get() actually does the signing.
-  private final Supplier<Transaction> transactionSupplier;
+  private final List<Supplier<Transaction>> transactionSuppliers;
 
   private final ReferenceTestWorldState initialWorldState;
 
@@ -51,7 +52,7 @@ public class GeneralStateTestCaseEipSpec {
 
   GeneralStateTestCaseEipSpec(
       final String fork,
-      final Supplier<Transaction> transactionSupplier,
+      final List<Supplier<Transaction>> transactionSuppliers,
       final ReferenceTestWorldState initialWorldState,
       final Hash expectedRootHash,
       final Hash expectedLogsHash,
@@ -61,7 +62,7 @@ public class GeneralStateTestCaseEipSpec {
       final int valueIndex,
       final String expectException) {
     this.fork = fork;
-    this.transactionSupplier = transactionSupplier;
+    this.transactionSuppliers = transactionSuppliers;
     this.initialWorldState = initialWorldState;
     this.expectedRootHash = expectedRootHash;
     this.expectedLogsHash = expectedLogsHash;
@@ -88,9 +89,13 @@ public class GeneralStateTestCaseEipSpec {
     return expectedLogsHash;
   }
 
-  public Transaction getTransaction() {
+  public int getTransactionsCount() {
+    return transactionSuppliers.size();
+  }
+
+  public Transaction getTransaction(final int txIndex) {
     try {
-      return transactionSupplier.get();
+      return transactionSuppliers.get(txIndex).get();
     } catch (RuntimeException re) {
       // some tests specify invalid transactions.  We throw exceptions in
       // GeneralStateTests but they are encoded in BlockchainTests, so we

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
@@ -72,11 +72,12 @@ public class GeneralStateTestCaseSpec {
                 .stateRoot(p.rootHash)
                 .blockHeaderFunctions(MAINNET_FUNCTIONS)
                 .buildBlockHeader();
-        final Supplier<Transaction> txSupplier = () -> versionedTransaction.get(p.indexes);
+        final List<Supplier<Transaction>> txSupplierList =
+                List.of(() -> versionedTransaction.get(p.indexes));
         specs.add(
             new GeneralStateTestCaseEipSpec(
                 eip,
-                txSupplier,
+                txSupplierList,
                 initialWorldState,
                 p.rootHash,
                 p.logsHash,

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/GeneralStateTestCaseSpec.java
@@ -73,7 +73,7 @@ public class GeneralStateTestCaseSpec {
                 .blockHeaderFunctions(MAINNET_FUNCTIONS)
                 .buildBlockHeader();
         final List<Supplier<Transaction>> txSupplierList =
-                List.of(() -> versionedTransaction.get(p.indexes));
+            List.of(() -> versionedTransaction.get(p.indexes));
         specs.add(
             new GeneralStateTestCaseEipSpec(
                 eip,

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -120,7 +120,7 @@ public class GeneralStateReferenceTestTools {
   public static void executeTest(final GeneralStateTestCaseEipSpec spec) {
     final BlockHeader blockHeader = spec.getBlockHeader();
     final ReferenceTestWorldState initialWorldState = spec.getInitialWorldState();
-    final Transaction transaction = spec.getTransaction();
+    final Transaction transaction = spec.getTransaction(0);
     ProtocolSpec protocolSpec = protocolSpec(spec.getFork());
 
     BlockchainReferenceTestTools.verifyJournaledEVMAccountCompatability(initialWorldState, protocolSpec);


### PR DESCRIPTION
## PR description
In linea arithmetization we are updating unit tests to use the GeneralStateTestCaseEipSpec for testing. For that I need to 

1. Update the constructor to public so that it can be instantiated in other packages.
2. Include multiple transactions as we have unit tests that test multiple transactions.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

