### PR TITLE
change set rpc gas limit log level during transaction simulation 

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -237,7 +237,7 @@ public class TransactionSimulator {
     if (rpcGasCap > 0) {
       gasLimit = rpcGasCap;
       LOG.trace(
-          "Gas limit capped at {} for transaction simulation due to a specific RPC gas cap value provided",
+          "Gas limit capped at {} for transaction simulation due to provided RPC gas cap.",
           rpcGasCap);
     }
     final Wei value = callParams.getValue() != null ? callParams.getValue() : Wei.ZERO;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -236,7 +236,7 @@ public class TransactionSimulator {
             : blockHeaderToProcess.getGasLimit();
     if (rpcGasCap > 0) {
       gasLimit = rpcGasCap;
-      LOG.info("Capping gasLimit to " + rpcGasCap);
+      LOG.atTrace().setMessage("Capping gasLimit to {}").addArgument(rpcGasCap).log();
     }
     final Wei value = callParams.getValue() != null ? callParams.getValue() : Wei.ZERO;
     final Bytes payload = callParams.getPayload() != null ? callParams.getPayload() : Bytes.EMPTY;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -236,7 +236,9 @@ public class TransactionSimulator {
             : blockHeaderToProcess.getGasLimit();
     if (rpcGasCap > 0) {
       gasLimit = rpcGasCap;
-      LOG.atTrace().setMessage("Capping gasLimit to {}").addArgument(rpcGasCap).log();
+      LOG.trace(
+          "Gas limit capped at {} for transaction simulation due to a specific RPC gas cap value provided",
+          rpcGasCap);
     }
     final Wei value = callParams.getValue() != null ? callParams.getValue() : Wei.ZERO;
     final Bytes payload = callParams.getPayload() != null ? callParams.getPayload() : Bytes.EMPTY;


### PR DESCRIPTION
## PR description

This PR allows changing the log level when the RPC gas limit is modified during a transaction simulation.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

