### PR TITLE
Consolidate all metric collectors into the metrics system

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcPara
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.Tracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
-import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.FlatTraceGenerator;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.RewardTraceGenerator;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.util.ArrayNodeWrapper;
@@ -41,12 +40,11 @@ import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.services.pipeline.Pipeline;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
@@ -58,10 +56,21 @@ public class TraceBlock extends AbstractBlockParameterMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceBlock.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final ProtocolSchedule protocolSchedule;
+  private final LabelledMetric<Counter> outputCounter;
 
-  public TraceBlock(final ProtocolSchedule protocolSchedule, final BlockchainQueries queries) {
+  public TraceBlock(
+      final ProtocolSchedule protocolSchedule,
+      final BlockchainQueries queries,
+      final MetricsSystem metricsSystem) {
     super(queries);
     this.protocolSchedule = protocolSchedule;
+    this.outputCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "transactions_traceblock_pipeline_processed_total",
+            "Number of transactions processed for each block",
+            "step",
+            "action");
   }
 
   @Override
@@ -115,14 +124,6 @@ public class TraceBlock extends AbstractBlockParameterMethod {
               final ChainUpdater chainUpdater = new ChainUpdater(traceableState);
 
               TransactionSource transactionSource = new TransactionSource(block);
-              final LabelledMetric<Counter> outputCounter =
-                  new PrometheusMetricsSystem(BesuMetricCategory.DEFAULT_METRIC_CATEGORIES, false)
-                      .createLabelledCounter(
-                          BesuMetricCategory.BLOCKCHAIN,
-                          "transactions_traceblock_pipeline_processed_total",
-                          "Number of transactions processed for each block",
-                          "step",
-                          "action");
               DebugOperationTracer debugOperationTracer =
                   new DebugOperationTracer(new TraceOptions(false, false, true), false);
               ExecuteTransactionStep executeTransactionStep =
@@ -171,18 +172,6 @@ public class TraceBlock extends AbstractBlockParameterMethod {
               return Optional.of(resultArrayNode);
             })
         .orElse(emptyResult());
-  }
-
-  protected void generateTracesFromTransactionTraceAndBlock(
-      final Optional<FilterParameter> filterParameter,
-      final List<TransactionTrace> transactionTraces,
-      final Block block,
-      final ArrayNodeWrapper resultArrayNode) {
-    transactionTraces.forEach(
-        transactionTrace ->
-            FlatTraceGenerator.generateFromTransactionTraceAndBlock(
-                    protocolSchedule, transactionTrace, block)
-                .forEachOrdered(resultArrayNode::addPOJO));
   }
 
   protected void generateRewardsFromBlock(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -151,7 +151,11 @@ public class JsonRpcMethodsFactory {
                   blockchainQueries, protocolSchedule, transactionPool, privacyParameters),
               new Web3JsonRpcMethods(clientNodeName),
               new TraceJsonRpcMethods(
-                  blockchainQueries, protocolSchedule, protocolContext, apiConfiguration),
+                  blockchainQueries,
+                  protocolSchedule,
+                  protocolContext,
+                  apiConfiguration,
+                  metricsSystem),
               new TxPoolJsonRpcMethods(transactionPool),
               new PluginsJsonRpcMethods(namedPlugins));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Map;
 
@@ -38,19 +39,21 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockchainQueries blockchainQueries;
   private final ProtocolSchedule protocolSchedule;
-
   private final ApiConfiguration apiConfiguration;
   private final ProtocolContext protocolContext;
+  private final MetricsSystem metricsSystem;
 
   TraceJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
-      final ApiConfiguration apiConfiguration) {
+      final ApiConfiguration apiConfiguration,
+      final MetricsSystem metricsSystem) {
     this.blockchainQueries = blockchainQueries;
     this.protocolSchedule = protocolSchedule;
     this.protocolContext = protocolContext;
     this.apiConfiguration = apiConfiguration;
+    this.metricsSystem = metricsSystem;
   }
 
   @Override
@@ -63,16 +66,16 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
     final BlockReplay blockReplay =
         new BlockReplay(protocolSchedule, protocolContext, blockchainQueries.getBlockchain());
     return mapOf(
-        new TraceReplayBlockTransactions(protocolSchedule, blockchainQueries),
+        new TraceReplayBlockTransactions(protocolSchedule, blockchainQueries, metricsSystem),
         new TraceFilter(
-            () -> new BlockTracer(blockReplay),
             protocolSchedule,
             blockchainQueries,
-            apiConfiguration.getMaxTraceFilterRange()),
+            apiConfiguration.getMaxTraceFilterRange(),
+            metricsSystem),
         new TraceGet(() -> new BlockTracer(blockReplay), blockchainQueries, protocolSchedule),
         new TraceTransaction(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
-        new TraceBlock(protocolSchedule, blockchainQueries),
+        new TraceBlock(protocolSchedule, blockchainQueries, metricsSystem),
         new TraceCall(
             blockchainQueries,
             protocolSchedule,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
 import java.util.function.Supplier;
 
@@ -69,7 +70,8 @@ public class TraceFilterTest {
             new JsonRpcRequest("2.0", "trace_filter", new Object[] {filterParameter}));
 
     method =
-        new TraceFilter(blockTracerSupplier, protocolSchedule, blockchainQueries, maxFilterRange);
+        new TraceFilter(
+            protocolSchedule, blockchainQueries, maxFilterRange, new NoOpMetricsSystem());
 
     final JsonRpcResponse response = method.response(request);
     assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);

--- a/ethereum/core/build.gradle
+++ b/ethereum/core/build.gradle
@@ -65,8 +65,6 @@ dependencies {
   implementation 'org.immutables:value-annotations'
   implementation 'tech.pegasys:jc-kzg-4844'
 
-  implementation 'io.prometheus:simpleclient_guava'
-
   implementation 'org.xerial.snappy:snappy-java'
 
   annotationProcessor 'org.immutables:value'

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/cache/BonsaiCachedMerkleTrieLoader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/cache/BonsaiCachedMerkleTrieLoader.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache;
 
+import static org.hyperledger.besu.metrics.BesuMetricCategory.BLOCKCHAIN;
+
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
@@ -22,9 +24,7 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.StorageSubscriber;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
-import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -33,7 +33,6 @@ import java.util.function.Function;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import io.prometheus.client.guava.cache.CacheMetricsCollector;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
@@ -47,12 +46,8 @@ public class BonsaiCachedMerkleTrieLoader implements StorageSubscriber {
       CacheBuilder.newBuilder().recordStats().maximumSize(STORAGE_CACHE_SIZE).build();
 
   public BonsaiCachedMerkleTrieLoader(final ObservableMetricsSystem metricsSystem) {
-
-    CacheMetricsCollector cacheMetrics = new CacheMetricsCollector();
-    cacheMetrics.addCache("accountsNodes", accountNodes);
-    cacheMetrics.addCache("storageNodes", storageNodes);
-    if (metricsSystem instanceof PrometheusMetricsSystem prometheusMetricsSystem)
-      prometheusMetricsSystem.addCollector(BesuMetricCategory.BLOCKCHAIN, () -> cacheMetrics);
+    metricsSystem.createGuavaCacheCollector(BLOCKCHAIN, "accountsNodes", accountNodes);
+    metricsSystem.createGuavaCacheCollector(BLOCKCHAIN, "storageNodes", storageNodes);
   }
 
   public void preLoadAccount(

--- a/ethereum/p2p/build.gradle
+++ b/ethereum/p2p/build.gradle
@@ -43,7 +43,6 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'dnsjava:dnsjava'
   implementation 'io.netty:netty-transport-native-unix-common'
-  implementation 'io.prometheus:simpleclient'
   implementation 'io.vertx:vertx-core'
 
   implementation 'io.tmio:tuweni-bytes'

--- a/metrics/core/build.gradle
+++ b/metrics/core/build.gradle
@@ -57,6 +57,7 @@ dependencies {
 
   implementation 'io.prometheus:simpleclient'
   implementation 'io.prometheus:simpleclient_common'
+  implementation 'io.prometheus:simpleclient_guava'
   implementation 'io.prometheus:simpleclient_hotspot'
   implementation 'io.prometheus:simpleclient_pushgateway'
   implementation 'io.vertx:vertx-core'

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/ObservableMetricsSystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/ObservableMetricsSystem.java
@@ -17,42 +17,25 @@ package org.hyperledger.besu.metrics;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
-import java.util.Set;
 import java.util.stream.Stream;
 
-/** The interface Observable metrics system. */
+/** The observable metrics system is used to inspect metrics for debug reasons */
 public interface ObservableMetricsSystem extends MetricsSystem {
-
   /**
-   * Stream observations.
+   * Stream observations by category
    *
    * @param category the category
-   * @return the stream
+   * @return the observations stream
    */
   Stream<Observation> streamObservations(MetricCategory category);
 
   /**
-   * Stream observations.
+   * Stream observations
    *
-   * @return the stream
+   * @return the observations stream
    */
   Stream<Observation> streamObservations();
 
-  /**
-   * Provides an immutable view into the metric categories enabled for metric collection.
-   *
-   * @return the set of enabled metric categories.
-   */
-  Set<MetricCategory> getEnabledCategories();
-
-  /**
-   * Checks if a particular category of metrics is enabled.
-   *
-   * @param category the category to check
-   * @return true if the category is enabled, false otherwise
-   */
-  default boolean isCategoryEnabled(final MetricCategory category) {
-    return getEnabledCategories().stream()
-        .anyMatch(metricCategory -> metricCategory.getName().equals(category.getName()));
-  }
+  /** Unregister all the collectors and perform other cleanup tasks */
+  void shutdown();
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpMetricsSystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpMetricsSystem.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.metrics.noop;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.Observation;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
 import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
@@ -27,9 +28,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
 
 /** The NoOp metrics system. */
 public class NoOpMetricsSystem implements ObservableMetricsSystem {
@@ -114,6 +117,13 @@ public class NoOpMetricsSystem implements ObservableMetricsSystem {
   }
 
   @Override
+  public void trackExternalSummary(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final Supplier<ExternalSummary> summarySupplier) {}
+
+  @Override
   public LabelledMetric<OperationTimer> createLabelledTimer(
       final MetricCategory category,
       final String name,
@@ -143,6 +153,10 @@ public class NoOpMetricsSystem implements ObservableMetricsSystem {
       final String name,
       final String help,
       final DoubleSupplier valueSupplier) {}
+
+  @Override
+  public void createGuavaCacheCollector(
+      final MetricCategory category, final String name, final Cache<?, ?> cache) {}
 
   @Override
   public LabelledGauge createLabelledGauge(
@@ -186,6 +200,9 @@ public class NoOpMetricsSystem implements ObservableMetricsSystem {
   public Set<MetricCategory> getEnabledCategories() {
     return Collections.emptySet();
   }
+
+  @Override
+  public void shutdown() {}
 
   /**
    * The Label counting NoOp metric.

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
@@ -250,9 +250,7 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
       final MetricCategory category,
       final String name,
       final String help,
-      final Supplier<ExternalSummary> summarySupplier) {
-    throw new UnsupportedOperationException();
-  }
+      final Supplier<ExternalSummary> summarySupplier) {}
 
   @Override
   public LabelledMetric<OperationTimer> createLabelledTimer(
@@ -291,9 +289,7 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
 
   @Override
   public void createGuavaCacheCollector(
-      final MetricCategory category, final String name, final Cache<?, ?> cache) {
-    throw new UnsupportedOperationException();
-  }
+      final MetricCategory category, final String name, final Cache<?, ?> cache) {}
 
   @Override
   public LabelledGauge createLabelledGauge(

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.metrics.Observation;
 import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
 import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
@@ -40,9 +41,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.inject.Singleton;
 
+import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableSet;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -243,6 +246,15 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
   }
 
   @Override
+  public void trackExternalSummary(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final Supplier<ExternalSummary> summarySupplier) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public LabelledMetric<OperationTimer> createLabelledTimer(
       final MetricCategory category,
       final String name,
@@ -275,6 +287,12 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
           .setDescription(help)
           .buildWithCallback(res -> res.record(valueSupplier.getAsDouble(), Attributes.empty()));
     }
+  }
+
+  @Override
+  public void createGuavaCacheCollector(
+      final MetricCategory category, final String name, final Cache<?, ?> cache) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -376,6 +394,7 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
   }
 
   /** Shuts down the OpenTelemetry exporters, blocking until they have completed orderly. */
+  @Override
   public void shutdown() {
     final CompletableResultCode result =
         CompletableResultCode.ofAll(

--- a/metrics/core/src/test-support/java/org/hyperledger/besu/metrics/StubMetricsSystem.java
+++ b/metrics/core/src/test-support/java/org/hyperledger/besu/metrics/StubMetricsSystem.java
@@ -18,6 +18,7 @@ import static java.util.Arrays.asList;
 
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
 import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
@@ -29,7 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.DoubleSupplier;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import com.google.common.cache.Cache;
 
 public class StubMetricsSystem implements ObservableMetricsSystem {
 
@@ -85,6 +89,13 @@ public class StubMetricsSystem implements ObservableMetricsSystem {
   }
 
   @Override
+  public void trackExternalSummary(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final Supplier<ExternalSummary> summarySupplier) {}
+
+  @Override
   public void createGauge(
       final MetricCategory category,
       final String name,
@@ -92,6 +103,10 @@ public class StubMetricsSystem implements ObservableMetricsSystem {
       final DoubleSupplier valueSupplier) {
     gauges.put(name, valueSupplier);
   }
+
+  @Override
+  public void createGuavaCacheCollector(
+      final MetricCategory category, final String name, final Cache<?, ?> cache) {}
 
   public double getGaugeValue(final String name) {
     final DoubleSupplier gauge = gauges.get(name);
@@ -114,6 +129,12 @@ public class StubMetricsSystem implements ObservableMetricsSystem {
   @Override
   public Set<MetricCategory> getEnabledCategories() {
     return Collections.emptySet();
+  }
+
+  @Override
+  public void shutdown() {
+    counters.clear();
+    gauges.clear();
   }
 
   public static class StubLabelledCounter implements LabelledMetric<Counter> {

--- a/metrics/rocksdb/build.gradle
+++ b/metrics/rocksdb/build.gradle
@@ -40,7 +40,5 @@ dependencies {
   implementation project(':metrics:core')
   implementation project(':plugin-api')
 
-  implementation 'com.google.guava:guava'
-  implementation 'io.prometheus:simpleclient'
   implementation 'org.rocksdb:rocksdbjni'
 }

--- a/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
+++ b/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
@@ -16,15 +16,14 @@ package org.hyperledger.besu.metrics.rocksdb;
 
 import static org.hyperledger.besu.metrics.BesuMetricCategory.KVSTORE_ROCKSDB_STATS;
 
-import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
+import org.hyperledger.besu.plugin.services.metrics.ExternalSummary.Quantile;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import io.prometheus.client.Collector;
 import org.rocksdb.HistogramData;
 import org.rocksdb.HistogramType;
 import org.rocksdb.Statistics;
@@ -32,22 +31,9 @@ import org.rocksdb.TickerType;
 
 /** The Rocks db stats. */
 public class RocksDBStats {
-
-  /** The Labels. */
-  static final List<String> LABELS = Collections.singletonList("quantile");
-
-  /** The Label 50. */
-  static final List<String> LABEL_50 = Collections.singletonList("0.5");
-
-  /** The Label 95. */
-  static final List<String> LABEL_95 = Collections.singletonList("0.95");
-
-  /** The Label 99. */
-  static final List<String> LABEL_99 = Collections.singletonList("0.99");
-
-  /** The constant TICKERS. */
+  /** The constant TICKER_TYPES. */
   // Tickers - RocksDB equivalent of counters
-  static final TickerType[] TICKERS = {
+  static final TickerType[] TICKER_TYPES = {
     TickerType.BLOCK_CACHE_ADD,
     TickerType.BLOCK_CACHE_HIT,
     TickerType.BLOCK_CACHE_ADD_FAILURES,
@@ -133,9 +119,9 @@ public class RocksDBStats {
     TickerType.NUMBER_MULTIGET_KEYS_FOUND,
   };
 
-  /** The constant HISTOGRAMS. */
+  /** The constant HISTOGRAM_TYPES. */
   // Histograms - treated as prometheus summaries
-  static final HistogramType[] HISTOGRAMS = {
+  static final HistogramType[] HISTOGRAM_TYPES = {
     HistogramType.DB_GET,
     HistogramType.DB_WRITE,
     HistogramType.COMPACTION_TIME,
@@ -175,47 +161,40 @@ public class RocksDBStats {
    * @param category the category
    */
   public static void registerRocksDBMetrics(
-      final Statistics stats,
-      final PrometheusMetricsSystem metricsSystem,
-      final MetricCategory category) {
-    if (!metricsSystem.isCategoryEnabled(category)) {
-      return;
-    }
-    for (final TickerType ticker : TICKERS) {
-      final String promCounterName = ticker.name().toLowerCase(Locale.ROOT);
+      final Statistics stats, final MetricsSystem metricsSystem, final MetricCategory category) {
+
+    for (final var tickerType : TICKER_TYPES) {
+      final String promCounterName = tickerType.name().toLowerCase(Locale.ROOT);
       metricsSystem.createLongGauge(
           category,
           promCounterName,
-          "RocksDB reported statistics for " + ticker.name(),
-          () -> stats.getTickerCount(ticker));
+          "RocksDB reported statistics for " + tickerType.name(),
+          () -> stats.getTickerCount(tickerType));
     }
 
-    for (final HistogramType histogram : HISTOGRAMS) {
-      metricsSystem.addCollector(category, () -> histogramToCollector(stats, histogram));
+    for (final var histogramType : HISTOGRAM_TYPES) {
+
+      metricsSystem.trackExternalSummary(
+          KVSTORE_ROCKSDB_STATS,
+          histogramType.name(),
+          "RocksDB histogram for " + histogramType.name(),
+          () -> provideExternalSummary(stats, histogramType));
     }
   }
 
-  private static Collector histogramToCollector(
-      final Statistics stats, final HistogramType histogram) {
-    return new Collector() {
-      final String metricName =
-          KVSTORE_ROCKSDB_STATS.getName() + "_" + histogram.name().toLowerCase(Locale.ROOT);
+  private static ExternalSummary provideExternalSummary(
+      final Statistics stats, final HistogramType histogramType) {
 
-      @Override
-      public List<MetricFamilySamples> collect() {
-        final HistogramData data = stats.getHistogramData(histogram);
-        return Collections.singletonList(
-            new MetricFamilySamples(
-                metricName,
-                Type.SUMMARY,
-                "RocksDB histogram for " + metricName,
-                Arrays.asList(
-                    new MetricFamilySamples.Sample(metricName, LABELS, LABEL_50, data.getMedian()),
-                    new MetricFamilySamples.Sample(
-                        metricName, LABELS, LABEL_95, data.getPercentile95()),
-                    new MetricFamilySamples.Sample(
-                        metricName, LABELS, LABEL_99, data.getPercentile99()))));
-      }
-    };
+    final HistogramData data = stats.getHistogramData(histogramType);
+
+    return new ExternalSummary(
+        data.getCount(),
+        data.getSum(),
+        List.of(
+            new Quantile(0.0, data.getMin()),
+            new Quantile(0.5, data.getMedian()),
+            new Quantile(0.95, data.getPercentile95()),
+            new Quantile(0.99, data.getPercentile99()),
+            new Quantile(1.0, data.getMax())));
   }
 }

--- a/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
+++ b/metrics/rocksdb/src/main/java/org/hyperledger/besu/metrics/rocksdb/RocksDBStats.java
@@ -176,7 +176,7 @@ public class RocksDBStats {
 
       metricsSystem.trackExternalSummary(
           KVSTORE_ROCKSDB_STATS,
-          histogramType.name(),
+          KVSTORE_ROCKSDB_STATS.getName() + "_" + histogramType.name().toLowerCase(Locale.ROOT),
           "RocksDB histogram for " + histogramType.name(),
           () -> provideExternalSummary(stats, histogramType));
     }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '8rPIE3fYl48RPRQXxYhMk559e/r+wHSKU9bGSJmruKQ='
+  knownHash = 'aYWbsgPoKTGDgq9d4QUBvQEaZYbKNJGMiBufzyKnusA='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/ExternalSummary.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/ExternalSummary.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.plugin.services.metrics;
+
+import java.util.List;
+
+/**
+ * Record of summary data the is kept outside the metric system. Useful when existing libraries
+ * calculate the summary data on their own, and we want to export that summary via the configured
+ * metric system. A notable example are RocksDB statistics.
+ *
+ * @param count the number of observations
+ * @param sum the sum of all the observations
+ * @param quantiles a list of quantiles with values
+ */
+public record ExternalSummary(long count, double sum, List<Quantile> quantiles) {
+  /**
+   * Represent a single quantile and its value
+   *
+   * @param quantile the quantile
+   * @param value the value
+   */
+  public record Quantile(double quantile, double value) {}
+}

--- a/plugins/rocksdb/build.gradle
+++ b/plugins/rocksdb/build.gradle
@@ -46,7 +46,6 @@ dependencies {
   implementation 'com.google.guava:guava'
   implementation 'info.picocli:picocli'
   implementation 'io.opentelemetry:opentelemetry-api'
-  implementation 'io.prometheus:simpleclient'
   implementation 'io.tmio:tuweni-bytes'
   implementation 'org.rocksdb:rocksdbjni'
   implementation project(path: ':ethereum:core')

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBMetricsFactory.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
 import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.metrics.prometheus.PrometheusMetricsSystem;
 import org.hyperledger.besu.metrics.rocksdb.RocksDBStats;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
@@ -107,10 +106,7 @@ public class RocksDBMetricsFactory {
                 "database")
             .labels(rocksDbConfiguration.getLabel());
 
-    if (metricsSystem instanceof PrometheusMetricsSystem) {
-      RocksDBStats.registerRocksDBMetrics(
-          stats, (PrometheusMetricsSystem) metricsSystem, statsDbMetricCategory);
-    }
+    RocksDBStats.registerRocksDBMetrics(stats, metricsSystem, statsDbMetricCategory);
 
     metricsSystem.createLongGauge(
         rocksDbMetricCategory,


### PR DESCRIPTION
## PR description

~~Built on top of #7879~~ [MERGED]

This is the first PR of a series to refresh the metrics system, to pay some tech debt, and to migrate to the new Prometheus Java lib to version 1.x, from the current legacy Simpleclient version 0.x.

Along with the upgrade to the new Prometheus lib, these other tasks are planned to refresh the metrics system:
- Refactor the way the observation mechanism works to simplify it and make it more OO
- Replace our HTTP server implementation with the provided one, so we can benefit from the new export formats (like protobuf) without having to re-implement them
- Use Prometheus to provide OpenTelemetry metrics, and so remove the dedicated OpenTelemetry deps and code
- Add support for Histogram and Summary metric types.


The scope of this first PR is to consolidate all metric collectors in the metrics system, since with the time, something has spilled out of it, in particular RocksDB internal metrics and Guava cache metrics collectors were created outside the metric system, with the assumption to only support Prometheus as backend.

Both those collectors have been moved into the metrics system, and the ability to add custom collectors from outside the metrics system has been removed.

There are no functional changes or fixes in this PR only refactoring, so no support for the refactored collectors have been implemented for OpenTelemetry, since there was no support before, and since the idea is to use Prometheus to provide OpenTelemetry in a future PR.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

