### PR TITLE
EIP-7742 Engine API Changes

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/CodeDelegationTransactionAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/CodeDelegationTransactionAcceptanceTest.java
@@ -58,7 +58,7 @@ public class CodeDelegationTransactionAcceptanceTest extends AcceptanceTestBase 
   public static final Bytes TRANSACTION_SPONSOR_PRIVATE_KEY =
       Bytes.fromHexString("3a4ff6d22d7502ef2452368165422861c01a0f72f851793b372b87888dc3c453");
 
-  private final Account otherAccount = accounts.createAccount("otherAccount");
+  private final Account otherAccount = accounts.getPrimaryBenefactor();
 
   private BesuNode besuNode;
   private PragueAcceptanceTestHelper testHelper;
@@ -85,7 +85,6 @@ public class CodeDelegationTransactionAcceptanceTest extends AcceptanceTestBase 
    */
   @Test
   public void shouldTransferAllEthOfAuthorizerToSponsor() throws IOException {
-
     // 7702 transaction
     final CodeDelegation authorization =
         org.hyperledger.besu.ethereum.core.CodeDelegation.builder()

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/PragueAcceptanceTestHelper.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/PragueAcceptanceTestHelper.java
@@ -161,7 +161,7 @@ public class PragueAcceptanceTestHelper {
               + "      \"withdrawals\": [],"
               + "      \"parentBeaconBlockRoot\": \"0x0000000000000000000000000000000000000000000000000000000000000000\","
               + "      \"targetBlobsPerBlock\": \"0x3\","
-              + "      \"maximumBlobCount\": \"0x6\""
+              + "      \"maxBlobsPerBlock\": \"0x6\""
               + "    }";
     }
 

--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/PragueAcceptanceTestHelper.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/ethereum/PragueAcceptanceTestHelper.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.tests.acceptance.dsl.node.BesuNode;
 import org.hyperledger.besu.tests.acceptance.dsl.transaction.eth.EthTransactions;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -92,11 +93,21 @@ public class PragueAcceptanceTestHelper {
       assertThat(newBlockHash).isNotEmpty();
     }
 
+    final String targetBlobsPerBlock = "0x3";
     final Call newPayloadRequest =
         createEngineCall(
             createNewPayloadRequest(
-                executionPayload.toString(), parentBeaconBlockRoot, executionRequests.toString()));
+                executionPayload.toString(),
+                parentBeaconBlockRoot,
+                executionRequests.toString(),
+                targetBlobsPerBlock));
     try (final Response newPayloadResponse = newPayloadRequest.execute()) {
+      final InputStream responseStr = newPayloadResponse.body().byteStream();
+      JsonNode jsonNode = mapper.readTree(responseStr);
+      if (jsonNode.has("error")) {
+        throw new AssertionError(
+            "Unexpected engine_newPayload error: " + jsonNode.get("error").get("message").asText());
+      }
       assertThat(newPayloadResponse.code()).isEqualTo(200);
     }
 
@@ -148,7 +159,9 @@ public class PragueAcceptanceTestHelper {
               + "      \"prevRandao\": \"0x0000000000000000000000000000000000000000000000000000000000000000\","
               + "      \"suggestedFeeRecipient\": \"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b\","
               + "      \"withdrawals\": [],"
-              + "      \"parentBeaconBlockRoot\": \"0x0000000000000000000000000000000000000000000000000000000000000000\""
+              + "      \"parentBeaconBlockRoot\": \"0x0000000000000000000000000000000000000000000000000000000000000000\","
+              + "      \"targetBlobsPerBlock\": \"0x3\","
+              + "      \"maximumBlobCount\": \"0x6\""
               + "    }";
     }
 
@@ -171,7 +184,8 @@ public class PragueAcceptanceTestHelper {
   private String createNewPayloadRequest(
       final String executionPayload,
       final String parentBeaconBlockRoot,
-      final String executionRequests) {
+      final String executionRequests,
+      final String targetBlobsPerBlock) {
     return "{"
         + "  \"jsonrpc\": \"2.0\","
         + "  \"method\": \"engine_newPayloadV4\","
@@ -183,7 +197,11 @@ public class PragueAcceptanceTestHelper {
         + "\""
         + ","
         + executionRequests
-        + "],"
+        + ","
+        + "\""
+        + targetBlobsPerBlock
+        + "\""
+        + "]," // end params
         + "  \"id\": 67"
         + "}";
   }

--- a/acceptance-tests/tests/src/test/resources/dev/dev_prague.json
+++ b/acceptance-tests/tests/src/test/resources/dev/dev_prague.json
@@ -110,5 +110,6 @@
   "number":"0x0",
   "gasUsed":"0x0",
   "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
-  "baseFeePerGas":"0x7"
+  "baseFeePerGas":"0x7",
+  "targetBlobsPerBlock":"0x1"
 }

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/cancun/test-cases/block-production/10_cancun_build_on_genesis.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/cancun/test-cases/block-production/10_cancun_build_on_genesis.json
@@ -1,5 +1,95 @@
 {
-  "request" : {"jsonrpc":"2.0","id":5,"method":"engine_forkchoiceUpdatedV3","params":[{"headBlockHash":"0x33235e7b7a78302cdb54e5ddba66c7ae49b01c1f5498bb00cd0c8ed5206784bf","safeBlockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","finalizedBlockHash":"0x0000000000000000000000000000000000000000000000000000000000000000"},{"timestamp":"0x1236","prevRandao":"0xc13da06dc53836ca0766057413b9683eb9a8773bbb8fcc5691e41c25b56dda1d","suggestedFeeRecipient":"0x0000000000000000000000000000000000000000","withdrawals":[{"index":"0xb","validatorIndex":"0x0","address":"0x0000000000000000000000000000000000000000","amount":"0x64"},{"index":"0xc","validatorIndex":"0x1","address":"0x0100000000000000000000000000000000000000","amount":"0x64"},{"index":"0xd","validatorIndex":"0x2","address":"0x0200000000000000000000000000000000000000","amount":"0x64"},{"index":"0xe","validatorIndex":"0x3","address":"0x0300000000000000000000000000000000000000","amount":"0x64"},{"index":"0xf","validatorIndex":"0x4","address":"0x0400000000000000000000000000000000000000","amount":"0x64"},{"index":"0x10","validatorIndex":"0x5","address":"0x0500000000000000000000000000000000000000","amount":"0x64"},{"index":"0x11","validatorIndex":"0x6","address":"0x0600000000000000000000000000000000000000","amount":"0x64"},{"index":"0x12","validatorIndex":"0x7","address":"0x0700000000000000000000000000000000000000","amount":"0x64"},{"index":"0x13","validatorIndex":"0x8","address":"0x0800000000000000000000000000000000000000","amount":"0x64"},{"index":"0x14","validatorIndex":"0x9","address":"0x0900000000000000000000000000000000000000","amount":"0x64"}],"parentBeaconBlockRoot":"0x062367f0b23e2d49ad5e770d9ad17b83c0c1c625c3f9a290cd9572b3fc6cfc9e"}]},
-  "response" : {"jsonrpc":"2.0","id":5,"result":{"payloadStatus":{"status":"VALID","latestValidHash":"0x33235e7b7a78302cdb54e5ddba66c7ae49b01c1f5498bb00cd0c8ed5206784bf","validationError":null},"payloadId":"0x29e12df730769ab6"}},
-  "statusCode" : 200
+  "request": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "method": "engine_forkchoiceUpdatedV3",
+    "params": [
+      {
+        "headBlockHash": "0x33235e7b7a78302cdb54e5ddba66c7ae49b01c1f5498bb00cd0c8ed5206784bf",
+        "safeBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "finalizedBlockHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      },
+      {
+        "timestamp": "0x1236",
+        "prevRandao": "0xc13da06dc53836ca0766057413b9683eb9a8773bbb8fcc5691e41c25b56dda1d",
+        "suggestedFeeRecipient": "0x0000000000000000000000000000000000000000",
+        "withdrawals": [
+          {
+            "index": "0xb",
+            "validatorIndex": "0x0",
+            "address": "0x0000000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0xc",
+            "validatorIndex": "0x1",
+            "address": "0x0100000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0xd",
+            "validatorIndex": "0x2",
+            "address": "0x0200000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0xe",
+            "validatorIndex": "0x3",
+            "address": "0x0300000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0xf",
+            "validatorIndex": "0x4",
+            "address": "0x0400000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0x10",
+            "validatorIndex": "0x5",
+            "address": "0x0500000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0x11",
+            "validatorIndex": "0x6",
+            "address": "0x0600000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0x12",
+            "validatorIndex": "0x7",
+            "address": "0x0700000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0x13",
+            "validatorIndex": "0x8",
+            "address": "0x0800000000000000000000000000000000000000",
+            "amount": "0x64"
+          },
+          {
+            "index": "0x14",
+            "validatorIndex": "0x9",
+            "address": "0x0900000000000000000000000000000000000000",
+            "amount": "0x64"
+          }
+        ],
+        "parentBeaconBlockRoot": "0x062367f0b23e2d49ad5e770d9ad17b83c0c1c625c3f9a290cd9572b3fc6cfc9e"
+      }
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 5,
+    "result": {
+      "payloadStatus": {
+        "status": "VALID",
+        "latestValidHash": "0x33235e7b7a78302cdb54e5ddba66c7ae49b01c1f5498bb00cd0c8ed5206784bf",
+        "validationError": null
+      },
+      "payloadId": "0x744ab0889222f836"
+    }
+  },
+  "statusCode": 200
 }

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/cancun/test-cases/block-production/12_cancun_get_built_block.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/cancun/test-cases/block-production/12_cancun_get_built_block.json
@@ -1,5 +1,5 @@
 {
-  "request" : {"jsonrpc":"2.0","id":2,"method":"engine_getPayloadV3","params":["0x29e12df730769ab6"]},
+  "request" : {"jsonrpc":"2.0","id":2,"method":"engine_getPayloadV3","params":["0x744ab0889222f836"]},
   "response" : {
     "jsonrpc" : "2.0",
     "id" : 2,

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/06_shanghai_prepare_payload.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/06_shanghai_prepare_payload.json
@@ -39,7 +39,7 @@
         "latestValidHash": "0xf4a1d287dd3bb7e877c57476912e6a6052bc4eed8ea70d032b55d77f26ee985f",
         "validationError": null
       },
-      "payloadId": "0x0065bd2db6663f59"
+      "payloadId": "0x48b9f464feba7610"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/07_shanghai_prepare_payload_replay_different_withdrawals.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/07_shanghai_prepare_payload_replay_different_withdrawals.json
@@ -39,7 +39,7 @@
         "latestValidHash": "0xf4a1d287dd3bb7e877c57476912e6a6052bc4eed8ea70d032b55d77f26ee985f",
         "validationError": null
       },
-      "payloadId": "0x0065bd2db6663ed9"
+      "payloadId": "0x48b9f5e4feba7610"
     }
   },
   "statusCode" : 200

--- a/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/08_shanghai_getPayloadV2.json
+++ b/acceptance-tests/tests/src/test/resources/jsonrpc/engine/shanghai/test-cases/08_shanghai_getPayloadV2.json
@@ -3,7 +3,7 @@
     "jsonrpc": "2.0",
     "method": "engine_getPayloadV2",
     "params": [
-      "0x0065bd2db6663ed9"
+      "0x48b9f5e4feba7610"
     ],
     "id": 67
   },

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -81,7 +81,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
       final long timestamp,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount,
+      final Optional<UInt64> targetBlobsPerBlock,
       final BlockHeader parentHeader) {
 
     return createBlock(
@@ -90,7 +90,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
         withdrawals,
         Optional.of(random),
         parentBeaconBlockRoot,
-        targetBlobCount,
+        targetBlobsPerBlock,
         timestamp,
         false,
         parentHeader);

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 
 /** The Merge block creator. */
 class MergeBlockCreator extends AbstractBlockCreator {
@@ -80,6 +81,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
       final long timestamp,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount,
       final BlockHeader parentHeader) {
 
     return createBlock(
@@ -88,6 +90,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
         withdrawals,
         Optional.of(random),
         parentBeaconBlockRoot,
+        targetBlobCount,
         timestamp,
         false,
         parentHeader);

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -298,6 +298,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 timestamp,
                 withdrawals,
                 parentBeaconBlockRoot,
+                targetBlobCount,
                 parentHeader)
             .getBlock();
 
@@ -329,6 +330,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
         mergeBlockCreator,
         withdrawals,
         parentBeaconBlockRoot,
+        targetBlobCount,
         parentHeader);
 
     return payloadIdentifier;
@@ -371,6 +373,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final MergeBlockCreator mergeBlockCreator,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount,
       final BlockHeader parentHeader) {
 
     final Supplier<BlockCreationResult> blockCreator =
@@ -381,6 +384,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 timestamp,
                 withdrawals,
                 parentBeaconBlockRoot,
+                targetBlobCount,
                 parentHeader);
 
     LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -259,7 +259,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobsPerBlock) {
+      final Optional<UInt64> targetBlobsPerBlock,
+      final Optional<UInt64> maxBlobsPerBlock) {
 
     // we assume that preparePayload is always called sequentially, since the RPC Engine calls
     // are sequential, if this assumption changes then more synchronization should be added to
@@ -273,7 +274,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             feeRecipient,
             withdrawals,
             parentBeaconBlockRoot,
-            targetBlobsPerBlock);
+            targetBlobsPerBlock,
+            maxBlobsPerBlock);
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -259,7 +259,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount) {
+      final Optional<UInt64> targetBlobsPerBlock) {
 
     // we assume that preparePayload is always called sequentially, since the RPC Engine calls
     // are sequential, if this assumption changes then more synchronization should be added to
@@ -273,7 +273,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             feeRecipient,
             withdrawals,
             parentBeaconBlockRoot,
-            targetBlobCount);
+            targetBlobsPerBlock);
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(
@@ -298,7 +298,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 timestamp,
                 withdrawals,
                 parentBeaconBlockRoot,
-                targetBlobCount,
+                targetBlobsPerBlock,
                 parentHeader)
             .getBlock();
 
@@ -330,7 +330,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
         mergeBlockCreator,
         withdrawals,
         parentBeaconBlockRoot,
-        targetBlobCount,
+        targetBlobsPerBlock,
         parentHeader);
 
     return payloadIdentifier;
@@ -373,7 +373,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final MergeBlockCreator mergeBlockCreator,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount,
+      final Optional<UInt64> targetBlobsPerBlock,
       final BlockHeader parentHeader) {
 
     final Supplier<BlockCreationResult> blockCreator =
@@ -384,7 +384,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
                 timestamp,
                 withdrawals,
                 parentBeaconBlockRoot,
-                targetBlobCount,
+                targetBlobsPerBlock,
                 parentHeader);
 
     LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -62,6 +62,7 @@ import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -257,7 +258,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
       final Bytes32 prevRandao,
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
-      final Optional<Bytes32> parentBeaconBlockRoot) {
+      final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount) {
 
     // we assume that preparePayload is always called sequentially, since the RPC Engine calls
     // are sequential, if this assumption changes then more synchronization should be added to
@@ -271,7 +273,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             feeRecipient,
             withdrawals,
             parentBeaconBlockRoot,
-            Optional.empty()); // TODO SLD EIP-7742
+            targetBlobCount);
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -270,7 +270,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
             prevRandao,
             feeRecipient,
             withdrawals,
-            parentBeaconBlockRoot);
+            parentBeaconBlockRoot,
+            Optional.empty()); // TODO SLD EIP-7742
 
     if (blockCreationTasks.containsKey(payloadIdentifier)) {
       LOG.debug(

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -44,7 +44,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
    * @param feeRecipient the fee recipient
    * @param withdrawals the optional list of withdrawals
    * @param parentBeaconBlockRoot optional root hash of the parent beacon block
-   * @param targetBlobCount optional target blob count
+   * @param targetBlobsPerBlock optional target blobs per block
    * @return the payload identifier
    */
   PayloadIdentifier preparePayload(
@@ -54,7 +54,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount);
+      final Optional<UInt64> targetBlobsPerBlock);
 
   @Override
   default boolean isCompatibleWithEngineApi() {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -44,7 +44,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
    * @param feeRecipient the fee recipient
    * @param withdrawals the optional list of withdrawals
    * @param parentBeaconBlockRoot optional root hash of the parent beacon block
-   * @param targetBlobsPerBlock optional target blobs per block
+   * @param targetBlobsPerBlock optional target blobs per block EIP-7742
+   * @param maxBlobsPerBlock optional max blobs per block EIP-7742
    * @return the payload identifier
    */
   PayloadIdentifier preparePayload(
@@ -54,7 +55,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobsPerBlock);
+      final Optional<UInt64> targetBlobsPerBlock,
+      final Optional<UInt64> maxBlobsPerBlock);
 
   @Override
   default boolean isCompatibleWithEngineApi() {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeMiningCoordinator.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 
 /** The interface Merge mining coordinator. */
 public interface MergeMiningCoordinator extends MiningCoordinator {
@@ -43,6 +44,7 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
    * @param feeRecipient the fee recipient
    * @param withdrawals the optional list of withdrawals
    * @param parentBeaconBlockRoot optional root hash of the parent beacon block
+   * @param targetBlobCount optional target blob count
    * @return the payload identifier
    */
   PayloadIdentifier preparePayload(
@@ -51,7 +53,8 @@ public interface MergeMiningCoordinator extends MiningCoordinator {
       final Bytes32 prevRandao,
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
-      final Optional<Bytes32> parentBeaconBlockRoot);
+      final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount);
 
   @Override
   default boolean isCompatibleWithEngineApi() {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
@@ -63,7 +63,7 @@ public class PayloadIdentifier implements Quantity {
    * @param feeRecipient the fee recipient
    * @param withdrawals the withdrawals
    * @param parentBeaconBlockRoot the parent beacon block root
-   * @param targetBlobCount the target blob count
+   * @param targetBlobsPerBlock the target blobs per block
    * @return the payload identifier
    */
   public static PayloadIdentifier forPayloadParams(
@@ -73,7 +73,7 @@ public class PayloadIdentifier implements Quantity {
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount) {
+      final Optional<UInt64> targetBlobsPerBlock) {
 
     return new PayloadIdentifier(
         timestamp
@@ -91,7 +91,7 @@ public class PayloadIdentifier implements Quantity {
                         .orElse(0)
                 << 32
             ^ ((long) parentBeaconBlockRoot.hashCode()) << 40
-            ^ ((long) targetBlobCount.hashCode()) << 48);
+            ^ ((long) targetBlobsPerBlock.hashCode()) << 48);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifier.java
@@ -63,6 +63,7 @@ public class PayloadIdentifier implements Quantity {
    * @param feeRecipient the fee recipient
    * @param withdrawals the withdrawals
    * @param parentBeaconBlockRoot the parent beacon block root
+   * @param targetBlobCount the target blob count
    * @return the payload identifier
    */
   public static PayloadIdentifier forPayloadParams(
@@ -71,7 +72,8 @@ public class PayloadIdentifier implements Quantity {
       final Bytes32 prevRandao,
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
-      final Optional<Bytes32> parentBeaconBlockRoot) {
+      final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount) {
 
     return new PayloadIdentifier(
         timestamp
@@ -79,15 +81,17 @@ public class PayloadIdentifier implements Quantity {
             ^ ((long) prevRandao.toHexString().hashCode()) << 16
             ^ ((long) feeRecipient.toHexString().hashCode()) << 24
             ^ (long)
-                withdrawals
-                    .map(
-                        ws ->
-                            ws.stream()
-                                .sorted(Comparator.comparing(Withdrawal::getIndex))
-                                .map(Withdrawal::hashCode)
-                                .reduce(1, (a, b) -> a ^ (b * 31)))
-                    .orElse(0)
-            ^ ((long) parentBeaconBlockRoot.hashCode()) << 40);
+                    withdrawals
+                        .map(
+                            ws ->
+                                ws.stream()
+                                    .sorted(Comparator.comparing(Withdrawal::getIndex))
+                                    .map(Withdrawal::hashCode)
+                                    .reduce(1, (a, b) -> a ^ (b * 31)))
+                        .orElse(0)
+                << 32
+            ^ ((long) parentBeaconBlockRoot.hashCode()) << 40
+            ^ ((long) targetBlobCount.hashCode()) << 48);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -149,7 +149,8 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobsPerBlock) {
+      final Optional<UInt64> targetBlobsPerBlock,
+      final Optional<UInt64> maxBlobsPerBlock) {
     return mergeCoordinator.preparePayload(
         parentHeader,
         timestamp,
@@ -157,7 +158,8 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
         feeRecipient,
         withdrawals,
         parentBeaconBlockRoot,
-        targetBlobsPerBlock);
+        targetBlobsPerBlock,
+        maxBlobsPerBlock);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 
 /** The Transition coordinator. */
 public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
@@ -147,9 +148,16 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
       final Bytes32 prevRandao,
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
-      final Optional<Bytes32> parentBeaconBlockRoot) {
+      final Optional<Bytes32> parentBeaconBlockRoot,
+      final Optional<UInt64> targetBlobCount) {
     return mergeCoordinator.preparePayload(
-        parentHeader, timestamp, prevRandao, feeRecipient, withdrawals, parentBeaconBlockRoot);
+        parentHeader,
+        timestamp,
+        prevRandao,
+        feeRecipient,
+        withdrawals,
+        parentBeaconBlockRoot,
+        targetBlobCount);
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -149,7 +149,7 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
       final Address feeRecipient,
       final Optional<List<Withdrawal>> withdrawals,
       final Optional<Bytes32> parentBeaconBlockRoot,
-      final Optional<UInt64> targetBlobCount) {
+      final Optional<UInt64> targetBlobsPerBlock) {
     return mergeCoordinator.preparePayload(
         parentHeader,
         timestamp,
@@ -157,7 +157,7 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
         feeRecipient,
         withdrawals,
         parentBeaconBlockRoot,
-        targetBlobCount);
+        targetBlobsPerBlock);
   }
 
   @Override

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -250,6 +250,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ArgumentCaptor<PayloadWrapper> payloadWrapper = ArgumentCaptor.forClass(PayloadWrapper.class);
@@ -331,6 +332,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     blockCreationTask.get();
@@ -370,6 +372,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
         suggestedFeeRecipient,
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     verify(badBlockManager, never()).addBadBlock(any(), any());
@@ -402,6 +405,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -463,6 +467,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     blockCreationTask.get();
@@ -513,6 +518,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -569,6 +575,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     try {
@@ -614,6 +621,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -671,6 +679,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     final CompletableFuture<Void> task1 = blockCreationTask;
@@ -681,6 +690,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             timestamp,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -725,6 +735,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             suggestedFeeRecipient,
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     assertThat(coordinator.isBlockCreationCancelled(payloadId1)).isFalse();
@@ -735,6 +746,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             timestamp + 1,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -769,6 +781,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             1L,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -249,6 +249,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.ZERO,
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     ArgumentCaptor<PayloadWrapper> payloadWrapper = ArgumentCaptor.forClass(PayloadWrapper.class);
@@ -328,6 +329,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.random(),
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     blockCreationTask.get();
@@ -366,6 +368,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
         Bytes32.ZERO,
         suggestedFeeRecipient,
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
 
     verify(badBlockManager, never()).addBadBlock(any(), any());
@@ -398,6 +401,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -457,6 +461,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.ZERO,
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     blockCreationTask.get();
@@ -507,6 +512,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -561,6 +567,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.ZERO,
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     try {
@@ -606,6 +613,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             System.currentTimeMillis() / 1000,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -661,6 +669,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.ZERO,
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     final CompletableFuture<Void> task1 = blockCreationTask;
@@ -671,6 +680,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             timestamp,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -713,6 +723,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             Bytes32.ZERO,
             suggestedFeeRecipient,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     assertThat(coordinator.isBlockCreationCancelled(payloadId1)).isFalse();
@@ -723,6 +734,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             timestamp + 1,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 
@@ -756,6 +768,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
             1L,
             Bytes32.ZERO,
             suggestedFeeRecipient,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -291,6 +291,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
                   anyLong(),
                   eq(Optional.empty()),
                   eq(Optional.empty()),
+                  eq(Optional.empty()),
                   any());
           return beingSpiedOn;
         };

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -53,6 +53,7 @@ public class PayloadIdentifierTest {
             Bytes32.random(),
             Address.fromHexString("0x42"),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
@@ -92,6 +93,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -100,6 +102,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
@@ -138,6 +141,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -146,6 +150,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isEqualTo(idForWithdrawals2);
   }
@@ -160,6 +165,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -168,6 +174,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(emptyList()),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
   }
@@ -175,44 +182,96 @@ public class PayloadIdentifierTest {
   @Test
   public void emptyOptionalAndNonEmptyParentBeaconBlockRootYieldDifferentHash() {
     final Bytes32 prevRandao = Bytes32.random();
-    var idForWithdrawals1 =
+    var idForPbbr1 =
         PayloadIdentifier.forPayloadParams(
             Hash.ZERO,
             1337L,
             prevRandao,
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
-    var idForWithdrawals2 =
+    var idForPbbr2 =
         PayloadIdentifier.forPayloadParams(
             Hash.ZERO,
             1337L,
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.empty(),
-            Optional.of(Bytes32.ZERO));
-    assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
+            Optional.of(Bytes32.ZERO),
+            Optional.empty());
+    assertThat(idForPbbr1).isNotEqualTo(idForPbbr2);
   }
 
   @Test
   public void differentParentBeaconBlockRootYieldDifferentHash() {
     final Bytes32 prevRandao = Bytes32.random();
-    var idForWithdrawals1 =
+    var idForPbbr1 =
         PayloadIdentifier.forPayloadParams(
             Hash.ZERO,
             1337L,
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.empty(),
-            Optional.of(Bytes32.fromHexStringLenient("0x1")));
-    var idForWithdrawals2 =
+            Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.empty());
+    var idForPbbr2 =
         PayloadIdentifier.forPayloadParams(
             Hash.ZERO,
             1337L,
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.empty(),
-            Optional.of(Bytes32.ZERO));
-    assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
+            Optional.of(Bytes32.ZERO),
+            Optional.empty());
+    assertThat(idForPbbr1).isNotEqualTo(idForPbbr2);
+  }
+
+  @Test
+  public void emptyOptionalAndNonEmptyTargetBlobCountYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForTbc1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    var idForTbc2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.of(Bytes32.ZERO),
+            Optional.of(UInt64.ZERO));
+    assertThat(idForTbc1).isNotEqualTo(idForTbc2);
+  }
+
+  @Test
+  public void differentTargetBlobCountYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForTbc1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(UInt64.ZERO));
+    var idForTbc2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(UInt64.ONE));
+    assertThat(idForTbc1).isNotEqualTo(idForTbc2);
   }
 }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -54,6 +54,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
     assertThat(new PayloadIdentifier(idTest.getAsBigInteger().longValue())).isEqualTo(idTest);
@@ -94,6 +95,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -102,6 +104,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
@@ -142,6 +145,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.of(withdrawals1),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -150,6 +154,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(withdrawals2),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isEqualTo(idForWithdrawals2);
@@ -166,6 +171,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForWithdrawals2 =
         PayloadIdentifier.forPayloadParams(
@@ -174,6 +180,7 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.of(emptyList()),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
     assertThat(idForWithdrawals1).isNotEqualTo(idForWithdrawals2);
@@ -190,6 +197,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForPbbr2 =
         PayloadIdentifier.forPayloadParams(
@@ -199,6 +207,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.ZERO),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForPbbr1).isNotEqualTo(idForPbbr2);
   }
@@ -214,6 +223,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.fromHexStringLenient("0x1")),
+            Optional.empty(),
             Optional.empty());
     var idForPbbr2 =
         PayloadIdentifier.forPayloadParams(
@@ -223,6 +233,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.of(Bytes32.ZERO),
+            Optional.empty(),
             Optional.empty());
     assertThat(idForPbbr1).isNotEqualTo(idForPbbr2);
   }
@@ -238,6 +249,7 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     var idForTbc2 =
         PayloadIdentifier.forPayloadParams(
@@ -246,8 +258,9 @@ public class PayloadIdentifierTest {
             prevRandao,
             Address.fromHexString("0x42"),
             Optional.empty(),
-            Optional.of(Bytes32.ZERO),
-            Optional.of(UInt64.ZERO));
+            Optional.empty(),
+            Optional.of(UInt64.ZERO),
+            Optional.empty());
     assertThat(idForTbc1).isNotEqualTo(idForTbc2);
   }
 
@@ -262,6 +275,59 @@ public class PayloadIdentifierTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.of(UInt64.ZERO),
+            Optional.empty());
+    var idForTbc2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(UInt64.ONE),
+            Optional.empty());
+    assertThat(idForTbc1).isNotEqualTo(idForTbc2);
+  }
+
+  @Test
+  public void emptyOptionalAndNonEmptyMaxBlobsPerBlockYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForTbc1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
+    var idForTbc2 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(UInt64.ZERO));
+    assertThat(idForTbc1).isNotEqualTo(idForTbc2);
+  }
+
+  @Test
+  public void differentMaxBlobsPerBlockYieldDifferentHash() {
+    final Bytes32 prevRandao = Bytes32.random();
+    var idForTbc1 =
+        PayloadIdentifier.forPayloadParams(
+            Hash.ZERO,
+            1337L,
+            prevRandao,
+            Address.fromHexString("0x42"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
             Optional.of(UInt64.ZERO));
     var idForTbc2 =
         PayloadIdentifier.forPayloadParams(
@@ -269,6 +335,7 @@ public class PayloadIdentifierTest {
             1337L,
             prevRandao,
             Address.fromHexString("0x42"),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.of(UInt64.ONE));

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/PayloadIdentifierTest.java
@@ -228,7 +228,7 @@ public class PayloadIdentifierTest {
   }
 
   @Test
-  public void emptyOptionalAndNonEmptyTargetBlobCountYieldDifferentHash() {
+  public void emptyOptionalAndNonEmptyTargetBlobsPerBlockYieldDifferentHash() {
     final Bytes32 prevRandao = Bytes32.random();
     var idForTbc1 =
         PayloadIdentifier.forPayloadParams(
@@ -252,7 +252,7 @@ public class PayloadIdentifierTest {
   }
 
   @Test
-  public void differentTargetBlobCountYieldDifferentHash() {
+  public void differentTargetBlobsPerBlockYieldDifferentHash() {
     final Bytes32 prevRandao = Bytes32.random();
     var idForTbc1 =
         PayloadIdentifier.forPayloadParams(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/RpcMethod.java
@@ -63,6 +63,7 @@ public enum RpcMethod {
   ENGINE_FORKCHOICE_UPDATED_V1("engine_forkchoiceUpdatedV1"),
   ENGINE_FORKCHOICE_UPDATED_V2("engine_forkchoiceUpdatedV2"),
   ENGINE_FORKCHOICE_UPDATED_V3("engine_forkchoiceUpdatedV3"),
+  ENGINE_FORKCHOICE_UPDATED_V4("engine_forkchoiceUpdatedV4"),
   ENGINE_EXCHANGE_TRANSITION_CONFIGURATION("engine_exchangeTransitionConfigurationV1"),
   ENGINE_GET_CLIENT_VERSION_V1("engine_getClientVersionV1"),
   ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1("engine_getPayloadBodiesByHashV1"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -224,7 +224,8 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                     payloadAttributes.getPrevRandao(),
                     payloadAttributes.getSuggestedFeeRecipient(),
                     finalWithdrawals,
-                    Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot())));
+                    Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()),
+                    Optional.of(tar)));
 
     payloadId.ifPresent(
         pid ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -225,7 +225,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                     payloadAttributes.getSuggestedFeeRecipient(),
                     finalWithdrawals,
                     Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()),
-                    Optional.of(tar)));
+                    Optional.ofNullable(payloadAttributes.getTargetBlobCount())));
 
     payloadId.ifPresent(
         pid ->
@@ -318,6 +318,10 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
           builder
               .setMessage(message)
               .addArgument(() -> payloadAttributes.getParentBeaconBlockRoot().toHexString());
+    }
+    if (payloadAttributes.getTargetBlobCount() != null) {
+      message += ", targetBlobCount: {}";
+      builder = builder.setMessage(message).addArgument(payloadAttributes::getTargetBlobCount);
     }
     builder.log();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -225,7 +225,8 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                     payloadAttributes.getSuggestedFeeRecipient(),
                     finalWithdrawals,
                     Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()),
-                    Optional.ofNullable(payloadAttributes.getTargetBlobsPerBlock())));
+                    Optional.ofNullable(payloadAttributes.getTargetBlobsPerBlock()),
+                    Optional.ofNullable(payloadAttributes.getMaxBlobsPerBlock())));
 
     payloadId.ifPresent(
         pid ->

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -225,7 +225,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
                     payloadAttributes.getSuggestedFeeRecipient(),
                     finalWithdrawals,
                     Optional.ofNullable(payloadAttributes.getParentBeaconBlockRoot()),
-                    Optional.ofNullable(payloadAttributes.getTargetBlobCount())));
+                    Optional.ofNullable(payloadAttributes.getTargetBlobsPerBlock())));
 
     payloadId.ifPresent(
         pid ->
@@ -319,9 +319,9 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
               .setMessage(message)
               .addArgument(() -> payloadAttributes.getParentBeaconBlockRoot().toHexString());
     }
-    if (payloadAttributes.getTargetBlobCount() != null) {
-      message += ", targetBlobCount: {}";
-      builder = builder.setMessage(message).addArgument(payloadAttributes::getTargetBlobCount);
+    if (payloadAttributes.getTargetBlobsPerBlock() != null) {
+      message += ", targetBlobsPerBlock: {}";
+      builder = builder.setMessage(message).addArgument(payloadAttributes::getTargetBlobsPerBlock);
     }
     builder.log();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -148,12 +148,12 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
           e);
     }
 
-    final Optional<String> maybeTargetBlobCountParam;
+    final Optional<String> maybeTargetBlobsPerBlockParam;
     try {
-      maybeTargetBlobCountParam = requestContext.getOptionalParameter(4, String.class);
+      maybeTargetBlobsPerBlockParam = requestContext.getOptionalParameter(4, String.class);
     } catch (JsonRpcParameterException e) {
       throw new InvalidJsonRpcRequestException(
-          "Invalid target blob count parameter (index 4)",
+          "Invalid target blobs per block parameter (index 4)",
           RpcErrorType.INVALID_TARGET_BLOB_COUNT_PARAM,
           e);
     }
@@ -164,7 +164,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             maybeVersionedHashParam,
             maybeParentBeaconBlockRootParam,
             maybeRequestsParam,
-            maybeTargetBlobCountParam);
+            maybeTargetBlobsPerBlockParam);
     if (!parameterValidationResult.isValid()) {
       return new JsonRpcErrorResponse(reqId, parameterValidationResult);
     }
@@ -223,16 +223,16 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
       return new JsonRpcErrorResponse(reqId, RpcErrorType.INVALID_EXECUTION_REQUESTS_PARAMS);
     }
 
-    final Optional<UInt64> maybeTargetBlobCount;
+    final Optional<UInt64> maybeTargetBlobsPerBlock;
     try {
-      maybeTargetBlobCount = maybeTargetBlobCountParam.map(UInt64::fromHexString);
+      maybeTargetBlobsPerBlock = maybeTargetBlobsPerBlockParam.map(UInt64::fromHexString);
     } catch (RuntimeException ex) {
       return respondWithInvalid(
           reqId,
           blockParam,
           mergeCoordinator.getLatestValidAncestor(blockParam.getParentHash()).orElse(null),
           INVALID,
-          "Invalid targetBlobCount");
+          "Invalid targetBlobsPerBlock");
     }
 
     if (mergeContext.get().isSyncing()) {
@@ -303,7 +303,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
                 : BlobGas.fromHexString(blockParam.getExcessBlobGas()),
             maybeParentBeaconBlockRoot.orElse(null),
             maybeRequests.map(BodyValidation::requestsHash).orElse(null),
-            maybeTargetBlobCount.orElse(null),
+            maybeTargetBlobsPerBlock.orElse(null),
             headerFunctions);
 
     // ensure the block hash matches the blockParam hash
@@ -482,7 +482,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
       final Optional<List<String>> maybeRequestsParam,
-      final Optional<String> maybeTargetBlobCountParam) {
+      final Optional<String> maybeTargetBlobsPerBlockParam) {
     return ValidationResult.valid();
   }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PRAGUE;
+
+import org.hyperledger.besu.consensus.merge.blockcreation.MergeMiningCoordinator;
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EngineForkchoiceUpdatedParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.EnginePayloadAttributesParameter;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+
+import java.util.Optional;
+
+import io.vertx.core.Vertx;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdated {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EngineForkchoiceUpdatedV4.class);
+  protected final Optional<Long> pragueMilestone;
+
+  public EngineForkchoiceUpdatedV4(
+      final Vertx vertx,
+      final ProtocolSchedule protocolSchedule,
+      final ProtocolContext protocolContext,
+      final MergeMiningCoordinator mergeCoordinator,
+      final EngineCallListener engineCallListener) {
+    super(vertx, protocolSchedule, protocolContext, mergeCoordinator, engineCallListener);
+    this.pragueMilestone = protocolSchedule.milestoneFor(PRAGUE);
+  }
+
+  @Override
+  public String getName() {
+    return RpcMethod.ENGINE_FORKCHOICE_UPDATED_V4.getMethodName();
+  }
+
+  @Override
+  protected ValidationResult<RpcErrorType> validateParameter(
+      final EngineForkchoiceUpdatedParameter fcuParameter,
+      final Optional<EnginePayloadAttributesParameter> maybePayloadAttributes) {
+    if (fcuParameter.getHeadBlockHash() == null) {
+      return ValidationResult.invalid(
+          getInvalidPayloadAttributesError(), "Missing head block hash");
+    } else if (fcuParameter.getSafeBlockHash() == null) {
+      return ValidationResult.invalid(
+          getInvalidPayloadAttributesError(), "Missing safe block hash");
+    } else if (fcuParameter.getFinalizedBlockHash() == null) {
+      return ValidationResult.invalid(
+          getInvalidPayloadAttributesError(), "Missing finalized block hash");
+    }
+    if (maybePayloadAttributes.isPresent()) {
+      if (maybePayloadAttributes.get().getParentBeaconBlockRoot() == null) {
+        return ValidationResult.invalid(
+            getInvalidPayloadAttributesError(), "Missing parent beacon block root hash");
+      }
+      if (maybePayloadAttributes.get().getTargetBlobCount() == null) {
+        return ValidationResult.invalid(
+            getInvalidPayloadAttributesError(), "Missing target blob count");
+      }
+      if (maybePayloadAttributes.get().getMaximumBlobCount() == null) {
+        return ValidationResult.invalid(
+            getInvalidPayloadAttributesError(), "Missing maximum blob count");
+      }
+    }
+    return ValidationResult.valid();
+  }
+
+  @Override
+  protected ValidationResult<RpcErrorType> validateForkSupported(final long blockTimestamp) {
+    return ForkSupportHelper.validateForkSupported(PRAGUE, pragueMilestone, blockTimestamp);
+  }
+
+  @Override
+  protected Optional<JsonRpcErrorResponse> isPayloadAttributesValid(
+      final Object requestId, final EnginePayloadAttributesParameter payloadAttributes) {
+    if (payloadAttributes.getParentBeaconBlockRoot() == null) {
+      LOG.error(
+          "Parent beacon block root hash not present in payload attributes after cancun hardfork");
+      return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
+    }
+    if (payloadAttributes.getTargetBlobCount() == null) {
+      LOG.error("targetBlobCount not present in payload attributes after prague hardfork");
+      return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
+    }
+    if (payloadAttributes.getMaximumBlobCount() == null) {
+      LOG.error("maximumBlobCount not present in payload attributes after prague hardfork");
+      return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
+    }
+
+    if (payloadAttributes.getTimestamp() == 0) {
+      return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
+    }
+
+    if (pragueMilestone.isEmpty() || payloadAttributes.getTimestamp() < pragueMilestone.get()) {
+      return Optional.of(new JsonRpcErrorResponse(requestId, RpcErrorType.UNSUPPORTED_FORK));
+    }
+
+    return Optional.empty();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -71,9 +71,9 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdated {
         return ValidationResult.invalid(
             getInvalidPayloadAttributesError(), "Missing parent beacon block root hash");
       }
-      if (maybePayloadAttributes.get().getTargetBlobCount() == null) {
+      if (maybePayloadAttributes.get().getTargetBlobsPerBlock() == null) {
         return ValidationResult.invalid(
-            getInvalidPayloadAttributesError(), "Missing target blob count");
+            getInvalidPayloadAttributesError(), "Missing target blobs per block");
       }
       if (maybePayloadAttributes.get().getMaximumBlobCount() == null) {
         return ValidationResult.invalid(
@@ -96,8 +96,8 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdated {
           "Parent beacon block root hash not present in payload attributes after cancun hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
     }
-    if (payloadAttributes.getTargetBlobCount() == null) {
-      LOG.error("targetBlobCount not present in payload attributes after prague hardfork");
+    if (payloadAttributes.getTargetBlobsPerBlock() == null) {
+      LOG.error("targetBlobsPerBlock not present in payload attributes after prague hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
     }
     if (payloadAttributes.getMaximumBlobCount() == null) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV4.java
@@ -75,9 +75,9 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdated {
         return ValidationResult.invalid(
             getInvalidPayloadAttributesError(), "Missing target blobs per block");
       }
-      if (maybePayloadAttributes.get().getMaximumBlobCount() == null) {
+      if (maybePayloadAttributes.get().getMaxBlobsPerBlock() == null) {
         return ValidationResult.invalid(
-            getInvalidPayloadAttributesError(), "Missing maximum blob count");
+            getInvalidPayloadAttributesError(), "Missing max blobs per block");
       }
     }
     return ValidationResult.valid();
@@ -100,8 +100,8 @@ public class EngineForkchoiceUpdatedV4 extends AbstractEngineForkchoiceUpdated {
       LOG.error("targetBlobsPerBlock not present in payload attributes after prague hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
     }
-    if (payloadAttributes.getMaximumBlobCount() == null) {
-      LOG.error("maximumBlobCount not present in payload attributes after prague hardfork");
+    if (payloadAttributes.getMaxBlobsPerBlock() == null) {
+      LOG.error("maxBlobsPerBlock not present in payload attributes after prague hardfork");
       return Optional.of(new JsonRpcErrorResponse(requestId, getInvalidPayloadAttributesError()));
     }
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
@@ -59,7 +59,7 @@ public class EngineNewPayloadV2 extends AbstractEngineNewPayload {
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
       final Optional<List<String>> maybeRequestsParam,
-      final Optional<String> maybeTargetBlobCountParam) {
+      final Optional<String> maybeTargetBlobsPerBlockParam) {
     if (payloadParameter.getBlobGasUsed() != null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Unexpected blob gas used field present");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV2.java
@@ -58,7 +58,8 @@ public class EngineNewPayloadV2 extends AbstractEngineNewPayload {
       final EnginePayloadParameter payloadParameter,
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
-      final Optional<List<String>> maybeRequestsParam) {
+      final Optional<List<String>> maybeRequestsParam,
+      final Optional<String> maybeTargetBlobCountParam) {
     if (payloadParameter.getBlobGasUsed() != null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Unexpected blob gas used field present");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
@@ -56,7 +56,8 @@ public class EngineNewPayloadV3 extends AbstractEngineNewPayload {
       final EnginePayloadParameter payloadParameter,
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
-      final Optional<List<String>> maybeRequestsParam) {
+      final Optional<List<String>> maybeRequestsParam,
+      final Optional<String> maybeTargetBlobCountParam) {
     if (payloadParameter.getBlobGasUsed() == null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Missing blob gas used field");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3.java
@@ -57,7 +57,7 @@ public class EngineNewPayloadV3 extends AbstractEngineNewPayload {
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
       final Optional<List<String>> maybeRequestsParam,
-      final Optional<String> maybeTargetBlobCountParam) {
+      final Optional<String> maybeTargetBlobsPerBlockParam) {
     if (payloadParameter.getBlobGasUsed() == null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Missing blob gas used field");

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -56,7 +56,8 @@ public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
       final EnginePayloadParameter payloadParameter,
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
-      final Optional<List<String>> maybeRequestsParam) {
+      final Optional<List<String>> maybeRequestsParam,
+      final Optional<String> maybeTargetBlobCountParam) {
     if (payloadParameter.getBlobGasUsed() == null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Missing blob gas used field");
@@ -73,6 +74,9 @@ public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
     } else if (maybeRequestsParam.isEmpty()) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_EXECUTION_REQUESTS_PARAMS, "Missing execution requests field");
+    } else if (maybeTargetBlobCountParam.isEmpty()) {
+      return ValidationResult.invalid(
+          RpcErrorType.INVALID_TARGET_BLOB_COUNT_PARAM, "Missing targetBlobCount field");
     } else {
       return ValidationResult.valid();
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4.java
@@ -57,7 +57,7 @@ public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
       final Optional<List<String>> maybeVersionedHashParam,
       final Optional<String> maybeBeaconBlockRootParam,
       final Optional<List<String>> maybeRequestsParam,
-      final Optional<String> maybeTargetBlobCountParam) {
+      final Optional<String> maybeTargetBlobsPerBlockParam) {
     if (payloadParameter.getBlobGasUsed() == null) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_BLOB_GAS_USED_PARAMS, "Missing blob gas used field");
@@ -74,9 +74,9 @@ public class EngineNewPayloadV4 extends AbstractEngineNewPayload {
     } else if (maybeRequestsParam.isEmpty()) {
       return ValidationResult.invalid(
           RpcErrorType.INVALID_EXECUTION_REQUESTS_PARAMS, "Missing execution requests field");
-    } else if (maybeTargetBlobCountParam.isEmpty()) {
+    } else if (maybeTargetBlobsPerBlockParam.isEmpty()) {
       return ValidationResult.invalid(
-          RpcErrorType.INVALID_TARGET_BLOB_COUNT_PARAM, "Missing targetBlobCount field");
+          RpcErrorType.INVALID_TARGET_BLOB_COUNT_PARAM, "Missing targetBlobsPerBlock field");
     } else {
       return ValidationResult.valid();
     }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -114,6 +114,7 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
                     param.getPrevRandao(),
                     param.getFeeRecipient(),
                     Optional.of(withdrawals),
-                    param.getParentBeaconBlockRoot()));
+                    param.getParentBeaconBlockRoot(),
+                    Optional.empty())); // TODO SLD EIP-7742
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -115,6 +115,8 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
                     param.getFeeRecipient(),
                     Optional.of(withdrawals),
                     param.getParentBeaconBlockRoot(),
-                    Optional.empty())); // TODO SLD EIP-7742
+                    // TODO SLD EIP-7742 add targetBlobsPerBlock or refactor to inherit from
+                    // EnginePayloadAttributesParameter?
+                    Optional.empty()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EnginePreparePayloadDebug.java
@@ -117,6 +117,7 @@ public class EnginePreparePayloadDebug extends ExecutionEngineJsonRpcMethod {
                     param.getParentBeaconBlockRoot(),
                     // TODO SLD EIP-7742 add targetBlobsPerBlock or refactor to inherit from
                     // EnginePayloadAttributesParameter?
+                    Optional.empty(),
                     Optional.empty()));
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -33,7 +33,7 @@ public class EnginePayloadAttributesParameter {
   final List<WithdrawalParameter> withdrawals;
   private final Bytes32 parentBeaconBlockRoot;
   private final UInt64 targetBlobsPerBlock;
-  private final UInt64 maximumBlobCount;
+  private final UInt64 maxBlobsPerBlock;
 
   @JsonCreator
   public EnginePayloadAttributesParameter(
@@ -43,7 +43,7 @@ public class EnginePayloadAttributesParameter {
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
       @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot,
       @JsonProperty("targetBlobsPerBlock") final String targetBlobsPerBlock,
-      @JsonProperty("maximumBlobCount") final String maximumBlobCount) {
+      @JsonProperty("maxBlobsPerBlock") final String maxBlobsPerBlock) {
     this.timestamp = Long.decode(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
@@ -52,8 +52,8 @@ public class EnginePayloadAttributesParameter {
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
     this.targetBlobsPerBlock =
         targetBlobsPerBlock == null ? null : UInt64.fromHexString(targetBlobsPerBlock);
-    this.maximumBlobCount =
-        maximumBlobCount == null ? null : UInt64.fromHexString(maximumBlobCount);
+    this.maxBlobsPerBlock =
+        maxBlobsPerBlock == null ? null : UInt64.fromHexString(maxBlobsPerBlock);
   }
 
   public Long getTimestamp() {
@@ -76,8 +76,8 @@ public class EnginePayloadAttributesParameter {
     return targetBlobsPerBlock;
   }
 
-  public UInt64 getMaximumBlobCount() {
-    return maximumBlobCount;
+  public UInt64 getMaxBlobsPerBlock() {
+    return maxBlobsPerBlock;
   }
 
   public List<WithdrawalParameter> getWithdrawals() {
@@ -101,8 +101,8 @@ public class EnginePayloadAttributesParameter {
     if (targetBlobsPerBlock != null) {
       json.put("targetBlobsPerBlock", targetBlobsPerBlock.toHexString());
     }
-    if (maximumBlobCount != null) {
-      json.put("maximumBlobCount", maximumBlobCount.toHexString());
+    if (maxBlobsPerBlock != null) {
+      json.put("maxBlobsPerBlock", maxBlobsPerBlock.toHexString());
     }
     return json.encode();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -32,7 +32,7 @@ public class EnginePayloadAttributesParameter {
   final Address suggestedFeeRecipient;
   final List<WithdrawalParameter> withdrawals;
   private final Bytes32 parentBeaconBlockRoot;
-  private final UInt64 targetBlobCount;
+  private final UInt64 targetBlobsPerBlock;
   private final UInt64 maximumBlobCount;
 
   @JsonCreator
@@ -42,7 +42,7 @@ public class EnginePayloadAttributesParameter {
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient,
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
       @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot,
-      @JsonProperty("targetBlobCount") final String targetBlobCount,
+      @JsonProperty("targetBlobsPerBlock") final String targetBlobsPerBlock,
       @JsonProperty("maximumBlobCount") final String maximumBlobCount) {
     this.timestamp = Long.decode(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
@@ -50,7 +50,8 @@ public class EnginePayloadAttributesParameter {
     this.withdrawals = withdrawals;
     this.parentBeaconBlockRoot =
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
-    this.targetBlobCount = targetBlobCount == null ? null : UInt64.fromHexString(targetBlobCount);
+    this.targetBlobsPerBlock =
+        targetBlobsPerBlock == null ? null : UInt64.fromHexString(targetBlobsPerBlock);
     this.maximumBlobCount =
         maximumBlobCount == null ? null : UInt64.fromHexString(maximumBlobCount);
   }
@@ -71,8 +72,8 @@ public class EnginePayloadAttributesParameter {
     return parentBeaconBlockRoot;
   }
 
-  public UInt64 getTargetBlobCount() {
-    return targetBlobCount;
+  public UInt64 getTargetBlobsPerBlock() {
+    return targetBlobsPerBlock;
   }
 
   public UInt64 getMaximumBlobCount() {
@@ -97,8 +98,8 @@ public class EnginePayloadAttributesParameter {
     if (parentBeaconBlockRoot != null) {
       json.put("parentBeaconBlockRoot", parentBeaconBlockRoot.toHexString());
     }
-    if (targetBlobCount != null) {
-      json.put("targetBlobCount", targetBlobCount.toHexString());
+    if (targetBlobsPerBlock != null) {
+      json.put("targetBlobsPerBlock", targetBlobsPerBlock.toHexString());
     }
     if (maximumBlobCount != null) {
       json.put("maximumBlobCount", maximumBlobCount.toHexString());

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameter.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.json.JsonObject;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 
 public class EnginePayloadAttributesParameter {
 
@@ -31,6 +32,8 @@ public class EnginePayloadAttributesParameter {
   final Address suggestedFeeRecipient;
   final List<WithdrawalParameter> withdrawals;
   private final Bytes32 parentBeaconBlockRoot;
+  private final UInt64 targetBlobCount;
+  private final UInt64 maximumBlobCount;
 
   @JsonCreator
   public EnginePayloadAttributesParameter(
@@ -38,13 +41,18 @@ public class EnginePayloadAttributesParameter {
       @JsonProperty("prevRandao") final String prevRandao,
       @JsonProperty("suggestedFeeRecipient") final String suggestedFeeRecipient,
       @JsonProperty("withdrawals") final List<WithdrawalParameter> withdrawals,
-      @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot) {
+      @JsonProperty("parentBeaconBlockRoot") final String parentBeaconBlockRoot,
+      @JsonProperty("targetBlobCount") final String targetBlobCount,
+      @JsonProperty("maximumBlobCount") final String maximumBlobCount) {
     this.timestamp = Long.decode(timestamp);
     this.prevRandao = Bytes32.fromHexString(prevRandao);
     this.suggestedFeeRecipient = Address.fromHexString(suggestedFeeRecipient);
     this.withdrawals = withdrawals;
     this.parentBeaconBlockRoot =
         parentBeaconBlockRoot == null ? null : Bytes32.fromHexString(parentBeaconBlockRoot);
+    this.targetBlobCount = targetBlobCount == null ? null : UInt64.fromHexString(targetBlobCount);
+    this.maximumBlobCount =
+        maximumBlobCount == null ? null : UInt64.fromHexString(maximumBlobCount);
   }
 
   public Long getTimestamp() {
@@ -61,6 +69,14 @@ public class EnginePayloadAttributesParameter {
 
   public Bytes32 getParentBeaconBlockRoot() {
     return parentBeaconBlockRoot;
+  }
+
+  public UInt64 getTargetBlobCount() {
+    return targetBlobCount;
+  }
+
+  public UInt64 getMaximumBlobCount() {
+    return maximumBlobCount;
   }
 
   public List<WithdrawalParameter> getWithdrawals() {
@@ -80,6 +96,12 @@ public class EnginePayloadAttributesParameter {
     }
     if (parentBeaconBlockRoot != null) {
       json.put("parentBeaconBlockRoot", parentBeaconBlockRoot.toHexString());
+    }
+    if (targetBlobCount != null) {
+      json.put("targetBlobCount", targetBlobCount.toHexString());
+    }
+    if (maximumBlobCount != null) {
+      json.put("maximumBlobCount", maximumBlobCount.toHexString());
     }
     return json.encode();
   }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -41,7 +41,8 @@ public class EnginePreparePayloadParameter {
       @JsonProperty("timestamp") final Optional<UnsignedLongParameter> timestamp,
       @JsonProperty("prevRandao") final Optional<String> prevRandao,
       @JsonProperty("withdrawals") final Optional<List<WithdrawalParameter>> withdrawals,
-      @JsonProperty("parentBeaconBlockRoot") final Optional<Bytes32> parentBeaconBlockRoot) {
+      @JsonProperty("parentBeaconBlockRoot")
+          final Optional<Bytes32> parentBeaconBlockRoot) { // TODO SLD EIP-7742
     this.parentHash = parentHash;
     this.feeRecipient = feeRecipient.orElse(Address.ZERO);
     this.timestamp = timestamp.map(UnsignedLongParameter::getValue);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePreparePayloadParameter.java
@@ -34,6 +34,8 @@ public class EnginePreparePayloadParameter {
   final List<WithdrawalParameter> withdrawals;
   private final Optional<Bytes32> parentBeaconBlockRoot;
 
+  // TODO SLD EIP-7742 add targetBlobsPerBlock or refactor to inherit from
+  // EnginePayloadAttributesParameter?
   @JsonCreator
   public EnginePreparePayloadParameter(
       @JsonProperty("parentHash") final Optional<Hash> parentHash,
@@ -41,8 +43,7 @@ public class EnginePreparePayloadParameter {
       @JsonProperty("timestamp") final Optional<UnsignedLongParameter> timestamp,
       @JsonProperty("prevRandao") final Optional<String> prevRandao,
       @JsonProperty("withdrawals") final Optional<List<WithdrawalParameter>> withdrawals,
-      @JsonProperty("parentBeaconBlockRoot")
-          final Optional<Bytes32> parentBeaconBlockRoot) { // TODO SLD EIP-7742
+      @JsonProperty("parentBeaconBlockRoot") final Optional<Bytes32> parentBeaconBlockRoot) {
     this.parentHash = parentHash;
     this.feeRecipient = feeRecipient.orElse(Address.ZERO);
     this.timestamp = timestamp.map(UnsignedLongParameter::getValue);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -63,7 +63,8 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_EXCESS_BLOB_GAS_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid excess blob gas params (missing or invalid)"),
   INVALID_EXECUTION_REQUESTS_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid execution requests params"),
-  INVALID_TARGET_BLOB_COUNT_PARAM(INVALID_PARAMS_ERROR_CODE, "Invalid target blob count param"),
+  INVALID_TARGET_BLOB_COUNT_PARAM(
+      INVALID_PARAMS_ERROR_CODE, "Invalid target blobs per block param"),
   INVALID_EXTRA_DATA_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid extra data params"),
   INVALID_FILTER_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid filter params"),
   INVALID_GAS_PRICE_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid gas price params"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/response/RpcErrorType.java
@@ -63,6 +63,7 @@ public enum RpcErrorType implements RpcMethodError {
   INVALID_EXCESS_BLOB_GAS_PARAMS(
       INVALID_PARAMS_ERROR_CODE, "Invalid excess blob gas params (missing or invalid)"),
   INVALID_EXECUTION_REQUESTS_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid execution requests params"),
+  INVALID_TARGET_BLOB_COUNT_PARAM(INVALID_PARAMS_ERROR_CODE, "Invalid target blob count param"),
   INVALID_EXTRA_DATA_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid extra data params"),
   INVALID_FILTER_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid filter params"),
   INVALID_GAS_PRICE_PARAMS(INVALID_PARAMS_ERROR_CODE, "Invalid gas price params"),

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV3.java
@@ -83,6 +83,8 @@ public class EngineGetPayloadResultV3 {
     private final String baseFeePerGas;
     private final String excessBlobGas;
     private final String blobGasUsed;
+    // TODO Don't think parentBeaconBlockRoot is needed as per the spec
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#ExecutionPayloadV3
     private final String parentBeaconBlockRoot;
 
     protected final List<String> transactions;
@@ -207,6 +209,8 @@ public class EngineGetPayloadResultV3 {
       return blobGasUsed;
     }
 
+    // TODO Don't think parentBeaconBlockRoot is needed as per the spec
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#ExecutionPayloadV3
     @JsonGetter(value = "parentBeaconBlockRoot")
     public String getParentBeaconBlockRoot() {
       return parentBeaconBlockRoot;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/EngineGetPayloadResultV4.java
@@ -97,6 +97,8 @@ public class EngineGetPayloadResultV4 {
     private final String baseFeePerGas;
     private final String excessBlobGas;
     private final String blobGasUsed;
+    // TODO Don't think parentBeaconBlockRoot is needed as per the spec
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#ExecutionPayloadV3
     private final String parentBeaconBlockRoot;
 
     protected final List<String> transactions;
@@ -221,6 +223,8 @@ public class EngineGetPayloadResultV4 {
       return blobGasUsed;
     }
 
+    // TODO Don't think parentBeaconBlockRoot is needed as per the spec
+    // https://github.com/ethereum/execution-apis/blob/main/src/engine/cancun.md#ExecutionPayloadV3
     @JsonGetter(value = "parentBeaconBlockRoot")
     public String getParentBeaconBlockRoot() {
       return parentBeaconBlockRoot;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/ExecutionEngineJsonRpcMethods.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineE
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdatedV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdatedV2;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdatedV3;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineForkchoiceUpdatedV4;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetBlobsV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetClientVersionV1;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.EngineGetPayloadBodiesByHashV1;
@@ -177,23 +178,28 @@ public class ExecutionEngineJsonRpcMethods extends ApiGroupJsonRpcMethods {
       }
 
       if (protocolSchedule.anyMatch(p -> p.spec().getName().equalsIgnoreCase("prague"))) {
-        executionEngineApisSupported.add(
-            new EngineGetPayloadV4(
-                consensusEngineServer,
-                protocolContext,
-                mergeCoordinator.get(),
-                blockResultFactory,
-                engineQosTimer,
-                protocolSchedule));
-
-        executionEngineApisSupported.add(
-            new EngineNewPayloadV4(
-                consensusEngineServer,
-                protocolSchedule,
-                protocolContext,
-                mergeCoordinator.get(),
-                ethPeers,
-                engineQosTimer));
+        executionEngineApisSupported.addAll(
+            List.of(
+                new EngineGetPayloadV4(
+                    consensusEngineServer,
+                    protocolContext,
+                    mergeCoordinator.get(),
+                    blockResultFactory,
+                    engineQosTimer,
+                    protocolSchedule),
+                new EngineNewPayloadV4(
+                    consensusEngineServer,
+                    protocolSchedule,
+                    protocolContext,
+                    mergeCoordinator.get(),
+                    ethPeers,
+                    engineQosTimer),
+                new EngineForkchoiceUpdatedV4(
+                    consensusEngineServer,
+                    protocolSchedule,
+                    protocolContext,
+                    mergeCoordinator.get(),
+                    engineQosTimer)));
       }
 
       return mapOf(executionEngineApisSupported);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -255,6 +255,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getSuggestedFeeRecipient(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -262,6 +263,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             Address.ECREC,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty()))
@@ -451,7 +453,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
     var forkchoiceRes = (EngineUpdateForkchoiceResult) resp.getResult();
 
     verify(mergeCoordinator, never())
-        .preparePayload(any(), any(), any(), any(), any(), any(), any());
+        .preparePayload(any(), any(), any(), any(), any(), any(), any(), any());
 
     assertThat(forkchoiceRes.getPayloadStatus().getStatus()).isEqualTo(VALID);
     assertThat(forkchoiceRes.getPayloadStatus().getError()).isNull();
@@ -543,6 +545,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getSuggestedFeeRecipient(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -550,6 +553,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             Address.ECREC,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty()))
@@ -635,6 +639,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getSuggestedFeeRecipient(),
             withdrawals,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -643,6 +648,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             Address.ECREC,
             withdrawals,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty()))
         .thenReturn(mockPayloadId);
@@ -682,6 +688,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getSuggestedFeeRecipient(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -689,6 +696,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             Address.ECREC,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty()))

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -244,6 +244,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
+            null,
             null);
     var mockPayloadId =
         PayloadIdentifier.forPayloadParams(
@@ -433,6 +435,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
+            null,
             null);
 
     var resp =
@@ -470,6 +474,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             emptyList(),
+            null,
+            null,
             null);
 
     var resp =
@@ -495,6 +501,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             emptyList(),
+            null,
+            null,
             null);
 
     var resp =
@@ -519,6 +527,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             String.valueOf(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
+            null,
             null,
             null);
 
@@ -564,6 +574,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
+            null,
             null);
 
     var resp =
@@ -600,6 +612,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             withdrawalParameters,
+            null,
+            null,
             null);
 
     final Optional<List<Withdrawal>> withdrawals =
@@ -648,6 +662,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             String.valueOf(mockHeader.getTimestamp() + 1),
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
+            null,
+            null,
             null,
             null);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -263,6 +263,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             Address.ECREC,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()))
         .thenReturn(mockPayloadId);
 
@@ -449,7 +450,8 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
 
     var forkchoiceRes = (EngineUpdateForkchoiceResult) resp.getResult();
 
-    verify(mergeCoordinator, never()).preparePayload(any(), any(), any(), any(), any(), any());
+    verify(mergeCoordinator, never())
+        .preparePayload(any(), any(), any(), any(), any(), any(), any());
 
     assertThat(forkchoiceRes.getPayloadStatus().getStatus()).isEqualTo(VALID);
     assertThat(forkchoiceRes.getPayloadStatus().getError()).isNull();
@@ -549,6 +551,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             Address.ECREC,
             Optional.empty(),
+            Optional.empty(),
             Optional.empty()))
         .thenReturn(mockPayloadId);
 
@@ -640,6 +643,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             Address.ECREC,
             withdrawals,
+            Optional.empty(),
             Optional.empty()))
         .thenReturn(mockPayloadId);
 
@@ -685,6 +689,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             Address.ECREC,
+            Optional.empty(),
             Optional.empty(),
             Optional.empty()))
         .thenReturn(mockPayloadId);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdatedTest.java
@@ -254,6 +254,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -539,6 +540,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -629,6 +631,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
             withdrawals,
+            Optional.empty(),
             Optional.empty());
 
     when(mergeCoordinator.preparePayload(
@@ -673,6 +676,7 @@ public abstract class AbstractEngineForkchoiceUpdatedTest {
             payloadParams.getTimestamp(),
             payloadParams.getPrevRandao(),
             payloadParams.getSuggestedFeeRecipient(),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -92,6 +92,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
           Address.fromHexString("0x42"),
           Optional.empty(),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
@@ -159,6 +160,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
                 0L,
                 Bytes32.random(),
                 Address.fromHexString("0x42"),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty()));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineGetPayloadTest.java
@@ -91,6 +91,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
           Bytes32.random(),
           Address.fromHexString("0x42"),
           Optional.empty(),
+          Optional.empty(),
           Optional.empty());
   protected static final BlockHeader mockHeader =
       new BlockHeaderTestFixture().prevRandao(Bytes32.random()).buildHeader();
@@ -158,6 +159,7 @@ public abstract class AbstractEngineGetPayloadTest extends AbstractScheduledApiT
                 0L,
                 Bytes32.random(),
                 Address.fromHexString("0x42"),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty()));
     assertThat(resp).isInstanceOf(JsonRpcErrorResponse.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineForkchoiceUpdatedV2Test.java
@@ -73,6 +73,8 @@ public class EngineForkchoiceUpdatedV2Test extends AbstractEngineForkchoiceUpdat
             Bytes32.fromHexStringLenient("0xDEADBEEF").toHexString(),
             Address.ECREC.toString(),
             null,
+            null,
+            null,
             null);
 
     final JsonRpcResponse resp = resp(param, Optional.of(payloadParams));

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -104,6 +104,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             Bytes32.random(),
             Address.fromHexString("0x42"),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV3Test.java
@@ -105,6 +105,7 @@ public class EngineGetPayloadV3Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
@@ -112,6 +112,7 @@ public class EngineGetPayloadV4Test extends AbstractEngineGetPayloadTest {
             Address.fromHexString("0x42"),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineGetPayloadV4Test.java
@@ -111,6 +111,7 @@ public class EngineGetPayloadV4Test extends AbstractEngineGetPayloadTest {
             Bytes32.random(),
             Address.fromHexString("0x42"),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     BlobTestFixture blobTestFixture = new BlobTestFixture();

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV3Test.java
@@ -150,7 +150,8 @@ public class EngineNewPayloadV3Test extends EngineNewPayloadV2Test {
             payload,
             Optional.of(List.of()),
             Optional.of("0x0000000000000000000000000000000000000000000000000000000000000000"),
-            Optional.of(emptyList()));
+            Optional.of(emptyList()),
+            Optional.of("0x3"));
     assertThat(res.isValid()).isTrue();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -133,8 +133,8 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
   }
 
   @Test
-  public void shouldReturnErrorIfTargetBlobCountIsMissing() {
-    var resp = respWithMissingTargetBlobCount();
+  public void shouldReturnErrorIfTargetBlobsPerBlockIsMissing() {
+    var resp = respWithMissingTargetBlobsPerBlock();
 
     assertThat(fromErrorResp(resp).getCode()).isEqualTo(INVALID_PARAMS.getCode());
     assertThat(fromErrorResp(resp).getMessage())
@@ -143,12 +143,12 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
   }
 
   @Test
-  public void shouldReturnInvalidIfTargetBlobCountIsInvalid() {
-    var resp = respWithInvalidTargetBlobCount();
+  public void shouldReturnInvalidIfTargetBlobsPerBlockIsInvalid() {
+    var resp = respWithInvalidTargetBlobsPerBlock();
     final EnginePayloadStatusResult result = fromSuccessResp(resp);
 
     assertThat(result.getStatusAsString()).isEqualTo(INVALID.name());
-    assertThat(result.getError()).isEqualTo("Invalid targetBlobCount");
+    assertThat(result.getError()).isEqualTo("Invalid targetBlobsPerBlock");
     verify(engineCallListener, times(1)).executionEngineCalled();
   }
 
@@ -225,7 +225,7 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", this.method.getName(), params)));
   }
 
-  private JsonRpcResponse respWithMissingTargetBlobCount() {
+  private JsonRpcResponse respWithMissingTargetBlobsPerBlock() {
     final EnginePayloadParameter payload =
         mockEnginePayload(createValidBlockHeaderForV4(Optional.empty()), emptyList());
     final List<String> requestsWithoutRequestId =
@@ -242,14 +242,14 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
                       emptyList(),
                       parentBeaconBlockRootBytes32.toHexString(),
                       requestsWithoutRequestId,
-                      // missing targetBlobCount param
+                      // missing targetBlobsPerBlock param
                     })
             .orElseGet(() -> new Object[] {payload});
     return method.response(
         new JsonRpcRequestContext(new JsonRpcRequest("2.0", this.method.getName(), params)));
   }
 
-  private JsonRpcResponse respWithInvalidTargetBlobCount() {
+  private JsonRpcResponse respWithInvalidTargetBlobsPerBlock() {
     final EnginePayloadParameter payload =
         mockEnginePayload(createValidBlockHeaderForV4(Optional.empty()), emptyList());
     final List<String> requestsWithoutRequestId =
@@ -266,7 +266,7 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
                       emptyList(),
                       parentBeaconBlockRootBytes32.toHexString(),
                       requestsWithoutRequestId,
-                      "invalidTargetBlobCount"
+                      "invalidTargetBlobsPerBlock"
                     })
             .orElseGet(() -> new Object[] {payload});
     return method.response(

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/EngineNewPayloadV4Test.java
@@ -156,7 +156,7 @@ public class EngineNewPayloadV4Test extends EngineNewPayloadV3Test {
       final Optional<List<Withdrawal>> maybeWithdrawals) {
     return createBlockHeaderFixtureForV3(maybeWithdrawals)
         .requestsHash(BodyValidation.requestsHash(VALID_REQUESTS))
-        .targetBlobCount(VALID_TARGET_BLOB_COUNT)
+        .targetBlobsPerBlock(VALID_TARGET_BLOB_COUNT)
         .buildHeader();
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/parameters/EnginePayloadAttributesParameterTest.java
@@ -98,13 +98,13 @@ public class EnginePayloadAttributesParameterTest {
 
   private EnginePayloadAttributesParameter parameterWithdrawalsOmitted() {
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, null, null, null, null);
   }
 
   private EnginePayloadAttributesParameter parameterWithdrawalsPresent() {
     final List<WithdrawalParameter> withdrawals = List.of(WITHDRAWAL_PARAM_1, WITHDRAWAL_PARAM_2);
     return new EnginePayloadAttributesParameter(
-        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null);
+        TIMESTAMP, PREV_RANDAO, SUGGESTED_FEE_RECIPIENT_ADDRESS, withdrawals, null, null, null);
   }
 
   // TODO: add a parent beacon block root test here

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -65,6 +65,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import com.google.common.collect.Lists;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.apache.tuweni.units.bigints.UInt64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,6 +149,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
         Optional.empty(),
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         timestamp,
         true,
         parentHeader);
@@ -171,6 +173,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
         maybeWithdrawals,
         Optional.empty(),
         Optional.empty(),
+        Optional.empty(),
         timestamp,
         true,
         parentHeader);
@@ -182,6 +185,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final Optional<List<Withdrawal>> maybeWithdrawals,
       final Optional<Bytes32> maybePrevRandao,
       final Optional<Bytes32> maybeParentBeaconBlockRoot,
+      final Optional<UInt64> maybeTargetBlobCount,
       final long timestamp,
       boolean rewardCoinbase,
       final BlockHeader parentHeader) {
@@ -200,7 +204,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
                   miningConfiguration,
                   timestamp,
                   maybePrevRandao,
-                  maybeParentBeaconBlockRoot)
+                  maybeParentBeaconBlockRoot,
+                  maybeTargetBlobCount)
               .buildProcessableBlockHeader();
 
       final Address miningBeneficiary =

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -185,7 +185,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final Optional<List<Withdrawal>> maybeWithdrawals,
       final Optional<Bytes32> maybePrevRandao,
       final Optional<Bytes32> maybeParentBeaconBlockRoot,
-      final Optional<UInt64> maybeTargetBlobCount,
+      final Optional<UInt64> maybeTargetBlobsPerBlock,
       final long timestamp,
       boolean rewardCoinbase,
       final BlockHeader parentHeader) {
@@ -205,7 +205,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
                   timestamp,
                   maybePrevRandao,
                   maybeParentBeaconBlockRoot,
-                  maybeTargetBlobCount)
+                  maybeTargetBlobsPerBlock)
               .buildProcessableBlockHeader();
 
       final Address miningBeneficiary =

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelector.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/selectors/BlobSizeTransactionSelector.java
@@ -56,7 +56,9 @@ public class BlobSizeTransactionSelector extends AbstractTransactionSelector {
     if (tx.getType().supportsBlob()) {
 
       final var remainingBlobGas =
-          context.gasLimitCalculator().currentBlobGasLimit()
+          context
+                  .gasLimitCalculator()
+                  .currentBlobGasLimit() // TODO SLD EIP-7742 max blobs may change
               - transactionSelectionResults.getCumulativeBlobGasUsed();
 
       if (remainingBlobGas == 0) {

--- a/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
+++ b/ethereum/blockcreation/src/test/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreatorTest.java
@@ -157,6 +157,7 @@ abstract class AbstractBlockCreatorTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             1L,
             false,
             miningOn.parentHeader);
@@ -171,6 +172,7 @@ abstract class AbstractBlockCreatorTest {
     final AbstractBlockCreator blockCreator = miningOn.blockCreator;
     final BlockCreationResult blockCreationResult =
         blockCreator.createBlock(
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -197,6 +199,7 @@ abstract class AbstractBlockCreatorTest {
             Optional.of(withdrawals),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             1L,
             false,
             miningOn.parentHeader);
@@ -219,6 +222,7 @@ abstract class AbstractBlockCreatorTest {
             Optional.empty(),
             Optional.empty(),
             Optional.of(withdrawals),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             1L,
@@ -251,6 +255,7 @@ abstract class AbstractBlockCreatorTest {
     final BlockCreationResult blockCreationResult =
         blockCreator.createBlock(
             Optional.of(List.of(fullOfBlobs)),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/GenesisState.java
@@ -221,8 +221,7 @@ public final class GenesisState {
         .requestsHash(isPragueAtGenesis(genesis) ? Hash.EMPTY_REQUESTS_HASH : null)
         .targetBlobsPerBlock(
             isPragueAtGenesis(genesis)
-                // TODO SLD EIP-7742 Currently defaulting to null due to dependency on web3j
-                // BlockHeader in CodeDelegationTransactionAcceptanceTest
+                // TODO SLD EIP-7742 should we enforce a value instead of allowing null?
                 ? genesis.getTargetBlobsPerBlock().map(UInt64::fromHexString).orElse(null)
                 : null)
         .buildBlockHeader();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/BlockHeaderBuilder.java
@@ -168,7 +168,8 @@ public class BlockHeaderBuilder {
       final MiningConfiguration miningConfiguration,
       final long timestamp,
       final Optional<Bytes32> maybePrevRandao,
-      final Optional<Bytes32> maybeParentBeaconBlockRoot) {
+      final Optional<Bytes32> maybeParentBeaconBlockRoot,
+      final Optional<UInt64> maybeTargetBlobsPerBlock) {
 
     final long newBlockNumber = parentHeader.getNumber() + 1;
     final long gasLimit =
@@ -208,7 +209,8 @@ public class BlockHeaderBuilder {
         .timestamp(timestamp)
         .baseFee(baseFee)
         .prevRandao(prevRandao)
-        .parentBeaconBlockRoot(parentBeaconBlockRoot);
+        .parentBeaconBlockRoot(parentBeaconBlockRoot)
+        .targetBlobsPerBlock(maybeTargetBlobsPerBlock.orElse(null));
   }
 
   public BlockHeader buildBlockHeader() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/ProcessableBlockHeader.java
@@ -47,7 +47,7 @@ public class ProcessableBlockHeader
   protected final Bytes32 mixHashOrPrevRandao;
   // parentBeaconBlockRoot is included for Cancun
   protected final Bytes32 parentBeaconBlockRoot;
-  // TODO SLD Quantity or UInt64Value<UInt64> instead?
+  // targetBlobsPerBlock is included for Prague EIP-7742
   protected final UInt64 targetBlobsPerBlock;
 
   protected ProcessableBlockHeader(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -188,6 +188,7 @@ public class TransactionSimulator {
                 miningConfiguration,
                 timestamp,
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty())
             .buildProcessableBlockHeader();
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/BlobCache.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/BlobCache.java
@@ -34,6 +34,7 @@ public class BlobCache {
   public BlobCache() {
     this.cache =
         Caffeine.newBuilder()
+            // TODO SLD EIP-7742 max blobs may change
             .maximumSize(6 * 32 * 3L) // 6 blobs max per 32 slots per 3 epochs
             .expireAfterWrite(
                 3 * 32 * 12L, TimeUnit.SECONDS) // 3 epochs of 32 slots which take 12 seconds each.

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -75,7 +75,7 @@ public interface TransactionPoolConfiguration {
   long DEFAULT_PENDING_TRANSACTIONS_LAYER_MAX_CAPACITY_BYTES = 12_500_000L;
   int DEFAULT_MAX_PRIORITIZED_TRANSACTIONS = 2000;
   EnumMap<TransactionType, Integer> DEFAULT_MAX_PRIORITIZED_TRANSACTIONS_BY_TYPE =
-      new EnumMap<>(Map.of(TransactionType.BLOB, 6));
+      new EnumMap<>(Map.of(TransactionType.BLOB, 6)); // TODO SLD EIP-7742? max blobs may change
   int DEFAULT_MAX_FUTURE_BY_SENDER = 200;
   Implementation DEFAULT_TX_POOL_IMPLEMENTATION = Implementation.LAYERED;
   Set<Address> DEFAULT_PRIORITY_SENDERS = Set.of();

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'TPCo4SZ61OrJxRAa2SIcAIOAOjVTdRw+UOeHMuiJP84='
+  knownHash = 'lgfTaInANOY3ueze2+tqEyyRi2foHhZDnFVfiO/Dhgk='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/ProcessableBlockHeader.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/data/ProcessableBlockHeader.java
@@ -113,7 +113,6 @@ public interface ProcessableBlockHeader {
    * @return The target blobs per block of this header.
    */
   @Unstable
-  // TODO SLD should be Quantity or new subclass of Quantity?
   default Optional<UInt64> getTargetBlobsPerBlock() {
     return Optional.empty();
   }


### PR DESCRIPTION
## PR description

**This makes Pectra require EIP-7742 fields so will break any pectra devnets that exclude 7742.** @daniellehrner will that be an issue? I could temporarily disable the engine api validation to avoid this if so.

This makes Besu usable for interop (has been tested with lodestar so far), however there are still some missing pieces that may cause 7742 to break depending on how maxBlobsPerBlock is set:
* The max isn't wired through to block creation so that still assumes Cancun's 6 blobs max.
* The 4844 block/tx max blob validation (via newPayload) hasn't been skipped for Prague so a newPayload with > 6 blobs may fail

In other words, in order for Besu to work for a Pectra interop we would require a EIP-7742 compatible CL and a max blob value of <= 6.

This PR was big enough already and I think uncontentious, whereas the implementations for the points above may require more discussion.

Also block creation wiring was required in this PR in order to satisfy CodeDelegationTransactionAcceptanceTest

Part of https://github.com/hyperledger/besu/issues/7605

Spec: https://github.com/ethereum/execution-apis/pull/574

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

