### PR TITLE
handling IllegalArgumentException caused by Discovery Disabled Nodes  in Endpoint.fromEnode

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
@@ -26,12 +26,15 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents an Ethereum node that we are interacting with through the discovery and wire
  * protocols.
  */
 public class DiscoveryPeer extends DefaultPeer {
+  private static final Logger log = LoggerFactory.getLogger(DiscoveryPeer.class);
   private PeerDiscoveryStatus status = PeerDiscoveryStatus.KNOWN;
   // Endpoint is a datastructure used in discovery messages
   private final Endpoint endpoint;
@@ -49,8 +52,14 @@ public class DiscoveryPeer extends DefaultPeer {
   }
 
   public static DiscoveryPeer fromEnode(final EnodeURL enode) {
-    return new DiscoveryPeer(enode, Endpoint.fromEnode(enode));
-  }
+    try {
+      return new DiscoveryPeer(enode, Endpoint.fromEnode(enode));
+    }
+    catch (IllegalArgumentException e) {
+      log.warn("Attempted to create a discovery endpoint for a node with discovery disabled: {}", enode);
+      return new DiscoveryPeer(enode, new Endpoint("defaultHost", 0, Optional.empty()));
+    }
+    }
 
   public static Optional<DiscoveryPeer> from(final Peer peer) {
     if (peer instanceof DiscoveryPeer) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/DiscoveryPeer.java
@@ -26,15 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.ethereum.beacon.discovery.schema.NodeRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Represents an Ethereum node that we are interacting with through the discovery and wire
  * protocols.
  */
 public class DiscoveryPeer extends DefaultPeer {
-  private static final Logger log = LoggerFactory.getLogger(DiscoveryPeer.class);
   private PeerDiscoveryStatus status = PeerDiscoveryStatus.KNOWN;
   // Endpoint is a datastructure used in discovery messages
   private final Endpoint endpoint;
@@ -52,14 +49,8 @@ public class DiscoveryPeer extends DefaultPeer {
   }
 
   public static DiscoveryPeer fromEnode(final EnodeURL enode) {
-    try {
-      return new DiscoveryPeer(enode, Endpoint.fromEnode(enode));
-    }
-    catch (IllegalArgumentException e) {
-      log.warn("Attempted to create a discovery endpoint for a node with discovery disabled: {}", enode);
-      return new DiscoveryPeer(enode, new Endpoint("defaultHost", 0, Optional.empty()));
-    }
-    }
+    return new DiscoveryPeer(enode, Endpoint.fromEnode(enode));
+  }
 
   public static Optional<DiscoveryPeer> from(final Peer peer) {
     if (peer instanceof DiscoveryPeer) {

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/Endpoint.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/Endpoint.java
@@ -29,12 +29,15 @@ import java.util.Optional;
 
 import com.google.common.net.InetAddresses;
 import org.apache.tuweni.bytes.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Encapsulates the network coordinates of a {@link DiscoveryPeer} as well as serialization logic
  * used in various Discovery messages.
  */
 public class Endpoint {
+  private static final Logger log = LoggerFactory.getLogger(Endpoint.class);
   private final Optional<String> host;
   private final int udpPort;
   private final Optional<Integer> tcpPort;
@@ -49,15 +52,15 @@ public class Endpoint {
   }
 
   public static Endpoint fromEnode(final EnodeURL enode) {
-    final int discoveryPort =
-        enode
-            .getDiscoveryPort()
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Attempt to create a discovery endpoint for an enode with discovery disabled."));
+    Optional<Integer> discoveryPort = enode.getDiscoveryPort();
+
+    if (discoveryPort.isEmpty()) {
+      log.warn("Attempted to create a discovery endpoint for a node with discovery disabled: {}", enode);
+      return new Endpoint("defaultHost", 0, Optional.empty());
+    }
+
     final Optional<Integer> listeningPort = enode.getListeningPort();
-    return new Endpoint(enode.getIp().getHostAddress(), discoveryPort, listeningPort);
+    return new Endpoint(enode.getIp().getHostAddress(), discoveryPort.get(), listeningPort);
   }
 
   public EnodeURL toEnode(final Bytes nodeId) {


### PR DESCRIPTION
## PR description
This PR modifies the Endpoint.fromEnode method to handle cases where discovery is disabled for a given EnodeURL more gracefully. Previously, the method threw an IllegalArgumentException when getDiscoveryPort returned an empty Optional, leading to potential disruptions in the system.
## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
#7887 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

