### PR TITLE
Add support for counter metric with external supplied value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
 ## [Unreleased]
-- Added isLabelsObserved to LabelledGauge in plugin-api. Default implementation returns false.
 
 ### Breaking Changes
 - Removed Retesteth rpc service and commands [#7833](https://github.com/hyperledger/besu/pull/7783)
 
 ### Upcoming Breaking Changes
+- `MetricSystem::createLabelledGauge` is deprecated and will be removed in a future release, replace it with `MetricSystem::createLabelledSuppliedGauge`
 
 ### Additions and Improvements
 - Fine tune already seen txs tracker when a tx is removed from the pool [#7755](https://github.com/hyperledger/besu/pull/7755)
@@ -16,6 +16,7 @@
 - Add a method to get all the transaction in the pool, to the `TransactionPoolService`, to easily access the transaction pool content from plugins [#7813](https://github.com/hyperledger/besu/pull/7813)
 - Add a method to check if a metric category is enabled to the plugin API [#7832](https://github.com/hyperledger/besu/pull/7832)
 - Add account and state overrides to `eth_call` and `eth_estimateGas` [#7801](https://github.com/hyperledger/besu/pull/7801)
+- Add a new metric collector for counters which get their value from suppliers [#7894](https://github.com/hyperledger/besu/pull/7894)
 
 ### Bug fixes
 - Fix registering new metric categories from plugins [#7825](https://github.com/hyperledger/besu/pull/7825)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1332,7 +1332,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private void setReleaseMetrics() {
     besuComponent
         .getMetricsSystem()
-        .createLabelledGauge(
+        .createLabelledSuppliedGauge(
             StandardMetricCategory.PROCESS, "release", "Release information", "version")
         .labels(() -> 1, BesuInfo.version());
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/MonitoredExecutors.java
@@ -153,13 +153,13 @@ public class MonitoredExecutors {
         "Current number of threads in the thread pool",
         executor::getPoolSize);
 
-    metricsSystem.createLongGauge(
+    metricsSystem.createCounter(
         BesuMetricCategory.EXECUTORS,
         metricName + "_completed_tasks_total",
         "Total number of tasks executed",
         executor::getCompletedTaskCount);
 
-    metricsSystem.createLongGauge(
+    metricsSystem.createCounter(
         BesuMetricCategory.EXECUTORS,
         metricName + "_submitted_tasks_total",
         "Total number of tasks executed",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutor.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutor.java
@@ -20,8 +20,8 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.Collection;
@@ -43,7 +43,7 @@ public class PeerTaskExecutor {
   private final LabelledMetric<Counter> timeoutCounter;
   private final LabelledMetric<Counter> invalidResponseCounter;
   private final LabelledMetric<Counter> internalExceptionCounter;
-  private final LabelledGauge inflightRequestGauge;
+  private final LabelledSuppliedMetric inflightRequestGauge;
   private final Map<String, AtomicInteger> inflightRequestCountByClassName;
 
   public PeerTaskExecutor(
@@ -77,7 +77,7 @@ public class PeerTaskExecutor {
             "Counter of the number of internal exceptions occurred",
             "taskName");
     inflightRequestGauge =
-        metricsSystem.createLabelledGauge(
+        metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.PEERS,
             "inflight_request_gauge",
             "Gauge of the number of inflight requests",

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolMetrics.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolMetrics.java
@@ -22,8 +22,8 @@ import org.hyperledger.besu.metrics.ReplaceableDoubleSupplier;
 import org.hyperledger.besu.metrics.RunnableCounter;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,10 +47,10 @@ public class TransactionPoolMetrics {
   private final LabelledMetric<Counter> removedCounter;
   private final LabelledMetric<Counter> rejectedCounter;
   private final LabelledMetric<Counter> penalizedCounter;
-  private final LabelledGauge spaceUsed;
-  private final LabelledGauge transactionCount;
-  private final LabelledGauge transactionCountByType;
-  private final LabelledGauge uniqueSenderCount;
+  private final LabelledSuppliedMetric spaceUsed;
+  private final LabelledSuppliedMetric transactionCount;
+  private final LabelledSuppliedMetric transactionCountByType;
+  private final LabelledSuppliedMetric uniqueSenderCount;
   private final LabelledMetric<Counter> expiredMessagesCounter;
   private final Map<String, RunnableCounter> expiredMessagesRunnableCounters = new HashMap<>();
   private final LabelledMetric<Counter> alreadySeenTransactionsCounter;
@@ -103,21 +103,21 @@ public class TransactionPoolMetrics {
             "layer");
 
     spaceUsed =
-        metricsSystem.createLabelledGauge(
+        metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.TRANSACTION_POOL,
             "space_used",
             "The amount of space used by the transactions in the layer",
             "layer");
 
     transactionCount =
-        metricsSystem.createLabelledGauge(
+        metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.TRANSACTION_POOL,
             "number_of_transactions",
             "The number of transactions currently present in the layer",
             "layer");
 
     transactionCountByType =
-        metricsSystem.createLabelledGauge(
+        metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.TRANSACTION_POOL,
             "number_of_transactions_by_type",
             "The number of transactions, of a specified type, currently present in the layer",
@@ -125,7 +125,7 @@ public class TransactionPoolMetrics {
             "type");
 
     uniqueSenderCount =
-        metricsSystem.createLabelledGauge(
+        metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.TRANSACTION_POOL,
             "unique_senders",
             "The number of senders with at least one transaction currently present in the layer",

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpValueCollector.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/noop/NoOpValueCollector.java
@@ -14,14 +14,14 @@
  */
 package org.hyperledger.besu.metrics.noop;
 
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.DoubleSupplier;
 
 /** The NoOp value collector. */
-public class NoOpValueCollector implements LabelledGauge {
+public class NoOpValueCollector implements LabelledSuppliedMetric {
   private final List<String> labelValuesCreated = new ArrayList<>();
 
   /** Default constructor */
@@ -35,11 +35,5 @@ public class NoOpValueCollector implements LabelledGauge {
           String.format("A gauge has already been created for label values %s", labelValuesString));
     }
     labelValuesCreated.add(labelValuesString);
-  }
-
-  @Override
-  public boolean isLabelsObserved(final String... labelValues) {
-    final String labelValuesString = String.join(",", labelValues);
-    return labelValuesCreated.contains(labelValuesString);
   }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetryLabelledSuppliedMetric.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetryLabelledSuppliedMetric.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.metrics.opentelemetry;
+
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.DoubleSupplier;
+
+import com.google.common.base.Preconditions;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.ObservableDoubleMeasurement;
+
+abstract class OpenTelemetryLabelledSuppliedMetric implements LabelledSuppliedMetric {
+  private final List<String> labelNames;
+  private final Map<Attributes, DoubleSupplier> observationsMap = new ConcurrentHashMap<>();
+
+  public OpenTelemetryLabelledSuppliedMetric(final List<String> labelNames) {
+    this.labelNames = labelNames;
+  }
+
+  @Override
+  public void labels(final DoubleSupplier valueSupplier, final String... labelValues) {
+    Preconditions.checkArgument(
+        labelValues.length == labelNames.size(),
+        "label values and label names need the same number of elements");
+    final Attributes labels = getLabels(labelValues);
+    if (observationsMap.putIfAbsent(labels, valueSupplier) != null) {
+      throw new IllegalStateException(
+          "Already registered a collector with label values " + Arrays.toString(labelValues));
+    }
+  }
+
+  private Attributes getLabels(final String... labelValues) {
+    final AttributesBuilder labelsBuilder = Attributes.builder();
+    for (int i = 0; i < labelNames.size(); i++) {
+      labelsBuilder.put(labelNames.get(i), labelValues[i]);
+    }
+    return labelsBuilder.build();
+  }
+
+  /**
+   * Callback to record the supplied values
+   *
+   * @param measurement where to record the values
+   */
+  protected void updater(final ObservableDoubleMeasurement measurement) {
+    observationsMap.forEach(
+        (labels, valueSupplier) -> measurement.record(valueSupplier.getAsDouble(), labels));
+  }
+}

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySuppliedCounter.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySuppliedCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,31 +14,30 @@
  */
 package org.hyperledger.besu.metrics.opentelemetry;
 
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
-
 import java.util.List;
 
 import io.opentelemetry.api.metrics.Meter;
 
-/** The Open telemetry gauge. */
-@SuppressWarnings("removal") // remove when deprecated LabelledGauge is removed
-public class OpenTelemetryGauge extends OpenTelemetryLabelledSuppliedMetric
-    implements LabelledGauge {
+/** The Open telemetry supplied counter. */
+public class OpenTelemetrySuppliedCounter extends OpenTelemetryLabelledSuppliedMetric {
   /**
-   * Instantiates a new Open telemetry gauge.
+   * Instantiates a new Open telemetry supplied counter.
    *
    * @param metricName the metric name
    * @param help the help
    * @param meter the meter
    * @param labelNames the label names
    */
-  public OpenTelemetryGauge(
+  public OpenTelemetrySuppliedCounter(
       final String metricName,
       final String help,
       final Meter meter,
       final List<String> labelNames) {
     super(labelNames);
-
-    meter.gaugeBuilder(metricName).setDescription(help).buildWithCallback(this::updater);
+    meter
+        .counterBuilder(metricName)
+        .setDescription(help)
+        .ofDoubles()
+        .buildWithCallback(this::updater);
   }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
@@ -21,8 +21,8 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
@@ -292,7 +292,21 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
       final MetricCategory category, final String name, final Cache<?, ?> cache) {}
 
   @Override
-  public LabelledGauge createLabelledGauge(
+  public LabelledSuppliedMetric createLabelledSuppliedCounter(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    LOG.trace("Creating a labelled supplied counter {}", name);
+    if (isCategoryEnabled(category)) {
+      return new OpenTelemetrySuppliedCounter(
+          name, help, sdkMeterProvider.get(category.getName()), List.of(labelNames));
+    }
+    return NoOpMetricsSystem.getLabelledSuppliedMetric(labelNames.length);
+  }
+
+  @Override
+  public LabelledSuppliedMetric createLabelledSuppliedGauge(
       final MetricCategory category,
       final String name,
       final String help,
@@ -302,7 +316,7 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
       return new OpenTelemetryGauge(
           name, help, sdkMeterProvider.get(category.getName()), List.of(labelNames));
     }
-    return NoOpMetricsSystem.getLabelledGauge(labelNames.length);
+    return NoOpMetricsSystem.getLabelledSuppliedMetric(labelNames.length);
   }
 
   @Override

--- a/metrics/core/src/test-support/java/org/hyperledger/besu/metrics/StubMetricsSystem.java
+++ b/metrics/core/src/test-support/java/org/hyperledger/besu/metrics/StubMetricsSystem.java
@@ -19,8 +19,8 @@ import static java.util.Arrays.asList;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
@@ -50,12 +50,21 @@ public class StubMetricsSystem implements ObservableMetricsSystem {
   }
 
   @Override
-  public LabelledGauge createLabelledGauge(
+  public LabelledSuppliedMetric createLabelledSuppliedCounter(
       final MetricCategory category,
       final String name,
       final String help,
       final String... labelNames) {
-    return NoOpMetricsSystem.getLabelledGauge(labelNames.length);
+    return NoOpMetricsSystem.getLabelledSuppliedMetric(labelNames.length);
+  }
+
+  @Override
+  public LabelledSuppliedMetric createLabelledSuppliedGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    return NoOpMetricsSystem.getLabelledSuppliedMetric(labelNames.length);
   }
 
   public long getCounterValue(final String name, final String... labels) {

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetryMetricsSystemTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetryMetricsSystemTest.java
@@ -31,8 +31,8 @@ import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.Collections;
@@ -231,8 +231,8 @@ public class OpenTelemetryMetricsSystemTest {
 
   @Test
   public void shouldCreateLabelledGauge() {
-    LabelledGauge labelledGauge =
-        metricsSystem.createLabelledGauge(RPC, "gaugeName", "help", "a", "b");
+    LabelledSuppliedMetric labelledGauge =
+        metricsSystem.createLabelledSuppliedGauge(RPC, "gaugeName", "help", "a", "b");
     labelledGauge.labels(() -> 1.0, "a1", "b1");
     labelledGauge.labels(() -> 11.0, "a2", "b2");
     labelledGauge.labels(() -> 21.0, "a3", "b3");

--- a/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/PrometheusMetricsSystemTest.java
+++ b/metrics/core/src/test/java/org/hyperledger/besu/metrics/prometheus/PrometheusMetricsSystemTest.java
@@ -33,8 +33,8 @@ import org.hyperledger.besu.metrics.Observation;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
 import java.util.Collections;
@@ -129,8 +129,8 @@ public class PrometheusMetricsSystemTest {
 
   @Test
   public void shouldCreateSeparateObservationsForEachLabelledGaugeValue() {
-    final LabelledGauge gauge =
-        metricsSystem.createLabelledGauge(PEERS, "test", "test help", "a", "b", "c");
+    final LabelledSuppliedMetric gauge =
+        metricsSystem.createLabelledSuppliedGauge(PEERS, "test", "test help", "a", "b", "c");
     final double value1 = 1.0;
     final double value2 = 11.0;
 
@@ -145,8 +145,8 @@ public class PrometheusMetricsSystemTest {
 
   @Test
   public void shouldNotUseSameLabelsTwiceOnSameGauge() {
-    final LabelledGauge gauge =
-        metricsSystem.createLabelledGauge(PEERS, "test", "test help", "a", "b", "c");
+    final LabelledSuppliedMetric gauge =
+        metricsSystem.createLabelledSuppliedGauge(PEERS, "test", "test help", "a", "b", "c");
     final double value1 = 1.0;
 
     gauge.labels(() -> value1, "a1", "b1", "c1");

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'aYWbsgPoKTGDgq9d4QUBvQEaZYbKNJGMiBufzyKnusA='
+  knownHash = 'ktVrmQXU7LMQi1ieb9OQ2vJNqZ0SVQ7Usauh1LMvUXY='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/MetricsSystem.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/MetricsSystem.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.plugin.services.metrics.Counter;
 import org.hyperledger.besu.plugin.services.metrics.ExternalSummary;
 import org.hyperledger.besu.plugin.services.metrics.LabelledGauge;
 import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.LabelledSuppliedMetric;
 import org.hyperledger.besu.plugin.services.metrics.MetricCategory;
 import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
 
@@ -46,6 +47,23 @@ public interface MetricsSystem extends BesuService {
   }
 
   /**
+   * Creates a Counter that gets its value from the specified supplier. To be used when the value of
+   * the counter is calculated outside the metric system.
+   *
+   * @param category The {@link MetricCategory} this counter is assigned to.
+   * @param name A name for this metric.
+   * @param help A human readable description of the metric.
+   * @param valueSupplier The supplier of the value.
+   */
+  default void createCounter(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final DoubleSupplier valueSupplier) {
+    createLabelledSuppliedCounter(category, name, help).labels(valueSupplier);
+  }
+
+  /**
    * Creates a Counter with assigned labels.
    *
    * @param category The {@link MetricCategory} this counter is assigned to.
@@ -58,7 +76,42 @@ public interface MetricsSystem extends BesuService {
       MetricCategory category, String name, String help, String... labelNames);
 
   /**
-   * Creates a Gauge with assigned labels.
+   * Creates a Counter with assigned labels, that gets its values from suppliers. To be used when
+   * the values of the counter are calculated outside the metric system.
+   *
+   * @param category The {@link MetricCategory} this counter is assigned to.
+   * @param name A name for this metric.
+   * @param help A human readable description of the metric.
+   * @param labelNames An array of labels to assign to the Counter.
+   * @return The created LabelledSupplierMetric instance.
+   */
+  LabelledSuppliedMetric createLabelledSuppliedCounter(
+      MetricCategory category, String name, String help, String... labelNames);
+
+  /**
+   * Creates a Gauge with assigned labels, that gets its values from suppliers. To be used when the
+   * values of the gauge are calculated outside the metric system.
+   *
+   * @param category The {@link MetricCategory} this gauge is assigned to.
+   * @param name A name for this metric.
+   * @param help A human readable description of the metric.
+   * @param labelNames An array of labels to assign to the Gauge.
+   * @return The created LabelledGauge instance.
+   * @deprecated Use {@link #createLabelledSuppliedGauge(MetricCategory, String, String, String...)}
+   */
+  @Deprecated(forRemoval = true)
+  @SuppressWarnings("removal") // remove when deprecated LabelledGauge is removed
+  default LabelledGauge createLabelledGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final String... labelNames) {
+    return (LabelledGauge) createLabelledSuppliedGauge(category, name, help, labelNames);
+  }
+
+  /**
+   * Creates a Gauge with assigned labels, that gets its values from suppliers. To be used when the
+   * values of the gauge are calculated outside the metric system.
    *
    * @param category The {@link MetricCategory} this gauge is assigned to.
    * @param name A name for this metric.
@@ -66,7 +119,7 @@ public interface MetricsSystem extends BesuService {
    * @param labelNames An array of labels to assign to the Gauge.
    * @return The created LabelledGauge instance.
    */
-  LabelledGauge createLabelledGauge(
+  LabelledSuppliedMetric createLabelledSuppliedGauge(
       MetricCategory category, String name, String help, String... labelNames);
 
   /**

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/LabelledSuppliedMetric.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/metrics/LabelledSuppliedMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,10 +14,15 @@
  */
 package org.hyperledger.besu.plugin.services.metrics;
 
-/**
- * The interface Labelled gauge.
- *
- * @deprecated Use {@link LabelledSuppliedMetric}
- */
-@Deprecated(forRemoval = true)
-public interface LabelledGauge extends LabelledSuppliedMetric {}
+import java.util.function.DoubleSupplier;
+
+/** The interface Labelled gauge. */
+public interface LabelledSuppliedMetric {
+  /**
+   * Labels.
+   *
+   * @param valueSupplier the value supplier
+   * @param labelValues the label values
+   */
+  void labels(final DoubleSupplier valueSupplier, final String... labelValues);
+}


### PR DESCRIPTION
## PR description

Another PR of the series to upgrade and refresh the metric system.
This time we fix the type of two metrics used in the `MonitoredExecutors` class, that are counters but were created as gauges, probably since there was no way to create counters with an external supplied value, so this kind of counter has been added, and the concept of metrics with external supplied values has been extended to cover both counters and gauges.

Other than for using the correct metric type, this fix is required, because with the following upgrade to Prometheus Java lib 1.x, only counters can have a `_total` suffix.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

