### PR TITLE
Fix: Extra Character in Git Command

### DIFF
--- a/scripts/dco_check.sh
+++ b/scripts/dco_check.sh
@@ -26,7 +26,7 @@ do
     status=1
     commit_hash="$(echo "$results" | cut -d' ' -f1)"
     >&2 echo "$commit_hash is missing Signed-off-by line."
-  done < <(git log "$branch" --no-merges --pretty="%H %ae" --grep 'Signed-off-by' --invert-grep -- )
+  done < <(git log "$branch" --no-merges --pretty="%H %ae" --grep 'Signed-off-by' --invert-grep )
 done
 
 exit $status


### PR DESCRIPTION
## PR description

### Subject: Fix Extra Character in Git Command

issue in the command used for filtering commits based on the "Signed-off-by" line.
there was an extra `--` symbol after the `--invert-grep` option in the following command.

this additional `--` was causing the command to behave incorrectly.

i've removed the extra symbol to ensure the command works as expected.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

