### PR TITLE
Fix array handling and improve variable naming in DCO check script

### DIFF
--- a/scripts/dco_check.sh
+++ b/scripts/dco_check.sh
@@ -15,16 +15,18 @@
 ##
 
 status=0
-while IFS= read -r -a line; do
+my_array=()
+while IFS= read -r line; do
   my_array+=( "$line" )
-  done < <( git branch -r | grep -v origin/HEAD )
+done < <( git branch -r | grep -v origin/HEAD )
+
 for branch in "${my_array[@]}"
 do
   branch=$(echo "$branch" | xargs)
   echo "Checking commits in branch $branch for commits missing DCO..."
-  while read -r results; do
+  while read -r commit_info; do
     status=1
-    commit_hash="$(echo "$results" | cut -d' ' -f1)"
+    commit_hash="$(echo "$commit_info" | cut -d' ' -f1)"
     >&2 echo "$commit_hash is missing Signed-off-by line."
   done < <(git log "$branch" --no-merges --pretty="%H %ae" --grep 'Signed-off-by' --invert-grep -- )
 done


### PR DESCRIPTION
### Description
This update addresses a couple of issues in the script responsible for checking DCO compliance in commit history.

1. **Array handling fix**: The original code used the `-a` flag with `read` to split the input into an array. However, this was unnecessary as the lines being read from `git branch -r | grep -v origin/HEAD` are simple strings, not arrays. The `-a` flag has been removed, and lines are now correctly stored into the `my_array` array.

   ```bash
   my_array=()
   while IFS= read -r line; do
     my_array+=( "$line" )
   done < <( git branch -r | grep -v origin/HEAD )
   ```

2. **Variable renaming**: The variable `results` was used in the loop that processes commit information. To improve clarity, I renamed it to `commit_info`, as it better reflects the data being handled — the commit hash and author email.

   ```bash
   while read -r commit_info; do
     status=1
     commit_hash="$(echo "$commit_info" | cut -d' ' -f1)"
     >&2 echo "$commit_hash is missing Signed-off-by line."
   done
   ```

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

