### PR TITLE
feature: Add optional worldstate move flag to debug_setHead

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -75,7 +75,11 @@ public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
       if (archive.isWorldStateAvailable(blockHeader.getStateRoot(), blockHeader.getBlockHash())) {
         // WARNING, this can be dangerous for a DiffBasedWorldstate if a concurrent
         //          process attempts to move or modify the head worldstate.
-        //          for Foreset worldstates, this is essentially a no-op.
+        //          Ensure no block processing is occuring when using this feature.
+        //          No engine-api, block import, sync, or mining should be running.
+        //          Even p2p transaction processing will be very expensive and should be disabled.
+        //
+        //          for Forest worldstates, this is essentially a no-op.
         archive.getMutable(blockHeader.getStateRoot(), blockHeader.getBlockHash());
       }
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -136,15 +136,15 @@ public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
 
             interimHead.ifPresent(
                 it -> {
-                  archive.getMutable(it.getStateRoot(), it.getBlockHash());
                   blockchain.rewindToBlock(it.getBlockHash());
+                  archive.getMutable(it.getStateRoot(), it.getBlockHash());
                   LOG.info("incrementally rolled worldstate to {}", it.toLogString());
                 });
             currentHead = interimHead;
 
           } else {
-            archive.getMutable(target.getStateRoot(), target.getBlockHash());
             blockchain.rewindToBlock(target.getBlockHash());
+            archive.getMutable(target.getStateRoot(), target.getBlockHash());
             currentHead = Optional.of(target);
             LOG.info("finished rolling worldstate to {}", target.toLogString());
           }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -21,16 +21,17 @@ import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.exception.InvalidJsonRpcParameters;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameterOrBlockHash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter.JsonRpcParameterException;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.util.Optional;
 
-public class DebugSetHead extends AbstractBlockParameterMethod {
+public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
   private final ProtocolContext protocolContext;
 
   public DebugSetHead(final BlockchainQueries blockchain, final ProtocolContext protocolContext) {
@@ -45,26 +46,51 @@ public class DebugSetHead extends AbstractBlockParameterMethod {
   }
 
   @Override
-  protected BlockParameter blockParameter(final JsonRpcRequestContext request) {
+  protected BlockParameterOrBlockHash blockParameterOrBlockHash(
+      final JsonRpcRequestContext requestContext) {
     try {
-      return request.getRequiredParameter(0, BlockParameter.class);
+      return requestContext.getRequiredParameter(0, BlockParameterOrBlockHash.class);
     } catch (JsonRpcParameterException e) {
       throw new InvalidJsonRpcParameters(
-          "Invalid block parameter (index 0)", RpcErrorType.INVALID_BLOCK_PARAMS, e);
+          "Invalid block or block hash parameter (index 0)", RpcErrorType.INVALID_BLOCK_PARAMS, e);
     }
   }
 
   @Override
-  protected Object resultByBlockNumber(
-      final JsonRpcRequestContext request, final long blockNumber) {
-    final Optional<Hash> maybeBlockHash = getBlockchainQueries().getBlockHashByNumber(blockNumber);
+  protected Object resultByBlockHash(final JsonRpcRequestContext request, final Hash blockHash) {
+    var blockchainQueries = getBlockchainQueries();
+    Optional<BlockHeader> maybeBlockHeader = blockchainQueries.getBlockHeaderByHash(blockHash);
+    Optional<Boolean> maybeMoveWorldstate = shouldMoveWorldstate(request);
 
-    if (maybeBlockHash.isEmpty()) {
+    if (maybeBlockHeader.isEmpty()) {
       return new JsonRpcErrorResponse(request.getRequest().getId(), UNKNOWN_BLOCK);
     }
 
-    protocolContext.getBlockchain().rewindToBlock(maybeBlockHash.get());
+    protocolContext.getBlockchain().rewindToBlock(maybeBlockHeader.get().getBlockHash());
+
+    // Optionally move the worldstate to the specified blockhash, if it is present
+    if (maybeMoveWorldstate.orElse(Boolean.FALSE)) {
+      var blockHeader = maybeBlockHeader.get();
+      var archive = blockchainQueries.getWorldStateArchive();
+      if (archive.isWorldStateAvailable(blockHeader.getStateRoot(), blockHeader.getBlockHash())) {
+        // WARNING, this can be dangerous for a DiffBasedWorldstate if a concurrent
+        //          process attempts to move or modify the head worldstate.
+        //          for Foreset worldstates, this is essentially a no-op.
+        archive.getMutable(blockHeader.getStateRoot(), blockHeader.getBlockHash());
+      }
+    }
 
     return JsonRpcSuccessResponse.SUCCESS_RESULT;
+  }
+
+  private Optional<Boolean> shouldMoveWorldstate(final JsonRpcRequestContext request) {
+    try {
+      return request.getOptionalParameter(1, Boolean.class);
+    } catch (JsonRpcParameterException e) {
+      throw new InvalidJsonRpcParameters(
+          "Invalid should move worldstate boolean parameter (index 1)",
+          RpcErrorType.INVALID_PARAMS,
+          e);
+    }
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -76,8 +76,7 @@ public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
         // WARNING, this can be dangerous for a DiffBasedWorldstate if a concurrent
         //          process attempts to move or modify the head worldstate.
         //          Ensure no block processing is occuring when using this feature.
-        //          No engine-api, block import, sync, or mining should be running.
-        //          Even p2p transaction processing will be very expensive and should be disabled.
+        //          No engine-api, block import, sync, mining or other rpc calls should be running.
         //
         //          for Forest worldstates, this is essentially a no-op.
         archive.getMutable(blockHeader.getStateRoot(), blockHeader.getBlockHash());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
@@ -27,7 +27,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParame
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
-import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
@@ -65,7 +65,7 @@ public class DebugSetHeadTest extends AbstractJsonRpcHttpServiceTest {
     debugSetHead =
         new DebugSetHead(
             new BlockchainQueries(
-                protocolSchedule, blockchain, archive, MiningParameters.MINING_DISABLED),
+                protocolSchedule, blockchain, archive, MiningConfiguration.MINING_DISABLED),
             protocolContext,
             // a value of 2 here exercises all the state rolling code paths
             2);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.hyperledger.besu.crypto.Hash;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.AbstractJsonRpcHttpServiceTest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.BlockParameterOrBlockHash;
+import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.MiningParameters;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
+
+import java.util.Optional;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.tuweni.bytes.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * This test only exercises bonsai worldstate since forest is essentially a no-op for moving the
+ * worldstate.
+ */
+public class DebugSetHeadTest extends AbstractJsonRpcHttpServiceTest {
+
+  DebugSetHead debugSetHead;
+  Blockchain blockchain;
+  WorldStateArchive archive;
+  ProtocolContext protocolContext;
+  ProtocolSchedule protocolSchedule;
+
+  @Override
+  @BeforeEach
+  public void setup() throws Exception {
+    setupBonsaiBlockchain();
+    blockchain = blockchainSetupUtil.getBlockchain();
+    protocolContext = blockchainSetupUtil.getProtocolContext();
+    protocolSchedule = blockchainSetupUtil.getProtocolSchedule();
+    ;
+    archive = blockchainSetupUtil.getWorldArchive();
+    debugSetHead =
+        new DebugSetHead(
+            new BlockchainQueries(
+                protocolSchedule, blockchain, archive, MiningParameters.MINING_DISABLED),
+            protocolContext);
+    startService();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "0x01",
+        "0x02",
+        "0x3d813a0ffc9cd04436e17e3e9c309f1e80df0407078e50355ce0d570b5424812",
+        "0x4e9a67b663f9abe03e7e9fd5452c9497998337077122f44ee78a466f6a7358de"
+      })
+  public void assertOnlyChainHeadMoves(final String blockParam) {
+    var chainTip = blockchain.getChainHead().getBlockHeader();
+    var blockOne = getBlockHeaderForHashOrNumber(blockParam).orElse(null);
+
+    assertThat(blockOne).isNotNull();
+    assertThat(blockOne).isNotEqualTo(chainTip);
+
+    // move the head to param val, number or hash
+    debugSetHead.response(debugSetHead(blockParam, false));
+
+    // get the new chainTip:
+    var newChainTip = blockchain.getChainHead().getBlockHeader();
+
+    // assert the chain moved, and the worldstate did not
+    assertThat(newChainTip).isEqualTo(blockOne);
+    assertThat(archive.getMutable().rootHash()).isEqualTo(chainTip.getStateRoot());
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "0x01",
+        "0x02",
+        "0x3d813a0ffc9cd04436e17e3e9c309f1e80df0407078e50355ce0d570b5424812",
+        "0x4e9a67b663f9abe03e7e9fd5452c9497998337077122f44ee78a466f6a7358de"
+      })
+  public void assertBothChainHeadAndWorldStatByNumber(final String blockParam) {
+    var chainTip = blockchain.getChainHead().getBlockHeader();
+    var blockOne = getBlockHeaderForHashOrNumber(blockParam).orElse(null);
+
+    assertThat(blockOne).isNotNull();
+    assertThat(blockOne).isNotEqualTo(chainTip);
+
+    // move the head and worldstate to param val number or hash
+    debugSetHead.response(debugSetHead(blockParam, true));
+
+    // get the new chainTip:
+    var newChainTip = blockchain.getChainHead().getBlockHeader();
+
+    // assert both the chain and worldstate moved to block one
+    assertThat(newChainTip).isEqualTo(blockOne);
+    assertThat(archive.getMutable().rootHash()).isEqualTo(blockOne.getStateRoot());
+  }
+
+  @Test
+  public void assertNotFound() {
+    var chainTip = blockchain.getChainHead().getBlockHeader();
+
+    // move the head to number just after chain head
+    var resp = debugSetHead.response(debugSetHead("" + chainTip.getNumber() + 1, false));
+    assertThat(resp.getType()).isEqualTo(RpcResponseType.ERROR);
+
+    // move the head to some arbitrary hash
+    var resp2 =
+        debugSetHead.response(
+            debugSetHead(Hash.keccak256(Bytes.fromHexString("0xdeadbeef")).toHexString(), false));
+    assertThat(resp2.getType()).isEqualTo(RpcResponseType.ERROR);
+
+    // get the new chainTip:
+    var newChainTip = blockchain.getChainHead().getBlockHeader();
+
+    // assert neither the chain nor the worldstate moved
+    assertThat(newChainTip).isEqualTo(chainTip);
+    assertThat(archive.getMutable().rootHash()).isEqualTo(chainTip.getStateRoot());
+  }
+
+  private JsonRpcRequestContext debugSetHead(
+      final String numberOrHash, final Boolean moveWorldState) {
+    return new JsonRpcRequestContext(
+        new JsonRpcRequest("2.0", "debug_setHead", new Object[] {numberOrHash, moveWorldState}));
+  }
+
+  private Optional<BlockHeader> getBlockHeaderForHashOrNumber(final String input) {
+    try {
+      var param = new BlockParameterOrBlockHash(input);
+      if (param.getHash().isPresent()) {
+        return blockchain.getBlockHeader(param.getHash().get());
+      } else if (param.getNumber().isPresent()) {
+        return blockchain.getBlockHeader(param.getNumber().getAsLong());
+      }
+    } catch (JsonProcessingException ignored) {
+      // meh
+    }
+    return Optional.empty();
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHeadTest.java
@@ -66,7 +66,9 @@ public class DebugSetHeadTest extends AbstractJsonRpcHttpServiceTest {
         new DebugSetHead(
             new BlockchainQueries(
                 protocolSchedule, blockchain, archive, MiningParameters.MINING_DISABLED),
-            protocolContext);
+            protocolContext,
+            // a value of 2 here exercises all the state rolling code paths
+            2);
     startService();
   }
 


### PR DESCRIPTION
## PR description

This PR adds an optional parameter to `debug_setHead` that allows one to move the head worldstate along with the blockchain.  This is a no-op for Forest, but for DiffBased worldstates like bonsai and verkle, this will roll the head worldstate to the specified block number / block hash.

This is a debug method only and __should  not__ be used when a consensus client is directing besu, or while the node is actively importing or proposing blocks.

This feature is a stop-gap measure until #7475 is complete.  This debug feature will allow users to move bonsai worldstate head far back into block history so that expensive operations like `debug_traceBlock` can be run on historical blocks.  Otherwise, trying to execute RPC calls on old historical states will inevitably encounter an OOM (out of memory) while trying to roll the worldstate back in-memory.

This is a debug feature, if used incorrectly (like while some concurrent process is trying to move or modify the worldstate) it will corrupt the database.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to #7804 

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

