### PR TITLE
Switch to a fail fast approach when creating duplicate metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 - Removed Retesteth rpc service and commands [#7833](https://github.com/hyperledger/besu/pull/7783)
+- With the switch to a fail fast approach when trying to create a metric that already exists, it is possible that plugins and other application depending on metric system needs to adapt to the new behavior
 
 ### Upcoming Breaking Changes
 - Plugin API will be deprecating the BesuContext interface to be replaced with the ServiceManager interface.
@@ -25,6 +26,7 @@
 - Add a method to check if a metric category is enabled to the plugin API [#7832](https://github.com/hyperledger/besu/pull/7832)
 - Add a new metric collector for counters which get their value from suppliers [#7894](https://github.com/hyperledger/besu/pull/7894)
 - Add account and state overrides to `eth_call` [#7801](https://github.com/hyperledger/besu/pull/7801) and `eth_estimateGas` [#7890](https://github.com/hyperledger/besu/pull/7890)
+- Switch to a fail fast approach when creating duplicate metrics [#7899](https://github.com/hyperledger/besu/pull/7899)
 
 ### Bug fixes
 - Fix registering new metric categories from plugins [#7825](https://github.com/hyperledger/besu/pull/7825)

--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -53,6 +53,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.ipc.JsonRpcIpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.ipc.JsonRpcIpcService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketMessageHandler;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketService;
@@ -839,6 +840,8 @@ public class RunnerBuilder {
 
     Optional<JsonRpcHttpService> jsonRpcHttpService = Optional.empty();
 
+    final var rpcMetrics = new RpcMetrics(metricsSystem);
+
     if (jsonRpcConfiguration.isEnabled()) {
       final Map<String, JsonRpcMethod> nonEngineMethods =
           jsonRpcMethods(
@@ -851,7 +854,7 @@ public class RunnerBuilder {
               transactionPool,
               miningConfiguration,
               miningCoordinator,
-              metricsSystem,
+              rpcMetrics,
               supportedCapabilities,
               jsonRpcConfiguration.getRpcApis().stream()
                   .filter(apiGroup -> !apiGroup.toLowerCase(Locale.ROOT).startsWith("engine"))
@@ -875,7 +878,7 @@ public class RunnerBuilder {
                   vertx,
                   dataDir,
                   jsonRpcConfiguration,
-                  metricsSystem,
+                  rpcMetrics,
                   natService,
                   nonEngineMethods,
                   new HealthService(new LivenessCheck()),
@@ -898,7 +901,7 @@ public class RunnerBuilder {
               transactionPool,
               miningConfiguration,
               miningCoordinator,
-              metricsSystem,
+              rpcMetrics,
               supportedCapabilities,
               engineJsonRpcConfiguration.get().getRpcApis(),
               filterManager,
@@ -938,7 +941,7 @@ public class RunnerBuilder {
                   vertx,
                   dataDir,
                   engineJsonRpcConfiguration.orElse(JsonRpcConfiguration.createEngineDefault()),
-                  metricsSystem,
+                  rpcMetrics,
                   natService,
                   websocketMethodsFactory.methods(),
                   Optional.ofNullable(engineSocketConfig),
@@ -991,7 +994,7 @@ public class RunnerBuilder {
               transactionPool,
               miningConfiguration,
               miningCoordinator,
-              metricsSystem,
+              rpcMetrics,
               supportedCapabilities,
               webSocketConfiguration.getRpcApis().stream()
                   .filter(apiGroup -> !apiGroup.toLowerCase(Locale.ROOT).startsWith("engine"))
@@ -1072,7 +1075,7 @@ public class RunnerBuilder {
               transactionPool,
               miningConfiguration,
               miningCoordinator,
-              metricsSystem,
+              rpcMetrics,
               supportedCapabilities,
               jsonRpcIpcConfiguration.getEnabledApis().stream()
                   .filter(apiGroup -> !apiGroup.toLowerCase(Locale.ROOT).startsWith("engine"))
@@ -1113,7 +1116,7 @@ public class RunnerBuilder {
               transactionPool,
               miningConfiguration,
               miningCoordinator,
-              metricsSystem,
+              rpcMetrics,
               supportedCapabilities,
               inProcessRpcConfiguration.getInProcessRpcApis(),
               filterManager,
@@ -1275,7 +1278,7 @@ public class RunnerBuilder {
       final TransactionPool transactionPool,
       final MiningConfiguration miningConfiguration,
       final MiningCoordinator miningCoordinator,
-      final ObservableMetricsSystem metricsSystem,
+      final RpcMetrics rpcMetrics,
       final Set<Capability> supportedCapabilities,
       final Collection<String> jsonRpcApis,
       final FilterManager filterManager,
@@ -1310,7 +1313,7 @@ public class RunnerBuilder {
                 transactionPool,
                 miningConfiguration,
                 miningCoordinator,
-                metricsSystem,
+                rpcMetrics,
                 supportedCapabilities,
                 accountAllowlistController,
                 nodeAllowlistController,

--- a/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
+++ b/ethereum/api/src/integration-test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcTestMethodsFactory.java
@@ -27,6 +27,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManagerBuilder;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -46,7 +47,6 @@ import org.hyperledger.besu.ethereum.p2p.network.P2PNetwork;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
-import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.nat.NatService;
@@ -157,7 +157,7 @@ public class JsonRpcTestMethodsFactory {
     final TransactionPool transactionPool = mock(TransactionPool.class);
     final MiningConfiguration miningConfiguration = mock(MiningConfiguration.class);
     final PoWMiningCoordinator miningCoordinator = mock(PoWMiningCoordinator.class);
-    final ObservableMetricsSystem metricsSystem = new NoOpMetricsSystem();
+    final RpcMetrics rpcMetrics = new RpcMetrics(new NoOpMetricsSystem());
     final Optional<AccountLocalConfigPermissioningController> accountWhitelistController =
         Optional.of(mock(AccountLocalConfigPermissioningController.class));
     final Optional<NodeLocalConfigPermissioningController> nodeWhitelistController =
@@ -203,7 +203,7 @@ public class JsonRpcTestMethodsFactory {
             transactionPool,
             miningConfiguration,
             miningCoordinator,
-            metricsSystem,
+            rpcMetrics,
             new HashSet<>(),
             accountWhitelistController,
             nodeWhitelistController,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceBlock.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.Tracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.TransactionTrace;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.tracing.flat.RewardTraceGenerator;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcTraceMetricsCollectors;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.util.ArrayNodeWrapper;
 import org.hyperledger.besu.ethereum.core.Block;
@@ -38,11 +39,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpec;
 import org.hyperledger.besu.ethereum.vm.DebugOperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
-import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-import org.hyperledger.besu.plugin.services.metrics.Counter;
-import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
 import org.hyperledger.besu.services.pipeline.Pipeline;
 
 import java.util.Optional;
@@ -56,21 +53,15 @@ public class TraceBlock extends AbstractBlockParameterMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceBlock.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final ProtocolSchedule protocolSchedule;
-  private final LabelledMetric<Counter> outputCounter;
+  private final RpcTraceMetricsCollectors rpcTraceMetricsCollectors;
 
   public TraceBlock(
       final ProtocolSchedule protocolSchedule,
       final BlockchainQueries queries,
-      final MetricsSystem metricsSystem) {
+      final RpcTraceMetricsCollectors rpcTraceMetricsCollectors) {
     super(queries);
     this.protocolSchedule = protocolSchedule;
-    this.outputCounter =
-        metricsSystem.createLabelledCounter(
-            BesuMetricCategory.BLOCKCHAIN,
-            "transactions_traceblock_pipeline_processed_total",
-            "Number of transactions processed for each block",
-            "step",
-            "action");
+    this.rpcTraceMetricsCollectors = rpcTraceMetricsCollectors;
   }
 
   @Override
@@ -143,7 +134,7 @@ public class TraceBlock extends AbstractBlockParameterMethod {
                           "getTransactions",
                           transactionSource,
                           4,
-                          outputCounter,
+                          rpcTraceMetricsCollectors.traceBlockTxsProcessedCounter(),
                           false,
                           "trace_block_transactions")
                       .thenProcess("executeTransaction", executeTransactionStep)

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/JsonRpcMethodsFactory.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcConfiguration;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.RpcModules;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.MiningCoordinator;
@@ -36,7 +37,6 @@ import org.hyperledger.besu.ethereum.p2p.peers.EnodeDnsConfiguration;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
 import org.hyperledger.besu.ethereum.permissioning.AccountLocalConfigPermissioningController;
 import org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController;
-import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.nat.NatService;
 import org.hyperledger.besu.plugin.BesuPlugin;
@@ -69,7 +69,7 @@ public class JsonRpcMethodsFactory {
       final TransactionPool transactionPool,
       final MiningConfiguration miningConfiguration,
       final MiningCoordinator miningCoordinator,
-      final ObservableMetricsSystem metricsSystem,
+      final RpcMetrics rpcMetrics,
       final Set<Capability> supportedCapabilities,
       final Optional<AccountLocalConfigPermissioningController> accountsAllowlistController,
       final Optional<NodeLocalConfigPermissioningController> nodeAllowlistController,
@@ -107,7 +107,7 @@ public class JsonRpcMethodsFactory {
                   blockchainQueries,
                   protocolContext,
                   protocolSchedule,
-                  metricsSystem,
+                  rpcMetrics.getObservableMetricsSystem(),
                   transactionPool,
                   synchronizer,
                   dataDir,
@@ -155,7 +155,7 @@ public class JsonRpcMethodsFactory {
                   protocolSchedule,
                   protocolContext,
                   apiConfiguration,
-                  metricsSystem),
+                  rpcMetrics.getRpcTraceMetrics()),
               new TxPoolJsonRpcMethods(transactionPool),
               new PluginsJsonRpcMethods(namedPlugins));
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/TraceJsonRpcMethods.java
@@ -28,10 +28,10 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceReplayBlo
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.TraceTransaction;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockReplay;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcTraceMetricsCollectors;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.util.Map;
 
@@ -41,19 +41,19 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
   private final ProtocolSchedule protocolSchedule;
   private final ApiConfiguration apiConfiguration;
   private final ProtocolContext protocolContext;
-  private final MetricsSystem metricsSystem;
+  private final RpcTraceMetricsCollectors rpcTraceMetricsCollectors;
 
   TraceJsonRpcMethods(
       final BlockchainQueries blockchainQueries,
       final ProtocolSchedule protocolSchedule,
       final ProtocolContext protocolContext,
       final ApiConfiguration apiConfiguration,
-      final MetricsSystem metricsSystem) {
+      final RpcTraceMetricsCollectors rpcTraceMetricsCollectors) {
     this.blockchainQueries = blockchainQueries;
     this.protocolSchedule = protocolSchedule;
     this.protocolContext = protocolContext;
     this.apiConfiguration = apiConfiguration;
-    this.metricsSystem = metricsSystem;
+    this.rpcTraceMetricsCollectors = rpcTraceMetricsCollectors;
   }
 
   @Override
@@ -66,16 +66,17 @@ public class TraceJsonRpcMethods extends ApiGroupJsonRpcMethods {
     final BlockReplay blockReplay =
         new BlockReplay(protocolSchedule, protocolContext, blockchainQueries.getBlockchain());
     return mapOf(
-        new TraceReplayBlockTransactions(protocolSchedule, blockchainQueries, metricsSystem),
+        new TraceReplayBlockTransactions(
+            protocolSchedule, blockchainQueries, rpcTraceMetricsCollectors),
         new TraceFilter(
             protocolSchedule,
             blockchainQueries,
             apiConfiguration.getMaxTraceFilterRange(),
-            metricsSystem),
+            rpcTraceMetricsCollectors),
         new TraceGet(() -> new BlockTracer(blockReplay), blockchainQueries, protocolSchedule),
         new TraceTransaction(
             () -> new BlockTracer(blockReplay), protocolSchedule, blockchainQueries),
-        new TraceBlock(protocolSchedule, blockchainQueries, metricsSystem),
+        new TraceBlock(protocolSchedule, blockchainQueries, rpcTraceMetricsCollectors),
         new TraceCall(
             blockchainQueries,
             protocolSchedule,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/metrics/RpcMetrics.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/metrics/RpcMetrics.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.metrics;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.metrics.ObservableMetricsSystem;
+import org.hyperledger.besu.metrics.opentelemetry.OpenTelemetrySystem;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+import org.hyperledger.besu.plugin.services.metrics.OperationTimer;
+
+import java.util.function.IntSupplier;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
+
+public class RpcMetrics {
+  private final ObservableMetricsSystem metricsSystem;
+  private final Tracer tracer;
+  private final RpcTraceMetricsCollectors rpcTraceMetricsCollectors;
+  private final LabelledMetric<OperationTimer> requestTimer;
+  private final LabelledMetric<Counter> errorsCounter;
+
+  public RpcMetrics(final ObservableMetricsSystem metricsSystem) {
+    this.metricsSystem = metricsSystem;
+    this.tracer = getTracer(metricsSystem);
+    this.rpcTraceMetricsCollectors = RpcTraceMetricsCollectors.create(metricsSystem);
+
+    this.requestTimer =
+        metricsSystem.createLabelledTimer(
+            BesuMetricCategory.RPC,
+            "request_time",
+            "Time taken to process a JSON-RPC request",
+            "methodName");
+
+    this.errorsCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.RPC,
+            "errors_count",
+            "Number of errors per RPC method and RPC error type",
+            "rpcMethod",
+            "errorType");
+  }
+
+  public void initActiveHttpConnectionCounter(final IntSupplier activeHttpConnectionCountSupplier) {
+    metricsSystem.createIntegerGauge(
+        BesuMetricCategory.RPC,
+        "active_http_connection_count",
+        "Total no of active rpc http connections",
+        activeHttpConnectionCountSupplier);
+  }
+
+  private Tracer getTracer(final MetricsSystem metricsSystem) {
+    return (metricsSystem instanceof OpenTelemetrySystem openTelemetrySystem)
+        ? openTelemetrySystem.getTracerProvider().get("org.hyperledger.besu.jsonrpc", "1.0.0")
+        : OpenTelemetry.noop().getTracer("org.hyperledger.besu.jsonrpc", "1.0.0");
+  }
+
+  public ObservableMetricsSystem getObservableMetricsSystem() {
+    return metricsSystem;
+  }
+
+  public Tracer getTracer() {
+    return tracer;
+  }
+
+  public RpcTraceMetricsCollectors getRpcTraceMetrics() {
+    return rpcTraceMetricsCollectors;
+  }
+
+  public void incErrorsCounter(
+      final JsonRpcMethod method, final JsonRpcErrorResponse errorResponse) {
+    errorsCounter.labels(method.getName(), errorResponse.getErrorType().name()).inc();
+  }
+
+  public OperationTimer.TimingContext startRequestTimer(final JsonRpcRequest request) {
+    return requestTimer.labels(request.getMethod()).startTimer();
+  }
+}

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/metrics/RpcTraceMetricsCollectors.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/metrics/RpcTraceMetricsCollectors.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.metrics;
+
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+
+public record RpcTraceMetricsCollectors(
+    LabelledMetric<Counter> traceBlockTxsProcessedCounter,
+    LabelledMetric<Counter> traceFilterTxsProcessedCounter,
+    LabelledMetric<Counter> traceReplayBlockTxsProcessedCounter) {
+  public static RpcTraceMetricsCollectors create(final MetricsSystem metricsSystem) {
+    final var traceBlockTxsProcessedCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "transactions_traceblock_pipeline_processed_total",
+            "Number of transactions processed for each block",
+            "step",
+            "action");
+
+    final var traceFilterTxsProcessedCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "transactions_tracefilter_pipeline_processed_total",
+            "Number of transactions processed for trace_filter",
+            "step",
+            "action");
+
+    final var traceReplayBlockTxsProcessedCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.BLOCKCHAIN,
+            "transactions_tracereplayblock_pipeline_processed_total",
+            "Number of transactions processed for each block",
+            "step",
+            "action");
+
+    return new RpcTraceMetricsCollectors(
+        traceBlockTxsProcessedCounter,
+        traceFilterTxsProcessedCounter,
+        traceReplayBlockTxsProcessedCounter);
+  }
+}

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AbstractJsonRpcHttpServiceTest.java
@@ -31,6 +31,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManagerBu
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterRepository;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -185,7 +186,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             transactionPoolMock,
             miningConfiguration,
             miningCoordinatorMock,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             supportedCapabilities,
             Optional.empty(),
             Optional.empty(),
@@ -221,7 +222,7 @@ public abstract class AbstractJsonRpcHttpServiceTest {
             vertx,
             folder,
             config,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             natService,
             methods,
             HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceCorsTest.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.nat.NatService;
 
@@ -224,7 +225,7 @@ public class JsonRpcHttpServiceCorsTest {
             vertx,
             folder,
             config,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             natService,
             new HashMap<>(),
             HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceHostAllowlistTest.java
@@ -26,6 +26,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -122,7 +123,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -151,7 +152,7 @@ public class JsonRpcHttpServiceHostAllowlistTest {
         vertx,
         Files.createTempDirectory(folder, "tempDir"),
         jsonRpcConfig,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceLoginTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.NetVersion;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Web3ClientVersion;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.Web3Sha3;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -153,7 +154,7 @@ public class JsonRpcHttpServiceLoginTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.empty(),
                 Optional.empty(),
@@ -194,7 +195,7 @@ public class JsonRpcHttpServiceLoginTest {
         vertx,
         folder,
         config,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceRpcApisTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -219,7 +220,7 @@ public class JsonRpcHttpServiceRpcApisTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -241,7 +242,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             vertx,
             folder,
             config,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             natService,
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,
@@ -330,7 +331,7 @@ public class JsonRpcHttpServiceRpcApisTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -352,7 +353,7 @@ public class JsonRpcHttpServiceRpcApisTest {
             vertx,
             folder,
             jsonRpcConfiguration,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             natService,
             rpcMethods,
             HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTestBase.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.blockcreation.PoWMiningCoordinator;
@@ -131,7 +132,7 @@ public class JsonRpcHttpServiceTestBase {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -164,7 +165,7 @@ public class JsonRpcHttpServiceTestBase {
         vertx,
         folder,
         config,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,
@@ -176,7 +177,7 @@ public class JsonRpcHttpServiceTestBase {
         vertx,
         folder,
         createLimitedJsonRpcConfig(),
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsClientAuthTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.tls.FileBasedPasswordProvider;
@@ -136,7 +137,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -169,7 +170,7 @@ public class JsonRpcHttpServiceTlsClientAuthTest {
         vertx,
         folder,
         jsonRpcConfig,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsMisconfigurationTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.tls.FileBasedPasswordProvider;
@@ -124,7 +125,7 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -299,7 +300,7 @@ class JsonRpcHttpServiceTlsMisconfigurationTest {
         vertx,
         tempDir,
         jsonRpcConfig,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTlsTest.java
@@ -29,6 +29,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.WebSocketConfiguration;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.api.tls.FileBasedPasswordProvider;
@@ -125,7 +126,7 @@ public class JsonRpcHttpServiceTlsTest {
                 mock(TransactionPool.class),
                 mock(MiningConfiguration.class),
                 mock(PoWMiningCoordinator.class),
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 supportedCapabilities,
                 Optional.of(mock(AccountLocalConfigPermissioningController.class)),
                 Optional.of(mock(NodeLocalConfigPermissioningController.class)),
@@ -153,7 +154,7 @@ public class JsonRpcHttpServiceTlsTest {
         vertx,
         Files.createTempDirectory(folder, "newFolder"),
         jsonRpcConfig,
-        new NoOpMetricsSystem(),
+        new RpcMetrics(new NoOpMetricsSystem()),
         natService,
         rpcMethods,
         HealthService.ALWAYS_HEALTHY,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/TraceFilterTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.processor.BlockTracer;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcTraceMetricsCollectors;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -71,7 +72,10 @@ public class TraceFilterTest {
 
     method =
         new TraceFilter(
-            protocolSchedule, blockchainQueries, maxFilterRange, new NoOpMetricsSystem());
+            protocolSchedule,
+            blockchainQueries,
+            maxFilterRange,
+            RpcTraceMetricsCollectors.create(new NoOpMetricsSystem()));
 
     final JsonRpcResponse response = method.response(request);
     assertThat(response).isInstanceOf(JsonRpcErrorResponse.class);

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/JsonRpcJWTTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.health.HealthService.ParamSourc
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequest;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.MutableJsonRpcSuccessResponse;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketMethodsFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
@@ -134,7 +135,7 @@ public class JsonRpcJWTTest {
             vertx,
             bufferDir,
             jsonRpcConfiguration,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             new NatService(Optional.empty(), true),
             websocketMethods,
             Optional.empty(),
@@ -193,7 +194,7 @@ public class JsonRpcJWTTest {
             vertx,
             bufferDir,
             jsonRpcConfiguration,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             new NatService(Optional.empty(), true),
             websocketMethods,
             Optional.empty(),
@@ -267,7 +268,7 @@ public class JsonRpcJWTTest {
                 vertx,
                 bufferDir,
                 strictHost,
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 new NatService(Optional.empty(), true),
                 websocketMethods,
                 Optional.empty(),
@@ -329,7 +330,7 @@ public class JsonRpcJWTTest {
                 vertx,
                 bufferDir,
                 strictHost,
-                new NoOpMetricsSystem(),
+                new RpcMetrics(new NoOpMetricsSystem()),
                 new NatService(Optional.empty(), true),
                 websocketMethods,
                 Optional.empty(),
@@ -384,7 +385,7 @@ public class JsonRpcJWTTest {
             vertx,
             bufferDir,
             jsonRpcConfiguration,
-            new NoOpMetricsSystem(),
+            new RpcMetrics(new NoOpMetricsSystem()),
             new NatService(Optional.empty(), true),
             websocketMethods,
             Optional.empty(),

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/websocket/WebSocketServiceLoginTest.java
@@ -39,6 +39,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.execution.JsonRpcExecutor;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.filter.FilterManager;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.JsonRpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.methods.JsonRpcMethodsFactory;
+import org.hyperledger.besu.ethereum.api.jsonrpc.metrics.RpcMetrics;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.methods.WebSocketMethodsFactory;
 import org.hyperledger.besu.ethereum.api.jsonrpc.websocket.subscription.SubscriptionManager;
 import org.hyperledger.besu.ethereum.api.query.BlockchainQueries;
@@ -189,7 +190,7 @@ public class WebSocketServiceLoginTest {
                     mock(TransactionPool.class),
                     mock(MiningConfiguration.class),
                     mock(PoWMiningCoordinator.class),
-                    new NoOpMetricsSystem(),
+                    new RpcMetrics(new NoOpMetricsSystem()),
                     supportedCapabilities,
                     Optional.empty(),
                     Optional.empty(),

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/PoolMetricsAdapter.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/PoolMetricsAdapter.java
@@ -14,49 +14,25 @@
  */
 package org.hyperledger.besu.metrics.vertx;
 
-import org.hyperledger.besu.metrics.BesuMetricCategory;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 
 import io.vertx.core.spi.metrics.PoolMetrics;
 
 final class PoolMetricsAdapter implements PoolMetrics<Object> {
-
   private final Counter submittedCounter;
   private final Counter completedCounter;
   private final Counter rejectedCounter;
 
   public PoolMetricsAdapter(
-      final MetricsSystem metricsSystem, final String poolType, final String poolName) {
-    submittedCounter =
-        metricsSystem
-            .createLabelledCounter(
-                BesuMetricCategory.NETWORK,
-                "vertx_worker_pool_submitted_total",
-                "Total number of tasks submitted to the Vertx worker pool",
-                "poolType",
-                "poolName")
-            .labels(poolType, poolName);
-
-    completedCounter =
-        metricsSystem
-            .createLabelledCounter(
-                BesuMetricCategory.NETWORK,
-                "vertx_worker_pool_completed_total",
-                "Total number of tasks completed by the Vertx worker pool",
-                "poolType",
-                "poolName")
-            .labels(poolType, poolName);
-
-    rejectedCounter =
-        metricsSystem
-            .createLabelledCounter(
-                BesuMetricCategory.NETWORK,
-                "vertx_worker_pool_rejected_total",
-                "Total number of tasks rejected by the Vertx worker pool",
-                "poolType",
-                "poolName")
-            .labels(poolType, poolName);
+      final VertxMetricsCollectors vertxMetricsCollectors,
+      final String poolType,
+      final String poolName) {
+    this.submittedCounter =
+        vertxMetricsCollectors.submittedLabelledCounter().labels(poolType, poolName);
+    this.completedCounter =
+        vertxMetricsCollectors.completedLabelledCounter().labels(poolType, poolName);
+    this.rejectedCounter =
+        vertxMetricsCollectors.rejectedLabelledCounter().labels(poolType, poolName);
   }
 
   @Override

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsAdapter.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsAdapter.java
@@ -14,28 +14,26 @@
  */
 package org.hyperledger.besu.metrics.vertx;
 
-import org.hyperledger.besu.plugin.services.MetricsSystem;
-
 import io.vertx.core.spi.metrics.PoolMetrics;
 import io.vertx.core.spi.metrics.VertxMetrics;
 
 /** The Vertx metrics adapter. */
 public class VertxMetricsAdapter implements VertxMetrics {
 
-  private final MetricsSystem metricsSystem;
+  private final VertxMetricsCollectors vertxMetricsCollectors;
 
   /**
    * Instantiates a new Vertx metrics adapter.
    *
-   * @param metricsSystem the metrics system
+   * @param vertxMetricsCollectors the Vertx metrics collectors
    */
-  public VertxMetricsAdapter(final MetricsSystem metricsSystem) {
-    this.metricsSystem = metricsSystem;
+  public VertxMetricsAdapter(final VertxMetricsCollectors vertxMetricsCollectors) {
+    this.vertxMetricsCollectors = vertxMetricsCollectors;
   }
 
   @Override
   public PoolMetrics<?> createPoolMetrics(
       final String poolType, final String poolName, final int maxPoolSize) {
-    return new PoolMetricsAdapter(metricsSystem, poolType, poolName);
+    return new PoolMetricsAdapter(vertxMetricsCollectors, poolType, poolName);
   }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsAdapterFactory.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsAdapterFactory.java
@@ -23,7 +23,7 @@ import io.vertx.core.spi.metrics.VertxMetrics;
 /** The Vertx metrics adapter factory. */
 public class VertxMetricsAdapterFactory implements VertxMetricsFactory {
 
-  private final MetricsSystem metricsSystem;
+  private final VertxMetricsCollectors vertxMetricsCollectors;
 
   /**
    * Instantiates a new Vertx metrics adapter factory.
@@ -31,11 +31,11 @@ public class VertxMetricsAdapterFactory implements VertxMetricsFactory {
    * @param metricsSystem the metrics system
    */
   public VertxMetricsAdapterFactory(final MetricsSystem metricsSystem) {
-    this.metricsSystem = metricsSystem;
+    this.vertxMetricsCollectors = VertxMetricsCollectors.create(metricsSystem);
   }
 
   @Override
   public VertxMetrics metrics(final VertxOptions options) {
-    return new VertxMetricsAdapter(metricsSystem);
+    return new VertxMetricsAdapter(vertxMetricsCollectors);
   }
 }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsCollectors.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/vertx/VertxMetricsCollectors.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.metrics.vertx;
+
+import org.hyperledger.besu.metrics.BesuMetricCategory;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
+import org.hyperledger.besu.plugin.services.metrics.Counter;
+import org.hyperledger.besu.plugin.services.metrics.LabelledMetric;
+
+/**
+ * Container for the metrics collectors used by Vertx
+ *
+ * @param submittedLabelledCounter counter for the number of tasks submitted
+ * @param completedLabelledCounter counter for the number of tasks completed
+ * @param rejectedLabelledCounter counter for the number of tasks rejected
+ */
+public record VertxMetricsCollectors(
+    LabelledMetric<Counter> submittedLabelledCounter,
+    LabelledMetric<Counter> completedLabelledCounter,
+    LabelledMetric<Counter> rejectedLabelledCounter) {
+  /**
+   * Creates the collectors
+   *
+   * @param metricsSystem the metrics system
+   * @return the record with all the collectors initialized
+   */
+  public static VertxMetricsCollectors create(final MetricsSystem metricsSystem) {
+    final var submittedLabelledCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.NETWORK,
+            "vertx_worker_pool_submitted_total",
+            "Total number of tasks submitted to the Vertx worker pool",
+            "poolType",
+            "poolName");
+
+    final var completedLabelledCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.NETWORK,
+            "vertx_worker_pool_completed_total",
+            "Total number of tasks completed by the Vertx worker pool",
+            "poolType",
+            "poolName");
+
+    final var rejectedLabelledCounter =
+        metricsSystem.createLabelledCounter(
+            BesuMetricCategory.NETWORK,
+            "vertx_worker_pool_rejected_total",
+            "Total number of tasks rejected by the Vertx worker pool",
+            "poolType",
+            "poolName");
+
+    return new VertxMetricsCollectors(
+        submittedLabelledCounter, completedLabelledCounter, rejectedLabelledCounter);
+  }
+}

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'IPpTJJxjDbjW08c3Cm8GbBhULYFy0jq9m3BzliGzrf8='
+  knownHash = 'uLL3taYv7TzuN2YMq7UdLp/NEZvsUEZuDNz5olmu0Xs='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/MetricsSystem.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/MetricsSystem.java
@@ -184,7 +184,13 @@ public interface MetricsSystem extends BesuService {
    * @param help A human readable description of the metric.
    * @param valueSupplier A supplier for the double value to be presented.
    */
-  void createGauge(MetricCategory category, String name, String help, DoubleSupplier valueSupplier);
+  default void createGauge(
+      final MetricCategory category,
+      final String name,
+      final String help,
+      final DoubleSupplier valueSupplier) {
+    createLabelledSuppliedGauge(category, name, help).labels(valueSupplier);
+  }
 
   /**
    * Creates a gauge for displaying integer values.


### PR DESCRIPTION
## PR description

Switch to a fail fast approach when trying to create a metric that already exists, that is less error prone of the current approach where instead in case the same metric is created twice, the first one is replaced to the second one, thus in case of a name clash that could have unwanted consequences, so better to fail in case this happens.

This change required a little refactoring to make sure metrics collectors are created only one in the RPC subsystem, with the introduction of the `RpcMetrics` and for Vert.x with the introduction of the `VertxMetricsCollectors`.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

