### PR TITLE
EIP-3155 Last Call Nitpicks

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
@@ -35,9 +35,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.web3j.utils.Strings;
 import picocli.CommandLine;
@@ -63,7 +65,7 @@ public class CodeValidateSubCommand implements Runnable {
 
   @ParentCommand EvmToolCommand parentCommand;
 
-  private final EVM evm;
+  private final Supplier<EVM> evm;
 
   @CommandLine.Option(
       names = {"--file"},
@@ -83,12 +85,18 @@ public class CodeValidateSubCommand implements Runnable {
 
   CodeValidateSubCommand(final EvmToolCommand parentCommand) {
     this.parentCommand = parentCommand;
-    String fork = EvmSpecVersion.PRAGUE.getName();
-    if (parentCommand != null && parentCommand.hasFork()) {
-      fork = parentCommand.getFork();
-    }
-    ProtocolSpec protocolSpec = ReferenceTestProtocolSchedules.create().geSpecByName(fork);
-    evm = protocolSpec.getEvm();
+    String fork =
+        parentCommand != null && parentCommand.hasFork()
+            ? parentCommand.getFork()
+            : EvmSpecVersion.PRAGUE.getName();
+
+    evm =
+        Suppliers.memoize(
+            () -> {
+              ProtocolSpec protocolSpec =
+                  ReferenceTestProtocolSchedules.create().geSpecByName(fork);
+              return protocolSpec.getEvm();
+            });
   }
 
   @Override
@@ -155,12 +163,12 @@ public class CodeValidateSubCommand implements Runnable {
       return "";
     }
 
-    EOFLayout layout = evm.parseEOF(codeBytes);
+    EOFLayout layout = evm.get().parseEOF(codeBytes);
     if (!layout.isValid()) {
       return "err: layout - " + layout.invalidReason();
     }
 
-    Code code = evm.getCodeUncached(codeBytes);
+    Code code = evm.get().getCodeUncached(codeBytes);
     if (code instanceof CodeInvalid codeInvalid) {
       return "err: " + codeInvalid.getInvalidReason();
     } else if (EOFContainerMode.INITCODE.equals(

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmToolCommandOptionsModule.java
@@ -145,5 +145,7 @@ public class EvmToolCommandOptionsModule {
   }
 
   /** Default constructor for the EvmToolCommandOptionsModule class. */
-  public EvmToolCommandOptionsModule() {}
+  public EvmToolCommandOptionsModule() {
+    // This is only here because of JavaDoc linting
+  }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/GenesisFileModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/GenesisFileModule.java
@@ -111,6 +111,20 @@ public class GenesisFileModule {
     return createGenesisModule(Files.readString(genesisFile.toPath(), Charset.defaultCharset()));
   }
 
+  static GenesisFileModule createGenesisModule() {
+    final JsonObject genesis = new JsonObject();
+    final JsonObject config = new JsonObject();
+    genesis.put("config", config);
+    config.put("chainId", 1337);
+    config.put("londonBlock", 0);
+    genesis.put("baseFeePerGas", "0x3b9aca00");
+    genesis.put("gasLimit", "0x2540be400");
+    genesis.put("difficulty", "0x0");
+    genesis.put("mixHash", "0x0000000000000000000000000000000000000000000000000000000000000000");
+    genesis.put("coinbase", "0x0000000000000000000000000000000000000000");
+    return createGenesisModule(genesis.toString());
+  }
+
   private static GenesisFileModule createGenesisModule(final String genesisConfig) {
     final JsonObject genesis = new JsonObject(genesisConfig);
     final JsonObject config = genesis.getJsonObject("config");

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/MainnetGenesisFileModule.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/MainnetGenesisFileModule.java
@@ -71,7 +71,7 @@ class MainnetGenesisFileModule extends GenesisFileModule {
       }
     }
 
-    var schedules = createSchedules();
+    var schedules = createSchedules(configOptions.getChainId().orElse(BigInteger.valueOf(1337)));
     var schedule =
         schedules.get(
             fork.orElse(EvmSpecVersion.defaultVersion().getName())
@@ -89,9 +89,9 @@ class MainnetGenesisFileModule extends GenesisFileModule {
         new NoOpMetricsSystem());
   }
 
-  public static Map<String, Supplier<ProtocolSchedule>> createSchedules() {
+  public static Map<String, Supplier<ProtocolSchedule>> createSchedules(final BigInteger chainId) {
     return Map.ofEntries(
-        Map.entry("frontier", createSchedule(new StubGenesisConfigOptions())),
+        Map.entry("frontier", createSchedule(new StubGenesisConfigOptions().chainId(chainId))),
         Map.entry("homestead", createSchedule(new StubGenesisConfigOptions().homesteadBlock(0))),
         Map.entry("eip150", createSchedule(new StubGenesisConfigOptions().eip150Block(0))),
         Map.entry("eip158", createSchedule(new StubGenesisConfigOptions().eip158Block(0))),
@@ -102,43 +102,86 @@ class MainnetGenesisFileModule extends GenesisFileModule {
         Map.entry(
             "constantinoplefix", createSchedule(new StubGenesisConfigOptions().petersburgBlock(0))),
         Map.entry("petersburg", createSchedule(new StubGenesisConfigOptions().petersburgBlock(0))),
-        Map.entry("istanbul", createSchedule(new StubGenesisConfigOptions().istanbulBlock(0))),
         Map.entry(
-            "muirglacier", createSchedule(new StubGenesisConfigOptions().muirGlacierBlock(0))),
-        Map.entry("berlin", createSchedule(new StubGenesisConfigOptions().berlinBlock(0))),
+            "istanbul",
+            createSchedule(new StubGenesisConfigOptions().istanbulBlock(0).chainId(chainId))),
+        Map.entry(
+            "muirglacier",
+            createSchedule(new StubGenesisConfigOptions().muirGlacierBlock(0).chainId(chainId))),
+        Map.entry(
+            "berlin",
+            createSchedule(new StubGenesisConfigOptions().berlinBlock(0).chainId(chainId))),
         Map.entry(
             "london",
-            createSchedule(new StubGenesisConfigOptions().londonBlock(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .londonBlock(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
-            "arrowglacier", createSchedule(new StubGenesisConfigOptions().arrowGlacierBlock(0))),
+            "arrowglacier",
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .arrowGlacierBlock(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
-            "grayglacier", createSchedule(new StubGenesisConfigOptions().grayGlacierBlock(0))),
+            "grayglacier",
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .grayGlacierBlock(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "merge",
             createSchedule(
-                new StubGenesisConfigOptions().mergeNetSplitBlock(0).baseFeePerGas(0x0a))),
+                new StubGenesisConfigOptions()
+                    .mergeNetSplitBlock(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "shanghai",
-            createSchedule(new StubGenesisConfigOptions().shanghaiTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .shanghaiTime(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "cancun",
-            createSchedule(new StubGenesisConfigOptions().cancunTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions().cancunTime(0).baseFeePerGas(0x0a).chainId(chainId))),
         Map.entry(
             "cancuneof",
-            createSchedule(new StubGenesisConfigOptions().cancunEOFTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .cancunEOFTime(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "prague",
-            createSchedule(new StubGenesisConfigOptions().pragueTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions().pragueTime(0).baseFeePerGas(0x0a).chainId(chainId))),
         Map.entry(
             "pragueeof",
-            createSchedule(new StubGenesisConfigOptions().pragueEOFTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .pragueEOFTime(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "futureeips",
-            createSchedule(new StubGenesisConfigOptions().futureEipsTime(0).baseFeePerGas(0x0a))),
+            createSchedule(
+                new StubGenesisConfigOptions()
+                    .futureEipsTime(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))),
         Map.entry(
             "experimentaleips",
             createSchedule(
-                new StubGenesisConfigOptions().experimentalEipsTime(0).baseFeePerGas(0x0a))));
+                new StubGenesisConfigOptions()
+                    .experimentalEipsTime(0)
+                    .baseFeePerGas(0x0a)
+                    .chainId(chainId))));
   }
 
   private static Supplier<ProtocolSchedule> createSchedule(final GenesisConfigOptions options) {

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/badcode.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/badcode.json
@@ -9,6 +9,6 @@
   "stdout": [
     {"pc":0,"op":96,"gas":"0x2540be400","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":2,"op":239,"gas":"0x2540be3fd","gasCost":"0x0","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"INVALID","error":"Bad instruction"},
-    {"gasUser":"0x2540be400","gasTotal":"0x2540be400","output":"0x"}
+    {"stateRoot":"0xfc9dc1be50c1b0a497afa545d770cc7064f0d71efbc4338f002dc2e086965d98","output":"0x","gasUsed":"0x2540be400","pass":false,"fork":"Cancun"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
@@ -70,6 +70,6 @@
     {"pc":24,"op":243,"gas":"0x45","gasCost":"0x0","memSize":96,"stack":["0x1","0x40"],"depth":2,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x71","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x6e","gasCost":"0x0","memSize":96,"stack":["0x1","0x40"],"depth":1,"refund":0,"opName":"RETURN"},
-    {"gasUser":"0x619e","gasTotal":"0x619e","output":"0x40"}
+    {"stateRoot":"0xcb5e8e232189003640b6f131ea2c09b1791ffd2e8357f64610f638e9a11ab2d2","output":"0x40","gasUsed":"0x619e","pass":true,"fork":"Cancun"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/coinbase-cold.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/coinbase-cold.json
@@ -7,13 +7,13 @@
     "--coinbase",
     "4444588443C3A91288C5002483449ABA1054192B",
     "--fork",
-    "paris"
+    "london"
   ],
   "stdin": "",
   "stdout": [
     {"pc":0,"op":65,"gas":"0x2540be400","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"COINBASE"},
     {"pc":1,"op":49,"gas":"0x2540be3fe","gasCost":"0xa28","memSize":0,"stack":["0x4444588443c3a91288c5002483449aba1054192b"],"depth":1,"refund":0,"opName":"BALANCE"},
-    {"pc":2,"op":255,"gas":"0x2540bd9d6","gasCost":"0x1388","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"SELFDESTRUCT"},
-    {"gasUser":"0x1db2","gasTotal":"0x1db2","output":"0x"}
+    {"pc":2,"op":255,"gas":"0x2540bd9d6","gasCost":"0x1db0","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"SELFDESTRUCT"},
+    {"stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","output":"0x","gasUsed":"0x27da","pass":true,"fork":"London"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/coinbase-warm.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/coinbase-warm.json
@@ -13,7 +13,7 @@
   "stdout": [
     {"pc":0,"op":65,"gas":"0x2540be400","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"COINBASE"},
     {"pc":1,"op":49,"gas":"0x2540be3fe","gasCost":"0x64","memSize":0,"stack":["0x4444588443c3a91288c5002483449aba1054192b"],"depth":1,"refund":0,"opName":"BALANCE"},
-    {"pc":2,"op":255,"gas":"0x2540be39a","gasCost":"0x1388","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"SELFDESTRUCT"},
-    {"gasUser":"0x13ee","gasTotal":"0x13ee","output":"0x"}
+    {"pc":2,"op":255,"gas":"0x2540be39a","gasCost":"0x1db0","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"SELFDESTRUCT"},
+    {"stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","output":"0x","gasUsed":"0x1e16","pass":true,"fork":"Shanghai"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/create-eof.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/create-eof.json
@@ -20,6 +20,6 @@
     {"pc":5,"section":0,"op":95,"gas":"0x2540be109","gasCost":"0x2","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH0"},
     {"pc":6,"section":0,"op":95,"gas":"0x2540be107","gasCost":"0x2","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"PUSH0"},
     {"pc":7,"section":0,"op":238,"immediate":"0x00","gas":"0x2540be105","gasCost":"0x0","memSize":0,"stack":["0x0","0x0"],"depth":1,"refund":0,"opName":"RETURNCONTRACT"},
-    {"gasUser":"0x129b","gasTotal":"0x129b","output":"0x"}
+    {"stateRoot":"0x9790b070a5749acec6a7252a867f795df3c2cb5b800fb509ea259a1c0b5d96c1","output":"0x","gasUsed":"0x129b","pass":true,"fork":"CancunEOF"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof-section.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof-section.json
@@ -12,8 +12,8 @@
   "stdin": "",
   "stdout": [
     {"pc":0,"section":0,"op":227,"immediate":"0x0002","gas":"0x2540be400","gasCost":"0x5","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"CALLF"},
-    {"pc":0,"section":2,"op":229,"immediate":"0x0002","gas":"0x2540be3fb","gasCost":"0x5","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"JUMPF"},
-    {"pc":0,"section":1,"op":228,"gas":"0x2540be3f6","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"RETF"},
+    {"pc":0,"section":2,"op":229,"immediate":"0x0002","gas":"0x2540be3fb","gasCost":"0x5","memSize":0,"stack":[],"depth":1,"fdepth":1,"refund":0,"opName":"JUMPF"},
+    {"pc":0,"section":1,"op":228,"gas":"0x2540be3f6","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"fdepth":1,"refund":0,"opName":"RETF"},
     {"pc":3,"section":0,"op":97,"immediate":"0x2015","gas":"0x2540be3f3","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH2"},
     {"pc":6,"section":0,"op":96,"immediate":"0x01","gas":"0x2540be3f0","gasCost":"0x3","memSize":0,"stack":["0x2015"],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":8,"section":0,"op":85,"gas":"0x2540be3ed","gasCost":"0x5654","memSize":0,"stack":["0x2015","0x1"],"depth":1,"refund":0,"opName":"SSTORE"},

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof-section.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof-section.json
@@ -1,0 +1,23 @@
+{
+  "cli": [
+    "--notime",
+    "--json",
+    "--code",
+    "0xef000101000c020003000a0001000304000000008000020000000000000000e3000261201560015500e4e50001",
+    "--coinbase",
+    "4444588443C3A91288C5002483449ABA1054192B",
+    "--fork",
+    "PragueEOF"
+  ],
+  "stdin": "",
+  "stdout": [
+    {"pc":0,"section":0,"op":227,"immediate":"0x0002","gas":"0x2540be400","gasCost":"0x5","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"CALLF"},
+    {"pc":0,"section":2,"op":229,"immediate":"0x0002","gas":"0x2540be3fb","gasCost":"0x5","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"JUMPF"},
+    {"pc":0,"section":1,"op":228,"gas":"0x2540be3f6","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"RETF"},
+    {"pc":3,"section":0,"op":97,"immediate":"0x2015","gas":"0x2540be3f3","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH2"},
+    {"pc":6,"section":0,"op":96,"immediate":"0x01","gas":"0x2540be3f0","gasCost":"0x3","memSize":0,"stack":["0x2015"],"depth":1,"refund":0,"opName":"PUSH1"},
+    {"pc":8,"section":0,"op":85,"gas":"0x2540be3ed","gasCost":"0x5654","memSize":0,"stack":["0x2015","0x1"],"depth":1,"refund":0,"opName":"SSTORE"},
+    {"pc":9,"section":0,"op":0,"gas":"0x2540b8d99","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"},
+    {"stateRoot":"0x761f723ceabb467d438fe74abf025c10bf65592b84ec389850038eb572f2b0fa","output":"0x","gasUsed":"0x5667","pass":true,"fork":"PragueEOF"}
+  ]
+}

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/eof.json
@@ -7,11 +7,11 @@
     "--coinbase",
     "4444588443C3A91288C5002483449ABA1054192B",
     "--fork",
-    "CancunEOF"
+    "PragueEOF"
   ],
   "stdin": "",
   "stdout": [
     {"pc":0,"section":0,"op":0,"gas":"0x2540be400","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"STOP"},
-    {"gasUser":"0x0","gasTotal":"0x0","output":"0x"}
+    {"stateRoot":"0xdae5f2c233bf9fbb7413d06ce744a3345dbf971b5bb5638736c0388f43a61a4b","output":"0x","gasUsed":"0x0","pass":true,"fork":"PragueEOF"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/revert.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/revert.json
@@ -13,6 +13,6 @@
     {"pc":8,"op":96,"gas":"0x2540be3f4","gasCost":"0x3","memSize":32,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":10,"op":96,"gas":"0x2540be3f1","gasCost":"0x3","memSize":32,"stack":["0x4"],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":12,"op":253,"gas":"0x2540be3ee","gasCost":"0x0","memSize":32,"stack":["0x4","0x1c"],"depth":1,"refund":0,"opName":"REVERT","error":"Nope"},
-    {"gasUser":"0x12","gasTotal":"0x12","output":"0x4e6f7065"}
+    {"stateRoot":"0x405bbd98da2aca6dff77f79e0b270270c48d6a3e07b76db675b20e454b50bbcb","output":"0x4e6f7065","gasUsed":"0x12","pass":true,"fork":"Cancun"}
   ]
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
@@ -67,6 +67,6 @@
     {"pc":24,"op":243,"gas":"0x45","gasCost":"0x0","memSize":96,"stack":["0x1","0x40"],"depth":2,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x71","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":1,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x6e","gasCost":"0x0","memSize":96,"stack":["0x1","0x40"],"depth":1,"refund":0,"opName":"RETURN"},
-    {"gasUser":"0x619e","gasTotal":"0x619e","output":"0x40"}
+    {"stateRoot":"0xcb5e8e232189003640b6f131ea2c09b1791ffd2e8357f64610f638e9a11ab2d2","output":"0x40","gasUsed":"0x619e","pass":true,"fork":"Cancun"}
   ]
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
@@ -152,7 +152,7 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
     final Wei balance = (zeroValue || account == null) ? Wei.ZERO : account.getBalance();
 
     // There myst be a minimum gas for a call to have access to.
-    if (childGas < gasCalculator().getMinRetainedGas()) {
+    if (childGas < gasCalculator().getMinCalleeGas()) {
       return softFailure(frame, cost);
     }
     // transferring value you don't have is not a halting exception, just a failure

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
@@ -215,8 +215,8 @@ public class StandardJsonTracer implements OperationTracer {
       sb.append("\"returnData\":\"").append(returnData.toHexString()).append("\",");
     }
     sb.append("\"depth\":").append(depth).append(",");
-    if (subdepth > 1) {
-      sb.append("\"subdepth\":").append(subdepth).append(",");
+    if (subdepth >= 1) {
+      sb.append("\"fdepth\":").append(subdepth).append(",");
     }
     sb.append("\"refund\":").append(messageFrame.getGasRefund()).append(",");
     sb.append("\"opName\":\"").append(currentOp.getName()).append("\"");

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
@@ -127,7 +127,9 @@ public class StandardJsonTracer implements OperationTracer {
     for (int i = messageFrame.stackSize() - 1; i >= 0; i--) {
       stack.add("\"" + shortBytes(messageFrame.getStackItem(i)) + "\"");
     }
-    pc = messageFrame.getPC() - messageFrame.getCode().getCodeSection(0).getEntryPoint();
+    pc =
+        messageFrame.getPC()
+            - messageFrame.getCode().getCodeSection(messageFrame.getSection()).getEntryPoint();
     section = messageFrame.getSection();
     gas = shortNumber(messageFrame.getRemainingGas());
     memorySize = messageFrame.memoryWordSize() * 32;


### PR DESCRIPTION
## PR description

A lot of small nitpicks for standard tracing conformance
* Change evmtool run defaults to mirror go-ethereum's choices
* Add fields to run summary
* Make EOF PC zero to section
* Correct EXT*CALL min gas

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

