### PR TITLE
Handle hadolint check failure with proper risk assessment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,6 +44,12 @@ ENV OTEL_RESOURCE_ATTRIBUTES="service.name=besu,service.version=$VERSION"
 ENV OLDPATH="${PATH}"
 ENV PATH="/opt/besu/bin:${OLDPATH}"
 
+
+# The entry script just sets permissions as needed based on besu config
+# and is replaced by the besu process running as besu user.
+# Suppressing this warning as there's no risk here because the root user
+# only sets permissions and does not continue running the main process.
+# hadolint ignore=DL3002
 USER root
 RUN chmod +x /opt/besu/bin/besu-entry.sh
 


### PR DESCRIPTION
## PR description
Suppressing/Ignoring hadolint warning about the last USER in Dockerfile being the root user - with reasoning that the root user has very specific job to do and then besu runs as besu user . 

Follow up to https://github.com/hyperledger/besu/pull/7575

## Fixed Issue(s)
Follow up fix to #4292 


