### PR TITLE
Fix flaky Clique tests waiting for nodes to be fully connected and in sync

### DIFF
--- a/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
+++ b/acceptance-tests/tests/src/test/java/org/hyperledger/besu/tests/acceptance/clique/CliqueMiningAcceptanceTest.java
@@ -120,6 +120,11 @@ public class CliqueMiningAcceptanceTest extends AcceptanceTestBase {
       final BesuNode minerNode1, final BesuNode minerNode2, final BesuNode minerNode3) {
     cluster.start(minerNode1, minerNode2, minerNode3);
 
+    // verify nodes are fully connected otherwise blocks could not be propagated
+    minerNode1.verify(net.awaitPeerCount(2));
+    minerNode2.verify(net.awaitPeerCount(2));
+    minerNode3.verify(net.awaitPeerCount(2));
+
     // verify that we have started producing blocks
     waitForBlockHeight(minerNode1, 1);
     final var minerChainHead = minerNode1.execute(ethTransactions.block());


### PR DESCRIPTION
## PR description

verify nodes are fully connected otherwise blocks could not be propagated

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

#7992

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

