### PR TITLE
fix: typos in documentation files

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
@@ -40,7 +40,7 @@ import org.apache.tuweni.bytes.Bytes;
  * The EOF layout.
  *
  * @param container The literal EOF bytes fo the whole container
- * @param version The parsed version id. zero if unparseable.
+ * @param version The parsed version id. zero if unparsable.
  * @param codeSections The parsed Code sections. Null if invalid.
  * @param subContainers The parsed subcontainers. Null if invalid.
  * @param dataLength The length of the data as reported by the container. For subcontainers this may

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/GasCalculator.java
@@ -673,7 +673,7 @@ public interface GasCalculator {
   }
 
   /**
-   * Calculates the refund for proessing the 7702 code delegation list if an delegater account
+   * Calculates the refund for processing the 7702 code delegation list if an delegater account
    * already exist in the trie.
    *
    * @param alreadyExistingAccountSize The number of accounts already in the trie


### PR DESCRIPTION
Corrected `unparseable` to `unparsable`
Corrected `proessing` to `processing`