### PR TITLE
Extend simulate transaction on pending block plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Upcoming Breaking Changes
 ### Additions and Improvements
 - Adds timestamps to enable Prague hardfork on Sepolia and Holesky test networks. [#8163](https://github.com/hyperledger/besu/pull/8163)
+- Extend simulate transaction on pending block plugin API [#8174](https://github.com/hyperledger/besu/pull/8174)
+
 ### Bug fixes
 
 

--- a/besu/src/main/java/org/hyperledger/besu/services/TransactionSimulationServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/TransactionSimulationServiceImpl.java
@@ -14,11 +14,15 @@
  */
 package org.hyperledger.besu.services;
 
+import static org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams.transactionSimulator;
+import static org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams.transactionSimulatorAllowExceedingBalance;
+import static org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams.transactionSimulatorAllowExceedingBalanceAndFutureNonce;
+import static org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams.transactionSimulatorAllowFutureNonce;
+
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StateOverrideMap;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.mainnet.TransactionValidationParams;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.CallParameter;
@@ -26,6 +30,7 @@ import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.Unstable;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSimulationResult;
 import org.hyperledger.besu.plugin.services.TransactionSimulationService;
 
@@ -52,49 +57,66 @@ public class TransactionSimulationServiceImpl implements TransactionSimulationSe
   }
 
   @Override
+  public ProcessableBlockHeader simulatePendingBlockHeader() {
+    return transactionSimulator.simulatePendingBlockHeader();
+  }
+
+  @Override
   public Optional<TransactionSimulationResult> simulate(
       final Transaction transaction,
       final Optional<StateOverrideMap> maybeStateOverrides,
-      final Optional<Hash> maybeBlockHash,
+      final Hash blockHash,
       final OperationTracer operationTracer,
       final boolean isAllowExceedingBalance) {
 
     final CallParameter callParameter = CallParameter.fromTransaction(transaction);
 
-    if (maybeBlockHash.isPresent()) {
-      final Hash blockHash = maybeBlockHash.get();
+    final var maybeBlockHeader =
+        blockchain.getBlockHeader(blockHash).or(() -> blockchain.getBlockHeaderSafe(blockHash));
 
-      final var maybeBlockHeader =
-          blockchain.getBlockHeader(blockHash).or(() -> blockchain.getBlockHeaderSafe(blockHash));
-
-      if (maybeBlockHeader.isEmpty()) {
-        return Optional.of(
-            new TransactionSimulationResult(
-                transaction,
-                TransactionProcessingResult.invalid(
-                    ValidationResult.invalid(TransactionInvalidReason.BLOCK_NOT_FOUND))));
-      }
-
-      return transactionSimulator
-          .process(
-              callParameter,
-              isAllowExceedingBalance
-                  ? TransactionValidationParams.transactionSimulatorAllowExceedingBalance()
-                  : TransactionValidationParams.transactionSimulator(),
-              operationTracer,
-              maybeBlockHeader.get())
-          .map(res -> new TransactionSimulationResult(transaction, res.result()));
+    if (maybeBlockHeader.isEmpty()) {
+      return Optional.of(
+          new TransactionSimulationResult(
+              transaction,
+              TransactionProcessingResult.invalid(
+                  ValidationResult.invalid(TransactionInvalidReason.BLOCK_NOT_FOUND))));
     }
+
+    return transactionSimulator
+        .process(
+            callParameter,
+            isAllowExceedingBalance
+                ? transactionSimulatorAllowExceedingBalance()
+                : transactionSimulator(),
+            operationTracer,
+            maybeBlockHeader.get())
+        .map(res -> new TransactionSimulationResult(transaction, res.result()));
+  }
+
+  @Override
+  public Optional<TransactionSimulationResult> simulate(
+      final Transaction transaction,
+      final Optional<StateOverrideMap> maybeStateOverrides,
+      final ProcessableBlockHeader pendingBlockHeader,
+      final OperationTracer operationTracer,
+      final boolean isAllowExceedingBalance,
+      final boolean isAllowFutureNonce) {
+
+    final CallParameter callParameter = CallParameter.fromTransaction(transaction);
 
     return transactionSimulator
         .processOnPending(
             callParameter,
             maybeStateOverrides,
             isAllowExceedingBalance
-                ? TransactionValidationParams.transactionSimulatorAllowExceedingBalance()
-                : TransactionValidationParams.transactionSimulator(),
+                ? isAllowFutureNonce
+                    ? transactionSimulatorAllowExceedingBalanceAndFutureNonce()
+                    : transactionSimulatorAllowExceedingBalance()
+                : isAllowFutureNonce
+                    ? transactionSimulatorAllowFutureNonce()
+                    : transactionSimulator(),
             operationTracer,
-            transactionSimulator.simulatePendingBlockHeader())
+            (org.hyperledger.besu.ethereum.core.ProcessableBlockHeader) pendingBlockHeader)
         .map(res -> new TransactionSimulationResult(transaction, res.result()));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/TransactionValidationParams.java
@@ -35,8 +35,14 @@ public interface TransactionValidationParams {
   TransactionValidationParams transactionSimulatorParams =
       ImmutableTransactionValidationParams.of(false, false, false, false, false, true);
 
+  TransactionValidationParams transactionSimulatorParamsAllowFutureNonce =
+      ImmutableTransactionValidationParams.of(true, false, false, false, false, true);
+
   TransactionValidationParams transactionSimulatorAllowExceedingBalanceParams =
       ImmutableTransactionValidationParams.of(false, true, false, false, false, true);
+
+  TransactionValidationParams transactionSimulatorAllowExceedingBalanceAndFutureNonceParams =
+      ImmutableTransactionValidationParams.of(true, true, false, false, false, true);
 
   @Value.Default
   default boolean isAllowFutureNonce() {
@@ -72,8 +78,16 @@ public interface TransactionValidationParams {
     return transactionSimulatorParams;
   }
 
+  static TransactionValidationParams transactionSimulatorAllowFutureNonce() {
+    return transactionSimulatorParamsAllowFutureNonce;
+  }
+
   static TransactionValidationParams transactionSimulatorAllowExceedingBalance() {
     return transactionSimulatorAllowExceedingBalanceParams;
+  }
+
+  static TransactionValidationParams transactionSimulatorAllowExceedingBalanceAndFutureNonce() {
+    return transactionSimulatorAllowExceedingBalanceAndFutureNonceParams;
   }
 
   static TransactionValidationParams processingBlock() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/transaction/TransactionSimulator.java
@@ -174,7 +174,7 @@ public class TransactionSimulator {
           operationTracer,
           pendingBlockHeader,
           updater,
-          Address.ZERO);
+          pendingBlockHeader.getCoinbase());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'E2b/W+IKnNxo6L7cHuijBMBUewHHRrkQ8dEVlcql5KE='
+  knownHash = 'gZIQWjSStog+2qxsbGPPp0OwpYjl8QDM5pv9QWdtADA='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSimulationService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/TransactionSimulationService.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.StateOverrideMap;
 import org.hyperledger.besu.datatypes.Transaction;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.plugin.Unstable;
+import org.hyperledger.besu.plugin.data.ProcessableBlockHeader;
 import org.hyperledger.besu.plugin.data.TransactionSimulationResult;
 
 import java.util.Optional;
@@ -28,12 +29,20 @@ import java.util.Optional;
 public interface TransactionSimulationService extends BesuService {
 
   /**
+   * Return a simulation of what could be current pending block, it can also be passed to {@link
+   * #simulate(Transaction, Optional, ProcessableBlockHeader, OperationTracer, boolean, boolean)}
+   *
+   * @return the simulated pending block header
+   */
+  ProcessableBlockHeader simulatePendingBlockHeader();
+
+  /**
    * Simulate transaction execution at the block identified by the hash if present, otherwise on the
    * pending block, with optional state overrides that can be applied before the simulation.
    *
    * @param transaction tx
    * @param stateOverrides state overrides to apply to this simulation
-   * @param maybeBlockHash optional hash of the block, empty to simulate on pending block
+   * @param blockHash hash of the block
    * @param operationTracer the tracer
    * @param isAllowExceedingBalance should ignore the sender balance during the simulation?
    * @return the result of the simulation
@@ -41,77 +50,27 @@ public interface TransactionSimulationService extends BesuService {
   Optional<TransactionSimulationResult> simulate(
       Transaction transaction,
       Optional<StateOverrideMap> stateOverrides,
-      Optional<Hash> maybeBlockHash,
+      Hash blockHash,
       OperationTracer operationTracer,
       boolean isAllowExceedingBalance);
 
   /**
    * Simulate transaction execution at the block identified by the hash if present, otherwise on the
-   * pending block
-   *
-   * @param transaction tx
-   * @param maybeBlockHash optional hash of the block, empty to simulate on pending block
-   * @param operationTracer the tracer
-   * @param isAllowExceedingBalance should ignore the sender balance during the simulation?
-   * @return the result of the simulation
-   */
-  default Optional<TransactionSimulationResult> simulate(
-      final Transaction transaction,
-      final Optional<Hash> maybeBlockHash,
-      final OperationTracer operationTracer,
-      final boolean isAllowExceedingBalance) {
-    return simulate(
-        transaction, Optional.empty(), maybeBlockHash, operationTracer, isAllowExceedingBalance);
-  }
-
-  /**
-   * Simulate transaction execution at the block identified by the hash
-   *
-   * @param transaction tx
-   * @param blockHash then hash of the block
-   * @param operationTracer the tracer
-   * @param isAllowExceedingBalance should ignore the sender balance during the simulation?
-   * @return the result of the simulation
-   * @deprecated use {@link #simulate(Transaction, Optional, OperationTracer, boolean)}
-   */
-  @Deprecated(since = "24.12", forRemoval = true)
-  default Optional<TransactionSimulationResult> simulate(
-      final Transaction transaction,
-      final Hash blockHash,
-      final OperationTracer operationTracer,
-      final boolean isAllowExceedingBalance) {
-    return simulate(
-        transaction,
-        Optional.empty(),
-        Optional.of(blockHash),
-        operationTracer,
-        isAllowExceedingBalance);
-  }
-
-  /**
-   * Simulate transaction execution at the block identified by the hash, with optional state
-   * overrides that can be applied before the simulation.
+   * pending block, with optional state overrides that can be applied before the simulation.
    *
    * @param transaction tx
    * @param stateOverrides state overrides to apply to this simulation
-   * @param blockHash the hash of the block
+   * @param processableBlockHeader block header to simulate on pending block
    * @param operationTracer the tracer
    * @param isAllowExceedingBalance should ignore the sender balance during the simulation?
+   * @param isAllowFutureNonce should skip strict check on sequential nonce?
    * @return the result of the simulation
-   * @deprecated use {@link #simulate(Transaction, Optional, Optional, OperationTracer, boolean)}
    */
-  @Deprecated(since = "24.12", forRemoval = true)
-  default Optional<TransactionSimulationResult> simulate(
-      final Transaction transaction,
-      final Optional<StateOverrideMap> stateOverrides,
-      final Hash blockHash,
-      final OperationTracer operationTracer,
-      final boolean isAllowExceedingBalance) {
-    return simulate(
-        transaction,
-        stateOverrides,
-        Optional.of(blockHash),
-        operationTracer,
-        isAllowExceedingBalance);
-  }
+  Optional<TransactionSimulationResult> simulate(
+      Transaction transaction,
+      Optional<StateOverrideMap> stateOverrides,
+      ProcessableBlockHeader processableBlockHeader,
+      OperationTracer operationTracer,
+      boolean isAllowExceedingBalance,
+      boolean isAllowFutureNonce);
 }


### PR DESCRIPTION
## PR description

Extend the simulate transaction plugin API to allow for plugin to access the pending block header, and giving the possibility of allowing future nonce during the simulation, for example we accepting txs to the txpool, also the coinbase of the pending block header is now correctly populated, and removed deprecated methods.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #8173 
### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

