### PR TITLE
Deprecate BlockAwareOperationTracer::traceStartBlock(BlockHeader, BlockBody, [Address])

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/TraceServiceImpl.java
@@ -191,7 +191,7 @@ public class TraceServiceImpl implements TraceService {
     final BlockHeader header = block.getHeader();
     final Address miningBeneficiary =
         protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(block.getHeader());
-    tracer.traceStartBlock(block.getHeader(), block.getBody(), miningBeneficiary);
+    tracer.traceStartBlock(block.getHeader(), miningBeneficiary);
 
     block
         .getBody()

--- a/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/services/TraceServiceImplTest.java
@@ -38,6 +38,7 @@ import org.hyperledger.besu.evm.worldstate.WorldView;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.data.BlockTraceResult;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionTraceResult;
 import org.hyperledger.besu.plugin.services.TraceService;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
@@ -116,7 +117,7 @@ class TraceServiceImplTest {
 
     verify(opTracer)
         .traceStartBlock(
-            tracedBlock.getHeader(), tracedBlock.getBody(), tracedBlock.getHeader().getCoinbase());
+            tracedBlock.getHeader(), tracedBlock.getHeader().getCoinbase());
 
     tracedBlock
         .getBody()
@@ -168,7 +169,6 @@ class TraceServiceImplTest {
               verify(opTracer)
                   .traceStartBlock(
                       tracedBlock.getHeader(),
-                      tracedBlock.getBody(),
                       tracedBlock.getHeader().getCoinbase());
               tracedBlock
                   .getBody()
@@ -282,7 +282,7 @@ class TraceServiceImplTest {
 
     private final Set<Transaction> traceStartTxCalled = new HashSet<>();
     private final Set<Transaction> traceEndTxCalled = new HashSet<>();
-    private final Set<Hash> traceStartBlockCalled = new HashSet<>();
+    private final Set<ProcessableBlockHeader> traceStartBlockCalled = new HashSet<>();
     private final Set<Hash> traceEndBlockCalled = new HashSet<>();
 
     @Override
@@ -319,8 +319,8 @@ class TraceServiceImplTest {
 
     @Override
     public void traceStartBlock(
-        final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {
-      if (!traceStartBlockCalled.add(blockHeader.getBlockHash())) {
+      final ProcessableBlockHeader blockHeader, final Address miningBeneficiary) {
+      if (!traceStartBlockCalled.add(blockHeader)) {
         fail("traceStartBlock already called for block " + blockHeader);
       }
     }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/txselection/InterruptibleOperationTracer.java
@@ -42,8 +42,8 @@ public class InterruptibleOperationTracer implements BlockAwareOperationTracer {
 
   @Override
   public void traceStartBlock(
-      final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {
-    delegate.traceStartBlock(blockHeader, blockBody, miningBeneficiary);
+      final BlockHeader blockHeader, final BlockBody blockBody) {
+    delegate.traceStartBlock(blockHeader, blockBody);
   }
 
   @Override

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/tracer/BlockAwareOperationTracer.java
@@ -35,7 +35,7 @@ public interface BlockAwareOperationTracer extends OperationTracer {
 
   /**
    * Trace the start of a block. Notice: This method has been marked for removal and will be removed
-   * in a future version. Avoid using it and use {@link #traceStartBlock(BlockHeader, BlockBody,
+   * in a future version. Avoid using it and use {@link #traceStartBlock(ProcessableBlockHeader,
    * Address)} instead.
    *
    * @param blockHeader the header of the block which is traced
@@ -43,24 +43,6 @@ public interface BlockAwareOperationTracer extends OperationTracer {
    */
   @Deprecated
   default void traceStartBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
-
-  /**
-   * Trace the start of a block.
-   *
-   * @param blockHeader the header of the block which is traced
-   * @param blockBody the body of the block which is traced
-   * @param miningBeneficiary the address of miner building the block
-   */
-  default void traceStartBlock(
-      final BlockHeader blockHeader, final BlockBody blockBody, final Address miningBeneficiary) {}
-
-  /**
-   * Trace the end of a block.
-   *
-   * @param blockHeader the header of the block which is traced
-   * @param blockBody the body of the block which is traced
-   */
-  default void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
 
   /**
    * When building a block this API is called at the start of the process. Notice: This method has
@@ -80,6 +62,14 @@ public interface BlockAwareOperationTracer extends OperationTracer {
    */
   default void traceStartBlock(
       final ProcessableBlockHeader processableBlockHeader, final Address miningBeneficiary) {}
+
+  /**
+   * Trace the end of a block.
+   *
+   * @param blockHeader the header of the block which is traced
+   * @param blockBody the body of the block which is traced
+   */
+  default void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {}
 
   @Override
   default boolean isExtendedTracing() {


### PR DESCRIPTION
## PR description
I found out that `BlockAwareOperationTracer::traceStartBlock(BlockHeader, BlockBody, Address)` is actually not used if not from the Tracing plugin and having access to the block body before building it does not seem to make sense. 

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

