### PR TITLE
shorten rolling increment to 32

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
   private final ProtocolContext protocolContext;
   private static final Logger LOG = LoggerFactory.getLogger(DebugSetHead.class);
-  private static final int DEFAULT_MAX_TRIE_LOGS_TO_ROLL_AT_ONCE = 512;
+  private static final int DEFAULT_MAX_TRIE_LOGS_TO_ROLL_AT_ONCE = 32;
 
   private final long maxTrieLogsToRollAtOnce;
 


### PR DESCRIPTION
## PR description
simple change to state rolling increment for `debug_setHead`.  This PR shortens this interval to 32.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

Discovered while verifying #7804, chain and state rolling with an interval of 512 can lead to out-of-memory.  

confirmed by rolling state 209k blocks back on main to the block referenced in #7804.  trace for the block in question attached

[trace_block_21030627.json](https://github.com/user-attachments/files/17872858/trace_block_21030627.json)


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

