### PR TITLE
Fix minor stylistic issue in tracing documentation

### DIFF
--- a/docs/tracing/README.md
+++ b/docs/tracing/README.md
@@ -2,7 +2,7 @@
 
 Hyperledger Besu integrates with the [open-telemetry](https://opentelemetry.io/) project to integrate tracing reporting.
 
-This allows to report all JSON-RPC traffic as traces.
+This allows reporting all JSON-RPC traffic as traces.
 
 To try out this example, start the Open Telemetry Collector and the Zipkin service with:
 


### PR DESCRIPTION
## PR description

**Issue:**
The original sentence:

> "This allows to report all JSON-RPC traffic as traces."

has an unusual sentence structure and could be improved for readability.

**Fix:**
The sentence has been changed to:

> "This allows reporting all JSON-RPC traffic as traces."

**Importance:**
While this is not a technical error, improving the sentence structure enhances the clarity and readability of the documentation. This change ensures that the documentation follows more natural English phrasing, making it easier for users to understand.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

