### PR TITLE
Restore previous behaviour for preMergeBesuControllerBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - In process RPC service [#7395](https://github.com/hyperledger/besu/pull/7395)
 
 ### Bug fixes
+- Fix behaviour when starting in a pre-merge network [#7431](https://github.com/hyperledger/besu/pull/7431)
 
 ## 24.7.1
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -129,7 +129,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                 transitionProtocolSchedule.getPreMergeSchedule(),
                 protocolContext,
                 transactionPool,
-                MiningParameters.MINING_DISABLED,
+                miningParameters.setMiningEnabled(false),
                 syncState,
                 ethProtocolManager),
             mergeBesuControllerBuilder.createTransitionMiningCoordinator(

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -137,7 +137,6 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                             .isMiningEnabled(false)
                             .build())
                     .build(),
-                //                miningParameters.setMiningEnabled(false),
                 syncState,
                 ethProtocolManager),
             mergeBesuControllerBuilder.createTransitionMiningCoordinator(

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
+import org.hyperledger.besu.ethereum.core.ImmutableMiningParameters;
 import org.hyperledger.besu.ethereum.core.MiningParameters;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
@@ -129,7 +130,14 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                 transitionProtocolSchedule.getPreMergeSchedule(),
                 protocolContext,
                 transactionPool,
-                miningParameters.setMiningEnabled(false),
+                ImmutableMiningParameters.builder()
+                    .from(miningParameters)
+                    .mutableInitValues(
+                        ImmutableMiningParameters.MutableInitValues.builder()
+                            .isMiningEnabled(false)
+                            .build())
+                    .build(),
+                //                miningParameters.setMiningEnabled(false),
                 syncState,
                 ethProtocolManager),
             mergeBesuControllerBuilder.createTransitionMiningCoordinator(


### PR DESCRIPTION
## PR description

Let me start by saying that I don't fully understand the intricacies of the `TransitionCoodinator`, so it is possible that this PR is going in the wrong direction. However, after analyzing the changes on https://github.com/hyperledger/besu/pull/6027 I noticed that we have changed the existing behaviour when we are on a pre-merge network. This was caught by one of our tests in Teku that tests the merge transition, when I was trying to upgrade the version of Besu we use in our ATs (we are using 23.10.1).

In the code before commit 20a82d45482194129e68133973533c290be8eb1c, we were building a copy of `MiningParameters` using the instance of mining parameter that was passed as a parameter, that contains the options specified by the user. In this particular case, I am focusing on the `miner-coinbase` option. This is the snippet of code that we were using before:
```
final TransitionCoordinator composedCoordinator =
    new TransitionCoordinator(
        preMergeBesuControllerBuilder.createMiningCoordinator(
            transitionProtocolSchedule.getPreMergeSchedule(),
            protocolContext,
            transactionPool,
            new MiningParameters.Builder(miningParameters).miningEnabled(false).build(), // HERE!!!
            syncState,
            ethProtocolManager),
        mergeBesuControllerBuilder.createTransitionMiningCoordinator(
            transitionProtocolSchedule,
            protocolContext,
            transactionPool,
            transitionMiningParameters,
            syncState,
            transitionBackwardsSyncContext,
            metricsSystem));
```
Using this option, the new instance would preserve all other options specified by the user (including miner-coinbase), but set the flag `mining-enabled` to false.

In the current version of the code, this is the snippet being used:
```
final TransitionCoordinator composedCoordinator =
    new TransitionCoordinator(
        preMergeBesuControllerBuilder.createMiningCoordinator(
            transitionProtocolSchedule.getPreMergeSchedule(),
            protocolContext,
            transactionPool,
            MiningParameters.MINING_DISABLED,  // HERE!!!
            syncState,
            ethProtocolManager),
        mergeBesuControllerBuilder.createTransitionMiningCoordinator(
            transitionProtocolSchedule,
            protocolContext,
            transactionPool,
            transitionMiningParameters,
            syncState,
            transitionBackwardsSyncContext,
            metricsSystem));
```
This way, using the static `MiningParameters.MINING_DISABLED` value, does not preserve any of the other options sey by the user, including the `miner-coinbase` value.

The consequence of such change is that when we follow the execution, there is a call to:
```
composedCoordinator.getPreMergeObject().start();
```
And that eventually lead us to this code from `PowMinerExecutior.java`:
```
@Override
public Optional<PoWBlockMiner> startAsyncMining(
    final Subscribers<MinedBlockObserver> observers,
    final Subscribers<PoWObserver> ethHashObservers,
    final BlockHeader parentHeader) {
  if (miningParameters.getCoinbase().isEmpty()) {
    throw new CoinbaseNotSetException("Unable to start mining without a coinbase.");
  }
  return super.startAsyncMining(observers, ethHashObservers, parentHeader);
}
```
And at this point, because we have completely wiped the user options in mining parameters, we do not have a coinbase set and the node exits with an error.

I am not 100% sure if this is caused by a configuration change that I need to do on my side or not. But what it looks like is that we have somewhat broken our ability to start from a pre-merged network.

I am going to attach one config file (`besu.toml`) and one genesis file (`genesis.json`) that I was using testing this issue. Maybe they will help.

## Fixed Issue(s)
N/A

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

