### PR TITLE
Update EOF validation error strings

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BlockchainTestSubCommand.java
@@ -44,12 +44,10 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes32;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -80,9 +78,6 @@ public class BlockchainTestSubCommand implements Runnable {
    * enter on the command line to invoke this command.
    */
   public static final String COMMAND_NAME = "block-test";
-
-  static final Supplier<ReferenceTestProtocolSchedules> referenceTestProtocolSchedules =
-      Suppliers.memoize(ReferenceTestProtocolSchedules::create);
 
   @Option(
       names = {"--test-name"},
@@ -177,7 +172,7 @@ public class BlockchainTestSubCommand implements Runnable {
             .orElseThrow();
 
     final ProtocolSchedule schedule =
-        referenceTestProtocolSchedules.get().getByName(spec.getNetwork());
+        ReferenceTestProtocolSchedules.getInstance().getByName(spec.getNetwork());
 
     final MutableBlockchain blockchain = spec.getBlockchain();
     final ProtocolContext context = spec.getProtocolContext();

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/CodeValidateSubCommand.java
@@ -94,7 +94,7 @@ public class CodeValidateSubCommand implements Runnable {
         Suppliers.memoize(
             () -> {
               ProtocolSpec protocolSpec =
-                  ReferenceTestProtocolSchedules.create().geSpecByName(fork);
+                  ReferenceTestProtocolSchedules.getInstance().geSpecByName(fork);
               return protocolSpec.getEvm();
             });
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EOFTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EOFTestSubCommand.java
@@ -93,7 +93,7 @@ public class EOFTestSubCommand implements Runnable {
       fork = parentCommand.getFork();
     }
     ProtocolSpec protocolSpec =
-        ReferenceTestProtocolSchedules.create()
+        ReferenceTestProtocolSchedules.getInstance()
             .geSpecByName(fork == null ? EvmSpecVersion.PRAGUE.getName() : fork);
     evm = protocolSpec.getEvm();
 

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/PrettyPrintSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/PrettyPrintSubCommand.java
@@ -99,7 +99,7 @@ public class PrettyPrintSubCommand implements Runnable {
         if (parentCommand.hasFork()) {
           fork = parentCommand.getFork();
         }
-        ProtocolSpec protocolSpec = ReferenceTestProtocolSchedules.create().geSpecByName(fork);
+        ProtocolSpec protocolSpec = ReferenceTestProtocolSchedules.getInstance().geSpecByName(fork);
         EVM evm = protocolSpec.getEvm();
         EOFLayout layout = evm.parseEOF(container);
         if (layout.isValid()) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/StateTestSubCommand.java
@@ -51,14 +51,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
-import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -89,9 +87,6 @@ public class StateTestSubCommand implements Runnable {
    * enter on the command line to invoke this command.
    */
   public static final String COMMAND_NAME = "state-test";
-
-  static final Supplier<ReferenceTestProtocolSchedules> referenceTestProtocolSchedules =
-      Suppliers.memoize(ReferenceTestProtocolSchedules::create);
 
   @SuppressWarnings({"FieldCanBeFinal"})
   @Option(
@@ -258,7 +253,7 @@ public class StateTestSubCommand implements Runnable {
 
         final String forkName = fork == null ? spec.getFork() : fork;
         final ProtocolSchedule protocolSchedule =
-            referenceTestProtocolSchedules.get().getByName(forkName);
+            ReferenceTestProtocolSchedules.getInstance().getByName(forkName);
         if (protocolSchedule == null) {
           throw new UnsupportedForkException(forkName);
         }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/create-eof-error.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/create-eof-error.json
@@ -11,5 +11,5 @@
     "CancunEOF"
   ],
   "stdin": "",
-  "stdout": "EOF Code Invalid : STOP is only a valid opcode in containers used for runtime operations.\n"
+  "stdout": "EOF Code Invalid : incompatible_container_kind opode STOP is only valid for runtime.\n"
 }

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
@@ -44,6 +44,15 @@ public class ReferenceTestProtocolSchedules {
   private static final List<String> SPECS_PRIOR_TO_DELETING_EMPTY_ACCOUNTS =
       Arrays.asList("Frontier", "Homestead", "EIP150");
 
+  private static ReferenceTestProtocolSchedules instance;
+
+  public static ReferenceTestProtocolSchedules getInstance() {
+    if (instance == null) {
+      instance = create();
+    }
+    return instance;
+  }
+
   public static ReferenceTestProtocolSchedules create() {
     return create(new StubGenesisConfigOptions());
   }

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/core/TransactionTest.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/core/TransactionTest.java
@@ -50,11 +50,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class TransactionTest {
 
-  private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
-      ReferenceTestProtocolSchedules.create();
-
   private static TransactionValidator transactionValidator(final String name) {
-    return REFERENCE_TEST_PROTOCOL_SCHEDULES
+    return ReferenceTestProtocolSchedules.getInstance()
         .getByName(name)
         .getByBlockHeader(BlockHeaderBuilder.createDefault().buildBlockHeader())
         .getTransactionValidatorFactory()

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -44,8 +44,6 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.assertj.core.api.Assertions;
 
 public class BlockchainReferenceTestTools {
-  private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
-      ReferenceTestProtocolSchedules.create();
 
   private static final List<String> NETWORKS_TO_RUN;
 
@@ -114,7 +112,7 @@ public class BlockchainReferenceTestTools {
             .orElseThrow();
 
     final ProtocolSchedule schedule =
-        REFERENCE_TEST_PROTOCOL_SCHEDULES.getByName(spec.getNetwork());
+        ReferenceTestProtocolSchedules.getInstance().getByName(spec.getNetwork());
 
     final MutableBlockchain blockchain = spec.getBlockchain();
     final ProtocolContext context = spec.getProtocolContext();

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/GeneralStateReferenceTestTools.java
@@ -44,8 +44,6 @@ import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.testutil.JsonTestParameters;
 
 public class GeneralStateReferenceTestTools {
-  private static final ReferenceTestProtocolSchedules REFERENCE_TEST_PROTOCOL_SCHEDULES =
-      ReferenceTestProtocolSchedules.create();
   private static final List<String> SPECS_PRIOR_TO_DELETING_EMPTY_ACCOUNTS =
       Arrays.asList("Frontier", "Homestead", "EIP150");
 
@@ -54,7 +52,7 @@ public class GeneralStateReferenceTestTools {
   }
 
   private static ProtocolSpec protocolSpec(final String name) {
-    return REFERENCE_TEST_PROTOCOL_SCHEDULES
+    return ReferenceTestProtocolSchedules.getInstance()
         .getByName(name)
         .getByBlockHeader(BlockHeaderBuilder.createDefault().buildBlockHeader());
   }

--- a/ethereum/referencetests/src/reference-test/templates/EOFReferenceTest.java.template
+++ b/ethereum/referencetests/src/reference-test/templates/EOFReferenceTest.java.template
@@ -6,15 +6,12 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.hyperledger.besu.ethereum.referencetests.EOFTestCaseSpec;
 
-import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /** The general state test operation testing framework entry point. */
 public class %%TESTS_NAME%% {
@@ -38,6 +35,6 @@ public class %%TESTS_NAME%% {
       final EOFTestCaseSpec.TestResult results,
       final boolean runTest) {
     assumeTrue(runTest, "Test " + name + " was ignored");
-    executeTest(fork, code, containerKind, results);
+    executeTest(name, fork, code, containerKind, results);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1Validation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1Validation.java
@@ -80,7 +80,7 @@ public class CodeV1Validation implements EOFValidator {
   @Override
   public String validate(final EOFLayout layout) {
     if (layout.container().size() > maxContainerSize) {
-      return "EOF container is larger than maximum size of " + maxContainerSize;
+      return "container_size_above_limit of " + maxContainerSize;
     }
 
     Queue<EOFLayout> workList = new ArrayDeque<>(layout.getSubcontainerCount());
@@ -90,7 +90,7 @@ public class CodeV1Validation implements EOFValidator {
       EOFLayout container = workList.poll();
       workList.addAll(List.of(container.subContainers()));
       if (container != layout && container.containerMode().get() == null) {
-        return "Unreferenced container #" + layout.indexOfSubcontainer(container);
+        return "orphan_subcontainer #" + layout.indexOfSubcontainer(container);
       }
       if (container.containerMode().get() != RUNTIME
           && container.data().size() != container.dataLength()) {
@@ -157,7 +157,7 @@ public class CodeV1Validation implements EOFValidator {
       opcodeInfo = V1_OPCODES[operationNum];
       if (!opcodeInfo.valid()) {
         // undefined instruction
-        return format("Invalid Instruction 0x%02x", operationNum);
+        return format("undefined_instruction 0x%02x", operationNum);
       }
       pos += 1;
       int pcPostInstruction = pos;
@@ -168,7 +168,7 @@ public class CodeV1Validation implements EOFValidator {
             eofLayout.containerMode().set(RUNTIME);
           } else if (!eofContainerMode.equals(RUNTIME)) {
             return format(
-                "%s is only a valid opcode in containers used for runtime operations.",
+                "incompatible_container_kind opode %s is only valid for runtime.",
                 opcodeInfo.name());
           }
           break;
@@ -210,54 +210,55 @@ public class CodeV1Validation implements EOFValidator {
           break;
         case DataLoadNOperation.OPCODE:
           if (pos + 2 > size) {
-            return "Truncated DataLoadN offset";
+            return "truncated_instruction DATALOADN";
           }
           pcPostInstruction += 2;
           final int dataLoadOffset = readBigEndianU16(pos, rawCode);
           // only verfy the last byte of the load is within the minimum data
           if (dataLoadOffset > eofLayout.dataLength() - 32) {
-            return "DataLoadN loads data past minimum data length";
+            return "invalid_dataloadn_index %d + 32 > %d"
+                .formatted(dataLoadOffset, eofLayout.dataLength());
           }
           break;
         case RelativeJumpOperation.OPCODE, RelativeJumpIfOperation.OPCODE:
           if (pos + 2 > size) {
-            return "Truncated relative jump offset";
+            return "truncated_instruction RJUMP";
           }
           pcPostInstruction += 2;
           final int offset = readBigEndianI16(pos, rawCode);
           final int rjumpdest = pcPostInstruction + offset;
           if (rjumpdest < 0 || rjumpdest >= size) {
-            return "Relative jump destination out of bounds";
+            return "invalid_rjump_destination out of bounds";
           }
           rjumpdests.set(rjumpdest);
           break;
         case RelativeJumpVectorOperation.OPCODE:
           pcPostInstruction += 1;
           if (pcPostInstruction > size) {
-            return "Truncated jump table";
+            return "truncated_instruction RJUMPV";
           }
           int jumpBasis = pcPostInstruction;
           final int jumpTableSize = RelativeJumpVectorOperation.getVectorSize(code, pos);
           pcPostInstruction += 2 * jumpTableSize;
           if (pcPostInstruction > size) {
-            return "Truncated jump table";
+            return "truncated_instruction RJUMPV";
           }
           for (int offsetPos = jumpBasis; offsetPos < pcPostInstruction; offsetPos += 2) {
             final int rjumpvOffset = readBigEndianI16(offsetPos, rawCode);
             final int rjumpvDest = pcPostInstruction + rjumpvOffset;
             if (rjumpvDest < 0 || rjumpvDest >= size) {
-              return "Relative jump destination out of bounds";
+              return "invalid_rjump_destination out of bounds";
             }
             rjumpdests.set(rjumpvDest);
           }
           break;
         case CallFOperation.OPCODE:
           if (pos + 2 > size) {
-            return "Truncated CALLF";
+            return "truncated_instruction CALLF";
           }
           int section = readBigEndianU16(pos, rawCode);
           if (section >= eofLayout.getCodeSectionCount()) {
-            return "CALLF to non-existent section - " + Integer.toHexString(section);
+            return "invalid_code_section_index CALLF to " + Integer.toHexString(section);
           }
           if (!eofLayout.getCodeSection(section).returning) {
             return "CALLF to non-returning section - " + Integer.toHexString(section);
@@ -269,17 +270,18 @@ public class CodeV1Validation implements EOFValidator {
           break;
         case JumpFOperation.OPCODE:
           if (pos + 2 > size) {
-            return "Truncated JUMPF";
+            return "truncated_instruction JUMPF";
           }
           int targetSection = readBigEndianU16(pos, rawCode);
           if (targetSection >= eofLayout.getCodeSectionCount()) {
-            return "JUMPF to non-existent section - " + Integer.toHexString(targetSection);
+            return "invalid_code_section_index JUMPF - " + Integer.toHexString(targetSection);
           }
           CodeSection targetCodeSection = eofLayout.getCodeSection(targetSection);
-          if (targetCodeSection.isReturning()
-              && thisCodeSection.getOutputs() < targetCodeSection.getOutputs()) {
+          if (targetCodeSection.isReturning() && !thisCodeSection.isReturning()) {
+            return "invalid_non_returning_flag non-returning JUMPF source must have non-returning target";
+          } else if (thisCodeSection.getOutputs() < targetCodeSection.getOutputs()) {
             return format(
-                "JUMPF targeting a returning code section %2x with more outputs %d than current section's outputs %d",
+                "jumpf_destination_incompatible_outputs target %2x with more outputs %d than current section's outputs %d",
                 targetSection, targetCodeSection.getOutputs(), thisCodeSection.getOutputs());
           }
           hasReturningOpcode |= eofLayout.getCodeSection(targetSection).isReturning();
@@ -288,13 +290,13 @@ public class CodeV1Validation implements EOFValidator {
         case EOFCreateOperation.OPCODE:
           if (pos + 1 > size) {
             return format(
-                "Dangling immediate for %s at pc=%d",
+                "truncated_instruction dangling immediate for %s at pc=%d",
                 opcodeInfo.name(), pos - opcodeInfo.pcAdvance());
           }
           int subcontainerNum = rawCode[pos] & 0xff;
           if (subcontainerNum >= eofLayout.getSubcontainerCount()) {
             return format(
-                "%s refers to non-existent subcontainer %d at pc=%d",
+                "invalid_container_section_index %s refers to non-existent subcontainer %d at pc=%d",
                 opcodeInfo.name(), subcontainerNum, pos - opcodeInfo.pcAdvance());
           }
           EOFLayout subContainer = eofLayout.getSubcontainer(subcontainerNum);
@@ -303,7 +305,7 @@ public class CodeV1Validation implements EOFValidator {
             subContainer.containerMode().set(INITCODE);
           } else if (subcontainerMode == RUNTIME) {
             return format(
-                "subcontainer %d cannot be used both as initcode and runtime", subcontainerNum);
+                "incompatible_container_kind subcontainer %d should be initcode", subcontainerNum);
           }
           if (subContainer.dataLength() != subContainer.data().size()) {
             return format(
@@ -320,17 +322,18 @@ public class CodeV1Validation implements EOFValidator {
             eofLayout.containerMode().set(INITCODE);
           } else if (!eofContainerMode.equals(INITCODE)) {
             return format(
-                "%s is only a valid opcode in containers used for initcode", opcodeInfo.name());
+                "incompatible_container_kind opcode %s is only valid for initcode",
+                opcodeInfo.name());
           }
           if (pos + 1 > size) {
             return format(
-                "Dangling immediate for %s at pc=%d",
+                "truncated_instruction dangling immediate for %s at pc=%d",
                 opcodeInfo.name(), pos - opcodeInfo.pcAdvance());
           }
           int returnedContractNum = rawCode[pos] & 0xff;
           if (returnedContractNum >= eofLayout.getSubcontainerCount()) {
             return format(
-                "%s refers to non-existent subcontainer %d at pc=%d",
+                "invalid_container_section_index %s refers to non-existent subcontainer %d at pc=%d",
                 opcodeInfo.name(), returnedContractNum, pos - opcodeInfo.pcAdvance());
           }
           EOFLayout returnedContract = eofLayout.getSubcontainer(returnedContractNum);
@@ -339,7 +342,8 @@ public class CodeV1Validation implements EOFValidator {
             returnedContract.containerMode().set(RUNTIME);
           } else if (returnedContractMode.equals(INITCODE)) {
             return format(
-                "subcontainer %d cannot be used both as initcode and runtime", returnedContractNum);
+                "incompatible_container_kind subcontainer %d should be runtime",
+                returnedContractNum);
           }
           pcPostInstruction += 1;
           break;
@@ -347,9 +351,9 @@ public class CodeV1Validation implements EOFValidator {
           // a few opcodes have potentially dangling immediates
           if (opcodeInfo.pcAdvance() > 1) {
             pcPostInstruction += opcodeInfo.pcAdvance() - 1;
-            if (pcPostInstruction >= size) {
+            if (pcPostInstruction > size) {
               return format(
-                  "Dangling immediate for %s at pc=%d",
+                  "truncated_instruction dangling immediate for %s at pc=%d",
                   opcodeInfo.name(), pos - opcodeInfo.pcAdvance());
             }
           }
@@ -360,14 +364,14 @@ public class CodeV1Validation implements EOFValidator {
     }
     if (thisCodeSection.isReturning() != hasReturningOpcode) {
       return thisCodeSection.isReturning()
-          ? "No RETF or qualifying JUMPF"
-          : "Non-returing section has RETF or JUMPF into returning section";
+          ? "unreachable_code_sections no RETF or qualifying JUMPF"
+          : "invalid_non_returning_flag RETF or JUMPF into returning section";
     }
     if (!opcodeInfo.terminal()) {
-      return "No terminating instruction";
+      return "missing_stop_opcode No terminating instruction";
     }
     if (rjumpdests.intersects(immediates)) {
-      return "Relative jump destinations targets invalid immediate data";
+      return "invalid_rjump_destination targets immediate data";
     }
     return null;
   }
@@ -472,7 +476,7 @@ public class CodeV1Validation implements EOFValidator {
 
         int nextPC;
         if (!opcodeInfo.valid()) {
-          return format("Invalid Instruction 0x%02x", thisOp);
+          return format("undefined_instruction 0x%02x", thisOp);
         }
         nextPC = currentPC + pcAdvance;
 
@@ -483,7 +487,7 @@ public class CodeV1Validation implements EOFValidator {
         }
         if (stack_max[currentPC] < 0) {
           return format(
-              "Code that was not forward referenced in section 0x%x pc %d",
+              "unreachable_instructions section 0x%x pc %d was not forward referenced",
               codeSectionToValidate, currentPC);
         }
         currentMin = min(stack_min[currentPC], currentMin);
@@ -491,7 +495,7 @@ public class CodeV1Validation implements EOFValidator {
 
         if (stackInputs > currentMin) {
           return format(
-              "Operation 0x%02X requires stack of %d but may only have %d items",
+              "stack_underflow operation 0x%02X wants stack of %d but may only have %d",
               thisOp, stackInputs, currentMin);
         }
 
@@ -515,13 +519,13 @@ public class CodeV1Validation implements EOFValidator {
             } else {
               if (stack_min[targetPC] != currentMin) {
                 return format(
-                    "Stack minimum violation on backwards jump from %d to %d, %d != %d",
-                    currentPC, targetPC, stack_min[currentPC], currentMax);
+                    "stack_height_mismatch backwards RJUMP from %d to %d, min %d != %d",
+                    currentPC, targetPC, stack_min[targetPC], currentMin);
               }
               if (stack_max[targetPC] != currentMax) {
                 return format(
-                    "Stack maximum violation on backwards jump from %d to %d, %d != %d",
-                    currentPC, targetPC, stack_max[currentPC], currentMax);
+                    "stack_height_mismatch backwards RJUMP from %d to %d, max %d != %d",
+                    currentPC, targetPC, stack_max[targetPC], currentMax);
               }
             }
 
@@ -542,13 +546,13 @@ public class CodeV1Validation implements EOFValidator {
             } else {
               if (stack_min[targetPCi] != currentMin) {
                 return format(
-                    "Stack minimum violation on backwards jump from %d to %d, %d != %d",
-                    currentPC, targetPCi, stack_min[currentPC], currentMin);
+                    "stack_height_mismatch backwards RJUMPI from %d to %d, min %d != %d",
+                    currentPC, targetPCi, stack_min[targetPCi], currentMin);
               }
               if (stack_max[targetPCi] != currentMax) {
                 return format(
-                    "Stack maximum violation on backwards jump from %d to %d, %d != %d",
-                    currentPC, targetPCi, stack_max[currentPC], currentMax);
+                    "stack_height_mismatch backwards RJUMPI from %d to %d, max %d != %d",
+                    currentPC, targetPCi, stack_max[targetPCi], currentMax);
               }
             }
             break;
@@ -568,13 +572,13 @@ public class CodeV1Validation implements EOFValidator {
               } else {
                 if (stack_min[targetPCv] != currentMin) {
                   return format(
-                      "Stack minimum violation on backwards jump from %d to %d, %d != %d",
-                      currentPC, targetPCv, stack_min[currentPC], currentMin);
+                      "stack_height_mismatch backwards RJUMPV from %d to %d, min %d != %d",
+                      currentPC, targetPCv, stack_min[targetPCv], currentMin);
                 }
                 if (stack_max[targetPCv] != currentMax) {
                   return format(
-                      "Stack maximum violation on backwards jump from %d to %d, %d != %d",
-                      currentPC, targetPCv, stack_max[currentPC], currentMax);
+                      "stack_height_mismatch backwards RJUMPV from %d to %d, max %d != %d",
+                      currentPC, targetPCv, stack_max[targetPCv], currentMax);
                 }
               }
             }
@@ -589,7 +593,7 @@ public class CodeV1Validation implements EOFValidator {
             if (stack_min[currentPC] != returnStackItems
                 || stack_min[currentPC] != stack_max[currentPC]) {
               return format(
-                  "RETF in section %d calculated height %d does not match configured return stack %d, min height %d, and max height %d",
+                  "stack_higher_than_outputs RETF in section %d calculated height %d does not match configured return stack %d, min height %d, and max height %d",
                   codeSectionToValidate,
                   currentMin,
                   returnStackItems,
@@ -620,9 +624,11 @@ public class CodeV1Validation implements EOFValidator {
                     "JUMPF at section %d pc %d has a variable stack height %d/%d",
                     codeSectionToValidate, currentPC, currentMin, currentMax);
               }
-              if (currentMax != toValidate.outputs + targetCs.inputs - targetCs.outputs) {
+              int expectedMax = toValidate.outputs + targetCs.inputs - targetCs.outputs;
+              if (currentMax != expectedMax) {
                 return format(
-                    "JUMPF at section %d pc %d has incompatible stack height for returning section %d (%d != %d + %d - %d)",
+                    "%s JUMPF at section %d pc %d has incompatible stack height for returning section %d (%d != %d + %d - %d)",
+                    currentMax < expectedMax ? "stack_underflow" : "stack_higher_than_outputs",
                     codeSectionToValidate,
                     currentPC,
                     jumpFTargetSectionNum,
@@ -634,7 +640,7 @@ public class CodeV1Validation implements EOFValidator {
             } else {
               if (currentMin < targetCs.getInputs()) {
                 return format(
-                    "JUMPF at section %d pc %d has insufficient minimum stack height for non returning section %d (%d != %d)",
+                    "stack_underflow JUMPF at section %d pc %d has insufficient minimum stack height for non returning section %d (%d != %d)",
                     codeSectionToValidate,
                     currentPC,
                     jumpFTargetSectionNum,
@@ -669,7 +675,7 @@ public class CodeV1Validation implements EOFValidator {
 
       if (maxStackHeight != toValidate.maxStackHeight) {
         return format(
-            "Calculated max stack height (%d) does not match reported stack height (%d)",
+            "invalid_max_stack_height Calculated (%d) != reported (%d)",
             maxStackHeight, toValidate.maxStackHeight);
       }
       if (unusedBytes != 0) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
@@ -766,7 +766,7 @@ public record EOFLayout(
             out.print("  ");
           }
           out.printf("%02x", byteCode[pc]);
-          for (int j = 1; j < advance; j++) {
+          for (int j = 1; j < advance && (pc + j) < byteCode.length; j++) {
             out.printf("%02x", byteCode[pc + j]);
           }
           out.printf(" # [%d] %s", pc, ci.name());
@@ -774,8 +774,11 @@ public record EOFLayout(
             out.printf("(%d)", byteCode[pc + 1] & 0xff);
           } else if (advance > 2) {
             out.print("(0x");
-            for (int j = 1; j < advance; j++) {
+            for (int j = 1; j < advance && (pc + j) < byteCode.length; j++) {
               out.printf("%02x", byteCode[pc + j]);
+            }
+            if ((pc + advance) >= byteCode.length) {
+              out.print(" <truncated immediate>");
             }
             out.print(")");
           }

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeFactoryTest.java
@@ -478,7 +478,7 @@ class CodeFactoryTest {
                        # Subcontainer 0 ends
                    # Data section (empty)
             """,
-        "STOP is only a valid opcode in containers used for runtime operations.");
+        "incompatible_container_kind");
   }
 
   @Test
@@ -527,7 +527,7 @@ class CodeFactoryTest {
                        # Subcontainer 0 ends
                    # Data section (empty)
             """,
-        "RETURN is only a valid opcode in containers used for runtime operations.");
+        "incompatible_container_kind");
   }
 
   @Test
@@ -590,7 +590,7 @@ class CodeFactoryTest {
                        # Subcontainer 0 ends
                    # Data section (empty)
             """,
-        "RETURNCONTRACT is only a valid opcode in containers used for initcode");
+        "incompatible_container_kind");
   }
 
   private static void validCode(final String str) {


### PR DESCRIPTION
## PR description

Update the EOF validation error strings so that they can validate
against expected exceptions.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

