### PR TITLE
Fix BOM pom publication to Artifactory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -579,7 +579,7 @@ subprojects {
           password = artifactoryKey
         }
         defaults {
-          publications('mavenJava')
+          publications('mavenJava', 'mavenJavaPlatform')
           publishArtifacts = true
           publishPom = true
         }

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -194,7 +194,7 @@ spotless {
 
 publishing {
   publications {
-    mavenPlatform(MavenPublication) {
+    mavenJavaPlatform(MavenPublication) {
       from components.javaPlatform
       groupId "org.hyperledger.besu"
       artifactId 'bom'


### PR DESCRIPTION
## PR description

Artifactory publication need to be extended to include also Java Platform BOM pom.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

