### PR TITLE
Fix unnecessary use of -a option in read command in dco_check.sh

### DIFF
--- a/scripts/dco_check.sh
+++ b/scripts/dco_check.sh
@@ -15,7 +15,7 @@
 ##
 
 status=0
-while IFS= read -r -a line; do
+while IFS= read -r line; do
   my_array+=( "$line" )
   done < <( git branch -r | grep -v origin/HEAD )
 for branch in "${my_array[@]}"


### PR DESCRIPTION
**Description:**

This PR fixes a typo in the script where the `read` command incorrectly used the `-a` option. 

### Issue:
In the following line:

```bash
while IFS= read -r -a line; do
```

The `-a` option was used, which is meant for reading input into an array. However, this was unnecessary because each line is added to an array with `my_array+=( "$line" )` after reading it. The correct approach is to simply read the line without the `-a` option.

### Fix:
```bash
while IFS= read -r line; do
```

### Importance:
- The `-a` option is not required here and could lead to confusion or unintended behavior.
- Removing the `-a` option simplifies the command and makes the script more efficient by avoiding the unnecessary creation of an array for each line.
- This change improves the clarity and correctness of the script.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

