### PR TITLE
Wait for Besu to be up before running Goss Docker test 02

### DIFF
--- a/docker/tests/02/goss_wait.yaml
+++ b/docker/tests/02/goss_wait.yaml
@@ -1,0 +1,7 @@
+---
+# runtime docker tests for interfaces & ports
+port:
+  tcp:30303:
+    listening: true
+    ip:
+    - 0.0.0.0


### PR DESCRIPTION
## PR description

Follow up of #7575, this fixes the current issue building Docker images on CI

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

