### PR TITLE
eth_call state override bugfix - movePrecompileToAddress

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/AccountOverride.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/AccountOverride.java
@@ -85,6 +85,7 @@ public class AccountOverride {
   }
 
   /** Builder class for Account overrides */
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Builder {
     private Optional<Wei> balance = Optional.empty();
     private Optional<Long> nonce = Optional.empty();

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_stateOverride_movePrecompileToAddress.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_call_stateOverride_movePrecompileToAddress.json
@@ -1,0 +1,33 @@
+{
+  "request": {
+    "id": 3,
+    "jsonrpc": "2.0",
+    "method": "eth_call",
+    "params": [
+      {
+        "to": "0x6295ee1b4f6dd65047762f924ecd367c17eabf8f",
+        "from": "a94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        "data": "0x12a7b914"
+      },
+      "latest",
+      {
+        "a94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+          "balance": "0xde0b6b3a7640000",
+          "nonce": 88
+        },
+        "0xb9741079a300Cb3B8f324CdDB847c0d1d273a05E": {
+          "stateDiff": {
+            "0x1cf7945003fc5b59d2f6736f0704557aa805c4f2844084ccd1173b8d56946962": "0x000000000000000000000000000000000000000000000000000000110ed03bf7"
+          },
+          "movePrecompileToAddress":null
+        }
+      }
+    ]
+  },
+  "response": {
+    "jsonrpc": "2.0",
+    "id": 3,
+    "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>
## PR description
Builder needed to ignore unknown properties also

## Fixed Issue(s)
Fixes #8023 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

