### PR TITLE
Set docker VCS_REF back to a 7 char hash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -819,7 +819,7 @@ task distDocker {
         dockerPlatform = "--platform ${project.getProperty('docker-platform')}"
         println "Building for platform ${project.getProperty('docker-platform')}"
       }
-      def gitDetails = getGitCommitDetails()
+      def gitDetails = getGitCommitDetails(7)
       executable shell
       workingDir dockerBuildDir
       args "-c", "docker build ${dockerPlatform} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${gitDetails.hash} -t ${image} ."


### PR DESCRIPTION
## PR description
Noticed in a PR for a hasty fix (https://github.com/hyperledger/besu/pull/7548) that the VCS_REF passed to docker build was unintentionally lengthened to 8 chars, when it should have stayed 7 chars.