### PR TITLE
revert to unchanged plugin interface signature

### DIFF
--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/BadCLIOptionsPlugin.java
@@ -16,8 +16,8 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
 import java.io.File;
@@ -39,7 +39,8 @@ public class BadCLIOptionsPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     LOG.info("Registering BadCliOptionsPlugin");
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));
     writeStatus("init");

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBesuEventsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBesuEventsPlugin.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -42,7 +43,8 @@ public class TestBesuEventsPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     this.context = context;
     LOG.info("Registered");
     callbackDir = new File(System.getProperty("besu.plugins.dir", "plugins"));

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBlockchainServiceFinalizedPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestBlockchainServiceFinalizedPlugin.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.parameters.JsonRpcParameter;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.data.BlockContext;
 import org.hyperledger.besu.plugin.services.BlockchainService;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
@@ -40,7 +40,8 @@ public class TestBlockchainServiceFinalizedPlugin implements BesuPlugin {
   private static final String RPC_METHOD_SAFE_BLOCK = "updateSafeBlockV1";
 
   @Override
-  public void register(final ServiceManager serviceManager) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext serviceManager) {
     LOG.trace("Registering plugin ...");
 
     final RpcEndpointService rpcEndpointService =

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestInProcessRpcServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestInProcessRpcServicePlugin.java
@@ -15,8 +15,8 @@
 package org.hyperledger.besu.tests.acceptance.plugins;
 
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
 import org.hyperledger.besu.plugin.services.rpc.RpcResponseType;
@@ -36,7 +36,8 @@ public class TestInProcessRpcServicePlugin implements BesuPlugin {
   long minGasPrice = -1;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     final PicoCLIOptions cmdlineOptions =
         context
             .getService(PicoCLIOptions.class)

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestMetricsPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestMetricsPlugin.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -33,7 +34,8 @@ public class TestMetricsPlugin implements BesuPlugin {
   private ServiceManager serviceManager;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     LOG.info("Registering TestMetricsPlugin");
     serviceManager = context;
     context

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPermissioningPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPermissioningPlugin.java
@@ -14,8 +14,8 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PermissioningService;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
@@ -40,7 +40,8 @@ public class TestPermissioningPlugin implements BesuPlugin {
   PermissioningService service;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     context.getService(PicoCLIOptions.class).orElseThrow().addPicoCLIOptions("permissioning", this);
     service = context.getService(PermissioningService.class).orElseThrow();
   }

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPicoCLIPlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPicoCLIPlugin.java
@@ -14,8 +14,8 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
 
 import java.io.File;
@@ -57,7 +57,8 @@ public class TestPicoCLIPlugin implements BesuPlugin {
   private File callbackDir;
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     LOG.info("Registering.  Test Option is '{}'", testOption);
     state = "registering";
 

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPrivacyServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestPrivacyServicePlugin.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.tests.acceptance.plugins;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -40,7 +41,8 @@ public class TestPrivacyServicePlugin implements BesuPlugin {
       new TestSigningPrivateMarkerTransactionFactory();
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     this.context = context;
 
     context

--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestRpcEndpointServicePlugin.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/TestRpcEndpointServicePlugin.java
@@ -16,8 +16,8 @@ package org.hyperledger.besu.tests.acceptance.plugins;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
-import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.RpcEndpointService;
 import org.hyperledger.besu.plugin.services.rpc.PluginRpcRequest;
 
@@ -51,7 +51,8 @@ public class TestRpcEndpointServicePlugin implements BesuPlugin {
   }
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     context
         .getService(RpcEndpointService.class)
         .ifPresent(

--- a/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BesuPluginContextImpl.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import org.hyperledger.besu.ethereum.core.plugins.PluginConfiguration;
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuService;
@@ -49,7 +50,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** The Besu plugin context implementation. */
-public class BesuPluginContextImpl implements ServiceManager, PluginVersionsProvider {
+@SuppressWarnings("removal")
+public class BesuPluginContextImpl implements BesuContext, ServiceManager, PluginVersionsProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(BesuPluginContextImpl.class);
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '3DEeEv1YPoZvRCrmkUygP1tuXZ5YKnY0mIRFNhHPUoc='
+  knownHash = 'KuKoCZT1A+gOlJlry5GQMCRKVWWAlO3lGAqt9MDv0r4='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/BesuPlugin.java
@@ -48,7 +48,8 @@ public interface BesuPlugin {
    *
    * @param context the context that provides access to Besu services.
    */
-  void register(ServiceManager context);
+  @SuppressWarnings("removal")
+  void register(BesuContext context);
 
   /**
    * Called once when besu has loaded configuration but before external services have been started

--- a/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
+++ b/plugins/rocksdb/src/main/java/org/hyperledger/besu/plugin/services/storage/rocksdb/RocksDBPlugin.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services.storage.rocksdb;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.PicoCLIOptions;
@@ -59,7 +60,8 @@ public class RocksDBPlugin implements BesuPlugin {
   }
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     LOG.debug("Registering plugin");
     this.context = context;
 

--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/InMemoryStoragePlugin.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.services.kvstore;
 
+import org.hyperledger.besu.plugin.BesuContext;
 import org.hyperledger.besu.plugin.BesuPlugin;
 import org.hyperledger.besu.plugin.ServiceManager;
 import org.hyperledger.besu.plugin.services.BesuConfiguration;
@@ -44,7 +45,8 @@ public class InMemoryStoragePlugin implements BesuPlugin {
   public InMemoryStoragePlugin() {}
 
   @Override
-  public void register(final ServiceManager context) {
+  @SuppressWarnings("removal")
+  public void register(final BesuContext context) {
     LOG.debug("Registering plugin");
     this.context = context;
 


### PR DESCRIPTION
Reverts change to Plugin interface's register() method to not require newly introduced class.

