### PR TITLE
Fix concurrent access of node permissioning allow list

### DIFF
--- a/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
+++ b/ethereum/permissioning/src/main/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningController.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -48,7 +49,7 @@ public class NodeLocalConfigPermissioningController implements NodeConnectionPer
   private LocalPermissioningConfiguration configuration;
   private final List<EnodeURL> fixedNodes;
   private final Bytes localNodeId;
-  private final List<EnodeURL> nodesAllowlist = new ArrayList<>();
+  private final List<EnodeURL> nodesAllowlist = new CopyOnWriteArrayList<>();
   private final AllowlistPersistor allowlistPersistor;
   private final Subscribers<Consumer<NodeAllowlistUpdatedEvent>> nodeAllowlistUpdatedObservers =
       Subscribers.create();

--- a/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
+++ b/ethereum/permissioning/src/test/java/org/hyperledger/besu/ethereum/permissioning/NodeLocalConfigPermissioningControllerTest.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import com.google.common.collect.Lists;
@@ -314,6 +315,56 @@ public class NodeLocalConfigPermissioningControllerTest {
 
     assertThat(controller.isConnectionPermitted(selfEnode, EnodeURLImpl.fromString(enode1)))
         .isTrue();
+  }
+
+  @Test
+  public void whenCallingIsPermittedAndRemovingEntryInAnotherThreadShouldNotThrowException()
+      throws InterruptedException {
+    // Add a node to the allowlist
+    controller.addNodes(Lists.newArrayList(enode1));
+
+    // Atomic flag to detect exceptions
+    AtomicBoolean exceptionOccurred = new AtomicBoolean(false);
+
+    // Create a thread to call isPermitted
+    Thread isPermittedThread =
+        new Thread(
+            () -> {
+              try {
+                for (int i = 0; i < 1000; i++) {
+                  controller.isPermitted(enode1);
+                }
+              } catch (Exception e) {
+                exceptionOccurred.set(true);
+                e.printStackTrace();
+              }
+            });
+
+    // Create a thread to modify the allowlist
+    Thread modifyAllowlistThread =
+        new Thread(
+            () -> {
+              try {
+                for (int i = 0; i < 1000; i++) {
+                  controller.removeNodes(Lists.newArrayList(enode1));
+                  controller.addNodes(Lists.newArrayList(enode1));
+                }
+              } catch (Exception e) {
+                exceptionOccurred.set(true);
+                e.printStackTrace();
+              }
+            });
+
+    // Start both threads
+    isPermittedThread.start();
+    modifyAllowlistThread.start();
+
+    // Wait for both threads to complete
+    isPermittedThread.join();
+    modifyAllowlistThread.join();
+
+    // Assert no exceptions were thrown
+    assert (!exceptionOccurred.get());
   }
 
   @Test


### PR DESCRIPTION
## PR description
ArrayList() used for allowlist is not threadsafe. Adding/removing entries while iterating the list to check for an entry in isPermitted() will throw this exception. Added a testcase for this situation.

```bash
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1687)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
	at java.base/java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:632)
	at org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController.isPermitted(NodeLocalConfigPermissioningController.java:245)
	at org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningController.isPermitted(NodeLocalConfigPermissioningController.java:238)
	at org.hyperledger.besu.ethereum.permissioning.NodeLocalConfigPermissioningControllerTest.lambda$whenCallingIsPermittedAndRemovingEntryInAnotherThreadShouldNotThrowException$0(NodeLocalConfigPermissioningControllerTest.java:335)
	at java.base/java.lang.Thread.run(Thread.java:1583)

....

OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
> Task :ethereum:permissioning:test
NodeLocalConfigPermissioningControllerTest > whenCallingIsPermittedAndRemovingEntryInAnotherThreadShouldNotThrowException() FAILED
    java.lang.AssertionError at NodeLocalConfigPermissioningControllerTest.java:367
1 test completed, 1 failed
```

Using CopyOnWriteArrayList is a simple fix considering it’s not a write heavy list

## Fixed Issue(s)
#7916 


