### PR TITLE
Precompile calls were not traced when insuficient gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Correct entrypoint in Docker evmtool [#7430](https://github.com/hyperledger/besu/pull/7430)
 - Fix protocol schedule check for devnets [#7429](https://github.com/hyperledger/besu/pull/7429)
 - Fix behaviour when starting in a pre-merge network [#7431](https://github.com/hyperledger/besu/pull/7431)
+- Fix tracing in precompiled contracts when halting for out of gas [#7318](https://github.com/hyperledger/besu/issues/7318)
 
 ## 24.7.1
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
@@ -38,7 +38,7 @@ public class StateDiffGenerator {
   public Stream<Trace> generateStateDiff(final TransactionTrace transactionTrace) {
     final List<TraceFrame> traceFrames = transactionTrace.getTraceFrames();
     if (traceFrames.isEmpty()) {
-      throw new RuntimeException("expected to have at least one processed frame");
+      return Stream.empty();
     }
 
     // This corresponds to the world state after the TX executed

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/tracing/diff/StateDiffGenerator.java
@@ -38,7 +38,7 @@ public class StateDiffGenerator {
   public Stream<Trace> generateStateDiff(final TransactionTrace transactionTrace) {
     final List<TraceFrame> traceFrames = transactionTrace.getTraceFrames();
     if (traceFrames.isEmpty()) {
-      return Stream.empty();
+      throw new RuntimeException("expected to have at least one processed frame");
     }
 
     // This corresponds to the world state after the TX executed

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
@@ -153,6 +153,7 @@ public class MessageCallProcessor extends AbstractMessageProcessor {
     if (frame.getRemainingGas() < gasRequirement) {
       frame.setExceptionalHaltReason(Optional.of(ExceptionalHaltReason.INSUFFICIENT_GAS));
       frame.setState(MessageFrame.State.EXCEPTIONAL_HALT);
+      operationTracer.tracePrecompileCall(frame, gasRequirement, null);
     } else {
       frame.decrementRemainingGas(gasRequirement);
       final PrecompiledContract.PrecompileContractResult result =

--- a/evm/src/test/java/org/hyperledger/besu/evm/processor/MessageCallProcessorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/processor/MessageCallProcessorTest.java
@@ -14,10 +14,23 @@
  */
 package org.hyperledger.besu.evm.processor;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
+import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.precompile.PrecompileContractRegistry;
+import org.hyperledger.besu.evm.precompile.PrecompiledContract;
+import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
+import org.hyperledger.besu.evm.toy.ToyWorld;
 
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,9 +41,62 @@ class MessageCallProcessorTest extends AbstractMessageProcessorTest<MessageCallP
 
   @Mock EVM evm;
   @Mock PrecompileContractRegistry precompileContractRegistry;
+  @Mock PrecompiledContract contract;
 
   @Override
   protected MessageCallProcessor getAbstractMessageProcessor() {
     return new MessageCallProcessor(evm, precompileContractRegistry);
+  }
+
+  @Test
+  public void shouldTracePrecompileContractCall() {
+    Address sender = Address.ZERO;
+    Address recipient = Address.fromHexString("0x1");
+
+    ToyWorld toyWorld = new ToyWorld();
+    toyWorld.createAccount(sender);
+    toyWorld.createAccount(recipient);
+
+    final MessageFrame messageFrame =
+        new TestMessageFrameBuilder()
+            .worldUpdater(toyWorld)
+            .sender(sender)
+            .address(recipient)
+            .initialGas(20L)
+            .build();
+
+    when(precompileContractRegistry.get(any())).thenReturn(contract);
+    when(contract.gasRequirement(any())).thenReturn(10L);
+    when(contract.computePrecompile(any(), eq(messageFrame)))
+        .thenReturn(PrecompiledContract.PrecompileContractResult.success(any()));
+
+    getAbstractMessageProcessor().process(messageFrame, operationTracer);
+
+    verify(operationTracer, times(1)).tracePrecompileCall(eq(messageFrame), anyLong(), any());
+  }
+
+  @Test
+  public void shouldTracePrecompileContractCallOutOfGas() {
+    Address sender = Address.ZERO;
+    Address recipient = Address.fromHexString("0x1");
+
+    ToyWorld toyWorld = new ToyWorld();
+    toyWorld.createAccount(sender);
+    toyWorld.createAccount(recipient);
+
+    final MessageFrame messageFrame =
+        new TestMessageFrameBuilder()
+            .worldUpdater(toyWorld)
+            .sender(sender)
+            .address(recipient)
+            .initialGas(5L)
+            .build();
+
+    when(precompileContractRegistry.get(any())).thenReturn(contract);
+    when(contract.gasRequirement(any())).thenReturn(10L);
+
+    getAbstractMessageProcessor().process(messageFrame, operationTracer);
+
+    verify(operationTracer, times(1)).tracePrecompileCall(eq(messageFrame), anyLong(), any());
   }
 }


### PR DESCRIPTION
## PR description
This fixes a tracing problem while replaying a transaction that executes a precompiled contract but it runs out of gas. We were getting an empty `TraceFrame` array back from the tracer because the halt condition was never traced.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7318 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

