### PR TITLE
dont' activate flight recorder dumps by default, RIP my ssd

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -690,7 +690,6 @@ startScripts {
     "-XX:G1ConcRefinementThreads=2",
     "-XX:G1HeapWastePercent=15",
     "-XX:MaxGCPauseMillis=100",
-    "-XX:StartFlightRecording,dumponexit=true,settings=default.jfc",
     "-Xlog:jfr*=off"
   ]
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/besu/src/main/scripts/unixStartScript.txt")

--- a/build.gradle
+++ b/build.gradle
@@ -690,6 +690,7 @@ startScripts {
     "-XX:G1ConcRefinementThreads=2",
     "-XX:G1HeapWastePercent=15",
     "-XX:MaxGCPauseMillis=100",
+    "-XX:StartFlightRecording,settings=default.jfc",
     "-Xlog:jfr*=off"
   ]
   unixStartScriptGenerator.template = resources.text.fromFile("${projectDir}/besu/src/main/scripts/unixStartScript.txt")


### PR DESCRIPTION
Removes enabling .jfr capture on every process started by acceptanceTest targets. This can still be added via any other target, or even explicitly via command line per-run.