### PR TITLE
Renaming state trie account for verkle integration

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/RestoreState.java
@@ -34,9 +34,9 @@ import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.trie.Node;
 import org.hyperledger.besu.ethereum.trie.PersistVisitor;
 import org.hyperledger.besu.ethereum.trie.RestoreVisitor;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.forest.ForestWorldStateArchive;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.util.io.RollingFileReader;
 
 import java.io.IOException;
@@ -192,8 +192,8 @@ public class RestoreState implements Runnable {
         final Bytes accountRlp = accountInput.readBytes();
         final Bytes code = accountInput.readBytes();
 
-        final StateTrieAccountValue trieAccount =
-            StateTrieAccountValue.readFrom(new BytesValueRLPInput(accountRlp, false, true));
+        final PmtStateTrieAccountValue trieAccount =
+            PmtStateTrieAccountValue.readFrom(new BytesValueRLPInput(accountRlp, false, true));
         if (!trieAccount.getCodeHash().equals(Hash.hash(code))) {
           throw new RuntimeException("Code hash doesn't match");
         }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/GetProofResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/proof/GetProofResult.java
@@ -18,7 +18,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.results.Quantity;
 import org.hyperledger.besu.ethereum.proof.WorldStateProof;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +64,8 @@ public class GetProofResult {
   public static GetProofResult buildGetProofResult(
       final Address address, final WorldStateProof worldStateProof) {
 
-    final StateTrieAccountValue stateTrieAccountValue = worldStateProof.getStateTrieAccountValue();
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        worldStateProof.getStateTrieAccountValue();
 
     final List<StorageEntryProof> storageEntries = new ArrayList<>();
     worldStateProof

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/query/StateBackupService.java
@@ -29,9 +29,9 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.trie.Node;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
 import org.hyperledger.besu.ethereum.trie.TrieIterator.State;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.util.io.RollingFileWriter;
 
 import java.io.IOException;
@@ -241,8 +241,8 @@ public class StateBackupService {
 
     backupStatus.currentAccount = nodeKey;
     final Bytes nodeValue = node.getValue().orElse(Hash.EMPTY);
-    final StateTrieAccountValue account =
-        StateTrieAccountValue.readFrom(new BytesValueRLPInput(nodeValue, false));
+    final PmtStateTrieAccountValue account =
+        PmtStateTrieAccountValue.readFrom(new BytesValueRLPInput(nodeValue, false));
 
     final Bytes code = worldStateKeyValueStorage.getCode(account.getCodeHash()).orElse(Bytes.EMPTY);
     backupStatus.codeSize.addAndGet(code.size());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetProofTest.java
@@ -42,7 +42,7 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.proof.WorldStateProof;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 
 import java.util.Collections;
@@ -202,7 +202,7 @@ class EthGetProofTest {
 
     when(blockchainQueries.getWorldStateArchive()).thenReturn(archive);
 
-    final StateTrieAccountValue stateTrieAccountValue = mock(StateTrieAccountValue.class);
+    final PmtStateTrieAccountValue stateTrieAccountValue = mock(PmtStateTrieAccountValue.class);
     when(stateTrieAccountValue.getBalance()).thenReturn(balance);
     when(stateTrieAccountValue.getCodeHash()).thenReturn(codeHash);
     when(stateTrieAccountValue.getNonce()).thenReturn(nonce);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProof.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProof.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.proof;
 
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.Proof;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,14 +29,14 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 public class WorldStateProof {
 
-  private final StateTrieAccountValue stateTrieAccountValue;
+  private final PmtStateTrieAccountValue stateTrieAccountValue;
 
   private final Proof<Bytes> accountProof;
 
   private final Map<UInt256, Proof<Bytes>> storageProofs;
 
   public WorldStateProof(
-      final StateTrieAccountValue stateTrieAccountValue,
+      final PmtStateTrieAccountValue stateTrieAccountValue,
       final Proof<Bytes> accountProof,
       final SortedMap<UInt256, Proof<Bytes>> storageProofs) {
     this.stateTrieAccountValue = stateTrieAccountValue;
@@ -44,7 +44,7 @@ public class WorldStateProof {
     this.storageProofs = storageProofs;
   }
 
-  public StateTrieAccountValue getStateTrieAccountValue() {
+  public PmtStateTrieAccountValue getStateTrieAccountValue() {
     return stateTrieAccountValue;
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProvider.java
@@ -22,10 +22,10 @@ import org.hyperledger.besu.ethereum.trie.InnerNodeDiscoveryManager.InnerNode;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.ethereum.trie.Proof;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.patricia.RemoveVisitor;
 import org.hyperledger.besu.ethereum.trie.patricia.SimpleMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
 import java.util.Comparator;
@@ -73,7 +73,7 @@ public class WorldStateProofProvider {
       return accountProof
           .getValue()
           .map(RLP::input)
-          .map(StateTrieAccountValue::readFrom)
+          .map(PmtStateTrieAccountValue::readFrom)
           .map(
               account -> {
                 final SortedMap<UInt256, Proof<Bytes>> storageProofs =
@@ -85,7 +85,7 @@ public class WorldStateProofProvider {
 
   private SortedMap<UInt256, Proof<Bytes>> getStorageProofs(
       final Hash accountHash,
-      final StateTrieAccountValue account,
+      final PmtStateTrieAccountValue account,
       final List<UInt256> accountStorageKeys) {
     final MerkleTrie<Bytes32, Bytes> storageTrie =
         newAccountStorageTrie(accountHash, account.getStorageRoot());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/AbstractStateTrieAccountValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/AbstractStateTrieAccountValue.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.common;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.hyperledger.besu.datatypes.AccountValue;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+
+/** Represents the raw values associated with an account in the world state trie. */
+public abstract class AbstractStateTrieAccountValue implements AccountValue {
+
+  protected final long nonce;
+  protected final Wei balance;
+  protected final Hash codeHash;
+
+  public AbstractStateTrieAccountValue(final long nonce, final Wei balance, final Hash codeHash) {
+    checkNotNull(balance, "balance cannot be null");
+    checkNotNull(codeHash, "codeHash cannot be null");
+    this.nonce = nonce;
+    this.balance = balance;
+    this.codeHash = codeHash;
+  }
+
+  /**
+   * The account nonce, that is the number of transactions sent from that account.
+   *
+   * @return the account nonce.
+   */
+  @Override
+  public long getNonce() {
+    return nonce;
+  }
+
+  /**
+   * The available balance of that account.
+   *
+   * @return the balance, in Wei, of the account.
+   */
+  @Override
+  public Wei getBalance() {
+    return balance;
+  }
+
+  /**
+   * The hash of the EVM bytecode associated with this account.
+   *
+   * @return the hash of the account code (which may be {@link Hash#EMPTY}).
+   */
+  @Override
+  public Hash getCodeHash() {
+    return codeHash;
+  }
+
+  /**
+   * The hash of the root of the storage trie associated with this account.
+   *
+   * @return the hash of the root node of the storage trie.
+   */
+  @Override
+  public Hash getStorageRoot() {
+    return Hash.EMPTY_TRIE_HASH;
+  }
+
+  @Override
+  public abstract void writeTo(final RLPOutput out);
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/PmtStateTrieAccountValue.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/PmtStateTrieAccountValue.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.worldstate;
+package org.hyperledger.besu.ethereum.trie.common;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,43 +26,17 @@ import java.util.Objects;
 
 import org.apache.tuweni.bytes.Bytes32;
 
-/** Represents the raw values associated with an account in the world state trie. */
-public class StateTrieAccountValue implements AccountValue {
+/** Represents the raw values associated with an account in the world state patricia merkle trie. */
+public class PmtStateTrieAccountValue extends AbstractStateTrieAccountValue
+    implements AccountValue {
 
-  protected final long nonce;
-  protected final Wei balance;
   protected final Hash storageRoot;
-  protected final Hash codeHash;
 
-  public StateTrieAccountValue(
+  public PmtStateTrieAccountValue(
       final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
-    checkNotNull(balance, "balance cannot be null");
+    super(nonce, balance, codeHash);
     checkNotNull(storageRoot, "storageRoot cannot be null");
-    checkNotNull(codeHash, "codeHash cannot be null");
-    this.nonce = nonce;
-    this.balance = balance;
     this.storageRoot = storageRoot;
-    this.codeHash = codeHash;
-  }
-
-  /**
-   * The account nonce, that is the number of transactions sent from that account.
-   *
-   * @return the account nonce.
-   */
-  @Override
-  public long getNonce() {
-    return nonce;
-  }
-
-  /**
-   * The available balance of that account.
-   *
-   * @return the balance, in Wei, of the account.
-   */
-  @Override
-  public Wei getBalance() {
-    return balance;
   }
 
   /**
@@ -75,25 +49,15 @@ public class StateTrieAccountValue implements AccountValue {
     return storageRoot;
   }
 
-  /**
-   * The hash of the EVM bytecode associated with this account.
-   *
-   * @return the hash of the account code (which may be {@link Hash#EMPTY}).
-   */
-  @Override
-  public Hash getCodeHash() {
-    return codeHash;
-  }
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    final StateTrieAccountValue that = (StateTrieAccountValue) o;
+    PmtStateTrieAccountValue that = (PmtStateTrieAccountValue) o;
     return nonce == that.nonce
-        && balance.equals(that.balance)
-        && storageRoot.equals(that.storageRoot)
-        && codeHash.equals(that.codeHash);
+        && Objects.equals(balance, that.balance)
+        && Objects.equals(storageRoot, that.storageRoot)
+        && Objects.equals(codeHash, that.codeHash);
   }
 
   @Override
@@ -109,11 +73,10 @@ public class StateTrieAccountValue implements AccountValue {
     out.writeUInt256Scalar(balance);
     out.writeBytes(storageRoot);
     out.writeBytes(codeHash);
-
     out.endList();
   }
 
-  public static StateTrieAccountValue readFrom(final RLPInput in) {
+  public static PmtStateTrieAccountValue readFrom(final RLPInput in) {
     in.enterList();
 
     final long nonce = in.readLongScalar();
@@ -132,9 +95,9 @@ public class StateTrieAccountValue implements AccountValue {
     } else {
       codeHash = in.readBytes32();
     }
-
     in.leaveList();
 
-    return new StateTrieAccountValue(nonce, balance, Hash.wrap(storageRoot), Hash.wrap(codeHash));
+    return new PmtStateTrieAccountValue(
+        nonce, balance, Hash.wrap(storageRoot), Hash.wrap(codeHash));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
@@ -18,6 +18,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedWorldStorageManager;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
@@ -26,7 +27,6 @@ import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedWorldStatePr
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogManager;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldStateConfig;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.plugin.ServiceManager;
 
@@ -120,7 +120,7 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
       accountTrie
           .get(accountHash)
           .map(RLP::input)
-          .map(StateTrieAccountValue::readFrom)
+          .map(PmtStateTrieAccountValue::readFrom)
           .ifPresent(
               account -> {
                 final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
@@ -24,13 +24,13 @@ import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.flat.BonsaiFlatDbStrategy;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.flat.BonsaiFlatDbStrategyProvider;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.storage.flat.FlatDbStrategy;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.evm.account.AccountStorageEntry;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -135,7 +135,7 @@ public class BonsaiWorldStateKeyValueStorage extends DiffBasedWorldStateKeyValue
             getAccount(accountHash)
                 .map(
                     b ->
-                        StateTrieAccountValue.readFrom(
+                        PmtStateTrieAccountValue.readFrom(
                                 org.hyperledger.besu.ethereum.rlp.RLP.input(b))
                             .getStorageRoot()),
         accountHash,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogFactoryImpl.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogFactoryImpl.java
@@ -22,9 +22,9 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLogAccumulator;
@@ -160,8 +160,10 @@ public class TrieLogFactoryImpl implements TrieLogFactory {
         input.skipNext();
       } else {
         input.enterList();
-        final StateTrieAccountValue oldValue = nullOrValue(input, StateTrieAccountValue::readFrom);
-        final StateTrieAccountValue newValue = nullOrValue(input, StateTrieAccountValue::readFrom);
+        final PmtStateTrieAccountValue oldValue =
+            nullOrValue(input, PmtStateTrieAccountValue::readFrom);
+        final PmtStateTrieAccountValue newValue =
+            nullOrValue(input, PmtStateTrieAccountValue::readFrom);
         final boolean isCleared = getOptionalIsCleared(input);
         input.leaveList();
         newLayer

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/forest/worldview/ForestMutableWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/forest/worldview/ForestMutableWorldState.java
@@ -23,9 +23,9 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStatePreimageStorage;
 import org.hyperledger.besu.evm.account.Account;
@@ -137,7 +137,7 @@ public class ForestMutableWorldState implements MutableWorldState {
   private WorldStateAccount deserializeAccount(
       final Address address, final Hash addressHash, final Bytes encoded) throws RLPException {
     final RLPInput in = RLP.input(encoded);
-    final StateTrieAccountValue accountValue = StateTrieAccountValue.readFrom(in);
+    final PmtStateTrieAccountValue accountValue = PmtStateTrieAccountValue.readFrom(in);
     return new WorldStateAccount(address, addressHash, accountValue);
   }
 
@@ -224,13 +224,15 @@ public class ForestMutableWorldState implements MutableWorldState {
     private final Address address;
     private final Hash addressHash;
 
-    final StateTrieAccountValue accountValue;
+    final PmtStateTrieAccountValue accountValue;
 
     // Lazily initialized since we don't always access storage.
     private volatile MerkleTrie<Bytes32, Bytes> storageTrie;
 
     private WorldStateAccount(
-        final Address address, final Hash addressHash, final StateTrieAccountValue accountValue) {
+        final Address address,
+        final Hash addressHash,
+        final PmtStateTrieAccountValue accountValue) {
 
       this.address = address;
       this.addressHash = addressHash;
@@ -454,8 +456,8 @@ public class ForestMutableWorldState implements MutableWorldState {
 
     private static Bytes serializeAccount(
         final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
-      final StateTrieAccountValue accountValue =
-          new StateTrieAccountValue(nonce, balance, storageRoot, codeHash);
+      final PmtStateTrieAccountValue accountValue =
+          new PmtStateTrieAccountValue(nonce, balance, storageRoot, codeHash);
       return RLP.encode(accountValue::writeTo);
     }
   }

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TrieGenerator.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/TrieGenerator.java
@@ -20,9 +20,9 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
@@ -74,8 +74,9 @@ public class TrieGenerator {
           });
       final Bytes code = Bytes32.leftPad(Bytes.of(i + 10));
       final Hash codeHash = Hash.hash(code);
-      final StateTrieAccountValue accountValue =
-          new StateTrieAccountValue(1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash);
+      final PmtStateTrieAccountValue accountValue =
+          new PmtStateTrieAccountValue(
+              1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash);
       accountStateTrie.put(accounts.get(i), RLP.encode(accountValue::writeTo));
       applyForStrategy(
           updater,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/proof/WorldStateProofProviderTest.java
@@ -21,9 +21,9 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.services.kvstore.InMemoryKeyValueStorage;
 
@@ -82,8 +82,9 @@ public class WorldStateProofProviderTest {
 
     // Define account value
     final Hash codeHash = Hash.hash(Bytes.fromHexString("0x1122"));
-    final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash);
+    final PmtStateTrieAccountValue accountValue =
+        new PmtStateTrieAccountValue(
+            1L, Wei.of(2L), Hash.wrap(storageTrie.getRootHash()), codeHash);
     // Save to storage
     worldStateTrie.put(addressHash, RLP.encode(accountValue::writeTo));
     worldStateTrie.commit((location, hash, value) -> updater.putAccountStateTrieNode(hash, value));

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiCachedMerkleTrieLoaderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiCachedMerkleTrieLoaderTest.java
@@ -25,11 +25,11 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
@@ -96,8 +96,8 @@ class BonsaiCachedMerkleTrieLoaderTest {
   @Test
   void shouldAddStorageNodesInCacheDuringPreload() {
     final Hash hashAccountZero = accounts.get(0).addressHash();
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(trie.get(hashAccountZero).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(trie.get(hashAccountZero).orElseThrow()));
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
             (location, hash) ->
@@ -154,8 +154,8 @@ class BonsaiCachedMerkleTrieLoaderTest {
   @Test
   void shouldFallbackWhenStorageNodesIsNotInCache() {
     final Hash hashAccountZero = accounts.get(0).addressHash();
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(trie.get(hashAccountZero).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(trie.get(hashAccountZero).orElseThrow()));
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
             (location, hash) ->

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/BonsaiWorldStateKeyValueStorageTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/BonsaiWorldStateKeyValueStorageTest.java
@@ -36,12 +36,12 @@ import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.StorageEntriesCollector;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
 import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.ImmutableDiffBasedSubStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
@@ -316,8 +316,8 @@ public class BonsaiWorldStateKeyValueStorageTest {
         (TreeMap<Bytes32, Bytes>)
             trie.entriesFrom(root -> StorageEntriesCollector.collectEntries(root, Hash.ZERO, 1));
 
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accounts.firstEntry().getValue()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(accounts.firstEntry().getValue()));
 
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogFactoryTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogFactoryTests.java
@@ -23,8 +23,8 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogLayer;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLogFactory;
@@ -54,7 +54,7 @@ public class TrieLogFactoryTests {
           .addAccountChange(
               accountFixture,
               null,
-              new StateTrieAccountValue(0, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY))
+              new PmtStateTrieAccountValue(0, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY))
           .addCodeChange(
               Address.ZERO,
               null,

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogLayerTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/common/trielog/TrieLogLayerTests.java
@@ -19,7 +19,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import java.util.Optional;
 
@@ -51,15 +51,16 @@ public class TrieLogLayerTests {
   @Test
   public void testAddAccountChange() {
     Address address = Address.fromHexString("0x00");
-    StateTrieAccountValue oldValue = new StateTrieAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
-    StateTrieAccountValue newValue =
-        new StateTrieAccountValue(1, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY);
+    PmtStateTrieAccountValue oldValue =
+        new PmtStateTrieAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
+    PmtStateTrieAccountValue newValue =
+        new PmtStateTrieAccountValue(1, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY);
 
     Address otherAddress = Address.fromHexString("0x000000");
-    StateTrieAccountValue otherOldValue =
-        new StateTrieAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
-    StateTrieAccountValue otherNewValue =
-        new StateTrieAccountValue(1, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY);
+    PmtStateTrieAccountValue otherOldValue =
+        new PmtStateTrieAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
+    PmtStateTrieAccountValue otherNewValue =
+        new PmtStateTrieAccountValue(1, Wei.fromEth(1), Hash.EMPTY, Hash.EMPTY);
 
     trieLogLayer.addAccountChange(address, oldValue, newValue);
     otherTrieLogLayer.addAccountChange(otherAddress, otherOldValue, otherNewValue);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValueTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/worldstate/StateTrieAccountValueTest.java
@@ -20,6 +20,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.Test;
@@ -41,11 +42,11 @@ public class StateTrieAccountValueTest {
   private void roundTripMainNetAccountValue(
       final long nonce, final Wei balance, final Hash storageRoot, final Hash codeHash) {
 
-    StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(nonce, balance, storageRoot, codeHash);
+    PmtStateTrieAccountValue accountValue =
+        new PmtStateTrieAccountValue(nonce, balance, storageRoot, codeHash);
     Bytes encoded = RLP.encode(accountValue::writeTo);
     final RLPInput in = RLP.input(encoded);
-    StateTrieAccountValue roundTripAccountValue = StateTrieAccountValue.readFrom(in);
+    PmtStateTrieAccountValue roundTripAccountValue = PmtStateTrieAccountValue.readFrom(in);
 
     assertThat(nonce).isEqualTo(roundTripAccountValue.getNonce());
     assertThat(balance).isEqualTo(roundTripAccountValue.getBalance());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/AccountRangeMessage.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/messages/snap/AccountRangeMessage.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.MessageData;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPInput;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -121,7 +121,7 @@ public final class AccountRangeMessage extends AbstractSnapMessageData {
 
   @VisibleForTesting
   public static Bytes toFullAccount(final RLPInput rlpInput) {
-    final StateTrieAccountValue accountValue = StateTrieAccountValue.readFrom(rlpInput);
+    final PmtStateTrieAccountValue accountValue = PmtStateTrieAccountValue.readFrom(rlpInput);
 
     final BytesValueRLPOutput rlpOutput = new BytesValueRLPOutput();
     rlpOutput.startList();
@@ -135,7 +135,7 @@ public final class AccountRangeMessage extends AbstractSnapMessageData {
   }
 
   public static Bytes toSlimAccount(final RLPInput rlpInput) {
-    StateTrieAccountValue accountValue = StateTrieAccountValue.readFrom(rlpInput);
+    PmtStateTrieAccountValue accountValue = PmtStateTrieAccountValue.readFrom(rlpInput);
     var rlpOutput = new BytesValueRLPOutput();
     rlpOutput.startList();
     rlpOutput.writeLongScalar(accountValue.getNonce());

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/AccountTrieNodeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/AccountTrieNodeDataRequest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import org.hyperledger.besu.ethereum.trie.CompactEncoding;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
@@ -73,7 +73,8 @@ class AccountTrieNodeDataRequest extends TrieNodeDataRequest {
       final Bytes path,
       final Bytes value) {
     final Stream.Builder<NodeDataRequest> builder = Stream.builder();
-    final StateTrieAccountValue accountValue = StateTrieAccountValue.readFrom(RLP.input(value));
+    final PmtStateTrieAccountValue accountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(value));
 
     final Optional<Hash> accountHash =
         Optional.of(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/AccountRangeDataRequest.java
@@ -31,9 +31,9 @@ import org.hyperledger.besu.ethereum.proof.WorldStateProofProvider;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 import org.hyperledger.besu.ethereum.trie.NodeUpdater;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
@@ -210,8 +210,8 @@ public class AccountRangeDataRequest extends SnapDataRequest {
 
     // find missing storages and code
     for (Map.Entry<Bytes32, Bytes> account : taskElement.keys().entrySet()) {
-      final StateTrieAccountValue accountValue =
-          StateTrieAccountValue.readFrom(RLP.input(account.getValue()));
+      final PmtStateTrieAccountValue accountValue =
+          PmtStateTrieAccountValue.readFrom(RLP.input(account.getValue()));
       if (!accountValue.getStorageRoot().equals(Hash.EMPTY_TRIE_HASH)) {
         childRequests.add(
             createStorageRangeDataRequest(

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/AccountFlatDatabaseHealingRangeRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/AccountFlatDatabaseHealingRangeRequest.java
@@ -31,9 +31,9 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.RangeStorageEntriesCollector;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
@@ -104,8 +104,8 @@ public class AccountFlatDatabaseHealingRangeRequest extends SnapDataRequest {
               if (downloadState
                   .getAccountsHealingList()
                   .contains(CompactEncoding.bytesToPath(account.getKey()))) {
-                final StateTrieAccountValue accountValue =
-                    StateTrieAccountValue.readFrom(RLP.input(account.getValue()));
+                final PmtStateTrieAccountValue accountValue =
+                    PmtStateTrieAccountValue.readFrom(RLP.input(account.getValue()));
                 childRequests.add(
                     createStorageFlatHealingRangeRequest(
                         getRootHash(),

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/AccountTrieNodeHealingRequest.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/AccountTrieNodeHealingRequest.java
@@ -25,8 +25,8 @@ import org.hyperledger.besu.ethereum.eth.sync.snapsync.request.SnapDataRequest;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.CompactEncoding;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 
@@ -120,7 +120,7 @@ public class AccountTrieNodeHealingRequest extends TrieNodeHealingRequest {
                   getLocation().size(),
                   account.size() - getLocation().size()))
           .map(RLP::input)
-          .map(StateTrieAccountValue::readFrom)
+          .map(PmtStateTrieAccountValue::readFrom)
           .filter(
               stateTrieAccountValue ->
                   // We need to ensure that the accounts to be healed do not have empty storage.
@@ -152,7 +152,8 @@ public class AccountTrieNodeHealingRequest extends TrieNodeHealingRequest {
       final Bytes path,
       final Bytes value) {
     final Stream.Builder<SnapDataRequest> builder = Stream.builder();
-    final StateTrieAccountValue accountValue = StateTrieAccountValue.readFrom(RLP.input(value));
+    final PmtStateTrieAccountValue accountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(value));
 
     // Retrieve account hash
     final Hash accountHash =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/snap/SnapServerTest.java
@@ -37,13 +37,13 @@ import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.CompactEncoding;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.flat.BonsaiFlatDbStrategyProvider;
 import org.hyperledger.besu.ethereum.trie.patricia.SimpleMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -71,7 +71,7 @@ public class SnapServerTest {
 
   record SnapTestAccount(
       Hash addressHash,
-      StateTrieAccountValue accountValue,
+      PmtStateTrieAccountValue accountValue,
       MerkleTrie<Bytes32, Bytes> storage,
       Bytes code) {
     Bytes accountRLP() {
@@ -722,7 +722,7 @@ public class SnapServerTest {
   static SnapTestAccount createTestAccount(final String hexAddr) {
     return new SnapTestAccount(
         Hash.wrap(Bytes32.rightPad(Bytes.fromHexString(hexAddr))),
-        new StateTrieAccountValue(
+        new PmtStateTrieAccountValue(
             rand.nextInt(0, 1), Wei.of(rand.nextLong(0L, 1L)), Hash.EMPTY_TRIE_HASH, Hash.EMPTY),
         new SimpleMerklePatriciaTrie<>(a -> a),
         Bytes.EMPTY);
@@ -768,7 +768,7 @@ public class SnapServerTest {
     updater.commit();
     return new SnapTestAccount(
         acctHash,
-        new StateTrieAccountValue(
+        new PmtStateTrieAccountValue(
             rand.nextInt(0, 1), Wei.of(rand.nextLong(0L, 1L)),
             Hash.wrap(trie.getRootHash()), Hash.hash(mockCode)),
         trie,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/AccountRangeMessageTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/messages/snap/AccountRangeMessageTest.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.ethereum.p2p.rlpx.wire.RawMessage;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,8 +39,8 @@ public final class AccountRangeMessageTest {
   @Test
   public void roundTripTest() {
     final Map<Bytes32, Bytes> keys = new HashMap<>();
-    final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(1L, Wei.of(2L), Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
+    final PmtStateTrieAccountValue accountValue =
+        new PmtStateTrieAccountValue(1L, Wei.of(2L), Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
     keys.put(Hash.wrap(Bytes32.leftPad(Bytes.of(1))), RLP.encode(accountValue::writeTo));
 
     final List<Bytes> proofs = new ArrayList<>();
@@ -65,8 +65,8 @@ public final class AccountRangeMessageTest {
     Wei balance = Wei.of(2L);
 
     // Create a StateTrieAccountValue with the given nonce and balance
-    final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(nonce, balance, Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
+    final PmtStateTrieAccountValue accountValue =
+        new PmtStateTrieAccountValue(nonce, balance, Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
 
     // Encode the account value to RLP
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();
@@ -104,8 +104,8 @@ public final class AccountRangeMessageTest {
     Wei balance = Wei.of(2L);
 
     // Create a StateTrieAccountValue with the given nonce and balance
-    final StateTrieAccountValue accountValue =
-        new StateTrieAccountValue(nonce, balance, Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
+    final PmtStateTrieAccountValue accountValue =
+        new PmtStateTrieAccountValue(nonce, balance, Hash.EMPTY_TRIE_HASH, Hash.EMPTY);
 
     // Encode the account value to RLP
     final BytesValueRLPOutput rlpOut = new BytesValueRLPOutput();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastWorldStateDownloaderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/fastsync/worldstate/FastWorldStateDownloaderTest.java
@@ -51,11 +51,11 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.storage.keyvalue.WorldStatePreimageKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.Node;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.forest.ForestWorldStateArchive;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.patricia.TrieNodeDecoder;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStatePreimageStorage;
@@ -589,8 +589,8 @@ class FastWorldStateDownloaderTest {
                 Function.identity())
             .entriesFrom(Bytes32.ZERO, 5).values().stream()
                 .map(RLP::input)
-                .map(StateTrieAccountValue::readFrom)
-                .map(StateTrieAccountValue::getStorageRoot)
+                .map(PmtStateTrieAccountValue::readFrom)
+                .map(PmtStateTrieAccountValue::getStorageRoot)
                 .collect(Collectors.toList());
     final Map<Bytes32, Bytes> allTrieNodes = new HashMap<>();
     final Set<Bytes32> knownNodes = new HashSet<>();

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/AccountHealingTrackingTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/AccountHealingTrackingTest.java
@@ -31,11 +31,11 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.RangeStorageEntriesCollector;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredNodeFactory;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
@@ -82,8 +82,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldMarkAccountForHealingWhenStorageProofIsReceived() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
 
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
@@ -130,8 +131,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldNotMarkAccountForHealingWhenAllStorageIsReceivedWithoutProof() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
 
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
@@ -171,8 +173,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldMarkAccountForHealingOnInvalidStorageProof() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
 
     final List<Bytes> proofs =
         List.of(
@@ -197,8 +200,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldMarkAccountForHealingOnInvalidStorageWithoutProof() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
 
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
@@ -236,8 +240,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldMarkAccountForHealingOnPartialStorageRange() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
 
     final StoredMerklePatriciaTrie<Bytes, Bytes> storageTrie =
         new StoredMerklePatriciaTrie<>(
@@ -286,8 +291,9 @@ public class AccountHealingTrackingTest {
   @Test
   void shouldNotMarkAccountForHealingOnValidStorageTrieNodeDetection() {
     final Hash accountHash = Hash.hash(accounts.get(0));
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(
+            RLP.input(accountStateTrie.get(accountHash).orElseThrow()));
     final StorageTrieNodeHealingRequest storageTrieNodeHealingRequest =
         SnapDataRequest.createStorageTrieNodeDataRequest(
             stateTrieAccountValue.getStorageRoot(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/TaskGenerator.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/TaskGenerator.java
@@ -27,10 +27,10 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.RangeStorageEntriesCollector;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.services.tasks.Task;
@@ -81,8 +81,8 @@ public class TaskGenerator {
       accountRangeDataRequest.addResponse(worldStateProofProvider, accounts, new ArrayDeque<>());
     }
 
-    final StateTrieAccountValue stateTrieAccountValue =
-        StateTrieAccountValue.readFrom(RLP.input(accounts.firstEntry().getValue()));
+    final PmtStateTrieAccountValue stateTrieAccountValue =
+        PmtStateTrieAccountValue.readFrom(RLP.input(accounts.firstEntry().getValue()));
     final Hash accountHash = Hash.wrap(accounts.firstKey());
 
     final StorageRangeDataRequest storageRangeDataRequest =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/StorageFlatDatabaseHealingRangeRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/StorageFlatDatabaseHealingRangeRequestTest.java
@@ -31,10 +31,10 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.RangeManager;
 import org.hyperledger.besu.ethereum.trie.RangeStorageEntriesCollector;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -97,8 +97,8 @@ class StorageFlatDatabaseHealingRangeRequestTest {
     account0StorageRoot =
         trie.get(account0Hash)
             .map(RLP::input)
-            .map(StateTrieAccountValue::readFrom)
-            .map(StateTrieAccountValue::getStorageRoot)
+            .map(PmtStateTrieAccountValue::readFrom)
+            .map(PmtStateTrieAccountValue::getStorageRoot)
             .orElseThrow();
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/StorageTrieNodeHealingRequestTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/snapsync/request/heal/StorageTrieNodeHealingRequestTest.java
@@ -23,10 +23,10 @@ import org.hyperledger.besu.ethereum.core.TrieGenerator;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
-import org.hyperledger.besu.ethereum.worldstate.StateTrieAccountValue;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateStorageCoordinator;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
@@ -92,8 +92,8 @@ class StorageTrieNodeHealingRequestTest {
     account0StorageRoot =
         trie.get(account0Hash)
             .map(RLP::input)
-            .map(StateTrieAccountValue::readFrom)
-            .map(StateTrieAccountValue::getStorageRoot)
+            .map(PmtStateTrieAccountValue::readFrom)
+            .map(PmtStateTrieAccountValue::getStorageRoot)
             .orElseThrow();
   }
 


### PR DESCRIPTION
## PR description

Idea of this PR is to prepare integration of verkle by doing a small renaming of the state trie account value class and creating an abstract class for the common part between verkle and pmt 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

