### PR TITLE
Add back deprecated traceStartBlock methods to the tracer API

### DIFF
--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'V3YwoXiJjbbrtpr7DmbebhJwAcj40J/3gb6VZcoFlF8='
+  knownHash = '2b6i9SVzINvYv2E4yHk10d6ad+pzA12xsMltKghnW+U='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
@@ -34,6 +34,17 @@ public interface BlockAwareOperationTracer extends OperationTracer {
   BlockAwareOperationTracer NO_TRACING = new BlockAwareOperationTracer() {};
 
   /**
+   * Trace the start of a block. Notice: This method has been marked for removal and will be removed
+   * in a future version. Avoid using it and use {@link #traceStartBlock(BlockHeader, BlockBody,
+   * Address)} instead.
+   *
+   * @param blockHeader the header of the block which is traced
+   * @param blockBody the body of the block which is traced
+   */
+  @Deprecated
+  default void traceStartBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
+
+  /**
    * Trace the start of a block.
    *
    * @param blockHeader the header of the block which is traced
@@ -50,6 +61,16 @@ public interface BlockAwareOperationTracer extends OperationTracer {
    * @param blockBody the body of the block which is traced
    */
   default void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
+
+  /**
+   * When building a block this API is called at the start of the process. Notice: This method has
+   * been marked for removal and will be removed in a future version. Avoid using it and use {@link
+   * #traceStartBlock(ProcessableBlockHeader, Address)} instead.
+   *
+   * @param processableBlockHeader the processable header
+   */
+  @Deprecated
+  default void traceStartBlock(final ProcessableBlockHeader processableBlockHeader) {}
 
   /**
    * When building a block this API is called at the start of the process


### PR DESCRIPTION
## PR description
This PR adds back removed methods from the tracer API that are now marked as deprecated and will removed at a later point. This is to avoid breaking any other existing customers of the API.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

