### PR TITLE
remove protocol name

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -625,7 +625,6 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             ethereumWireProtocolConfiguration.isLegacyEth64ForkIdEnabled());
     final EthPeers ethPeers =
         new EthPeers(
-            EthProtocol.NAME,
             currentProtocolSpecSupplier,
             clock,
             metricsSystem,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/results/PeerResult.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.results;
 
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.Capability;
@@ -52,7 +53,7 @@ public interface PeerResult {
                 connection.inboundInitiated()))
         .port(Quantity.create(peerInfo.getPort()))
         .id(peerInfo.getNodeId().toString())
-        .protocols(Map.of(peer.getProtocolName(), ProtocolsResult.fromEthPeer(peer)))
+        .protocols(Map.of(EthProtocol.NAME, ProtocolsResult.fromEthPeer(peer)))
         .enode(connection.getRemoteEnode().toString())
         .build();
   }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/AdminJsonRpcHttpServiceTest.java
@@ -74,7 +74,6 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     peerList.add(
         new EthPeer(
             MockPeerConnection.create(info1, addr60301, addr30302),
-            "eth",
             c -> {},
             List.of(),
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
@@ -84,7 +83,6 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     peerList.add(
         new EthPeer(
             MockPeerConnection.create(info2, addr30301, addr60302),
-            "eth",
             c -> {},
             List.of(),
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
@@ -94,7 +92,6 @@ public class AdminJsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
     peerList.add(
         new EthPeer(
             MockPeerConnection.create(info3, addr30301, addr60303),
-            "eth",
             c -> {},
             List.of(),
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AdminPeersTest.java
@@ -120,7 +120,6 @@ public class AdminPeersTest {
     final EthPeer ethPeer =
         new EthPeer(
             p,
-            "eth",
             c -> {},
             List.of(),
             EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer.DisconnectCallback;
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerSelector;
@@ -92,7 +93,6 @@ public class EthPeers implements PeerSelector {
           .concurrencyLevel(1)
           .removalListener(this::onCacheRemoval)
           .build();
-  private final String protocolName;
   private final Clock clock;
   private final List<NodeMessagePermissioningProvider> permissioningProviders;
   private final int maxMessageSize;
@@ -122,7 +122,6 @@ public class EthPeers implements PeerSelector {
       () -> TrailingPeerRequirements.UNRESTRICTED;
 
   public EthPeers(
-      final String protocolName,
       final Supplier<ProtocolSpec> currentProtocolSpecSupplier,
       final Clock clock,
       final MetricsSystem metricsSystem,
@@ -134,7 +133,6 @@ public class EthPeers implements PeerSelector {
       final Boolean randomPeerPriority,
       final SyncMode syncMode,
       final ForkIdManager forkIdManager) {
-    this.protocolName = protocolName;
     this.currentProtocolSpecSupplier = currentProtocolSpecSupplier;
     this.clock = clock;
     this.permissioningProviders = permissioningProviders;
@@ -191,7 +189,6 @@ public class EthPeers implements PeerSelector {
             peerInList.orElse(
                 new EthPeer(
                     newConnection,
-                    protocolName,
                     this::ethPeerStatusExchanged,
                     peerValidators,
                     maxMessageSize,
@@ -294,7 +291,7 @@ public class EthPeers implements PeerSelector {
   }
 
   public void dispatchMessage(final EthPeer peer, final EthMessage ethMessage) {
-    dispatchMessage(peer, ethMessage, protocolName);
+    dispatchMessage(peer, ethMessage, EthProtocol.NAME);
   }
 
   @VisibleForTesting

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/task/GetReceiptsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/peertask/task/GetReceiptsFromPeerTask.java
@@ -123,9 +123,8 @@ public class GetReceiptsFromPeerTask
   @Override
   public Predicate<EthPeer> getPeerRequirementFilter() {
     return (ethPeer) ->
-        ethPeer.getProtocolName().equals(getSubProtocol().getName())
-            && (protocolSchedule.anyMatch((ps) -> ps.spec().isPoS())
-                || ethPeer.chainState().getEstimatedHeight() >= requiredBlockchainHeight);
+        (protocolSchedule.anyMatch((ps) -> ps.spec().isPoS())
+            || ethPeer.chainState().getEstimatedHeight() >= requiredBlockchainHeight);
   }
 
   @Override

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthPeerTest.java
@@ -477,7 +477,6 @@ public class EthPeerTest {
     final Consumer<EthPeer> onPeerReady = (peer) -> {};
     return new EthPeer(
         peerConnection,
-        "foo",
         onPeerReady,
         Collections.emptyList(),
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
@@ -513,7 +512,6 @@ public class EthPeerTest {
     // that extend the sub-protocol work correctly
     return new EthPeer(
         peerConnection,
-        "foo",
         onPeerReady,
         peerValidators,
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/EthProtocolManagerTestUtil.java
@@ -84,7 +84,6 @@ public class EthProtocolManagerTestUtil {
 
     final EthPeers peers =
         new EthPeers(
-            EthProtocol.NAME,
             () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
             TestClock.fixed(),
             new NoOpMetricsSystem(),
@@ -211,7 +210,6 @@ public class EthProtocolManagerTestUtil {
 
     final EthPeers peers =
         new EthPeers(
-            EthProtocol.NAME,
             () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
             TestClock.fixed(),
             new NoOpMetricsSystem(),
@@ -262,7 +260,6 @@ public class EthProtocolManagerTestUtil {
 
     final EthPeers peers =
         new EthPeers(
-            EthProtocol.NAME,
             () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
             TestClock.fixed(),
             new NoOpMetricsSystem(),
@@ -294,7 +291,6 @@ public class EthProtocolManagerTestUtil {
       final EthScheduler ethScheduler) {
     final EthPeers ethPeers =
         new EthPeers(
-            EthProtocol.NAME,
             () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
             TestClock.fixed(),
             new NoOpMetricsSystem(),

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/RequestManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/RequestManagerTest.java
@@ -303,7 +303,6 @@ public class RequestManagerTest {
     final Consumer<EthPeer> onPeerReady = (peer) -> {};
     return new EthPeer(
         peerConnection,
-        EthProtocol.NAME,
         onPeerReady,
         Collections.emptyList(),
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/AbstractMessageTaskTest.java
@@ -27,7 +27,6 @@ import org.hyperledger.besu.ethereum.chain.BadBlockManager;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
-import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.EthProtocolConfiguration;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthMessages;
@@ -114,7 +113,6 @@ public abstract class AbstractMessageTaskTest<T, R> {
     ethPeers =
         spy(
             new EthPeers(
-                EthProtocol.NAME,
                 () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
                 TestClock.fixed(),
                 metricsSystem,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/PeerMessageTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/ethtaskutils/PeerMessageTaskTest.java
@@ -162,7 +162,6 @@ public abstract class PeerMessageTaskTest<T>
     final Consumer<EthPeer> onPeerReady = (peer) -> {};
     return new EthPeer(
         peerConnection,
-        EthProtocol.NAME,
         onPeerReady,
         Collections.emptyList(),
         EthProtocolConfiguration.DEFAULT_MAX_MESSAGE_SIZE,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/task/GetReceiptsFromPeerTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/task/GetReceiptsFromPeerTaskTest.java
@@ -214,11 +214,9 @@ public class GetReceiptsFromPeerTaskTest {
         new GetReceiptsFromPeerTask(
             List.of(blockHeader1, blockHeader2, blockHeader3), protocolSchedule);
 
-    EthPeer failForIncorrectProtocol = mockPeer("incorrectProtocol", 5);
-    EthPeer failForShortChainHeight = mockPeer("incorrectProtocol", 1);
-    EthPeer successfulCandidate = mockPeer(EthProtocol.NAME, 5);
+    EthPeer failForShortChainHeight = mockPeer(1);
+    EthPeer successfulCandidate = mockPeer(5);
 
-    Assertions.assertFalse(task.getPeerRequirementFilter().test(failForIncorrectProtocol));
     Assertions.assertFalse(task.getPeerRequirementFilter().test(failForShortChainHeight));
     Assertions.assertTrue(task.getPeerRequirementFilter().test(successfulCandidate));
   }
@@ -251,11 +249,10 @@ public class GetReceiptsFromPeerTaskTest {
     return blockHeader;
   }
 
-  private EthPeer mockPeer(final String protocol, final long chainHeight) {
+  private EthPeer mockPeer(final long chainHeight) {
     EthPeer ethPeer = Mockito.mock(EthPeer.class);
     ChainState chainState = Mockito.mock(ChainState.class);
 
-    Mockito.when(ethPeer.getProtocolName()).thenReturn(protocol);
     Mockito.when(ethPeer.chainState()).thenReturn(chainState);
     Mockito.when(chainState.getEstimatedHeight()).thenReturn(chainHeight);
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/AbstractBlockPropagationManagerTest.java
@@ -641,7 +641,6 @@ public abstract class AbstractBlockPropagationManagerTest {
     final EthContext ethContext =
         new EthContext(
             new EthPeers(
-                "eth",
                 () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
                 TestClock.fixed(),
                 metricsSystem,
@@ -783,7 +782,6 @@ public abstract class AbstractBlockPropagationManagerTest {
     final EthContext ethContext =
         new EthContext(
             new EthPeers(
-                "eth",
                 () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
                 TestClock.fixed(),
                 metricsSystem,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TestNode.java
@@ -154,7 +154,6 @@ public class TestNode implements Closeable {
         };
     final EthPeers ethPeers =
         new EthPeers(
-            EthProtocol.NAME,
             () -> protocolSchedule.getByBlockHeader(blockchain.getChainHeadHeader()),
             TestClock.fixed(),
             metricsSystem,

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactoryTest.java
@@ -112,7 +112,6 @@ public class TransactionPoolFactoryTest {
     final NodeMessagePermissioningProvider nmpp = (destinationEnode, code) -> true;
     ethPeers =
         new EthPeers(
-            "ETH",
             () -> protocolSpec,
             TestClock.fixed(),
             new NoOpMetricsSystem(),


### PR DESCRIPTION
## PR description
Removes the protocol name from EthPeers and EthPeer. The protocol name was always set to "eth".

Fixes #7810