### PR TITLE
Shutdown MetricsSystem when stopping MetricsService

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/MetricsService.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.metrics;
 
 import org.hyperledger.besu.metrics.opentelemetry.MetricsOtelPushService;
+import org.hyperledger.besu.metrics.opentelemetry.OpenTelemetrySystem;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.metrics.prometheus.MetricsHttpService;
 import org.hyperledger.besu.metrics.prometheus.MetricsPushGatewayService;
@@ -48,13 +49,14 @@ public interface MetricsService {
         return Optional.of(
             new MetricsHttpService(configuration, (PrometheusMetricsSystem) metricsSystem));
       } else if (configuration.isPushEnabled()) {
-        return Optional.of(new MetricsPushGatewayService(configuration, metricsSystem));
+        return Optional.of(
+            new MetricsPushGatewayService(configuration, (PrometheusMetricsSystem) metricsSystem));
       } else {
         return Optional.empty();
       }
     } else if (configuration.getProtocol() == MetricsProtocol.OPENTELEMETRY) {
       if (configuration.isEnabled()) {
-        return Optional.of(new MetricsOtelPushService());
+        return Optional.of(new MetricsOtelPushService((OpenTelemetrySystem) metricsSystem));
       } else {
         return Optional.empty();
       }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/MetricsOtelPushService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/MetricsOtelPushService.java
@@ -26,9 +26,16 @@ import org.slf4j.LoggerFactory;
 public class MetricsOtelPushService implements MetricsService {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsOtelPushService.class);
+  private final OpenTelemetrySystem metricsSystem;
 
-  /** Instantiates a new Metrics open telemetry push service. */
-  public MetricsOtelPushService() {}
+  /**
+   * Instantiates a new Metrics open telemetry push service.
+   *
+   * @param metricsSystem The OpenTelemetry metrics system
+   */
+  public MetricsOtelPushService(final OpenTelemetrySystem metricsSystem) {
+    this.metricsSystem = metricsSystem;
+  }
 
   @Override
   public CompletableFuture<?> start() {
@@ -39,6 +46,7 @@ public class MetricsOtelPushService implements MetricsService {
 
   @Override
   public CompletableFuture<?> stop() {
+    metricsSystem.shutdown();
     return CompletableFuture.completedFuture(null);
   }
 

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsHttpService.java
@@ -121,6 +121,7 @@ public class MetricsHttpService implements MetricsService {
 
   @Override
   public CompletableFuture<?> stop() {
+    metricsSystem.shutdown();
     if (httpServer == null) {
       return CompletableFuture.completedFuture(null);
     }

--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsPushGatewayService.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/prometheus/MetricsPushGatewayService.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.metrics.prometheus;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import org.hyperledger.besu.metrics.MetricsService;
-import org.hyperledger.besu.plugin.services.MetricsSystem;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -37,7 +36,7 @@ public class MetricsPushGatewayService implements MetricsService {
   private PushGateway pushGateway;
   private ScheduledExecutorService scheduledExecutorService;
   private final MetricsConfiguration config;
-  private final MetricsSystem metricsSystem;
+  private final PrometheusMetricsSystem metricsSystem;
 
   /**
    * Instantiates a new Metrics push gateway service.
@@ -46,7 +45,7 @@ public class MetricsPushGatewayService implements MetricsService {
    * @param metricsSystem the metrics system
    */
   public MetricsPushGatewayService(
-      final MetricsConfiguration configuration, final MetricsSystem metricsSystem) {
+      final MetricsConfiguration configuration, final PrometheusMetricsSystem metricsSystem) {
     this.metricsSystem = metricsSystem;
     validateConfig(configuration);
     config = configuration;
@@ -59,9 +58,6 @@ public class MetricsPushGatewayService implements MetricsService {
     checkArgument(
         !(config.isEnabled() && config.isPushEnabled()),
         "Metrics Push Gateway Service cannot run concurrent with the normal metrics.");
-    checkArgument(
-        metricsSystem instanceof PrometheusMetricsSystem,
-        "Push Gateway requires a Prometheus Metrics System.");
   }
 
   @Override
@@ -73,7 +69,7 @@ public class MetricsPushGatewayService implements MetricsService {
 
     pushGateway =
         PushGateway.builder()
-            .registry(((PrometheusMetricsSystem) metricsSystem).getRegistry())
+            .registry(metricsSystem.getRegistry())
             .address(config.getPushHost() + ":" + config.getPushPort())
             .job(config.getPrometheusJob())
             .build();
@@ -90,6 +86,7 @@ public class MetricsPushGatewayService implements MetricsService {
 
   @Override
   public CompletableFuture<?> stop() {
+    metricsSystem.shutdown();
     final CompletableFuture<?> resultFuture = new CompletableFuture<>();
     try {
       // Calling shutdown now cancels the pending push, which is desirable.


### PR DESCRIPTION
## PR description

Shutdown `MetricsSystem` when stopping `MetricsService`, so any registered collector is cleaned, that is most useful during acceptance tests.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

