### PR TITLE
Fix consolidation request json key casing

### DIFF
--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/16_prague_getPayloadV4.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/prague/test-cases/16_prague_getPayloadV4.json
@@ -40,8 +40,8 @@
         "consolidationRequests": [
           {
             "sourceAddress": "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8f",
-            "sourcePubKey": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            "targetPubKey": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
+            "sourcePubkey": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+            "targetPubkey": "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"
           }
         ],
         "blockNumber": "0x4",

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ConsolidationRequestParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/ConsolidationRequestParameter.java
@@ -61,12 +61,12 @@ public class ConsolidationRequestParameter {
   }
 
   @JsonGetter
-  public String getSourcePubKey() {
+  public String getSourcePubkey() {
     return sourcePubkey;
   }
 
   @JsonGetter
-  public String getTargetPubKey() {
+  public String getTargetPubkey() {
     return targetPubkey;
   }
 


### PR DESCRIPTION
## PR description

Fixing the serialization of `ConsolidationRequestV1`. The casing on `sourcePubkey` and `targetPubkey` was wrong (it was using capital `K`).

Reference: https://github.com/ethereum/execution-apis/blob/main/src/engine/prague.md#consolidationrequestv1

## Fixed Issue(s)
N/A