### PR TITLE
Enhance Code Readability Update MergeProtocolSchedule.java

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -144,7 +144,7 @@ public class MergeProtocolSchedule {
       final Map<Long, Function<ProtocolSpecBuilder, ProtocolSpecBuilder>> postMergeModifications) {
     // Any post-Paris fork can rely on the MainnetProtocolSpec definitions again
     // Must allow for config to skip Shanghai and go straight to a later fork.
-    if (config.getForkBlockTimestamps().size() > 0) {
+    if (!config.getForkBlockTimestamps().isEmpty()) {
       postMergeModifications.put(config.getForkBlockTimestamps().get(0), Function.identity());
     }
   }


### PR DESCRIPTION
### Description:  

This update refactors the conditional statement in the `unapplyModificationsFromShanghaiOnwards` method to improve code readability and alignment with Java standards.  

#### Issue:  
Previously, the code used `size() > 0` to check whether the list `config.getForkBlockTimestamps()` contains elements:  
```java
if (config.getForkBlockTimestamps().size() > 0) {
  postMergeModifications.put(config.getForkBlockTimestamps().get(0), Function.identity());
}
```  
While this is functionally correct, using `isEmpty()` is more idiomatic, concise, and clearer in intent.

#### Solution:  
The condition was updated to use the `isEmpty()` method:  
```java
if (!config.getForkBlockTimestamps().isEmpty()) {
  postMergeModifications.put(config.getForkBlockTimestamps().get(0), Function.identity());
}
```

#### Importance:  
1. **Improved Readability:** The new approach explicitly conveys the intent of checking for an empty list, making the code easier to understand.  
2. **Consistency with Java Standards:** Using `isEmpty()` is the recommended practice in Java, as it directly reflects the operation being performed and aligns with modern coding standards.  
3. **Future Maintenance:** This change reduces potential confusion for new contributors and ensures better maintainability.  

#### Additional Notes:  
This is a non-breaking change with no impact on functionality, focused purely on improving code quality.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

