### PR TITLE
Update newling handling in fuzzing CLI tools

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.web3j.utils.Strings;
 import picocli.CommandLine;
 import picocli.CommandLine.ParentCommand;
 
@@ -107,7 +108,10 @@ public class CodeValidateSubCommand implements Runnable {
       }
     } else {
       for (String code : cliCode) {
-        parentCommand.out.println(considerCode(code));
+        String validation = considerCode(code);
+        if (!Strings.isBlank(validation)) {
+          parentCommand.out.println(validation);
+        }
       }
     }
     parentCommand.out.flush();
@@ -116,7 +120,10 @@ public class CodeValidateSubCommand implements Runnable {
   private void checkCodeFromBufferedReader(final BufferedReader in) {
     try {
       for (String code = in.readLine(); code != null; code = in.readLine()) {
-        parentCommand.out.println(considerCode(code));
+        String validation = considerCode(code);
+        if (!Strings.isBlank(validation)) {
+          parentCommand.out.println(validation);
+        }
       }
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
@@ -107,7 +107,7 @@ public class CodeValidateSubCommand implements Runnable {
       }
     } else {
       for (String code : cliCode) {
-        parentCommand.out.print(considerCode(code));
+        parentCommand.out.println(considerCode(code));
       }
     }
     parentCommand.out.flush();
@@ -116,7 +116,7 @@ public class CodeValidateSubCommand implements Runnable {
   private void checkCodeFromBufferedReader(final BufferedReader in) {
     try {
       for (String code = in.readLine(); code != null; code = in.readLine()) {
-        parentCommand.out.print(considerCode(code));
+        parentCommand.out.println(considerCode(code));
       }
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -142,7 +142,7 @@ public class CodeValidateSubCommand implements Runnable {
           Bytes.fromHexString(
               hexCode.replaceAll("(^|\n)#[^\n]*($|\n)", "").replaceAll("[^0-9A-Za-z]", ""));
     } catch (RuntimeException re) {
-      return "err: hex string -" + re + "\n";
+      return "err: hex string -" + re;
     }
     if (codeBytes.isEmpty()) {
       return "";
@@ -150,7 +150,7 @@ public class CodeValidateSubCommand implements Runnable {
 
     EOFLayout layout = evm.parseEOF(codeBytes);
     if (!layout.isValid()) {
-      return "err: layout - " + layout.invalidReason() + "\n";
+      return "err: layout - " + layout.invalidReason();
     }
 
     Code code = evm.getCodeUncached(codeBytes);
@@ -165,8 +165,7 @@ public class CodeValidateSubCommand implements Runnable {
               .mapToObj(code::getCodeSection)
               .map(cs -> code.getBytes().slice(cs.getEntryPoint(), cs.getLength()))
               .map(Bytes::toUnprefixedHexString)
-              .collect(Collectors.joining(","))
-          + "\n";
+              .collect(Collectors.joining(","));
     }
   }
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/code-validate/initcode.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/code-validate/initcode.json
@@ -3,5 +3,5 @@
     "code-validate"
   ],
   "stdin": "ef000101000402000100060300010014040000000080000260006000ee00ef00010100040200010001040000000080000000",
-  "stdout": "err: code is valid initcode.  Runtime code expected"
+  "stdout": "err: code is valid initcode.  Runtime code expected\n"
 }


### PR DESCRIPTION
## PR description

Update how newlines are handled for fuzzing CLI tools.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

