### PR TITLE
Privacy deprecation warnings on CLI

### DIFF
--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyPluginPayloadProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyPluginPayloadProvider.java
@@ -28,6 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "24.11.0")
 public class TestPrivacyPluginPayloadProvider implements PrivacyPluginPayloadProvider {
   private static final Logger LOG = LoggerFactory.getLogger(TestPrivacyPluginPayloadProvider.class);
   private String prefix;

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -505,77 +505,95 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @CommandLine.ArgGroup(validate = false, heading = "@|bold In-Process RPC Options|@%n")
   InProcessRpcOptions inProcessRpcOptions = InProcessRpcOptions.create();
 
+  private static final String PRIVACY_DEPRECATION_PREFIX =
+      "Deprecated. Tessera-based privacy is deprecated. See CHANGELOG for alternative options. ";
+
   // Privacy Options Group
-  @CommandLine.ArgGroup(validate = false, heading = "@|bold Privacy Options|@%n")
+  @CommandLine.ArgGroup(validate = false, heading = "@|bold (Deprecated) Privacy Options |@%n")
   PrivacyOptionGroup privacyOptionGroup = new PrivacyOptionGroup();
 
   static class PrivacyOptionGroup {
     @Option(
         names = {"--privacy-tls-enabled"},
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
-        description = "Enable TLS for connecting to privacy enclave (default: ${DEFAULT-VALUE})")
+        description =
+            PRIVACY_DEPRECATION_PREFIX
+                + "Enable TLS for connecting to privacy enclave (default: ${DEFAULT-VALUE})")
     private final Boolean isPrivacyTlsEnabled = false;
 
     @Option(
         names = "--privacy-tls-keystore-file",
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
         description =
-            "Path to a PKCS#12 formatted keystore; used to enable TLS on inbound connections.")
+            PRIVACY_DEPRECATION_PREFIX
+                + "Path to a PKCS#12 formatted keystore; used to enable TLS on inbound connections.")
     private final Path privacyKeyStoreFile = null;
 
     @Option(
         names = "--privacy-tls-keystore-password-file",
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
-        description = "Path to a file containing the password used to decrypt the keystore.")
+        description =
+            PRIVACY_DEPRECATION_PREFIX
+                + "Path to a file containing the password used to decrypt the keystore.")
     private final Path privacyKeyStorePasswordFile = null;
 
     @Option(
         names = "--privacy-tls-known-enclave-file",
         paramLabel = MANDATORY_FILE_FORMAT_HELP,
         description =
-            "Path to a file containing the fingerprints of the authorized privacy enclave.")
+            PRIVACY_DEPRECATION_PREFIX
+                + "Path to a file containing the fingerprints of the authorized privacy enclave.")
     private final Path privacyTlsKnownEnclaveFile = null;
 
     @Option(
         names = {"--privacy-enabled"},
-        description = "Enable private transactions (default: ${DEFAULT-VALUE})")
+        description =
+            PRIVACY_DEPRECATION_PREFIX + "Enable private transactions (default: ${DEFAULT-VALUE})")
     private final Boolean isPrivacyEnabled = false;
 
     @Option(
         names = {"--privacy-multi-tenancy-enabled"},
-        description = "Enable multi-tenant private transactions (default: ${DEFAULT-VALUE})")
+        description =
+            PRIVACY_DEPRECATION_PREFIX
+                + "Enable multi-tenant private transactions (default: ${DEFAULT-VALUE})")
     private final Boolean isPrivacyMultiTenancyEnabled = false;
 
     @Option(
         names = {"--privacy-url"},
-        description = "The URL on which the enclave is running")
+        description = PRIVACY_DEPRECATION_PREFIX + "The URL on which the enclave is running")
     private final URI privacyUrl = PrivacyParameters.DEFAULT_ENCLAVE_URL;
 
     @Option(
         names = {"--privacy-public-key-file"},
-        description = "The enclave's public key file")
+        description = PRIVACY_DEPRECATION_PREFIX + "The enclave's public key file")
     private final File privacyPublicKeyFile = null;
 
     @Option(
         names = {"--privacy-marker-transaction-signing-key-file"},
         description =
-            "The name of a file containing the private key used to sign privacy marker transactions. If unset, each will be signed with a random key.")
+            PRIVACY_DEPRECATION_PREFIX
+                + "The name of a file containing the private key used to sign privacy marker transactions. If unset, each will be signed with a random key.")
     private final Path privateMarkerTransactionSigningKeyPath = null;
 
     @Option(
         names = {"--privacy-enable-database-migration"},
-        description = "Enable private database metadata migration (default: ${DEFAULT-VALUE})")
+        description =
+            PRIVACY_DEPRECATION_PREFIX
+                + "Enable private database metadata migration (default: ${DEFAULT-VALUE})")
     private final Boolean migratePrivateDatabase = false;
 
     @Option(
         names = {"--privacy-flexible-groups-enabled"},
-        description = "Enable flexible privacy groups (default: ${DEFAULT-VALUE})")
+        description =
+            PRIVACY_DEPRECATION_PREFIX
+                + "Enable flexible privacy groups (default: ${DEFAULT-VALUE})")
     private final Boolean isFlexiblePrivacyGroupsEnabled = false;
 
     @Option(
         names = {"--privacy-nonce-always-increments"},
         description =
-            "Enable private nonce "
+            PRIVACY_DEPRECATION_PREFIX
+                + "Enable private nonce "
                 + "incrementation even if the transaction didn't succeeded (default: ${DEFAULT-VALUE})")
     private final Boolean isPrivateNonceAlwaysIncrementsEnabled = false;
   }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1311,6 +1311,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
     // after start has been called on plugins
 
     if (Boolean.TRUE.equals(privacyOptionGroup.isPrivacyEnabled)) {
+      logger.warn(
+          "--Xprivacy-plugin-enabled and related options are " + PRIVACY_DEPRECATION_PREFIX);
 
       if (privacyOptionGroup.privateMarkerTransactionSigningKeyPath != null
           && privacyPluginService != null

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -1940,6 +1940,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
     final PrivacyParameters.Builder privacyParametersBuilder = new PrivacyParameters.Builder();
     if (Boolean.TRUE.equals(privacyOptionGroup.isPrivacyEnabled)) {
+      logger.warn("--privacy-enabled and related options are " + PRIVACY_DEPRECATION_PREFIX);
       final String errorSuffix = "cannot be enabled with privacy.";
       if (syncMode == SyncMode.FAST) {
         throw new ParameterException(commandLine, String.format("%s %s", "Fast sync", errorSuffix));

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
@@ -33,7 +33,7 @@ public class PrivacyPluginOptions {
   @Option(
       names = "--Xprivacy-plugin-enabled",
       description =
-          "Enables the use of a plugin to implement your own privacy strategy (default: ${DEFAULT-VALUE})",
+          "Deprecated. Tessera-based privacy is deprecated. See CHANGELOG for alternative options. Enables the use of a plugin to implement your own privacy strategy (default: ${DEFAULT-VALUE})",
       hidden = true)
   private final Boolean isPrivacyPluginEnabled = false;
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.cli.options;
 import static picocli.CommandLine.Option;
 
 /** The Privacy plugin Cli options. */
+@Deprecated(since = "24.11.0")
 public class PrivacyPluginOptions {
   /** Default Constructor. */
   PrivacyPluginOptions() {}

--- a/besu/src/main/java/org/hyperledger/besu/services/PrivacyPluginServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PrivacyPluginServiceImpl.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** The Privacy plugin service implementation. */
+@Deprecated(since = "24.11.0")
 public class PrivacyPluginServiceImpl implements PrivacyPluginService {
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyPluginServiceImpl.class);
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
@@ -34,6 +34,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Deprecated(since = "24.11.0")
 public class PrivacyPluginPrecompiledContract extends PrivacyPrecompiledContract {
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyPluginPrecompiledContract.class);
   private final PrivacyParameters privacyParameters;

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'IPpTJJxjDbjW08c3Cm8GbBhULYFy0jq9m3BzliGzrf8='
+  knownHash = 'vI9RTAGD6sRzAaMp1BMJY7x4cB3wh7FA4rYvDGYRceg='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PrivacyPluginService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PrivacyPluginService.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
  * optionally register a {@link PrivateMarkerTransactionFactory} and a {@link
  * PrivacyGroupGenesisProvider}*
  */
+@Deprecated(since = "24.11.0")
 public interface PrivacyPluginService extends BesuService {
 
   /**

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/privacy/PrivacyPluginPayloadProvider.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/privacy/PrivacyPluginPayloadProvider.java
@@ -25,6 +25,7 @@ import org.apache.tuweni.bytes.Bytes;
  * Allows you to register a provider that will dictate how the payload of a privacy marker
  * transaction is handled.
  */
+@Deprecated(since = "24.11.0")
 public interface PrivacyPluginPayloadProvider {
 
   /**


### PR DESCRIPTION
## PR description
* Add deprecation messages to help descriptions
* Add warning log if privacy-enabled option is specified

Note I did not add any `@Deprecation` annotations to types or methods - feedback welcome on whether you think this is needed.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

