### PR TITLE
[MINOR] (privacy deprecation) 24.12.0 target 

### DIFF
--- a/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyPluginPayloadProvider.java
+++ b/acceptance-tests/test-plugins/src/main/java/org/hyperledger/besu/tests/acceptance/plugins/privacy/TestPrivacyPluginPayloadProvider.java
@@ -28,7 +28,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class TestPrivacyPluginPayloadProvider implements PrivacyPluginPayloadProvider {
   private static final Logger LOG = LoggerFactory.getLogger(TestPrivacyPluginPayloadProvider.class);
   private String prefix;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/PrivacyPluginOptions.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli.options;
 import static picocli.CommandLine.Option;
 
 /** The Privacy plugin Cli options. */
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivacyPluginOptions {
   /** Default Constructor. */
   PrivacyPluginOptions() {}

--- a/besu/src/main/java/org/hyperledger/besu/services/PrivacyPluginServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/PrivacyPluginServiceImpl.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** The Privacy plugin service implementation. */
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivacyPluginServiceImpl implements PrivacyPluginService {
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyPluginServiceImpl.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/DisabledPrivacyRpcMethod.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/DisabledPrivacyRpcMethod.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcErrorR
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcResponse;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class DisabledPrivacyRpcMethod implements JsonRpcMethod {
 
   private final String methodName;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecorator.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyRpcMethodDecorator.java
@@ -27,7 +27,7 @@ import io.vertx.ext.auth.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class MultiTenancyRpcMethodDecorator implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(MultiTenancyRpcMethodDecorator.class);
   private final JsonRpcMethod rpcMethod;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtil.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/MultiTenancyUserUtil.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 import io.vertx.ext.auth.User;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class MultiTenancyUserUtil {
   private static final String PRIVACY_USER_ID_CLAIM = "privacyUserId";
   private static final String ENCLAVE_PRIVACY_PUBLIC_KEY_CLAIM = "privacyPublicKey";

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterChanges.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterChanges.java
@@ -31,7 +31,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.List;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetFilterChanges implements JsonRpcMethod {
 
   private final PrivacyController privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivGetFilterLogs.java
@@ -31,7 +31,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.List;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetFilterLogs implements JsonRpcMethod {
 
   private final PrivacyController privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivUninstallFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivUninstallFilter.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivUninstallFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacyIdProvider.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/PrivacyIdProvider.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 
 @FunctionalInterface
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public interface PrivacyIdProvider {
 
   String getPrivacyUserId(Optional<User> user);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/AbstractEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/AbstractEeaSendRawTransaction.java
@@ -48,7 +48,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public abstract class AbstractEeaSendRawTransaction implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractEeaSendRawTransaction.class);
   private final TransactionPool transactionPool;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/JsonRpcErrorResponseException.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/JsonRpcErrorResponseException.java
@@ -16,7 +16,7 @@ package org.hyperledger.besu.ethereum.api.jsonrpc.internal.privacy.methods.eea;
 
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class JsonRpcErrorResponseException extends RuntimeException {
 
   private final RpcErrorType jsonRpcError;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/PluginEeaSendRawTransaction.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PluginEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
   private final PrivacyController privacyController;
   private final PrivacyIdProvider privacyIdProvider;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedFlexibleEeaSendRawTransaction.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class RestrictedFlexibleEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
 
   private final PrivacyController privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/eea/RestrictedOffchainEeaSendRawTransaction.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import io.vertx.ext.auth.User;
 import org.apache.tuweni.bytes.Bytes;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class RestrictedOffchainEeaSendRawTransaction extends AbstractEeaSendRawTransaction {
 
   final PrivacyController privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/AbstractPrivateTraceByHash.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/AbstractPrivateTraceByHash.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public abstract class AbstractPrivateTraceByHash implements JsonRpcMethod {
 
   protected final Supplier<PrivateBlockTracer> blockTracerSupplier;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCall.java
@@ -33,7 +33,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivCall extends AbstractBlockParameterMethod {
 
   private final PrivacyIdProvider privacyIdProvider;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivCreatePrivacyGroup.java
@@ -32,7 +32,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivCreatePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivCreatePrivacyGroup.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRoot.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDebugGetStateRoot.java
@@ -39,7 +39,7 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivDebugGetStateRoot extends AbstractBlockParameterMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDebugGetStateRoot.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDeletePrivacyGroup.java
@@ -32,7 +32,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivDeletePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDeletePrivacyGroup.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivDistributeRawTransaction.java
@@ -48,7 +48,7 @@ import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivDistributeRawTransaction implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivDistributeRawTransaction.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivFindPrivacyGroup.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("MockNotUsedInProduction")
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivFindPrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivFindPrivacyGroup.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetCode.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import org.apache.tuweni.bytes.Bytes;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetCode extends AbstractBlockParameterMethod {
 
   private final PrivacyController privacyController;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetEeaTransactionCount.java
@@ -42,7 +42,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetEeaTransactionCount implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetEeaTransactionCount.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetLogs.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetLogs implements JsonRpcMethod {
 
   private final BlockchainQueries blockchainQueries;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivacyPrecompileAddress.java
@@ -22,7 +22,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcRespon
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.JsonRpcSuccessResponse;
 import org.hyperledger.besu.ethereum.core.PrivacyParameters;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetPrivacyPrecompileAddress implements JsonRpcMethod {
 
   private final Address privacyAddress;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetPrivateTransaction.java
@@ -38,7 +38,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetPrivateTransaction implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetPrivateTransaction.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionCount.java
@@ -34,7 +34,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetTransactionCount implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetTransactionCount.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivGetTransactionReceipt.java
@@ -43,7 +43,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivGetTransactionReceipt implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivGetTransactionReceipt.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivNewFilter.java
@@ -29,7 +29,7 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import org.hyperledger.besu.ethereum.privacy.MultiTenancyPrivacyController;
 import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivNewFilter implements JsonRpcMethod {
 
   private final FilterManager filterManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivTraceTransaction.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivTraceTransaction.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivTraceTransaction extends AbstractPrivateTraceByHash implements JsonRpcMethod {
   private static final Logger LOG = LoggerFactory.getLogger(TraceTransaction.class);
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUtil.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/priv/PrivUtil.java
@@ -20,7 +20,7 @@ import org.hyperledger.besu.ethereum.privacy.PrivacyController;
 
 import java.util.Optional;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivUtil {
 
   public static void checkMembershipForAuthenticatedUser(

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroup.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/methods/privx/PrivxFindFlexiblePrivacyGroup.java
@@ -36,7 +36,7 @@ import graphql.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivxFindFlexiblePrivacyGroup implements JsonRpcMethod {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrivxFindFlexiblePrivacyGroup.class);

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/parameters/CreatePrivacyGroupParameter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/privacy/parameters/CreatePrivacyGroupParameter.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class CreatePrivacyGroupParameter {
 
   private final List<String> addresses;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivJsonRpcMethods.java
@@ -46,7 +46,7 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
 
 import java.util.Map;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivJsonRpcMethods extends PrivacyApiGroupJsonRpcMethods {
 
   private final FilterManager filterManager;

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/methods/PrivacyApiGroupJsonRpcMethods.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public abstract class PrivacyApiGroupJsonRpcMethods extends ApiGroupJsonRpcMethods {
 
   private final BlockchainQueries blockchainQueries;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContract.java
@@ -34,7 +34,7 @@ import org.apache.tuweni.bytes.Bytes32;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public class PrivacyPluginPrecompiledContract extends PrivacyPrecompiledContract {
   private static final Logger LOG = LoggerFactory.getLogger(PrivacyPluginPrecompiledContract.class);
   private final PrivacyParameters privacyParameters;

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'f6fi+lsYVZtFjmGOyiMPPCfNDie4SIPpj6HVgXRxF8Q='
+  knownHash = 'bULFOchupNjcCw+oZ4tykpgxzL4vsOTtDPimyiKGF98='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PrivacyPluginService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/PrivacyPluginService.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.plugin.services.privacy.PrivateMarkerTransactionFact
  * optionally register a {@link PrivateMarkerTransactionFactory} and a {@link
  * PrivacyGroupGenesisProvider}*
  */
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public interface PrivacyPluginService extends BesuService {
 
   /**

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/privacy/PrivacyPluginPayloadProvider.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/privacy/PrivacyPluginPayloadProvider.java
@@ -25,7 +25,7 @@ import org.apache.tuweni.bytes.Bytes;
  * Allows you to register a provider that will dictate how the payload of a privacy marker
  * transaction is handled.
  */
-@Deprecated(since = "24.11.0")
+@Deprecated(since = "24.12.0")
 public interface PrivacyPluginPayloadProvider {
 
   /**


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>

## PR description
Follow on from #7903 - update deprecation target to 24.12.0

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

