### PR TITLE
fix: Fix grammatical issue in interface description

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -31,7 +31,7 @@ bash $TEST_PATH/dgoss dockerfile $DOCKER_IMAGE $DOCKER_FILE \
 if [[ $i != 0 ]]; then exit $i; fi
 
 # Test for normal startup with ports opened
-# we test that things listen on the right interface/port, not what interface the advertise
+# we test that things listen on the right interface/port, not what interface they advertise
 # hence we dont set p2p-host=0.0.0.0 because this sets what its advertising to devp2p; the important piece is that it defaults to listening on all interfaces
 GOSS_FILES_PATH=$TEST_PATH/01 \
 bash $TEST_PATH/dgoss run --sysctl net.ipv6.conf.all.disable_ipv6=1 $DOCKER_IMAGE \


### PR DESCRIPTION
## PR description

I noticed a grammatical mistake in the documentation where the phrase "what interface the advertise" was used.

The correct version should be "what interface **they** advertise."


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

