### PR TITLE
Feature/rebuild trie from flat

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.subcommands.storage;
+
+import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
+import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage.WORLD_BLOCK_HASH_KEY;
+import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage.WORLD_ROOT_HASH_KEY;
+
+import org.hyperledger.besu.cli.util.VersionProvider;
+import org.hyperledger.besu.controller.BesuController;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.MiningConfiguration;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.rlp.RLPInput;
+import org.hyperledger.besu.ethereum.trie.MerkleTrie;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
+import org.hyperledger.besu.ethereum.trie.patricia.StoredNodeFactory;
+import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
+
+import java.util.function.Function;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+/** The revert metadata to v1 subcommand. */
+@Command(
+    name = "rebuild-bonsai-state-trie",
+    description = "Rebuilds bonsai state trie from flat database",
+    mixinStandardHelpOptions = true,
+    versionProvider = VersionProvider.class)
+public class RebuildBonsaiStateTrieSubCommand implements Runnable {
+  private static final Logger LOG = LoggerFactory.getLogger(RebuildBonsaiStateTrieSubCommand.class);
+  private static final Hash HASH_LAST =
+      Hash.wrap(Bytes32.leftPad(Bytes.fromHexString("FF"), (byte) 0xFF));
+
+  @SuppressWarnings("unused")
+  @ParentCommand
+  private StorageSubCommand parentCommand;
+
+  @SuppressWarnings("unused")
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
+  /** Default Constructor. */
+  public RebuildBonsaiStateTrieSubCommand() {}
+
+  @Override
+  public void run() {
+    // spec.commandLine().usage(System.out);
+    try (final BesuController controller = createController()) {
+
+      var storageProvider = controller.getStorageProvider();
+
+      // TODO: assuming bonsai, fix or qualify
+      var worldStateStorage =
+          (BonsaiWorldStateKeyValueStorage)
+              storageProvider.createWorldStateStorage(
+                  DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
+
+      var header = controller.getProtocolContext().getBlockchain().getChainHeadHeader();
+      // TODO: add a check to ensure the flat db state root and block hash either match or are
+      // absent from state trie
+
+      // truncate the TRIE_BRANCH_STORAGE column family,
+      //   subsequently rewrite blockhash and state root after we rebuild the trie
+      worldStateStorage.clearTrie();
+
+      // rebuild the trie by inserting everything into a StoredMerklePatriciaTrie
+      // and incrementally (naively) commit after each account while streaming
+      // TODO: optimize to incrementally commit tx after a certain threshold
+
+      final var wss = worldStateStorage.getComposedWorldStateStorage();
+      final var accountTrie =
+          new StoredMerklePatriciaTrie<>(
+              new StoredNodeFactory<>(
+                  (location, hash) -> worldStateStorage.getAccount(Hash.wrap(hash)),
+                  Function.identity(),
+                  Function.identity()),
+              MerkleTrie.EMPTY_TRIE_NODE_HASH);
+
+      final var flatdb = worldStateStorage.getFlatDbStrategy();
+      flatdb
+          .accountsToPairStream(wss, Bytes32.ZERO)
+          .forEach(
+              accountPair -> {
+                final SegmentedKeyValueStorageTransaction perAccountTx =
+                    worldStateStorage.getComposedWorldStateStorage().startTransaction();
+
+                // if the account has storage, write the account storage trie values
+                if (isNonEmptyStorage(accountPair.getSecond())) {
+                  // create account storage trie
+                  var accountStorageTrie =
+                      new StoredMerklePatriciaTrie<>(
+                          new StoredNodeFactory<>(
+                              (location, hash) ->
+                                  worldStateStorage.getAccountStorageTrieNode(
+                                      Hash.wrap(accountPair.getFirst()), location, hash),
+                              Function.identity(),
+                              Function.identity()),
+                          MerkleTrie.EMPTY_TRIE_NODE_HASH);
+
+                  // put into account trie
+                  flatdb
+                      .storageToPairStream(
+                          wss,
+                          Hash.wrap(accountPair.getFirst()),
+                          Bytes32.ZERO,
+                          HASH_LAST,
+                          Function.identity())
+                      .forEach(
+                          storagePair -> {
+                            accountStorageTrie.put(storagePair.getFirst(), storagePair.getSecond());
+                          });
+
+                  // commit the account storage trie
+                  accountStorageTrie.commit(
+                      (location, hash, value) ->
+                          perAccountTx.put(
+                              TRIE_BRANCH_STORAGE,
+                              Bytes.concatenate(accountPair.getFirst(), location).toArrayUnsafe(),
+                              value.toArrayUnsafe()));
+                }
+
+                // write the account info
+                accountTrie.put(accountPair.getFirst(), accountPair.getSecond());
+
+                // commit the account trie
+                accountTrie.commit(
+                    (location, hash, value) ->
+                        perAccountTx.put(
+                            TRIE_BRANCH_STORAGE, location.toArrayUnsafe(), value.toArrayUnsafe()));
+
+                LOG.info("committing accountHash {}", accountPair.getFirst());
+                perAccountTx.commit();
+              });
+
+      // rewrite state root and blockhash
+      var tx = worldStateStorage.getComposedWorldStateStorage().startTransaction();
+      tx.put(TRIE_BRANCH_STORAGE, WORLD_ROOT_HASH_KEY, header.getStateRoot().toArrayUnsafe());
+      tx.put(TRIE_BRANCH_STORAGE, WORLD_BLOCK_HASH_KEY, header.getBlockHash().toArrayUnsafe());
+      LOG.info("committing blockhash and stateroot {}", header.toLogString());
+      tx.commit();
+    }
+  }
+
+  private boolean isNonEmptyStorage(final Bytes accountRLP) {
+    final RLPInput in = RLP.input(accountRLP);
+    in.enterList();
+
+    // nonce
+    in.readLongScalar();
+    // balance
+    in.readUInt256Scalar();
+    // storageRoot
+    final Hash storageRoot = Hash.wrap(in.readBytes32());
+    // final Hash codeHash = Hash.wrap(in.readBytes32());
+
+    in.leaveList();
+    return !storageRoot.equals(Hash.EMPTY_TRIE_HASH);
+  }
+
+  private BesuController createController() {
+    try {
+      // Set some defaults
+      return parentCommand
+          .besuCommand
+          .setupControllerBuilder()
+          .miningParameters(MiningConfiguration.MINING_DISABLED)
+          .build();
+    } catch (final Exception e) {
+      throw new CommandLine.ExecutionException(spec.commandLine(), e.getMessage(), e);
+    }
+  }
+}

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -177,7 +177,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
       // write the account info
       accountTrie.put(accountPair.getFirst(), accountPair.getSecond());
 
-      if (accountsCount++ % FORCED_COMMIT_INTERVAL == 0) {
+      if (++accountsCount % FORCED_COMMIT_INTERVAL == 0) {
         LOG.info("committing account trie at account {}", accountPair.getFirst());
 
         // commit the account trie if we have exceeded the forced commit interval
@@ -255,7 +255,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
       accountStorageTrie.put(storagePair.getFirst(), encodeTrieValue(storagePair.getSecond()));
 
       // commit the account storage trie
-      if (accountStorageCount++ % FORCED_COMMIT_INTERVAL == 0) {
+      if (++accountStorageCount % FORCED_COMMIT_INTERVAL == 0) {
         LOG.info("interim commit for account hash {}, at {}", accountHash, storagePair.getFirst());
         accountStorageCommit.accept(accountStorageTrie);
         accountStorageTx.commitAndReopen();

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -60,7 +60,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(RebuildBonsaiStateTrieSubCommand.class);
   private static final Hash HASH_LAST =
       Hash.wrap(Bytes32.leftPad(Bytes.fromHexString("FF"), (byte) 0xFF));
-  static final long FORCED_COMMIT_INTERVAL = 50_000L;
+  static final long FORCED_COMMIT_INTERVAL = 5_000L;
 
   @SuppressWarnings("unused")
   @ParentCommand
@@ -256,6 +256,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
 
       // commit the account storage trie
       if (accountStorageCount++ % FORCED_COMMIT_INTERVAL == 0) {
+        LOG.info("interim commit for account hash {}, at {}", accountHash, storagePair.getFirst());
         accountStorageCommit.accept(accountStorageTrie);
         accountStorageTx.commitAndReopen();
         // new trie with new root, GC trie nodes

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.cli.subcommands.storage;
 import static org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier.TRIE_BRANCH_STORAGE;
 import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage.WORLD_BLOCK_HASH_KEY;
 import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBasedWorldStateKeyValueStorage.WORLD_ROOT_HASH_KEY;
+import static org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldView.encodeTrieValue;
 
 import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.controller.BesuController;
@@ -236,7 +237,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
     long accountStorageCount = 0L;
     while (accountStorageIterator.hasNext()) {
       var storagePair = accountStorageIterator.next();
-      accountStorageTrie.put(storagePair.getFirst(), storagePair.getSecond());
+      accountStorageTrie.put(storagePair.getFirst(), encodeTrieValue(storagePair.getSecond()));
 
       // commit the account storage trie
       if (accountStorageCount++ % FORCED_COMMIT_INTERVAL == 0) {

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.ethereum.trie.diffbased.common.storage.DiffBa
 import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
@@ -28,7 +29,8 @@ import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredNodeFactory;
-import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
+import org.hyperledger.besu.ethereum.worldstate.FlatDbMode;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
 import org.hyperledger.besu.plugin.services.storage.SegmentedKeyValueStorageTransaction;
 
 import java.util.function.Function;
@@ -68,98 +70,142 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
     // spec.commandLine().usage(System.out);
     try (final BesuController controller = createController()) {
 
-      var storageProvider = controller.getStorageProvider();
+      var storageConfig = controller.getDataStorageConfiguration();
 
-      // TODO: assuming bonsai, fix or qualify
+      if (!storageConfig.getDataStorageFormat().equals(DataStorageFormat.BONSAI)) {
+        LOG.error("Data Storage format is not BONSAI.  Refusing to rebuild state trie.");
+        System.exit(-1);
+      }
+
       var worldStateStorage =
           (BonsaiWorldStateKeyValueStorage)
-              storageProvider.createWorldStateStorage(
-                  DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
+              controller
+                  .getStorageProvider()
+                  .createWorldStateStorage(controller.getDataStorageConfiguration());
 
-      var header = controller.getProtocolContext().getBlockchain().getChainHeadHeader();
-      // TODO: add a check to ensure the flat db state root and block hash either match or are
-      // absent from state trie
+      if (!worldStateStorage.getFlatDbMode().equals(FlatDbMode.FULL)) {
+        LOG.error("Database is not fully flattened. Refusing to rebuild state trie.");
+        System.exit(-1);
+      }
 
-      // truncate the TRIE_BRANCH_STORAGE column family,
-      //   subsequently rewrite blockhash and state root after we rebuild the trie
-      worldStateStorage.clearTrie();
+      final BlockHeader header =
+          controller.getProtocolContext().getBlockchain().getChainHeadHeader();
 
-      // rebuild the trie by inserting everything into a StoredMerklePatriciaTrie
-      // and incrementally (naively) commit after each account while streaming
-      // TODO: optimize to incrementally commit tx after a certain threshold
-
-      final var wss = worldStateStorage.getComposedWorldStateStorage();
-      final var accountTrie =
-          new StoredMerklePatriciaTrie<>(
-              new StoredNodeFactory<>(
-                  (location, hash) -> worldStateStorage.getAccount(Hash.wrap(hash)),
-                  Function.identity(),
-                  Function.identity()),
-              MerkleTrie.EMPTY_TRIE_NODE_HASH);
-
-      final var flatdb = worldStateStorage.getFlatDbStrategy();
-      flatdb
-          .accountsToPairStream(wss, Bytes32.ZERO)
-          .forEach(
-              accountPair -> {
-                final SegmentedKeyValueStorageTransaction perAccountTx =
-                    worldStateStorage.getComposedWorldStateStorage().startTransaction();
-
-                // if the account has storage, write the account storage trie values
-                if (isNonEmptyStorage(accountPair.getSecond())) {
-                  // create account storage trie
-                  var accountStorageTrie =
-                      new StoredMerklePatriciaTrie<>(
-                          new StoredNodeFactory<>(
-                              (location, hash) ->
-                                  worldStateStorage.getAccountStorageTrieNode(
-                                      Hash.wrap(accountPair.getFirst()), location, hash),
-                              Function.identity(),
-                              Function.identity()),
-                          MerkleTrie.EMPTY_TRIE_NODE_HASH);
-
-                  // put into account trie
-                  flatdb
-                      .storageToPairStream(
-                          wss,
-                          Hash.wrap(accountPair.getFirst()),
-                          Bytes32.ZERO,
-                          HASH_LAST,
-                          Function.identity())
-                      .forEach(
-                          storagePair -> {
-                            accountStorageTrie.put(storagePair.getFirst(), storagePair.getSecond());
-                          });
-
-                  // commit the account storage trie
-                  accountStorageTrie.commit(
-                      (location, hash, value) ->
-                          perAccountTx.put(
-                              TRIE_BRANCH_STORAGE,
-                              Bytes.concatenate(accountPair.getFirst(), location).toArrayUnsafe(),
-                              value.toArrayUnsafe()));
-                }
-
-                // write the account info
-                accountTrie.put(accountPair.getFirst(), accountPair.getSecond());
-
-                // commit the account trie
-                accountTrie.commit(
-                    (location, hash, value) ->
-                        perAccountTx.put(
-                            TRIE_BRANCH_STORAGE, location.toArrayUnsafe(), value.toArrayUnsafe()));
-
-                LOG.info("committing accountHash {}", accountPair.getFirst());
-                perAccountTx.commit();
+      worldStateStorage
+          .getWorldStateRootHash()
+          // we want state root hash to either be empty or same the same as chain head
+          .filter(root -> !root.equals(header.getStateRoot()))
+          .ifPresent(
+              foundRoot -> {
+                LOG.error(
+                    "Chain head {} does not match state root {}.  Refusing to rebuild state trie.",
+                    header.getStateRoot(),
+                    foundRoot);
+                System.exit(-1);
               });
 
-      // rewrite state root and blockhash
-      var tx = worldStateStorage.getComposedWorldStateStorage().startTransaction();
-      tx.put(TRIE_BRANCH_STORAGE, WORLD_ROOT_HASH_KEY, header.getStateRoot().toArrayUnsafe());
-      tx.put(TRIE_BRANCH_STORAGE, WORLD_BLOCK_HASH_KEY, header.getBlockHash().toArrayUnsafe());
-      LOG.info("committing blockhash and stateroot {}", header.toLogString());
-      tx.commit();
+      // rebuild trie:
+      var newHash = rebuildTrie(worldStateStorage);
+
+      // write state root and block hash from the header:
+      if (!header.getStateRoot().equals(newHash)) {
+        LOG.error(
+            "Catastrophic: calculated state root {} after state rebuild, was expecting {}.",
+            newHash,
+            header.getStateRoot());
+        System.exit(-1);
+      }
+      writeStateRootAndBlockHash(header, worldStateStorage);
     }
+  }
+
+  Hash rebuildTrie(final BonsaiWorldStateKeyValueStorage worldStateStorage) {
+    // truncate the TRIE_BRANCH_STORAGE column family,
+    //   subsequently rewrite blockhash and state root after we rebuild the trie
+    worldStateStorage.clearTrie();
+
+    // rebuild the trie by inserting everything into a StoredMerklePatriciaTrie
+    // and incrementally (naively) commit after each account while streaming
+    // TODO: optimize to incrementally commit tx after a certain threshold
+
+    final var wss = worldStateStorage.getComposedWorldStateStorage();
+    final var accountTrie =
+        new StoredMerklePatriciaTrie<>(
+            new StoredNodeFactory<>(
+                // this may be inefficient, and we can read through an incrementally committing tx
+                // instead
+                worldStateStorage::getAccountStateTrieNode,
+                Function.identity(),
+                Function.identity()),
+            MerkleTrie.EMPTY_TRIE_NODE_HASH);
+
+    final var flatdb = worldStateStorage.getFlatDbStrategy();
+    flatdb
+        .accountsToPairStream(wss, Bytes32.ZERO)
+        .forEach(
+            accountPair -> {
+              final SegmentedKeyValueStorageTransaction perAccountTx =
+                  worldStateStorage.getComposedWorldStateStorage().startTransaction();
+
+              // if the account has storage, write the account storage trie values
+              if (isNonEmptyStorage(accountPair.getSecond())) {
+                // create account storage trie
+                var accountStorageTrie =
+                    new StoredMerklePatriciaTrie<>(
+                        new StoredNodeFactory<>(
+                            (location, hash) ->
+                                worldStateStorage.getAccountStorageTrieNode(
+                                    Hash.wrap(accountPair.getFirst()), location, hash),
+                            Function.identity(),
+                            Function.identity()),
+                        MerkleTrie.EMPTY_TRIE_NODE_HASH);
+
+                // put into account trie
+                flatdb
+                    .storageToPairStream(
+                        wss,
+                        Hash.wrap(accountPair.getFirst()),
+                        Bytes32.ZERO,
+                        HASH_LAST,
+                        Function.identity())
+                    .forEach(
+                        storagePair -> {
+                          accountStorageTrie.put(storagePair.getFirst(), storagePair.getSecond());
+                        });
+
+                // commit the account storage trie
+                accountStorageTrie.commit(
+                    (location, hash, value) ->
+                        perAccountTx.put(
+                            TRIE_BRANCH_STORAGE,
+                            Bytes.concatenate(accountPair.getFirst(), location).toArrayUnsafe(),
+                            value.toArrayUnsafe()));
+              }
+
+              // write the account info
+              accountTrie.put(accountPair.getFirst(), accountPair.getSecond());
+
+              // commit the account trie
+              accountTrie.commit(
+                  (location, hash, value) ->
+                      perAccountTx.put(
+                          TRIE_BRANCH_STORAGE, location.toArrayUnsafe(), value.toArrayUnsafe()));
+
+              LOG.info("committing accountHash {}", accountPair.getFirst());
+              perAccountTx.commit();
+            });
+
+    // perhaps not the safest cast
+    return Hash.wrap(accountTrie.getRootHash());
+  }
+
+  void writeStateRootAndBlockHash(
+      final BlockHeader header, final BonsaiWorldStateKeyValueStorage worldStateStorage) {
+    var tx = worldStateStorage.getComposedWorldStateStorage().startTransaction();
+    tx.put(TRIE_BRANCH_STORAGE, WORLD_ROOT_HASH_KEY, header.getStateRoot().toArrayUnsafe());
+    tx.put(TRIE_BRANCH_STORAGE, WORLD_BLOCK_HASH_KEY, header.getBlockHash().toArrayUnsafe());
+    LOG.info("committing blockhash and stateroot {}", header.toLogString());
+    tx.commit();
   }
 
   private boolean isNonEmptyStorage(final Bytes accountRLP) {
@@ -174,7 +220,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
     final Hash storageRoot = Hash.wrap(in.readBytes32());
     // final Hash codeHash = Hash.wrap(in.readBytes32());
 
-    in.leaveList();
+    //    in.leaveList();
     return !storageRoot.equals(Hash.EMPTY_TRIE_HASH);
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommand.java
@@ -67,7 +67,7 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
       description =
           "when rebuilding the state trie, force the usage of the specified blockhash:stateroot.  "
               + "This will bypass block header and worldstate checks.  "
-              + "e.g. --override-blockhash-and-stateroot=0xdeadbeef..deadbeef:0xc0ffee..coffee",
+              + "e.g. --override-blockhash-and-stateroot=0xdeadbeef..deadbeef:0xc0ffee..c0ffee",
       arity = "1..1")
   private String overrideHashes = null;
 
@@ -128,6 +128,12 @@ public class RebuildBonsaiStateTrieSubCommand implements Runnable {
     }
   }
 
+  /**
+   * entry point for testing, verify the block hash and state root and rebuild the trie.
+   *
+   * @param blockHashAndStateRoot record tuple for block hash and state root.
+   * @param worldStateStorage bonsai worldstate storage.
+   */
   @VisibleForTesting
   protected void verifyAndRebuild(
       final BlockHashAndStateRoot blockHashAndStateRoot,

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/StorageSubCommand.java
@@ -50,7 +50,8 @@ import picocli.CommandLine.Spec;
       StorageSubCommand.RevertVariablesStorage.class,
       RocksDbSubCommand.class,
       TrieLogSubCommand.class,
-      RevertMetadataSubCommand.class
+      RevertMetadataSubCommand.class,
+      RebuildBonsaiStateTrieSubCommand.class
     })
 public class StorageSubCommand implements Runnable {
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.cli.subcommands.storage;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.hyperledger.besu.ethereum.ProtocolContext;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+import org.hyperledger.besu.ethereum.mainnet.HeaderValidationMode;
+import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
+import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+import org.hyperledger.besu.testutil.BlockTestUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test only exercises bonsai worldstate since forest is essentially a no-op for moving the
+ * worldstate.
+ */
+public class RebuildBonsaiStateTrieSubCommandTest {
+
+  Blockchain blockchain;
+  WorldStateArchive archive;
+  ProtocolContext protocolContext;
+  ProtocolSchedule protocolSchedule;
+  BlockchainSetupUtil blockchainSetupUtil;
+  RebuildBonsaiStateTrieSubCommand command = new RebuildBonsaiStateTrieSubCommand();
+
+  @BeforeEach
+  public void setup() throws Exception {
+    setupBonsaiBlockchain();
+    blockchain = blockchainSetupUtil.getBlockchain();
+    protocolContext = blockchainSetupUtil.getProtocolContext();
+    protocolSchedule = blockchainSetupUtil.getProtocolSchedule();
+    archive = blockchainSetupUtil.getWorldArchive();
+  }
+
+  void setupBonsaiBlockchain() {
+    blockchainSetupUtil =
+        BlockchainSetupUtil.createForEthashChain(
+            // Mainnet is a more robust test resource, but it takes upwards of 1 minute to generate
+            // BlockTestUtil.getMainnetResources(),
+            BlockTestUtil.getSnapTestChainResources(), DataStorageFormat.BONSAI);
+    blockchainSetupUtil.importAllBlocks(
+        HeaderValidationMode.LIGHT_DETACHED_ONLY, HeaderValidationMode.LIGHT);
+  }
+
+  @Test
+  public void assertStateRootMatchesAfterRebuild() {
+    var worldstate = (BonsaiWorldState) archive.getMutable();
+    var headRootHash = worldstate.rootHash();
+
+    // drop the trie:
+    worldstate.getWorldStateStorage().clearTrie();
+
+    // rebuild the trie:
+    var newHash = command.rebuildTrie(worldstate.getWorldStateStorage());
+
+    assertThat(newHash).isEqualTo(headRootHash);
+  }
+}

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -55,9 +55,8 @@ public class RebuildBonsaiStateTrieSubCommandTest {
     blockchainSetupUtil =
         BlockchainSetupUtil.createForEthashChain(
             // Mainnet is a more robust test resource, but it takes upwards of 1 minute to generate
-            //BlockTestUtil.getMainnetResources(),
-            BlockTestUtil.getSnapTestChainResources(),
-            DataStorageFormat.BONSAI);
+            // BlockTestUtil.getMainnetResources(),
+            BlockTestUtil.getSnapTestChainResources(), DataStorageFormat.BONSAI);
     blockchainSetupUtil.importAllBlocks(HeaderValidationMode.NONE, HeaderValidationMode.NONE);
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -56,10 +56,9 @@ public class RebuildBonsaiStateTrieSubCommandTest {
         BlockchainSetupUtil.createForEthashChain(
             // Mainnet is a more robust test resource, but it takes upwards of 1 minute to generate
             BlockTestUtil.getMainnetResources(),
-            //BlockTestUtil.getSnapTestChainResources(),  /* snap only has a
+            // BlockTestUtil.getSnapTestChainResources(),  /* snap only has a
             DataStorageFormat.BONSAI);
-    blockchainSetupUtil.importAllBlocks(
-        HeaderValidationMode.NONE, HeaderValidationMode.NONE);
+    blockchainSetupUtil.importAllBlocks(HeaderValidationMode.NONE, HeaderValidationMode.NONE);
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -55,10 +55,11 @@ public class RebuildBonsaiStateTrieSubCommandTest {
     blockchainSetupUtil =
         BlockchainSetupUtil.createForEthashChain(
             // Mainnet is a more robust test resource, but it takes upwards of 1 minute to generate
-            // BlockTestUtil.getMainnetResources(),
-            BlockTestUtil.getSnapTestChainResources(), DataStorageFormat.BONSAI);
+            BlockTestUtil.getMainnetResources(),
+            //BlockTestUtil.getSnapTestChainResources(),  /* snap only has a
+            DataStorageFormat.BONSAI);
     blockchainSetupUtil.importAllBlocks(
-        HeaderValidationMode.LIGHT_DETACHED_ONLY, HeaderValidationMode.LIGHT);
+        HeaderValidationMode.NONE, HeaderValidationMode.NONE);
   }
 
   @Test

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.cli.subcommands.storage;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
+import org.hyperledger.besu.cli.subcommands.storage.RebuildBonsaiStateTrieSubCommand.BlockHashAndStateRoot;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
@@ -72,5 +74,16 @@ public class RebuildBonsaiStateTrieSubCommandTest {
     var newHash = command.rebuildTrie(worldstate.getWorldStateStorage());
 
     assertThat(newHash).isEqualTo(headRootHash);
+  }
+
+  @Test
+  public void assertBlockHashAndStateRootParsing() {
+
+    assertThat(BlockHashAndStateRoot.create("0xdeadbeef:0xdeadbeef")).isNull();
+
+    var mockVal = BlockHashAndStateRoot.create(Hash.EMPTY + ":" + Hash.EMPTY_TRIE_HASH);
+    assertThat(mockVal).isNotNull();
+    assertThat(mockVal.blockHash()).isEqualTo(Hash.EMPTY);
+    assertThat(mockVal.stateRoot()).isEqualTo(Hash.EMPTY_TRIE_HASH);
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/storage/RebuildBonsaiStateTrieSubCommandTest.java
@@ -55,8 +55,8 @@ public class RebuildBonsaiStateTrieSubCommandTest {
     blockchainSetupUtil =
         BlockchainSetupUtil.createForEthashChain(
             // Mainnet is a more robust test resource, but it takes upwards of 1 minute to generate
-            BlockTestUtil.getMainnetResources(),
-            // BlockTestUtil.getSnapTestChainResources(),  /* snap only has a
+            //BlockTestUtil.getMainnetResources(),
+            BlockTestUtil.getSnapTestChainResources(),
             DataStorageFormat.BONSAI);
     blockchainSetupUtil.importAllBlocks(HeaderValidationMode.NONE, HeaderValidationMode.NONE);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/flat/BonsaiFlatDbStrategy.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/storage/flat/BonsaiFlatDbStrategy.java
@@ -136,7 +136,8 @@ public abstract class BonsaiFlatDbStrategy extends FlatDbStrategy {
   }
 
   @Override
-  protected Stream<Pair<Bytes32, Bytes>> storageToPairStream(
+  // TODO: this should probably remain protected, public for now to enable trie rebuilding
+  public Stream<Pair<Bytes32, Bytes>> storageToPairStream(
       final SegmentedKeyValueStorage storage,
       final Hash accountHash,
       final Bytes startKeyHash,
@@ -164,7 +165,8 @@ public abstract class BonsaiFlatDbStrategy extends FlatDbStrategy {
   }
 
   @Override
-  protected Stream<Pair<Bytes32, Bytes>> accountsToPairStream(
+  // TODO: this should probably remain protected, public for now to enable trie rebuilding
+  public Stream<Pair<Bytes32, Bytes>> accountsToPairStream(
       final SegmentedKeyValueStorage storage, final Bytes startKeyHash) {
     return storage
         .streamFromKey(ACCOUNT_INFO_STATE, startKeyHash.toArrayUnsafe())


### PR DESCRIPTION
## PR description
Implement a storage subcommand to rebuild the bonsai state trie from flat db.  This subcommand can be used to fix a broken state trie by re-inserting all of the elements from the flat database into the state trie.

usage:

`besu --config-file=<config_toml> storage rebuild-bonsai-state-trie`

This is a destructive action, but has appropriate safeguards to ensure the state trie reconstruction will be successful.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7934

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

