### PR TITLE
Implement block parameter support for eth_estimateGas

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGas.java
@@ -37,9 +37,6 @@ import org.slf4j.LoggerFactory;
 
 public class EthEstimateGas extends AbstractEstimateGas {
 
-  @SuppressWarnings("unused")
-  private static final Logger LOG = LoggerFactory.getLogger(EthEstimateGas.class);
-
   public EthEstimateGas(
       final BlockchainQueries blockchainQueries, final TransactionSimulator transactionSimulator) {
     super(blockchainQueries, transactionSimulator);
@@ -142,7 +139,7 @@ public class EthEstimateGas extends AbstractEstimateGas {
       return blockchainQueries.headBlockNumber();
     } else if (blockParameter.isEarliest()) {
       return BlockHeader.GENESIS_BLOCK_NUMBER;
-    } else if (blockParameter.isPending()) {
+    } else if (blockParameter.isLatest() || blockParameter.isPending()) {
       return blockchainQueries.headBlockNumber() + 1;
     } else {
       return blockParameter.getNumber().orElse(blockchainQueries.headBlockNumber());


### PR DESCRIPTION
Fixes #7414 

Implement support for the optional `block` parameter in the `eth_estimateGas` RPC method.

- Add a `blockParameter` method to parse the optional block parameter from the request.
- Modify `response` method to use the specified block for gas estimation.
- Implement `getBlockNumberFromParameter` method to convert block parameters to block numbers.
- Update existing tests to include the new block parameter functionality.
- Add new tests to verify behaviour with different block parameters.
- Update mocking in test methods to handle block number queries.