### PR TITLE
Unignore Prague ref tests and remove osakaTime from Prague

### DIFF
--- a/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
+++ b/ethereum/referencetests/src/main/java/org/hyperledger/besu/ethereum/referencetests/ReferenceTestProtocolSchedules.java
@@ -106,14 +106,7 @@ public class ReferenceTestProtocolSchedules {
                 Map.entry(
                     "CancunToPragueAtTime15k",
                     createSchedule(genesisStub.clone().cancunTime(0).pragueTime(15000))),
-                Map.entry(
-                    "Prague",
-                    createSchedule(
-                        genesisStub
-                            .clone()
-                            .pragueTime(0)
-                            .osakaTime(0) // TODO remove this once osaka_devnet_0 ships
-                        )),
+                Map.entry("Prague", createSchedule(genesisStub.clone().pragueTime(0))),
                 Map.entry("Osaka", createSchedule(genesisStub.clone().osakaTime(0))),
                 Map.entry("Amsterdam", createSchedule(genesisStub.clone().futureEipsTime(0))),
                 Map.entry("Bogota", createSchedule(genesisStub.clone().futureEipsTime(0))),

--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/vm/BlockchainReferenceTestTools.java
@@ -91,9 +91,6 @@ public class BlockchainReferenceTestTools {
     // EOF tests don't have Prague stuff like deposits right now
     params.ignore("/stEOF/");
 
-    // None of the Prague tests have withdrawals and deposits handling
-    params.ignore("\\[Prague\\]");
-
     // TODO: remove once updated EIP-2537 gas cost artifacts exist
     params.ignore("/eip2537_bls_12_381_precompiles/");
     params.ignore("/stEIP2537/");


### PR DESCRIPTION
## PR description

No need to ignore Prague tests now (think the specific BLS ignores were all that were required)

Removing osakaTime from Prague Schedule fixes some tests when using https://github.com/ethereum/execution-spec-tests/releases/tag/pectra-devnet-5%40v1.2.0
and doesn't break main.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

