### PR TITLE
fix: Update Bash variable increment syntax to use ((i++))

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -26,20 +26,20 @@ i=0
 ## Checks on the Dockerfile
 GOSS_FILES_PATH=$TEST_PATH/00 \
 bash $TEST_PATH/dgoss dockerfile $DOCKER_IMAGE $DOCKER_FILE \
-> ./reports/00.xml || i=`expr $i + 1`
+> ./reports/00.xml || ((i++))
 # fail fast if we dont pass static checks
 if [[ $i != 0 ]]; then exit $i; fi
 
 # Test for normal startup with ports opened
-# we test that things listen on the right interface/port, not what interface the advertise
-# hence we dont set p2p-host=0.0.0.0 because this sets what its advertising to devp2p; the important piece is that it defaults to listening on all interfaces
+# we test that things listen on the right interface/port, not what interface they advertise
+# hence we don't set p2p-host=0.0.0.0 because this sets what it's advertising to devp2p; the important piece is that it defaults to listening on all interfaces
 GOSS_FILES_PATH=$TEST_PATH/01 \
 bash $TEST_PATH/dgoss run --sysctl net.ipv6.conf.all.disable_ipv6=1 $DOCKER_IMAGE \
 --network=dev \
 --rpc-http-enabled \
 --rpc-ws-enabled \
 --graphql-http-enabled \
-> ./reports/01.xml || i=`expr $i + 1`
+> ./reports/01.xml || ((i++))
 
 if [[ $i != 0 ]]; then exit $i; fi
 
@@ -47,6 +47,6 @@ if [[ $i != 0 ]]; then exit $i; fi
 GOSS_FILES_PATH=$TEST_PATH/02 \
 bash $TEST_PATH/dgoss run --sysctl net.ipv6.conf.all.disable_ipv6=1 -v besu-data:/var/lib/besu $DOCKER_IMAGE --data-path=/var/lib/besu \
 --network=dev \
-> ./reports/02.xml || i=`expr $i + 1`
+> ./reports/02.xml || ((i++))
 
 exit $i


### PR DESCRIPTION
## PR description

I noticed that the script contained an outdated syntax for incrementing the variable, using `i=\expr $i + 1`. In Bash, this can be more effectively done using `((i++))`, which is not only more idiomatic but also cleaner and easier to read.

I’ve updated the increment logic to use `((i++))` throughout the code.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

