### PR TITLE
Add pending block header to `TransactionEvaluationContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Additions and Improvements
 - Add 'inbound' field to admin_peers JSON-RPC Call [#7461](https://github.com/hyperledger/besu/pull/7461)
+- Add pending block header to `TransactionEvaluationContext` plugin API [#7483](https://github.com/hyperledger/besu/pull/7483)
 
 ### Bug fixes
 - Fix tracing in precompiled contracts when halting for out of gas [#7318](https://github.com/hyperledger/besu/issues/7318)

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockSelectionContext.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockSelectionContext.java
@@ -29,7 +29,7 @@ public record BlockSelectionContext(
     GasCalculator gasCalculator,
     GasLimitCalculator gasLimitCalculator,
     BlockHashProcessor blockHashProcessor,
-    ProcessableBlockHeader processableBlockHeader,
+    ProcessableBlockHeader pendingBlockHeader,
     FeeMarket feeMarket,
     Wei blobGasPrice,
     Address miningBeneficiary,

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/BlockTransactionSelector.java
@@ -263,9 +263,10 @@ public class BlockTransactionSelector {
             .getTransactionPriceCalculator()
             .price(
                 pendingTransaction.getTransaction(),
-                blockSelectionContext.processableBlockHeader().getBaseFee());
+                blockSelectionContext.pendingBlockHeader().getBaseFee());
 
     return new TransactionEvaluationContext(
+        blockSelectionContext.pendingBlockHeader(),
         pendingTransaction,
         Stopwatch.createStarted(),
         transactionGasPriceInBlock,
@@ -330,10 +331,10 @@ public class BlockTransactionSelector {
   private TransactionProcessingResult processTransaction(
       final PendingTransaction pendingTransaction, final WorldUpdater worldStateUpdater) {
     final BlockHashLookup blockHashLookup =
-        new CachingBlockHashLookup(blockSelectionContext.processableBlockHeader(), blockchain);
+        new CachingBlockHashLookup(blockSelectionContext.pendingBlockHeader(), blockchain);
     return transactionProcessor.processTransaction(
         worldStateUpdater,
-        blockSelectionContext.processableBlockHeader(),
+        blockSelectionContext.pendingBlockHeader(),
         pendingTransaction.getTransaction(),
         blockSelectionContext.miningBeneficiary(),
         pluginOperationTracer,

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionEvaluationContext.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/TransactionEvaluationContext.java
@@ -17,23 +17,26 @@ package org.hyperledger.besu.ethereum.blockcreation.txselection;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 import com.google.common.base.Stopwatch;
 
 public class TransactionEvaluationContext
     implements org.hyperledger.besu.plugin.services.txselection.TransactionEvaluationContext<
         PendingTransaction> {
-  private final org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction
-      pendingTransaction;
+  private final ProcessableBlockHeader pendingBlockHeader;
+  private final PendingTransaction pendingTransaction;
   private final Stopwatch evaluationTimer;
   private final Wei transactionGasPrice;
   private final Wei minGasPrice;
 
   public TransactionEvaluationContext(
+      final ProcessableBlockHeader pendingBlockHeader,
       final PendingTransaction pendingTransaction,
       final Stopwatch evaluationTimer,
       final Wei transactionGasPrice,
       final Wei minGasPrice) {
+    this.pendingBlockHeader = pendingBlockHeader;
     this.pendingTransaction = pendingTransaction;
     this.evaluationTimer = evaluationTimer;
     this.transactionGasPrice = transactionGasPrice;
@@ -42,6 +45,11 @@ public class TransactionEvaluationContext
 
   public Transaction getTransaction() {
     return pendingTransaction.getTransaction();
+  }
+
+  @Override
+  public ProcessableBlockHeader getPendingBlockHeader() {
+    return pendingBlockHeader;
   }
 
   @Override

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlockSizeTransactionSelector.java
@@ -91,7 +91,7 @@ public class BlockSizeTransactionSelector extends AbstractTransactionSelector {
       final TransactionSelectionResults transactionSelectionResults) {
 
     return transaction.getGasLimit()
-        > context.processableBlockHeader().getGasLimit()
+        > context.pendingBlockHeader().getGasLimit()
             - transactionSelectionResults.getCumulativeGasUsed();
   }
 
@@ -104,7 +104,7 @@ public class BlockSizeTransactionSelector extends AbstractTransactionSelector {
    */
   private boolean blockOccupancyAboveThreshold(
       final TransactionSelectionResults transactionSelectionResults) {
-    final long gasAvailable = context.processableBlockHeader().getGasLimit();
+    final long gasAvailable = context.pendingBlockHeader().getGasLimit();
 
     final long gasUsed = transactionSelectionResults.getCumulativeGasUsed();
     final long gasRemaining = gasAvailable - gasUsed;
@@ -129,7 +129,7 @@ public class BlockSizeTransactionSelector extends AbstractTransactionSelector {
    * @return True if the block is full, false otherwise.
    */
   private boolean blockFull(final TransactionSelectionResults transactionSelectionResults) {
-    final long gasAvailable = context.processableBlockHeader().getGasLimit();
+    final long gasAvailable = context.pendingBlockHeader().getGasLimit();
     final long gasUsed = transactionSelectionResults.getCumulativeGasUsed();
 
     final long gasRemaining = gasAvailable - gasUsed;

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/MinPriorityFeePerGasTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/MinPriorityFeePerGasTransactionSelector.java
@@ -68,7 +68,7 @@ public class MinPriorityFeePerGasTransactionSelector extends AbstractTransaction
     Wei priorityFeePerGas =
         pendingTransaction
             .getTransaction()
-            .getEffectivePriorityFeePerGas(context.processableBlockHeader().getBaseFee());
+            .getEffectivePriorityFeePerGas(context.pendingBlockHeader().getBaseFee());
     return priorityFeePerGas.lessThan(context.miningParameters().getMinPriorityFeePerGas());
   }
 

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/MinPriorityFeePerGasTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/MinPriorityFeePerGasTransactionSelectorTest.java
@@ -33,11 +33,16 @@ import org.hyperledger.besu.plugin.data.TransactionSelectionResult;
 import com.google.common.base.Stopwatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 public class MinPriorityFeePerGasTransactionSelectorTest {
   private AbstractTransactionSelector transactionSelector;
 
   private final int minPriorityFeeParameter = 7;
+  @Mock private ProcessableBlockHeader pendingBlockHeader;
 
   @BeforeEach
   public void initialize() {
@@ -45,15 +50,7 @@ public class MinPriorityFeePerGasTransactionSelectorTest {
         MiningParameters.newDefault().setMinPriorityFeePerGas(Wei.of(minPriorityFeeParameter));
     BlockSelectionContext context =
         new BlockSelectionContext(
-            miningParameters,
-            null,
-            null,
-            null,
-            mock(ProcessableBlockHeader.class),
-            null,
-            null,
-            null,
-            null);
+            miningParameters, null, null, null, pendingBlockHeader, null, null, null, null);
     transactionSelector = new MinPriorityFeePerGasTransactionSelector(context);
   }
 
@@ -100,6 +97,6 @@ public class MinPriorityFeePerGasTransactionSelectorTest {
     when(pendingTransaction.getTransaction()).thenReturn(transaction);
     when(transaction.getEffectivePriorityFeePerGas(any())).thenReturn(Wei.of(priorityFeePerGas));
     return new TransactionEvaluationContext(
-        pendingTransaction, Stopwatch.createStarted(), Wei.ONE, Wei.ONE);
+        pendingBlockHeader, pendingTransaction, Stopwatch.createStarted(), Wei.ONE, Wei.ONE);
   }
 }

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelectorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelectorTest.java
@@ -76,7 +76,9 @@ class BlobSizeTransactionSelectorTest {
 
     final var nonBlobTx = createEIP1559PendingTransaction();
 
-    final var txEvaluationContext = new TransactionEvaluationContext(nonBlobTx, null, null, null);
+    final var txEvaluationContext =
+        new TransactionEvaluationContext(
+            blockSelectionContext.pendingBlockHeader(), nonBlobTx, null, null, null);
 
     final var result =
         selector.evaluateTransactionPreProcessing(txEvaluationContext, selectionResults);
@@ -94,7 +96,9 @@ class BlobSizeTransactionSelectorTest {
 
     final var firstBlobTx = createBlobPendingTransaction(MAX_BLOBS);
 
-    final var txEvaluationContext = new TransactionEvaluationContext(firstBlobTx, null, null, null);
+    final var txEvaluationContext =
+        new TransactionEvaluationContext(
+            blockSelectionContext.pendingBlockHeader(), firstBlobTx, null, null, null);
 
     when(selectionResults.getCumulativeBlobGasUsed()).thenReturn(0L);
 
@@ -112,7 +116,9 @@ class BlobSizeTransactionSelectorTest {
 
     final var firstBlobTx = createBlobPendingTransaction(1);
 
-    final var txEvaluationContext = new TransactionEvaluationContext(firstBlobTx, null, null, null);
+    final var txEvaluationContext =
+        new TransactionEvaluationContext(
+            blockSelectionContext.pendingBlockHeader(), firstBlobTx, null, null, null);
 
     when(selectionResults.getCumulativeBlobGasUsed()).thenReturn(MAX_BLOB_GAS);
 
@@ -132,7 +138,9 @@ class BlobSizeTransactionSelectorTest {
 
     final var firstBlobTx = createBlobPendingTransaction(MAX_BLOBS);
 
-    final var txEvaluationContext = new TransactionEvaluationContext(firstBlobTx, null, null, null);
+    final var txEvaluationContext =
+        new TransactionEvaluationContext(
+            blockSelectionContext.pendingBlockHeader(), firstBlobTx, null, null, null);
 
     when(selectionResults.getCumulativeBlobGasUsed()).thenReturn(MAX_BLOB_GAS - 1);
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -70,7 +70,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '6Hy3eaCpnxehyDO3smSAr1i2DsB2q/V37/m8POycikI='
+  knownHash = '2tFIKwEd8T5I37ywbFnVcMwTR8HiiCC6gO1Chd3hZp8='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionEvaluationContext.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/txselection/TransactionEvaluationContext.java
@@ -16,6 +16,7 @@ package org.hyperledger.besu.plugin.services.txselection;
 
 import org.hyperledger.besu.datatypes.PendingTransaction;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 
 import com.google.common.base.Stopwatch;
 
@@ -26,6 +27,13 @@ import com.google.common.base.Stopwatch;
  * @param <PT> the type of the pending transaction
  */
 public interface TransactionEvaluationContext<PT extends PendingTransaction> {
+
+  /**
+   * Gets the pending block header
+   *
+   * @return the pending block header
+   */
+  ProcessableBlockHeader getPendingBlockHeader();
 
   /**
    * Gets the pending transaction.


### PR DESCRIPTION
## PR description

Add pending block header to `TransactionEvaluationContext` plugin API, so `PluginTransactionSelector` can access info of the pending block

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

