### PR TITLE
Plumb maxCode overriddes into EVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Include current chain head block when computing `eth_maxPriorityFeePerGas` [#7485](https://github.com/hyperledger/besu/pull/7485)
 
 ### Bug fixes
+- The genesis config override `contractSizeLimit` was not wired into code size limits [#7557](https://github.com/hyperledger/besu/issues/7557)
 
 ## 24.9.0
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -650,7 +650,7 @@ public abstract class MainnetProtocolSpecs {
                         TransactionType.FRONTIER,
                         TransactionType.ACCESS_LIST,
                         TransactionType.EIP1559),
-                    evm.getEvmVersion().getMaxInitcodeSize()))
+                    evm.getMaxInitcodeSize()))
         .withdrawalsProcessor(new WithdrawalsProcessor())
         .withdrawalsValidator(new WithdrawalsValidator.AllowedWithdrawals())
         .name("Shanghai");
@@ -730,7 +730,7 @@ public abstract class MainnetProtocolSpecs {
                         TransactionType.ACCESS_LIST,
                         TransactionType.EIP1559,
                         TransactionType.BLOB),
-                    evm.getEvmVersion().getMaxInitcodeSize()))
+                    evm.getMaxInitcodeSize()))
         .precompileContractRegistryBuilder(MainnetPrecompiledContractRegistries::cancun)
         .blockHeaderValidatorBuilder(MainnetBlockHeaderValidator::cancunBlockHeaderValidator)
         .blockHashProcessor(new CancunBlockHashProcessor())
@@ -814,7 +814,7 @@ public abstract class MainnetProtocolSpecs {
                         TransactionType.EIP1559,
                         TransactionType.BLOB,
                         TransactionType.SET_CODE),
-                    evm.getEvmVersion().getMaxInitcodeSize()))
+                    evm.getMaxInitcodeSize()))
 
         // EIP-2935 Blockhash processor
         .blockHashProcessor(new PragueBlockHashProcessor())

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/eof/EOFReferenceTestTools.java
@@ -124,7 +124,7 @@ public class EOFReferenceTestTools {
     // hardwire in the magic byte transaction checks
     if (evm.getMaxEOFVersion() < 1) {
       assertThat(expected.exception()).isEqualTo("EOF_InvalidCode");
-    } else if (code.size() > evm.getEvmVersion().getMaxInitcodeSize()) {
+    } else if (code.size() > evm.getMaxInitcodeSize()) {
       // this check is in EOFCREATE and Transaction validator, but unit tests sniff it out.
       assertThat(false)
           .withFailMessage(

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -143,6 +143,24 @@ public class EVM {
   }
 
   /**
+   * Gets the max code size, taking configuration and version into account
+   *
+   * @return The max code size override, if not set the max code size for the EVM version.
+   */
+  public int getMaxCodeSize() {
+    return evmConfiguration.maxCodeSizeOverride().orElse(evmSpecVersion.maxCodeSize);
+  }
+
+  /**
+   * Gets the max initcode Size, taking configuration and version into account
+   *
+   * @return The max initcode size override, if not set the max initcode size for the EVM version.
+   */
+  public int getMaxInitcodeSize() {
+    return evmConfiguration.maxInitcodeSizeOverride().orElse(evmSpecVersion.maxInitcodeSize);
+  }
+
+  /**
    * Returns the non-fork related configuration parameters of the EVM.
    *
    * @return the EVM configuration.

--- a/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/MaxCodeSizeRule.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/contractvalidation/MaxCodeSizeRule.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.util.Optional;
 
@@ -75,16 +76,19 @@ public class MaxCodeSizeRule implements ContractValidationRule {
    * @return the contract validation rule
    */
   public static ContractValidationRule from(final EVM evm) {
-    return from(evm.getEvmVersion());
+    return from(evm.getEvmVersion(), evm.getEvmConfiguration());
   }
 
   /**
    * Fluent MaxCodeSizeRule from the EVM it is working with.
    *
    * @param evmspec The evm spec version to get the size rules from.
+   * @param evmConfiguration The evm configuration, including overrides
    * @return the contract validation rule
    */
-  public static ContractValidationRule from(final EvmSpecVersion evmspec) {
-    return new MaxCodeSizeRule(evmspec.getMaxCodeSize());
+  public static ContractValidationRule from(
+      final EvmSpecVersion evmspec, final EvmConfiguration evmConfiguration) {
+    return new MaxCodeSizeRule(
+        evmConfiguration.maxCodeSizeOverride().orElse(evmspec.getMaxCodeSize()));
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/fluent/EVMExecutor.java
@@ -77,7 +77,9 @@ public class EVMExecutor {
   private OperationTracer tracer = OperationTracer.NO_TRACING;
   private boolean requireDeposit = true;
   private List<ContractValidationRule> contractValidationRules =
-      List.of(MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON), PrefixCodeRule.of());
+      List.of(
+          MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON, EvmConfiguration.DEFAULT),
+          PrefixCodeRule.of());
   private long initialNonce = 1;
   private Collection<Address> forceCommitAddresses = List.of(Address.fromHexString("0x03"));
   private Set<Address> accessListWarmAddresses = new BytesTrieSet<>(Address.SIZE);
@@ -241,8 +243,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.spuriousDragon(evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.frontier(executor.evm.getGasCalculator());
-    executor.contractValidationRules =
-        List.of(MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 
@@ -256,7 +257,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.byzantium(evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.byzantium(executor.evm.getGasCalculator());
-    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(EvmSpecVersion.BYZANTIUM));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 
@@ -270,7 +271,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.constantinople(evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.byzantium(executor.evm.getGasCalculator());
-    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(EvmSpecVersion.CONSTANTINOPLE));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 
@@ -284,7 +285,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.petersburg(evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.byzantium(executor.evm.getGasCalculator());
-    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(EvmSpecVersion.PETERSBURG));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 
@@ -319,7 +320,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.istanbul(chainId, evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.istanbul(executor.evm.getGasCalculator());
-    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(EvmSpecVersion.ISTANBUL));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 
@@ -354,7 +355,7 @@ public class EVMExecutor {
     final EVMExecutor executor = new EVMExecutor(MainnetEVMs.berlin(chainId, evmConfiguration));
     executor.precompileContractRegistry =
         MainnetPrecompiledContracts.istanbul(executor.evm.getGasCalculator());
-    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(EvmSpecVersion.BERLIN));
+    executor.contractValidationRules = List.of(MaxCodeSizeRule.from(executor.evm));
     return executor;
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -97,7 +97,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
 
     Code code = codeSupplier.get();
 
-    if (code != null && code.getSize() > evm.getEvmVersion().getMaxInitcodeSize()) {
+    if (code != null && code.getSize() > evm.getMaxInitcodeSize()) {
       frame.popStackItems(getStackItemsConsumed());
       return new OperationResult(cost, ExceptionalHaltReason.CODE_TOO_LARGE);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnContractOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnContractOperation.java
@@ -64,7 +64,7 @@ public class ReturnContractOperation extends AbstractOperation {
     }
 
     Bytes auxData = frame.readMemory(from, length);
-    if (code.getDataSize() + auxData.size() > evm.getEvmVersion().getMaxCodeSize()) {
+    if (code.getDataSize() + auxData.size() > evm.getMaxCodeSize()) {
       return new OperationResult(cost, ExceptionalHaltReason.CODE_TOO_LARGE);
     }
     if (code.getDataSize() + auxData.size() < code.getDeclaredDataSize()) {

--- a/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/processor/ContractCreationProcessorTest.java
@@ -206,7 +206,8 @@ class ContractCreationProcessorTest
         new ContractCreationProcessor(
             evm,
             true,
-            Collections.singletonList(MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON)),
+            Collections.singletonList(
+                MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON, EvmConfiguration.DEFAULT)),
             1,
             Collections.emptyList());
     final Bytes contractCode =
@@ -227,7 +228,8 @@ class ContractCreationProcessorTest
         new ContractCreationProcessor(
             evm,
             true,
-            Collections.singletonList(MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON)),
+            Collections.singletonList(
+                MaxCodeSizeRule.from(EvmSpecVersion.SPURIOUS_DRAGON, EvmConfiguration.DEFAULT)),
             1,
             Collections.emptyList());
     final Bytes contractCode =


### PR DESCRIPTION
## PR description

Restore lost functionality: the maxcodesize and maxinitcodesize should
be plumed into the operations and validation rules when set.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

