### PR TITLE
Fine tune already seen txs tracker when a tx is removed from the pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Upcoming Breaking Changes
 
 ### Additions and Improvements
+- Fine tune already seen txs tracker when a tx is removed from the pool [#7755](https://github.com/hyperledger/besu/pull/7755)
 
 ### Bug fixes
 

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuEventsImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuEventsImpl.java
@@ -133,7 +133,7 @@ public class BesuEventsImpl implements BesuEvents {
   public long addTransactionDroppedListener(
       final TransactionDroppedListener transactionDroppedListener) {
     return transactionPool.subscribeDroppedTransactions(
-        transactionDroppedListener::onTransactionDropped);
+        (transaction, reason) -> transactionDroppedListener.onTransactionDropped(transaction));
   }
 
   @Override

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionService.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.Subscrip
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.SubscriptionType;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
+import org.hyperledger.besu.ethereum.eth.transactions.RemovalReason;
 
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class PendingTransactionDroppedSubscriptionService
   }
 
   @Override
-  public void onTransactionDropped(final Transaction transaction) {
+  public void onTransactionDropped(final Transaction transaction, final RemovalReason reason) {
     notifySubscribers(transaction.getHash());
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/subscription/pending/PendingTransactionDroppedSubscriptionServiceTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.request.
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.transactions.RemovalReason;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,6 +48,18 @@ public class PendingTransactionDroppedSubscriptionServiceTest {
 
   private static final Hash TX_ONE =
       Hash.fromHexString("0x15876958423545c3c7b0fcf9be8ffb543305ee1b43db87ed380dcf0cd16589f7");
+  private static final RemovalReason DUMMY_REMOVAL_REASON =
+      new RemovalReason() {
+        @Override
+        public String label() {
+          return "";
+        }
+
+        @Override
+        public boolean stopTracking() {
+          return false;
+        }
+      };
 
   @Mock private SubscriptionManager subscriptionManager;
   @Mock private Blockchain blockchain;
@@ -65,7 +78,7 @@ public class PendingTransactionDroppedSubscriptionServiceTest {
     setUpSubscriptions(subscriptionIds);
     final Transaction pending = transaction(TX_ONE);
 
-    service.onTransactionDropped(pending);
+    service.onTransactionDropped(pending, DUMMY_REMOVAL_REASON);
 
     verifyNoInteractions(block);
     verifyNoInteractions(blockchain);

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -125,7 +125,7 @@ public class PeerTransactionTracker
   private <T> Set<T> createTransactionsSet() {
     return Collections.synchronizedSet(
         Collections.newSetFromMap(
-            new LinkedHashMap<>(1 << 4, 0.75f, true) {
+            new LinkedHashMap<>(16, 0.75f, true) {
               @Override
               protected boolean removeEldestEntry(final Map.Entry<T, Boolean> eldest) {
                 return size() > MAX_TRACKED_SEEN_TRANSACTIONS;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTracker.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
+public class PeerTransactionTracker
+    implements EthPeer.DisconnectCallback, PendingTransactionDroppedListener {
   private static final Logger LOG = LoggerFactory.getLogger(PeerTransactionTracker.class);
 
   private static final int MAX_TRACKED_SEEN_TRANSACTIONS = 100_000;
@@ -122,13 +123,14 @@ public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
   }
 
   private <T> Set<T> createTransactionsSet() {
-    return Collections.newSetFromMap(
-        new LinkedHashMap<>(1 << 4, 0.75f, true) {
-          @Override
-          protected boolean removeEldestEntry(final Map.Entry<T, Boolean> eldest) {
-            return size() > MAX_TRACKED_SEEN_TRANSACTIONS;
-          }
-        });
+    return Collections.synchronizedSet(
+        Collections.newSetFromMap(
+            new LinkedHashMap<>(1 << 4, 0.75f, true) {
+              @Override
+              protected boolean removeEldestEntry(final Map.Entry<T, Boolean> eldest) {
+                return size() > MAX_TRACKED_SEEN_TRANSACTIONS;
+              }
+            }));
   }
 
   @Override
@@ -174,5 +176,12 @@ public class PeerTransactionTracker implements EthPeer.DisconnectCallback {
 
   private String logPeerSet(final Set<EthPeer> peers) {
     return peers.stream().map(EthPeer::getLoggableId).collect(Collectors.joining(","));
+  }
+
+  @Override
+  public void onTransactionDropped(final Transaction transaction, final RemovalReason reason) {
+    if (reason.stopTracking()) {
+      seenTransactions.values().stream().forEach(st -> st.remove(transaction.getHash()));
+    }
   }
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/RemovalReason.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/RemovalReason.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Hyperledger Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,10 +14,19 @@
  */
 package org.hyperledger.besu.ethereum.eth.transactions;
 
-import org.hyperledger.besu.ethereum.core.Transaction;
+/** The reason why a pending tx has been removed */
+public interface RemovalReason {
+  /**
+   * Return a label that identify this reason to be used in the metric system.
+   *
+   * @return a label
+   */
+  String label();
 
-@FunctionalInterface
-public interface PendingTransactionDroppedListener {
-
-  void onTransactionDropped(Transaction transaction, final RemovalReason reason);
+  /**
+   * Return true if we should stop tracking the tx as already seen
+   *
+   * @return true if no more tracking is needed
+   */
+  boolean stopTracking();
 }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -137,7 +137,8 @@ public class TransactionPool implements BlockAddedObserver {
     initializeBlobMetrics();
     initLogForReplay();
     subscribePendingTransactions(this::mapBlobsOnTransactionAdded);
-    subscribeDroppedTransactions(this::unmapBlobsOnTransactionDropped);
+    subscribeDroppedTransactions(
+        (transaction, reason) -> unmapBlobsOnTransactionDropped(transaction));
   }
 
   private void initLogForReplay() {
@@ -720,7 +721,9 @@ public class TransactionPool implements BlockAddedObserver {
 
     void subscribe() {
       onAddedListenerId = pendingTransactions.subscribePendingTransactions(this::onAdded);
-      onDroppedListenerId = pendingTransactions.subscribeDroppedTransactions(this::onDropped);
+      onDroppedListenerId =
+          pendingTransactions.subscribeDroppedTransactions(
+              (transaction, reason) -> onDropped(transaction, reason));
     }
 
     void unsubscribe() {
@@ -728,8 +731,8 @@ public class TransactionPool implements BlockAddedObserver {
       pendingTransactions.unsubscribeDroppedTransactions(onDroppedListenerId);
     }
 
-    private void onDropped(final Transaction transaction) {
-      onDroppedListeners.forEach(listener -> listener.onTransactionDropped(transaction));
+    private void onDropped(final Transaction transaction, final RemovalReason reason) {
+      onDroppedListeners.forEach(listener -> listener.onTransactionDropped(transaction, reason));
     }
 
     private void onAdded(final Transaction transaction) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractPrioritizedTransactions.java
@@ -137,7 +137,7 @@ public abstract class AbstractPrioritizedTransactions extends AbstractSequential
   protected void internalRemove(
       final NavigableMap<Long, PendingTransaction> senderTxs,
       final PendingTransaction removedTx,
-      final RemovalReason removalReason) {
+      final LayeredRemovalReason removalReason) {
     orderByFee.remove(removedTx);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractSequentialTransactionsLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/AbstractSequentialTransactionsLayer.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.AddReason.MOVE;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.LayerMoveReason.EVICTED;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.LayerMoveReason.FOLLOW_INVALIDATED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.LayerMoveReason.EVICTED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.LayerMoveReason.FOLLOW_INVALIDATED;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
@@ -24,7 +24,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
-import org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
 
 import java.util.Map;
 import java.util.NavigableMap;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/BaseFeePrioritizedTransactions.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.AddReason.MOVE;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.LayerMoveReason.DEMOTED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.LayerMoveReason.DEMOTED;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/EndLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/EndLayer.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.DROPPED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.DROPPED;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -25,7 +25,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedLis
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
-import org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.util.Subscribers;
 
@@ -78,7 +78,7 @@ public class EndLayer implements TransactionsLayer {
   @Override
   public TransactionAddedResult add(
       final PendingTransaction pendingTransaction, final int gap, final AddReason reason) {
-    notifyTransactionDropped(pendingTransaction);
+    notifyTransactionDropped(pendingTransaction, DROPPED);
     metrics.incrementRemoved(pendingTransaction, DROPPED.label(), name());
     ++droppedCount;
     return TransactionAddedResult.DROPPED;
@@ -152,9 +152,10 @@ public class EndLayer implements TransactionsLayer {
     onDroppedListeners.unsubscribe(id);
   }
 
-  protected void notifyTransactionDropped(final PendingTransaction pendingTransaction) {
+  protected void notifyTransactionDropped(
+      final PendingTransaction pendingTransaction, final LayeredRemovalReason reason) {
     onDroppedListeners.forEach(
-        listener -> listener.onTransactionDropped(pendingTransaction.getTransaction()));
+        listener -> listener.onTransactionDropped(pendingTransaction.getTransaction(), reason));
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactions.java
@@ -21,8 +21,8 @@ import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedRes
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.INTERNAL_ERROR;
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.NONCE_TOO_FAR_IN_FUTURE_FOR_SENDER;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.AddReason.NEW;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.INVALIDATED;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.RECONCILED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.INVALIDATED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.RECONCILED;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/ReadyTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/ReadyTransactions.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.LayerMoveReason.PROMOTED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.LayerMoveReason.PROMOTED;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -109,7 +109,7 @@ public class ReadyTransactions extends AbstractSequentialTransactionsLayer {
   protected void internalRemove(
       final NavigableMap<Long, PendingTransaction> senderTxs,
       final PendingTransaction removedTx,
-      final RemovalReason removalReason) {
+      final LayeredRemovalReason removalReason) {
     orderByMaxFee.remove(removedTx);
     if (!senderTxs.isEmpty()) {
       orderByMaxFee.add(senderTxs.firstEntry().getValue());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SparseTransactions.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/SparseTransactions.java
@@ -14,8 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.LayerMoveReason.PROMOTED;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.INVALIDATED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.LayerMoveReason.PROMOTED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.INVALIDATED;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
-import org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 
 import java.util.ArrayList;
@@ -278,7 +278,7 @@ public class SparseTransactions extends AbstractTransactionsLayer {
   protected void internalRemove(
       final NavigableMap<Long, PendingTransaction> senderTxs,
       final PendingTransaction removedTx,
-      final RemovalReason removalReason) {
+      final LayeredRemovalReason removalReason) {
 
     sparseEvictionOrder.remove(removedTx);
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/TransactionsLayer.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/layered/TransactionsLayer.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.PendingTransaction;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionAddedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.PendingTransactionDroppedListener;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult;
-import org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason;
+import org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 
 import java.util.List;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/SequencedRemovalReason.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/SequencedRemovalReason.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.transactions.sorter;
+
+import org.hyperledger.besu.ethereum.eth.transactions.RemovalReason;
+
+import java.util.Locale;
+
+/** The reason why a pending tx has been removed */
+enum SequencedRemovalReason implements RemovalReason {
+  EVICTED(true),
+  TIMED_EVICTION(true),
+  REPLACED(false),
+  INVALID(false);
+
+  private final String label;
+  private final boolean stopTracking;
+
+  SequencedRemovalReason(final boolean stopTracking) {
+    this.label = name().toLowerCase(Locale.ROOT);
+    this.stopTracking = stopTracking;
+  }
+
+  @Override
+  public String label() {
+    return label;
+  }
+
+  @Override
+  public boolean stopTracking() {
+    return stopTracking;
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTrackerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PeerTransactionTrackerTest.java
@@ -66,6 +66,28 @@ public class PeerTransactionTrackerTest {
   }
 
   @Test
+  public void shouldStopTrackingSeenTransactionsWhenRemovalReasonSaysSo() {
+    tracker.markTransactionsAsSeen(ethPeer1, ImmutableSet.of(transaction2));
+
+    assertThat(tracker.hasSeenTransaction(transaction2.getHash())).isTrue();
+
+    tracker.onTransactionDropped(transaction2, createRemovalReason(true));
+
+    assertThat(tracker.hasSeenTransaction(transaction2.getHash())).isFalse();
+  }
+
+  @Test
+  public void shouldKeepTrackingSeenTransactionsWhenRemovalReasonSaysSo() {
+    tracker.markTransactionsAsSeen(ethPeer1, ImmutableSet.of(transaction2));
+
+    assertThat(tracker.hasSeenTransaction(transaction2.getHash())).isTrue();
+
+    tracker.onTransactionDropped(transaction2, createRemovalReason(false));
+
+    assertThat(tracker.hasSeenTransaction(transaction2.getHash())).isTrue();
+  }
+
+  @Test
   public void shouldExcludeAlreadySeenTransactionsAsACollectionFromTransactionsToSend() {
     tracker.markTransactionsAsSeen(ethPeer1, ImmutableSet.of(transaction1, transaction2));
 
@@ -124,5 +146,20 @@ public class PeerTransactionTrackerTest {
     // since no peers are connected, all the transaction trackers have been removed
     assertThat(tracker.hasPeerSeenTransaction(ethPeer1, transaction1)).isFalse();
     assertThat(tracker.hasPeerSeenTransaction(ethPeer2, transaction2)).isFalse();
+  }
+
+  private RemovalReason createRemovalReason(final boolean stopTracking) {
+    return new RemovalReason() {
+
+      @Override
+      public String label() {
+        return "";
+      }
+
+      @Override
+      public boolean stopTracking() {
+        return stopTracking;
+      }
+    };
   }
 }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayeredPendingTransactionsTest.java
@@ -22,8 +22,8 @@ import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedRes
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.REJECTED_UNDERPRICED_REPLACEMENT;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.AddReason.MOVE;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.AddReason.NEW;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.DROPPED;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.REPLACED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.DROPPED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.REPLACED;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.GAS_PRICE_BELOW_CURRENT_BASE_FEE;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.UPFRONT_COST_EXCEEDS_BALANCE;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.BLOB_PRICE_BELOW_CURRENT_MIN;
@@ -281,7 +281,7 @@ public class LayeredPendingTransactionsTest extends BaseTransactionPoolTest {
     assertThat(smallLayers.evictedCollector.getEvictedTransactions())
         .map(PendingTransaction::getTransaction)
         .contains(firstTxs.get(0));
-    verify(droppedListener).onTransactionDropped(firstTxs.get(0));
+    verify(droppedListener).onTransactionDropped(firstTxs.get(0), DROPPED);
   }
 
   @Test

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayersTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/LayersTest.java
@@ -21,13 +21,13 @@ import static org.hyperledger.besu.datatypes.TransactionType.ACCESS_LIST;
 import static org.hyperledger.besu.datatypes.TransactionType.BLOB;
 import static org.hyperledger.besu.datatypes.TransactionType.EIP1559;
 import static org.hyperledger.besu.datatypes.TransactionType.FRONTIER;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.INVALIDATED;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.S1;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.S2;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.S3;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.S4;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.SP1;
 import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayersTest.Sender.SP2;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.INVALIDATED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1409,7 +1409,8 @@ public class LayersTest extends BaseTransactionPoolTest {
       this.pending = new LayeredPendingTransactions(poolConfig, this.prio, ethScheduler);
 
       this.pending.subscribePendingTransactions(notificationsChecker::collectAddNotification);
-      this.pending.subscribeDroppedTransactions(notificationsChecker::collectDropNotification);
+      this.pending.subscribeDroppedTransactions(
+          (tx, reason) -> notificationsChecker.collectDropNotification(tx));
     }
 
     @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/ReplayTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/layered/ReplayTest.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.eth.transactions.layered;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hyperledger.besu.ethereum.eth.transactions.layered.RemovalReason.PoolRemovalReason.INVALIDATED;
+import static org.hyperledger.besu.ethereum.eth.transactions.layered.LayeredRemovalReason.PoolRemovalReason.INVALIDATED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/sorter/AbstractPendingTransactionsTestBase.java
@@ -18,6 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.ADDED;
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.ALREADY_KNOWN;
 import static org.hyperledger.besu.ethereum.eth.transactions.TransactionAddedResult.REJECTED_UNDERPRICED_REPLACEMENT;
+import static org.hyperledger.besu.ethereum.eth.transactions.sorter.SequencedRemovalReason.EVICTED;
+import static org.hyperledger.besu.ethereum.eth.transactions.sorter.SequencedRemovalReason.INVALID;
+import static org.hyperledger.besu.ethereum.eth.transactions.sorter.SequencedRemovalReason.REPLACED;
+import static org.hyperledger.besu.ethereum.eth.transactions.sorter.SequencedRemovalReason.TIMED_EVICTION;
 import static org.hyperledger.besu.plugin.data.TransactionSelectionResult.SELECTED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -292,9 +296,9 @@ public abstract class AbstractPendingTransactionsTestBase {
 
     transactions.subscribeDroppedTransactions(droppedListener);
 
-    transactions.removeTransaction(transaction1);
+    transactions.removeTransaction(transaction1, TIMED_EVICTION);
 
-    verify(droppedListener).onTransactionDropped(transaction1);
+    verify(droppedListener).onTransactionDropped(transaction1, TIMED_EVICTION);
   }
 
   @Test
@@ -304,13 +308,13 @@ public abstract class AbstractPendingTransactionsTestBase {
 
     final long id = transactions.subscribeDroppedTransactions(droppedListener);
 
-    transactions.removeTransaction(transaction1);
+    transactions.removeTransaction(transaction1, EVICTED);
 
-    verify(droppedListener).onTransactionDropped(transaction1);
+    verify(droppedListener).onTransactionDropped(transaction1, EVICTED);
 
     transactions.unsubscribeDroppedTransactions(id);
 
-    transactions.removeTransaction(transaction2);
+    transactions.removeTransaction(transaction2, EVICTED);
 
     verifyNoMoreInteractions(droppedListener);
   }
@@ -321,9 +325,9 @@ public abstract class AbstractPendingTransactionsTestBase {
 
     transactions.subscribeDroppedTransactions(droppedListener);
 
-    transactions.removeTransaction(transaction1);
+    transactions.removeTransaction(transaction1, REPLACED);
 
-    verify(droppedListener).onTransactionDropped(transaction1);
+    verify(droppedListener).onTransactionDropped(transaction1, REPLACED);
   }
 
   @Test
@@ -473,7 +477,7 @@ public abstract class AbstractPendingTransactionsTestBase {
   public void shouldReturnEmptyOptionalAsMaximumNonceWhenLastTransactionForSenderRemoved() {
     final Transaction transaction = transactionWithNonceAndSender(1, KEYS1);
     transactions.addTransaction(createRemotePendingTransaction(transaction), Optional.empty());
-    transactions.removeTransaction(transaction);
+    transactions.removeTransaction(transaction, INVALID);
     assertThat(transactions.getNextNonceForSender(SENDER1)).isEmpty();
   }
 
@@ -822,6 +826,8 @@ public abstract class AbstractPendingTransactionsTestBase {
                 .build(),
             Optional.of(clock));
 
+    twoHourEvictionTransactionPool.subscribeDroppedTransactions(droppedListener);
+
     twoHourEvictionTransactionPool.addTransaction(
         createRemotePendingTransaction(transaction1, clock.millis()), Optional.empty());
     assertThat(twoHourEvictionTransactionPool.size()).isEqualTo(1);
@@ -832,6 +838,7 @@ public abstract class AbstractPendingTransactionsTestBase {
     twoHourEvictionTransactionPool.evictOldTransactions();
     assertThat(twoHourEvictionTransactionPool.size()).isEqualTo(1);
     assertThat(metricsSystem.getCounterValue(REMOVED_COUNTER, REMOTE, DROPPED)).isEqualTo(1);
+    verify(droppedListener).onTransactionDropped(transaction1, TIMED_EVICTION);
   }
 
   @Test
@@ -949,7 +956,8 @@ public abstract class AbstractPendingTransactionsTestBase {
   public void shouldPrioritizeGasPriceThenTimeAddedToPool() {
     // Make sure the 100 gas price TX isn't dropped
     transactions.subscribeDroppedTransactions(
-        transaction -> assertThat(transaction.getGasPrice().get().toLong()).isLessThan(100));
+        (transaction, reason) ->
+            assertThat(transaction.getGasPrice().get().toLong()).isLessThan(100));
 
     // Fill the pool with transactions from random senders
     final List<Transaction> lowGasPriceTransactions =


### PR DESCRIPTION
## PR description

If a tx is removed from the pool due to eviction policies, but it is valid, we should be able to accept that tx again in future, but now this could not happen, since we keep track, in a cache, of all the tx hashes that we have seen, to avoid reprocessing txs, and so if the hash of the evicted txs is still in the cache, it will not be accepted again.
This PR tune the already seen txs tracker to stop tracking a valid tx that is removed from the pool, opening to the possibility to re-accept it in future.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #7081 

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

