### PR TITLE
Do not return gas cost along with ExceptionalHaltReason in OperationResult unless OOG

### DIFF
--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x10.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x10.json
@@ -214,12 +214,12 @@
               "sub": null
             },
             {
-              "cost": 8,
+              "cost": 0,
               "ex": {
                 "mem": null,
                 "push": [],
                 "store": null,
-                "used": 16756191
+                "used": 16756199
               },
               "pc": 2,
               "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x1E.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x1E.json
@@ -244,7 +244,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 30000,
+                    "cost": 0,
                     "ex": null,
                     "pc": 21,
                     "sub": null
@@ -411,7 +411,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 30000,
+                    "cost": 0,
                     "ex": null,
                     "pc": 21,
                     "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x1E.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/all/trace_replayBlockTransactions_all_0x1E.json
@@ -244,7 +244,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 0,
+                    "cost": 30000,
                     "ex": null,
                     "pc": 21,
                     "sub": null
@@ -411,7 +411,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 0,
+                    "cost": 30000,
                     "ex": null,
                     "pc": 21,
                     "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/halt-cases/trace_replayBlockTransactions_halt_case_0x10.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/halt-cases/trace_replayBlockTransactions_halt_case_0x10.json
@@ -83,12 +83,12 @@
               "sub": null
             },
             {
-              "cost": 8,
+              "cost": 0,
               "ex": {
                 "mem": null,
                 "push": [],
                 "store": null,
-                "used": 16756191
+                "used": 16756199
               },
               "pc": 2,
               "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x10.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x10.json
@@ -83,12 +83,12 @@
               "sub": null
             },
             {
-              "cost": 8,
+              "cost": 0,
               "ex": {
                 "mem": null,
                 "push": [],
                 "store": null,
-                "used": 16756191
+                "used": 16756199
               },
               "pc": 2,
               "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x1E.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x1E.json
@@ -153,7 +153,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 0,
+                    "cost": 30000,
                     "ex": null,
                     "pc": 21,
                     "sub": null
@@ -320,7 +320,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 0,
+                    "cost": 30000,
                     "ex": null,
                     "pc": 21,
                     "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x1E.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/replay-trace-transaction/vm-trace/trace_replayBlockTransactions_0x1E.json
@@ -153,7 +153,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 30000,
+                    "cost": 0,
                     "ex": null,
                     "pc": 21,
                     "sub": null
@@ -320,7 +320,7 @@
                     "sub": null
                   },
                   {
-                    "cost": 30000,
+                    "cost": 0,
                     "ex": null,
                     "pc": 21,
                     "sub": null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_10_2_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_10_2_vmTrace.json
@@ -32,12 +32,12 @@
           "pc" : 0,
           "sub" : null
         }, {
-          "cost" : 8,
+          "cost" : 0,
           "ex" : {
             "mem" : null,
             "push" : [ ],
             "store" : null,
-            "used" : 16756191
+            "used" : 16756199
           },
           "pc" : 2,
           "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_1e_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_1e_0_vmTrace.json
@@ -124,7 +124,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 30000,
+              "cost" : 0,
               "ex" : null,
               "pc" : 21,
               "sub" : null
@@ -255,7 +255,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 30000,
+              "cost" : 0,
               "ex" : null,
               "pc" : 21,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_1e_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_1e_0_vmTrace.json
@@ -124,7 +124,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 30000,
               "ex" : null,
               "pc" : 21,
               "sub" : null
@@ -255,7 +255,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 30000,
               "ex" : null,
               "pc" : 21,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_20_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_20_0_vmTrace.json
@@ -160,7 +160,7 @@
               "pc" : 9,
               "sub" : null
             }, {
-              "cost" : 32009,
+              "cost" : 0,
               "ex" : null,
               "pc" : 11,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_20_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-call/trace_call_20_0_vmTrace.json
@@ -160,7 +160,7 @@
               "pc" : 9,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 32009,
               "ex" : null,
               "pc" : 11,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_10_2_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_10_2_vmTrace.json
@@ -25,12 +25,12 @@
           "pc" : 0,
           "sub" : null
         }, {
-          "cost" : 8,
+          "cost" : 0,
           "ex" : {
             "mem" : null,
             "push" : [ ],
             "store" : null,
-            "used" : 16756191
+            "used" : 16756199
           },
           "pc" : 2,
           "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_1e_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_1e_0_vmTrace.json
@@ -116,7 +116,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 30000,
+              "cost" : 0,
               "ex" : null,
               "pc" : 21,
               "sub" : null
@@ -247,7 +247,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 30000,
+              "cost" : 0,
               "ex" : null,
               "pc" : 21,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_1e_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_1e_0_vmTrace.json
@@ -116,7 +116,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 30000,
               "ex" : null,
               "pc" : 21,
               "sub" : null
@@ -247,7 +247,7 @@
               "pc" : 0,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 30000,
               "ex" : null,
               "pc" : 21,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_20_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_20_0_vmTrace.json
@@ -152,7 +152,7 @@
               "pc" : 9,
               "sub" : null
             }, {
-              "cost" : 0,
+              "cost" : 32009,
               "ex" : null,
               "pc" : 11,
               "sub" : null

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_20_0_vmTrace.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/trace/specs/trace-raw-transaction/trace_rawTransaction_20_0_vmTrace.json
@@ -152,7 +152,7 @@
               "pc" : 9,
               "sub" : null
             }, {
-              "cost" : 32009,
+              "cost" : 0,
               "ex" : null,
               "pc" : 11,
               "sub" : null

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.log.Log;
-import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -67,8 +67,7 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
   }
 
   @Override
-  public void tracePostExecution(
-      final MessageFrame frame, final Operation.OperationResult operationResult) {
+  public void tracePostExecution(final MessageFrame frame, final OperationResult operationResult) {
     checkInterrupt();
     delegate.tracePostExecution(frame, operationResult);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/FlexiblePrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/FlexiblePrivacyPrecompiledContract.java
@@ -205,8 +205,7 @@ public class FlexiblePrivacyPrecompiledContract extends PrivacyPrecompiledContra
           pmtHash, privacyGroupId, disposablePrivateState, privateMetadataUpdater, result);
     }
 
-    return new PrecompileContractResult(
-        result.getOutput(), true, MessageFrame.State.CODE_EXECUTING, Optional.empty());
+    return PrecompileContractResult.executing(result.getOutput());
   }
 
   private void sendParticipantRemovedEvent(final PrivateTransaction privateTransaction) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
@@ -116,7 +116,6 @@ public class PrivacyPluginPrecompiledContract extends PrivacyPrecompiledContract
           pmtHash, privacyGroupId, disposablePrivateState, privateMetadataUpdater, result);
     }
 
-    return new PrecompileContractResult(
-        result.getOutput(), true, MessageFrame.State.CODE_EXECUTING, Optional.empty());
+    return PrecompileContractResult.executing(result.getOutput());
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContract.java
@@ -50,7 +50,6 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Base64;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -68,9 +67,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyPrecompiledContract.class);
 
-  static final PrecompileContractResult NO_RESULT =
-      new PrecompileContractResult(
-          Bytes.EMPTY, true, MessageFrame.State.CODE_EXECUTING, Optional.empty());
+  static final PrecompileContractResult NO_RESULT = PrecompileContractResult.executing(Bytes.EMPTY);
 
   public PrivacyPrecompiledContract(
       final GasCalculator gasCalculator,
@@ -219,8 +216,7 @@ public class PrivacyPrecompiledContract extends AbstractPrecompiledContract {
           pmtHash, privacyGroupId, disposablePrivateState, privateMetadataUpdater, result);
     }
 
-    return new PrecompileContractResult(
-        result.getOutput(), true, MessageFrame.State.CODE_EXECUTING, Optional.empty());
+    return PrecompileContractResult.executing(result.getOutput());
   }
 
   protected void maybeApplyGenesisToPrivateWorldState(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracer.java
@@ -23,7 +23,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.AbstractCallOperation;
 import org.hyperledger.besu.evm.operation.Operation;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -193,7 +193,7 @@ class DebugOperationTracerTest {
 
     final DebugOperationTracer tracer =
         new DebugOperationTracer(new TraceOptions(true, true, true), false);
-    tracer.tracePostExecution(frame, OperationResult.insufficientGas());
+    tracer.tracePostExecution(frame, OperationResult.insufficientGas(50L));
 
     final TraceFrame traceFrame = getOnlyTraceFrame(tracer);
     assertThat(traceFrame.getExceptionalHaltReason())

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/DebugOperationTracerTest.java
@@ -33,7 +33,7 @@ import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.operation.AbstractOperation;
 import org.hyperledger.besu.evm.operation.CallOperation;
 import org.hyperledger.besu.evm.operation.Operation;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import java.util.Map;
@@ -62,7 +62,7 @@ class DebugOperationTracerTest {
       new AbstractOperation(0x02, "MUL", 2, 1, null) {
         @Override
         public OperationResult execute(final MessageFrame frame, final EVM evm) {
-          return new OperationResult(20L, null);
+          return new OperationResult(20L);
         }
       };
 
@@ -193,8 +193,7 @@ class DebugOperationTracerTest {
 
     final DebugOperationTracer tracer =
         new DebugOperationTracer(new TraceOptions(true, true, true), false);
-    tracer.tracePostExecution(
-        frame, new OperationResult(50L, ExceptionalHaltReason.INSUFFICIENT_GAS));
+    tracer.tracePostExecution(frame, OperationResult.insufficientGas());
 
     final TraceFrame traceFrame = getOnlyTraceFrame(tracer);
     assertThat(traceFrame.getExceptionalHaltReason())

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/EstimateGasOperationTracerTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/vm/EstimateGasOperationTracerTest.java
@@ -21,7 +21,7 @@ import org.hyperledger.besu.ethereum.core.MessageFrameTestFixture;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.operation.CallCodeOperation;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.operation.SStoreOperation;
 import org.hyperledger.besu.evm.tracing.EstimateGasOperationTracer;
 
@@ -45,7 +45,7 @@ public class EstimateGasOperationTracerTest {
   @Test
   public void shouldDetectChangeInDepthDuringExecution() {
 
-    final OperationResult testResult = new OperationResult(6, null);
+    final OperationResult testResult = new OperationResult(6);
 
     assertThat(operationTracer.getMaxDepth()).isZero();
 
@@ -76,7 +76,7 @@ public class EstimateGasOperationTracerTest {
   @Test
   public void shouldDetectMinimumGasRemainingForSStoreOperation() {
 
-    final OperationResult testResult = new OperationResult(6, null);
+    final OperationResult testResult = new OperationResult(6);
     final long minimumGasRemaining = 2300L;
 
     assertThat(operationTracer.getStipendNeeded()).isZero();

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
@@ -63,7 +63,7 @@
     {"pc":3,"op":83,"gas":"0x8c6","gasCost":"0xc","memSize":0,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"MSTORE8"},
     {"pc":4,"op":96,"gas":"0x8ba","gasCost":"0x3","memSize":96,"stack":[],"depth":4,"refund":0,"opName":"PUSH1"},
     {"pc":6,"op":96,"gas":"0x8b7","gasCost":"0x3","memSize":96,"stack":["0x40"],"depth":4,"refund":0,"opName":"PUSH1"},
-    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x8fc","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
+    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x0","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
     {"pc":22,"op":96,"gas":"0x23","gasCost":"0x3","memSize":96,"stack":["0x0"],"depth":3,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x20","gasCost":"0x0","memSize":96,"stack":["0x0","0x40"],"depth":3,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x48","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":2,"refund":0,"opName":"PUSH1"},

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/charge-intrinsic.json
@@ -63,7 +63,7 @@
     {"pc":3,"op":83,"gas":"0x8c6","gasCost":"0xc","memSize":0,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"MSTORE8"},
     {"pc":4,"op":96,"gas":"0x8ba","gasCost":"0x3","memSize":96,"stack":[],"depth":4,"refund":0,"opName":"PUSH1"},
     {"pc":6,"op":96,"gas":"0x8b7","gasCost":"0x3","memSize":96,"stack":["0x40"],"depth":4,"refund":0,"opName":"PUSH1"},
-    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x0","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
+    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x8fc","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
     {"pc":22,"op":96,"gas":"0x23","gasCost":"0x3","memSize":96,"stack":["0x0"],"depth":3,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x20","gasCost":"0x0","memSize":96,"stack":["0x0","0x40"],"depth":3,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x48","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":2,"refund":0,"opName":"PUSH1"},

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
@@ -60,7 +60,7 @@
     {"pc":3,"op":83,"gas":"0x8c6","gasCost":"0xc","memSize":0,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"MSTORE8"},
     {"pc":4,"op":96,"gas":"0x8ba","gasCost":"0x3","memSize":96,"stack":[],"depth":4,"refund":0,"opName":"PUSH1"},
     {"pc":6,"op":96,"gas":"0x8b7","gasCost":"0x3","memSize":96,"stack":["0x40"],"depth":4,"refund":0,"opName":"PUSH1"},
-    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x8fc","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
+    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x0","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
     {"pc":22,"op":96,"gas":"0x23","gasCost":"0x3","memSize":96,"stack":["0x0"],"depth":3,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x20","gasCost":"0x0","memSize":96,"stack":["0x0","0x40"],"depth":3,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x48","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":2,"refund":0,"opName":"PUSH1"},

--- a/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
+++ b/ethereum/evmtool/src/test/resources/org/hyperledger/besu/evmtool/trace/warm-contract.json
@@ -60,7 +60,7 @@
     {"pc":3,"op":83,"gas":"0x8c6","gasCost":"0xc","memSize":0,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"MSTORE8"},
     {"pc":4,"op":96,"gas":"0x8ba","gasCost":"0x3","memSize":96,"stack":[],"depth":4,"refund":0,"opName":"PUSH1"},
     {"pc":6,"op":96,"gas":"0x8b7","gasCost":"0x3","memSize":96,"stack":["0x40"],"depth":4,"refund":0,"opName":"PUSH1"},
-    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x0","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
+    {"pc":8,"op":85,"gas":"0x8b4","gasCost":"0x8fc","memSize":96,"stack":["0x40","0x40"],"depth":4,"refund":0,"opName":"SSTORE","error":"Out of gas"},
     {"pc":22,"op":96,"gas":"0x23","gasCost":"0x3","memSize":96,"stack":["0x0"],"depth":3,"refund":0,"opName":"PUSH1"},
     {"pc":24,"op":243,"gas":"0x20","gasCost":"0x0","memSize":96,"stack":["0x0","0x40"],"depth":3,"refund":0,"opName":"RETURN"},
     {"pc":22,"op":96,"gas":"0x48","gasCost":"0x3","memSize":96,"stack":["0x1"],"depth":2,"refund":0,"opName":"PUSH1"},

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -233,7 +233,6 @@ public class EVM {
               case 0x0a -> ExpOperation.staticOperation(frame, gasCalculator);
               case 0x0b -> SignExtendOperation.staticOperation(frame);
               case 0x0c, 0x0d, 0x0e, 0x0f -> OperationResult.invalidOperation();
-
               case 0x10 -> LtOperation.staticOperation(frame);
               case 0x11 -> GtOperation.staticOperation(frame);
               case 0x12 -> SLtOperation.staticOperation(frame);

--- a/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/EVM.java
@@ -38,7 +38,6 @@ import org.hyperledger.besu.evm.operation.DivOperation;
 import org.hyperledger.besu.evm.operation.DupOperation;
 import org.hyperledger.besu.evm.operation.ExpOperation;
 import org.hyperledger.besu.evm.operation.GtOperation;
-import org.hyperledger.besu.evm.operation.InvalidOperation;
 import org.hyperledger.besu.evm.operation.IsZeroOperation;
 import org.hyperledger.besu.evm.operation.JumpDestOperation;
 import org.hyperledger.besu.evm.operation.JumpOperation;
@@ -49,8 +48,8 @@ import org.hyperledger.besu.evm.operation.MulModOperation;
 import org.hyperledger.besu.evm.operation.MulOperation;
 import org.hyperledger.besu.evm.operation.NotOperation;
 import org.hyperledger.besu.evm.operation.Operation;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.operation.OperationRegistry;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.operation.OrOperation;
 import org.hyperledger.besu.evm.operation.PopOperation;
 import org.hyperledger.besu.evm.operation.Push0Operation;
@@ -76,14 +75,6 @@ import org.slf4j.LoggerFactory;
 /** The Evm. */
 public class EVM {
   private static final Logger LOG = LoggerFactory.getLogger(EVM.class);
-
-  /** The constant OVERFLOW_RESPONSE. */
-  protected static final OperationResult OVERFLOW_RESPONSE =
-      new OperationResult(0L, ExceptionalHaltReason.TOO_MANY_STACK_ITEMS);
-
-  /** The constant UNDERFLOW_RESPONSE. */
-  protected static final OperationResult UNDERFLOW_RESPONSE =
-      new OperationResult(0L, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
 
   private final OperationRegistry operations;
   private final GasCalculator gasCalculator;
@@ -241,7 +232,8 @@ public class EVM {
               case 0x09 -> MulModOperation.staticOperation(frame);
               case 0x0a -> ExpOperation.staticOperation(frame, gasCalculator);
               case 0x0b -> SignExtendOperation.staticOperation(frame);
-              case 0x0c, 0x0d, 0x0e, 0x0f -> InvalidOperation.INVALID_RESULT;
+              case 0x0c, 0x0d, 0x0e, 0x0f -> OperationResult.invalidOperation();
+
               case 0x10 -> LtOperation.staticOperation(frame);
               case 0x11 -> GtOperation.staticOperation(frame);
               case 0x12 -> SLtOperation.staticOperation(frame);
@@ -259,7 +251,7 @@ public class EVM {
               case 0x5f ->
                   enableShanghai
                       ? Push0Operation.staticOperation(frame)
-                      : InvalidOperation.INVALID_RESULT;
+                      : OperationResult.invalidOperation();
               case 0x60, // PUSH1-32
                       0x61,
                       0x62,
@@ -333,9 +325,9 @@ public class EVM {
               }
             };
       } catch (final OverflowException oe) {
-        result = OVERFLOW_RESPONSE;
+        result = OperationResult.overFlow();
       } catch (final UnderflowException ue) {
-        result = UNDERFLOW_RESPONSE;
+        result = OperationResult.underFlow();
       }
       final ExceptionalHaltReason haltReason = result.getHaltReason();
       if (haltReason != null) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCallOperation.java
@@ -179,7 +179,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
     final boolean accountIsWarm = frame.warmUpAddress(to) || gasCalculator().isPrecompile(to);
     final long cost = cost(frame, accountIsWarm);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
     frame.decrementRemainingGas(cost);
 
@@ -191,7 +191,7 @@ public abstract class AbstractCallOperation extends AbstractOperation {
       final DelegatedCodeGasCostHelper.Result result =
           deductDelegatedCodeGasCost(frame, gasCalculator(), contract);
       if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-        return OperationResult.insufficientGas();
+        return OperationResult.insufficientGas(result.gasCost());
       }
     }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractCreateOperation.java
@@ -78,7 +78,7 @@ public abstract class AbstractCreateOperation extends AbstractOperation {
     if (frame.isStatic()) {
       return OperationResult.illegalStateChange();
     } else if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
     final Wei value = Wei.wrap(frame.getStackItem(0));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractExtCallOperation.java
@@ -122,7 +122,7 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
       final DelegatedCodeGasCostHelper.Result result =
           deductDelegatedCodeGasCost(frame, gasCalculator, contract);
       if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-        return OperationResult.insufficientGas();
+        return OperationResult.insufficientGas(result.gasCost());
       }
     }
 
@@ -136,7 +136,7 @@ public abstract class AbstractExtCallOperation extends AbstractCallOperation {
             + (accountCreation ? gasCalculator.newAccountGasCost() : 0);
     long currentGas = frame.getRemainingGas() - cost;
     if (currentGas < 0) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Code code =

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractFixedCostOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AbstractFixedCostOperation.java
@@ -52,7 +52,7 @@ abstract class AbstractFixedCostOperation extends AbstractOperation {
   @Override
   public final OperationResult execute(final MessageFrame frame, final EVM evm) {
     if (frame.getRemainingGas() < gasCost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(gasCost);
     } else {
       return executeFixedCostOperation(frame, evm);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AddModOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AddModOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 /** The Add mod operation. */
 public class AddModOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult addModSuccess = new OperationResult(8, null);
+  private static final OperationResult addModSuccess = new OperationResult(8);
 
   /**
    * Instantiates a new Add mod operation.
@@ -38,8 +38,7 @@ public class AddModOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AddOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AddOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class AddOperation extends AbstractFixedCostOperation {
 
   /** The Add operation success result. */
-  static final OperationResult addSuccess = new OperationResult(3, null);
+  static final OperationResult addSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Add operation.
@@ -38,8 +38,7 @@ public class AddOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AddressOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AddressOperation.java
@@ -31,8 +31,7 @@ public class AddressOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(frame.getRecipientAddress());
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/AndOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/AndOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class AndOperation extends AbstractFixedCostOperation {
 
   /** The And operation success result. */
-  static final OperationResult andSuccess = new OperationResult(3, null);
+  static final OperationResult andSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new And operation.
@@ -36,8 +36,7 @@ public class AndOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/BalanceOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/BalanceOperation.java
@@ -55,7 +55,7 @@ public class BalanceOperation extends AbstractOperation {
         frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
     final long cost = cost(accountIsWarm);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else {
       final Account account = frame.getWorldUpdater().get(address);
       frame.pushStackItem(account == null ? Bytes.EMPTY : account.getBalance());

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/BaseFeeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/BaseFeeOperation.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -35,11 +34,10 @@ public class BaseFeeOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Optional<Wei> maybeBaseFee = frame.getBlockValues().getBaseFee();
     if (maybeBaseFee.isEmpty()) {
-      return new Operation.OperationResult(gasCost, ExceptionalHaltReason.INVALID_OPERATION);
+      return OperationResult.invalidOperation();
     }
     frame.pushStackItem(maybeBaseFee.orElseThrow());
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/BlobHashOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/BlobHashOperation.java
@@ -54,7 +54,7 @@ public class BlobHashOperation extends AbstractOperation {
       if (trimmedIndex.size() > 4) {
         // won't fit in an int
         frame.pushStackItem(Bytes.EMPTY);
-        return new OperationResult(3, null);
+        return new OperationResult(3);
       }
       int versionedHashIndex = trimmedIndex.toInt();
       if (versionedHashIndex < versionedHashes.size() && versionedHashIndex >= 0) {
@@ -66,6 +66,6 @@ public class BlobHashOperation extends AbstractOperation {
     } else {
       frame.pushStackItem(Bytes.EMPTY);
     }
-    return new OperationResult(3, null);
+    return new OperationResult(3);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/BlockHashOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/BlockHashOperation.java
@@ -52,8 +52,7 @@ public class BlockHashOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Bytes blockArg = frame.popStackItem().trimLeadingZeros();
 
     // Short-circuit if value is unreasonably large

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ByteOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ByteOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class ByteOperation extends AbstractFixedCostOperation {
 
   /** The Byte operation success result. */
-  static final OperationResult byteSuccess = new OperationResult(3, null);
+  static final OperationResult byteSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Byte operation.
@@ -53,8 +53,7 @@ public class ByteOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataCopyOperation.java
@@ -42,7 +42,7 @@ public class CallDataCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Bytes callData = frame.getInputData();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataCopyOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -43,13 +42,13 @@ public class CallDataCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Bytes callData = frame.getInputData();
 
     frame.writeMemory(memOffset, sourceOffset, numBytes, callData, true);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataLoadOperation.java
@@ -35,8 +35,7 @@ public class CallDataLoadOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Bytes startWord = frame.popStackItem().trimLeadingZeros();
 
     // If the start index doesn't fit in an int, it comes after anything in data, and so the

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallDataSizeOperation.java
@@ -34,8 +34,7 @@ public class CallDataSizeOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Bytes callData = frame.getInputData();
     frame.pushStackItem(Words.intBytes(callData.size()));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallFOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallFOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.code.CodeSection;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.ReturnStack;
@@ -29,10 +28,7 @@ public class CallFOperation extends AbstractOperation {
   public static final int OPCODE = 0xe3;
 
   /** The Call F success. */
-  static final OperationResult callfSuccess = new OperationResult(5, null);
-
-  static final OperationResult callfStackOverflow =
-      new OperationResult(5, ExceptionalHaltReason.TOO_MANY_STACK_ITEMS);
+  static final OperationResult callfSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Call F operation.
@@ -47,7 +43,7 @@ public class CallFOperation extends AbstractOperation {
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
 
     int pc = frame.getPC();
@@ -55,7 +51,7 @@ public class CallFOperation extends AbstractOperation {
     CodeSection info = code.getCodeSection(section);
     int operandStackSize = frame.stackSize();
     if (operandStackSize > 1024 - info.getMaxStackHeight() + info.getInputs()) {
-      return callfStackOverflow;
+      return OperationResult.overFlow();
     }
     frame.getReturnStack().push(new ReturnStack.ReturnStackItem(frame.getSection(), pc + 2));
     frame.setPC(info.getEntryPoint() - 1); // will be +1ed at end of operations loop

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallOperation.java
@@ -19,7 +19,6 @@ import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
@@ -89,7 +88,7 @@ public class CallOperation extends AbstractCallOperation {
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     if (frame.isStatic() && !value(frame).isZero()) {
-      return new OperationResult(cost(frame, true), ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+      return OperationResult.illegalStateChange();
     } else {
       return super.execute(frame, evm);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallValueOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallValueOperation.java
@@ -32,8 +32,7 @@ public class CallValueOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Wei value = frame.getApparentValue();
     frame.pushStackItem(value.toBytes());
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CallerOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CallerOperation.java
@@ -31,8 +31,7 @@ public class CallerOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(frame.getSenderAddress());
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ChainIdOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ChainIdOperation.java
@@ -50,8 +50,7 @@ public class ChainIdOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(chainId);
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeCopyOperation.java
@@ -41,7 +41,7 @@ public class CodeCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Code code = frame.getCode();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeCopyOperation.java
@@ -18,7 +18,6 @@ import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -42,13 +41,13 @@ public class CodeCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Code code = frame.getCode();
 
     frame.writeMemory(memOffset, sourceOffset, numBytes, code.getBytes(), true);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CodeSizeOperation.java
@@ -33,8 +33,7 @@ public class CodeSizeOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Code code = frame.getCode();
     frame.pushStackItem(Words.intBytes(code.getSize()));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/CoinbaseOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/CoinbaseOperation.java
@@ -32,8 +32,7 @@ public class CoinbaseOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Address coinbase = frame.getMiningBeneficiary();
     frame.pushStackItem(coinbase);
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DataCopyOperation.java
@@ -18,7 +18,6 @@ import static org.hyperledger.besu.evm.internal.Words.clampedToInt;
 
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -53,19 +52,19 @@ public class DataCopyOperation extends AbstractOperation {
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     final int memOffset = clampedToInt(frame.popStackItem());
     final int sourceOffset = clampedToInt(frame.popStackItem());
     final int length = clampedToInt(frame.popStackItem());
     final long cost = cost(frame, memOffset, length);
     if (cost > frame.getRemainingGas()) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Bytes data = code.getData(sourceOffset, length);
     frame.writeMemory(memOffset, length, data);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DataCopyOperation.java
@@ -59,7 +59,7 @@ public class DataCopyOperation extends AbstractOperation {
     final int length = clampedToInt(frame.popStackItem());
     final long cost = cost(frame, memOffset, length);
     if (cost > frame.getRemainingGas()) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Bytes data = code.getData(sourceOffset, length);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DataLoadNOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DataLoadNOperation.java
@@ -40,7 +40,7 @@ public class DataLoadNOperation extends AbstractFixedCostOperation {
   public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
 
     int pc = frame.getPC();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DataLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DataLoadOperation.java
@@ -36,11 +36,10 @@ public class DataLoadOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     final int sourceOffset = clampedToInt(frame.popStackItem());
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DataSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DataSizeOperation.java
@@ -37,7 +37,7 @@ public class DataSizeOperation extends AbstractFixedCostOperation {
   public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     final int size = code.getDataSize();
     frame.pushStackItem(Bytes.ofUnsignedInt(size));

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DifficultyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DifficultyOperation.java
@@ -31,8 +31,7 @@ public class DifficultyOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(frame.getBlockValues().getDifficultyBytes());
     return successResponse;
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DivOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DivOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class DivOperation extends AbstractFixedCostOperation {
 
   /** The Div success. */
-  static final OperationResult divSuccess = new OperationResult(5, null);
+  static final OperationResult divSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Div operation.
@@ -38,8 +38,7 @@ public class DivOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DupNOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DupNOperation.java
@@ -26,7 +26,7 @@ public class DupNOperation extends AbstractFixedCostOperation {
   public static final int OPCODE = 0xe6;
 
   /** The Dup success operation result. */
-  static final OperationResult dupSuccess = new OperationResult(3, null);
+  static final OperationResult dupSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Dup operation.
@@ -38,11 +38,10 @@ public class DupNOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     int pc = frame.getPC();
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/DupOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/DupOperation.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -26,10 +25,7 @@ public class DupOperation extends AbstractFixedCostOperation {
   public static final int DUP_BASE = 0x7F;
 
   /** The Dup success operation result. */
-  static final OperationResult dupSuccess = new OperationResult(3, null);
-
-  /** The Underflow response. */
-  protected final Operation.OperationResult underflowResponse;
+  static final OperationResult dupSuccess = new OperationResult(3);
 
   private final int index;
 
@@ -48,13 +44,10 @@ public class DupOperation extends AbstractFixedCostOperation {
         gasCalculator,
         gasCalculator.getVeryLowTierGasCost());
     this.index = index;
-    this.underflowResponse =
-        new Operation.OperationResult(gasCost, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame, index);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/EqOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/EqOperation.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 public class EqOperation extends AbstractFixedCostOperation {
 
   /** The Eq operation success result. */
-  static final OperationResult eqSuccess = new OperationResult(3, null);
+  static final OperationResult eqSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Eq operation.
@@ -37,8 +37,7 @@ public class EqOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExchangeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExchangeOperation.java
@@ -28,7 +28,7 @@ public class ExchangeOperation extends AbstractFixedCostOperation {
   public static final int OPCODE = 0xe8;
 
   /** The Exchange operation success result. */
-  static final OperationResult exchangeSuccess = new OperationResult(3, null);
+  static final OperationResult exchangeSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Exchange operation.
@@ -43,7 +43,7 @@ public class ExchangeOperation extends AbstractFixedCostOperation {
   public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     int pc = frame.getPC();
     int imm = code.readU8(pc + 1);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExpOperation.java
@@ -57,7 +57,7 @@ public class ExpOperation extends AbstractOperation {
 
     final long cost = gasCalculator.expOperationGasCost(numBytes);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     byte[] numberBytes = number.toArrayUnsafe();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExpOperation.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -58,7 +57,7 @@ public class ExpOperation extends AbstractOperation {
 
     final long cost = gasCalculator.expOperationGasCost(numBytes);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     byte[] numberBytes = number.toArrayUnsafe();
@@ -75,6 +74,6 @@ public class ExpOperation extends AbstractOperation {
     } else {
       frame.pushStackItem(Bytes.wrap(resultArray));
     }
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.code.EOFLayout;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
@@ -91,7 +90,7 @@ public class ExtCodeCopyOperation extends AbstractOperation {
     final long cost = cost(frame, memOffset, numBytes, accountIsWarm);
 
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Account account = frame.getWorldUpdater().get(address);
@@ -100,8 +99,7 @@ public class ExtCodeCopyOperation extends AbstractOperation {
       final DelegatedCodeGasCostHelper.Result result =
           deductDelegatedCodeGasCost(frame, gasCalculator(), account);
       if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-        return new Operation.OperationResult(
-            result.gasCost(), ExceptionalHaltReason.INSUFFICIENT_GAS);
+        return OperationResult.insufficientGas();
       }
     }
 
@@ -116,6 +114,6 @@ public class ExtCodeCopyOperation extends AbstractOperation {
       frame.writeMemory(memOffset, sourceOffset, numBytes, code);
     }
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperation.java
@@ -90,7 +90,7 @@ public class ExtCodeCopyOperation extends AbstractOperation {
     final long cost = cost(frame, memOffset, numBytes, accountIsWarm);
 
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Account account = frame.getWorldUpdater().get(address);
@@ -99,7 +99,7 @@ public class ExtCodeCopyOperation extends AbstractOperation {
       final DelegatedCodeGasCostHelper.Result result =
           deductDelegatedCodeGasCost(frame, gasCalculator(), account);
       if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-        return OperationResult.insufficientGas();
+        return OperationResult.insufficientGas(result.gasCost());
       }
     }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperation.java
@@ -76,7 +76,7 @@ public class ExtCodeHashOperation extends AbstractOperation {
         frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
     final long cost = cost(accountIsWarm);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Account account = frame.getWorldUpdater().get(address);
@@ -85,7 +85,7 @@ public class ExtCodeHashOperation extends AbstractOperation {
       final DelegatedCodeGasCostHelper.Result result =
           deductDelegatedCodeGasCost(frame, gasCalculator(), account);
       if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-        return OperationResult.insufficientGas();
+        return OperationResult.insufficientGas(result.gasCost());
       }
     }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeSizeOperation.java
@@ -74,7 +74,7 @@ public class ExtCodeSizeOperation extends AbstractOperation {
         frame.warmUpAddress(address) || gasCalculator().isPrecompile(address);
     final long cost = cost(accountIsWarm);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else {
       final Account account = frame.getWorldUpdater().get(address);
 
@@ -82,7 +82,7 @@ public class ExtCodeSizeOperation extends AbstractOperation {
         final DelegatedCodeGasCostHelper.Result result =
             deductDelegatedCodeGasCost(frame, gasCalculator(), account);
         if (result.status() != DelegatedCodeGasCostHelper.Status.SUCCESS) {
-          return OperationResult.insufficientGas();
+          return OperationResult.insufficientGas(result.gasCost());
         }
       }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/GasLimitOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/GasLimitOperation.java
@@ -32,8 +32,7 @@ public class GasLimitOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(Words.longBytes(frame.getBlockValues().getGasLimit()));
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/GasOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/GasOperation.java
@@ -34,8 +34,7 @@ public class GasOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final long gasRemaining = frame.getRemainingGas() - gasCost;
     final Bytes value = Words.longBytes(gasRemaining);
     frame.pushStackItem(value);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/GasPriceOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/GasPriceOperation.java
@@ -32,8 +32,7 @@ public class GasPriceOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Wei gasPrice = frame.getGasPrice();
     frame.pushStackItem(gasPrice.toBytes());
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/GtOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/GtOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class GtOperation extends AbstractFixedCostOperation {
 
   /** The GT operation success result. */
-  static final OperationResult gtSuccess = new OperationResult(3, null);
+  static final OperationResult gtSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new GT operation.
@@ -36,8 +36,7 @@ public class GtOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/InvalidOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/InvalidOperation.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -24,13 +23,6 @@ public class InvalidOperation extends AbstractOperation {
 
   /** The constant OPCODE. */
   public static final int OPCODE = 0xFE;
-
-  /** The constant INVALID_RESULT. */
-  public static final OperationResult INVALID_RESULT =
-      new OperationResult(0, ExceptionalHaltReason.INVALID_OPERATION);
-
-  /** The Invalid operation result. */
-  protected final OperationResult invalidResult;
 
   /**
    * Instantiates a new Invalid operation.
@@ -49,11 +41,10 @@ public class InvalidOperation extends AbstractOperation {
    */
   public InvalidOperation(final int opcode, final GasCalculator gasCalculator) {
     super(opcode, "INVALID", -1, -1, gasCalculator);
-    invalidResult = new OperationResult(0L, ExceptionalHaltReason.INVALID_OPERATION);
   }
 
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
-    return invalidResult;
+    return OperationResult.invalidOperation();
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/IsZeroOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/IsZeroOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class IsZeroOperation extends AbstractFixedCostOperation {
 
   /** The Is zero operation success result. */
-  static final OperationResult isZeroSuccess = new OperationResult(3, null);
+  static final OperationResult isZeroSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Is zero operation.
@@ -36,8 +36,7 @@ public class IsZeroOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpDestOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpDestOperation.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 public class JumpDestOperation extends AbstractFixedCostOperation {
 
   /** constant for a successful jumpdest * */
-  public static final OperationResult JUMPDEST_SUCCESS = new OperationResult(1L, null);
+  public static final OperationResult JUMPDEST_SUCCESS = new OperationResult(1L);
 
   /** The constant OPCODE. */
   public static final int OPCODE = 0x5B;
@@ -37,8 +37,7 @@ public class JumpDestOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return successResponse;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpFOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpFOperation.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -27,10 +26,7 @@ public class JumpFOperation extends AbstractOperation {
   public static final int OPCODE = 0xe5;
 
   /** The Jump F success operation result. */
-  static final OperationResult jumpfSuccess = new OperationResult(5, null);
-
-  static final OperationResult jumpfStackOverflow =
-      new OperationResult(5, ExceptionalHaltReason.TOO_MANY_STACK_ITEMS);
+  static final OperationResult jumpfSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Jump F operation.
@@ -45,14 +41,14 @@ public class JumpFOperation extends AbstractOperation {
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     int pc = frame.getPC();
     int section = code.readBigEndianU16(pc + 1);
     var info = code.getCodeSection(section);
     int operandStackSize = frame.stackSize();
     if (operandStackSize > 1024 - info.getMaxStackHeight() + info.getInputs()) {
-      return jumpfStackOverflow;
+      return OperationResult.overFlow();
     }
     frame.setPC(info.getEntryPoint() - 1); // will be +1ed at end of operations loop
     frame.setSection(section);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpOperation.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -25,9 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 /** The Jump operation. */
 public class JumpOperation extends AbstractFixedCostOperation {
 
-  private static final Operation.OperationResult invalidJumpResponse =
-      new Operation.OperationResult(8L, ExceptionalHaltReason.INVALID_JUMP_DESTINATION);
-  private static final OperationResult jumpResponse = new OperationResult(8L, null, 0);
+  private static final OperationResult jumpResponse = new OperationResult(8L, 0);
 
   /**
    * Instantiates a new Jump operation.
@@ -39,8 +36,7 @@ public class JumpOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 
@@ -56,11 +52,11 @@ public class JumpOperation extends AbstractFixedCostOperation {
     try {
       jumpDestination = bytes.toInt();
     } catch (final RuntimeException iae) {
-      return invalidJumpResponse;
+      return OperationResult.invalidJumpDestination();
     }
     final Code code = frame.getCode();
     if (code.isJumpDestInvalid(jumpDestination)) {
-      return invalidJumpResponse;
+      return OperationResult.invalidJumpDestination();
     } else {
       frame.setPC(jumpDestination);
       return jumpResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpiOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/JumpiOperation.java
@@ -16,7 +16,6 @@ package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.Code;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -25,10 +24,8 @@ import org.apache.tuweni.bytes.Bytes;
 /** The JUMPI operation. */
 public class JumpiOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult invalidJumpResponse =
-      new Operation.OperationResult(10L, ExceptionalHaltReason.INVALID_JUMP_DESTINATION);
-  private static final OperationResult jumpiResponse = new OperationResult(10L, null, 0);
-  private static final OperationResult nojumpResponse = new OperationResult(10L, null);
+  private static final OperationResult jumpiResponse = new OperationResult(10L, 0);
+  private static final OperationResult nojumpResponse = new OperationResult(10L);
 
   /**
    * Instantiates a new JUMPI operation.
@@ -55,18 +52,18 @@ public class JumpiOperation extends AbstractFixedCostOperation {
     final Bytes condition = frame.popStackItem().trimLeadingZeros();
 
     // If condition is zero (false), no jump is will be performed. Therefore, skip the test.
-    if (condition.size() == 0) {
+    if (condition.isEmpty()) {
       return nojumpResponse;
     } else {
       final int jumpDestination;
       try {
         jumpDestination = dest.toInt();
       } catch (final RuntimeException re) {
-        return invalidJumpResponse;
+        return OperationResult.invalidJumpDestination();
       }
       final Code code = frame.getCode();
       if (code.isJumpDestInvalid(jumpDestination)) {
-        return invalidJumpResponse;
+        return OperationResult.invalidJumpDestination();
       }
       frame.setPC(jumpDestination);
       return jumpiResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Keccak256Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Keccak256Operation.java
@@ -42,7 +42,7 @@ public class Keccak256Operation extends AbstractOperation {
 
     final long cost = gasCalculator().keccak256OperationGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Bytes bytes = frame.readMutableMemory(from, length);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Keccak256Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Keccak256Operation.java
@@ -18,7 +18,6 @@ import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -43,11 +42,11 @@ public class Keccak256Operation extends AbstractOperation {
 
     final long cost = gasCalculator().keccak256OperationGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Bytes bytes = frame.readMutableMemory(from, length);
     frame.pushStackItem(keccak256(bytes));
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/LogOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/LogOperation.java
@@ -52,7 +52,7 @@ public class LogOperation extends AbstractOperation {
     if (frame.isStatic()) {
       return OperationResult.illegalStateChange();
     } else if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Address address = frame.getRecipientAddress();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/LogOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/LogOperation.java
@@ -19,7 +19,6 @@ import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.log.Log;
@@ -51,9 +50,9 @@ public class LogOperation extends AbstractOperation {
 
     final long cost = gasCalculator().logOperationGasCost(frame, dataLocation, numBytes, numTopics);
     if (frame.isStatic()) {
-      return new OperationResult(cost, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+      return OperationResult.illegalStateChange();
     } else if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Address address = frame.getRecipientAddress();
@@ -67,6 +66,6 @@ public class LogOperation extends AbstractOperation {
     }
 
     frame.addLog(new Log(address, data, builder.build()));
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/LtOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/LtOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class LtOperation extends AbstractFixedCostOperation {
 
   /** The LT operation success result. */
-  static final OperationResult ltSuccess = new OperationResult(3, null);
+  static final OperationResult ltSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new LT operation.
@@ -36,8 +36,7 @@ public class LtOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MCopyOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -41,11 +40,11 @@ public class MCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, Math.max(src, dst), length);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     frame.copyMemory(dst, src, length, true);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MCopyOperation.java
@@ -40,7 +40,7 @@ public class MCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, Math.max(src, dst), length);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     frame.copyMemory(dst, src, length, true);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MLoadOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -41,12 +40,12 @@ public class MLoadOperation extends AbstractOperation {
 
     final long cost = gasCalculator().mLoadOperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Bytes value = frame.readMutableMemory(location, 32, true).copy();
 
     frame.pushStackItem(value);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MLoadOperation.java
@@ -40,7 +40,7 @@ public class MLoadOperation extends AbstractOperation {
 
     final long cost = gasCalculator().mLoadOperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Bytes value = frame.readMutableMemory(location, 32, true).copy();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MSizeOperation.java
@@ -32,8 +32,7 @@ public class MSizeOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(Words.longBytes(frame.memoryByteSize()));
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MStore8Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MStore8Operation.java
@@ -42,7 +42,7 @@ public class MStore8Operation extends AbstractOperation {
 
     final long cost = gasCalculator().mStore8OperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     frame.writeMemory(location, theByte, true);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MStore8Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MStore8Operation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -43,10 +42,10 @@ public class MStore8Operation extends AbstractOperation {
 
     final long cost = gasCalculator().mStore8OperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     frame.writeMemory(location, theByte, true);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MStoreOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -42,10 +41,10 @@ public class MStoreOperation extends AbstractOperation {
 
     final long cost = gasCalculator().mStoreOperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     frame.writeMemoryRightAligned(location, 32, value, true);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MStoreOperation.java
@@ -41,7 +41,7 @@ public class MStoreOperation extends AbstractOperation {
 
     final long cost = gasCalculator().mStoreOperationGasCost(frame, location);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     frame.writeMemoryRightAligned(location, 32, value, true);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ModOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ModOperation.java
@@ -27,7 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 /** The Mod operation. */
 public class ModOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult modSuccess = new OperationResult(5, null);
+  private static final OperationResult modSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Mod operation.
@@ -39,8 +39,7 @@ public class ModOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MulModOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MulModOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 /** The Mul mod operation. */
 public class MulModOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult mulModSuccess = new OperationResult(8, null);
+  private static final OperationResult mulModSuccess = new OperationResult(8);
 
   /**
    * Instantiates a new Mul mod operation.
@@ -38,8 +38,7 @@ public class MulModOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/MulOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/MulOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class MulOperation extends AbstractFixedCostOperation {
 
   /** The Mul operation success result. */
-  static final OperationResult mulSuccess = new OperationResult(5, null);
+  static final OperationResult mulSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Mul operation.
@@ -38,8 +38,7 @@ public class MulOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/NotOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/NotOperation.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class NotOperation extends AbstractFixedCostOperation {
 
   /** The Not operation success result. */
-  static final OperationResult notSuccess = new OperationResult(3, null);
+  static final OperationResult notSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Not operation.
@@ -37,8 +37,7 @@ public class NotOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/NumberOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/NumberOperation.java
@@ -32,8 +32,7 @@ public class NumberOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final long number = frame.getBlockValues().getNumber();
     frame.pushStackItem(Words.longBytes(number));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Operation.java
@@ -15,74 +15,10 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
 /** The interface Operation. */
 public interface Operation {
-
-  /** The Operation result. */
-  class OperationResult {
-    /** The Gas cost. */
-    final long gasCost;
-
-    /** The Halt reason. */
-    final ExceptionalHaltReason haltReason;
-
-    /** The increment. */
-    final int pcIncrement;
-
-    /**
-     * Instantiates a new Operation result.
-     *
-     * @param gasCost the gas cost
-     * @param haltReason the halt reason
-     */
-    public OperationResult(final long gasCost, final ExceptionalHaltReason haltReason) {
-      this(gasCost, haltReason, 1);
-    }
-
-    /**
-     * Instantiates a new Operation result.
-     *
-     * @param gasCost the gas cost
-     * @param haltReason the halt reason
-     * @param pcIncrement the increment
-     */
-    public OperationResult(
-        final long gasCost, final ExceptionalHaltReason haltReason, final int pcIncrement) {
-      this.gasCost = gasCost;
-      this.haltReason = haltReason;
-      this.pcIncrement = pcIncrement;
-    }
-
-    /**
-     * Gets gas cost.
-     *
-     * @return the gas cost
-     */
-    public long getGasCost() {
-      return gasCost;
-    }
-
-    /**
-     * Gets halt reason.
-     *
-     * @return the halt reason
-     */
-    public ExceptionalHaltReason getHaltReason() {
-      return haltReason;
-    }
-
-    /**
-     * Gets increment.
-     *
-     * @return the increment
-     */
-    public int getPcIncrement() {
-      return pcIncrement;
-    }
-  }
 
   /**
    * Executes the logic behind this operation.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/OperationResult.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/OperationResult.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.evm.operation;
+
+import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
+
+/** The Operation result. */
+public class OperationResult {
+  /** The Gas cost. */
+  private final long gasCost;
+
+  /** The Halt reason. */
+  private final ExceptionalHaltReason haltReason;
+
+  /** The increment. */
+  private final int pcIncrement;
+
+  /**
+   * Instantiates a new Operation result.
+   *
+   * @param haltReason the halt reason
+   */
+  private OperationResult(final ExceptionalHaltReason haltReason) {
+    this.gasCost = 0L;
+    this.pcIncrement = 0;
+    this.haltReason = haltReason;
+  }
+
+  /**
+   * Instantiates a new Operation result.
+   *
+   * @param gasCost the gas cost
+   */
+  public OperationResult(final long gasCost) {
+    this(gasCost, 1);
+  }
+
+  /**
+   * Instantiates a new Operation result.
+   *
+   * @param gasCost the gas cost
+   * @param pcIncrement the increment
+   */
+  public OperationResult(final long gasCost, final int pcIncrement) {
+    this.gasCost = gasCost;
+    this.pcIncrement = pcIncrement;
+    this.haltReason = null;
+  }
+
+  /**
+   * Gets gas cost.
+   *
+   * @return the gas cost
+   */
+  public long getGasCost() {
+    return gasCost;
+  }
+
+  /**
+   * Gets halt reason.
+   *
+   * @return the halt reason
+   */
+  public ExceptionalHaltReason getHaltReason() {
+    return haltReason;
+  }
+
+  /**
+   * Gets increment.
+   *
+   * @return the increment
+   */
+  public int getPcIncrement() {
+    return pcIncrement;
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult underFlow() {
+    return new OperationResult(ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.TOO_MANY_STACK_ITEMS.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult overFlow() {
+    return new OperationResult(ExceptionalHaltReason.TOO_MANY_STACK_ITEMS);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INSUFFICIENT_GAS.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult insufficientGas() {
+    return new OperationResult(ExceptionalHaltReason.INSUFFICIENT_GAS);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.ILLEGAL_STATE_CHANGE.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult illegalStateChange() {
+    return new OperationResult(ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INVALID_OPERATION.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult invalidOperation() {
+    return new OperationResult(ExceptionalHaltReason.INVALID_OPERATION);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INVALID_JUMP_DESTINATION.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult invalidJumpDestination() {
+    return new OperationResult(ExceptionalHaltReason.INVALID_JUMP_DESTINATION);
+  }
+
+  /**
+   * Returns a halted OperationResult due to
+   * ExceptionalHaltReason.INVALID_RETURN_DATA_BUFFER_ACCESS.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult invalidReturnDataBufferAccess() {
+    return new OperationResult(ExceptionalHaltReason.INVALID_RETURN_DATA_BUFFER_ACCESS);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.OUT_OF_BOUNDS.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult outOfBounds() {
+    return new OperationResult(ExceptionalHaltReason.OUT_OF_BOUNDS);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.CODE_TOO_LARGE.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult codeTooLarge() {
+    return new OperationResult(ExceptionalHaltReason.CODE_TOO_LARGE);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INVALID_CODE.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult invalidCode() {
+    return new OperationResult(ExceptionalHaltReason.INVALID_CODE);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.NONEXISTENT_CONTAINER.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult nonExistentContainer() {
+    return new OperationResult(ExceptionalHaltReason.NONEXISTENT_CONTAINER);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.INVALID_CONTAINER.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult invalidContainer() {
+    return new OperationResult(ExceptionalHaltReason.INVALID_CONTAINER);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.DATA_TOO_SMALL.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult dataTooSmall() {
+    return new OperationResult(ExceptionalHaltReason.DATA_TOO_SMALL);
+  }
+
+  /**
+   * Returns a halted OperationResult due to ExceptionalHaltReason.ADDRESS_OUT_OF_RANGE.
+   *
+   * @return halted OperationResult
+   */
+  public static OperationResult addressOutOfRange() {
+    return new OperationResult(ExceptionalHaltReason.ADDRESS_OUT_OF_RANGE);
+  }
+}

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/OperationResult.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/OperationResult.java
@@ -28,12 +28,24 @@ public class OperationResult {
   private final int pcIncrement;
 
   /**
-   * Instantiates a new Operation result.
+   * Instantiates a new Operation result when due to an ExceptionalHaltReason.
    *
    * @param haltReason the halt reason
    */
   private OperationResult(final ExceptionalHaltReason haltReason) {
-    this.gasCost = 0L;
+    this(0L, haltReason);
+  }
+
+  /**
+   * Instantiates a new Operation result when due to an ExceptionalHaltReason with an associated
+   * gasCost increment. Only InsufficientGas has a gas cost increment associated with the reason for
+   * halting, all other halt reasons should use this constructor.
+   *
+   * @param gasCost the gas cost increment that caused the execution to halt
+   * @param haltReason the halt reason
+   */
+  private OperationResult(final long gasCost, final ExceptionalHaltReason haltReason) {
+    this.gasCost = gasCost;
     this.pcIncrement = 0;
     this.haltReason = haltReason;
   }
@@ -107,10 +119,11 @@ public class OperationResult {
   /**
    * Returns a halted OperationResult due to ExceptionalHaltReason.INSUFFICIENT_GAS.
    *
+   * @param overshotGasCost gas cost that exceeded the remaining gas during execution
    * @return halted OperationResult
    */
-  public static OperationResult insufficientGas() {
-    return new OperationResult(ExceptionalHaltReason.INSUFFICIENT_GAS);
+  public static OperationResult insufficientGas(final long overshotGasCost) {
+    return new OperationResult(overshotGasCost, ExceptionalHaltReason.INSUFFICIENT_GAS);
   }
 
   /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/OrOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/OrOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class OrOperation extends AbstractFixedCostOperation {
 
   /** The Or operation success result. */
-  static final OperationResult orSuccess = new OperationResult(3, null);
+  static final OperationResult orSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Or operation.
@@ -36,8 +36,7 @@ public class OrOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/OriginOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/OriginOperation.java
@@ -31,8 +31,7 @@ public class OriginOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(frame.getOriginatorAddress());
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/PCOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/PCOperation.java
@@ -32,8 +32,7 @@ public class PCOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     frame.pushStackItem(Words.intBytes(frame.getPC()));
 
     return successResponse;

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/PopOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/PopOperation.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 public class PopOperation extends AbstractFixedCostOperation {
 
   /** The Pop operation success result. */
-  static final OperationResult popSuccess = new OperationResult(2, null);
+  static final OperationResult popSuccess = new OperationResult(2);
 
   /**
    * Instantiates a new Pop operation.
@@ -34,8 +34,7 @@ public class PopOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/Push0Operation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/Push0Operation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class Push0Operation extends AbstractFixedCostOperation {
 
   /** The Push0 operation success result. */
-  static final OperationResult push0Success = new OperationResult(2, null);
+  static final OperationResult push0Success = new OperationResult(2);
 
   /**
    * Instantiates a new Push 0 operation.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/PushOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/PushOperation.java
@@ -32,7 +32,7 @@ public class PushOperation extends AbstractFixedCostOperation {
   private final int length;
 
   /** The Push operation success result. */
-  static final OperationResult pushSuccess = new OperationResult(3, null);
+  static final OperationResult pushSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Push operation.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpIfOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpIfOperation.java
@@ -40,14 +40,14 @@ public class RelativeJumpIfOperation extends AbstractFixedCostOperation {
   protected OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     final Bytes condition = frame.popStackItem();
     if (!condition.isZero()) {
       final int pcPostInstruction = frame.getPC() + 1;
-      return new OperationResult(gasCost, null, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
+      return new OperationResult(gasCost, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
     } else {
-      return new OperationResult(gasCost, null, 2 + 1);
+      return new OperationResult(gasCost, 2 + 1);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpOperation.java
@@ -58,9 +58,9 @@ public class RelativeJumpOperation extends AbstractFixedCostOperation {
   protected OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     final int pcPostInstruction = frame.getPC() + 1;
-    return new OperationResult(gasCost, null, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
+    return new OperationResult(gasCost, 2 + code.readBigEndianI16(pcPostInstruction) + 1);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpVectorOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RelativeJumpVectorOperation.java
@@ -40,7 +40,7 @@ public class RelativeJumpVectorOperation extends AbstractFixedCostOperation {
   protected OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     int offsetCase;
     try {
@@ -59,7 +59,6 @@ public class RelativeJumpVectorOperation extends AbstractFixedCostOperation {
             : 0; // if offsetCase is outside the vector the jump delta is zero / next opcode.
     return new OperationResult(
         gasCost,
-        null,
         2 // Opcode + length immediate
             + 2 * vectorSize // vector size
             + jumpDelta);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RetFOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RetFOperation.java
@@ -26,7 +26,7 @@ public class RetFOperation extends AbstractOperation {
   public static final int OPCODE = 0xe4;
 
   /** The Ret F success. */
-  static final OperationResult retfSuccess = new OperationResult(3, null);
+  static final OperationResult retfSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Ret F operation.
@@ -41,7 +41,7 @@ public class RetFOperation extends AbstractOperation {
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     var rStack = frame.getReturnStack();
     var returnInfo = rStack.pop();

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnContractOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnContractOperation.java
@@ -55,7 +55,7 @@ public class ReturnContractOperation extends AbstractOperation {
 
     final long cost = gasCalculator().memoryExpansionGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     if (index >= code.getSubcontainerCount()) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataCopyOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -25,15 +24,6 @@ import org.apache.tuweni.bytes.Bytes;
 
 /** The Return data copy operation. */
 public class ReturnDataCopyOperation extends AbstractOperation {
-
-  /** The constant INVALID_RETURN_DATA_BUFFER_ACCESS. */
-  protected static final OperationResult INVALID_RETURN_DATA_BUFFER_ACCESS =
-      new OperationResult(0L, ExceptionalHaltReason.INVALID_RETURN_DATA_BUFFER_ACCESS);
-
-  /** The constant OUT_OF_BOUNDS. */
-  protected static final OperationResult OUT_OF_BOUNDS =
-      new OperationResult(0L, ExceptionalHaltReason.OUT_OF_BOUNDS);
-
   /**
    * Instantiates a new Return data copy operation.
    *
@@ -55,20 +45,20 @@ public class ReturnDataCopyOperation extends AbstractOperation {
       try {
         final long end = Math.addExact(sourceOffset, numBytes);
         if (end > returnDataLength) {
-          return INVALID_RETURN_DATA_BUFFER_ACCESS;
+          return OperationResult.invalidReturnDataBufferAccess();
         }
       } catch (final ArithmeticException ae) {
-        return OUT_OF_BOUNDS;
+        return OperationResult.outOfBounds();
       }
     }
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     frame.writeMemory(memOffset, sourceOffset, numBytes, returnData, true);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataCopyOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataCopyOperation.java
@@ -54,7 +54,7 @@ public class ReturnDataCopyOperation extends AbstractOperation {
 
     final long cost = gasCalculator().dataCopyOperationGasCost(frame, memOffset, numBytes);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     frame.writeMemory(memOffset, sourceOffset, numBytes, returnData, true);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataLoadOperation.java
@@ -40,7 +40,7 @@ public class ReturnDataLoadOperation extends AbstractOperation {
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
 
     final int offset = clampedToInt(frame.popStackItem());
@@ -57,6 +57,6 @@ public class ReturnDataLoadOperation extends AbstractOperation {
     }
 
     frame.pushStackItem(value);
-    return new OperationResult(3L, null);
+    return new OperationResult(3L);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataSizeOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnDataSizeOperation.java
@@ -34,8 +34,7 @@ public class ReturnDataSizeOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Bytes returnData = frame.getReturnData();
     frame.pushStackItem(Words.longBytes(returnData.size()));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnOperation.java
@@ -42,7 +42,7 @@ public class ReturnOperation extends AbstractOperation {
 
     final long cost = gasCalculator().memoryExpansionGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     frame.setOutputData(frame.readMemory(from, length));

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ReturnOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -43,11 +42,11 @@ public class ReturnOperation extends AbstractOperation {
 
     final long cost = gasCalculator().memoryExpansionGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     frame.setOutputData(frame.readMemory(from, length));
     frame.setState(MessageFrame.State.CODE_SUCCESS);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RevertOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RevertOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import static org.hyperledger.besu.evm.internal.Words.clampedToLong;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -45,13 +44,13 @@ public class RevertOperation extends AbstractOperation {
 
     final long cost = gasCalculator().memoryExpansionGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     final Bytes reason = frame.readMemory(from, length);
     frame.setOutputData(reason);
     frame.setRevertReason(reason);
     frame.setState(MessageFrame.State.REVERT);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/RevertOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/RevertOperation.java
@@ -44,7 +44,7 @@ public class RevertOperation extends AbstractOperation {
 
     final long cost = gasCalculator().memoryExpansionGasCost(frame, from, length);
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     final Bytes reason = frame.readMemory(from, length);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SDivOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SDivOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes32;
 /** The SDiv operation. */
 public class SDivOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult sdivSuccess = new OperationResult(5, null);
+  private static final OperationResult sdivSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new SDiv operation.
@@ -38,8 +38,7 @@ public class SDivOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SGtOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SGtOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class SGtOperation extends AbstractFixedCostOperation {
 
   /** The SGt operation success result. */
-  static final OperationResult sgtSuccess = new OperationResult(3, null);
+  static final OperationResult sgtSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new SGt operation.
@@ -38,8 +38,7 @@ public class SGtOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SLoadOperation.java
@@ -55,7 +55,7 @@ public class SLoadOperation extends AbstractOperation {
     final boolean slotIsWarm = frame.warmUpStorage(address, key);
     final long cost = slotIsWarm ? warmCost : coldCost;
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else {
       frame.pushStackItem(account.getStorageValue(UInt256.fromBytes(key)));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SLtOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SLtOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class SLtOperation extends AbstractFixedCostOperation {
 
   /** The Slt operation success result. */
-  static final OperationResult sltSuccess = new OperationResult(3, null);
+  static final OperationResult sltSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new SLt operation.
@@ -38,8 +38,7 @@ public class SLtOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SModOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SModOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 /** The SMod operation. */
 public class SModOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult smodSuccess = new OperationResult(5, null);
+  private static final OperationResult smodSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new SMod operation.
@@ -38,8 +38,7 @@ public class SModOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -82,9 +82,9 @@ public class SStoreOperation extends AbstractOperation {
     if (frame.isStatic()) {
       return OperationResult.illegalStateChange();
     } else if (remainingGas < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else if (remainingGas <= minimumGasRemaining) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(minimumGasRemaining);
     }
 
     // Increment the refund counter.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SStoreOperation.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evm.operation;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.account.MutableAccount;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -34,10 +33,6 @@ public class SStoreOperation extends AbstractOperation {
 
   /** The constant EIP_1706_MINIMUM. */
   public static final long EIP_1706_MINIMUM = 2300L;
-
-  /** The constant ILLEGAL_STATE_CHANGE. */
-  protected static final OperationResult ILLEGAL_STATE_CHANGE =
-      new OperationResult(0L, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
 
   private final long minimumGasRemaining;
 
@@ -69,7 +64,7 @@ public class SStoreOperation extends AbstractOperation {
 
     final MutableAccount account = frame.getWorldUpdater().getAccount(frame.getRecipientAddress());
     if (account == null) {
-      return ILLEGAL_STATE_CHANGE;
+      return OperationResult.illegalStateChange();
     }
 
     final Address address = account.getAddress();
@@ -85,11 +80,11 @@ public class SStoreOperation extends AbstractOperation {
 
     final long remainingGas = frame.getRemainingGas();
     if (frame.isStatic()) {
-      return new OperationResult(remainingGas, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+      return OperationResult.illegalStateChange();
     } else if (remainingGas < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     } else if (remainingGas <= minimumGasRemaining) {
-      return new OperationResult(minimumGasRemaining, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     // Increment the refund counter.
@@ -99,6 +94,6 @@ public class SStoreOperation extends AbstractOperation {
 
     account.setStorageValue(key, newValue);
     frame.storageWasUpdated(key, newValue);
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SarOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SarOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class SarOperation extends AbstractFixedCostOperation {
 
   /** The Sar operation success result. */
-  static final OperationResult sarSuccess = new OperationResult(3, null);
+  static final OperationResult sarSuccess = new OperationResult(3);
 
   private static final Bytes ALL_BITS =
       Bytes.fromHexString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -41,8 +41,7 @@ public class SarOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfBalanceOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfBalanceOperation.java
@@ -35,8 +35,7 @@ public class SelfBalanceOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final Address accountAddress = frame.getRecipientAddress();
     final Account account = frame.getWorldUpdater().get(accountAddress);
     frame.pushStackItem(account == null ? Bytes.EMPTY : account.getBalance());

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
@@ -19,7 +19,6 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.account.Account;
 import org.hyperledger.besu.evm.account.MutableAccount;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
@@ -70,9 +69,9 @@ public class SelfDestructOperation extends AbstractOperation {
 
     // With the cost we can test for two early WithdrawalRequests: static or not enough gas.
     if (frame.isStatic()) {
-      return new OperationResult(cost, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+      return OperationResult.illegalStateChange();
     } else if (frame.getRemainingGas() < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     }
 
     // We passed preliminary checks, get mutable accounts.
@@ -97,6 +96,6 @@ public class SelfDestructOperation extends AbstractOperation {
     // Set frame to CODE_SUCCESS so that the frame performs a normal halt.
     frame.setState(MessageFrame.State.CODE_SUCCESS);
 
-    return new OperationResult(cost, null);
+    return new OperationResult(cost);
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SelfDestructOperation.java
@@ -71,7 +71,7 @@ public class SelfDestructOperation extends AbstractOperation {
     if (frame.isStatic()) {
       return OperationResult.illegalStateChange();
     } else if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     }
 
     // We passed preliminary checks, get mutable accounts.

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ShlOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ShlOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class ShlOperation extends AbstractFixedCostOperation {
 
   /** The Shl operation success result. */
-  static final OperationResult shlSuccess = new OperationResult(3, null);
+  static final OperationResult shlSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Shl operation.
@@ -38,8 +38,7 @@ public class ShlOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/ShrOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/ShrOperation.java
@@ -26,7 +26,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class ShrOperation extends AbstractFixedCostOperation {
 
   /** The Shr operation success result. */
-  static final OperationResult shrSuccess = new OperationResult(3, null);
+  static final OperationResult shrSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Shr operation.
@@ -38,8 +38,7 @@ public class ShrOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SignExtendOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SignExtendOperation.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.MutableBytes32;
 /** The Sign extend operation. */
 public class SignExtendOperation extends AbstractFixedCostOperation {
 
-  private static final OperationResult signExtendSuccess = new OperationResult(5, null);
+  private static final OperationResult signExtendSuccess = new OperationResult(5);
 
   /**
    * Instantiates a new Sign extend operation.
@@ -37,8 +37,7 @@ public class SignExtendOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/StopOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/StopOperation.java
@@ -27,7 +27,7 @@ public class StopOperation extends AbstractFixedCostOperation {
   public static final int OPCODE = 0x00;
 
   /** The Stop operation success result. */
-  static final OperationResult stopSuccess = new OperationResult(0, null);
+  static final OperationResult stopSuccess = new OperationResult(0);
 
   /**
    * Instantiates a new Stop operation.
@@ -39,8 +39,7 @@ public class StopOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SubOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SubOperation.java
@@ -27,7 +27,7 @@ import org.apache.tuweni.bytes.Bytes32;
 public class SubOperation extends AbstractFixedCostOperation {
 
   /** The Sub operation success result. */
-  static final OperationResult subSuccess = new OperationResult(3, null);
+  static final OperationResult subSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Sub operation.
@@ -39,8 +39,7 @@ public class SubOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SwapNOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SwapNOperation.java
@@ -28,7 +28,7 @@ public class SwapNOperation extends AbstractFixedCostOperation {
   public static final int OPCODE = 0xe7;
 
   /** The Swap operation success result. */
-  static final OperationResult swapSuccess = new OperationResult(3, null);
+  static final OperationResult swapSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new SwapN operation.
@@ -40,11 +40,10 @@ public class SwapNOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     Code code = frame.getCode();
     if (code.getEofVersion() == 0) {
-      return InvalidOperation.INVALID_RESULT;
+      return OperationResult.invalidOperation();
     }
     int pc = frame.getPC();
     int index = code.readU8(pc + 1);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/SwapOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/SwapOperation.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -28,12 +27,9 @@ public class SwapOperation extends AbstractFixedCostOperation {
   public static final int SWAP_BASE = 0x8F;
 
   /** The Swap operation success result. */
-  static final OperationResult swapSuccess = new OperationResult(3, null);
+  static final OperationResult swapSuccess = new OperationResult(3);
 
   private final int index;
-
-  /** The operation result due to underflow. */
-  protected final Operation.OperationResult underflowResponse;
 
   /**
    * Instantiates a new Swap operation.
@@ -50,13 +46,10 @@ public class SwapOperation extends AbstractFixedCostOperation {
         gasCalculator,
         gasCalculator.getVeryLowTierGasCost());
     this.index = index;
-    this.underflowResponse =
-        new Operation.OperationResult(gasCost, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame, index);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/TLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/TLoadOperation.java
@@ -38,7 +38,7 @@ public class TLoadOperation extends AbstractOperation {
     final long cost = gasCalculator().getTransientLoadOperationGasCost();
     final Bytes32 slot = UInt256.fromBytes(frame.popStackItem());
     if (frame.getRemainingGas() < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else {
       frame.pushStackItem(frame.getTransientStorageValue(frame.getRecipientAddress(), slot));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/TLoadOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/TLoadOperation.java
@@ -15,10 +15,8 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.hyperledger.besu.evm.internal.UnderflowException;
 
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -38,17 +36,13 @@ public class TLoadOperation extends AbstractOperation {
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     final long cost = gasCalculator().getTransientLoadOperationGasCost();
-    try {
-      final Bytes32 slot = UInt256.fromBytes(frame.popStackItem());
-      if (frame.getRemainingGas() < cost) {
-        return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
-      } else {
-        frame.pushStackItem(frame.getTransientStorageValue(frame.getRecipientAddress(), slot));
+    final Bytes32 slot = UInt256.fromBytes(frame.popStackItem());
+    if (frame.getRemainingGas() < cost) {
+      return OperationResult.insufficientGas();
+    } else {
+      frame.pushStackItem(frame.getTransientStorageValue(frame.getRecipientAddress(), slot));
 
-        return new OperationResult(cost, null);
-      }
-    } catch (final UnderflowException ufe) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_STACK_ITEMS);
+      return new OperationResult(cost);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/TStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/TStoreOperation.java
@@ -43,7 +43,7 @@ public class TStoreOperation extends AbstractOperation {
     if (frame.isStatic()) {
       return OperationResult.illegalStateChange();
     } else if (remainingGas < cost) {
-      return OperationResult.insufficientGas();
+      return OperationResult.insufficientGas(cost);
     } else {
       frame.setTransientStorageValue(frame.getRecipientAddress(), key, value);
       return new OperationResult(cost);

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/TStoreOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/TStoreOperation.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.evm.operation;
 
 import org.hyperledger.besu.evm.EVM;
-import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
@@ -42,12 +41,12 @@ public class TStoreOperation extends AbstractOperation {
 
     final long remainingGas = frame.getRemainingGas();
     if (frame.isStatic()) {
-      return new OperationResult(remainingGas, ExceptionalHaltReason.ILLEGAL_STATE_CHANGE);
+      return OperationResult.illegalStateChange();
     } else if (remainingGas < cost) {
-      return new OperationResult(cost, ExceptionalHaltReason.INSUFFICIENT_GAS);
+      return OperationResult.insufficientGas();
     } else {
       frame.setTransientStorageValue(frame.getRecipientAddress(), key, value);
-      return new OperationResult(cost, null);
+      return new OperationResult(cost);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/TimestampOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/TimestampOperation.java
@@ -32,8 +32,7 @@ public class TimestampOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     final long timestamp = frame.getBlockValues().getTimestamp();
     frame.pushStackItem(Words.longBytes(timestamp));
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/VirtualOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/VirtualOperation.java
@@ -34,7 +34,10 @@ public class VirtualOperation implements Operation {
   @Override
   public OperationResult execute(final MessageFrame frame, final EVM evm) {
     OperationResult result = delegate.execute(frame, evm);
-    return new OperationResult(result.getGasCost(), result.getHaltReason(), 0);
+    if (result.getHaltReason() != null) {
+      return result;
+    }
+    return new OperationResult(result.getGasCost(), 0);
   }
 
   @Override

--- a/evm/src/main/java/org/hyperledger/besu/evm/operation/XorOperation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/operation/XorOperation.java
@@ -24,7 +24,7 @@ import org.apache.tuweni.bytes.Bytes;
 public class XorOperation extends AbstractFixedCostOperation {
 
   /** The XOR operation success result. */
-  static final OperationResult xorSuccess = new OperationResult(3, null);
+  static final OperationResult xorSuccess = new OperationResult(3);
 
   /**
    * Instantiates a new Xor operation.
@@ -36,8 +36,7 @@ public class XorOperation extends AbstractFixedCostOperation {
   }
 
   @Override
-  public Operation.OperationResult executeFixedCostOperation(
-      final MessageFrame frame, final EVM evm) {
+  public OperationResult executeFixedCostOperation(final MessageFrame frame, final EVM evm) {
     return staticOperation(frame);
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractAltBnPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractAltBnPrecompiledContract.java
@@ -21,7 +21,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import com.sun.jna.ptr.IntByReference;
@@ -130,8 +129,7 @@ public abstract class AbstractAltBnPrecompiledContract extends AbstractPrecompil
       final String errorString = new String(error, 0, err_len.getValue(), UTF_8);
       messageFrame.setRevertReason(Bytes.wrap(error, 0, err_len.getValue()));
       LOG.trace("Error executing precompiled contract {}: '{}'", getName(), errorString);
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import com.sun.jna.ptr.IntByReference;
@@ -115,8 +114,7 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
       final String errorMessage = new String(error, 0, err_len.getValue(), UTF_8);
       messageFrame.setRevertReason(Bytes.wrap(error, 0, err_len.getValue()));
       LOG.trace("Error executing precompiled contract {}: '{}'", name, errorMessage);
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -90,8 +89,7 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
     final AltBn128Point p1 = new AltBn128Point(Fq.create(x1), Fq.create(y1));
     final AltBn128Point p2 = new AltBn128Point(Fq.create(x2), Fq.create(y2));
     if (!p1.isOnCurve() || !p2.isOnCurve()) {
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     final AltBn128Point sum = p1.add(p2);
     final Bytes x = sum.getX().toBytes();

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP196;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -81,8 +80,7 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
 
     if (input.size() >= 64 && input.slice(0, 64).equals(POINT_AT_INFINITY)) {
-      return new PrecompileContractResult(
-          POINT_AT_INFINITY, false, MessageFrame.State.COMPLETED_SUCCESS, Optional.empty());
+      return PrecompileContractResult.success(POINT_AT_INFINITY);
     }
 
     if (useNative) {
@@ -100,8 +98,7 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
 
     final AltBn128Point p = new AltBn128Point(Fq.create(x), Fq.create(y));
     if (!p.isOnCurve() || n.compareTo(MAX_N) > 0) {
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     final AltBn128Point product = p.multiply(n);
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -29,7 +29,6 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -96,8 +95,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       return PrecompileContractResult.success(TRUE);
     }
     if (input.size() % PARAMETER_LENGTH != 0) {
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     if (useNative) {
       return computeNative(input, messageFrame);
@@ -116,8 +114,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       final BigInteger p1_y = extractParameter(input, i * PARAMETER_LENGTH + 32, FIELD_LENGTH);
       final AltBn128Point p1 = new AltBn128Point(Fq.create(p1_x), Fq.create(p1_y));
       if (!p1.isOnCurve()) {
-        return PrecompileContractResult.halt(
-            null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+        return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
       }
       a.add(p1);
 
@@ -129,8 +126,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       final Fq2 p2_y = Fq2.create(p2_yReal, p2_yImag);
       final AltBn128Fq2Point p2 = new AltBn128Fq2Point(p2_x, p2_y);
       if (!p2.isOnCurve() || !p2.isInGroup()) {
-        return PrecompileContractResult.halt(
-            null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+        return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
       }
       b.add(p2);
     }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import java.math.BigInteger;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import org.apache.tuweni.bytes.Bytes;
@@ -69,13 +68,11 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
     if (input.size() != MESSAGE_LENGTH_BYTES) {
       LOG.trace(
           "Incorrect input length.  Expected {} and got {}", MESSAGE_LENGTH_BYTES, input.size());
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     if ((input.get(212) & 0xFE) != 0) {
       LOG.trace("Incorrect finalization flag, expected 0 or 1 and got {}", input.get(212));
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     return PrecompileContractResult.success(Hash.blake2bf(input));
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BigIntegerModularExponentiationPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BigIntegerModularExponentiationPrecompiledContract.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.nativelib.arithmetic.LibArithmetic;
 
 import java.math.BigInteger;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 
 import com.sun.jna.ptr.IntByReference;
@@ -258,8 +257,7 @@ public class BigIntegerModularExponentiationPrecompiledContract
       return PrecompileContractResult.success(Bytes.wrap(result, 0, o_len.getValue()));
     } else {
       LOG.trace("Error executing precompiled contract {}: {}", getName(), errorNo);
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -20,7 +20,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.Words;
 
 import java.nio.file.Path;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
 
@@ -109,8 +108,7 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
 
     if (input.size() != 192) {
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
     Bytes32 versionedHash = Bytes32.wrap(input.slice(0, 32));
     Bytes z = input.slice(32, 32);
@@ -118,14 +116,12 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
     Bytes commitment = input.slice(96, 48);
     Bytes proof = input.slice(144, 48);
     if (versionedHash.get(0) != 0x01) { // unsupported hash version
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     } else {
       byte[] hash = Hash.sha256(commitment).toArrayUnsafe();
       hash[0] = 0x01;
       if (!versionedHash.equals(Bytes32.wrap(hash))) {
-        return PrecompileContractResult.halt(
-            null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+        return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
       }
     }
     try {
@@ -136,14 +132,12 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
       if (proved) {
         return PrecompileContractResult.success(successResult);
       } else {
-        return PrecompileContractResult.halt(
-            null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+        return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
       }
     } catch (RuntimeException kzgFailed) {
       LOG.debug("Native KZG failed", kzgFailed);
 
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.PRECOMPILE_ERROR);
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.evm.precompile;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -59,7 +61,7 @@ public interface PrecompiledContract {
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
     final Bytes result = compute(input, messageFrame);
     if (result == null) {
-      return PrecompileContractResult.halt(null, Optional.of(ExceptionalHaltReason.NONE));
+      return PrecompileContractResult.halt(ExceptionalHaltReason.NONE);
     } else {
       return PrecompileContractResult.success(result);
     }
@@ -94,8 +96,7 @@ public interface PrecompiledContract {
      *     ExceptionalHalt)
      * @param haltReason the exceptional halt reason
      */
-    // TOO JDK17 use a record
-    public PrecompileContractResult(
+    private PrecompileContractResult(
         final Bytes output,
         final boolean refundGas,
         final MessageFrame.State state,
@@ -118,6 +119,17 @@ public interface PrecompiledContract {
     }
 
     /**
+     * precompile contract result with code executing state.
+     *
+     * @param output the output
+     * @return the precompile contract result
+     */
+    public static PrecompileContractResult executing(final Bytes output) {
+      return new PrecompileContractResult(
+          output, true, MessageFrame.State.CODE_EXECUTING, Optional.empty());
+    }
+
+    /**
      * precompile contract result with revert state.
      *
      * @param output the output
@@ -131,17 +143,13 @@ public interface PrecompiledContract {
     /**
      * precompile contract result with Halt state.
      *
-     * @param output the output
      * @param haltReason the halt reason
      * @return the precompile contract result
      */
-    public static PrecompileContractResult halt(
-        final Bytes output, final Optional<ExceptionalHaltReason> haltReason) {
-      if (haltReason.isEmpty()) {
-        throw new IllegalArgumentException("Halt reason cannot be empty");
-      }
+    public static PrecompileContractResult halt(final ExceptionalHaltReason haltReason) {
+      checkNotNull(haltReason, "haltReason is null");
       return new PrecompileContractResult(
-          output, false, MessageFrame.State.EXCEPTIONAL_HALT, haltReason);
+          null, false, MessageFrame.State.EXCEPTIONAL_HALT, Optional.of(haltReason));
     }
 
     /**

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/AccessListOperationTracer.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.evm.tracing;
 import org.hyperledger.besu.datatypes.AccessListEntry;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/EstimateGasOperationTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/EstimateGasOperationTracer.java
@@ -15,7 +15,7 @@
 package org.hyperledger.besu.evm.tracing;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.operation.SStoreOperation;
 
 /** The Estimate gas operation tracer. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/OperationTracer.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.log.Log;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.worldstate.WorldView;
 
 import java.util.List;

--- a/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/tracing/StandardJsonTracer.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.operation.AbstractCallOperation;
 import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.OperationResult;
 
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -167,7 +168,7 @@ public class StandardJsonTracer implements OperationTracer {
 
   @Override
   public void tracePostExecution(
-      final MessageFrame messageFrame, final Operation.OperationResult executeResult) {
+      final MessageFrame messageFrame, final OperationResult executeResult) {
     final Operation currentOp = messageFrame.getCurrentOperation();
     if (currentOp.isVirtualOperation()) {
       return;

--- a/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/code/CodeV0Test.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.operation.JumpOperation;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.worldstate.WorldUpdater;
 
 import javax.annotation.Nonnull;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/BaseFeeOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/BaseFeeOperationTest.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.BerlinGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 
 import java.util.Optional;
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/BlobHashOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/BlobHashOperationTest.java
@@ -49,7 +49,7 @@ class BlobHashOperationTest {
     when(frame.popStackItem()).thenReturn(Bytes.of(0));
     when(frame.getVersionedHashes()).thenReturn(Optional.of(versionedHashes));
     EVM fakeEVM = mock(EVM.class);
-    Operation.OperationResult r = getHash.execute(frame, fakeEVM);
+    OperationResult r = getHash.execute(frame, fakeEVM);
     assertThat(r.getGasCost()).isEqualTo(3);
     assertThat(r.getHaltReason()).isNull();
     verify(frame).pushStackItem(version0Hash.toBytes());
@@ -65,13 +65,13 @@ class BlobHashOperationTest {
     when(frame.popStackItem()).thenReturn(Bytes.of(0));
     when(frame.getVersionedHashes()).thenReturn(Optional.empty());
 
-    Operation.OperationResult failed1 = getHash.execute(frame, fakeEVM);
+    OperationResult failed1 = getHash.execute(frame, fakeEVM);
     assertThat(failed1.getGasCost()).isEqualTo(3);
     assertThat(failed1.getHaltReason()).isNull();
 
     when(frame.popStackItem()).thenReturn(Bytes.of(0));
     when(frame.getVersionedHashes()).thenReturn(Optional.of(new ArrayList<>()));
-    Operation.OperationResult failed2 = getHash.execute(frame, fakeEVM);
+    OperationResult failed2 = getHash.execute(frame, fakeEVM);
     assertThat(failed2.getGasCost()).isEqualTo(3);
     assertThat(failed2.getHaltReason()).isNull();
     verify(frame, times(2)).pushStackItem(Bytes.EMPTY);
@@ -86,7 +86,7 @@ class BlobHashOperationTest {
     when(frame.popStackItem()).thenReturn(Bytes.of(1));
     when(frame.getVersionedHashes()).thenReturn(Optional.of(versionedHashes));
     EVM fakeEVM = mock(EVM.class);
-    Operation.OperationResult r = getHash.execute(frame, fakeEVM);
+    OperationResult r = getHash.execute(frame, fakeEVM);
     assertThat(r.getGasCost()).isEqualTo(3);
     assertThat(r.getHaltReason()).isNull();
     verify(frame).pushStackItem(Bytes.EMPTY);
@@ -101,7 +101,7 @@ class BlobHashOperationTest {
     when(frame.popStackItem()).thenReturn(Bytes32.repeat((byte) 0x2C));
     when(frame.getVersionedHashes()).thenReturn(Optional.of(versionedHashes));
     EVM fakeEVM = mock(EVM.class);
-    Operation.OperationResult r = getHash.execute(frame, fakeEVM);
+    OperationResult r = getHash.execute(frame, fakeEVM);
     assertThat(r.getGasCost()).isEqualTo(3);
     assertThat(r.getHaltReason()).isNull();
     verify(frame).pushStackItem(Bytes.EMPTY);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/CallFOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/CallFOperationTest.java
@@ -49,7 +49,7 @@ class CallFOperationTest {
             .build();
 
     CallFOperation callF = new CallFOperation(gasCalculator);
-    Operation.OperationResult callfResult = callF.execute(messageFrame, null);
+    OperationResult callfResult = callF.execute(messageFrame, null);
 
     assertThat(callfResult.getHaltReason()).isNull();
     assertThat(callfResult.getPcIncrement()).isEqualTo(1);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ChainIdOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ChainIdOperationTest.java
@@ -64,9 +64,7 @@ class ChainIdOperationTest {
     Bytes32 chainId = Bytes32.fromHexString(chainIdString);
     ChainIdOperation operation = new ChainIdOperation(new ConstantinopleGasCalculator(), chainId);
     final OperationResult result = operation.execute(messageFrame, null);
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(expectedGas);
-    }
+    assertThat(result.getGasCost()).isEqualTo(expectedGas);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ChainIdOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ChainIdOperationTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.when;
 
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 
 import java.util.List;
 
@@ -65,7 +64,9 @@ class ChainIdOperationTest {
     Bytes32 chainId = Bytes32.fromHexString(chainIdString);
     ChainIdOperation operation = new ChainIdOperation(new ConstantinopleGasCalculator(), chainId);
     final OperationResult result = operation.execute(messageFrame, null);
-    assertThat(result.getGasCost()).isEqualTo(expectedGas);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(expectedGas);
+    }
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/Create2OperationTest.java
@@ -35,7 +35,6 @@ import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.internal.Words;
 import org.hyperledger.besu.evm.log.Log;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.processor.ContractCreationProcessor;
 import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
 import org.hyperledger.besu.evm.tracing.OperationTracer;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/DataCopyOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/DataCopyOperationTest.java
@@ -151,9 +151,7 @@ class DataCopyOperationTest {
 
     assertThat(frame.memoryWordSize()).isEqualTo((expected.size() + 31) / 32);
     assertThat(frame.readMemory(0, expected.size())).isEqualTo(expected);
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(gasCost);
-    }
+    assertThat(result.getGasCost()).isEqualTo(gasCost);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/DataCopyOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/DataCopyOperationTest.java
@@ -147,11 +147,13 @@ class DataCopyOperationTest {
             .code(code)
             .build();
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
 
     assertThat(frame.memoryWordSize()).isEqualTo((expected.size() + 31) / 32);
     assertThat(frame.readMemory(0, expected.size())).isEqualTo(expected);
-    assertThat(result.getGasCost()).isEqualTo(gasCost);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(gasCost);
+    }
   }
 
   @Test
@@ -170,7 +172,7 @@ class DataCopyOperationTest {
             .pc(6)
             .build();
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
     assertThat(result.getGasCost()).isZero();
     assertThat(result.getHaltReason()).isEqualTo(ExceptionalHaltReason.INVALID_OPERATION);
   }

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCallOperationTest.java
@@ -96,7 +96,7 @@ public class ExtCallOperationTest {
         Arguments.of(
             "Invalid code",
             384100,
-            100,
+            0,
             384100,
             ExceptionalHaltReason.INVALID_CODE,
             CONTRACT_ADDRESS,
@@ -140,9 +140,7 @@ public class ExtCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(chargedGas);
-    }
+    assertThat(result.getGasCost()).isEqualTo(chargedGas);
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();
@@ -167,7 +165,7 @@ public class ExtCallOperationTest {
         Arguments.of(
             "static context",
             40000,
-            9000,
+            0,
             40000,
             ExceptionalHaltReason.ILLEGAL_STATE_CHANGE,
             CONTRACT_ADDRESS,
@@ -232,9 +230,7 @@ public class ExtCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(chargedGas);
-    }
+    assertThat(result.getGasCost()).isEqualTo(chargedGas);
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCallOperationTest.java
@@ -140,7 +140,9 @@ public class ExtCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    }
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();
@@ -230,7 +232,9 @@ public class ExtCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    }
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeCopyOperationTest.java
@@ -187,7 +187,7 @@ class ExtCodeCopyOperationTest {
             .pushStackItem(REQUESTED_ADDRESS)
             .build();
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
 
     assertThat(frame.readMemory(0, expected.size())).isEqualTo(expected);
     assertThat(frame.memoryWordSize()).isEqualTo((expected.size() + 31) / 32);
@@ -211,7 +211,7 @@ class ExtCodeCopyOperationTest {
             .build();
     frame.warmUpAddress(REQUESTED_ADDRESS);
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
 
     assertThat(frame.readMemory(0, 9)).isEqualTo(code);
     assertThat(frame.memoryWordSize()).isEqualTo(1);
@@ -235,7 +235,7 @@ class ExtCodeCopyOperationTest {
             .build();
     frame.writeMemory(0, 15, Bytes.fromHexString("0x112233445566778899aabbccddeeff"));
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
 
     assertThat(frame.readMemory(0, 16))
         .isEqualTo(Bytes.fromHexString("0xEF0000000000000000aabbccddeeff00"));

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperationTest.java
@@ -26,7 +26,6 @@ import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.IstanbulGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
 import org.hyperledger.besu.evm.toy.ToyWorld;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeSizeOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtCodeSizeOperationTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.IstanbulGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.PragueGasCalculator;
 import org.hyperledger.besu.evm.internal.Words;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
 import org.hyperledger.besu.evm.toy.ToyWorld;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtDelegateCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtDelegateCallOperationTest.java
@@ -99,7 +99,7 @@ public class ExtDelegateCallOperationTest {
         Arguments.of(
             "Invalid code",
             384100,
-            100,
+            0,
             384100,
             ExceptionalHaltReason.INVALID_CODE,
             CONTRACT_ADDRESS,
@@ -143,9 +143,7 @@ public class ExtDelegateCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(chargedGas);
-    }
+    assertThat(result.getGasCost()).isEqualTo(chargedGas);
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtDelegateCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtDelegateCallOperationTest.java
@@ -143,7 +143,9 @@ public class ExtDelegateCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    }
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtStaticCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtStaticCallOperationTest.java
@@ -139,7 +139,9 @@ public class ExtStaticCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    if (result.getHaltReason() == null) {
+      assertThat(result.getGasCost()).isEqualTo(chargedGas);
+    }
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtStaticCallOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/ExtStaticCallOperationTest.java
@@ -96,7 +96,7 @@ public class ExtStaticCallOperationTest {
         Arguments.of(
             "Invalid code",
             384100,
-            100,
+            0,
             384100,
             ExceptionalHaltReason.INVALID_CODE,
             CONTRACT_ADDRESS,
@@ -139,9 +139,7 @@ public class ExtStaticCallOperationTest {
 
     var result = operation.execute(messageFrame, EOF_EVM);
 
-    if (result.getHaltReason() == null) {
-      assertThat(result.getGasCost()).isEqualTo(chargedGas);
-    }
+    assertThat(result.getGasCost()).isEqualTo(chargedGas);
     assertThat(result.getHaltReason()).isEqualTo(haltReason);
 
     MessageFrame childFrame = messageFrame.getMessageFrameStack().getFirst();

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/JumpFOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/JumpFOperationTest.java
@@ -49,7 +49,7 @@ class JumpFOperationTest {
             .build();
 
     JumpFOperation jumpF = new JumpFOperation(gasCalculator);
-    Operation.OperationResult jumpFResult = jumpF.execute(messageFrame, null);
+    OperationResult jumpFResult = jumpF.execute(messageFrame, null);
 
     assertThat(jumpFResult.getHaltReason()).isNull();
     assertThat(jumpFResult.getPcIncrement()).isEqualTo(1);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/JumpOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/JumpOperationTest.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.IstanbulGasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/MCopyOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/MCopyOperationTest.java
@@ -127,7 +127,7 @@ class MCopyOperationTest {
             .memory(memory)
             .build();
 
-    Operation.OperationResult result = subject.execute(frame, evm);
+    OperationResult result = subject.execute(frame, evm);
 
     assertThat(frame.memoryWordSize()).isEqualTo((expected.size() + 31) / 32);
     assertThat(frame.readMemory(0, expected.size())).isEqualTo(expected);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/PrevRanDaoOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/PrevRanDaoOperationTest.java
@@ -41,7 +41,7 @@ class PrevRanDaoOperationTest {
     when(blockHeader.getMixHashOrPrevRandao()).thenReturn(prevRandao);
     when(messageFrame.getBlockValues()).thenReturn(blockHeader);
     EVM evm = mock(EVM.class);
-    Operation.OperationResult r = op.executeFixedCostOperation(messageFrame, evm);
+    OperationResult r = op.executeFixedCostOperation(messageFrame, evm);
     assertThat(r.getHaltReason()).isNull();
     verify(messageFrame).pushStackItem(prevRandao);
   }
@@ -57,7 +57,7 @@ class PrevRanDaoOperationTest {
     when(blockHeader.getMixHashOrPrevRandao()).thenReturn(prevRandao);
     when(messageFrame.getBlockValues()).thenReturn(blockHeader);
     EVM evm = mock(EVM.class);
-    Operation.OperationResult r = op.executeFixedCostOperation(messageFrame, evm);
+    OperationResult r = op.executeFixedCostOperation(messageFrame, evm);
     assertThat(r.getHaltReason()).isNull();
     verify(messageFrame).pushStackItem(prevRandao);
   }

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/Push0OperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/Push0OperationTest.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.BerlinGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 
 import java.util.Optional;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/RelativeJumpOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/RelativeJumpOperationTest.java
@@ -47,7 +47,7 @@ class RelativeJumpOperationTest {
     when(messageFrame.getPC()).thenReturn(rjumpOperationIndex);
 
     RelativeJumpOperation rjump = new RelativeJumpOperation(gasCalculator);
-    Operation.OperationResult rjumpResult = rjump.execute(messageFrame, null);
+    OperationResult rjumpResult = rjump.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement())
         .isEqualTo(mockCode.getBytes().size() - rjumpOperationIndex + jumpLength);
@@ -68,7 +68,7 @@ class RelativeJumpOperationTest {
             .build();
 
     RelativeJumpIfOperation rjumpi = new RelativeJumpIfOperation(gasCalculator);
-    Operation.OperationResult rjumpResult = rjumpi.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpi.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(2 + 1);
   }
@@ -88,7 +88,7 @@ class RelativeJumpOperationTest {
             .build();
 
     RelativeJumpIfOperation rjumpi = new RelativeJumpIfOperation(gasCalculator);
-    Operation.OperationResult rjumpResult = rjumpi.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpi.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(-1);
   }
@@ -113,7 +113,7 @@ class RelativeJumpOperationTest {
             .build();
 
     RelativeJumpVectorOperation rjumpv = new RelativeJumpVectorOperation(gasCalculator);
-    Operation.OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(1 + 2 * jumpVectorSize + 1);
   }
@@ -163,7 +163,7 @@ class RelativeJumpOperationTest {
             .pushStackItem(Bytes.fromHexString(stackValue))
             .build();
 
-    Operation.OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(1 + 2 * jumpVectorSize + 1);
   }
@@ -190,7 +190,7 @@ class RelativeJumpOperationTest {
             .pushStackItem(Bytes.fromHexString(stackValue))
             .build();
 
-    Operation.OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(2 + 2 * jumpVectorSize + jumpLength);
   }
@@ -212,7 +212,7 @@ class RelativeJumpOperationTest {
             .build();
 
     RelativeJumpVectorOperation rjumpv = new RelativeJumpVectorOperation(gasCalculator);
-    Operation.OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
+    OperationResult rjumpResult = rjumpv.execute(messageFrame, null);
 
     assertThat(rjumpResult.getPcIncrement()).isEqualTo(2 + 2 * jumpVectorSize + 0x5678);
   }

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/RetFOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/RetFOperationTest.java
@@ -52,7 +52,7 @@ class RetFOperationTest {
     messageFrame.pushReturnStackItem(new ReturnStack.ReturnStackItem(2, 3));
 
     RetFOperation retF = new RetFOperation(gasCalculator);
-    Operation.OperationResult retFResult = retF.execute(messageFrame, null);
+    OperationResult retFResult = retF.execute(messageFrame, null);
 
     assertThat(retFResult.getHaltReason()).isNull();
     assertThat(retFResult.getPcIncrement()).isEqualTo(1);

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SStoreOperationTest.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.ConstantinopleGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 import org.hyperledger.besu.evm.testutils.TestMessageFrameBuilder;
 import org.hyperledger.besu.evm.toy.ToyWorld;

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/SelfDestructOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/SelfDestructOperationTest.java
@@ -103,7 +103,7 @@ public class SelfDestructOperationTest {
     when(accountOriginator.getAddress()).thenReturn(originatorAddress);
     when(accountOriginator.getBalance()).thenReturn(Wei.fromHexString(balanceHex));
 
-    final Operation.OperationResult operationResult = operation.execute(messageFrame, evm);
+    final OperationResult operationResult = operation.execute(messageFrame, evm);
     assertThat(operationResult).isNotNull();
 
     // The interactions with the contracts varies based on the parameterized tests, but it will be

--- a/evm/src/test/java/org/hyperledger/besu/evm/operation/TStoreOperationTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/operation/TStoreOperationTest.java
@@ -25,7 +25,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.CancunGasCalculator;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
-import org.hyperledger.besu.evm.operation.Operation.OperationResult;
 import org.hyperledger.besu.evm.testutils.ByteCodeBuilder;
 import org.hyperledger.besu.evm.testutils.FakeBlockValues;
 import org.hyperledger.besu.evm.testutils.TestCodeExecutor;

--- a/evm/src/test/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessorTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/processor/AbstractMessageProcessorTest.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.EvmSpecVersion;
 import org.hyperledger.besu.evm.fluent.EVMExecutor;
 import org.hyperledger.besu.evm.frame.MessageFrame;
-import org.hyperledger.besu.evm.operation.Operation;
+import org.hyperledger.besu.evm.operation.OperationResult;
 import org.hyperledger.besu.evm.toy.ToyWorld;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 
@@ -169,7 +169,7 @@ abstract class AbstractMessageProcessorTest<T extends AbstractMessageProcessor> 
 
     @Override
     public void tracePostExecution(
-        final MessageFrame frame, final Operation.OperationResult operationResult) {
+        final MessageFrame frame, final OperationResult operationResult) {
       traceHistory.add(POST_EXECUTION);
     }
 


### PR DESCRIPTION
## PR description
### Rationale
While working on something unrelated I discovered that EVM halt events also require to pass in a gas cost. The meaning of this gas cost is not totally clear across all halt event types (insufficient gas, stack underflow/overflow, invalid jump destination, illegal state change, ...), so this inconsistency makes it harder for devs building new EVM features, see [example on code from initial verkle gas schedule efforts](https://github.com/hyperledger/besu/blob/140fc2c651d8257ea2477e0a87786609e824f65e/evm/src/main/java/org/hyperledger/besu/evm/operation/ExtCodeHashOperation.java#L83-L87). In the Ethereum Yellow paper it is mentioned that at the start of a transaction an upfront gas cost is taken captive and, then, if code is executed correctly the remaining unused gas is refunded to the account. In the event of an EVM error, halting the code execution, no gas is refunded and so the entire upfront gas made captive is consumed. Therefore, clients do not need any cost information upon halting.

### Tracer cases
There is the case of tracers that have access to `OperationResult` when calling `tracePostExecution`. IMO, the only case where returning a gas cost along with the halt condition might make sense is the insufficient gas case. This seems to show exactly in which amount of gas charging did the EVM halted on. It does not make any sense at all to report a gas cost when the reason for the halt was not related to gas. In fact, I would question if it's really useful to report the gas cost at all even in the insufficient gas case because this is not specific enough (was it the static gas or a dynamic part? which type of gas exactly?). Currently the default in clients is to compound all gas costs for an opcode execution in advance of any DB lookups or computation. But one could incrementally compute the cost before any computation and check for out of gas incrementally also. I believe this will happen with stateless clients. This is also used by tracing APIs (in particular trace_* calls) but the [current spec](https://eips.ethereum.org/EIPS/eip-3155#summary-and-error-handling) or [future spec with EOF](https://eips.ethereum.org/EIPS/eip-7756) do not mention any standards around EVM halting cases. Right now I'm told that Nethermind and Reth implement these but I haven't checked how they handle this case in particular. A quick scan on Reth's website didn't show many details on this edge case either.

### Changes
This PR refactors and streamlines the `OperationResult`, the outcome of executing an opcode, to split up between halting and successful results. It also enforces the creation of new halt `OperationResults` through static factory methods for better encapsulation, that always create a new instance since, on a halt event, the execution context is not recoverable so the overhead is negligible.
I'm proposing that we get rid of this gas cost reporting in `OperationResult` when an `ExceptionalHaltReason` is used, to make it all consistent. I changed some tests to cope with this modification so please review carefully. On the other hand, if someone feels strongly we could very well keep reporting gas cost upon insufficient gas.

EDIT: Latest tip allows for gasCost reporting for insufficient gas only.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

