### PR TITLE
Add a method to check if a metric category is enabled to the plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Create and publish Besu BOM (Bill of Materials) [#7615](https://github.com/hyperledger/besu/pull/7615) 
 - Update Java dependencies [#7786](https://github.com/hyperledger/besu/pull/7786)
 - Add a method to get all the transaction in the pool, to the `TransactionPoolService`, to easily access the transaction pool content from plugins [#7813](https://github.com/hyperledger/besu/pull/7813)
+- Add a method to check if a metric category is enabled to the plugin API [#7832](https://github.com/hyperledger/besu/pull/7832)
 
 ### Bug fixes
 - Fix registering new metric categories from plugins [#7825](https://github.com/hyperledger/besu/pull/7825)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1899,7 +1899,9 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
                 ? p2PDiscoveryOptions.autoDiscoverDefaultIP().getHostAddress()
                 : metricsOptions.getMetricsPushHost())
         .hostsAllowlist(hostsAllowlist);
-    return metricsConfigurationBuilder.build();
+    final var metricsConfiguration = metricsConfigurationBuilder.build();
+    metricCategoryRegistry.setMetricsConfiguration(metricsConfiguration);
+    return metricsConfiguration;
   }
 
   private PrivacyParameters privacyParameters() {

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/MetricsOptionsTest.java
@@ -60,4 +60,9 @@ public class MetricsOptionsTest
   protected MetricsOptions getOptionsFromBesuCommand(final TestBesuCommand besuCommand) {
     return besuCommand.getMetricsOptions();
   }
+
+  @Override
+  protected String[] getNonOptionFields() {
+    return new String[] {"metricCategoryRegistry"};
+  }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImpl.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImpl.java
@@ -14,6 +14,9 @@
  */
 package org.hyperledger.besu.metrics;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategoryRegistry;
 
@@ -25,6 +28,7 @@ import java.util.Map;
 /** The Metric category registry implementation. */
 public class MetricCategoryRegistryImpl implements MetricCategoryRegistry {
   private final Map<String, MetricCategory> metricCategories = new HashMap<>();
+  private MetricsConfiguration metricsConfiguration;
 
   /** Default constructor */
   public MetricCategoryRegistryImpl() {}
@@ -49,6 +53,14 @@ public class MetricCategoryRegistryImpl implements MetricCategoryRegistry {
     metricCategories.put(metricCategory.getName().toUpperCase(Locale.ROOT), metricCategory);
   }
 
+  @Override
+  public boolean isMetricCategoryEnabled(final MetricCategory metricCategory) {
+    checkNotNull(
+        metricsConfiguration, "Metrics configuration must be set before calling this method");
+    return (metricsConfiguration.isEnabled() || metricsConfiguration.isPushEnabled())
+        && metricsConfiguration.getMetricCategories().contains(metricCategory);
+  }
+
   /**
    * Return true if a category with that name is already registered
    *
@@ -67,5 +79,15 @@ public class MetricCategoryRegistryImpl implements MetricCategoryRegistry {
    */
   public MetricCategory getMetricCategory(final String name) {
     return metricCategories.get(name.toUpperCase(Locale.ROOT));
+  }
+
+  /**
+   * Set the metric configuration via a method since it is still not available when creating this
+   * object
+   *
+   * @param metricsConfiguration the metrics configuration
+   */
+  public void setMetricsConfiguration(final MetricsConfiguration metricsConfiguration) {
+    this.metricsConfiguration = metricsConfiguration;
   }
 }

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImplTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/MetricCategoryRegistryImplTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class MetricCategoryRegistryImplTest {
+
+  @Test
+  void metricCategoryIsEnabledAndMetricsAreEnabled() {
+    final var registry = new MetricCategoryRegistryImpl();
+    registry.addMetricCategory(BesuMetricCategory.BLOCKCHAIN);
+    final var metricsConfiguration =
+        MetricsConfiguration.builder()
+            .enabled(true)
+            .metricCategories(Set.of(BesuMetricCategory.BLOCKCHAIN))
+            .build();
+    registry.setMetricsConfiguration(metricsConfiguration);
+    assertTrue(registry.isMetricCategoryEnabled(BesuMetricCategory.BLOCKCHAIN));
+  }
+
+  @Test
+  void metricCategoryIsDisabledAndMetricsAreEnabled() {
+    final var registry = new MetricCategoryRegistryImpl();
+    registry.addMetricCategory(BesuMetricCategory.ETHEREUM);
+    final var metricsConfiguration =
+        MetricsConfiguration.builder()
+            .enabled(true)
+            .metricCategories(Set.of(BesuMetricCategory.ETHEREUM))
+            .build();
+    registry.setMetricsConfiguration(metricsConfiguration);
+    assertFalse(registry.isMetricCategoryEnabled(BesuMetricCategory.BLOCKCHAIN));
+  }
+
+  @Test
+  void metricCategoryNotEnabledWhenMetricsAreDisabled() {
+    final var registry = new MetricCategoryRegistryImpl();
+    registry.addMetricCategory(BesuMetricCategory.BLOCKCHAIN);
+    final var metricsConfiguration =
+        MetricsConfiguration.builder()
+            .enabled(false)
+            .metricCategories(Set.of(BesuMetricCategory.BLOCKCHAIN))
+            .build();
+    registry.setMetricsConfiguration(metricsConfiguration);
+    assertFalse(registry.isMetricCategoryEnabled(BesuMetricCategory.BLOCKCHAIN));
+  }
+}

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'uNQzVjMa7m1fw3d10NuVOjmzGxmCkgZd88yGFgP3qoY='
+  knownHash = '8rPIE3fYl48RPRQXxYhMk559e/r+wHSKU9bGSJmruKQ='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/MetricCategoryRegistry.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/MetricCategoryRegistry.java
@@ -29,5 +29,13 @@ public interface MetricCategoryRegistry extends BesuService {
    *
    * @param newMetricCategory The {@link MetricCategory} that is being registered.
    */
-  public void addMetricCategory(final MetricCategory newMetricCategory);
+  void addMetricCategory(final MetricCategory newMetricCategory);
+
+  /**
+   * Return true if the metrics are enabled and the metric category is enabled
+   *
+   * @param metricCategory the metric category
+   * @return true if the metrics are enabled and the metric category is enabled
+   */
+  boolean isMetricCategoryEnabled(final MetricCategory metricCategory);
 }


### PR DESCRIPTION
## PR description

Adding the new method `MetricCategoryRegistry::isMetricCategoryEnabled` to plugin API, so plugins can check if their added metrics categories are enabled, that include checking both that the metrics are enabled and the category is enabled.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

