### PR TITLE
Fix tx validation if sender has delegated it's code via 7702 transaction

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionValidator.java
@@ -32,6 +32,7 @@ import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
+import org.hyperledger.besu.evm.worldstate.DelegatedCodeService;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -305,7 +306,8 @@ public class MainnetTransactionValidator implements TransactionValidator {
   }
 
   private static boolean canSendTransaction(final Account sender, final Hash codeHash) {
-    return codeHash.equals(Hash.EMPTY) || sender.hasDelegatedCode();
+    return codeHash.equals(Hash.EMPTY)
+        || DelegatedCodeService.hasDelegatedCode(sender.getUnprocessedCode());
   }
 
   private ValidationResult<TransactionInvalidReason> validateTransactionSignature(

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/DelegatedCodeService.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/DelegatedCodeService.java
@@ -85,13 +85,19 @@ public class DelegatedCodeService {
         worldUpdater, account, resolveDelegatedAddress(account.getCode()));
   }
 
-  private Address resolveDelegatedAddress(final Bytes code) {
-    return Address.wrap(code.slice(DELEGATED_CODE_PREFIX.size()));
-  }
-
-  private boolean hasDelegatedCode(final Bytes code) {
+  /**
+   * Returns if the provided code is delegated code.
+   *
+   * @param code the code to check.
+   * @return {@code true} if the code is delegated code, {@code false} otherwise.
+   */
+  public static boolean hasDelegatedCode(final Bytes code) {
     return code != null
         && code.size() == DELEGATED_CODE_SIZE
         && code.slice(0, DELEGATED_CODE_PREFIX.size()).equals(DELEGATED_CODE_PREFIX);
+  }
+
+  private Address resolveDelegatedAddress(final Bytes code) {
+    return Address.wrap(code.slice(DELEGATED_CODE_PREFIX.size()));
   }
 }


### PR DESCRIPTION
## PR description
 Transactions from account with delegated code are currently not validated correctly. This PR makes sure that those accounts can send tx, as specified in EIP-7702.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

