### PR TITLE
Improve equals performance on Address

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.rlp.RLPException;
 import org.hyperledger.besu.ethereum.rlp.RLPInput;
 
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -290,5 +291,17 @@ public class Address extends DelegatingBytes {
     } catch (ExecutionException e) {
       return Hash.hash(this);
     }
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (!(obj instanceof Address)) {
+      return false;
+    }
+    Address other = (Address) obj;
+    return Arrays.equals(this.toArray(), other.toArray());
   }
 }

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
@@ -294,7 +294,7 @@ public class Address extends DelegatingBytes {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(final Object obj) {
     if (obj == this) {
       return true;
     }

--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Address.java
@@ -302,6 +302,6 @@ public class Address extends DelegatingBytes {
       return false;
     }
     Address other = (Address) obj;
-    return Arrays.equals(this.toArray(), other.toArray());
+    return Arrays.equals(this.toArrayUnsafe(), other.toArrayUnsafe());
   }
 }


### PR DESCRIPTION
## PR description
We've noticed when profiling the SELFBALANCE during load testing that the throughput issue is related to the equals operation on the address class. 
![image](https://github.com/user-attachments/assets/87baa55f-37bb-408c-b6a9-d5b737e9d477)

This PR introduces a new implementation of the equals method in the Address class to replace the one inherited from AbstractBytes. The issue with equals in AbstractBytes is that it compares each byte from both addresses individually, and the get method used is megamorphic.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

