### PR TITLE
CI: new job to upload HTML test reports even if tests fail

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -85,6 +85,12 @@ jobs:
         with:
           name: acceptance-node-${{matrix.runner_index}}-test-results
           path: 'acceptance-tests/tests/build/test-results/**/TEST-*.xml'
+      - name: Upload Acceptance Test HTML Reports
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        if: success() || failure()
+        with:
+          name: acceptance-node-${{matrix.runner_index}}-test-html-reports
+          path: 'acceptance-tests/tests/build/reports/tests/**'
   accepttests-passed:
     name: "accepttests-passed"
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-review.yml
+++ b/.github/workflows/pre-review.yml
@@ -141,6 +141,12 @@ jobs:
         with:
           name: unit-${{matrix.runner_index}}-test-results
           path: '**/test-results/**/TEST-*.xml'
+      - name: Upload Unit Test HTML Reports
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        if: success() || failure()
+        with:
+          name: unit-${{matrix.runner_index}}-test-html-reports
+          path: '**/build/reports/tests/test/**'
   unittests-passed:
     name: "unittests-passed"
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## PR description

Added new GHA job to upload HTML test reports on every run, even if tests fail, so it will be easier to investigate why a test is failing on CI. 
This already helped fixing https://github.com/hyperledger/besu/issues/7525

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes  #7540


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

