### PR TITLE
Fix possible incomplete txpool restore from dump file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug fixes
 - Fix serialization of state overrides when `movePrecompileToAddress` is present [#8204](https://github.com/hyperledger/besu/pull/8024)
 - Revise the approach for setting level_compaction_dynamic_level_bytes RocksDB configuration option [#8037](https://github.com/hyperledger/besu/pull/8037)
+- Fix possible incomplete txpool restore from dump file [#7991](https://github.com/hyperledger/besu/pull/7991)
 
 ## 24.12.2 Hotfix
 


### PR DESCRIPTION
## PR description

it could happen, especially at startup, that the node switch from in sync to out of sync quickly, and if that happens during the txpool restore from the dump file, the restore could be incomplete.

This is an log example of this issue:

```
1. Loading transaction pool content from file /data/besu/txpool.dump
2. Node out of sync, disabling transaction handling
3. Added 88 transactions of 442 loaded from file /data/besu/txpool.dump
4. Saving 88 transactions to file /data/besu/txpool.dump
5. Saved 88 transactions to file /data/besu/txpool.dump
6. Node is in sync, enabling transaction handling
7. Loading transaction pool content from file /data/besu/txpool.dump
8. Added 87 transactions of 88 loaded from file /data/besu/txpool.dump
```

So at the beginning the node was restoring the txpool (1.), 
but while this restore was still in progress, the node went out of sync and the txpool was disabled(2.), 
the issue manifest itself at this moment, since with the txpool disabled, restore txs are just ignored but technically the restore was completed successfully and the dump file removed, with only a subset of the txs restored (3.),
last part of disabling the txpool, consist in saving its content to the dump file (4.),
so the dump file is created with the current content of the txpool, that only has the subset of txs loaded from point 3 (5.)
Then after the node get in sync again, the process restart, but this time the dump file contains only a subset of the original txs set (6., 7., 8.)

To fix this issue, when disabling the txpool, we make sure that any in progress restore operation is cancelled correctly, removing from the dump file only the txs that have been restored, and changing the save operation to append to an existing dump file, so that no save txs are lost in case of a partial restore.

Below the new log with the fix
```
1. Loading transaction pool content from file /data/besu/txpool.dump
2. Node out of sync, disabling transaction handling
3. Added 94 transactions of 94 loaded from file /data/besu/txpool.dump, before operation was cancelled
4. Appending 94 transactions to file /data/besu/txpool.dump
5. Appended 94 transactions to file /data/besu/txpool.dump
6. Node is in sync, enabling transaction handling
7. Loading transaction pool content from file /data/besu/txpool.dump
8. Added 248 transactions of 348 loaded from file /data/besu/txpool.dump, deleting file
```

Note that restore operation is correctly stopped when the node goes out of sync (3.),
the save operation appends to the partially restored dump file (4., 5.)
and when the node goes in sync again the restore operation read the full set of txs from the dump, and deleted the file at the end (8.)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

