### PR TITLE
Round change upon f+1 RC messages (experimental option)

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/bftsoak/BftMiningSoakTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/bftsoak/BftMiningSoakTest.java
@@ -41,7 +41,7 @@ public class BftMiningSoakTest extends ParameterizedBftTestBase {
 
   private static final long ONE_MINUTE = Duration.of(1, ChronoUnit.MINUTES).toMillis();
 
-  private static final long THREE_MINUTES = Duration.of(1, ChronoUnit.MINUTES).toMillis();
+  private static final long THREE_MINUTES = Duration.of(3, ChronoUnit.MINUTES).toMillis();
 
   private static final long TEN_SECONDS = Duration.of(10, ChronoUnit.SECONDS).toMillis();
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -68,6 +68,7 @@ import org.hyperledger.besu.cli.options.unstable.NativeLibraryOptions;
 import org.hyperledger.besu.cli.options.unstable.NetworkingOptions;
 import org.hyperledger.besu.cli.options.unstable.P2PTLSConfigOptions;
 import org.hyperledger.besu.cli.options.unstable.PrivacyPluginOptions;
+import org.hyperledger.besu.cli.options.unstable.QBFTOptions;
 import org.hyperledger.besu.cli.options.unstable.RPCOptions;
 import org.hyperledger.besu.cli.options.unstable.SynchronizerOptions;
 import org.hyperledger.besu.cli.presynctasks.PreSynchronizationTaskRunner;
@@ -303,6 +304,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private final EvmOptions unstableEvmOptions = EvmOptions.create();
   private final IpcOptions unstableIpcOptions = IpcOptions.create();
   private final ChainPruningOptions unstableChainPruningOptions = ChainPruningOptions.create();
+  private final QBFTOptions unstableQbftOptions = QBFTOptions.create();
 
   // stable CLI options
   final DataStorageOptions dataStorageOptions = DataStorageOptions.create();
@@ -1162,6 +1164,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .put("EVM Options", unstableEvmOptions)
             .put("IPC Options", unstableIpcOptions)
             .put("Chain Data Pruning Options", unstableChainPruningOptions)
+            .put("QBFT options", unstableQbftOptions)
             .build();
 
     UnstableOptionsSubCommand.createUnstableOptions(commandLine, unstableOptions);
@@ -1806,6 +1809,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .isRevertReasonEnabled(isRevertReasonEnabled)
         .isParallelTxProcessingEnabled(
             dataStorageConfiguration.getUnstable().isParallelTxProcessingEnabled())
+        .isEarlyRoundChangeEnabled(unstableQbftOptions.isEarlyRoundChangeEnabled())
         .storageProvider(storageProvider)
         .gasLimitCalculator(
             miningParametersSupplier.get().getTargetGasLimit().isPresent()

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/QBFTOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/unstable/QBFTOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.options.unstable;
+
+import picocli.CommandLine;
+
+public class QBFTOptions {
+
+  public static QBFTOptions create() {
+    return new QBFTOptions();
+  }
+
+  @CommandLine.Option(
+      names = {"--Xqbft-enable-early-round-change"},
+      description =
+          "Enable early round change upon receiving f+1 valid future Round Change messages from different validators (experimental)",
+      hidden = true)
+  private boolean enableEarlyRoundChange = false;
+
+  public boolean isEarlyRoundChangeEnabled() {
+    return enableEarlyRoundChange;
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -206,6 +206,8 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
   /** whether parallel transaction processing is enabled or not */
   protected boolean isParallelTxProcessingEnabled;
 
+  protected boolean isEarlyRoundChangeEnabled = false;
+
   /** Instantiates a new Besu controller builder. */
   protected BesuControllerBuilder() {}
 
@@ -526,6 +528,11 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
   public BesuControllerBuilder isParallelTxProcessingEnabled(
       final boolean isParallelTxProcessingEnabled) {
     this.isParallelTxProcessingEnabled = isParallelTxProcessingEnabled;
+    return this;
+  }
+
+  public BesuControllerBuilder isEarlyRoundChangeEnabled(final boolean isEarlyRoundChangeEnabled) {
+    this.isEarlyRoundChangeEnabled = isEarlyRoundChangeEnabled;
     return this;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -249,23 +249,28 @@ public class QbftBesuControllerBuilder extends BftBesuControllerBuilder {
 
     final MessageFactory messageFactory = new MessageFactory(nodeKey);
 
+    QbftBlockHeightManagerFactory qbftBlockHeightManagerFactory =
+        new QbftBlockHeightManagerFactory(
+            finalState,
+            new QbftRoundFactory(
+                finalState,
+                protocolContext,
+                bftProtocolSchedule,
+                minedBlockObservers,
+                messageValidatorFactory,
+                messageFactory,
+                bftExtraDataCodec().get()),
+            messageValidatorFactory,
+            messageFactory,
+            new ValidatorModeTransitionLogger(qbftForksSchedule));
+
+    qbftBlockHeightManagerFactory.isEarlyRoundChangeEnabled(isEarlyRoundChangeEnabled);
+
     final BftEventHandler qbftController =
         new QbftController(
             blockchain,
             finalState,
-            new QbftBlockHeightManagerFactory(
-                finalState,
-                new QbftRoundFactory(
-                    finalState,
-                    protocolContext,
-                    bftProtocolSchedule,
-                    minedBlockObservers,
-                    messageValidatorFactory,
-                    messageFactory,
-                    bftExtraDataCodec().get()),
-                messageValidatorFactory,
-                messageFactory,
-                new ValidatorModeTransitionLogger(qbftForksSchedule)),
+            qbftBlockHeightManagerFactory,
             gossiper,
             duplicateMessageTracker,
             futureMessageBuffer,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftHelpers.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BftHelpers.java
@@ -44,6 +44,16 @@ public class BftHelpers {
   }
 
   /**
+   * Calculate required future RC messages count quorum for a round change.
+   *
+   * @param validatorCount the validator count
+   * @return the int
+   */
+  public static int calculateRequiredFutureRCQuorum(final int validatorCount) {
+    return validatorCount - Util.fastDivCeiling(2 * validatorCount, 3) + 1;
+  }
+
+  /**
    * Prepare message count for quorum.
    *
    * @param quorum the quorum

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/RoundTimer.java
@@ -83,8 +83,7 @@ public class RoundTimer {
     // Once we are up to round 2 start logging round expiries
     if (round.getRoundNumber() >= 2) {
       LOG.info(
-          "BFT round {} expired. Moved to round {} which will expire in {} seconds",
-          round.getRoundNumber() - 1,
+          "Moved to round {} which will expire in {} seconds",
           round.getRoundNumber(),
           (expiryTime / 1000));
     }

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/statemachine/QbftBlockHeightManager.java
@@ -68,6 +68,7 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
 
   private Optional<PreparedCertificate> latestPreparedCertificate = Optional.empty();
   private Optional<QbftRound> currentRound = Optional.empty();
+  private boolean isEarlyRoundChangeEnabled = false;
 
   /**
    * Instantiates a new Qbft block height manager.
@@ -213,37 +214,50 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
   @Override
   public void roundExpired(final RoundExpiry expire) {
     if (currentRound.isEmpty()) {
-      LOG.error(
+      LOG.info(
           "Received Round timer expiry before round is created timerRound={}", expire.getView());
       return;
     }
 
     QbftRound qbftRound = currentRound.get();
     if (!expire.getView().equals(qbftRound.getRoundIdentifier())) {
-      LOG.trace(
+      LOG.info(
           "Ignoring Round timer expired which does not match current round. round={}, timerRound={}",
           qbftRound.getRoundIdentifier(),
           expire.getView());
       return;
     }
 
+    doRoundChange(qbftRound.getRoundIdentifier().getRoundNumber() + 1);
+  }
+
+  private synchronized void doRoundChange(final int newRoundNumber) {
+
+    if (currentRound.isPresent()
+        && currentRound.get().getRoundIdentifier().getRoundNumber() >= newRoundNumber) {
+      return;
+    }
     LOG.debug(
-        "Round has expired, creating PreparedCertificate and notifying peers. round={}",
-        qbftRound.getRoundIdentifier());
+        "Round has expired or changing based on RC quorum, creating PreparedCertificate and notifying peers. round={}",
+        currentRound.get().getRoundIdentifier());
     final Optional<PreparedCertificate> preparedCertificate =
-        qbftRound.constructPreparedCertificate();
+        currentRound.get().constructPreparedCertificate();
 
     if (preparedCertificate.isPresent()) {
       latestPreparedCertificate = preparedCertificate;
     }
 
-    startNewRound(qbftRound.getRoundIdentifier().getRoundNumber() + 1);
-    qbftRound = currentRound.get();
+    startNewRound(newRoundNumber);
+    if (currentRound.isEmpty()) {
+      LOG.info("Failed to start round ");
+      return;
+    }
+    QbftRound qbftRoundNew = currentRound.get();
 
     try {
       final RoundChange localRoundChange =
           messageFactory.createRoundChange(
-              qbftRound.getRoundIdentifier(), latestPreparedCertificate);
+              qbftRoundNew.getRoundIdentifier(), latestPreparedCertificate);
 
       // Its possible the locally created RoundChange triggers the transmission of a NewRound
       // message - so it must be handled accordingly.
@@ -252,7 +266,7 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
       LOG.warn("Failed to create signed RoundChange message.", e);
     }
 
-    transmitter.multicastRoundChange(qbftRound.getRoundIdentifier(), latestPreparedCertificate);
+    transmitter.multicastRoundChange(qbftRoundNew.getRoundIdentifier(), latestPreparedCertificate);
   }
 
   @Override
@@ -333,23 +347,54 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
     final Optional<Collection<RoundChange>> result =
         roundChangeManager.appendRoundChangeMessage(message);
 
-    if (result.isPresent()) {
-      LOG.debug(
-          "Received sufficient RoundChange messages to change round to targetRound={}",
-          targetRound);
-      if (messageAge == MessageAge.FUTURE_ROUND) {
-        startNewRound(targetRound.getRoundNumber());
-      }
-
-      final RoundChangeArtifacts roundChangeMetadata = RoundChangeArtifacts.create(result.get());
-
-      if (finalState.isLocalNodeProposerForRound(targetRound)) {
-        if (currentRound.isEmpty()) {
-          startNewRound(0);
+    if (!isEarlyRoundChangeEnabled) {
+      if (result.isPresent()) {
+        LOG.debug(
+            "Received sufficient RoundChange messages to change round to targetRound={}",
+            targetRound);
+        if (messageAge == MessageAge.FUTURE_ROUND) {
+          startNewRound(targetRound.getRoundNumber());
         }
+
+        final RoundChangeArtifacts roundChangeMetadata = RoundChangeArtifacts.create(result.get());
+
+        if (finalState.isLocalNodeProposerForRound(targetRound)) {
+          if (currentRound.isEmpty()) {
+            startNewRound(0);
+          }
+          currentRound
+              .get()
+              .startRoundWith(roundChangeMetadata, TimeUnit.MILLISECONDS.toSeconds(clock.millis()));
+        }
+      }
+    } else {
+
+      if (currentRound.isEmpty()) {
+        startNewRound(0);
+      }
+      int currentRoundNumber = currentRound.get().getRoundIdentifier().getRoundNumber();
+      // If this node is proposer for the current round, check if quorum is achieved for RC messages
+      // aiming this round
+      if (targetRound.getRoundNumber() == currentRoundNumber
+          && finalState.isLocalNodeProposerForRound(targetRound)
+          && result.isPresent()) {
+
+        final RoundChangeArtifacts roundChangeMetadata = RoundChangeArtifacts.create(result.get());
+
         currentRound
             .get()
             .startRoundWith(roundChangeMetadata, TimeUnit.MILLISECONDS.toSeconds(clock.millis()));
+      }
+
+      // check if f+1 RC messages for future rounds are received
+      QbftRound qbftRound = currentRound.get();
+      Optional<Integer> nextHigherRound =
+          roundChangeManager.futureRCQuorumReceived(qbftRound.getRoundIdentifier());
+      if (nextHigherRound.isPresent()) {
+        LOG.info(
+            "Received sufficient RoundChange messages to change round to targetRound={}",
+            nextHigherRound.get());
+        doRoundChange(nextHigherRound.get());
       }
     }
   }
@@ -389,6 +434,10 @@ public class QbftBlockHeightManager implements BaseQbftBlockHeightManager {
       return MessageAge.CURRENT_ROUND;
     }
     return MessageAge.PRIOR_ROUND;
+  }
+
+  public void isEarlyRoundChangeEnabled(final boolean isEarlyRoundChangeEnabled) {
+    this.isEarlyRoundChangeEnabled = isEarlyRoundChangeEnabled;
   }
 
   /** The enum Message age. */


### PR DESCRIPTION
## PR description
- Added an experimental option to enable round change upon receiving f+1 valid round change messages from different validators for future rounds 
- move to least of the future rounds 
- If node is proposer for the new round, wait till the new round receives ceil(2*N/3) quorum of RC messages to propose the new block.

## Fixed Issue(s)
#1822 
