### PR TITLE
Move EIP-4762 gas charging for contract account creation from code su…

### DIFF
--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -258,7 +258,7 @@ dependencies {
   }
   verkleRefTestImplemention dependencies.create('ethereum:execution-spec-tests') {
     version {
-      strictly 'verkle@v0.0.5'
+      strictly 'verkle@v0.0.8'
     }
     artifact {
       name = 'fixtures'

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/AccessEvents.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/AccessEvents.java
@@ -16,6 +16,12 @@ package org.hyperledger.besu.evm.gascalculator.stateless;
 
 public final class AccessEvents {
 
+  private static final long WITNESS_BRANCH_COST = 1900;
+  private static final long WITNESS_CHUNK_COST = 200;
+  private static final long SUBTREE_EDIT_COST = 3000;
+  private static final long CHUNK_EDIT_COST = 500;
+  private static final long CHUNK_FILL_COST = 6200;
+
   public static final short NONE = 0;
   public static final short BRANCH_READ = 1;
   public static final short BRANCH_WRITE = 2;
@@ -43,5 +49,25 @@ public final class AccessEvents {
 
   public static boolean isLeafSet(final short accessEvents) {
     return (accessEvents & LEAF_SET) != 0;
+  }
+
+  public static long getBranchReadCost() {
+    return WITNESS_BRANCH_COST;
+  }
+
+  public static long getLeafReadCost() {
+    return WITNESS_CHUNK_COST;
+  }
+
+  public static long getBranchWriteCost() {
+    return SUBTREE_EDIT_COST;
+  }
+
+  public static long getLeafResetCost() {
+    return CHUNK_EDIT_COST;
+  }
+
+  public static long getLeafSetCost() {
+    return CHUNK_FILL_COST;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/Eip4762AccessWitness.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/Eip4762AccessWitness.java
@@ -40,11 +40,6 @@ public class Eip4762AccessWitness implements AccessWitness {
 
   private static final Logger LOG = LoggerFactory.getLogger(Eip4762AccessWitness.class);
   private static final TrieKeyAdapter TRIE_KEY_ADAPTER = new TrieKeyAdapter(new PedersenHasher());
-  private static final long WITNESS_BRANCH_COST = 1900;
-  private static final long WITNESS_CHUNK_COST = 200;
-  private static final long SUBTREE_EDIT_COST = 3000;
-  private static final long CHUNK_EDIT_COST = 500;
-  private static final long CHUNK_FILL_COST = 6200;
 
   private static final UInt256 zeroTreeIndex = UInt256.ZERO;
   private final Map<LeafAccessKey, Integer> leaves;
@@ -288,89 +283,56 @@ public class Eip4762AccessWitness implements AccessWitness {
       final int accessMode) {
     final short accessEvents = touchAddress(address, treeIndex, subIndex, accessMode);
     long gas = 0;
-    LOG.atDebug().log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
     if (AccessEvents.isBranchRead(accessEvents)) {
-      gas = clampedAdd(gas, WITNESS_BRANCH_COST);
-      final long gasView = gas;
-      LOG.atDebug().log(
-          () ->
-              "touchAddressAndChargeGas WITNESS_BRANCH_COST "
-                  + address
-                  + " "
-                  + treeIndex
-                  + " "
-                  + subIndex
-                  + " "
-                  + AccessMode.toString(accessMode)
-                  + " "
-                  + gasView);
+      gas = clampedAdd(gas, AccessEvents.getBranchReadCost());
     }
     if (AccessEvents.isLeafRead(accessEvents)) {
-      gas = clampedAdd(gas, WITNESS_CHUNK_COST);
-      final long gasView = gas;
-      LOG.atDebug().log(
-          () ->
-              "touchAddressAndChargeGas WITNESS_CHUNK_COST "
-                  + address
-                  + " "
-                  + treeIndex
-                  + " "
-                  + subIndex
-                  + " "
-                  + AccessMode.toString(accessMode)
-                  + " "
-                  + gasView);
+      gas = clampedAdd(gas, AccessEvents.getLeafReadCost());
     }
     if (AccessEvents.isBranchWrite(accessEvents)) {
-      gas = clampedAdd(gas, SUBTREE_EDIT_COST);
-      final long gasView = gas;
-      LOG.atDebug().log(
-          () ->
-              "touchAddressAndChargeGas SUBTREE_EDIT_COST "
-                  + address
-                  + " "
-                  + treeIndex
-                  + " "
-                  + subIndex
-                  + " "
-                  + AccessMode.toString(accessMode)
-                  + " "
-                  + gasView);
+      gas = clampedAdd(gas, AccessEvents.getBranchWriteCost());
     }
     if (AccessEvents.isLeafReset(accessEvents)) {
-      gas = clampedAdd(gas, CHUNK_EDIT_COST);
-      final long gasView = gas;
-      LOG.atDebug().log(
-          () ->
-              "touchAddressAndChargeGas CHUNK_EDIT_COST "
-                  + address
-                  + " "
-                  + treeIndex
-                  + " "
-                  + subIndex
-                  + " "
-                  + AccessMode.toString(accessMode)
-                  + " "
-                  + gasView);
+      gas = clampedAdd(gas, AccessEvents.getLeafResetCost());
     }
     if (AccessEvents.isLeafSet(accessEvents)) {
-      gas = clampedAdd(gas, CHUNK_FILL_COST);
-      final long gasView = gas;
-      LOG.atDebug().log(
-          () ->
-              "touchAddressAndChargeGas CHUNK_FILL_COST "
-                  + address
-                  + " "
-                  + treeIndex
-                  + " "
-                  + subIndex
-                  + " "
-                  + AccessMode.toString(accessMode)
-                  + " "
-                  + gasView);
+      gas = clampedAdd(gas, AccessEvents.getLeafSetCost());
     }
-    LOG.atDebug().log("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+
+    final long gasView = gas;
+    LOG.atDebug().log(
+        () ->
+            "touch witness "
+                + address
+                + " "
+                + treeIndex.toShortHexString()
+                + " "
+                + subIndex.toShortHexString()
+                + "\ntotal charges "
+                + gasView
+                + costSchedulePrettyPrint(accessEvents));
+
     return gas;
+  }
+
+  private static String costSchedulePrettyPrint(final short accessEvents) {
+    String message = "";
+    if (AccessEvents.isBranchRead(accessEvents)) {
+      message += "\n\tWITNESS_BRANCH_COST " + AccessEvents.getBranchReadCost();
+    }
+    if (AccessEvents.isLeafRead(accessEvents)) {
+      message += "\n\tWITNESS_CHUNK_COST " + AccessEvents.getLeafReadCost();
+    }
+    if (AccessEvents.isBranchWrite(accessEvents)) {
+      message += "\n\tSUBTREE_EDIT_COST " + AccessEvents.getBranchWriteCost();
+    }
+    if (AccessEvents.isLeafReset(accessEvents)) {
+      message += "\n\tCHUNK_EDIT_COST " + AccessEvents.getLeafResetCost();
+    }
+    if (AccessEvents.isLeafSet(accessEvents)) {
+      message += "\n\tCHUNK_FILL_COST " + AccessEvents.getLeafSetCost();
+    }
+    return message;
   }
 
   public short touchAddress(

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/Eip4762AccessWitness.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/stateless/Eip4762AccessWitness.java
@@ -288,6 +288,7 @@ public class Eip4762AccessWitness implements AccessWitness {
       final int accessMode) {
     final short accessEvents = touchAddress(address, treeIndex, subIndex, accessMode);
     long gas = 0;
+    LOG.atDebug().log(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>");
     if (AccessEvents.isBranchRead(accessEvents)) {
       gas = clampedAdd(gas, WITNESS_BRANCH_COST);
       final long gasView = gas;
@@ -368,7 +369,7 @@ public class Eip4762AccessWitness implements AccessWitness {
                   + " "
                   + gasView);
     }
-
+    LOG.atDebug().log("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
     return gas;
   }
 


### PR DESCRIPTION
## PR description

This fixes gas charges when creating contracts. While other clients charge the contract account creation while writing the nonce, besu was charging when the contract code was written to storage. A mismatch occurs if the code fails to deploy but the nonce is still written. In that case BASIC_DATA and CODE_HASH (empty contract hashcode) are still written to, despite code not being deployed.