### PR TITLE
Return rpc error in eth_getLogs on unknown block hash

### DIFF
--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getLogs_blockhash_missingBlockHash.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_getLogs_blockhash_missingBlockHash.json
@@ -10,9 +10,12 @@
     }]
   },
   "response": {
-    "jsonrpc": "2.0",
-    "id": 406,
-    "result" : [ ]
+    "jsonrpc" : "2.0",
+    "id" : 406,
+    "error" : {
+      "code": -32000,
+      "message": "Block not found"
+    }
   },
   "statusCode": 200
 }


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes #8007 

The issue describes the problem well, so I won't repeat it here.

The root cause is `org.hyperledger.besu.ethereum.api.query.BlockchainQueries.matchingLogs` detects an unknown hash and returns an empty list.  This was the desired behaviour at some point in time, as there was even a test to validate it.

I have updated the method to throw an exception in this situation now, as IMO it really is a bad input if it's being called with an unknown hash.  This has potentially larger impacts as there are other callers of this function, but to my knowledge they are all passing in a valid hash (acquired via a `BlockHeader`).  An alternative approach could be to just patch `EthGetLogs` and check the block header prior to calling `matchingLogs`, which limits the impact.

I'm not sure if it's ok to be throwing an `InvalidJsonRpcParameters` from within the `org.hyperledger.besu.ethereum.api.query` package, there do not seem to be any other imports, so let me know if that should be cleaned up (I originally was going to raise a new exception type here, but I also noticed this package doesn't have any custom exceptions either).

Finally I am re-using the existing `RpcErrorType.BLOCK_NOT_FOUND` for this response, as I did not want to introduce a type to keep the change small.  But I can if that is better.

:information_source: I could not run the acceptance tests locally, they killed my (high-end) laptop.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

