### PR TITLE
Precompile Caching MVP

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -983,7 +983,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
       configureNativeLibs(Optional.ofNullable(network));
       if (enablePrecompileCaching
-          && getDataStorageConfiguration()
+          || getDataStorageConfiguration()
               .getPathBasedExtraStorageConfiguration()
               .getUnstable()
               .isParallelTxProcessingEnabled()) {
@@ -1019,6 +1019,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private void configurePrecompileCaching() {
     // enable precompile caching:
     AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
+    // separately set KZG precompile to cache, it does not extend AbstractPrecompiledContract:
+    KZGPointEvalPrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
 
     // set a metric logger
     final var precompileCounter =

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -984,7 +984,6 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
 
       configureNativeLibs(Optional.ofNullable(network));
       if (enablePrecompileCaching) {
-        // enable precompile caching if it is enabled and parallel tx processing is enabled:
         configurePrecompileCaching();
       }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -700,7 +700,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   @CommandLine.Option(
       names = {"--cache-precompiles"},
       description = "Specifies whether to cache precompile results (default: ${DEFAULT-VALUE})")
-  private final Boolean enablePrecompileCaching = true;
+  private final Boolean enablePrecompileCaching = false;
 
   // Plugins Configuration Option Group
   @CommandLine.ArgGroup(validate = false)

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -982,11 +982,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       VersionMetadata.versionCompatibilityChecks(versionCompatibilityProtection, dataDir());
 
       configureNativeLibs(Optional.ofNullable(network));
-      if (enablePrecompileCaching
-          || getDataStorageConfiguration()
-              .getPathBasedExtraStorageConfiguration()
-              .getUnstable()
-              .isParallelTxProcessingEnabled()) {
+      if (enablePrecompileCaching) {
         // enable precompile caching if it is enabled and parallel tx processing is enabled:
         configurePrecompileCaching();
       }

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -139,6 +139,7 @@ import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguratio
 import org.hyperledger.besu.ethereum.worldstate.ImmutablePathBasedExtraStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.PathBasedExtraStorageConfiguration;
 import org.hyperledger.besu.evm.precompile.AbstractAltBnPrecompiledContract;
+import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.BigIntegerModularExponentiationPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -695,6 +696,11 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       description = "Specifies the number of last blocks to cache  (default: ${DEFAULT-VALUE})")
   private final Integer numberOfBlocksToCache = 0;
 
+  @CommandLine.Option(
+      names = {"--cache-precompiles"},
+      description = "Specifies whether to cache precompile results (default: ${DEFAULT-VALUE})")
+  private final Boolean enablePrecompileCaching = true;
+
   // Plugins Configuration Option Group
   @CommandLine.ArgGroup(validate = false)
   PluginsConfigurationOptions pluginsConfigurationOptions = new PluginsConfigurationOptions();
@@ -976,6 +982,8 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
       VersionMetadata.versionCompatibilityChecks(versionCompatibilityProtection, dataDir());
 
       configureNativeLibs(Optional.ofNullable(network));
+      AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
+
       besuController = buildController();
 
       besuPluginContext.beforeExternalServices();

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -139,6 +139,7 @@ import org.hyperledger.besu.ethereum.worldstate.ImmutableDataStorageConfiguratio
 import org.hyperledger.besu.ethereum.worldstate.ImmutablePathBasedExtraStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.PathBasedExtraStorageConfiguration;
 import org.hyperledger.besu.evm.precompile.AbstractAltBnPrecompiledContract;
+import org.hyperledger.besu.evm.precompile.AbstractBLS12PrecompiledContract;
 import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.BigIntegerModularExponentiationPrecompiledContract;
 import org.hyperledger.besu.evm.precompile.KZGPointEvalPrecompiledContract;
@@ -1015,8 +1016,10 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
   private void configurePrecompileCaching() {
     // enable precompile caching:
     AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
-    // separately set KZG precompile to cache, it does not extend AbstractPrecompiledContract:
+    // separately set KZG precompile caching, it does not extend AbstractPrecompiledContract:
     KZGPointEvalPrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
+    // separately set BLS precompiles caching, they do not extend AbstractPrecompiledContract:
+    AbstractBLS12PrecompiledContract.setPrecompileCaching(enablePrecompileCaching);
 
     // set a metric logger
     final var precompileCounter =

--- a/besu/src/test/resources/everything_config.toml
+++ b/besu/src/test/resources/everything_config.toml
@@ -94,6 +94,7 @@ rpc-http-max-request-content-length = 5242880
 rpc-max-logs-range=100
 json-pretty-print-enabled=false
 cache-last-blocks=512
+cache-precompiles=true
 rpc-gas-cap = 50000000
 rpc-max-trace-filter-range=100
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/FlexiblePrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/FlexiblePrivacyPrecompiledContractTest.java
@@ -167,7 +167,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contractSpy.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -199,7 +199,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contractSpy.computePrecompile(privateTransactionLookupId64, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -213,7 +213,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -225,7 +225,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(null, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -237,7 +237,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId.slice(10), messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -249,7 +249,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId64.slice(40), messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -299,7 +299,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -369,7 +369,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contractSpy.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -409,7 +409,7 @@ public class FlexiblePrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contractSpy.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPluginPrecompiledContractTest.java
@@ -180,7 +180,7 @@ public class PrivacyPluginPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(payload, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/precompiles/privacy/PrivacyPrecompiledContractTest.java
@@ -168,7 +168,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -182,7 +182,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -228,7 +228,8 @@ public class PrivacyPrecompiledContractTest {
         new ReceiveResponse(payload, PAYLOAD_TEST_PRIVACY_GROUP_ID, senderKey);
     when(enclave.receive(eq(privateTransactionLookupId.toBase64String()))).thenReturn(response);
 
-    final Bytes expected = contract.compute(privateTransactionLookupId, messageFrame);
+    final Bytes expected =
+        contract.computePrecompile(privateTransactionLookupId, messageFrame).output();
     assertThat(expected).isEqualTo(Bytes.EMPTY);
   }
 
@@ -247,7 +248,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -279,7 +280,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.fromHexString(DEFAULT_OUTPUT));
   }
@@ -321,7 +322,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(privateTransactionLookupId, messageFrame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }
@@ -337,7 +338,7 @@ public class PrivacyPrecompiledContractTest {
 
     final PrecompiledContract.PrecompileContractResult result =
         emptyContract.computePrecompile(null, frame);
-    final Bytes actual = result.getOutput();
+    final Bytes actual = result.output();
 
     assertThat(actual).isEqualTo(Bytes.EMPTY);
   }

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
@@ -18,6 +18,7 @@ import static org.hyperledger.besu.evmtool.BenchmarkSubCommand.COMMAND_NAME;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evmtool.benchmarks.AltBN128Benchmark;
 import org.hyperledger.besu.evmtool.benchmarks.BLS12Benchmark;
 import org.hyperledger.besu.evmtool.benchmarks.BenchmarkExecutor;
@@ -75,6 +76,13 @@ public class BenchmarkSubCommand implements Runnable {
       negatable = true)
   Boolean nativeCode;
 
+  @Option(
+      names = {"--use-precompile-cache"},
+      description = "Benchmark using precompile caching.",
+      scope = INHERIT,
+      negatable = true)
+  Boolean enablePrecompileCache = false;
+
   @Parameters(description = "One or more of ${COMPLETION-CANDIDATES}.")
   EnumSet<Benchmark> benchmarks = EnumSet.noneOf(Benchmark.class);
 
@@ -99,6 +107,7 @@ public class BenchmarkSubCommand implements Runnable {
   public void run() {
     LogConfigurator.setLevel("", "DEBUG");
     System.out.println(BesuInfo.version());
+    AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     var benchmarksToRun = benchmarks.isEmpty() ? EnumSet.allOf(Benchmark.class) : benchmarks;
     for (var benchmark : benchmarksToRun) {
       System.out.println("Benchmarks for " + benchmark);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
@@ -18,6 +18,7 @@ import static org.hyperledger.besu.evmtool.BenchmarkSubCommand.COMMAND_NAME;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
 import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.evm.precompile.AbstractBLS12PrecompiledContract;
 import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evmtool.benchmarks.AltBN128Benchmark;
 import org.hyperledger.besu.evmtool.benchmarks.BLS12Benchmark;
@@ -108,6 +109,7 @@ public class BenchmarkSubCommand implements Runnable {
     LogConfigurator.setLevel("", "DEBUG");
     System.out.println(BesuInfo.version());
     AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCache);
+    AbstractBLS12PrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     var benchmarksToRun = benchmarks.isEmpty() ? EnumSet.allOf(Benchmark.class) : benchmarks;
     for (var benchmark : benchmarksToRun) {
       System.out.println("Benchmarks for " + benchmark);

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/BenchmarkExecutor.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/benchmarks/BenchmarkExecutor.java
@@ -96,7 +96,7 @@ public abstract class BenchmarkExecutor {
    * @return the mean number of seconds each timed iteration took.
    */
   protected double runPrecompileBenchmark(final Bytes arg, final PrecompiledContract contract) {
-    if (contract.computePrecompile(arg, fakeFrame).getOutput() == null) {
+    if (contract.computePrecompile(arg, fakeFrame).output() == null) {
       throw new RuntimeException("Input is Invalid");
     }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
@@ -147,9 +147,6 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
       }
     }
 
-
-
-
     final byte[] result = new byte[LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_RESULT_BYTES];
     final byte[] error = new byte[LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_ERROR_BYTES];
 
@@ -159,19 +156,30 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
         new IntByReference(LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_ERROR_BYTES);
 
     final int inputSize = Math.min(inputLimit, input.size());
-    final int errorNo = LibGnarkEIP2537.eip2537_perform_operation(operationId,
-        input.slice(0, inputSize).toArrayUnsafe(), inputSize, result, o_len, error, err_len);
+    final int errorNo =
+        LibGnarkEIP2537.eip2537_perform_operation(
+            operationId,
+            input.slice(0, inputSize).toArrayUnsafe(),
+            inputSize,
+            result,
+            o_len,
+            error,
+            err_len);
 
     if (errorNo == 0) {
-      res = new PrecompileInputResultTuple(enableResultCaching ? input.copy() : input,
-          PrecompileContractResult.success(Bytes.wrap(result, 0, o_len.getValue())));
+      res =
+          new PrecompileInputResultTuple(
+              enableResultCaching ? input.copy() : input,
+              PrecompileContractResult.success(Bytes.wrap(result, 0, o_len.getValue())));
     } else {
       final String errorMessage = new String(error, 0, err_len.getValue(), UTF_8);
       messageFrame.setRevertReason(Bytes.wrap(error, 0, err_len.getValue()));
       LOG.trace("Error executing precompiled contract {}: '{}'", name, errorMessage);
-      res = new PrecompileInputResultTuple(enableResultCaching ? input.copy() : input,
-          PrecompileContractResult.halt(null,
-              Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR)));
+      res =
+          new PrecompileInputResultTuple(
+              enableResultCaching ? input.copy() : input,
+              PrecompileContractResult.halt(
+                  null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR)));
     }
 
     if (enableResultCaching && cacheKey != null) {
@@ -227,5 +235,10 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
     enableResultCaching = enablePrecompileCaching;
   }
 
+  /**
+   * get the presompile-specific cache.
+   *
+   * @return precompile cache.
+   */
   protected abstract Cache<Integer, PrecompileInputResultTuple> getCache();
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractBLS12PrecompiledContract.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.evm.precompile;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract.cacheEventConsumer;
 
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -23,6 +24,7 @@ import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.sun.jna.ptr.IntByReference;
 import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
@@ -37,6 +39,9 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
     // set parallel 1 for testing.  Remove this for prod code (or set a rational limit)
     // LibGnarkEIP2537.setDegreeOfMSMParallelism(1);
   }
+
+  /** Default result caching to false unless otherwise set. */
+  protected static Boolean enableResultCaching = Boolean.FALSE;
 
   /** The Discount table. */
   static final int[] G1_DISCOUNT_TABLE =
@@ -108,6 +113,43 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
   @Override
   public PrecompileContractResult computePrecompile(
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
+
+    PrecompileInputResultTuple res = null;
+
+    Integer cacheKey = null;
+
+    if (enableResultCaching) {
+      cacheKey = AbstractPrecompiledContract.getCacheKey(input);
+      res = getCache().getIfPresent(cacheKey);
+      if (res != null) {
+        if (res.cachedInput().equals(input)) {
+          cacheEventConsumer.accept(
+              new AbstractPrecompiledContract.CacheEvent(
+                  name, AbstractPrecompiledContract.CacheMetric.HIT));
+          return res.cachedResult();
+        } else {
+          LOG.debug(
+              "false positive {} {}, cache key {}, cached input: {}, input: {}",
+              name,
+              input.getClass().getSimpleName(),
+              cacheKey,
+              res.cachedInput().toHexString(),
+              input.toHexString());
+
+          cacheEventConsumer.accept(
+              new AbstractPrecompiledContract.CacheEvent(
+                  name, AbstractPrecompiledContract.CacheMetric.FALSE_POSITIVE));
+        }
+      } else {
+        cacheEventConsumer.accept(
+            new AbstractPrecompiledContract.CacheEvent(
+                name, AbstractPrecompiledContract.CacheMetric.MISS));
+      }
+    }
+
+
+
+
     final byte[] result = new byte[LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_RESULT_BYTES];
     final byte[] error = new byte[LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_ERROR_BYTES];
 
@@ -117,25 +159,25 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
         new IntByReference(LibGnarkEIP2537.EIP2537_PREALLOCATE_FOR_ERROR_BYTES);
 
     final int inputSize = Math.min(inputLimit, input.size());
-    final int errorNo =
-        LibGnarkEIP2537.eip2537_perform_operation(
-            operationId,
-            input.slice(0, inputSize).toArrayUnsafe(),
-            inputSize,
-            result,
-            o_len,
-            error,
-            err_len);
+    final int errorNo = LibGnarkEIP2537.eip2537_perform_operation(operationId,
+        input.slice(0, inputSize).toArrayUnsafe(), inputSize, result, o_len, error, err_len);
 
     if (errorNo == 0) {
-      return PrecompileContractResult.success(Bytes.wrap(result, 0, o_len.getValue()));
+      res = new PrecompileInputResultTuple(enableResultCaching ? input.copy() : input,
+          PrecompileContractResult.success(Bytes.wrap(result, 0, o_len.getValue())));
     } else {
       final String errorMessage = new String(error, 0, err_len.getValue(), UTF_8);
       messageFrame.setRevertReason(Bytes.wrap(error, 0, err_len.getValue()));
       LOG.trace("Error executing precompiled contract {}: '{}'", name, errorMessage);
-      return PrecompileContractResult.halt(
-          null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
+      res = new PrecompileInputResultTuple(enableResultCaching ? input.copy() : input,
+          PrecompileContractResult.halt(null,
+              Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR)));
     }
+
+    if (enableResultCaching && cacheKey != null) {
+      getCache().put(cacheKey, res);
+    }
+    return res.cachedResult();
   }
 
   /**
@@ -175,4 +217,15 @@ public abstract class AbstractBLS12PrecompiledContract implements PrecompiledCon
     }
     return G2_DISCOUNT_TABLE[k];
   }
+
+  /**
+   * Enable or disable precompile result caching.
+   *
+   * @param enablePrecompileCaching boolean indicating whether to cache precompile results
+   */
+  public static void setPrecompileCaching(final boolean enablePrecompileCaching) {
+    enableResultCaching = enablePrecompileCaching;
+  }
+
+  protected abstract Cache<Integer, PrecompileInputResultTuple> getCache();
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -68,9 +68,7 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
     enableResultCaching = enablePrecompileCaching;
   }
 
-  /**
-   * enum for precompile cache metric
-   */
+  /** enum for precompile cache metric */
   public enum CacheMetric {
     /** a successful cache hit metric */
     HIT,
@@ -81,12 +79,12 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
   }
 
   /**
-   *  record type used for cache event
+   * record type used for cache event
+   *
    * @param precompile precompile name
    * @param cacheMetric cache metric type (hit, miss, false positive).
    */
   public record CacheEvent(String precompile, CacheMetric cacheMetric) {}
-
 
   static Consumer<CacheEvent> cacheEventConsumer = __ -> {};
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+import java.util.function.Consumer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,5 +66,24 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
    */
   public static void setPrecompileCaching(final boolean enablePrecompileCaching) {
     enableResultCaching = enablePrecompileCaching;
+  }
+
+  public enum CacheMetric {
+    HIT,
+    MISS,
+    FALSE_POSITIVE
+  }
+
+  public record CacheEvent(String precompile, CacheMetric cacheMetric) {}
+
+  public static Consumer<CacheEvent> cacheEventConsumer = __ -> {};
+
+  /**
+   * Set an optional cache event consumer, such as a metrics system logger.
+   *
+   * @param eventConsumer consumer of the CacheEvent.
+   */
+  public static void setCacheEventConsumer(final Consumer<CacheEvent> eventConsumer) {
+    cacheEventConsumer = eventConsumer;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -53,4 +53,10 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
   public String getName() {
     return name;
   }
+
+  protected static Boolean enableResultCaching = Boolean.TRUE;
+
+  public static void setPrecompileCaching(final boolean enablePrecompileCaching) {
+    enableResultCaching = enablePrecompileCaching;
+  }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -101,6 +101,7 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
 
   /**
    * calculate a cache key based on input bytes
+   *
    * @param input bytes
    * @return integer cache key
    */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -16,8 +16,10 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+import java.util.Arrays;
 import java.util.function.Consumer;
 
+import org.apache.tuweni.bytes.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,5 +97,9 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
    */
   public static void setCacheEventConsumer(final Consumer<CacheEvent> eventConsumer) {
     cacheEventConsumer = eventConsumer;
+  }
+
+  public static Integer getCacheKey(final Bytes input) {
+    return Arrays.hashCode(input.toArrayUnsafe());
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -68,15 +68,27 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
     enableResultCaching = enablePrecompileCaching;
   }
 
+  /**
+   * enum for precompile cache metric
+   */
   public enum CacheMetric {
+    /** a successful cache hit metric */
     HIT,
+    /** a cache miss metric */
     MISS,
+    /** a false positive cache hit metric */
     FALSE_POSITIVE
   }
 
+  /**
+   *  record type used for cache event
+   * @param precompile precompile name
+   * @param cacheMetric cache metric type (hit, miss, false positive).
+   */
   public record CacheEvent(String precompile, CacheMetric cacheMetric) {}
 
-  public static Consumer<CacheEvent> cacheEventConsumer = __ -> {};
+
+  static Consumer<CacheEvent> cacheEventConsumer = __ -> {};
 
   /**
    * Set an optional cache event consumer, such as a metrics system logger.

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -54,8 +54,14 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
     return name;
   }
 
-  protected static Boolean enableResultCaching = Boolean.TRUE;
+  /** Default result caching to false unless otherwise set. */
+  protected static Boolean enableResultCaching = Boolean.FALSE;
 
+  /**
+   * Enable or disable precompile result caching.
+   *
+   * @param enablePrecompileCaching boolean indicating whether to cache precompile results
+   */
   public static void setPrecompileCaching(final boolean enablePrecompileCaching) {
     enableResultCaching = enablePrecompileCaching;
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AbstractPrecompiledContract.java
@@ -99,6 +99,11 @@ public abstract class AbstractPrecompiledContract implements PrecompiledContract
     cacheEventConsumer = eventConsumer;
   }
 
+  /**
+   * calculate a cache key based on input bytes
+   * @param input bytes
+   * @return integer cache key
+   */
   public static Integer getCacheKey(final Bytes input) {
     return Arrays.hashCode(input.toArrayUnsafe());
   }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -35,7 +35,7 @@ import org.apache.tuweni.bytes.MutableBytes;
 public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 128;
-  public static final String PRECOMPILE_NAME = "AltBN128Add";
+  private static final String PRECOMPILE_NAME = "AltBN128Add";
 
   private final long gasCost;
   private static final Cache<Integer, PrecompileInputResultTuple> bnAddCache =

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.MutableBytes;
 
@@ -35,6 +37,9 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
   private static final int PARAMETER_LENGTH = 128;
 
   private final long gasCost;
+
+  private static final Cache<Bytes, PrecompileContractResult> bnAddCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   private AltBN128AddPrecompiledContract(final GasCalculator gasCalculator, final long gasCost) {
     super(
@@ -74,11 +79,18 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
   @Override
   public PrecompileContractResult computePrecompile(
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
-    if (useNative) {
-      return computeNative(input, messageFrame);
-    } else {
-      return computeDefault(input);
+    var res = bnAddCache.getIfPresent(input);
+    if (res != null) {
+      return res;
     }
+
+    if (useNative) {
+      res = computeNative(input, messageFrame);
+    } else {
+      res = computeDefault(input);
+    }
+    bnAddCache.put(input, res);
+    return res;
   }
 
   private static PrecompileContractResult computeDefault(final Bytes input) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128AddPrecompiledContract.java
@@ -86,7 +86,7 @@ public class AltBN128AddPrecompiledContract extends AbstractAltBnPrecompiledCont
     Integer cacheKey = null;
 
     if (enableResultCaching) {
-      cacheKey = Arrays.hashCode(input.toArrayUnsafe());
+      cacheKey = getCacheKey(input);
       res = bnAddCache.getIfPresent(cacheKey);
       if (res != null) {
         if (res.cachedInput().equals(input)) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -84,9 +84,12 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
   public PrecompileContractResult computePrecompile(
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
 
-    var res = bnMulCache.getIfPresent(input.hashCode());
-    if (res != null && res.cachedInput().equals(input)) {
-      return res.cachedResult();
+    PrecompileInputResultTuple res;
+    if (enableResultCaching) {
+      res = bnMulCache.getIfPresent(input.hashCode());
+      if (res != null && res.cachedInput().equals(input)) {
+        return res.cachedResult();
+      }
     }
 
     if (input.size() >= 64 && input.slice(0, 64).equals(POINT_AT_INFINITY)) {
@@ -99,7 +102,9 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
     } else {
       res = new PrecompileInputResultTuple(input, computeDefault(input));
     }
-    bnMulCache.put(input.hashCode(), res);
+    if (enableResultCaching) {
+      bnMulCache.put(input.hashCode(), res);
+    }
     return res.cachedResult();
   }
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -88,6 +88,11 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
   public PrecompileContractResult computePrecompile(
       final Bytes input, @Nonnull final MessageFrame messageFrame) {
 
+    if (input.size() >= 64 && input.slice(0, 64).equals(POINT_AT_INFINITY)) {
+      return new PrecompileContractResult(
+          POINT_AT_INFINITY, false, MessageFrame.State.COMPLETED_SUCCESS, Optional.empty());
+    }
+
     PrecompileInputResultTuple res;
     Integer cacheKey = null;
     if (enableResultCaching) {
@@ -110,11 +115,6 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
       } else {
         cacheEventConsumer.accept(new CacheEvent(PRECOMPILE_NAME, CacheMetric.MISS));
       }
-    }
-
-    if (input.size() >= 64 && input.slice(0, 64).equals(POINT_AT_INFINITY)) {
-      return new PrecompileContractResult(
-          POINT_AT_INFINITY, false, MessageFrame.State.COMPLETED_SUCCESS, Optional.empty());
     }
 
     if (useNative) {
@@ -161,9 +161,5 @@ public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledCont
     }
     final byte[] raw = Arrays.copyOfRange(input.toArrayUnsafe(), offset, offset + length);
     return new BigInteger(1, raw);
-  }
-
-  private static Integer getCacheKey(final Bytes input) {
-    return Arrays.hashCode(input.toArrayUnsafe());
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128MulPrecompiledContract.java
@@ -35,7 +35,7 @@ import org.apache.tuweni.bytes.MutableBytes;
 public class AltBN128MulPrecompiledContract extends AbstractAltBnPrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 96;
-  public static final String PRECOMPILE_NAME = "AltBN128Mul";
+  private static final String PRECOMPILE_NAME = "AltBN128Mul";
 
   private static final BigInteger MAX_N =
       new BigInteger(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -41,7 +41,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
 
   private static final int FIELD_LENGTH = 32;
   private static final int PARAMETER_LENGTH = 192;
-  public static final String PRECOMPILE_NAME = "AltBN128Pairing";
+  private static final String PRECOMPILE_NAME = "AltBN128Pairing";
   private static final Cache<Integer, PrecompileInputResultTuple> bnPairingCache =
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 
 import com.github.benmanes.caffeine.cache.Cache;
@@ -50,6 +51,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .expireAfterWrite(15, TimeUnit.MINUTES)  // Evict 15 minutes after each entry is written
           .build();
 
   /** The constant FALSE. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The AltBN128Pairing precompiled contract. */
@@ -39,6 +41,11 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
 
   private static final int FIELD_LENGTH = 32;
   private static final int PARAMETER_LENGTH = 192;
+  private static final Cache<Bytes, PrecompileContractResult> bnPairingCache =
+      Caffeine.newBuilder()
+          .maximumWeight(16_000_000)
+          .weigher((k, v) -> ((Bytes) k).size())
+          .build();
 
   /** The constant FALSE. */
   static final Bytes FALSE =
@@ -99,11 +106,17 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       return PrecompileContractResult.halt(
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
-    if (useNative) {
-      return computeNative(input, messageFrame);
-    } else {
-      return computeDefault(input);
+    var res = bnPairingCache.getIfPresent(input);
+    if (res != null) {
+      return res;
     }
+    if (useNative) {
+      res = computeNative(input, messageFrame);
+    } else {
+      res = computeDefault(input);
+    }
+    bnPairingCache.put(input, res);
+    return res;
   }
 
   @Nonnull

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -198,8 +198,4 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
     final byte[] raw = Arrays.copyOfRange(input.toArrayUnsafe(), offset, offset + length);
     return new BigInteger(1, raw);
   }
-
-  private static Integer getCacheKey(final Bytes input) {
-    return Arrays.hashCode(input.toArrayUnsafe());
-  }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -41,11 +41,8 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
 
   private static final int FIELD_LENGTH = 32;
   private static final int PARAMETER_LENGTH = 192;
-  private static final Cache<Bytes, PrecompileContractResult> bnPairingCache =
-      Caffeine.newBuilder()
-          .maximumWeight(16_000_000)
-          .weigher((k, v) -> ((Bytes) k).size())
-          .build();
+  private static final Cache<Integer, PrecompileInputResultTuple> bnPairingCache =
+      Caffeine.newBuilder().maximumWeight(16_000_000).weigher((k, v) -> ((Bytes) k).size()).build();
 
   /** The constant FALSE. */
   static final Bytes FALSE =
@@ -106,17 +103,17 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       return PrecompileContractResult.halt(
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
-    var res = bnPairingCache.getIfPresent(input);
-    if (res != null) {
-      return res;
+    var res = bnPairingCache.getIfPresent(input.hashCode());
+    if (res != null && res.cachedInput().equals(input)) {
+      return res.cachedResult();
     }
     if (useNative) {
-      res = computeNative(input, messageFrame);
+      res = new PrecompileInputResultTuple(input, computeNative(input, messageFrame));
     } else {
-      res = computeDefault(input);
+      res = new PrecompileInputResultTuple(input, computeDefault(input));
     }
-    bnPairingCache.put(input, res);
-    return res;
+    bnPairingCache.put(input.hashCode(), res);
+    return res.cachedResult();
   }
 
   @Nonnull

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContract.java
@@ -51,7 +51,7 @@ public class AltBN128PairingPrecompiledContract extends AbstractAltBnPrecompiled
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
-          .expireAfterWrite(15, TimeUnit.MINUTES)  // Evict 15 minutes after each entry is written
+          .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
 
   /** The constant FALSE. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -23,7 +23,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 
@@ -110,16 +109,13 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
 
     res =
         new PrecompileInputResultTuple(
-            input.copy(), PrecompileContractResult.success(Hash.blake2bf(input)));
+            enableResultCaching ? input.copy() : input,
+            PrecompileContractResult.success(Hash.blake2bf(input)));
 
     if (cacheKey != null) {
       blakeCache.put(cacheKey, res);
     }
 
     return res.cachedResult();
-  }
-
-  private Integer getCacheKey(final Bytes input) {
-    return Arrays.hashCode(input.toArrayUnsafe());
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -81,14 +81,22 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
       return PrecompileContractResult.halt(
           null, Optional.of(ExceptionalHaltReason.PRECOMPILE_ERROR));
     }
-    var res = blakeCache.getIfPresent(input.hashCode());
-    if (res != null && res.cachedInput().equals(input)) {
-      return res.cachedResult();
+    PrecompileInputResultTuple res = null;
+    if (enableResultCaching) {
+      res = blakeCache.getIfPresent(input.hashCode());
+      if (res != null && res.cachedInput().equals(input)) {
+        return res.cachedResult();
+      }
     }
+
     res =
         new PrecompileInputResultTuple(
             input, PrecompileContractResult.success(Hash.blake2bf(input)));
-    blakeCache.put(input.hashCode(), res);
+
+    if (enableResultCaching) {
+      blakeCache.put(input.hashCode(), res);
+    }
+
     return res.cachedResult();
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
 
   private static final Logger LOG = LoggerFactory.getLogger(BLAKE2BFPrecompileContract.class);
-  public static final String PRECOMPILE_NAME = "BLAKE2f";
+  private static final String PRECOMPILE_NAME = "BLAKE2f";
   private static final Cache<Integer, PrecompileInputResultTuple> blakeCache =
       Caffeine.newBuilder().maximumSize(1000).build();
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContract.java
@@ -105,7 +105,7 @@ public class BLAKE2BFPrecompileContract extends AbstractPrecompiledContract {
             input, PrecompileContractResult.success(Hash.blake2bf(input)));
 
     if (cacheKey != null) {
-      blakeCache.put(input.hashCode(), res);
+      blakeCache.put(cacheKey, res);
     }
 
     return res.cachedResult();

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12G1 Add precompiled contract. */
 public class BLS12G1AddPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 256;
+  private static final Cache<Integer, PrecompileInputResultTuple> g1AddCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12G1 Add precompiled contract. */
   public BLS12G1AddPrecompiledContract() {
@@ -31,5 +35,10 @@ public class BLS12G1AddPrecompiledContract extends AbstractBLS12PrecompiledContr
   @Override
   public long gasRequirement(final Bytes input) {
     return 375L;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return g1AddCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
@@ -25,7 +25,10 @@ public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12Precompiled
 
   private static final int PARAMETER_LENGTH = 160;
   private static final Cache<Integer, PrecompileInputResultTuple> g1MSMCache =
-      Caffeine.newBuilder().maximumSize(1000).build();
+      Caffeine.newBuilder()
+          .maximumWeight(16_000_000)
+          .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .build();
 
   /** Instantiates a new BLS12_G1 MultiExp precompiled contract. */
   public BLS12G1MultiExpPrecompiledContract() {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import java.util.concurrent.TimeUnit;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
@@ -28,6 +30,7 @@ public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12Precompiled
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
 
   /** Instantiates a new BLS12_G1 MultiExp precompiled contract. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The type BLS12_G1 MultiExp precompiled contract. */
 public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 160;
+  private static final Cache<Integer, PrecompileInputResultTuple> g1MSMCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12_G1 MultiExp precompiled contract. */
   public BLS12G1MultiExpPrecompiledContract() {
@@ -35,5 +39,10 @@ public class BLS12G1MultiExpPrecompiledContract extends AbstractBLS12Precompiled
   public long gasRequirement(final Bytes input) {
     final int k = input.size() / PARAMETER_LENGTH;
     return 12L * k * getG1Discount(k);
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return g1MSMCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12_G2 Add precompiled contract. */
 public class BLS12G2AddPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 512;
+  private static final Cache<Integer, PrecompileInputResultTuple> g2AddCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12_G2 Add precompiled contract. */
   public BLS12G2AddPrecompiledContract() {
@@ -31,5 +35,10 @@ public class BLS12G2AddPrecompiledContract extends AbstractBLS12PrecompiledContr
   @Override
   public long gasRequirement(final Bytes input) {
     return 600L;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return g2AddCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import java.util.concurrent.TimeUnit;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
@@ -28,6 +30,7 @@ public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12Precompiled
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
 
   /** Instantiates a new BLS12_G2 MultiExp precompiled contract. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
@@ -25,8 +25,10 @@ public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12Precompiled
 
   private static final int PARAMETER_LENGTH = 288;
   private static final Cache<Integer, PrecompileInputResultTuple> g2MSMCache =
-      Caffeine.newBuilder().maximumSize(1000).build();
-
+      Caffeine.newBuilder()
+          .maximumWeight(16_000_000)
+          .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .build();
   /** Instantiates a new BLS12_G2 MultiExp precompiled contract. */
   public BLS12G2MultiExpPrecompiledContract() {
     super(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
@@ -29,6 +29,7 @@ public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12Precompiled
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
           .build();
+
   /** Instantiates a new BLS12_G2 MultiExp precompiled contract. */
   public BLS12G2MultiExpPrecompiledContract() {
     super(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12_G2 MultiExp precompiled contract. */
 public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 288;
+  private static final Cache<Integer, PrecompileInputResultTuple> g2MSMCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12_G2 MultiExp precompiled contract. */
   public BLS12G2MultiExpPrecompiledContract() {
@@ -35,5 +39,10 @@ public class BLS12G2MultiExpPrecompiledContract extends AbstractBLS12Precompiled
   public long gasRequirement(final Bytes input) {
     final int k = input.size() / PARAMETER_LENGTH;
     return 22_500L * k * getG2Discount(k) / 1000L;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return g2MSMCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12MapFp2ToG2 precompiled contract. */
 public class BLS12MapFp2ToG2PrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 128;
+  private static final Cache<Integer, PrecompileInputResultTuple> mapfp2g2Cache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12MapFp2ToG2 precompiled contract. */
   public BLS12MapFp2ToG2PrecompiledContract() {
@@ -34,5 +38,10 @@ public class BLS12MapFp2ToG2PrecompiledContract extends AbstractBLS12Precompiled
   @Override
   public long gasRequirement(final Bytes input) {
     return 23_800L;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return mapfp2g2Cache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12MapFpToG1 precompiled contract. */
 public class BLS12MapFpToG1PrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 64;
+  private static final Cache<Integer, PrecompileInputResultTuple> mapFpToG1Cache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12MapFpToG1 precompiled contract. */
   public BLS12MapFpToG1PrecompiledContract() {
@@ -34,5 +38,10 @@ public class BLS12MapFpToG1PrecompiledContract extends AbstractBLS12PrecompiledC
   @Override
   public long gasRequirement(final Bytes input) {
     return 5_500;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return mapFpToG1Cache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
@@ -25,8 +25,10 @@ public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledCon
 
   private static final int PARAMETER_LENGTH = 384;
   private static final Cache<Integer, PrecompileInputResultTuple> pairingCache =
-      Caffeine.newBuilder().maximumSize(1000).build();
-
+      Caffeine.newBuilder()
+          .maximumWeight(16_000_000)
+          .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .build();
   /** Instantiates a new BLS12Pairing precompiled contract. */
   public BLS12PairingPrecompiledContract() {
     super(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
@@ -29,6 +29,7 @@ public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledCon
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
           .build();
+
   /** Instantiates a new BLS12Pairing precompiled contract. */
   public BLS12PairingPrecompiledContract() {
     super(

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
@@ -16,6 +16,8 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import java.util.concurrent.TimeUnit;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
@@ -28,6 +30,7 @@ public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledCon
       Caffeine.newBuilder()
           .maximumWeight(16_000_000)
           .weigher((k, v) -> ((PrecompileInputResultTuple) v).cachedInput().size())
+          .expireAfterWrite(15, TimeUnit.MINUTES) // Evict 15 minutes after each entry is written
           .build();
 
   /** Instantiates a new BLS12Pairing precompiled contract. */

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContract.java
@@ -16,12 +16,16 @@ package org.hyperledger.besu.evm.precompile;
 
 import org.hyperledger.besu.nativelib.gnark.LibGnarkEIP2537;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.tuweni.bytes.Bytes;
 
 /** The BLS12Pairing precompiled contract. */
 public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledContract {
 
   private static final int PARAMETER_LENGTH = 384;
+  private static final Cache<Integer, PrecompileInputResultTuple> pairingCache =
+      Caffeine.newBuilder().maximumSize(1000).build();
 
   /** Instantiates a new BLS12Pairing precompiled contract. */
   public BLS12PairingPrecompiledContract() {
@@ -35,5 +39,10 @@ public class BLS12PairingPrecompiledContract extends AbstractBLS12PrecompiledCon
   public long gasRequirement(final Bytes input) {
     final int k = input.size() / PARAMETER_LENGTH;
     return 32_600L * k + 37_700L;
+  }
+
+  @Override
+  protected Cache<Integer, PrecompileInputResultTuple> getCache() {
+    return pairingCache;
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
@@ -82,9 +82,13 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
       return PrecompileContractResult.success(Bytes.EMPTY);
     }
 
-    var res = ecrecCache.getIfPresent(input.hashCode());
-    if (res != null && res.cachedInput().equals(input)) {
-      return res.cachedResult();
+    PrecompileInputResultTuple res;
+
+    if (enableResultCaching) {
+      res = ecrecCache.getIfPresent(input.hashCode());
+      if (res != null && res.cachedInput().equals(input)) {
+        return res.cachedResult();
+      }
     }
 
     final int recId = d.get(63) - V_BASE;
@@ -115,7 +119,9 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
       final MutableBytes32 result = MutableBytes32.create();
       hashed.slice(12).copyTo(result, 12);
       res = new PrecompileInputResultTuple(input, PrecompileContractResult.success(result));
-      ecrecCache.put(input.hashCode(), res);
+      if (enableResultCaching) {
+        ecrecCache.put(input.hashCode(), res);
+      }
       return res.cachedResult();
     } catch (final IllegalArgumentException e) {
       return PrecompileContractResult.success(Bytes.EMPTY);

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
@@ -89,7 +89,7 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
     PrecompileInputResultTuple res;
     Integer cacheKey = null;
     if (enableResultCaching) {
-      cacheKey = input.hashCode();
+      cacheKey = getCacheKey(input);
       res = ecrecCache.getIfPresent(cacheKey);
 
       if (res != null) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java
@@ -41,7 +41,7 @@ public class ECRECPrecompiledContract extends AbstractPrecompiledContract {
   private static final Logger LOG = LoggerFactory.getLogger(ECRECPrecompiledContract.class);
   private static final int V_BASE = 27;
   final SignatureAlgorithm signatureAlgorithm;
-  public static final String PRECOMPILE_NAME = "ECREC";
+  private static final String PRECOMPILE_NAME = "ECREC";
   private static final Cache<Integer, PrecompileInputResultTuple> ecrecCache =
       Caffeine.newBuilder().maximumSize(1000).build();
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompiledContract.java
@@ -22,7 +22,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.internal.Words;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nonnull;
@@ -138,7 +137,7 @@ public class KZGPointEvalPrecompiledContract implements PrecompiledContract {
     Integer cacheKey = null;
 
     if (enableResultCaching) {
-      cacheKey = Arrays.hashCode(input.toArrayUnsafe());
+      cacheKey = AbstractPrecompiledContract.getCacheKey(input);
       res = kzgCache.getIfPresent(cacheKey);
       if (res != null) {
         if (res.cachedInput().equals(input)) {

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
@@ -53,58 +53,23 @@ public interface PrecompiledContract {
    * @param messageFrame context for this message
    * @return the output of the pre-compiled contract.
    */
-  @SuppressWarnings("deprecation")
   @Nonnull
-  default PrecompileContractResult computePrecompile(
-      final Bytes input, @Nonnull final MessageFrame messageFrame) {
-    final Bytes result = compute(input, messageFrame);
-    if (result == null) {
-      return PrecompileContractResult.halt(null, Optional.of(ExceptionalHaltReason.NONE));
-    } else {
-      return PrecompileContractResult.success(result);
-    }
-  }
+  PrecompileContractResult computePrecompile(
+      final Bytes input, @Nonnull final MessageFrame messageFrame);
 
   /**
-   * Executes the pre-compiled contract.
+   * Encapsulated result of precompiled contract.
    *
-   * @param input the input for the pre-compiled contract.
-   * @param messageFrame context for this message
-   * @return the output of the pre-compiled contract.
-   * @deprecated Migrate to use {@link #computePrecompile(Bytes, MessageFrame)}.
+   * @param output output if successful
+   * @param isRefundGas Should we charge the gasRequirement?
+   * @param state state of the EVM after execution (for format errors this would be ExceptionalHalt)
+   * @param haltReason the exceptional halt reason
    */
-  @Deprecated(since = "22.1.2")
-  default Bytes compute(final Bytes input, final @Nonnull MessageFrame messageFrame) {
-    return computePrecompile(input, messageFrame).getOutput();
-  }
-
-  /** The Precompile contract result. */
-  class PrecompileContractResult {
-    private final Bytes output;
-    private final boolean refundGas;
-    private final MessageFrame.State state;
-    private final Optional<ExceptionalHaltReason> haltReason;
-
-    /**
-     * Encapsulated result of precompiled contract.
-     *
-     * @param output output if successful
-     * @param refundGas Should we charge the gasRequirement?
-     * @param state state of the EVM after execution (for format errors this would be
-     *     ExceptionalHalt)
-     * @param haltReason the exceptional halt reason
-     */
-    // TOO JDK17 use a record
-    public PrecompileContractResult(
-        final Bytes output,
-        final boolean refundGas,
-        final MessageFrame.State state,
-        final Optional<ExceptionalHaltReason> haltReason) {
-      this.output = output;
-      this.refundGas = refundGas;
-      this.state = state;
-      this.haltReason = haltReason;
-    }
+  record PrecompileContractResult(
+      Bytes output,
+      boolean isRefundGas,
+      MessageFrame.State state,
+      Optional<ExceptionalHaltReason> haltReason) {
 
     /**
      * precompile contract result with Success state.
@@ -142,42 +107,6 @@ public interface PrecompiledContract {
       }
       return new PrecompileContractResult(
           output, false, MessageFrame.State.EXCEPTIONAL_HALT, haltReason);
-    }
-
-    /**
-     * Gets output.
-     *
-     * @return the output
-     */
-    public Bytes getOutput() {
-      return output;
-    }
-
-    /**
-     * Is refund gas.
-     *
-     * @return the boolean
-     */
-    public boolean isRefundGas() {
-      return refundGas;
-    }
-
-    /**
-     * Gets state.
-     *
-     * @return the state
-     */
-    public MessageFrame.State getState() {
-      return state;
-    }
-
-    /**
-     * Gets halt reason.
-     *
-     * @return the halt reason
-     */
-    public Optional<ExceptionalHaltReason> getHaltReason() {
-      return haltReason;
     }
   }
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
@@ -110,5 +110,11 @@ public interface PrecompiledContract {
     }
   }
 
+  /**
+   * Record type used for precompile result caching.
+   *
+   * @param cachedInput cached input bytes
+   * @param cachedResult cached result
+   */
   record PrecompileInputResultTuple(Bytes cachedInput, PrecompileContractResult cachedResult) {}
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/precompile/PrecompiledContract.java
@@ -109,4 +109,6 @@ public interface PrecompiledContract {
           output, false, MessageFrame.State.EXCEPTIONAL_HALT, haltReason);
     }
   }
+
+  record PrecompileInputResultTuple(Bytes cachedInput, PrecompileContractResult cachedResult) {}
 }

--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/MessageCallProcessor.java
@@ -160,17 +160,17 @@ public class MessageCallProcessor extends AbstractMessageProcessor {
       frame.decrementRemainingGas(gasRequirement);
       final PrecompiledContract.PrecompileContractResult result =
           contract.computePrecompile(frame.getInputData(), frame);
-      operationTracer.tracePrecompileCall(frame, gasRequirement, result.getOutput());
+      operationTracer.tracePrecompileCall(frame, gasRequirement, result.output());
       if (result.isRefundGas()) {
         frame.incrementRemainingGas(gasRequirement);
       }
       if (frame.getState() == MessageFrame.State.REVERT) {
-        frame.setRevertReason(result.getOutput());
+        frame.setRevertReason(result.output());
       } else {
-        frame.setOutputData(result.getOutput());
+        frame.setOutputData(result.output());
       }
-      frame.setState(result.getState());
-      frame.setExceptionalHaltReason(result.getHaltReason());
+      frame.setState(result.state());
+      frame.setExceptionalHaltReason(result.haltReason());
     }
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/AltBN128PairingPrecompiledContractTest.java
@@ -47,7 +47,7 @@ class AltBN128PairingPrecompiledContractTest {
       AbstractAltBnPrecompiledContract.disableNative();
     }
     final Bytes input = validPointBytes();
-    final Bytes result = byzantiumContract.computePrecompile(input, messageFrame).getOutput();
+    final Bytes result = byzantiumContract.computePrecompile(input, messageFrame).output();
     assertThat(result).isEqualTo(AltBN128PairingPrecompiledContract.TRUE);
   }
 
@@ -130,7 +130,7 @@ class AltBN128PairingPrecompiledContractTest {
                 "0x1fbf8045ce3e79b5cde4112d38bcd0efbdb1295d2eefdf58151ae309d7ded7db"));
 
     final Bytes input = Bytes.concatenate(g1Point0, g2Point0, g1Point1, g2Point1);
-    final Bytes result = byzantiumContract.computePrecompile(input, messageFrame).getOutput();
+    final Bytes result = byzantiumContract.computePrecompile(input, messageFrame).output();
     assertThat(result).isNull();
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLAKE2BFPrecompileContractTest.java
@@ -89,7 +89,7 @@ class BLAKE2BFPrecompileContractTest {
     final Bytes input = Bytes.fromHexString(inputString);
     final Bytes expectedComputation =
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
-    assertThat(contract.computePrecompile(input, messageFrame).getOutput())
+    assertThat(contract.computePrecompile(input, messageFrame).output())
         .isEqualTo(expectedComputation);
     assertThat(contract.gasRequirement(input)).isEqualTo(expectedGasUsed);
   }

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1AddPrecompiledContractTest.java
@@ -68,7 +68,7 @@ class BLS12G1AddPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       Mockito.verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1MulPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1MulPrecompiledContractTest.java
@@ -72,7 +72,7 @@ class BLS12G1MulPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G1MultiExpPrecompiledContractTest.java
@@ -69,7 +69,7 @@ class BLS12G1MultiExpPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2AddPrecompiledContractTest.java
@@ -68,7 +68,7 @@ class BLS12G2AddPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2MulPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2MulPrecompiledContractTest.java
@@ -72,7 +72,7 @@ class BLS12G2MulPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12G2MultiExpPrecompiledContractTest.java
@@ -68,7 +68,7 @@ class BLS12G2MultiExpPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12MapFp2ToG2PrecompiledContractTest.java
@@ -69,7 +69,7 @@ class BLS12MapFp2ToG2PrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12MapFpToG1PrecompiledContractTest.java
@@ -69,7 +69,7 @@ class BLS12MapFpToG1PrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/BLS12PairingPrecompiledContractTest.java
@@ -78,7 +78,7 @@ class BLS12PairingPrecompiledContractTest {
         expectedResult == null ? null : Bytes.fromHexString(expectedResult);
     final PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(input, messageFrame);
-    Bytes actualComputation = result.getOutput();
+    Bytes actualComputation = result.output();
     if (actualComputation == null) {
       final ArgumentCaptor<Bytes> revertReason = ArgumentCaptor.forClass(Bytes.class);
       verify(messageFrame).setRevertReason(revertReason.capture());

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/Benchmarks.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/Benchmarks.java
@@ -596,7 +596,7 @@ public class Benchmarks {
   }
 
   private static double runBenchmark(final Bytes arg, final PrecompiledContract contract) {
-    if (contract.computePrecompile(arg, fakeFrame).getOutput() == null) {
+    if (contract.computePrecompile(arg, fakeFrame).output() == null) {
       throw new RuntimeException("Input is Invalid");
     }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContractTest.java
@@ -354,7 +354,7 @@ class ECRECPrecompiledContractTest {
     final Bytes input = Bytes.fromHexString(inputString);
     final Bytes expected =
         expectedResult == null ? Bytes.EMPTY : Bytes32.fromHexString(expectedResult);
-    assertThat(contract.computePrecompile(input, messageFrame).getOutput()).isEqualTo(expected);
+    assertThat(contract.computePrecompile(input, messageFrame).output()).isEqualTo(expected);
   }
 
   @ParameterizedTest
@@ -364,7 +364,7 @@ class ECRECPrecompiledContractTest {
     final Bytes input = Bytes.fromHexString(inputString);
     final Bytes expected =
         expectedResult == null ? Bytes.EMPTY : Bytes32.fromHexString(expectedResult);
-    assertThat(contract.computePrecompile(input, messageFrame).getOutput()).isEqualTo(expected);
+    assertThat(contract.computePrecompile(input, messageFrame).output()).isEqualTo(expected);
   }
 
   @Test

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompileContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/KZGPointEvalPrecompileContractTest.java
@@ -61,10 +61,10 @@ public class KZGPointEvalPrecompileContractTest {
     PrecompiledContract.PrecompileContractResult result =
         contract.computePrecompile(parameters.input, toRun);
     if (parameters.valid) {
-      assertThat(result.getState()).isEqualTo(MessageFrame.State.COMPLETED_SUCCESS);
-      assertThat(result.getOutput()).isEqualTo(parameters.returnValue);
+      assertThat(result.state()).isEqualTo(MessageFrame.State.COMPLETED_SUCCESS);
+      assertThat(result.output()).isEqualTo(parameters.returnValue);
     } else {
-      assertThat(result.getState()).isNotEqualTo(MessageFrame.State.COMPLETED_SUCCESS);
+      assertThat(result.state()).isNotEqualTo(MessageFrame.State.COMPLETED_SUCCESS);
     }
   }
 

--- a/evm/src/test/java/org/hyperledger/besu/evm/precompile/MODEXPPrecompiledContractTest.java
+++ b/evm/src/test/java/org/hyperledger/besu/evm/precompile/MODEXPPrecompiledContractTest.java
@@ -179,10 +179,9 @@ class MODEXPPrecompiledContractTest {
     assumeThat(precompiledResult).isNotNull();
     final Bytes input = Bytes.fromHexString(inputString);
     final Bytes expected = Bytes.fromHexString(precompiledResult);
-    assertThat(byzantiumContract.computePrecompile(input, messageFrame).getOutput())
+    assertThat(byzantiumContract.computePrecompile(input, messageFrame).output())
         .isEqualTo(expected);
-    assertThat(berlinContract.computePrecompile(input, messageFrame).getOutput())
-        .isEqualTo(expected);
+    assertThat(berlinContract.computePrecompile(input, messageFrame).output()).isEqualTo(expected);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## PR description

PR adds precompile caching behavior for an MVP set of precompiles that are costly enough to benefit from caching.    Provision is added to disable caching via command line arg (for gas costing reasons), but it is enabled by default in besu, and disabled by default in evmtool and benchmark subcommand.  

Changes:
* add a static member and setter in AbstractPrecompiledContract used to control whether we want to cache results
* add precompile-specific LRU caches with rational size limits in each MVP precompile
* add a cli arg for precompile caching, defaulted to true

MVP precompiles include:
 * altbn128/bn254 precompiles for add, mul and pairing
 * ecrecover precompile
 * blake2 precompile
 * kzg point precompile
 * bls precompiles

Feedback welcome on the design choices:
* one cache per precompile contract (since each will have different input and output size characteristics)
* cache is <hashCode, input_and_result_tuple> in order to verify input is truly identical rather than just matching by hashCode (it is trivial to construct requests that have different inputs, but similar Bytes hashCode)

Parallel transaction execution should benefit from precompile caching when state conflicts are detected.  Attached are preliminary results from the nethermind gas-benchmarks suite which indicate performance does not seem to take a hit for cache checking and misses, and the caching itself is effective for repetitive/identical inputs

updated:
[ecmul_new.pdf](https://github.com/user-attachments/files/19396239/ecmul_new.pdf)
[ecrec_new.pdf](https://github.com/user-attachments/files/19396240/ecrec_new.pdf)
[blake2f_new.pdf](https://github.com/user-attachments/files/19396241/blake2f_new.pdf)





## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

