### PR TITLE
Refactor TrieLogPruner preload timeout to be more testable

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
@@ -161,13 +161,11 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
       int prunedCount = pruneFromQueue();
       LOG.atInfo().log("Pruned {} trie logs", prunedCount);
     } catch (Exception e) {
-      LOG.warn(e.getClass().getSimpleName() + " occurred while preloading queue", e);
-      if (e.getCause() != null && e.getCause() instanceof InterruptedException) {
+      if (e instanceof InterruptedException
+          || (e.getCause() != null && e.getCause() instanceof InterruptedException)) {
         LOG.info("Operation interrupted, but will attempt to prune what's in the queue so far...");
         int prunedCount = pruneFromQueue();
-        if (prunedCount > 0) {
-          LOG.atInfo().log("...pruned {} trie logs", prunedCount);
-        }
+        LOG.atInfo().log("...pruned {} trie logs", prunedCount);
         Thread.currentThread().interrupt(); // Preserve interrupt status
       } else {
         LOG.error("Error loading trie logs from database, nothing pruned", e);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
@@ -98,6 +98,7 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
   @VisibleForTesting
   void preloadQueueWithTimeout(final int timeoutInSeconds) {
 
+    LOG.info("Trie log pruner queue preload starting...");
     LOG.atInfo()
         .setMessage("Attempting to load first {} trie logs from database...")
         .addArgument(loadingLimit)
@@ -125,6 +126,7 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
             .log();
       }
     }
+    LOG.info("Trie log pruner queue preload complete.");
   }
 
   private void preloadQueue() {
@@ -153,12 +155,14 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
           "Added {} trie logs to prune queue. Commencing pruning of eligible trie logs...",
           addToPruneQueueCount.intValue());
       int prunedCount = pruneFromQueue();
-      LOG.atInfo().log("Pruned {} trie logs.", prunedCount);
+      LOG.atInfo().log("Pruned {} trie logs", prunedCount);
     } catch (Exception e) {
+      LOG.warn(e.getClass().getSimpleName() + " occurred while preloading queue", e);
       if (e instanceof InterruptedException) {
+        LOG.info("Operation interrupted, but will attempt to prune what's in the queue so far...");
         int prunedCount = pruneFromQueue();
         if (prunedCount > 0) {
-          LOG.atInfo().log("Operation interrupted, but still pruned {} trie logs.", prunedCount);
+          LOG.atInfo().log("...pruned {} trie logs", prunedCount);
         }
       } else {
         LOG.error("Error loading trie logs from database, nothing pruned", e);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPruner.java
@@ -26,16 +26,17 @@ import org.hyperledger.besu.plugin.services.trielogs.TrieLogEvent;
 
 import java.util.Comparator;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
@@ -91,43 +92,42 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
   }
 
   public void initialize() {
-    preloadQueueWithTimeout();
+    preloadQueueWithTimeout(PRELOAD_TIMEOUT_IN_SECONDS);
   }
 
-  private void preloadQueueWithTimeout() {
+  @VisibleForTesting
+  void preloadQueueWithTimeout(final int timeoutInSeconds) {
 
     LOG.atInfo()
         .setMessage("Attempting to load first {} trie logs from database...")
         .addArgument(loadingLimit)
         .log();
 
-    try (final ScheduledExecutorService preloadExecutor = Executors.newScheduledThreadPool(1)) {
+    try (final ExecutorService preloadExecutor = Executors.newSingleThreadExecutor()) {
+      final Future<?> future = preloadExecutor.submit(this::preloadQueue);
 
-      final AtomicBoolean timeoutOccurred = new AtomicBoolean(false);
-      final Runnable timeoutTask =
-          () -> {
-            timeoutOccurred.set(true);
-            LOG.atWarn()
-                .setMessage(
-                    "Timeout occurred while loading and processing {} trie logs from database")
-                .addArgument(loadingLimit)
-                .log();
-          };
-
-      final ScheduledFuture<?> timeoutFuture =
-          preloadExecutor.schedule(timeoutTask, PRELOAD_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
       LOG.atInfo()
           .setMessage(
               "Trie log pruning will timeout after {} seconds. If this is timing out, consider using `besu storage trie-log prune` subcommand, see https://besu.hyperledger.org/public-networks/how-to/bonsai-limit-trie-logs")
-          .addArgument(PRELOAD_TIMEOUT_IN_SECONDS)
+          .addArgument(timeoutInSeconds)
           .log();
 
-      preloadQueue(timeoutOccurred, timeoutFuture);
+      try {
+        future.get(timeoutInSeconds, TimeUnit.SECONDS);
+      } catch (InterruptedException | ExecutionException e) {
+        LOG.error("Error loading trie logs from database", e);
+        future.cancel(true);
+      } catch (TimeoutException e) {
+        future.cancel(true);
+        LOG.atWarn()
+            .setMessage("Timeout occurred while loading and processing {} trie logs from database")
+            .addArgument(loadingLimit)
+            .log();
+      }
     }
   }
 
-  private void preloadQueue(
-      final AtomicBoolean timeoutOccurred, final ScheduledFuture<?> timeoutFuture) {
+  private void preloadQueue() {
 
     try (final Stream<byte[]> trieLogKeys = rootWorldStateStorage.streamTrieLogKeys(loadingLimit)) {
 
@@ -135,10 +135,6 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
       final AtomicLong orphansPruned = new AtomicLong();
       trieLogKeys.forEach(
           blockHashAsBytes -> {
-            if (timeoutOccurred.get()) {
-              throw new RuntimeException(
-                  new TimeoutException("Timeout occurred while preloading trie log prune queue"));
-            }
             final Hash blockHash = Hash.wrap(Bytes32.wrap(blockHashAsBytes));
             final Optional<BlockHeader> header = blockchain.getBlockHeader(blockHash);
             if (header.isPresent()) {
@@ -152,7 +148,6 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
             }
           });
 
-      timeoutFuture.cancel(true);
       LOG.atDebug().log("Pruned {} orphaned trie logs from database...", orphansPruned.intValue());
       LOG.atInfo().log(
           "Added {} trie logs to prune queue. Commencing pruning of eligible trie logs...",
@@ -160,9 +155,11 @@ public class TrieLogPruner implements TrieLogEvent.TrieLogObserver {
       int prunedCount = pruneFromQueue();
       LOG.atInfo().log("Pruned {} trie logs.", prunedCount);
     } catch (Exception e) {
-      if (e.getCause() != null && e.getCause() instanceof TimeoutException) {
+      if (e instanceof InterruptedException) {
         int prunedCount = pruneFromQueue();
-        LOG.atInfo().log("Operation timed out, but still pruned {} trie logs.", prunedCount);
+        if (prunedCount > 0) {
+          LOG.atInfo().log("Operation interrupted, but still pruned {} trie logs.", prunedCount);
+        }
       } else {
         LOG.error("Error loading trie logs from database, nothing pruned", e);
       }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPrunerTest.java
@@ -123,6 +123,8 @@ public class TrieLogPrunerTest {
 
     // Then
     assertThat(elapsedTime).isLessThan(timeoutInMillis * 2);
+    verify(worldState, times(1)).pruneTrieLog(key(1));
+    verify(worldState, times(1)).pruneTrieLog(key(2));
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPrunerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogPrunerTest.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.trielog;
+package org.hyperledger.besu.ethereum.trie.diffbased.common.trielog;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,9 +26,6 @@ import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockDataGenerator;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
-import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogAddedEvent;
-import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
-import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogPruner;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.Optional;
@@ -43,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.mockito.internal.stubbing.answers.AnswersWithDelay;
 
 public class TrieLogPrunerTest {
 
@@ -80,6 +78,51 @@ public class TrieLogPrunerTest {
     // Then
     verify(worldState, times(1)).streamTrieLogKeys(2);
     verify(worldState, times(1)).pruneTrieLog(header2.getBlockHash());
+  }
+
+  @Test
+  public void preloadQueueWithTimeout_handles_timeout_during_streamTrieLogKeys() {
+    // Given
+    final int timeoutInSeconds = 1;
+    final long timeoutInMillis = timeoutInSeconds * 1000;
+    final int loadingLimit = 2;
+    TrieLogPruner trieLogPruner =
+        new TrieLogPruner(
+            worldState, blockchain, executeAsync, 3, loadingLimit, false, new NoOpMetricsSystem());
+
+    // Simulate a long-running operation
+    when(worldState.streamTrieLogKeys(loadingLimit))
+        .thenAnswer(new AnswersWithDelay(timeoutInMillis * 2, invocation -> Stream.empty()));
+
+    // When
+    long startTime = System.currentTimeMillis();
+    trieLogPruner.preloadQueueWithTimeout(timeoutInSeconds);
+    long elapsedTime = System.currentTimeMillis() - startTime;
+
+    // Then
+    assertThat(elapsedTime).isLessThan(timeoutInMillis * 2);
+  }
+
+  @Test
+  public void preloadQueueWithTimeout_handles_timeout_during_getBlockHeader() {
+    // Given
+    final int timeoutInSeconds = 1;
+    final long timeoutInMillis = timeoutInSeconds * 1000;
+    TrieLogPruner trieLogPruner = setupPrunerAndFinalizedBlock(3, 1);
+
+    // Simulate a long-running operation
+    when(blockchain.getBlockHeader(any(Hash.class)))
+        // delay on first invocation, then return empty
+        .thenAnswer(new AnswersWithDelay(timeoutInMillis * 2, invocation -> Optional.empty()))
+        .thenReturn(Optional.empty());
+
+    // When
+    long startTime = System.currentTimeMillis();
+    trieLogPruner.preloadQueueWithTimeout(timeoutInSeconds);
+    long elapsedTime = System.currentTimeMillis() - startTime;
+
+    // Then
+    assertThat(elapsedTime).isLessThan(timeoutInMillis * 2);
   }
 
   @Test


### PR DESCRIPTION
An improved version of https://github.com/hyperledger/besu/pull/7365

Example of INFO level logging during timeout...
```
{"@timestamp":"2024-07-29T11:58:49,398","level":"INFO","thread":"main","class":"TrieLogPruner","message":"Trie log pruner queue preload starting...","throwable":""}
{"@timestamp":"2024-07-29T11:58:49,399","level":"INFO","thread":"main","class":"TrieLogPruner","message":"Attempting to load first 5000 trie logs from database...","throwable":""}
{"@timestamp":"2024-07-29T11:58:49,400","level":"INFO","thread":"main","class":"TrieLogPruner","message":"Trie log pruning will timeout after 30 seconds. If this is timing out, consider using `besu storage trie-log prune` subcommand, see https://besu.hyperledger.org/public-networks/how-to/bonsai-limit-trie-logs","throwable":""}
{"@timestamp":"2024-07-29T11:59:19,401","level":"WARN","thread":"main","class":"TrieLogPruner","message":"Timeout occurred while loading and processing 5000 trie logs from database","throwable":""}
{"@timestamp":"2024-07-29T11:59:19,437","level":"INFO","thread":"pool-8-thread-1","class":"TrieLogPruner","message":"Operation interrupted, but will attempt to prune what's in the queue so far...","throwable":""}
{"@timestamp":"2024-07-29T11:59:19,452","level":"INFO","thread":"pool-8-thread-1","class":"TrieLogPruner","message":"...pruned 412 trie logs","throwable":""}
{"@timestamp":"2024-07-29T11:59:19,452","level":"INFO","thread":"main","class":"TrieLogPruner","message":"Trie log pruner queue preload complete.","throwable":""}
```

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

Signed-off-by: Simon Dudley <simon.dudley@consensys.net>