### PR TITLE
Revert "Re-enable TxPoolOptionsTest::txpoolForcePriceBumpToZeroWhenZeroBaseFeeMarket (#7565)"

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/cli/TxPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/TxPoolOptionsTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class TxPoolOptionsTest extends CommandTestAbstract {
@@ -97,6 +98,7 @@ public class TxPoolOptionsTest extends CommandTestAbstract {
   }
 
   @Test
+  @Disabled // Failing in CI, but not locally
   public void txpoolForcePriceBumpToZeroWhenZeroBaseFeeMarket() throws IOException {
     final Path genesisFile = createFakeGenesisFile(GENESIS_WITH_ZERO_BASE_FEE_MARKET);
     parseCommand("--genesis-file", genesisFile.toString());


### PR DESCRIPTION
This reverts commit 07adb415eec5341fe22442ac9938e7f7b8a9de11.

## PR description

this test is failing again in CI https://github.com/hyperledger/besu/actions/runs/10830553170/job/30055039117#step:13:324, 
the test seems to fail only in specific conditions, so it is hard to reproduce the failure, so until there is a fix when need to disable it to be able to merge PRs.

The test seems to fail only in specific conditions, so it is hard to reproduce the failure.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

related to #7451

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

