### PR TITLE
debug_traceBlock use existing block header instead of hash

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractDebugTraceBlock.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/AbstractDebugTraceBlock.java
@@ -102,7 +102,7 @@ public abstract class AbstractDebugTraceBlock implements JsonRpcMethod {
             block ->
                 Tracer.processTracing(
                     getBlockchainQueries(),
-                    block.getHash(),
+                    Optional.of(block.getHeader()),
                     traceableState -> {
                       List<DebugTraceTransactionResult> tracesList =
                           Collections.synchronizedList(new ArrayList<>());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/DebugTraceBlockTest.java
@@ -154,7 +154,9 @@ public class DebugTraceBlockTest {
           .when(
               () ->
                   Tracer.processTracing(
-                      eq(blockchainQueries), eq(block.getHash()), any(Function.class)))
+                      eq(blockchainQueries),
+                      eq(Optional.of(block.getHeader())),
+                      any(Function.class)))
           .thenReturn(Optional.of(resultList));
 
       final JsonRpcResponse jsonRpcResponse = debugTraceBlock.response(request);


### PR DESCRIPTION
By using the other Tracing.processTracing overloaded method, this avoids this lookup https://github.com/hyperledger/besu/blob/b3192a5960bd9f277e5bdd063598a117c6fb4807/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/processor/Tracer.java#L38

and means you don't need to have the block already in the chain when you call `debug_traceBlock` with a block's RLP in the request.

Since this is an Abstract class, I'm not 100% sure how this might impact the other subclasses (think it's just DebugTraceBlockByHash).

Would like some clarification from someone who knows the API better.

Tested output is the same between `debug_traceBlock` vs `debug_traceBlockByNumber` vs `debug_traceBlockByHash`.
