### PR TITLE
Small fuzzing fixes

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
@@ -755,6 +755,7 @@ public class EVMExecutor {
           })
           .process(messageFrame, tracer);
     }
+    initialMessageFrame.getSelfDestructs().forEach(worldUpdater::deleteAccount);
     if (commitWorldState) {
       worldUpdater.commit();
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -140,7 +140,7 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
             null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
       }
     } catch (RuntimeException kzgFailed) {
-      System.out.println(kzgFailed.getMessage());
+      LOG.debug("Native KZG failed", kzgFailed);
 
       return PrecompileContractResult.halt(
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));


### PR DESCRIPTION
## PR description

- Addresses an issue in the Fluent API where certain EVM bytecode could lead to executions that mismatch canonical execution.
- Uses `LOG.debug` instead of `System.out.println` to prevent console spam during fuzzing.

## Fixed Issue(s)

Both lines were written by @shemnon, he can provide more information if required.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

