### PR TITLE
Pectra testnet fork slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## Unreleased
+### Breaking Changes
+### Upcoming Breaking Changes
+### Additions and Improvements
+- Adds timestamps to enable Prague hardfork on Sepolia and Holesky test networks. [#8163](https://github.com/hyperledger/besu/pull/8163)
+### Bug fixes
+
+
+## 25.1.0
 
 ### Breaking Changes
 - `--host-whitelist` has been deprecated since 2020 and this option is removed. Use the equivalent `--host-allowlist` instead. 

--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -63,16 +63,18 @@ public class ForkIdsNetworkConfigTest {
               new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L),
               new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 1677557088L),
               new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 1706655072L),
-              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 0L),
-              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 0L))
+              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 1739980128L),
+              new ForkId(Bytes.ofUnsignedInt(0xbafd09c3L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0xbafd09c3L), 0L))
         },
         new Object[] {
           NetworkName.HOLESKY,
           List.of(
               new ForkId(Bytes.ofUnsignedInt(0xc61a6098L), 1696000704L),
               new ForkId(Bytes.ofUnsignedInt(0xfd4f016bL), 1707305664L),
-              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 0L),
-              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 0L))
+              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 1739352768L),
+              new ForkId(Bytes.ofUnsignedInt(0xf818a0d6L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0xf818a0d6L), 0L))
         },
         new Object[] {
           NetworkName.MAINNET,

--- a/config/src/main/resources/holesky.json
+++ b/config/src/main/resources/holesky.json
@@ -15,6 +15,7 @@
     "terminalTotalDifficulty": 0,
     "shanghaiTime": 1696000704,
     "cancunTime": 1707305664,
+    "pragueTime":1739352768,
     "blobSchedule": {
       "cancun": {
         "target": 3,

--- a/config/src/main/resources/holesky.json
+++ b/config/src/main/resources/holesky.json
@@ -15,7 +15,7 @@
     "terminalTotalDifficulty": 0,
     "shanghaiTime": 1696000704,
     "cancunTime": 1707305664,
-    "pragueTime":1739352768,
+    "pragueTime": 1739352768,
     "blobSchedule": {
       "cancun": {
         "target": 3,

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -15,6 +15,7 @@
     "terminalTotalDifficulty": 17000000000000000,
     "shanghaiTime": 1677557088,
     "cancunTime": 1706655072,
+    "pragueTime": 1739980128,
     "blobSchedule": {
       "cancun": {
         "target": 3,


### PR DESCRIPTION
Pectra testnet fork slot proposals (TBC based on how devnet-6 goes next week): 

Holesky: 3620864 (Wed, Feb 12 at 09:32:48 UTC)
Sepolia: 219392 (Wed, Feb 19 at 15:48:48 UTC)

for those speaking epoch time:
Holesky: 1739352768
Sepolia: 1739980128

forkids for confirming:
holesky: 0xf818a0d6
sepolia: 0xbafd09c3
