### PR TITLE
Fleet-mode safe behavior for fcU in SynchronizationService

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
@@ -74,7 +74,8 @@ public class SynchronizationServiceImpl implements SynchronizationService {
   @Override
   public void fireNewUnverifiedForkchoiceEvent(
       final Hash head, final Hash safeBlock, final Hash finalizedBlock) {
-    protocolContext.safeConsensusContext(MergeContext.class)
+    protocolContext
+        .safeConsensusContext(MergeContext.class)
         .ifPresent(mc -> mc.fireNewUnverifiedForkchoiceEvent(head, safeBlock, finalizedBlock));
     protocolContext.getBlockchain().setFinalized(finalizedBlock);
     protocolContext.getBlockchain().setSafeBlock(safeBlock);

--- a/besu/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/SynchronizationServiceImpl.java
@@ -74,17 +74,10 @@ public class SynchronizationServiceImpl implements SynchronizationService {
   @Override
   public void fireNewUnverifiedForkchoiceEvent(
       final Hash head, final Hash safeBlock, final Hash finalizedBlock) {
-    final MergeContext mergeContext = protocolContext.getConsensusContext(MergeContext.class);
-    if (mergeContext != null) {
-      mergeContext.fireNewUnverifiedForkchoiceEvent(head, safeBlock, finalizedBlock);
-      protocolContext.getBlockchain().setFinalized(finalizedBlock);
-      protocolContext.getBlockchain().setSafeBlock(safeBlock);
-    } else {
-      LOG.atWarn()
-          .setMessage(
-              "The merge context is unavailable, hence the fork choice event cannot be triggered")
-          .log();
-    }
+    protocolContext.safeConsensusContext(MergeContext.class)
+        .ifPresent(mc -> mc.fireNewUnverifiedForkchoiceEvent(head, safeBlock, finalizedBlock));
+    protocolContext.getBlockchain().setFinalized(finalizedBlock);
+    protocolContext.getBlockchain().setSafeBlock(safeBlock);
   }
 
   @Override


### PR DESCRIPTION
## PR description

make fireNewUnverifiedForkchoiceEvent() method in SynchronizationServiceImpl safe for use not-in-the-context-of post merge networks.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

