### PR TITLE
Wrapped WorldUpdater into `EVMWorldupdater`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Additions and Improvements
 - Expose set finalized/safe block in plugin api BlockchainService. These method can be used by plugins to set finalized/safe block for a PoA network (such as QBFT, IBFT and Clique).[#7382](https://github.com/hyperledger/besu/pull/7382)
 - In process RPC service [#7395](https://github.com/hyperledger/besu/pull/7395)
+- Wrap WorldUpdater into EVMWorldupdater [#7434](https://github.com/hyperledger/besu/pull/7434)
 
 ### Bug fixes
 - Correct entrypoint in Docker evmtool [#7430](https://github.com/hyperledger/besu/pull/7430)

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -42,7 +42,7 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.processor.AbstractMessageProcessor;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
-import org.hyperledger.besu.evm.worldstate.AuthorizedCodeService;
+import org.hyperledger.besu.evm.worldstate.EVMWorldUpdater;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Deque;
@@ -286,9 +286,8 @@ public class MainnetTransactionProcessor {
       final TransactionValidationParams transactionValidationParams,
       final PrivateMetadataUpdater privateMetadataUpdater,
       final Wei blobGasPrice) {
+    final EVMWorldUpdater evmWorldUpdater = new EVMWorldUpdater(worldState);
     try {
-      final AuthorizedCodeService authorizedCodeService = new AuthorizedCodeService();
-      worldState.setAuthorizedCodeService(authorizedCodeService);
       final var transactionValidator = transactionValidatorFactory.get();
       LOG.trace("Starting execution of {}", transaction);
       ValidationResult<TransactionInvalidReason> validationResult =
@@ -306,7 +305,7 @@ public class MainnetTransactionProcessor {
       }
 
       final Address senderAddress = transaction.getSender();
-      final MutableAccount sender = worldState.getOrCreateSenderAccount(senderAddress);
+      final MutableAccount sender = evmWorldUpdater.getOrCreateSenderAccount(senderAddress);
 
       validationResult =
           transactionValidator.validateForSender(transaction, sender, transactionValidationParams);
@@ -315,7 +314,7 @@ public class MainnetTransactionProcessor {
         return TransactionProcessingResult.invalid(validationResult);
       }
 
-      operationTracer.tracePrepareTransaction(worldState, transaction);
+      operationTracer.tracePrepareTransaction(evmWorldUpdater, transaction);
 
       final Set<Address> addressList = new BytesTrieSet<>(Address.SIZE);
 
@@ -324,10 +323,8 @@ public class MainnetTransactionProcessor {
           throw new RuntimeException("Authority processor is required for 7702 transactions");
         }
 
-        maybeAuthorityProcessor
-            .get()
-            .addContractToAuthority(worldState, authorizedCodeService, transaction);
-        addressList.addAll(authorizedCodeService.getAuthorities());
+        maybeAuthorityProcessor.get().addContractToAuthority(evmWorldUpdater, transaction);
+        addressList.addAll(evmWorldUpdater.authorizedCodeService().getAuthorities());
       }
 
       final long previousNonce = sender.incrementNonce();
@@ -384,8 +381,7 @@ public class MainnetTransactionProcessor {
           accessListGas,
           setCodeGas);
 
-      final WorldUpdater worldUpdater = worldState.updater();
-      worldUpdater.setAuthorizedCodeService(authorizedCodeService);
+      final WorldUpdater worldUpdater = evmWorldUpdater.updater();
       final ImmutableMap.Builder<String, Object> contextVariablesBuilder =
           ImmutableMap.<String, Object>builder()
               .put(KEY_IS_PERSISTING_PRIVATE_STATE, isPersistingPrivateState)
@@ -437,12 +433,11 @@ public class MainnetTransactionProcessor {
                 .contract(contractAddress)
                 .inputData(initCodeBytes.slice(code.getSize()))
                 .code(code)
-                .authorizedCodeService(authorizedCodeService)
                 .build();
       } else {
         @SuppressWarnings("OptionalGetWithoutIsPresent") // isContractCall tests isPresent
         final Address to = transaction.getTo().get();
-        final Optional<Account> maybeContract = Optional.ofNullable(worldState.get(to));
+        final Optional<Account> maybeContract = Optional.ofNullable(evmWorldUpdater.get(to));
         initialFrame =
             commonMessageFrameBuilder
                 .type(MessageFrame.Type.MESSAGE_CALL)
@@ -453,7 +448,6 @@ public class MainnetTransactionProcessor {
                     maybeContract
                         .map(c -> messageCallProcessor.getCodeFromEVM(c.getCodeHash(), c.getCode()))
                         .orElse(CodeV0.EMPTY_CODE))
-                .authorizedCodeService(authorizedCodeService)
                 .build();
       }
       Deque<MessageFrame> messageFrameStack = initialFrame.getMessageFrameStack();
@@ -532,9 +526,9 @@ public class MainnetTransactionProcessor {
 
       operationTracer.traceBeforeRewardTransaction(worldUpdater, transaction, coinbaseWeiDelta);
 
-      final var coinbase = worldState.getOrCreate(miningBeneficiary);
+      final var coinbase = evmWorldUpdater.getOrCreate(miningBeneficiary);
       coinbase.incrementBalance(coinbaseWeiDelta);
-      authorizedCodeService.resetAuthorities();
+      evmWorldUpdater.authorizedCodeService().resetAuthorities();
 
       operationTracer.traceEndTransaction(
           worldUpdater,
@@ -546,10 +540,10 @@ public class MainnetTransactionProcessor {
           initialFrame.getSelfDestructs(),
           0L);
 
-      initialFrame.getSelfDestructs().forEach(worldState::deleteAccount);
+      initialFrame.getSelfDestructs().forEach(evmWorldUpdater::deleteAccount);
 
       if (clearEmptyAccounts) {
-        worldState.clearAccountsThatAreEmpty();
+        evmWorldUpdater.clearAccountsThatAreEmpty();
       }
 
       if (initialFrame.getState() == MessageFrame.State.COMPLETED_SUCCESS) {
@@ -577,7 +571,7 @@ public class MainnetTransactionProcessor {
       }
     } catch (final MerkleTrieException re) {
       operationTracer.traceEndTransaction(
-          worldState.updater(),
+          evmWorldUpdater.updater(),
           transaction,
           false,
           Bytes.EMPTY,
@@ -590,7 +584,7 @@ public class MainnetTransactionProcessor {
       throw re;
     } catch (final RuntimeException re) {
       operationTracer.traceEndTransaction(
-          worldState.updater(),
+          evmWorldUpdater.updater(),
           transaction,
           false,
           Bytes.EMPTY,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/accumulator/DiffBasedWorldStateUpdateAccumulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/accumulator/DiffBasedWorldStateUpdateAccumulator.java
@@ -250,8 +250,7 @@ public abstract class DiffBasedWorldStateUpdateAccumulator<ACCOUNT extends DiffB
       accountsToUpdate.put(address, diffBasedValue);
     } else if (diffBasedValue.getUpdated() != null) {
       if (diffBasedValue.getUpdated().isEmpty()) {
-        return authorizedCodeService.processMutableAccount(
-            this, track(new UpdateTrackingAccount<>(diffBasedValue.getUpdated())), address);
+        return track(new UpdateTrackingAccount<>(diffBasedValue.getUpdated()));
       } else {
         throw new IllegalStateException("Cannot create an account when one already exists");
       }
@@ -268,8 +267,7 @@ public abstract class DiffBasedWorldStateUpdateAccumulator<ACCOUNT extends DiffB
             Hash.EMPTY,
             true);
     diffBasedValue.setUpdated(newAccount);
-    return authorizedCodeService.processMutableAccount(
-        this, track(new UpdateTrackingAccount<>(newAccount)), address);
+    return track(new UpdateTrackingAccount<>(newAccount));
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/frame/MessageFrame.java
@@ -33,7 +33,6 @@ import org.hyperledger.besu.evm.internal.UnderflowException;
 import org.hyperledger.besu.evm.log.Log;
 import org.hyperledger.besu.evm.operation.BlockHashOperation.BlockHashLookup;
 import org.hyperledger.besu.evm.operation.Operation;
-import org.hyperledger.besu.evm.worldstate.AuthorizedCodeService;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.ArrayDeque;
@@ -202,7 +201,6 @@ public class MessageFrame {
 
   // Global data fields.
   private final WorldUpdater worldUpdater;
-  private final AuthorizedCodeService authorizedCodeService;
 
   // Metadata fields.
   private final Type type;
@@ -272,8 +270,7 @@ public class MessageFrame {
       final Consumer<MessageFrame> completer,
       final Map<String, Object> contextVariables,
       final Optional<Bytes> revertReason,
-      final TxValues txValues,
-      final AuthorizedCodeService authorizedCodeService) {
+      final TxValues txValues) {
 
     this.txValues = txValues;
     this.type = type;
@@ -293,7 +290,6 @@ public class MessageFrame {
     this.completer = completer;
     this.contextVariables = contextVariables;
     this.revertReason = revertReason;
-    this.authorizedCodeService = authorizedCodeService;
 
     this.undoMark = txValues.transientStorage().mark();
   }
@@ -425,15 +421,6 @@ public class MessageFrame {
    */
   public Bytes getReturnData() {
     return returnData;
-  }
-
-  /**
-   * Return the authorized account service.
-   *
-   * @return the authorized account service
-   */
-  public AuthorizedCodeService getAuthorizedCodeService() {
-    return authorizedCodeService;
   }
 
   /**
@@ -1360,7 +1347,6 @@ public class MessageFrame {
     private Optional<Bytes> reason = Optional.empty();
     private Set<Address> accessListWarmAddresses = emptySet();
     private Multimap<Address, Bytes32> accessListWarmStorage = HashMultimap.create();
-    private AuthorizedCodeService authorizedCodeService;
 
     private Optional<List<VersionedHash>> versionedHashes = Optional.empty();
 
@@ -1645,17 +1631,6 @@ public class MessageFrame {
       return this;
     }
 
-    /**
-     * Sets authorized account service.
-     *
-     * @param authorizedCodeService the authorized account service
-     * @return the builder
-     */
-    public Builder authorizedCodeService(final AuthorizedCodeService authorizedCodeService) {
-      this.authorizedCodeService = authorizedCodeService;
-      return this;
-    }
-
     private void validate() {
       if (parentMessageFrame == null) {
         checkState(worldUpdater != null, "Missing message frame world updater");
@@ -1690,10 +1665,6 @@ public class MessageFrame {
       boolean newStatic;
       TxValues newTxValues;
 
-      if (authorizedCodeService == null) {
-        authorizedCodeService = new AuthorizedCodeService();
-      }
-
       if (parentMessageFrame == null) {
         newTxValues =
             new TxValues(
@@ -1720,8 +1691,6 @@ public class MessageFrame {
         newStatic = isStatic || parentMessageFrame.isStatic;
       }
 
-      updater.setAuthorizedCodeService(authorizedCodeService);
-
       MessageFrame messageFrame =
           new MessageFrame(
               type,
@@ -1738,8 +1707,7 @@ public class MessageFrame {
               completer,
               contextVariables == null ? Map.of() : contextVariables,
               reason,
-              newTxValues,
-              authorizedCodeService);
+              newTxValues);
       newTxValues.messageFrameStack().addFirst(messageFrame);
       messageFrame.warmUpAddress(sender);
       messageFrame.warmUpAddress(contract);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -230,7 +230,6 @@ public abstract class AbstractCallOperation extends AbstractOperation {
         .code(code)
         .isStatic(isStatic(frame))
         .completer(child -> complete(frame, child))
-        .authorizedCodeService(frame.getAuthorizedCodeService())
         .build();
     // see note in stack depth check about incrementing cost
     frame.incrementRemainingGas(cost);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -195,7 +195,6 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
         .apparentValue(value)
         .code(code)
         .completer(child -> complete(parent, child, evm))
-        .authorizedCodeService(parent.getAuthorizedCodeService())
         .build();
 
     parent.setState(MessageFrame.State.CODE_SUSPENDED);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
@@ -180,7 +180,6 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
         .code(code)
         .isStatic(isStatic(frame))
         .completer(child -> complete(frame, child))
-        .authorizedCodeService(frame.getAuthorizedCodeService())
         .build();
 
     frame.setState(MessageFrame.State.CODE_SUSPENDED);

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/EVMWorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/EVMWorldUpdater.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.worldstate;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.account.MutableAccount;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * The EVM world updater. This class is a wrapper around a WorldUpdater that provides an
+ * AuthorizedCodeService to manage the authorized code for accounts.
+ */
+public class EVMWorldUpdater implements WorldUpdater {
+  private final WorldUpdater rootWorldUpdater;
+  private final AuthorizedCodeService authorizedCodeService;
+
+  /**
+   * Instantiates a new EVM world updater.
+   *
+   * @param rootWorldUpdater the root world updater
+   */
+  public EVMWorldUpdater(final WorldUpdater rootWorldUpdater) {
+    this(rootWorldUpdater, new AuthorizedCodeService());
+  }
+
+  private EVMWorldUpdater(
+      final WorldUpdater rootWorldUpdater, final AuthorizedCodeService authorizedCodeService) {
+    this.rootWorldUpdater = rootWorldUpdater;
+    this.authorizedCodeService = authorizedCodeService;
+  }
+
+  /**
+   * Authorized code service.
+   *
+   * @return the authorized code service
+   */
+  public AuthorizedCodeService authorizedCodeService() {
+    return authorizedCodeService;
+  }
+
+  @Override
+  public MutableAccount createAccount(final Address address, final long nonce, final Wei balance) {
+    return authorizedCodeService.processMutableAccount(
+        this, rootWorldUpdater.createAccount(address, nonce, balance), address);
+  }
+
+  @Override
+  public MutableAccount getAccount(final Address address) {
+    return authorizedCodeService.processMutableAccount(
+        this, rootWorldUpdater.getAccount(address), address);
+  }
+
+  @Override
+  public MutableAccount getOrCreate(final Address address) {
+    return authorizedCodeService.processMutableAccount(
+        this, rootWorldUpdater.getOrCreate(address), address);
+  }
+
+  @Override
+  public MutableAccount getOrCreateSenderAccount(final Address address) {
+    return authorizedCodeService.processMutableAccount(
+        this, rootWorldUpdater.getOrCreateSenderAccount(address), address);
+  }
+
+  @Override
+  public MutableAccount getSenderAccount(final MessageFrame frame) {
+    return authorizedCodeService.processMutableAccount(
+        this, rootWorldUpdater.getSenderAccount(frame), frame.getSenderAddress());
+  }
+
+  @Override
+  public void deleteAccount(final Address address) {
+    rootWorldUpdater.deleteAccount(address);
+  }
+
+  @Override
+  public Collection<? extends Account> getTouchedAccounts() {
+    return rootWorldUpdater.getTouchedAccounts();
+  }
+
+  @Override
+  public Collection<Address> getDeletedAccountAddresses() {
+    return rootWorldUpdater.getDeletedAccountAddresses();
+  }
+
+  @Override
+  public void revert() {
+    rootWorldUpdater.revert();
+  }
+
+  @Override
+  public void commit() {
+    rootWorldUpdater.commit();
+  }
+
+  @Override
+  public Optional<WorldUpdater> parentUpdater() {
+    return rootWorldUpdater.parentUpdater();
+  }
+
+  @Override
+  public WorldUpdater updater() {
+    return new EVMWorldUpdater(rootWorldUpdater.updater(), authorizedCodeService);
+  }
+
+  @Override
+  public Account get(final Address address) {
+    return authorizedCodeService.processAccount(this, rootWorldUpdater.get(address), address);
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/WorldUpdater.java
@@ -179,12 +179,4 @@ public interface WorldUpdater extends MutableWorldView {
   default void markTransactionBoundary() {
     // default is to ignore
   }
-
-  /**
-   * Sets the {@link AuthorizedCodeService} associated with this {@link WorldUpdater}.
-   *
-   * @param authorizedCodeService the {@link AuthorizedCodeService} to associate with this {@link
-   *     WorldUpdater}
-   */
-  void setAuthorizedCodeService(AuthorizedCodeService authorizedCodeService);
 }

--- a/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyWorld.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/toy/ToyWorld.java
@@ -18,7 +18,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.MutableAccount;
-import org.hyperledger.besu.evm.worldstate.AuthorizedCodeService;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Collection;
@@ -33,7 +32,6 @@ public class ToyWorld implements WorldUpdater {
 
   ToyWorld parent;
   Map<Address, ToyAccount> accounts = new HashMap<>();
-  private AuthorizedCodeService authorizedCodeService;
 
   public ToyWorld() {
     this(null);
@@ -41,7 +39,6 @@ public class ToyWorld implements WorldUpdater {
 
   public ToyWorld(final ToyWorld parent) {
     this.parent = parent;
-    this.authorizedCodeService = new AuthorizedCodeService();
   }
 
   @Override
@@ -52,11 +49,11 @@ public class ToyWorld implements WorldUpdater {
   @Override
   public Account get(final Address address) {
     if (accounts.containsKey(address)) {
-      return authorizedCodeService.processAccount(this, accounts.get(address), address);
+      return accounts.get(address);
     } else if (parent != null) {
-      return authorizedCodeService.processAccount(this, parent.get(address), address);
+      return parent.get(address);
     } else {
-      return authorizedCodeService.processAccount(this, null, address);
+      return null;
     }
   }
 
@@ -73,17 +70,17 @@ public class ToyWorld implements WorldUpdater {
       final Bytes code) {
     ToyAccount account = new ToyAccount(parentAccount, address, nonce, balance, code);
     accounts.put(address, account);
-    return authorizedCodeService.processMutableAccount(this, account, address);
+    return account;
   }
 
   @Override
   public MutableAccount getAccount(final Address address) {
     if (accounts.containsKey(address)) {
-      return authorizedCodeService.processMutableAccount(this, accounts.get(address), address);
+      return accounts.get(address);
     } else if (parent != null) {
       Account parentAccount = parent.getAccount(address);
       if (parentAccount == null) {
-        return authorizedCodeService.processMutableAccount(this, null, address);
+        return null;
       } else {
         return createAccount(
             parentAccount,
@@ -93,7 +90,7 @@ public class ToyWorld implements WorldUpdater {
             parentAccount.getCode());
       }
     } else {
-      return authorizedCodeService.processMutableAccount(this, null, address);
+      return null;
     }
   }
 
@@ -130,10 +127,5 @@ public class ToyWorld implements WorldUpdater {
   @Override
   public Optional<WorldUpdater> parentUpdater() {
     return Optional.empty();
-  }
-
-  @Override
-  public void setAuthorizedCodeService(final AuthorizedCodeService authorizedCodeService) {
-    this.authorizedCodeService = authorizedCodeService;
   }
 }


### PR DESCRIPTION
## PR description

In a first version of 7702 the code injection into the EOA accounts required every class that implements the `WorldUpdater` interface to have the correct plumbing to inject that code from 7702 transactions. This PR introduces a new world updater `EVMWorldUpdater` which wraps the actual world updater and the code injection only needs to happen in this new wrapper. The previous code injection is removed from the other world updaters.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

