### PR TITLE
EOF testing error codes for layout

### DIFF
--- a/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/CodeValidationSubCommandTest.java
+++ b/ethereum/evmtool/src/test/java/org/hyperledger/besu/evmtool/CodeValidationSubCommandTest.java
@@ -57,7 +57,8 @@ class CodeValidationSubCommandTest {
     EvmToolCommand parentCommand = new EvmToolCommand(bais, new PrintWriter(baos, true, UTF_8));
     final CodeValidateSubCommand codeValidateSubCommand = new CodeValidateSubCommand(parentCommand);
     codeValidateSubCommand.run();
-    assertThat(baos.toString(UTF_8)).contains("err: layout - EOF header byte 1 incorrect\n");
+    assertThat(baos.toString(UTF_8))
+        .contains("err: layout - invalid_magic EOF header byte 1 incorrect\n");
   }
 
   @Test
@@ -71,7 +72,7 @@ class CodeValidationSubCommandTest {
         .contains(
             """
                 OK 1/0/0
-                err: layout - EOF header byte 1 incorrect
+                err: layout - invalid_magic EOF header byte 1 incorrect
                 OK 1/0/0
                 """);
   }
@@ -97,7 +98,8 @@ class CodeValidationSubCommandTest {
     final CommandLine cmd = new CommandLine(codeValidateSubCommand);
     cmd.parseArgs(CODE_BAD_MAGIC);
     codeValidateSubCommand.run();
-    assertThat(baos.toString(UTF_8)).contains("err: layout - EOF header byte 1 incorrect\n");
+    assertThat(baos.toString(UTF_8))
+        .contains("err: layout - invalid_magic EOF header byte 1 incorrect\n");
   }
 
   @Test
@@ -113,7 +115,7 @@ class CodeValidationSubCommandTest {
         .contains(
             """
                 OK 1/0/0
-                err: layout - EOF header byte 1 incorrect
+                err: layout - invalid_magic EOF header byte 1 incorrect
                 OK 1/0/0
                 """);
   }
@@ -154,7 +156,7 @@ class CodeValidationSubCommandTest {
         .isEqualTo(
             """
                 OK 1/0/0
-                err: layout - EOF header byte 1 incorrect
+                err: layout - invalid_magic EOF header byte 1 incorrect
                 OK 1/0/0
                 """);
   }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/pretty-print/dangling-data.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/pretty-print/dangling-data.json
@@ -4,5 +4,5 @@
     "ef00010100040200010001040000000080000000ff"
   ],
   "stdin": "",
-  "stdout": "EOF layout is invalid - Dangling data after end of all sections\n"
+  "stdout": "EOF layout is invalid - invalid_section_bodies_size data after end of all sections\n"
 }

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/state-test/create-invalid-eof.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/state-test/create-invalid-eof.json
@@ -71,7 +71,7 @@
     }
   },
   "stdout": [
-    {"output":"","gasUsed":"0xd198","test":"create-eof","fork":"Prague","d":0,"g":0,"v":0,"postHash":"0x2a9c58298ba5d4ec86ca682b9fcc9ff67c3fc44dbd39f85a2f9b74bfe4e5178e","postLogsHash":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","pass":false,"error":"Invalid EOF Layout: Expected kind 1 but read kind 17"},
+    {"output":"","gasUsed":"0xd198","test":"create-eof","fork":"Prague","d":0,"g":0,"v":0,"postHash":"0x2a9c58298ba5d4ec86ca682b9fcc9ff67c3fc44dbd39f85a2f9b74bfe4e5178e","postLogsHash":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","pass":false,"error":"Invalid EOF Layout: unexpected_header_kind expected 1 actual 17"},
     {"pc":0,"op":239,"gas":"0x794068","gasCost":"0x0","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"INVALID","error":"Bad instruction"},
     {"output":"","gasUsed":"0x7a1200","test":"create-eof","fork":"Cancun","d":0,"g":0,"v":0,"postHash":"0xaa80d89bc89f58da8de41d3894bd1a241896ff91f7a5964edaefb39e8e3a4a98","postLogsHash":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","pass":true,"error":"INVALID_OPERATION"}
   ]

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV1Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV1Test.java
@@ -100,7 +100,7 @@ class CodeV1Test {
 
     assertThat(validationError)
         .isEqualTo(
-            "Invalid EOF container - Code section at zero expected non-returning flag, but had return stack of 0");
+            "Invalid EOF container - invalid_first_section_type want 0x80 (non-returning flag) has 0");
   }
 
   @ParameterizedTest
@@ -751,7 +751,7 @@ class CodeV1Test {
     return Stream.of(
         Arguments.of(
             "0 outputs at section 0",
-            "EOF Layout invalid - Code section at zero expected non-returning flag, but had return stack of 0",
+            "EOF Layout invalid - invalid_first_section_type want 0x80 (non-returning flag) has 0",
             0,
             List.of(List.of("e4", 0, 0, 0), List.of("e4", 0, 0, 0))),
         Arguments.of(
@@ -766,12 +766,12 @@ class CodeV1Test {
             List.of(List.of("00", 0, 0x80, 0), List.of("e4", 1, 1, 1), List.of("e4", 0, 0, 0))),
         Arguments.of(
             "more than 0 outputs section 0",
-            "EOF Layout invalid - Code section at zero expected non-returning flag, but had return stack of 0",
+            "EOF Layout invalid - invalid_first_section_type want 0x80 (non-returning flag) has 0",
             0,
             List.of(List.of("44 50 e4", 0, 0, 1), List.of("4400", 0, 1, 1))),
         Arguments.of(
             "more than 0 outputs section 0",
-            "EOF Layout invalid - Code section at zero expected non-returning flag, but had return stack of 0",
+            "EOF Layout invalid - invalid_first_section_type want 0x80 (non-returning flag) has 0",
             1,
             List.of(List.of("00", 0, 0, 0), List.of("44 e4", 0, 1, 1))),
         Arguments.of(

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/EOFLayoutTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/EOFLayoutTest.java
@@ -29,162 +29,187 @@ public class EOFLayoutTest {
   public static Collection<Object[]> containersWithFormatErrors() {
     return Arrays.asList(
         new Object[][] {
-          {"EF", "No magic", "EOF Container too small", -1},
-          {"FFFFFF", "Wrong magic", "EOF header byte 0 incorrect", -1},
-          {"EFFF01010002020004006000AABBCCDD", "Invalid magic", "EOF header byte 1 incorrect", -1},
-          {"EF00", "No version", "EOF Container too small", -1},
-          {"EF0000010002020004006000AABBCCDD", "Invalid version", "Unsupported EOF Version 0", 0},
-          {"EF0002010002020004006000AABBCCDD", "Invalid version", "Unsupported EOF Version 2", 2},
+          {"EF", "No magic", "invalid_magic EOF Container too small", -1},
+          {"FFFFFF", "Wrong magic", "invalid_magic EOF header byte 0 incorrect", -1},
           {
-            "EF00FF010002020004006000AABBCCDD",
-            "Invalid version",
-            "Unsupported EOF Version 255",
-            255
+            "EFFF01010002020004006000AABBCCDD",
+            "Invalid magic",
+            "invalid_magic EOF header byte 1 incorrect",
+            -1
           },
-          {"EF0001", "No header", "Improper section headers", 1},
-          {"EF0001 00", "No code section", "Expected kind 1 but read kind 0", 1},
-          {"EF0001 01", "No code section size", "Invalid Types section size", 1},
-          {"EF0001 0100", "Code section size incomplete", "Invalid Types section size", 1},
-          {"EF0001 010004", "No section terminator", "Improper section headers", 1},
-          {"EF0001 010004 00", "No code section contents", "Expected kind 2 but read kind 0", 1},
-          {"EF0001 010004 02", "No code section count", "Invalid Code section count", 1},
-          {"EF0001 010004 0200", "Short code section count", "Invalid Code section count", 1},
+          {"EF00", "No version", "invalid_magic EOF Container too small", -1},
+          {"EF0000010002020004006000AABBCCDD", "Invalid version", "invalid_version 0", 0},
+          {"EF0002010002020004006000AABBCCDD", "Invalid version", "invalid_version 2", 2},
+          {"EF00FF010002020004006000AABBCCDD", "Invalid version", "invalid_version 255", 255},
+          {"EF0001", "No header", "missing_headers_terminator Improper section headers", 1},
+          {"EF0001 00", "No code section", "unexpected_header_kind expected 1 actual 0", 1},
           {
-            "EF0001 010004 020001",
+            "EF0001 01",
             "No code section size",
-            "Invalid Code section size for section 0",
+            "invalid_type_section_size Invalid Types section size (mod 4 != 0)",
             1
           },
           {
-            "EF0001 010004 02000100",
-            "Short code section size",
-            "Invalid Code section size for section 0",
+            "EF0001 0100",
+            "Code section size incomplete",
+            "invalid_type_section_size Invalid Types section size (mod 4 != 0)",
             1
           },
+          {
+            "EF0001 010004",
+            "No section terminator",
+            "missing_headers_terminator Improper section headers",
+            1
+          },
+          {
+            "EF0001 010004 00",
+            "No code section contents",
+            "unexpected_header_kind expected 2 actual 0",
+            1
+          },
+          {
+            "EF0001 010004 02",
+            "No code section count",
+            "incomplete_section_number Too few code sections",
+            1
+          },
+          {
+            "EF0001 010004 0200",
+            "Short code section count",
+            "incomplete_section_number Too few code sections",
+            1
+          },
+          {"EF0001 010004 020001", "No code section size", "zero_section_size code 0", 1},
+          {"EF0001 010004 02000100", "Short code section size", "zero_section_size code 0", 1},
           {
             "EF0001 010008 0200020001",
             "No code section size multiple codes",
-            "Invalid Code section size for section 1",
+            "zero_section_size code 1",
             1
           },
           {
             "EF0001 010008 020002000100",
             "No code section size multiple codes",
-            "Invalid Code section size for section 1",
+            "zero_section_size code 1",
             1
           },
-          {"EF0001 010004 0200010001 04", "No data section size", "Invalid Data section size", 1},
+          {"EF0001 010004 0200010001 04", "No data section size", "incomplete_data_header", 1},
+          {"EF0001 010004 0200010001 0400", "Short data section size", "incomplete_data_header", 1},
           {
-            "EF0001 010004 0200010001 0400",
-            "Short data section size",
-            "Invalid Data section size",
+            "EF0001 010004 0200010001 040000",
+            "No Terminator",
+            "missing_headers_terminator Improper section headers",
             1
           },
-          {"EF0001 010004 0200010001 040000", "No Terminator", "Improper section headers", 1},
-          {"EF0001 010004 0200010002 040000 00", "No type section", "Incomplete type section", 1},
+          {
+            "EF0001 010004 0200010002 040000 00",
+            "No type section",
+            "invalid_section_bodies_size Incomplete type section",
+            1
+          },
           {
             "EF0001 010004 0200010002 040001 040001 00 DA DA",
             "Duplicate data sections",
-            "Expected kind 0 but read kind 4",
+            "unexpected_header_kind expected 0 actual 4",
             1
           },
           {
             "EF0001 010004 0200010002 040000 00 00",
             "Incomplete type section",
-            "Incomplete type section",
+            "invalid_section_bodies_size Incomplete type section",
             1
           },
           {
             "EF0001 010008 02000200020002 040000 00 00000000FE",
             "Incomplete type section",
-            "Incomplete type section",
+            "invalid_section_bodies_size Incomplete type section",
             1
           },
           {
             "EF0001 010008 0200010001 040000 00 00000000 FE ",
             "Incorrect type section size",
-            "Type section length incompatible with code section count - 0x1 * 4 != 0x8",
+            "invalid_section_bodies_size Type section - 0x1 * 4 != 0x8",
             1
           },
           {
             "EF0001 010008 02000200010001 040000 00 0100000000000000 FE FE",
             "Incorrect section zero type input",
-            "Code section does not have zero inputs and outputs",
+            "invalid_first_section_type must be zero input non-returning",
             1
           },
           {
             "EF0001 010008 02000200010001 040000 00 0001000000000000 FE FE",
             "Incorrect section zero type output",
-            "Code section does not have zero inputs and outputs",
+            "invalid_first_section_type must be zero input non-returning",
             1
           },
           {
             "EF0001 010004 0200010002 040000 00 00000000 ",
             "Incomplete code section",
-            "Incomplete code section 0",
+            "invalid_section_bodies_size code section 0",
             1
           },
           {
             "EF0001 010004 0200010002 040000 00 00000000 FE",
             "Incomplete code section",
-            "Incomplete code section 0",
+            "invalid_section_bodies_size code section 0",
             1
           },
           {
             "EF0001 010008 02000200020002 040000 00 00800000 00000000 FEFE ",
             "No code section multiple",
-            "Incomplete code section 1",
+            "invalid_section_bodies_size code section 1",
             1
           },
           {
             "EF0001 010008 02000200020002 040000 00 00800000 00000000 FEFE FE",
             "Incomplete code section multiple",
-            "Incomplete code section 1",
+            "invalid_section_bodies_size code section 1",
             1
           },
           {
             "EF0001 010004 0200010001 040003 00 00800000 FE DEADBEEF",
             "Excess data section",
-            "Dangling data after end of all sections",
+            "invalid_section_bodies_size data after end of all sections",
             1
           },
           {
             "EF0001 0200010001 040001 00 FE DA",
             "type section missing",
-            "Expected kind 1 but read kind 2",
+            "unexpected_header_kind expected 1 actual 2",
             1
           },
           {
             "EF0001 010004 040001 00 00000000 DA",
             "code section missing",
-            "Expected kind 2 but read kind 4",
+            "unexpected_header_kind expected 2 actual 4",
             1
           },
           {
             "EF0001 010004 0200010001 00 00000000 FE",
             "data section missing",
-            "Expected kind 4 but read kind 0",
+            "unexpected_header_kind expected 4 actual 0",
             1
           },
           {
             "EF0001 040001 00 DA",
             "type and code section missing",
-            "Expected kind 1 but read kind 4",
+            "unexpected_header_kind expected 1 actual 4",
             1
           },
           {
             "EF0001 0200010001 00 FE",
             "type and data section missing",
-            "Expected kind 1 but read kind 2",
+            "unexpected_header_kind expected 1 actual 2",
             1
           },
           {
             "EF0001 010004 00 00000000",
             "code and data sections missing",
-            "Expected kind 2 but read kind 0",
+            "unexpected_header_kind expected 2 actual 0",
             1
           },
-          {"EF0001 00", "all sections missing", "Expected kind 1 but read kind 0", 1},
+          {"EF0001 00", "all sections missing", "unexpected_header_kind expected 1 actual 0", 1},
           {
             "EF0001 011004 020401"
                 + " 0001".repeat(1025)
@@ -192,18 +217,33 @@ public class EOFLayoutTest {
                 + " 00000000".repeat(1025)
                 + " FE".repeat(1025),
             "no data section, 1025 code sections",
-            "Too many code sections - 0x401",
+            "too_many_code_sections - 0x401",
             1
           },
-          {"ef000101000002000003000000", "All kinds zero size", "Invalid Types section size", 1},
-          {"ef0001010000020001000103000000ef", "Zero type size ", "Invalid Types section size", 1},
+          {
+            "ef000101000002000003000000",
+            "All kinds zero size",
+            "incomplete_section_number Too few code sections",
+            1
+          },
+          {
+            "ef0001010000020001000103000000ef",
+            "Zero type size ",
+            "invalid_section_bodies_size Type section - 0x1 * 4 != 0x0",
+            1
+          },
           {
             "ef0001010004020001000003000000",
             "Zero code section length",
-            "Invalid Code section size for section 0",
+            "zero_section_size code 0",
             1
           },
-          {"ef000101000402000003000000", "Zero code sections", "Invalid Code section count", 1},
+          {
+            "ef000101000402000003000000",
+            "Zero code sections",
+            "incomplete_section_number Too few code sections",
+            1
+          },
         });
   }
 
@@ -241,31 +281,31 @@ public class EOFLayoutTest {
           {
             "EF0001 010008 02000200020002 040000 00 0100000000000000",
             "Incorrect section zero type input",
-            "Code section does not have zero inputs and outputs",
+            "invalid_first_section_type must be zero input non-returning",
             1
           },
           {
             "EF0001 010008 02000200020002 040000 00 0001000000000000",
             "Incorrect section zero type output",
-            "Code section does not have zero inputs and outputs",
+            "invalid_first_section_type must be zero input non-returning",
             1
           },
           {
             "EF0001 010010 0200040001000200020002 040000 00 00800000 F0000000 00010000 02030000 FE 5000 3000 8000",
             "inputs too large",
-            "Type data input stack too large - 0xf0",
+            "inputs_outputs_num_above_limit Type data input stack too large - 0xf0",
             1
           },
           {
             "EF0001 010010 0200040001000200020002 040000 00 00800000 01000000 00F00000 02030000 FE 5000 3000 8000",
             "outputs too large",
-            "Type data output stack too large - 0xf0",
+            "inputs_outputs_num_above_limit - 0xf0",
             1
           },
           {
             "EF0001 010010 0200040001000200020002 040000 00 00000400 01000000 00010000 02030400 FE 5000 3000 8000",
             "stack too large",
-            "Type data max stack too large - 0x400",
+            "max_stack_height_above_limit Type data max stack too large - 0x400",
             1
           },
           {
@@ -336,13 +376,13 @@ public class EOFLayoutTest {
           {
             "EF00 01 010004 0200010001 0300010015 040000 00 00800000 00 (EF0001 010004 0200010001 040000 00 00800000 00ff)",
             "dangling data in subcontainer",
-            "subcontainer size mismatch",
+            "invalid_section_bodies_size subcontainer size mismatch",
             1
           },
           {
             "EF00 01 010004 0200010001 0300010014 040000 00 00800000 00 (EF0001 010004 0200010001 040000 00 00800000 00ff)",
             "dangling data in container",
-            "Dangling data after end of all sections",
+            "invalid_section_bodies_size data after end of all sections",
             1
           },
         });
@@ -363,6 +403,11 @@ public class EOFLayoutTest {
     final Bytes container = Bytes.fromHexString(containerString.replaceAll("[^a-fxA-F0-9]", ""));
     final EOFLayout layout = EOFLayout.parseEOF(container, true);
 
+    if (failureReason != null) {
+      assertThat(failureReason)
+          .withFailMessage("Error string should start with a reference test error code")
+          .matches("^[a-zA-Z]+_.*");
+    }
     assertThat(layout.version()).isEqualTo(expectedVersion);
     assertThat(layout.invalidReason()).isEqualTo(failureReason);
     assertThat(layout.container()).isEqualTo(container);


### PR DESCRIPTION
## PR description

Update the eof layout error codes to match codes in reference tests.
This includes support for multiple possible errors for a specific test.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

