### PR TITLE
fix: Remove redundant throws IllegalArgumentException declaration

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/BftFork.java
+++ b/config/src/main/java/org/hyperledger/besu/config/BftFork.java
@@ -158,7 +158,7 @@ public class BftFork implements Fork {
    * @return the validators
    * @throws IllegalArgumentException the illegal argument exception
    */
-  public Optional<List<String>> getValidators() throws IllegalArgumentException {
+  public Optional<List<String>> getValidators() {
     final Optional<ArrayNode> validatorNode = JsonUtil.getArrayNode(forkConfigRoot, VALIDATORS_KEY);
 
     if (validatorNode.isEmpty()) {


### PR DESCRIPTION
## PR description

This change removes the redundant `throws IllegalArgumentException` declaration from the method signature. Since `IllegalArgumentException` is an unchecked exception (runtime exception), it doesn't need to be explicitly declared.  

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

