### PR TITLE
Refactor max code size

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/ClassicEVMs.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/ClassicEVMs.java
@@ -14,13 +14,10 @@
  */
 package org.hyperledger.besu.evm;
 
-import static org.hyperledger.besu.evm.MainnetEVMs.SHANGHAI_INIT_CODE_SIZE_LIMIT;
 import static org.hyperledger.besu.evm.MainnetEVMs.registerIstanbulOperations;
 
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
-import org.hyperledger.besu.evm.operation.Create2Operation;
-import org.hyperledger.besu.evm.operation.CreateOperation;
 import org.hyperledger.besu.evm.operation.OperationRegistry;
 import org.hyperledger.besu.evm.operation.Push0Operation;
 
@@ -62,8 +59,6 @@ public class ClassicEVMs {
     OperationRegistry registry = new OperationRegistry();
     registerIstanbulOperations(registry, gasCalculator, chainId);
     registry.put(new Push0Operation(gasCalculator));
-    registry.put(new CreateOperation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
-    registry.put(new Create2Operation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
     return registry;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
@@ -264,7 +264,7 @@ public class MainnetEVMs {
     registry.put(new InvalidOperation(gasCalculator));
     registry.put(new StopOperation(gasCalculator));
     registry.put(new SelfDestructOperation(gasCalculator));
-    registry.put(new CreateOperation(gasCalculator, Integer.MAX_VALUE));
+    registry.put(new CreateOperation(gasCalculator));
     registry.put(new CallOperation(gasCalculator));
     registry.put(new CallCodeOperation(gasCalculator));
 
@@ -474,7 +474,7 @@ public class MainnetEVMs {
   public static void registerConstantinopleOperations(
       final OperationRegistry registry, final GasCalculator gasCalculator) {
     registerByzantiumOperations(registry, gasCalculator);
-    registry.put(new Create2Operation(gasCalculator, Integer.MAX_VALUE));
+    registry.put(new Create2Operation(gasCalculator));
     registry.put(new SarOperation(gasCalculator));
     registry.put(new ShlOperation(gasCalculator));
     registry.put(new ShrOperation(gasCalculator));
@@ -809,8 +809,6 @@ public class MainnetEVMs {
       final BigInteger chainID) {
     registerParisOperations(registry, gasCalculator, chainID);
     registry.put(new Push0Operation(gasCalculator));
-    registry.put(new CreateOperation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
-    registry.put(new Create2Operation(gasCalculator, SHANGHAI_INIT_CODE_SIZE_LIMIT));
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/MainnetEVMs.java
@@ -147,12 +147,6 @@ public class MainnetEVMs {
   /** The constant DEV_NET_CHAIN_ID. */
   public static final BigInteger DEV_NET_CHAIN_ID = BigInteger.valueOf(1337);
 
-  /** The constant SPURIOUS_DRAGON_CONTRACT_SIZE_LIMIT. */
-  public static final int SPURIOUS_DRAGON_CONTRACT_SIZE_LIMIT = 0x6000;
-
-  /** The constant SHANGHAI_INIT_CODE_SIZE_LIMIT. */
-  public static final int SHANGHAI_INIT_CODE_SIZE_LIMIT = 2 * SPURIOUS_DRAGON_CONTRACT_SIZE_LIMIT;
-
   private MainnetEVMs() {
     // utility class
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -45,9 +45,6 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
   protected static final OperationResult INVALID_OPERATION =
       new OperationResult(0L, ExceptionalHaltReason.INVALID_OPERATION);
 
-  /** The maximum init code size */
-  protected final int maxInitcodeSize;
-
   /** The EOF Version this create operation requires initcode to be in */
   protected final int eofVersion;
 
@@ -59,7 +56,6 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
    * @param stackItemsConsumed the stack items consumed
    * @param stackItemsProduced the stack items produced
    * @param gasCalculator the gas calculator
-   * @param maxInitcodeSize Maximum init code size
    * @param eofVersion the EOF version this create operation is valid in
    */
   protected AbstractCreateOperation(
@@ -68,10 +64,8 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
       final int stackItemsConsumed,
       final int stackItemsProduced,
       final GasCalculator gasCalculator,
-      final int maxInitcodeSize,
       final int eofVersion) {
     super(opcode, name, stackItemsConsumed, stackItemsProduced, gasCalculator);
-    this.maxInitcodeSize = maxInitcodeSize;
     this.eofVersion = eofVersion;
   }
 
@@ -103,7 +97,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
 
     Code code = codeSupplier.get();
 
-    if (code != null && code.getSize() > maxInitcodeSize) {
+    if (code != null && code.getSize() > evm.getEvmVersion().getMaxInitcodeSize()) {
       frame.popStackItems(getStackItemsConsumed());
       return new OperationResult(cost, ExceptionalHaltReason.CODE_TOO_LARGE);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Create2Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Create2Operation.java
@@ -39,10 +39,9 @@ public class Create2Operation extends AbstractCreateOperation {
    * Instantiates a new Create2 operation.
    *
    * @param gasCalculator the gas calculator
-   * @param maxInitcodeSize Maximum init code size
    */
-  public Create2Operation(final GasCalculator gasCalculator, final int maxInitcodeSize) {
-    super(0xF5, "CREATE2", 4, 1, gasCalculator, maxInitcodeSize, 0);
+  public Create2Operation(final GasCalculator gasCalculator) {
+    super(0xF5, "CREATE2", 4, 1, gasCalculator, 0);
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CreateOperation.java
@@ -36,10 +36,9 @@ public class CreateOperation extends AbstractCreateOperation {
    * Instantiates a new Create operation.
    *
    * @param gasCalculator the gas calculator
-   * @param maxInitcodeSize Maximum init code size
    */
-  public CreateOperation(final GasCalculator gasCalculator, final int maxInitcodeSize) {
-    super(0xF0, "CREATE", 3, 1, gasCalculator, maxInitcodeSize, 0);
+  public CreateOperation(final GasCalculator gasCalculator) {
+    super(0xF0, "CREATE", 3, 1, gasCalculator, 0);
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/EOFCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/EOFCreateOperation.java
@@ -44,7 +44,7 @@ public class EOFCreateOperation extends AbstractCreateOperation {
    * @param gasCalculator the gas calculator
    */
   public EOFCreateOperation(final GasCalculator gasCalculator) {
-    super(OPCODE, "EOFCREATE", 4, 1, gasCalculator, Integer.MAX_VALUE, 1);
+    super(OPCODE, "EOFCREATE", 4, 1, gasCalculator, 1);
   }
 
   @Override

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCreateOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/AbstractCreateOperationTest.java
@@ -57,7 +57,7 @@ class AbstractCreateOperationTest {
   private final MutableAccount account = mock(MutableAccount.class);
   private final MutableAccount newAccount = mock(MutableAccount.class);
   private final FakeCreateOperation operation =
-      new FakeCreateOperation(new ConstantinopleGasCalculator(), Integer.MAX_VALUE);
+      new FakeCreateOperation(new ConstantinopleGasCalculator());
 
   private static final Bytes SIMPLE_CREATE =
       Bytes.fromHexString(
@@ -100,10 +100,9 @@ class AbstractCreateOperationTest {
      * Instantiates a new Create operation.
      *
      * @param gasCalculator the gas calculator
-     * @param maxInitcodeSize Maximum init code size
      */
-    public FakeCreateOperation(final GasCalculator gasCalculator, final int maxInitcodeSize) {
-      super(0xEF, "FAKECREATE", 3, 1, gasCalculator, maxInitcodeSize, 0);
+    public FakeCreateOperation(final GasCalculator gasCalculator) {
+      super(0xEF, "FAKECREATE", 3, 1, gasCalculator, 0);
     }
 
     @Override

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
@@ -60,11 +60,7 @@ public class Create2OperationTest {
   private final MutableAccount newAccount = mock(MutableAccount.class);
 
   private final Create2Operation operation =
-      new Create2Operation(new ConstantinopleGasCalculator(), Integer.MAX_VALUE);
-
-  private final Create2Operation maxInitCodeOperation =
-      new Create2Operation(
-          new ConstantinopleGasCalculator(), MainnetEVMs.SHANGHAI_INIT_CODE_SIZE_LIMIT);
+      new Create2Operation(new ConstantinopleGasCalculator());
 
   private static final String TOPIC =
       "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"; // 32 FFs
@@ -221,7 +217,7 @@ public class Create2OperationTest {
     when(worldUpdater.updater()).thenReturn(worldUpdater);
 
     final EVM myEVM = MainnetEVMs.shanghai(DEV_NET_CHAIN_ID, EvmConfiguration.DEFAULT);
-    var result = maxInitCodeOperation.execute(messageFrame, myEVM);
+    var result = operation.execute(messageFrame, myEVM);
     final MessageFrame createFrame = messageFrame.getMessageFrameStack().peek();
     final ContractCreationProcessor ccp =
         new ContractCreationProcessor(myEVM, false, List.of(), 0, List.of());
@@ -250,7 +246,7 @@ public class Create2OperationTest {
     when(worldUpdater.updater()).thenReturn(worldUpdater);
 
     final EVM evm = MainnetEVMs.shanghai(DEV_NET_CHAIN_ID, EvmConfiguration.DEFAULT);
-    var result = maxInitCodeOperation.execute(messageFrame, evm);
+    var result = operation.execute(messageFrame, evm);
     assertThat(result.getHaltReason()).isEqualTo(CODE_TOO_LARGE);
   }
 


### PR DESCRIPTION
## PR description

Refactor the max code size to no longer be a part of the operation but
instead is queried from the EVM version specification.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

