### PR TITLE
Treat timestamp as unsigned long in engine api fork validation

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/ForkSupportHelper.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/ForkSupportHelper.java
@@ -31,7 +31,7 @@ public class ForkSupportHelper {
           "Configuration error, no schedule for " + hardforkId.name() + " fork set");
     }
 
-    if (blockTimestamp < maybeForkMilestone.get()) {
+    if (Long.compareUnsigned(blockTimestamp, maybeForkMilestone.get()) < 0) {
       return ValidationResult.invalid(
           RpcErrorType.UNSUPPORTED_FORK,
           hardforkId.name() + " configured to start at timestamp: " + maybeForkMilestone.get());

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/ForkSupportHelperTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/ForkSupportHelperTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hyperledger.besu.datatypes.HardforkId.MainnetHardforkId.PRAGUE;
+import static org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.engine.ForkSupportHelper.validateForkSupported;
+
+import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
+import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class ForkSupportHelperTest {
+
+  @Test
+  void validForkIfMilestoneOlderThanBlock() {
+    assertThat(validateForkSupported(PRAGUE, Optional.of(0L), 1))
+        .isEqualTo(ValidationResult.valid());
+  }
+
+  @Test
+  void validForkIfMilestoneEqualToBlock() {
+    assertThat(validateForkSupported(PRAGUE, Optional.of(0L), 0))
+        .isEqualTo(ValidationResult.valid());
+  }
+
+  @Test
+  void validForkWhenTimestampOverflowsSignedLong() {
+    long unsignedLongMaxValue = Long.parseUnsignedLong("18446744073709551615");
+    assertThat(validateForkSupported(PRAGUE, Optional.of(1L), unsignedLongMaxValue))
+        .isEqualTo(ValidationResult.valid());
+  }
+
+  @Test
+  void unsupportedForkIfMilestoneMisconfigured() {
+    assertThat(validateForkSupported(PRAGUE, Optional.empty(), 0))
+        .isEqualTo(
+            ValidationResult.invalid(RpcErrorType.UNSUPPORTED_FORK, "message equality ignored"));
+  }
+
+  @Test
+  void unsupportedForkIfBlockOlderThanMilestone() {
+    assertThat(validateForkSupported(PRAGUE, Optional.of(1L), 0))
+        .isEqualTo(
+            ValidationResult.invalid(RpcErrorType.UNSUPPORTED_FORK, "message equality ignored"));
+  }
+}


### PR DESCRIPTION
## PR description

If the timestamp is set to `> 2^63 - 1 and <= 2^64 - 1 (UnsignedLong.MAX_VALUE = 18446744073709551615)`, then since we use a (signed) primitive long by default this can overflow and e.g. we interpret `18446744073709551615` as timestamp = -1

This fixes some hive tests as part of #8177 