### PR TITLE
Typo Update Private-Txns-Migration.md

### DIFF
--- a/docs/Private-Txns-Migration.md
+++ b/docs/Private-Txns-Migration.md
@@ -12,7 +12,7 @@ state storage when upgrading to v1.4. It is not possible to upgrade to v1.4 with
 ## Private transactions created using v1.3.4 or earlier 
 
 A critical issue for privacy users with private transactions created using Hyperledger Besu v1.3.4 
-or earlier has been identified. If you have a network with private transaction created using v1.3.4 
+or earlier has been identified. If you have a network with private transactions created using v1.3.4 
 or earlier, please read the following and take the appropriate steps: 
 
 https://wiki.hyperledger.org/display/BESU/Critical+Issue+for+Privacy+Users 


### PR DESCRIPTION
## PR description

I found a minor grammatical inconsistency in the section **"Private transactions created using v1.3.4 or earlier"**. The original text reads:

**"private transaction created using v1.3.4 or earlier"**

This should be updated to:

**"private transactions created using v1.3.4 or earlier"**

### Importance:
The word **"transaction"** should be plural (**"transactions"**) to maintain consistency with the context of the paragraph, which refers to multiple private transactions. This small correction improves clarity and ensures the text accurately reflects the intended meaning.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

