### PR TITLE
Move `JsonRpcResponseType` to `RpcResponseType` in the plugin API module

### DIFF
--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/DiscardTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/DiscardTest.java
@@ -28,9 +28,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +61,7 @@ public class DiscardTest {
 
     final JsonRpcResponse response = discard.response(requestWithParams(a0));
 
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
@@ -77,7 +77,7 @@ public class DiscardTest {
     final JsonRpcResponse response = discard.response(requestWithParams(a0));
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -92,7 +92,7 @@ public class DiscardTest {
     final JsonRpcResponse response = discard.response(requestWithParams(a0));
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -111,7 +111,7 @@ public class DiscardTest {
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.ADD);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/ProposeTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/jsonrpc/methods/ProposeTest.java
@@ -27,10 +27,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.ADD);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -72,7 +72,7 @@ public class ProposeTest {
     final JsonRpcResponse response = propose.response(requestWithParams(a0, true));
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
     final JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(RpcErrorType.INVALID_REQUEST);
   }
@@ -86,7 +86,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.DROP);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -99,7 +99,7 @@ public class ProposeTest {
     final JsonRpcResponse response = propose.response(requestWithParams(a0, false));
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0)).isNull();
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
     final JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(RpcErrorType.INVALID_REQUEST);
   }
@@ -114,7 +114,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.ADD);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -129,7 +129,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.DROP);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -144,7 +144,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a1))
         .isEqualTo(VoteType.ADD);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }
@@ -159,7 +159,7 @@ public class ProposeTest {
 
     assertThat(validatorProvider.getVoteProviderAtHead().get().getProposals().get(a0))
         .isEqualTo(VoteType.DROP);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo(true);
   }

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugTraceTransactionIntegrationTest.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/DebugTraceTransactionIntegrationTest.java
@@ -23,9 +23,9 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.DebugTraceTransactionResult;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 import org.hyperledger.besu.testutil.BlockTestUtil;
 
 import java.util.Map;
@@ -69,7 +69,7 @@ public class DebugTraceTransactionIntegrationTest {
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", DEBUG_TRACE_TRANSACTION, params));
 
     final JsonRpcResponse response = method.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     DebugTraceTransactionResult debugTraceTransactionResult =
         (DebugTraceTransactionResult) ((JsonRpcSuccessResponse) response).getResult();
     assertThat(debugTraceTransactionResult.getGas()).isEqualTo(23705L);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcArrayExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcArrayExecutor.java
@@ -22,8 +22,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.context.ContextKey;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.io.IOException;
 
@@ -74,7 +74,7 @@ public class JsonRpcArrayExecutor extends AbstractJsonRpcExecutor {
       generator.writeStartArray();
       for (int i = 0; i < rpcRequestBatch.size(); i++) {
         JsonRpcResponse response = processMaybeRequest(rpcRequestBatch.getValue(i));
-        if (response.getType() != JsonRpcResponseType.NONE) {
+        if (response.getType() != RpcResponseType.NONE) {
           generator.writeObject(response);
         }
       }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcObjectExecutor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcObjectExecutor.java
@@ -22,8 +22,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.context.ContextKey;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.io.IOException;
 
@@ -70,7 +70,7 @@ public class JsonRpcObjectExecutor extends AbstractJsonRpcExecutor {
       final RoutingContext ctx)
       throws IOException {
     response.setStatusCode(status(jsonRpcResponse).code());
-    if (jsonRpcResponse.getType() == JsonRpcResponseType.NONE) {
+    if (jsonRpcResponse.getType() == RpcResponseType.NONE) {
       response.end();
     } else {
       try (final JsonResponseStreamer streamer =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TracedJsonRpcProcessor.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/execution/TracedJsonRpcProcessor.java
@@ -19,11 +19,11 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestId;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -52,7 +52,7 @@ public class TracedJsonRpcProcessor implements JsonRpcProcessor {
       final Span metricSpan,
       final JsonRpcRequestContext request) {
     JsonRpcResponse jsonRpcResponse = rpcProcessor.process(id, method, metricSpan, request);
-    if (JsonRpcResponseType.ERROR == jsonRpcResponse.getType()) {
+    if (RpcResponseType.ERROR == jsonRpcResponse.getType()) {
       JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) jsonRpcResponse;
       this.rpcErrorsCounter.labels(method.getName(), errorResponse.getErrorType().name()).inc();
       switch (errorResponse.getErrorType()) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcErrorResponse.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,8 +73,8 @@ public class JsonRpcErrorResponse implements JsonRpcResponse {
 
   @Override
   @JsonIgnore
-  public JsonRpcResponseType getType() {
-    return JsonRpcResponseType.ERROR;
+  public RpcResponseType getType() {
+    return RpcResponseType.ERROR;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcNoResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcNoResponse.java
@@ -14,10 +14,12 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
 public class JsonRpcNoResponse implements JsonRpcResponse {
 
   @Override
-  public JsonRpcResponseType getType() {
-    return JsonRpcResponseType.NONE;
+  public RpcResponseType getType() {
+    return RpcResponseType.NONE;
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcResponse.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
 import com.fasterxml.jackson.annotation.JsonGetter;
 
 public interface JsonRpcResponse {
@@ -23,5 +25,5 @@ public interface JsonRpcResponse {
     return "2.0";
   }
 
-  JsonRpcResponseType getType();
+  RpcResponseType getType();
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcSuccessResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcSuccessResponse.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -50,8 +52,8 @@ public class JsonRpcSuccessResponse implements JsonRpcResponse {
 
   @Override
   @JsonIgnore
-  public JsonRpcResponseType getType() {
-    return JsonRpcResponseType.SUCCESS;
+  public RpcResponseType getType() {
+    return RpcResponseType.SUCCESS;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcUnauthorizedResponse.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/JsonRpcUnauthorizedResponse.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -50,8 +52,8 @@ public class JsonRpcUnauthorizedResponse implements JsonRpcResponse {
 
   @Override
   @JsonIgnore
-  public JsonRpcResponseType getType() {
-    return JsonRpcResponseType.UNAUTHORIZED;
+  public RpcResponseType getType() {
+    return RpcResponseType.UNAUTHORIZED;
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/ipc/JsonRpcIpcService.java
@@ -20,8 +20,8 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -155,7 +155,7 @@ public class JsonRpcIpcService {
                                                 .filter(
                                                     jsonRpcResponse ->
                                                         jsonRpcResponse.getType()
-                                                            != JsonRpcResponseType.NONE)
+                                                            != RpcResponseType.NONE)
                                                 .toArray(JsonRpcResponse[]::new);
 
                                         socket.write(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketMessageHandler.java
@@ -20,10 +20,10 @@ import org.hyperledger.besu.ethereum.api.handlers.IsAliveHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketRpcRequest;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -151,7 +151,7 @@ public class WebSocketMessageHandler {
                         jsonRpcBatchResponse.stream()
                             .filter(
                                 jsonRpcResponse ->
-                                    jsonRpcResponse.getType() != JsonRpcResponseType.NONE)
+                                    jsonRpcResponse.getType() != RpcResponseType.NONE)
                             .toArray(JsonRpcResponse[]::new);
                     replyToClient(websocket, completed);
                   })

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResult;
@@ -41,6 +40,7 @@ import org.hyperledger.besu.ethereum.core.Synchronizer;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.List;
 
@@ -146,7 +146,7 @@ public class EthGetBlockByNumberTest {
   @Test
   public void errorWhenAskingFinalizedButFinalizedIsNotPresent() {
     JsonRpcResponse resp = method.response(requestWithParams("finalized", "false"));
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     JsonRpcErrorResponse errorResp = (JsonRpcErrorResponse) resp;
     assertThat(errorResp.getErrorType()).isEqualTo(RpcErrorType.UNKNOWN_BLOCK);
   }
@@ -154,7 +154,7 @@ public class EthGetBlockByNumberTest {
   @Test
   public void errorWhenAskingSafeButSafeIsNotPresent() {
     JsonRpcResponse resp = method.response(requestWithParams("safe", "false"));
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     JsonRpcErrorResponse errorResp = (JsonRpcErrorResponse) resp;
     assertThat(errorResp.getErrorType()).isEqualTo(RpcErrorType.UNKNOWN_BLOCK);
   }
@@ -181,7 +181,7 @@ public class EthGetBlockByNumberTest {
 
   private void assertSuccess(final String tag, final long height) {
     JsonRpcResponse resp = method.response(requestWithParams(tag, "false"));
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     JsonRpcSuccessResponse successResp = (JsonRpcSuccessResponse) resp;
     BlockResult blockResult = (BlockResult) successResp.getResult();
     assertThat(blockResult.getHash())

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -44,7 +44,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePaylo
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.WithdrawalParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineUpdateForkchoiceResult;
@@ -55,6 +54,7 @@ import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.mainnet.WithdrawalsValidator;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.List;
 import java.util.Optional;
@@ -752,7 +752,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
   abstract String getMethodName();
 
   private EngineUpdateForkchoiceResult fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)
@@ -766,7 +766,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
 
   private void assertInvalidForkchoiceState(
       final JsonRpcResponse resp, final RpcErrorType jsonRpcError) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
 
     var errorResp = (JsonRpcErrorResponse) resp;
     assertThat(errorResp.getErrorType()).isEqualTo(jsonRpcError);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayloadTest.java
@@ -47,7 +47,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.WithdrawalR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EnginePayloadStatusResult;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -66,6 +65,7 @@ import org.hyperledger.besu.ethereum.mainnet.WithdrawalsValidator;
 import org.hyperledger.besu.ethereum.mainnet.requests.RequestsValidatorCoordinator;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.plugin.services.exception.StorageException;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -459,7 +459,7 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
   }
 
   protected EnginePayloadStatusResult fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)
@@ -468,7 +468,7 @@ public abstract class AbstractEngineNewPayloadTest extends AbstractScheduledApiT
   }
 
   protected JsonRpcError fromErrorResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     return Optional.of(resp)
         .map(JsonRpcErrorResponse.class::cast)
         .map(JsonRpcErrorResponse::getError)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeCapabilitiesTest.java
@@ -23,8 +23,8 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Collections;
 import java.util.List;
@@ -85,7 +85,7 @@ public class EngineExchangeCapabilitiesTest {
 
   @SuppressWarnings("unchecked")
   private List<String> fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineExchangeTransitionConfigurationTest.java
@@ -30,7 +30,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineExchangeTransitionConfigurationParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.UnsignedLongParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineExchangeTransitionConfigurationResult;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -39,6 +38,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.Difficulty;
 import org.hyperledger.besu.ethereum.core.ParsedExtraData;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.math.BigInteger;
 import java.util.Map;
@@ -223,7 +223,7 @@ public class EngineExchangeTransitionConfigurationTest {
   }
 
   private EngineExchangeTransitionConfigurationResult fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByHashV1Test.java
@@ -31,7 +31,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
@@ -40,6 +39,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Collections;
 import java.util.List;
@@ -255,7 +255,7 @@ public class EngineGetPayloadBodiesByHashV1Test {
   }
 
   private EngineGetPayloadBodiesResultV1 fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)
@@ -264,7 +264,7 @@ public class EngineGetPayloadBodiesByHashV1Test {
   }
 
   private RpcErrorType fromErrorResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     return Optional.of(resp)
         .map(JsonRpcErrorResponse.class::cast)
         .map(JsonRpcErrorResponse::getErrorType)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadBodiesByRangeV1Test.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcError;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.BlockResultFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.EngineGetPayloadBodiesResultV1;
@@ -41,6 +40,7 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.TransactionTestFixture;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Collections;
 import java.util.List;
@@ -344,7 +344,7 @@ public class EngineGetPayloadBodiesByRangeV1Test {
   }
 
   private EngineGetPayloadBodiesResultV1 fromSuccessResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.SUCCESS);
     return Optional.of(resp)
         .map(JsonRpcSuccessResponse.class::cast)
         .map(JsonRpcSuccessResponse::getResult)
@@ -353,7 +353,7 @@ public class EngineGetPayloadBodiesByRangeV1Test {
   }
 
   private JsonRpcError fromErrorResp(final JsonRpcResponse resp) {
-    assertThat(resp.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
     return Optional.of(resp)
         .map(JsonRpcErrorResponse.class::cast)
         .map(JsonRpcErrorResponse::getError)

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecoratorTest.java
@@ -22,10 +22,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcUnauthorizedResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.auth.User;
@@ -58,7 +58,7 @@ public class MultiTenancyRpcMethodDecoratorTest {
     assertThat(tokenRpcDecorator.getName()).isEqualTo("delegate");
 
     final JsonRpcResponse response = tokenRpcDecorator.response(rpcRequestContext);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final JsonRpcSuccessResponse successResponse = (JsonRpcSuccessResponse) response;
     assertThat(successResponse.getResult()).isEqualTo("b");
   }
@@ -73,7 +73,7 @@ public class MultiTenancyRpcMethodDecoratorTest {
     assertThat(tokenRpcDecorator.getName()).isEqualTo("delegate");
 
     final JsonRpcResponse response = tokenRpcDecorator.response(rpcRequestContext);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.UNAUTHORIZED);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.UNAUTHORIZED);
     final JsonRpcUnauthorizedResponse errorResponse = (JsonRpcUnauthorizedResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(RpcErrorType.UNAUTHORIZED);
   }
@@ -89,7 +89,7 @@ public class MultiTenancyRpcMethodDecoratorTest {
     assertThat(tokenRpcDecorator.getName()).isEqualTo("delegate");
 
     final JsonRpcResponse response = tokenRpcDecorator.response(rpcRequestContext);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
     final JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(RpcErrorType.INVALID_REQUEST);
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRootTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRootTest.java
@@ -33,11 +33,11 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacyIdProvider;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.privacy.RestrictedDefaultPrivacyController;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -91,7 +91,7 @@ public class PrivDebugGetStateRootTest {
     when(privacyController.findPrivacyGroupByGroupId(anyString(), anyString()))
         .thenReturn(Optional.empty());
     final JsonRpcResponse response = method.response(request("not_base64", "latest"));
-    assertThat(response.getType()).isEqualByComparingTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualByComparingTo(RpcResponseType.ERROR);
     assertThat(((JsonRpcErrorResponse) response).getError().getMessage())
         .contains(FIND_PRIVACY_GROUP_ERROR.getMessage());
   }
@@ -102,7 +102,7 @@ public class PrivDebugGetStateRootTest {
         .thenReturn(Optional.empty());
     final String invalidGroupId = Base64.toBase64String("invalid_group_id".getBytes(UTF_8));
     final JsonRpcResponse response = method.response(request(invalidGroupId, "latest"));
-    assertThat(response.getType()).isEqualByComparingTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualByComparingTo(RpcResponseType.ERROR);
     assertThat(((JsonRpcErrorResponse) response).getError().getMessage())
         .contains(FIND_PRIVACY_GROUP_ERROR.getMessage());
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/MutableJsonRpcSuccessResponse.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/MutableJsonRpcSuccessResponse.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
 
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -74,8 +76,8 @@ public class MutableJsonRpcSuccessResponse {
   }
 
   @JsonIgnore
-  public JsonRpcResponseType getType() {
-    return JsonRpcResponseType.SUCCESS;
+  public RpcResponseType getType() {
+    return RpcResponseType.SUCCESS;
   }
 
   @Override

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethodsTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.MultiT
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.PrivacyIdProvider;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
@@ -35,6 +34,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFactory;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.util.Map;
 import java.util.Optional;
@@ -140,7 +140,7 @@ public class PrivacyApiGroupJsonRpcMethodsTest {
     final JsonRpcRequestContext request =
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", "priv_method", null));
     final JsonRpcResponse response = privMethod.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
 
     JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse) response;
     assertThat(errorResponse.getErrorType()).isEqualTo(PRIVACY_NOT_ENABLED);

--- a/ethereum/retesteth/src/test/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlockTest.java
+++ b/ethereum/retesteth/src/test/java/org/hyperledger/besu/ethereum/retesteth/methods/TestImportRawBlockTest.java
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponseType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.retesteth.RetestethContext;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
 
 import java.io.IOException;
 
@@ -69,7 +69,7 @@ public class TestImportRawBlockTest {
                 "2.0", TestImportRawBlock.METHOD_NAME, new Object[] {rawBlockRLPString}));
 
     final var response = test_importRawBlock.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
     assertThat(((JsonRpcErrorResponse) response).getErrorType())
         .isEqualTo(RpcErrorType.BLOCK_IMPORT_ERROR);
   }
@@ -84,7 +84,7 @@ public class TestImportRawBlockTest {
                 "2.0", TestImportRawBlock.METHOD_NAME, new Object[] {rawBlockRLPString}));
 
     final var response = test_importRawBlock.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.ERROR);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.ERROR);
     assertThat(((JsonRpcErrorResponse) response).getErrorType())
         .isEqualTo(RpcErrorType.BLOCK_RLP_IMPORT_ERROR);
   }
@@ -100,7 +100,7 @@ public class TestImportRawBlockTest {
                 "2.0", TestImportRawBlock.METHOD_NAME, new Object[] {rawBlockRLPString}));
 
     final var response = test_importRawBlock.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
   }
 
   @Test
@@ -118,11 +118,11 @@ public class TestImportRawBlockTest {
             new JsonRpcRequest("2.0", TestRewindToBlock.METHOD_NAME, new Object[] {0L}));
 
     final var response = test_importRawBlock.response(request);
-    assertThat(response.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(response.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final var rewindResponse = test_rewindToBlock.response(requestRewind);
-    assertThat(rewindResponse.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(rewindResponse.getType()).isEqualTo(RpcResponseType.SUCCESS);
     final var reimportResponse = test_importRawBlock.response(request);
-    assertThat(reimportResponse.getType()).isEqualTo(JsonRpcResponseType.SUCCESS);
+    assertThat(reimportResponse.getType()).isEqualTo(RpcResponseType.SUCCESS);
 
     assertThat(context.getBlockchain().getChainHead().getHeight()).isEqualTo(1L);
   }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -70,7 +70,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '6L5dNJ975Ka/X7g4lTdpkBvPQrJgJu+vAf/m1dFCneU='
+  knownHash = 'oPsVhFhdIkzHqD+jjwRX7dbgeNeKbpCmPjiBWDdMV7o='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/rpc/RpcResponseType.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/rpc/RpcResponseType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Hyperledger Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -12,12 +12,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.api.jsonrpc.internal.response;
+package org.hyperledger.besu.plugin.services.rpc;
 
-/** Various types of responses that the JSON-RPC component may produce. */
-public enum JsonRpcResponseType {
+/** Various types of responses that the RPC component may produce. */
+public enum RpcResponseType {
+  /** No response */
   NONE,
+  /** Successful response */
   SUCCESS,
+  /** Error response */
   ERROR,
+  /** Not authorized response */
   UNAUTHORIZED
 }


### PR DESCRIPTION
## PR description

This PR has is preparatory for PR https://github.com/hyperledger/besu/pull/7379/, to make the latter easier to review, there are no functional changes here, but just the move `JsonRpcResponseType` to `RpcResponseType` in the plugin API module.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

