### PR TITLE
Fix minor grammatical error Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -73,7 +73,7 @@ How to become a maintainer:
 
 The requirement to be able to be proposed as a maintainer is:
 
-- 5 significant changes on code have been authored in this repos by the proposed maintainer and accepted (merged PRs).
+- 5 significant changes to code have been authored in this repos by the proposed maintainer and accepted (merged PRs).
   
 ### Maintainers approval process
 


### PR DESCRIPTION
**Description:**
I noticed a small grammatical issue in the "Maintainers" section of the documentation. The sentence:

> "5 significant changes on code have been authored in this repos by the proposed maintainer and accepted (merged PRs)."

should be corrected to:

> "5 significant changes to code have been authored in this repo by the proposed maintainer and accepted (merged PRs)."

Explanation:
- The phrase **"changes to code"** is the correct usage, as it indicates changes made to the code itself.

This correction ensures better clarity and grammatical accuracy in the documentation.


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

