### PR TITLE
Check if ENR is no more than 300 bytes when reading ENR in ENRResponsePacketData

### DIFF
--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRResponsePacketData.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/discovery/internal/ENRResponsePacketData.java
@@ -46,7 +46,10 @@ public class ENRResponsePacketData implements PacketData {
     in.enterList();
     final Bytes requestHash = in.readBytes();
     in.leaveListLenient();
-    final NodeRecord enr = NodeRecordFactory.DEFAULT.fromBytes(in.currentListAsBytes());
+
+    final Bytes rawEnrRlp = in.currentListAsBytes();
+    checkArgument(rawEnrRlp.size() <= 300, "enr must be no more than 300 bytes");
+    final NodeRecord enr = NodeRecordFactory.DEFAULT.fromBytes(rawEnrRlp);
 
     return new ENRResponsePacketData(requestHash, enr);
   }


### PR DESCRIPTION
## PR description
Add a check that the ENR is no more than 300 bytes, per the [spec](https://eips.ethereum.org/EIPS/eip-778#rlp-encoding) before attempting to parse
