### PR TITLE
Fix eth_getBlockByNumber with empty params returns

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumber.java
@@ -69,7 +69,7 @@ public class EthGetBlockByNumber extends AbstractBlockParameterMethod {
       return request.getRequiredParameter(0, BlockParameter.class);
     } catch (JsonRpcParameterException e) {
       throw new InvalidJsonRpcParameters(
-          "Invalid block parameter (index 0)", RpcErrorType.INVALID_BLOCK_PARAMS, e);
+          "Invalid block parameter (index 0)", RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS, e);
     }
   }
 

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/JsonRpcHttpServiceTest.java
@@ -980,7 +980,7 @@ public class JsonRpcHttpServiceTest extends JsonRpcHttpServiceTestBase {
       // Check general format of result
       final String respBody = resp.body().string();
       final JsonObject json = new JsonObject(respBody);
-      final RpcErrorType expectedError = RpcErrorType.INVALID_BLOCK_PARAMS;
+      final RpcErrorType expectedError = RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS;
       testHelper.assertValidJsonRpcError(
           json, id, expectedError.getCode(), expectedError.getMessage());
     }

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthGetBlockByNumberTest.java
@@ -106,14 +106,17 @@ public class EthGetBlockByNumberTest {
   @Test
   public void exceptionWhenNoParamsSupplied() {
     assertThatThrownBy(() -> method.response(requestWithParams()))
-        .isInstanceOf(InvalidJsonRpcParameters.class);
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasFieldOrPropertyWithValue("rpcErrorType", RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS);
     verifyNoMoreInteractions(blockchainQueries);
   }
 
   @Test
   public void exceptionWhenNoNumberSupplied() {
     assertThatThrownBy(() -> method.response(requestWithParams("false")))
-        .isInstanceOf(InvalidJsonRpcParameters.class);
+        .isInstanceOf(InvalidJsonRpcParameters.class)
+        .hasFieldOrPropertyWithValue("rpcErrorType", RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS);
+
     verifyNoMoreInteractions(blockchainQueries);
   }
 
@@ -129,7 +132,8 @@ public class EthGetBlockByNumberTest {
   public void exceptionWhenNumberParamInvalid() {
     assertThatThrownBy(() -> method.response(requestWithParams("invalid", "true")))
         .isInstanceOf(InvalidJsonRpcParameters.class)
-        .hasMessage("Invalid block parameter (index 0)");
+        .hasMessage("Invalid block parameter (index 0)")
+        .hasFieldOrPropertyWithValue("rpcErrorType", RpcErrorType.INVALID_BLOCK_NUMBER_PARAMS);
     verifyNoMoreInteractions(blockchainQueries);
   }
 


### PR DESCRIPTION
## PR description
This PR addresses a bug in the eth_getBlockByNumber method, where invoking it with empty parameters results in the error message "Invalid block, unable to parse RLP".

There're some consideration while I investigate & fix the bug
- I would have preferred to use the message proposed in the issue; however, a pre-defined error message better fits this situation, so I opted to use it.
- Adding data would require modifications to org.hyperledger.besu.ethereum.api.jsonrpc.execution.BaseJsonRpcProcessor.process(), which is outside the scope of this fix.
- The message for RpcErrorType.INVALID_BLOCK_PARAMS might seem slightly inconsistent, but adjusting it is also beyond the scope of this PR.

- Request
```
POST http://localhost:8545
Content-Type: application/json

{"jsonrpc":"2.0","id":"53","method":"eth_getBlockByNumber","params":[]}
```

- Before
```
{
  "jsonrpc": "2.0",
  "id": "53",
  "error": {
    "code": -32602,
    "message": "Invalid block, unable to parse RLP"
  }
}
```
- After
```
{
  "jsonrpc": "2.0",
  "id": "53",
  "error": {
    "code": -32602,
    "message": "Invalid block number params"
  }
}
```
## Fixed Issue(s)
fixes #7918 

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`
