### PR TITLE
Fix verkle state root calculation

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
@@ -130,6 +130,9 @@ public class VerkleWorldState extends DiffBasedWorldState {
               final List<Bytes32> accountKeyIds = new ArrayList<>();
               if (accountUpdate != null && !accountUpdate.isUnchanged()) {
                 accountKeyIds.add(trieKeyPreloader.generateAccountKeyId());
+                if (accountUpdate.getPrior() == null) {
+                  accountKeyIds.add(Parameters.CODE_HASH_LEAF_KEY);
+                }
               }
 
               // generate storage triekeys
@@ -212,13 +215,16 @@ public class VerkleWorldState extends DiffBasedWorldState {
       return;
     }
     if (accountUpdate.getUpdated() == null) {
-      verkleEntryFactory.generateAccountKeysForRemoval(accountKey);
+      verkleEntryFactory.generateAccountKeyForRemoval(accountKey);
       final Hash addressHash = hashAndSavePreImage(accountKey);
       maybeStateUpdater.ifPresent(
           bonsaiUpdater -> bonsaiUpdater.removeAccountInfoState(addressHash));
       return;
     }
     final VerkleAccount updatedAcount = accountUpdate.getUpdated();
+    if (accountUpdate.getPrior() == null) {
+      verkleEntryFactory.generateCodeHashKeyValueForUpdate(accountKey, updatedAcount.getCodeHash());
+    }
     verkleEntryFactory.generateAccountKeyValueForUpdate(
         accountKey, updatedAcount.getNonce(), updatedAcount.getBalance());
     maybeStateUpdater.ifPresent(
@@ -274,7 +280,7 @@ public class VerkleWorldState extends DiffBasedWorldState {
       if (!storageUpdate.getValue().isUnchanged()) {
         final UInt256 updatedStorage = storageUpdate.getValue().getUpdated();
         if (updatedStorage == null) {
-          verkleEntryFactory.generateStorageKeysForRemoval(accountKey, storageUpdate.getKey());
+          verkleEntryFactory.generateStorageKeyForRemoval(accountKey, storageUpdate.getKey());
           maybeStateUpdater.ifPresent(
               diffBasedUpdater ->
                   diffBasedUpdater.removeStorageValueBySlotHash(updatedAddressHash, slotHash));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
@@ -328,7 +328,7 @@ public class VerkleWorldState extends DiffBasedWorldState {
         .getNonStorageKeyValuesForUpdate()
         .forEach(
             (key, value) -> {
-              System.out.println("add key " + key + "  leaf value " + value);
+              System.out.println("add key " + key + " leaf value " + value);
               stateTrie.put(key, value);
             });
     verkleEntryFactory

--- a/ethereum/verkletrie/src/main/java/org/hyperledger/besu/ethereum/verkletrie/VerkleEntryFactory.java
+++ b/ethereum/verkletrie/src/main/java/org/hyperledger/besu/ethereum/verkletrie/VerkleEntryFactory.java
@@ -69,15 +69,15 @@ public class VerkleEntryFactory {
     Bytes32 basicDataValue;
     if ((basicDataValue = nonStorageKeyValuesForUpdate.get(basicDataKey)) == null) {
       basicDataValue = Bytes32.ZERO;
-    } else {
-      basicDataValue = SuffixTreeEncoder.eraseVersion(basicDataValue);
-      basicDataValue = SuffixTreeEncoder.eraseNonce(basicDataValue);
-      basicDataValue = SuffixTreeEncoder.eraseBalance(basicDataValue);
     }
 
-    basicDataValue = SuffixTreeEncoder.addVersionIntoValue(basicDataValue, Bytes32.ZERO);
-    basicDataValue = SuffixTreeEncoder.addNonceIntoValue(basicDataValue, UInt256.valueOf(nonce));
-    basicDataValue = SuffixTreeEncoder.addBalanceIntoValue(basicDataValue, balance);
+    basicDataValue = SuffixTreeEncoder.setVersionInValue(basicDataValue, Bytes.of(0));
+    basicDataValue = SuffixTreeEncoder.setNonceInValue(basicDataValue, Bytes.ofUnsignedLong(nonce));
+    basicDataValue =
+        SuffixTreeEncoder.setBalanceInValue(
+            basicDataValue,
+            // balance size is exactly 16 bytes
+            balance.slice(16));
     nonStorageKeyValuesForUpdate.put(basicDataKey, basicDataValue);
   }
 
@@ -87,12 +87,13 @@ public class VerkleEntryFactory {
     Bytes32 basicDataValue;
     if ((basicDataValue = nonStorageKeyValuesForUpdate.get(basicDataKey)) == null) {
       basicDataValue = Bytes32.ZERO;
-    } else {
-      basicDataValue = SuffixTreeEncoder.eraseCodeSize(basicDataValue);
     }
 
     basicDataValue =
-        SuffixTreeEncoder.addCodeSizeIntoValue(basicDataValue, UInt256.valueOf(code.size()));
+        SuffixTreeEncoder.setCodeSizeInValue(
+            basicDataValue,
+            // code size is exactly 3 bytes
+            Bytes.ofUnsignedInt(code.size()).slice(1));
     nonStorageKeyValuesForUpdate.put(basicDataKey, basicDataValue);
     nonStorageKeyValuesForUpdate.put(trieKeyAdapter.codeHashKey(address), codeHash);
     List<UInt256> codeChunks = trieKeyAdapter.chunkifyCode(code);

--- a/ethereum/verkletrie/src/main/java/org/hyperledger/besu/ethereum/verkletrie/VerkleEntryFactory.java
+++ b/ethereum/verkletrie/src/main/java/org/hyperledger/besu/ethereum/verkletrie/VerkleEntryFactory.java
@@ -45,7 +45,7 @@ public class VerkleEntryFactory {
     trieKeyAdapter = new TrieKeyBatchAdapter(hasher);
   }
 
-  public void generateAccountKeysForRemoval(final Address address) {
+  public void generateAccountKeyForRemoval(final Address address) {
     keysForRemoval.add(trieKeyAdapter.basicDataKey(address));
   }
 
@@ -58,8 +58,7 @@ public class VerkleEntryFactory {
     }
   }
 
-  public void generateStorageKeysForRemoval(
-      final Address address, final StorageSlotKey storageKey) {
+  public void generateStorageKeyForRemoval(final Address address, final StorageSlotKey storageKey) {
     keysForRemoval.add(trieKeyAdapter.storageKey(address, storageKey.getSlotKey().orElseThrow()));
   }
 
@@ -81,6 +80,10 @@ public class VerkleEntryFactory {
     nonStorageKeyValuesForUpdate.put(basicDataKey, basicDataValue);
   }
 
+  public void generateCodeHashKeyValueForUpdate(final Address address, final Hash codeHash) {
+    nonStorageKeyValuesForUpdate.put(trieKeyAdapter.codeHashKey(address), codeHash);
+  }
+
   public void generateCodeKeyValuesForUpdate(
       final Address address, final Bytes code, final Hash codeHash) {
     Bytes32 basicDataKey = trieKeyAdapter.basicDataKey(address);
@@ -95,7 +98,9 @@ public class VerkleEntryFactory {
             // code size is exactly 3 bytes
             Bytes.ofUnsignedInt(code.size()).slice(1));
     nonStorageKeyValuesForUpdate.put(basicDataKey, basicDataValue);
-    nonStorageKeyValuesForUpdate.put(trieKeyAdapter.codeHashKey(address), codeHash);
+
+    generateCodeHashKeyValueForUpdate(address, codeHash);
+
     List<UInt256> codeChunks = trieKeyAdapter.chunkifyCode(code);
     for (int i = 0; i < codeChunks.size(); i++) {
       nonStorageKeyValuesForUpdate.put(

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -169,7 +169,7 @@ dependencyManagement {
       entry 'ipa-multipoint'
     }
 
-    dependency 'org.hyperledger.besu:besu-verkle-trie:0.0.3-20240917.164246-1'
+    dependency 'org.hyperledger.besu:besu-verkle-trie:0.0.3-20240926.131636-2'
 
     dependencySet(group: 'org.immutables', version: '2.10.0') {
       entry 'value-annotations'


### PR DESCRIPTION
## PR description
This PR addresses 2 noted issues:
- See PR from [besu-verkle-trie](https://github.com/hyperledger/besu-verkle-trie/pull/70) for fixing BASIC_DATA_LEAF encoding.
- Code hash even if code is empty needs to be inserted in the tree on account creation.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

