### PR TITLE
Make healing an action of the WorldStateArchive

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/MainnetBlockValidator.java
@@ -181,7 +181,7 @@ public class MainnetBlockValidator implements BlockValidator {
             Optional.of(new BlockProcessingOutputs(worldState, receipts, maybeRequests)));
       }
     } catch (MerkleTrieException ex) {
-      context.getSynchronizer().healWorldState(ex.getMaybeAddress(), ex.getLocation());
+      context.getWorldStateArchive().heal(ex.getMaybeAddress(), ex.getLocation());
       return new BlockProcessingResult(Optional.empty(), ex);
     } catch (StorageException ex) {
       var retval = new BlockProcessingResult(Optional.empty(), ex);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
@@ -44,6 +45,7 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(BonsaiWorldStateProvider.class);
   private final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader;
+  private final Supplier<WorldStateHealer> worldStateHealerSupplier;
 
   public BonsaiWorldStateProvider(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
@@ -51,9 +53,11 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
       final Optional<Long> maxLayersToLoad,
       final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader,
       final BesuContext pluginContext,
-      final EvmConfiguration evmConfiguration) {
+      final EvmConfiguration evmConfiguration,
+      final Supplier<WorldStateHealer> worldStateHealerSupplier) {
     super(worldStateKeyValueStorage, blockchain, maxLayersToLoad, pluginContext);
     this.bonsaiCachedMerkleTrieLoader = bonsaiCachedMerkleTrieLoader;
+    this.worldStateHealerSupplier = worldStateHealerSupplier;
     provideCachedWorldStorageManager(
         new BonsaiCachedWorldStorageManager(
             this, worldStateKeyValueStorage, this::cloneBonsaiWorldStateConfig));
@@ -69,9 +73,11 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Blockchain blockchain,
       final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader,
-      final EvmConfiguration evmConfiguration) {
+      final EvmConfiguration evmConfiguration,
+      final Supplier<WorldStateHealer> worldStateHealerSupplier) {
     super(worldStateKeyValueStorage, blockchain, trieLogManager);
     this.bonsaiCachedMerkleTrieLoader = bonsaiCachedMerkleTrieLoader;
+    this.worldStateHealerSupplier = worldStateHealerSupplier;
     provideCachedWorldStorageManager(bonsaiCachedWorldStorageManager);
     loadPersistedState(
         new BonsaiWorldState(
@@ -150,5 +156,10 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
 
   private DiffBasedWorldStateConfig cloneBonsaiWorldStateConfig() {
     return new DiffBasedWorldStateConfig(defaultWorldStateConfig);
+  }
+
+  @Override
+  public void heal(final Optional<Address> maybeAccountToRepair, final Bytes location) {
+    worldStateHealerSupplier.get().heal(maybeAccountToRepair, location);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/forest/ForestWorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/forest/ForestWorldStateArchive.java
@@ -113,6 +113,11 @@ public class ForestWorldStateArchive implements WorldStateArchive {
   }
 
   @Override
+  public void heal(final Optional<Address> maybeAccountToRepair, final Bytes location) {
+    // no heal needed for Forest
+  }
+
+  @Override
   public void close() {
     // no op
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/worldstate/WorldStateArchive.java
@@ -64,4 +64,24 @@ public interface WorldStateArchive extends Closeable {
       final Address accountAddress,
       final List<UInt256> accountStorageKeys,
       final Function<Optional<WorldStateProof>, ? extends Optional<U>> mapper);
+
+  /**
+   * Heal the world state to fix inconsistency
+   *
+   * @param maybeAccountToRepair the optional account to repair
+   * @param location the location of the inconsistency
+   */
+  void heal(Optional<Address> maybeAccountToRepair, Bytes location);
+
+  /** A world state healer */
+  @FunctionalInterface
+  interface WorldStateHealer {
+    /**
+     * Heal the world state to fix inconsistency
+     *
+     * @param maybeAccountToRepair the optional account to repair
+     * @param location the location of the inconsistency
+     */
+    void heal(Optional<Address> maybeAccountToRepair, Bytes location);
+  }
 }

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
+import static org.hyperledger.besu.ethereum.core.WorldStateHealerHelper.throwingWorldStateHealerSupplier;
+
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.chain.DefaultBlockchain;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
@@ -105,7 +107,8 @@ public class InMemoryKeyValueStorageProvider extends KeyValueStorageProvider {
         Optional.empty(),
         bonsaiCachedMerkleTrieLoader,
         null,
-        evmConfiguration);
+        evmConfiguration,
+        throwingWorldStateHealerSupplier());
   }
 
   public static MutableWorldState createInMemoryWorldState() {

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/WorldStateHealerHelper.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/WorldStateHealerHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.core;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive.WorldStateHealer;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.apache.tuweni.bytes.Bytes;
+
+public class WorldStateHealerHelper {
+
+  public static WorldStateHealer throwingHealer(
+      final Optional<Address> maybeAccountToRepair, final Bytes location) {
+    throw new RuntimeException(
+        "World state needs to be healed: "
+            + maybeAccountToRepair.map(address -> "account to repair: " + address).orElse("")
+            + " location: "
+            + location.toHexString());
+  }
+
+  public static Supplier<WorldStateHealer> throwingWorldStateHealerSupplier() {
+    return () -> WorldStateHealerHelper::throwingHealer;
+  }
+}

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/AbstractIsolationTests.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.trie.diffbased.bonsai;
 
 import static org.hyperledger.besu.ethereum.core.InMemoryKeyValueStorageProvider.createInMemoryBlockchain;
+import static org.hyperledger.besu.ethereum.core.WorldStateHealerHelper.throwingWorldStateHealerSupplier;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -167,7 +168,8 @@ public abstract class AbstractIsolationTests {
             Optional.of(16L),
             new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
             null,
-            EvmConfiguration.DEFAULT);
+            EvmConfiguration.DEFAULT,
+            throwingWorldStateHealerSupplier());
     var ws = archive.getMutable();
     genesisState.writeStateTo(ws);
     protocolContext = new ProtocolContext(blockchain, archive, null, new BadBlockManager());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProviderTest.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.trie.diffbased.bonsai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.ethereum.core.WorldStateHealerHelper.throwingWorldStateHealerSupplier;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.BLOCKCHAIN;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage.WORLD_BLOCK_HASH_KEY;
@@ -111,7 +112,8 @@ class BonsaiWorldStateProviderTest {
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
             blockchain,
             new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-            EvmConfiguration.DEFAULT);
+            EvmConfiguration.DEFAULT,
+            throwingWorldStateHealerSupplier());
 
     assertThat(bonsaiWorldStateArchive.getMutable(chainHead, true))
         .containsInstanceOf(BonsaiWorldState.class);
@@ -129,7 +131,8 @@ class BonsaiWorldStateProviderTest {
             Optional.of(512L),
             new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
             null,
-            EvmConfiguration.DEFAULT);
+            EvmConfiguration.DEFAULT,
+            throwingWorldStateHealerSupplier());
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
     final BlockHeader chainHead = blockBuilder.number(512).buildHeader();
     when(blockchain.getChainHeadHeader()).thenReturn(chainHead);
@@ -150,7 +153,8 @@ class BonsaiWorldStateProviderTest {
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
             blockchain,
             new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-            EvmConfiguration.DEFAULT);
+            EvmConfiguration.DEFAULT,
+            throwingWorldStateHealerSupplier());
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
     final BlockHeader chainHead = blockBuilder.number(511).buildHeader();
     final BonsaiWorldState mockWorldState = mock(BonsaiWorldState.class);
@@ -185,7 +189,8 @@ class BonsaiWorldStateProviderTest {
                 worldStateKeyValueStorage,
                 blockchain,
                 new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-                EvmConfiguration.DEFAULT));
+                EvmConfiguration.DEFAULT,
+                throwingWorldStateHealerSupplier()));
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
 
     when(blockchain.getBlockHeader(blockHeader.getHash())).thenReturn(Optional.of(blockHeader));
@@ -214,7 +219,8 @@ class BonsaiWorldStateProviderTest {
                 worldStateKeyValueStorage,
                 blockchain,
                 new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-                EvmConfiguration.DEFAULT));
+                EvmConfiguration.DEFAULT,
+                throwingWorldStateHealerSupplier()));
 
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
 
@@ -254,7 +260,8 @@ class BonsaiWorldStateProviderTest {
                 worldStateKeyValueStorage,
                 blockchain,
                 new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-                EvmConfiguration.DEFAULT));
+                EvmConfiguration.DEFAULT,
+                throwingWorldStateHealerSupplier()));
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(Hash.ZERO)).thenReturn(Optional.of(blockHeaderChainA));
@@ -297,7 +304,8 @@ class BonsaiWorldStateProviderTest {
                     DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
                 blockchain,
                 new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
-                EvmConfiguration.DEFAULT));
+                EvmConfiguration.DEFAULT,
+                throwingWorldStateHealerSupplier()));
 
     // initial persisted state hash key
     when(blockchain.getBlockHeader(Hash.ZERO)).thenReturn(Optional.of(blockHeaderChainA));


### PR DESCRIPTION
## PR description

A followup to this suggestion https://github.com/hyperledger/besu/pull/7792#issuecomment-2434648358
to remove the circular dependency between `ProtocolContext` and `Synchronizer` and also make the heal action a native function of the `WorldStateArchive` as this seems to be more appropriate.

Next PR will complete the removal of the `Synchronizer` from `ProtocolContext`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

