### PR TITLE
narrows dependencies of BlockchainService

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -327,7 +327,9 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
     @Singleton
     BlockchainServiceImpl provideBlockchainService(final BesuController besuController) {
       BlockchainServiceImpl retval = new BlockchainServiceImpl();
-      retval.init(besuController.getProtocolContext(), besuController.getProtocolSchedule());
+      retval.init(
+          besuController.getProtocolContext().getBlockchain(),
+          besuController.getProtocolSchedule());
       return retval;
     }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1233,7 +1233,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
   private void startPlugins(final Runner runner) {
     blockchainServiceImpl.init(
-        besuController.getProtocolContext(), besuController.getProtocolSchedule());
+        besuController.getProtocolContext().getBlockchain(), besuController.getProtocolSchedule());
     transactionSimulationServiceImpl.init(
         besuController.getProtocolContext().getBlockchain(),
         new TransactionSimulator(

--- a/besu/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.services;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
@@ -40,7 +39,6 @@ import java.util.stream.Collectors;
 @Unstable
 public class BlockchainServiceImpl implements BlockchainService {
 
-  private ProtocolContext protocolContext;
   private ProtocolSchedule protocolSchedule;
   private MutableBlockchain blockchain;
 
@@ -50,13 +48,12 @@ public class BlockchainServiceImpl implements BlockchainService {
   /**
    * Initialize the Blockchain service.
    *
-   * @param protocolContext the protocol context
+   * @param blockchain the blockchain
    * @param protocolSchedule the protocol schedule
    */
-  public void init(final ProtocolContext protocolContext, final ProtocolSchedule protocolSchedule) {
-    this.protocolContext = protocolContext;
+  public void init(final MutableBlockchain blockchain, final ProtocolSchedule protocolSchedule) {
     this.protocolSchedule = protocolSchedule;
-    this.blockchain = protocolContext.getBlockchain();
+    this.blockchain = blockchain;
   }
 
   /**
@@ -67,25 +64,24 @@ public class BlockchainServiceImpl implements BlockchainService {
    */
   @Override
   public Optional<BlockContext> getBlockByNumber(final long number) {
-    return protocolContext
-        .getBlockchain()
+    return blockchain
         .getBlockByNumber(number)
         .map(block -> blockContext(block::getHeader, block::getBody));
   }
 
   @Override
   public Hash getChainHeadHash() {
-    return protocolContext.getBlockchain().getChainHeadHash();
+    return blockchain.getChainHeadHash();
   }
 
   @Override
   public BlockHeader getChainHeadHeader() {
-    return protocolContext.getBlockchain().getChainHeadHeader();
+    return blockchain.getChainHeadHeader();
   }
 
   @Override
   public Optional<Wei> getNextBlockBaseFee() {
-    final var chainHeadHeader = protocolContext.getBlockchain().getChainHeadHeader();
+    final var chainHeadHeader = blockchain.getChainHeadHeader();
     final var protocolSpec =
         protocolSchedule.getForNextBlockHeader(chainHeadHeader, System.currentTimeMillis());
     return Optional.of(protocolSpec.getFeeMarket())


### PR DESCRIPTION
## PR description

Blockchain service does not need the entire ProtocolContext, just the Blockchain. Narrowing this will help us avoid circular dependencies.


