### PR TITLE
Simplify difficulty calculator interface

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/CliqueBesuControllerBuilder.java
@@ -14,12 +14,11 @@
  */
 package org.hyperledger.besu.controller;
 
-import static org.hyperledger.besu.consensus.clique.CliqueHelpers.installCliqueBlockChoiceRule;
-
 import org.hyperledger.besu.config.CliqueConfigOptions;
 import org.hyperledger.besu.consensus.clique.CliqueBlockInterface;
 import org.hyperledger.besu.consensus.clique.CliqueContext;
 import org.hyperledger.besu.consensus.clique.CliqueForksSchedulesFactory;
+import org.hyperledger.besu.consensus.clique.CliqueHelpers;
 import org.hyperledger.besu.consensus.clique.CliqueMiningTracker;
 import org.hyperledger.besu.consensus.clique.CliqueProtocolSchedule;
 import org.hyperledger.besu.consensus.clique.blockcreation.CliqueBlockScheduler;
@@ -167,7 +166,8 @@ public class CliqueBesuControllerBuilder extends BesuControllerBuilder {
                 blockchain, epochManager, blockInterface),
             epochManager,
             blockInterface);
-    installCliqueBlockChoiceRule(blockchain, cliqueContext);
+    CliqueHelpers.setCliqueContext(cliqueContext);
+    CliqueHelpers.installCliqueBlockChoiceRule(blockchain, cliqueContext);
     return cliqueContext;
   }
 

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueDifficultyCalculator.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueDifficultyCalculator.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.consensus.clique;
 
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.mainnet.DifficultyCalculator;
 
@@ -39,12 +38,9 @@ public class CliqueDifficultyCalculator implements DifficultyCalculator {
   }
 
   @Override
-  public BigInteger nextDifficulty(
-      final long time, final BlockHeader parent, final ProtocolContext context) {
+  public BigInteger nextDifficulty(final long time, final BlockHeader parent) {
 
-    final Address nextProposer =
-        CliqueHelpers.getProposerForBlockAfter(
-            parent, context.getConsensusContext(CliqueContext.class).getValidatorProvider());
+    final Address nextProposer = CliqueHelpers.getProposerForBlockAfter(parent);
     return nextProposer.equals(localAddress) ? IN_TURN_DIFFICULTY : OUT_OF_TURN_DIFFICULTY;
   }
 }

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueHelpers.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueHelpers.java
@@ -27,8 +27,19 @@ import java.util.Comparator;
 
 /** The Clique helpers. */
 public class CliqueHelpers {
+  private static CliqueContext cliqueContext;
+
   /** Default constructor. */
   CliqueHelpers() {}
+
+  /**
+   * Set the clique consensus context
+   *
+   * @param cliqueContext the clique consensus context
+   */
+  public static void setCliqueContext(final CliqueContext cliqueContext) {
+    CliqueHelpers.cliqueContext = cliqueContext;
+  }
 
   /**
    * Gets proposer of block.
@@ -45,12 +56,11 @@ public class CliqueHelpers {
    * Gets proposer for block after.
    *
    * @param parent the parent
-   * @param validatorProvider the validator provider
    * @return the proposer for block after
    */
-  static Address getProposerForBlockAfter(
-      final BlockHeader parent, final ValidatorProvider validatorProvider) {
-    final CliqueProposerSelector proposerSelector = new CliqueProposerSelector(validatorProvider);
+  static Address getProposerForBlockAfter(final BlockHeader parent) {
+    final CliqueProposerSelector proposerSelector =
+        new CliqueProposerSelector(cliqueContext.getValidatorProvider());
     return proposerSelector.selectProposerForNextBlock(parent);
   }
 

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueMiningTracker.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueMiningTracker.java
@@ -42,10 +42,7 @@ public class CliqueMiningTracker {
    * @return the boolean
    */
   public boolean isProposerAfter(final BlockHeader header) {
-    final Address nextProposer =
-        CliqueHelpers.getProposerForBlockAfter(
-            header,
-            protocolContext.getConsensusContext(CliqueContext.class).getValidatorProvider());
+    final Address nextProposer = CliqueHelpers.getProposerForBlockAfter(header);
     return localAddress.equals(nextProposer);
   }
 

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/CliqueProtocolSchedule.java
@@ -44,8 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
-import com.google.common.annotations.VisibleForTesting;
-
 /** Defines the protocol behaviours for a blockchain using Clique. */
 public class CliqueProtocolSchedule {
 
@@ -63,7 +61,7 @@ public class CliqueProtocolSchedule {
    * @param privacyParameters the privacy parameters
    * @param isRevertReasonEnabled the is revert reason enabled
    * @param evmConfiguration the evm configuration
-   * @param miningConfiguration the mining parameters
+   * @param miningConfiguration the mining configuration
    * @param badBlockManager the cache to use to keep invalid blocks
    * @param isParallelTxProcessingEnabled indicates whether parallel transaction is enabled
    * @param metricsSystem A metricSystem instance to be able to expose metrics in the underlying
@@ -120,45 +118,6 @@ public class CliqueProtocolSchedule {
             isParallelTxProcessingEnabled,
             metricsSystem)
         .createProtocolSchedule();
-  }
-
-  /**
-   * Create protocol schedule.
-   *
-   * @param config the config
-   * @param forksSchedule the transitions
-   * @param nodeKey the node key
-   * @param isRevertReasonEnabled the is revert reason enabled
-   * @param evmConfiguration the evm configuration
-   * @param miningConfiguration the mining parameters
-   * @param badBlockManager the cache to use to keep invalid blocks
-   * @param isParallelTxProcessingEnabled indicates whether parallel transaction is enabled
-   * @param metricsSystem A metricSystem instance to be able to expose metrics in the underlying
-   *     calls
-   * @return the protocol schedule
-   */
-  @VisibleForTesting
-  public static ProtocolSchedule create(
-      final GenesisConfigOptions config,
-      final ForksSchedule<CliqueConfigOptions> forksSchedule,
-      final NodeKey nodeKey,
-      final boolean isRevertReasonEnabled,
-      final EvmConfiguration evmConfiguration,
-      final MiningConfiguration miningConfiguration,
-      final BadBlockManager badBlockManager,
-      final boolean isParallelTxProcessingEnabled,
-      final MetricsSystem metricsSystem) {
-    return create(
-        config,
-        forksSchedule,
-        nodeKey,
-        PrivacyParameters.DEFAULT,
-        isRevertReasonEnabled,
-        evmConfiguration,
-        miningConfiguration,
-        badBlockManager,
-        isParallelTxProcessingEnabled,
-        metricsSystem);
   }
 
   private static ProtocolSpecBuilder applyCliqueSpecificModifications(

--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/headervalidationrules/CliqueDifficultyValidationRule.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/headervalidationrules/CliqueDifficultyValidationRule.java
@@ -38,10 +38,9 @@ public class CliqueDifficultyValidationRule implements AttachedBlockHeaderValida
   public boolean validate(
       final BlockHeader header, final BlockHeader parent, final ProtocolContext protocolContext) {
     final Address actualBlockCreator = CliqueHelpers.getProposerOfBlock(header);
-
     final CliqueDifficultyCalculator diffCalculator =
         new CliqueDifficultyCalculator(actualBlockCreator);
-    final BigInteger expectedDifficulty = diffCalculator.nextDifficulty(0, parent, protocolContext);
+    final BigInteger expectedDifficulty = diffCalculator.nextDifficulty(0, parent);
 
     final BigInteger actualDifficulty = header.getDifficulty().toBigInteger();
 

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueDifficultyCalculatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueDifficultyCalculatorTest.java
@@ -23,8 +23,6 @@ import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.ethereum.ProtocolContext;
-import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.AddressHelpers;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
@@ -43,9 +41,7 @@ public class CliqueDifficultyCalculatorTest {
   private Address localAddr;
 
   private final List<Address> validatorList = Lists.newArrayList();
-  private ProtocolContext cliqueProtocolContext;
   private BlockHeaderTestFixture blockHeaderBuilder;
-  private final CliqueBlockInterface blockInterface = new CliqueBlockInterface();
 
   @BeforeEach
   public void setup() {
@@ -56,9 +52,7 @@ public class CliqueDifficultyCalculatorTest {
 
     final ValidatorProvider validatorProvider = mock(ValidatorProvider.class);
     when(validatorProvider.getValidatorsAfterBlock(any())).thenReturn(validatorList);
-
-    final CliqueContext cliqueContext = new CliqueContext(validatorProvider, null, blockInterface);
-    cliqueProtocolContext = new ProtocolContext(null, null, cliqueContext, new BadBlockManager());
+    CliqueHelpers.setCliqueContext(new CliqueContext(validatorProvider, null, null));
     blockHeaderBuilder = new BlockHeaderTestFixture();
   }
 
@@ -68,8 +62,7 @@ public class CliqueDifficultyCalculatorTest {
 
     final BlockHeader parentHeader = blockHeaderBuilder.number(1).buildHeader();
 
-    assertThat(calculator.nextDifficulty(0, parentHeader, cliqueProtocolContext))
-        .isEqualTo(BigInteger.valueOf(2));
+    assertThat(calculator.nextDifficulty(0, parentHeader)).isEqualTo(BigInteger.valueOf(2));
   }
 
   @Test
@@ -78,7 +71,6 @@ public class CliqueDifficultyCalculatorTest {
 
     final BlockHeader parentHeader = blockHeaderBuilder.number(2).buildHeader();
 
-    assertThat(calculator.nextDifficulty(0, parentHeader, cliqueProtocolContext))
-        .isEqualTo(BigInteger.valueOf(1));
+    assertThat(calculator.nextDifficulty(0, parentHeader)).isEqualTo(BigInteger.valueOf(1));
   }
 }

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/CliqueProtocolScheduleTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
+import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
@@ -66,6 +67,7 @@ public class CliqueProtocolScheduleTest {
             config,
             new ForksSchedule<>(List.of()),
             NODE_KEY,
+            PrivacyParameters.DEFAULT,
             false,
             EvmConfiguration.DEFAULT,
             MiningConfiguration.MINING_DISABLED,
@@ -92,6 +94,7 @@ public class CliqueProtocolScheduleTest {
                 GenesisConfigFile.DEFAULT.getConfigOptions(),
                 forksSchedule,
                 NODE_KEY,
+                PrivacyParameters.DEFAULT,
                 false,
                 EvmConfiguration.DEFAULT,
                 MiningConfiguration.MINING_DISABLED,
@@ -118,6 +121,7 @@ public class CliqueProtocolScheduleTest {
                     genesisConfig,
                     new ForksSchedule<>(List.of()),
                     NODE_KEY,
+                    PrivacyParameters.DEFAULT,
                     false,
                     EvmConfiguration.DEFAULT,
                     MiningConfiguration.MINING_DISABLED,
@@ -140,6 +144,7 @@ public class CliqueProtocolScheduleTest {
                     genesisConfig,
                     new ForksSchedule<>(List.of()),
                     NODE_KEY,
+                    PrivacyParameters.DEFAULT,
                     false,
                     EvmConfiguration.DEFAULT,
                     MiningConfiguration.MINING_DISABLED,
@@ -166,6 +171,7 @@ public class CliqueProtocolScheduleTest {
             config,
             forksSchedule,
             NODE_KEY,
+            PrivacyParameters.DEFAULT,
             false,
             EvmConfiguration.DEFAULT,
             MiningConfiguration.MINING_DISABLED,

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreatorTest.java
@@ -122,6 +122,7 @@ public class CliqueBlockCreatorTest {
             new NoOpMetricsSystem());
 
     final CliqueContext cliqueContext = new CliqueContext(validatorProvider, null, blockInterface);
+    CliqueHelpers.setCliqueContext(cliqueContext);
 
     final Block genesis =
         GenesisState.fromConfig(GenesisConfigFile.mainnet(), protocolSchedule).getBlock();
@@ -149,7 +150,7 @@ public class CliqueBlockCreatorTest {
 
     final Address coinbase = AddressHelpers.ofValue(1);
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(extraData, coinbase);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(extraData, coinbase);
 
     final CliqueBlockCreator blockCreator =
         new CliqueBlockCreator(
@@ -178,7 +179,7 @@ public class CliqueBlockCreatorTest {
     when(voteProvider.getVoteAfterBlock(any(), any()))
         .thenReturn(Optional.of(new ValidatorVote(VoteType.ADD, coinbase, a1)));
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(extraData, coinbase);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(extraData, coinbase);
 
     final CliqueBlockCreator blockCreator =
         new CliqueBlockCreator(
@@ -212,7 +213,7 @@ public class CliqueBlockCreatorTest {
     when(mockVoteProvider.getVoteAfterBlock(any(), any()))
         .thenReturn(Optional.of(new ValidatorVote(VoteType.ADD, coinbase, a1)));
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(extraData, coinbase);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(extraData, coinbase);
 
     final CliqueBlockCreator blockCreator =
         new CliqueBlockCreator(
@@ -255,7 +256,7 @@ public class CliqueBlockCreatorTest {
     return transactionPool;
   }
 
-  private static MiningConfiguration createMiningParameters(
+  private static MiningConfiguration createMiningConfiguration(
       final Bytes extraData, final Address coinbase) {
     final MiningConfiguration miningConfiguration =
         ImmutableMiningConfiguration.builder()

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMinerExecutorTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.consensus.clique.CliqueBlockHeaderFunctions;
 import org.hyperledger.besu.consensus.clique.CliqueBlockInterface;
 import org.hyperledger.besu.consensus.clique.CliqueContext;
 import org.hyperledger.besu.consensus.clique.CliqueExtraData;
+import org.hyperledger.besu.consensus.clique.CliqueHelpers;
 import org.hyperledger.besu.consensus.clique.CliqueProtocolSchedule;
 import org.hyperledger.besu.consensus.common.EpochManager;
 import org.hyperledger.besu.consensus.common.ForksSchedule;
@@ -98,6 +99,7 @@ public class CliqueMinerExecutorTest {
     when(validatorProvider.getValidatorsAfterBlock(any())).thenReturn(validatorList);
 
     final CliqueContext cliqueContext = new CliqueContext(validatorProvider, null, blockInterface);
+    CliqueHelpers.setCliqueContext(cliqueContext);
     cliqueProtocolContext = new ProtocolContext(null, null, cliqueContext, new BadBlockManager());
     cliqueProtocolSchedule =
         CliqueProtocolSchedule.create(
@@ -119,7 +121,7 @@ public class CliqueMinerExecutorTest {
   public void extraDataCreatedOnEpochBlocksContainsValidators() {
     final Bytes vanityData = generateRandomVanityData();
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(vanityData);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(vanityData);
 
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
@@ -155,7 +157,7 @@ public class CliqueMinerExecutorTest {
   public void extraDataForNonEpochBlocksDoesNotContainValidaors() {
     final Bytes vanityData = generateRandomVanityData();
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(vanityData);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(vanityData);
 
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
@@ -191,7 +193,7 @@ public class CliqueMinerExecutorTest {
     final Bytes initialVanityData = generateRandomVanityData();
     final Bytes modifiedVanityData = generateRandomVanityData();
 
-    final MiningConfiguration miningConfiguration = createMiningParameters(initialVanityData);
+    final MiningConfiguration miningConfiguration = createMiningConfiguration(initialVanityData);
 
     final CliqueMinerExecutor executor =
         new CliqueMinerExecutor(
@@ -255,7 +257,7 @@ public class CliqueMinerExecutorTest {
     return Bytes.wrap(vanityData);
   }
 
-  private static MiningConfiguration createMiningParameters(final Bytes vanityData) {
+  private static MiningConfiguration createMiningConfiguration(final Bytes vanityData) {
     return ImmutableMiningConfiguration.builder()
         .mutableInitValues(
             MutableInitValues.builder()

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueMiningCoordinatorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.clique.CliqueBlockInterface;
 import org.hyperledger.besu.consensus.clique.CliqueContext;
+import org.hyperledger.besu.consensus.clique.CliqueHelpers;
 import org.hyperledger.besu.consensus.clique.CliqueMiningTracker;
 import org.hyperledger.besu.consensus.clique.TestHelpers;
 import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
@@ -258,6 +259,7 @@ public class CliqueMiningCoordinatorTest {
     when(validatorProvider.getValidatorsAfterBlock(any())).thenReturn(validators);
 
     final CliqueContext cliqueContext = new CliqueContext(validatorProvider, null, blockInterface);
+    CliqueHelpers.setCliqueContext(cliqueContext);
     when(protocolContext.getConsensusContext(CliqueContext.class)).thenReturn(cliqueContext);
 
     when(protocolContext.getBlockchain()).thenReturn(blockChain);

--- a/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/headervalidationrules/CliqueDifficultyValidationRuleTest.java
+++ b/consensus/clique/src/test/java/org/hyperledger/besu/consensus/clique/headervalidationrules/CliqueDifficultyValidationRuleTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.consensus.clique.CliqueBlockInterface;
 import org.hyperledger.besu.consensus.clique.CliqueContext;
+import org.hyperledger.besu.consensus.clique.CliqueHelpers;
 import org.hyperledger.besu.consensus.clique.TestHelpers;
 import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
 import org.hyperledger.besu.crypto.KeyPair;
@@ -58,6 +59,7 @@ public class CliqueDifficultyValidationRuleTest {
     when(validatorProvider.getValidatorsAfterBlock(any())).thenReturn(validatorList);
 
     final CliqueContext cliqueContext = new CliqueContext(validatorProvider, null, blockInterface);
+    CliqueHelpers.setCliqueContext(cliqueContext);
     cliqueProtocolContext = new ProtocolContext(null, null, cliqueContext, new BadBlockManager());
     blockHeaderBuilder = new BlockHeaderTestFixture();
   }

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleBuilder.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/BaseBftProtocolScheduleBuilder.java
@@ -133,7 +133,7 @@ public abstract class BaseBftProtocolScheduleBuilder {
         .blockBodyValidatorBuilder(MainnetBlockBodyValidator::new)
         .blockValidatorBuilder(MainnetProtocolSpecs.blockValidatorBuilder())
         .blockImporterBuilder(MainnetBlockImporter::new)
-        .difficultyCalculator((time, parent, protocolContext) -> BigInteger.ONE)
+        .difficultyCalculator((time, parent) -> BigInteger.ONE)
         .skipZeroBlockRewards(true)
         .blockHeaderFunctions(BftBlockHeaderFunctions.forOnchainBlock(bftExtraDataCodec))
         .blockReward(Wei.of(configOptions.getBlockRewardWei()))

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -129,7 +129,7 @@ public class MergeProtocolSchedule {
                     gasCalculator, chainId.orElse(BigInteger.ZERO), EvmConfiguration.DEFAULT))
         .blockHeaderValidatorBuilder(MergeProtocolSchedule::getBlockHeaderValidator)
         .blockReward(Wei.ZERO)
-        .difficultyCalculator((a, b, c) -> BigInteger.ZERO)
+        .difficultyCalculator((a, b) -> BigInteger.ZERO)
         .skipZeroBlockRewards(true)
         .isPoS(true)
         .name("Paris");

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/MergeProtocolScheduleTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/MergeProtocolScheduleTest.java
@@ -193,8 +193,7 @@ public class MergeProtocolScheduleTest {
   private static void assertProofOfStakeConfigIsEnabled(final ProtocolSpec spec) {
     assertThat(spec.isPoS()).isTrue();
     assertThat(spec.getEvm().getOperationsUnsafe()[0x44]).isInstanceOf(PrevRanDaoOperation.class);
-    assertThat(spec.getDifficultyCalculator().nextDifficulty(-1, null, null))
-        .isEqualTo(BigInteger.ZERO);
+    assertThat(spec.getDifficultyCalculator().nextDifficulty(-1, null)).isEqualTo(BigInteger.ZERO);
     assertThat(spec.getBlockReward()).isEqualTo(Wei.ZERO);
     assertThat(spec.isSkipZeroBlockRewards()).isTrue();
     assertThat(spec.getBlockProcessor()).isInstanceOf(MainnetBlockProcessor.class);

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -437,8 +437,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
                 newBlockNumber);
 
     final DifficultyCalculator difficultyCalculator = protocolSpec.getDifficultyCalculator();
-    final BigInteger difficulty =
-        difficultyCalculator.nextDifficulty(timestamp, parentHeader, protocolContext);
+    final BigInteger difficulty = difficultyCalculator.nextDifficulty(timestamp, parentHeader);
 
     final Wei baseFee =
         Optional.of(protocolSpec.getFeeMarket())

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/difficulty/fixed/FixedDifficultyCalculators.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/difficulty/fixed/FixedDifficultyCalculators.java
@@ -34,6 +34,6 @@ public class FixedDifficultyCalculators {
 
   public static DifficultyCalculator calculator(final GenesisConfigOptions config) {
     long difficulty = config.getEthashConfigOptions().getFixedDifficulty().getAsLong();
-    return (time, parent, context) -> BigInteger.valueOf(difficulty);
+    return (time, parent) -> BigInteger.valueOf(difficulty);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicDifficultyCalculators.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/ClassicDifficultyCalculators.java
@@ -32,7 +32,7 @@ public abstract class ClassicDifficultyCalculators {
   private static final long DELAY = (CONTINUE_BLOCK - PAUSE_BLOCK) / EXPONENTIAL_DIFF_PERIOD;
 
   public static DifficultyCalculator DIFFICULTY_BOMB_PAUSED =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final BigInteger difficulty =
             ensureMinimumDifficulty(
@@ -43,7 +43,7 @@ public abstract class ClassicDifficultyCalculators {
       };
 
   public static DifficultyCalculator DIFFICULTY_BOMB_DELAYED =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final BigInteger difficulty =
             ensureMinimumDifficulty(
@@ -55,7 +55,7 @@ public abstract class ClassicDifficultyCalculators {
       };
 
   public static DifficultyCalculator DIFFICULTY_BOMB_REMOVED =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final BigInteger difficulty =
             ensureMinimumDifficulty(
@@ -66,7 +66,7 @@ public abstract class ClassicDifficultyCalculators {
       };
 
   public static DifficultyCalculator EIP100 =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final boolean hasOmmers = !parent.getOmmersHash().equals(Hash.EMPTY_LIST_HASH);
         final BigInteger difficulty =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculator.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
-import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 
 import java.math.BigInteger;
@@ -28,8 +27,7 @@ public interface DifficultyCalculator {
    *
    * @param time the time the block was generated
    * @param parent the block's parent block header
-   * @param context the context in which the difficulty calculator should operate
    * @return the block difficulty
    */
-  BigInteger nextDifficulty(long time, BlockHeader parent, ProtocolContext context);
+  BigInteger nextDifficulty(long time, BlockHeader parent);
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetDifficultyCalculators.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetDifficultyCalculators.java
@@ -45,7 +45,7 @@ public abstract class MainnetDifficultyCalculators {
   private MainnetDifficultyCalculators() {}
 
   static final DifficultyCalculator FRONTIER =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final BigInteger adjust = parentDifficulty.divide(DIFFICULTY_BOUND_DIVISOR);
         BigInteger difficulty;
@@ -60,7 +60,7 @@ public abstract class MainnetDifficultyCalculators {
       };
 
   static final DifficultyCalculator HOMESTEAD =
-      (time, parent, protocolContext) -> {
+      (time, parent) -> {
         final BigInteger parentDifficulty = difficulty(parent.getDifficulty());
         final BigInteger difficulty =
             ensureMinimumDifficulty(
@@ -72,35 +72,28 @@ public abstract class MainnetDifficultyCalculators {
       };
 
   static final DifficultyCalculator BYZANTIUM =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, BYZANTIUM_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, BYZANTIUM_FAKE_BLOCK_OFFSET);
 
   static final DifficultyCalculator CONSTANTINOPLE =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, CONSTANTINOPLE_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, CONSTANTINOPLE_FAKE_BLOCK_OFFSET);
 
   static final DifficultyCalculator MUIR_GLACIER =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, MUIR_GLACIER_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, MUIR_GLACIER_FAKE_BLOCK_OFFSET);
 
   // As per https://eips.ethereum.org/EIPS/eip-3554
   static final DifficultyCalculator LONDON =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, LONDON_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, LONDON_FAKE_BLOCK_OFFSET);
 
   // As per https://eips.ethereum.org/EIPS/eip-4345
   static final DifficultyCalculator ARROW_GLACIER =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, ARROW_GLACIER_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, ARROW_GLACIER_FAKE_BLOCK_OFFSET);
 
   // As per https://eips.ethereum.org/EIPS/eip-5133
   static final DifficultyCalculator GRAY_GLACIER =
-      (time, parent, protocolContext) ->
-          calculateThawedDifficulty(time, parent, GRAY_GLACIER_FAKE_BLOCK_OFFSET);
+      (time, parent) -> calculateThawedDifficulty(time, parent, GRAY_GLACIER_FAKE_BLOCK_OFFSET);
 
   // Proof-of-Stake difficulty must not be altered
-  static final DifficultyCalculator PROOF_OF_STAKE_DIFFICULTY =
-      (time, parent, protocolContext) -> BigInteger.ZERO;
+  static final DifficultyCalculator PROOF_OF_STAKE_DIFFICULTY = (time, parent) -> BigInteger.ZERO;
 
   private static BigInteger calculateThawedDifficulty(
       final long time, final BlockHeader parent, final long fakeBlockOffset) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/headervalidationrules/CalculatedDifficultyValidationRule.java
@@ -39,7 +39,7 @@ public class CalculatedDifficultyValidationRule implements AttachedBlockHeaderVa
 
     final BigInteger actualDifficulty = new BigInteger(1, header.getDifficulty().toArray());
     final BigInteger expectedDifficulty =
-        difficultyCalculator.nextDifficulty(header.getTimestamp(), parent, context);
+        difficultyCalculator.nextDifficulty(header.getTimestamp(), parent);
 
     if (actualDifficulty.compareTo(expectedDifficulty) != 0) {
       LOG.info(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/difficulty/fixed/FixedProtocolScheduleTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/difficulty/fixed/FixedProtocolScheduleTest.java
@@ -49,21 +49,21 @@ public class FixedProtocolScheduleTest {
             schedule
                 .getByBlockHeader(blockHeader(0))
                 .getDifficultyCalculator()
-                .nextDifficulty(1, parentHeader, null))
+                .nextDifficulty(1, parentHeader))
         .isEqualTo(FixedDifficultyCalculators.DEFAULT_DIFFICULTY);
 
     assertThat(
             schedule
                 .getByBlockHeader(blockHeader(500))
                 .getDifficultyCalculator()
-                .nextDifficulty(1, parentHeader, null))
+                .nextDifficulty(1, parentHeader))
         .isEqualTo(FixedDifficultyCalculators.DEFAULT_DIFFICULTY);
 
     assertThat(
             schedule
                 .getByBlockHeader(blockHeader(500_000))
                 .getDifficultyCalculator()
-                .nextDifficulty(1, parentHeader, null))
+                .nextDifficulty(1, parentHeader))
         .isEqualTo(FixedDifficultyCalculators.DEFAULT_DIFFICULTY);
   }
 

--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestEnv.java
@@ -224,8 +224,7 @@ public class ReferenceTestEnv extends BlockHeader {
                       BlockHeaderBuilder.createDefault()
                           .difficulty(Difficulty.fromHexOrDecimalString(parentDifficulty))
                           .number(number - 1)
-                          .buildBlockHeader(),
-                      null)));
+                          .buildBlockHeader())));
     }
     if (parentExcessBlobGas != null && parentBlobGasUsed != null) {
       builder.excessBlobGas(BlobGas.of(Long.decode(parentExcessBlobGas)));

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculatorTests.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculatorTests.java
@@ -181,7 +181,7 @@ public class DifficultyCalculatorTests {
           UInt256.fromHexString(value.get("currentDifficulty").asText());
       final var spec = protocolSchedule.getByBlockHeader(testHeader);
       final var calculator = spec.getDifficultyCalculator();
-      assertThat(UInt256.valueOf(calculator.nextDifficulty(currentTime, testHeader, null)))
+      assertThat(UInt256.valueOf(calculator.nextDifficulty(currentTime, testHeader)))
           .describedAs("File %s Test %s", testFile, entry.getKey())
           .isEqualTo(currentDifficulty);
     }


### PR DESCRIPTION
## PR description

Cleanup and little refactoring PR, with no functional changes, to remove the need to pass the protocol context when calculating the difficulty for the next block, since that was only needed by Clique and so we can take a different approach and move everything related to Clique difficulty calculation inside the Clique specific classes, without having to touch other consensus mechanism.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

