### PR TITLE
Pass miningBeneficiary address to BlockAwareOperationTracer::traceStartBlock calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 - `--host-whitelist` has been deprecated since 2020 and this option is removed. Use the equivalent `--host-allowlist` instead. 
+- Changed tracer API to include the mining beneficiary in BlockAwareOperationTracer::traceStartBlock [#8096](https://github.com/hyperledger/besu/pull/8096)
 
 ### Upcoming Breaking Changes
 - `MetricSystem::createLabelledGauge` is deprecated and will be removed in a future release, replace it with `MetricSystem::createLabelledSuppliedGauge`

--- a/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.services;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.ethereum.mainnet.feemarket.ExcessBlobGasCalculator.calculateExcessBlobGasForParent;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.BlobGas;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -152,16 +153,13 @@ public class TraceServiceImpl implements TraceService {
             .toList();
     Tracer.processTracing(
         blockchainQueries,
-        blocks.get(0).getHash(),
+        blocks.getFirst().getHash(),
         traceableState -> {
           final WorldUpdater worldStateUpdater = traceableState.updater();
           final ChainUpdater chainUpdater = new ChainUpdater(traceableState, worldStateUpdater);
           beforeTracing.accept(worldStateUpdater);
           final List<TransactionProcessingResult> results = new ArrayList<>();
-          blocks.forEach(
-              block -> {
-                results.addAll(trace(blockchain, block, chainUpdater, tracer));
-              });
+          blocks.forEach(block -> results.addAll(trace(blockchain, block, chainUpdater, tracer)));
           afterTracing.accept(chainUpdater.getNextUpdater());
           return Optional.of(results);
         });
@@ -191,7 +189,9 @@ public class TraceServiceImpl implements TraceService {
     final ProtocolSpec protocolSpec = protocolSchedule.getByBlockHeader(block.getHeader());
     final MainnetTransactionProcessor transactionProcessor = protocolSpec.getTransactionProcessor();
     final BlockHeader header = block.getHeader();
-    tracer.traceStartBlock(block.getHeader(), block.getBody());
+    final Address miningBeneficiary =
+        protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(block.getHeader());
+    tracer.traceStartBlock(block.getHeader(), block.getBody(), miningBeneficiary);
 
     block
         .getBody()

--- a/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
@@ -114,7 +114,9 @@ class TraceServiceImplTest {
 
     final Block tracedBlock = blockchain.getBlockByNumber(blockNumber).get();
 
-    verify(opTracer).traceStartBlock(tracedBlock.getHeader(), tracedBlock.getBody());
+    verify(opTracer)
+        .traceStartBlock(
+            tracedBlock.getHeader(), tracedBlock.getBody(), tracedBlock.getHeader().getCoinbase());
 
     tracedBlock
         .getBody()
@@ -163,7 +165,11 @@ class TraceServiceImplTest {
         .map(Optional::get)
         .forEach(
             tracedBlock -> {
-              verify(opTracer).traceStartBlock(tracedBlock.getHeader(), tracedBlock.getBody());
+              verify(opTracer)
+                  .traceStartBlock(
+                      tracedBlock.getHeader(),
+                      tracedBlock.getBody(),
+                      tracedBlock.getHeader().getCoinbase());
               tracedBlock
                   .getBody()
                   .getTransactions()
@@ -312,7 +318,8 @@ class TraceServiceImplTest {
     }
 
     @Override
-    public void traceStartBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
+    public void traceStartBlock(
+        final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {
       if (!traceStartBlockCalled.add(blockHeader.getBlockHash())) {
         fail("traceStartBlock already called for block " + blockHeader);
       }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -221,7 +221,7 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
       final BlockAwareOperationTracer operationTracer =
           pluginTransactionSelector.getOperationTracer();
 
-      operationTracer.traceStartBlock(processableBlockHeader);
+      operationTracer.traceStartBlock(processableBlockHeader, miningBeneficiary);
       timings.register("preTxsSelection");
       final TransactionSelectionResults transactionResults =
           selectTransactions(

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
@@ -41,8 +41,9 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
   }
 
   @Override
-  public void traceStartBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
-    delegate.traceStartBlock(blockHeader, blockBody);
+  public void traceStartBlock(
+      final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {
+    delegate.traceStartBlock(blockHeader, blockBody, miningBeneficiary);
   }
 
   @Override
@@ -51,8 +52,9 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
   }
 
   @Override
-  public void traceStartBlock(final ProcessableBlockHeader processableBlockHeader) {
-    delegate.traceStartBlock(processableBlockHeader);
+  public void traceStartBlock(
+      final ProcessableBlockHeader processableBlockHeader, final Address miningBeneficiary) {
+    delegate.traceStartBlock(processableBlockHeader, miningBeneficiary);
   }
 
   @Override

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'By1EMWJvyXiRxNf52xZ0BUC2LpE6D4VlNHI0jYJryj0='
+  knownHash = 'b/u9Ety5B+Ni8UwGhvU8dq4jcZtulNczsVQZgG0Q5fw='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.plugin.services.tracer;
 
+import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
@@ -37,8 +38,10 @@ public interface BlockAwareOperationTracer extends OperationTracer {
    *
    * @param blockHeader the header of the block which is traced
    * @param blockBody the body of the block which is traced
+   * @param miningBeneficiary the address of miner building the block
    */
-  default void traceStartBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
+  default void traceStartBlock(
+      final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {}
 
   /**
    * Trace the end of a block.
@@ -52,8 +55,10 @@ public interface BlockAwareOperationTracer extends OperationTracer {
    * When building a block this API is called at the start of the process
    *
    * @param processableBlockHeader the processable header
+   * @param miningBeneficiary the address of miner building the block
    */
-  default void traceStartBlock(final ProcessableBlockHeader processableBlockHeader) {}
+  default void traceStartBlock(
+      final ProcessableBlockHeader processableBlockHeader, final Address miningBeneficiary) {}
 
   @Override
   default boolean isExtendedTracing() {


### PR DESCRIPTION
## PR description
This passes the miningBeneficiary, which in most cases should be the coinbase but for other consensus approaches could be different, to BlockAwareOperationTracer::traceStartBlock calls.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8094

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

