### PR TITLE
Issue# 953 3D Pricing Metrics: Part 1 of 3: Node's perception of extraData (variable cost, fixed cost, eth gas price) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ site/
 **/src/*/generated
 jitpack.yml
 /ethereum/eth/src/test/resources/tx.csv.gz
+.run/

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/BesuMetricCategory.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/BesuMetricCategory.java
@@ -55,7 +55,9 @@ public enum BesuMetricCategory implements MetricCategory {
   /** Stratum besu metric category. */
   STRATUM("stratum"),
   /** Block processing besu metric category. */
-  BLOCK_PROCESSING("block_processing");
+  BLOCK_PROCESSING("block_processing"),
+  /** Transaction profitability besu metric category. */
+  TRANSACTION_PROFITABILITY("transaction_profitability");
 
   private static final Optional<String> BESU_PREFIX = Optional.of("besu_");
 


### PR DESCRIPTION
## PR description

Part 1 of 3 PRs for Issue# 953:

Part 1: Node's perception of extraData (variable cost, fixed cost, eth gas price)
Part 2: Profitability levels of the TxPool's contents (low, high, average)
Part 3: Profitability levels in the context of the last sealed block

Metrics to cover 3D pricing#953
Since we're introducing 3D pricing (extraData driven), we'll need to monitor it. Few high level things to cover:
P1 metrics:

Node's perception on the latest extraData contents (variable cost, fixed cost, eth gas price)
Node's perception on Profitability levels of TxPool's contents (lo, hi, avg of TransactionProfitabilityCalculator.profitablePriorityFeePerGas(transaction) / transaction.priorityFeePerGas)
Same metrics as above, but in context of last sealed block (this is relevant only for Sequencer)
Nice to have:

Profitability levels in context of transactions evaluated by TransactionProfitabilityCalculator
priorityFeePerGas returned by TransactionProfitabilityCalculator
compressedTxSize evaluated by TransactionProfitabilityCalculator
Describe the solution you'd like
For all the metrics described it would be ideal to have Histograms that would capture all of it

Acceptance Criteria
Linea-Besu exposes described metrics

## Fixed Issue(s)
["fixes #953"](https://app.zenhub.com/workspaces/besu-team-65de4730380c1800c30a9f3a/issues/gh/consensys/protocol-misc/953)


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).


### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

This PR is associated with changes in linea-sequencer. See the related PR https://github.com/Consensys/linea-sequencer/pull/103.