### PR TITLE
Fix BlockchainQueries::gasPrice when chain head block body still not fully persisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 - Fix tracing in precompiled contracts when halting for out of gas [#7318](https://github.com/hyperledger/besu/issues/7318)
 - Correctly release txpool save and restore lock in case of exceptions [#7473](https://github.com/hyperledger/besu/pull/7473)
+- Fix for `eth_gasPrice` could not retrieve block error [#7482](https://github.com/hyperledger/besu/pull/7482)
 
 ## 24.8.0
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGasPriceTest.java
@@ -17,7 +17,9 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -61,7 +63,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
-import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -106,8 +107,8 @@ public class EthGasPriceTest {
     final JsonRpcResponse actualResponse = method.response(request);
     assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
 
-    verify(blockchain).getChainHeadBlockNumber();
-    verify(blockchain, VerificationModeFactory.times(100)).getBlockByNumber(anyLong());
+    verify(blockchain).getChainHeadBlock();
+    verify(blockchain, times(99)).getBlockByNumber(anyLong());
     verifyNoMoreInteractions(blockchain);
   }
 
@@ -127,8 +128,7 @@ public class EthGasPriceTest {
     final JsonRpcResponse actualResponse = method.response(request);
     assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
 
-    verify(blockchain).getChainHeadBlockNumber();
-    verify(blockchain, VerificationModeFactory.times(1)).getBlockByNumber(anyLong());
+    verify(blockchain).getChainHeadBlock();
     verifyNoMoreInteractions(blockchain);
   }
 
@@ -146,8 +146,8 @@ public class EthGasPriceTest {
     final JsonRpcResponse actualResponse = method.response(request);
     assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
 
-    verify(blockchain).getChainHeadBlockNumber();
-    verify(blockchain, VerificationModeFactory.times(100)).getBlockByNumber(anyLong());
+    verify(blockchain).getChainHeadBlock();
+    verify(blockchain, times(99)).getBlockByNumber(anyLong());
     verifyNoMoreInteractions(blockchain);
   }
 
@@ -165,8 +165,8 @@ public class EthGasPriceTest {
     final JsonRpcResponse actualResponse = method.response(request);
     assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
 
-    verify(blockchain).getChainHeadBlockNumber();
-    verify(blockchain, VerificationModeFactory.times(81)).getBlockByNumber(anyLong());
+    verify(blockchain).getChainHeadBlock();
+    verify(blockchain, times(80)).getBlockByNumber(anyLong());
     verifyNoMoreInteractions(blockchain);
   }
 
@@ -252,8 +252,7 @@ public class EthGasPriceTest {
     final JsonRpcResponse actualResponse = method.response(request);
     assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
 
-    verify(blockchain).getChainHeadBlockNumber();
-    verify(blockchain, VerificationModeFactory.times(1)).getBlockByNumber(anyLong());
+    verify(blockchain).getChainHeadBlock();
     verifyNoMoreInteractions(blockchain);
   }
 
@@ -328,12 +327,14 @@ public class EthGasPriceTest {
       blocksByNumber.put(i, createFakeBlock(i, txsNum, baseFee));
     }
 
-    when(blockchain.getChainHeadBlockNumber()).thenReturn(chainHeadBlockNumber);
-    when(blockchain.getBlockByNumber(anyLong()))
-        .thenAnswer(
-            invocation -> Optional.of(blocksByNumber.get(invocation.getArgument(0, Long.class))));
-
-    when(blockchain.getChainHeadHeader())
+    when(blockchain.getChainHeadBlock()).thenReturn(blocksByNumber.get(chainHeadBlockNumber));
+    if (chainHeadBlockNumber > 1) {
+      when(blockchain.getBlockByNumber(anyLong()))
+          .thenAnswer(
+              invocation -> Optional.of(blocksByNumber.get(invocation.getArgument(0, Long.class))));
+    }
+    lenient()
+        .when(blockchain.getChainHeadHeader())
         .thenReturn(blocksByNumber.get(chainHeadBlockNumber).getHeader());
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/Blockchain.java
@@ -168,6 +168,15 @@ public interface Blockchain {
   Optional<BlockBody> getBlockBody(Hash blockHeaderHash);
 
   /**
+   * Safe version of {@code getBlockBody} (it should take any locks necessary to ensure any block
+   * updates that might be taking place have been completed first)
+   *
+   * @param blockHeaderHash The hash of the block whose header we want to retrieve.
+   * @return The block body corresponding to this block hash.
+   */
+  Optional<BlockBody> getBlockBodySafe(Hash blockHeaderHash);
+
+  /**
    * Given a block's hash, returns the list of transaction receipts associated with this block's
    * transactions. Associated block is not necessarily on the canonical chain.
    *

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
@@ -299,7 +299,10 @@ public class DefaultBlockchain implements MutableBlockchain {
 
   @Override
   public Block getChainHeadBlock() {
-    return new Block(chainHeader, blockchainStorage.getBlockBody(chainHeader.getHash()).get());
+    return new Block(
+        chainHeader,
+        getBlockBody(chainHeader.getHash())
+            .orElseGet(() -> getBlockBodySafe(chainHeader.getHash()).get()));
   }
 
   @Override
@@ -335,6 +338,11 @@ public class DefaultBlockchain implements MutableBlockchain {
                 Optional.ofNullable(cache.getIfPresent(blockHeaderHash))
                     .or(() -> blockchainStorage.getBlockBody(blockHeaderHash)))
         .orElseGet(() -> blockchainStorage.getBlockBody(blockHeaderHash));
+  }
+
+  @Override
+  public synchronized Optional<BlockBody> getBlockBodySafe(final Hash blockHeaderHash) {
+    return getBlockBody(blockHeaderHash);
   }
 
   @Override

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/t8n/T8nBlockchain.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/t8n/T8nBlockchain.java
@@ -146,6 +146,11 @@ public class T8nBlockchain implements Blockchain {
   }
 
   @Override
+  public synchronized Optional<BlockBody> getBlockBodySafe(final Hash blockHeaderHash) {
+    return getBlockBody(blockHeaderHash);
+  }
+
+  @Override
   public Optional<List<TransactionReceipt>> getTxReceipts(final Hash blockHeaderHash) {
     // Deterministic, but just not implemented.
     throw new UnsupportedOperationException();

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestBlockchain.java
@@ -143,6 +143,11 @@ public class ReferenceTestBlockchain implements Blockchain {
   }
 
   @Override
+  public synchronized Optional<BlockBody> getBlockBodySafe(final Hash blockHeaderHash) {
+    return getBlockBody(blockHeaderHash);
+  }
+
+  @Override
   public Optional<List<TransactionReceipt>> getTxReceipts(final Hash blockHeaderHash) {
     // Deterministic, but just not implemented.
     throw new UnsupportedOperationException();


### PR DESCRIPTION
## PR description

As well explained by @matthew1001 [here](https://github.com/hyperledger/besu/issues/7287#issuecomment-2244649612), since in PR https://github.com/hyperledger/besu/pull/7102, the current chain head is correctly included in the computation of the gasPrice, it could happen that the chain head block body is still not persisted, so in order to always retrieve it successfully we first try optimistically, then if not found, the new `getBlockBodySafe` that is synchronized and so will wait until the pending persist operation is done.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #7287

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

