### PR TITLE
docs: clarify purpose of max memory metric in OpenTelemetry

### DIFF
--- a/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
+++ b/metrics/core/src/main/java/org/hyperledger/besu/metrics/opentelemetry/OpenTelemetrySystem.java
@@ -372,7 +372,11 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
     final Attributes usedNonHeap = Attributes.of(typeKey, USED, areaKey, NON_HEAP);
     final Attributes committedHeap = Attributes.of(typeKey, COMMITTED, areaKey, HEAP);
     final Attributes committedNonHeap = Attributes.of(typeKey, COMMITTED, areaKey, NON_HEAP);
-    // TODO: Decide if max is needed or not. May be derived with some approximation from max(used).
+    // The max memory metric represents the upper limit of memory that can be allocated by the JVM.
+    // This is different from the historical maximum of used memory and is important for:
+    // 1. Capacity planning
+    // 2. Calculating memory utilization percentage (used/max)
+    // 3. Monitoring memory pressure
     final Attributes maxHeap = Attributes.of(typeKey, MAX, areaKey, HEAP);
     final Attributes maxNonHeap = Attributes.of(typeKey, MAX, areaKey, NON_HEAP);
     meter
@@ -410,8 +414,8 @@ public class OpenTelemetrySystem implements ObservableMetricsSystem {
                 MemoryUsage poolUsage = poolBeans.get(i).getUsage();
                 resultLongObserver.record(poolUsage.getUsed(), usedLabelSets.get(i));
                 resultLongObserver.record(poolUsage.getCommitted(), committedLabelSets.get(i));
-                // TODO: Decide if max is needed or not. May be derived with some approximation from
-                //  max(used).
+                // The max memory metric represents the upper limit of memory that can be allocated by the JVM.
+                // This is different from the historical maximum of used memory and is important for capacity planning.
                 resultLongObserver.record(poolUsage.getMax(), maxLabelSets.get(i));
               }
             });


### PR DESCRIPTION
## PR description

The max memory metric in OpenTelemetry was marked with a TODO suggesting it might be redundant. This commit clarifies that the max memory metric is essential as it:
1. Represents the upper limit of memory that can be allocated by the JVM
2. Is different from the historical maximum of used memory
3. Is important for capacity planning and monitoring memory pressure
4. Helps calculate memory utilization percentage (used/max)

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

