### PR TITLE
account overrides: parse hex string into nonce long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 
 ### Bug fixes
 - Correct default parameters for frontier transactions in `eth_call` and `eth_estimateGas` [#7965](https://github.com/hyperledger/besu/pull/7965)
-- Correctly parse nonce as hex in `eth_call` account overrides [#7999](https://github.com/hyperledger/besu/pull/7999)
 
 ## 24.12.0
 
@@ -74,6 +73,7 @@
 - Fix registering new metric categories from plugins [#7825](https://github.com/hyperledger/besu/pull/7825)
 - Fix CVE-2024-47535 [7878](https://github.com/hyperledger/besu/pull/7878)
 - Fix QBFT prepared block based proposal validation [#7875](https://github.com/hyperledger/besu/pull/7875)
+- Correctly parse nonce as hex in `eth_call` account overrides [#7999](https://github.com/hyperledger/besu/pull/7999)
 
 ## 24.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - Proper support for `pending` block tag when calling `eth_estimateGas` and `eth_createAccessList` [#7951](https://github.com/hyperledger/besu/pull/7951)
 
 ### Bug fixes
--  Correct default parameters for frontier transactions in `eth_call` and `eth_estimateGas` [#7965](https://github.com/hyperledger/besu/pull/7965)
+- Correct default parameters for frontier transactions in `eth_call` and `eth_estimateGas` [#7965](https://github.com/hyperledger/besu/pull/7965)
+- Correctly parse nonce as hex in `eth_call` account overrides [#7999](https://github.com/hyperledger/besu/pull/7999)
 
 ## 24.12.0
 

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/AccountOverride.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/AccountOverride.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,11 +107,11 @@ public class AccountOverride {
     /**
      * Sets the nonce override
      *
-     * @param nonce the nonce override
+     * @param nonce the nonce override in hex
      * @return the builder
      */
-    public Builder withNonce(final Long nonce) {
-      this.nonce = Optional.ofNullable(nonce);
+    public Builder withNonce(final String nonce) {
+      this.nonce = Optional.of(Bytes.fromHexStringLenient(nonce).toLong());
       return this;
     }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCallTest.java
@@ -104,7 +104,7 @@ public class EthCallTest {
   @Test
   public void someAccountOverrides() {
     AccountOverrideMap expectedOverrides = new AccountOverrideMap();
-    AccountOverride override = new AccountOverride.Builder().withNonce(88L).build();
+    AccountOverride override = new AccountOverride.Builder().withNonce("0x9e").build();
     final Address address = Address.fromHexString("0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3");
     expectedOverrides.put(address, override);
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthEstimateGasTest.java
@@ -116,7 +116,7 @@ public class EthEstimateGasTest {
   @Test
   public void someAccountOverrides() {
     AccountOverrideMap expectedOverrides = new AccountOverrideMap();
-    AccountOverride override = new AccountOverride.Builder().withNonce(88L).build();
+    AccountOverride override = new AccountOverride.Builder().withNonce("0x9e").build();
     final Address address = Address.fromHexString("0xd9c9cd5f6779558b6e0ed4e6acf6b1947e7fa1f3");
     expectedOverrides.put(address, override);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/AccountOverrideParameterTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/util/AccountOverrideParameterTest.java
@@ -52,7 +52,7 @@ public class AccountOverrideParameterTest {
             + "\":"
             + "{"
             + "\"balance\": \"0x01\","
-            + "\"nonce\": 88"
+            + "\"nonce\": \"0x9e\""
             + "}}],\"id\":1}";
 
     final JsonRpcRequestContext request = new JsonRpcRequestContext(readJsonAsJsonRpcRequest(json));
@@ -62,7 +62,7 @@ public class AccountOverrideParameterTest {
     final AccountOverride accountOverride =
         accountOverrideParam.get(Address.fromHexString(ADDRESS_HEX1));
 
-    assertThat(accountOverride.getNonce()).isEqualTo(Optional.of(88L));
+    assertThat(accountOverride.getNonce().get()).isEqualTo(158);
     assertThat(accountOverride.getBalance()).isEqualTo(Optional.of(Wei.of(1)));
     assertFalse(accountOverride.getStateDiff().isPresent());
   }
@@ -97,6 +97,34 @@ public class AccountOverrideParameterTest {
   }
 
   @Test
+  public void jsonWithHexNonceDeserializesCorrectly() throws Exception {
+    final String json =
+        "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{"
+            + "\"from\":\"0x0\", \"to\": \"0x0\"}, "
+            + "\"latest\","
+            + "{\""
+            + ADDRESS_HEX1
+            + "\":"
+            + "{"
+            + "\"balance\": \"0x01\","
+            + "\"nonce\": \""
+            + "0x9e"
+            + "\""
+            + "}}],\"id\":1}";
+
+    final JsonRpcRequestContext request = new JsonRpcRequestContext(readJsonAsJsonRpcRequest(json));
+    final AccountOverrideMap accountOverrideParam =
+        request.getRequiredParameter(2, AccountOverrideMap.class);
+
+    final AccountOverride accountOverride =
+        accountOverrideParam.get(Address.fromHexString(ADDRESS_HEX1));
+
+    assertThat(accountOverride.getBalance()).isEqualTo(Optional.of(Wei.of(1)));
+    assertThat(accountOverride.getNonce().get()).isEqualTo(158); // 0x9e
+    assertFalse(accountOverride.getStateDiff().isPresent());
+  }
+
+  @Test
   public void jsonWithStorageOverridesDeserializesCorrectly() throws Exception {
     final String json =
         "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{"
@@ -107,7 +135,7 @@ public class AccountOverrideParameterTest {
             + "\":"
             + "{"
             + "\"balance\": \"0x01\","
-            + "\"nonce\": 88,"
+            + "\"nonce\": \"0x9E\","
             + "\"stateDiff\": {"
             + "\""
             + STORAGE_KEY
@@ -124,7 +152,7 @@ public class AccountOverrideParameterTest {
 
     final AccountOverride accountOverride =
         accountOverrideParam.get(Address.fromHexString(ADDRESS_HEX1));
-    assertThat(accountOverride.getNonce()).isEqualTo(Optional.of(88L));
+    assertThat(accountOverride.getNonce().get()).isEqualTo(158);
 
     assertTrue(accountOverride.getStateDiff().isPresent());
     assertThat(accountOverride.getStateDiff().get().get(STORAGE_KEY)).isEqualTo(STORAGE_VALUE);
@@ -141,7 +169,7 @@ public class AccountOverrideParameterTest {
             + "\":"
             + "{"
             + "\"balance\": \"0x01\","
-            + "\"nonce\": 88,"
+            + "\"nonce\": \"0x9E\","
             + "\"stateDiff\": {"
             + "\""
             + STORAGE_KEY
@@ -154,7 +182,7 @@ public class AccountOverrideParameterTest {
             + "\":"
             + "{"
             + "\"balance\": \"0xFF\","
-            + "\"nonce\": 99,"
+            + "\"nonce\": \"0x9D\","
             + "\"stateDiff\": {"
             + "\""
             + STORAGE_KEY
@@ -171,14 +199,14 @@ public class AccountOverrideParameterTest {
 
     final AccountOverride accountOverride1 =
         accountOverrideParam.get(Address.fromHexString(ADDRESS_HEX1));
-    assertThat(accountOverride1.getNonce()).isEqualTo(Optional.of(88L));
+    assertThat(accountOverride1.getNonce().get()).isEqualTo(158);
     assertThat(accountOverride1.getBalance()).isEqualTo(Optional.of(Wei.fromHexString("0x01")));
     assertTrue(accountOverride1.getStateDiff().isPresent());
     assertThat(accountOverride1.getStateDiff().get().get(STORAGE_KEY)).isEqualTo(STORAGE_VALUE);
 
     final AccountOverride accountOverride2 =
         accountOverrideParam.get(Address.fromHexString(ADDRESS_HEX2));
-    assertThat(accountOverride2.getNonce()).isEqualTo(Optional.of(99L));
+    assertThat(accountOverride2.getNonce().get()).isEqualTo(157);
     assertThat(accountOverride2.getBalance()).isEqualTo(Optional.of(Wei.fromHexString("0xFF")));
     assertTrue(accountOverride2.getStateDiff().isPresent());
     assertThat(accountOverride2.getStateDiff().get().get(STORAGE_KEY)).isEqualTo(STORAGE_VALUE);


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
fixes #7998


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

