### PR TITLE
Add jna native setup to besu and evmtool

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/Besu.java
+++ b/besu/src/main/java/org/hyperledger/besu/Besu.java
@@ -25,10 +25,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.RunLast;
 
+import java.util.Locale;
+
 /** Besu bootstrap class. */
 public final class Besu {
   /** Default constructor. */
-  public Besu() {}
+  public Besu() {
+  }
 
   /**
    * The main entrypoint to Besu application
@@ -36,6 +39,7 @@ public final class Besu {
    * @param args command line arguments.
    */
   public static void main(final String... args) {
+    setupNative();
     setupLogging();
     final BesuComponent besuComponent = DaggerBesuComponent.create();
     final BesuCommand besuCommand = besuComponent.getBesuCommand();
@@ -59,20 +63,17 @@ public final class Besu {
     try {
       InternalLoggerFactory.setDefaultFactory(Log4J2LoggerFactory.INSTANCE);
     } catch (Throwable t) {
-      System.out.printf(
-          "Could not set netty log4j logger factory: %s - %s%n",
+      System.out.printf("Could not set netty log4j logger factory: %s - %s%n",
           t.getClass().getSimpleName(), t.getMessage());
     }
     try {
-      System.setProperty(
-          "vertx.logger-delegate-factory-class-name",
+      System.setProperty("vertx.logger-delegate-factory-class-name",
           "io.vertx.core.logging.Log4j2LogDelegateFactory");
-      System.setProperty(
-          "log4j.configurationFactory", BesuLoggingConfigurationFactory.class.getName());
+      System.setProperty("log4j.configurationFactory",
+          BesuLoggingConfigurationFactory.class.getName());
       System.setProperty("log4j.skipJansi", String.valueOf(false));
     } catch (Throwable t) {
-      System.out.printf(
-          "Could not set logging system property: %s - %s%n",
+      System.out.printf("Could not set logging system property: %s - %s%n",
           t.getClass().getSimpleName(), t.getMessage());
     }
   }
@@ -96,5 +97,47 @@ public final class Besu {
         logger.error(String.format("Uncaught exception in thread \"%s\"", thread.getName()), error);
       }
     };
+  }
+
+  /**
+   * Set up the system jna path to include the paths used by besu-native.  Different JVMs
+   * have different expectations about platform-arch strings for jna library locations.  This
+   * method ensures we at least have the conventions used in besu-native.
+   */
+  public static void setupNative() {
+    // Get existing jna.library.path if set, otherwise use an empty string
+    String currentLibraryPath = System.getProperty("jna.library.path", "");
+
+    // Get the OS and architecture properties
+    String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+    String arch = System.getProperty("os.arch");
+
+    // Determine the correct directory based on OS and architecture
+    String additionalLibraryPath = "";
+
+    if (os.contains("linux")) {
+      if (arch.equalsIgnoreCase("x86_64") || arch.equalsIgnoreCase("amd64")) {
+        additionalLibraryPath = "linux-gnu-x86_64";
+      } else if (arch.equalsIgnoreCase("aarch64")) {
+        additionalLibraryPath = "linux-gnu-aarch64";
+      }
+    } else if (os.contains("mac")) {
+      if (arch.equalsIgnoreCase("x86_64")) {
+        additionalLibraryPath = "darwin-x86-64";
+      } else if (arch.equalsIgnoreCase("aarch64")) {
+        additionalLibraryPath = "darwin-aarch64";
+      }
+    }
+
+    // If current path is not empty, append with the system path separator
+    if (!currentLibraryPath.isEmpty()) {
+      currentLibraryPath += System.getProperty("path.separator");
+    }
+
+    // Add the new path
+    currentLibraryPath += additionalLibraryPath;
+
+    // Set the updated jna.library.path
+    System.setProperty("jna.library.path", currentLibraryPath);
   }
 }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/EvmTool.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.evmtool;
 
+import org.hyperledger.besu.Besu;
 import org.hyperledger.besu.util.LogConfigurator;
 
 /** The main entry point for the EVM (Ethereum Virtual Machine) tool. */
@@ -29,6 +30,7 @@ public final class EvmTool {
    */
   public static void main(final String... args) {
     LogConfigurator.setLevel("", "OFF");
+    Besu.setupNative();
     final EvmToolCommand evmToolCommand = new EvmToolCommand();
 
     evmToolCommand.execute(args);


### PR DESCRIPTION
## PR description

PR to normalize jna path for native library loading, so that os identification is not a problem when loading besu-native libs with JNA.  

For example, an x86_64 linux system might identify as either `linux-gnu-x86_64` or `linux-x86_64`.  Rather than duplicating the library files in besu-native so that the native loader will find them, this PR just ensures we look in both locations.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

