### PR TITLE
Fix consensus issue due to modified precompile list

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip4762GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip4762GasCalculator.java
@@ -41,6 +41,9 @@ public class Eip4762GasCalculator extends CancunGasCalculator {
       Address.fromHexString("0xfffffffffffffffffffffffffffffffffffffffe");
   private static final long CREATE_OPERATION_GAS_COST = 1_000L;
 
+  /** Instantiates a new EIP-4762 Gas Calculator. */
+  public Eip4762GasCalculator() {}
+
   @Override
   public long getColdSloadCost() {
     return 0; // no cold gas cost after verkle

--- a/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip4762GasCalculator.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/gascalculator/Eip4762GasCalculator.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.evm.gascalculator;
 
-import static org.hyperledger.besu.datatypes.Address.KZG_POINT_EVAL;
 import static org.hyperledger.besu.ethereum.trie.verkle.util.Parameters.BASIC_DATA_LEAF_KEY;
 import static org.hyperledger.besu.ethereum.trie.verkle.util.Parameters.CODE_HASH_LEAF_KEY;
 import static org.hyperledger.besu.evm.internal.Words.clampedAdd;
@@ -37,15 +36,10 @@ import org.apache.tuweni.units.bigints.UInt256;
  *   <LI>Gas costs for EIP-4762 (Stateless trie)
  * </UL>
  */
-public class Eip4762GasCalculator extends PragueGasCalculator {
+public class Eip4762GasCalculator extends CancunGasCalculator {
   private static final Address HISTORY_STORAGE_ADDRESS =
       Address.fromHexString("0xfffffffffffffffffffffffffffffffffffffffe");
   private static final long CREATE_OPERATION_GAS_COST = 1_000L;
-
-  /** Instantiates a new EIP-4762 Gas Calculator. */
-  public Eip4762GasCalculator() {
-    super(KZG_POINT_EVAL.toArrayUnsafe()[19]);
-  }
 
   @Override
   public long getColdSloadCost() {


### PR DESCRIPTION
## PR description
An issue was spotted during verkle devnet-7 sync after merging main@b3b33da540 into verkle, where the precompile list was not being taken from Cancun but would be from Prague instead. 

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

