### PR TITLE
fix: typos in documentation files

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugSetHead.java
@@ -113,7 +113,7 @@ public class DebugSetHead extends AbstractBlockParameterOrBlockHashMethod {
       if (archive.isWorldStateAvailable(target.getStateRoot(), target.getBlockHash())) {
         // WARNING, this can be dangerous for a DiffBasedWorldstate if a concurrent
         //          process attempts to move or modify the head worldstate.
-        //          Ensure no block processing is occuring when using this feature.
+        //          Ensure no block processing is occurring when using this feature.
         //          No engine-api, block import, sync, mining or other rpc calls should be running.
 
         Optional<BlockHeader> currentHead =

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthNewFilter.java
@@ -45,7 +45,7 @@ public class EthNewFilter implements JsonRpcMethod {
       filter = requestContext.getRequiredParameter(0, FilterParameter.class);
     } catch (JsonRpcParameterException e) {
       throw new InvalidJsonRpcParameters(
-          "Invalid filter paramters (index 0)", RpcErrorType.INVALID_FILTER_PARAMS, e);
+          "Invalid filter parameters (index 0)", RpcErrorType.INVALID_FILTER_PARAMS, e);
     }
 
     if (!filter.isValid()) {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/PrettyPrintSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/PrettyPrintSubCommand.java
@@ -59,7 +59,7 @@ public class PrettyPrintSubCommand implements Runnable {
 
   @CommandLine.Option(
       names = {"-f", "--force"},
-      description = "Always print well formated code, even if there is an error",
+      description = "Always print well formatted code, even if there is an error",
       paramLabel = "<boolean>")
   private final Boolean force = false;
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeSection.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeSection.java
@@ -36,7 +36,7 @@ public final class CodeSection {
   /** The byte offset from the beginning of the container that the section starts at */
   final int entryPoint;
 
-  /** Is this a returing code section (i.e. contains RETF or JUMPF into a returning section)? */
+  /** Is this a returning code section (i.e. contains RETF or JUMPF into a returning section)? */
   final boolean returning;
 
   /**
@@ -95,7 +95,7 @@ public final class CodeSection {
   }
 
   /**
-   * Does this code seciton have a RETF return anywhere?
+   * Does this code section have a RETF return anywhere?
    *
    * @return returning
    */

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1Validation.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/CodeV1Validation.java
@@ -60,7 +60,7 @@ public class CodeV1Validation implements EOFValidator {
   protected final int maxContainerSize;
 
   /**
-   * Create a new container, with a configurable maximim container size.
+   * Create a new container, with a configurable maximum container size.
    *
    * @param maxContainerSize the maximum size of any container.
    */

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/EOFLayout.java
@@ -60,7 +60,7 @@ public record EOFLayout(
     AtomicReference<EOFContainerMode> containerMode) {
 
   /**
-   * Enum tracking the useage mode of an EOF container. Detected either by opcode usage or
+   * Enum tracking the usage mode of an EOF container. Detected either by opcode usage or
    * determined by the source.
    */
   public enum EOFContainerMode {

--- a/evm/src/main/java/org/hyperledger/besu/evm/code/EOFValidator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/code/EOFValidator.java
@@ -39,7 +39,7 @@ public interface EOFValidator {
   String validateCode(final EOFLayout eofLayout);
 
   /**
-   * Performs stack validation of the EOF layout. Presumes that code validation has been perfromed
+   * Performs stack validation of the EOF layout. Presumes that code validation has been performed
    *
    * @param eofLayout The EOF Layout
    * @return validation code, null otherwise.

--- a/testfuzz/README.md
+++ b/testfuzz/README.md
@@ -6,7 +6,7 @@ BesuFuzz is where all the besu guided fuzzing tools live.
 
 Performs differential fuzzing between Ethereum clients based on
 the [txparse eofparse](https://github.com/holiman/txparse/blob/main/README.md#eof-parser-eofparse)
-format. Note that only the inital `OK` and `err` values are used to determine if
+format. Note that only the initial `OK` and `err` values are used to determine if
 there is a difference.
 
 ### Prototypical CLI Usage:


### PR DESCRIPTION
Corrected `occuring` to `occurring`
Corrected `paramters` to `parameters`
Corrected `formated` to `formatted`
Corrected `returing` to `returning`
Corrected `seciton` to`section`
Corrected `maximim` to `maximum`
Corrected `useage` to `usage`
Corrected `perfromed` to `performed`
Corrected `inital` to `initial`
