### PR TITLE
Change default gasLimit to 36 million

### DIFF
--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -79,7 +79,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
    */
   private static final double TRY_FILL_BLOCK = 1.0;
 
-  private static final long DEFAULT_TARGET_GAS_LIMIT = 30000000L;
+  private static final long DEFAULT_TARGET_GAS_LIMIT = 36000000L;
 
   /** The Mining parameters. */
   protected final MiningConfiguration miningConfiguration;


### PR DESCRIPTION
Update default gasLimit to 36M as currently voted on by validators with first 36M block [https://etherscan.io/block/21773000](https://etherscan.io/block/21773000)

36M is the current safe limit for all participants pre-Pectra (EIP-7623) and taking into account an active propagation size limit bug in CL clients. This change has already been done by [Erigon](https://github.com/erigontech/erigon/pull/13057) and [Nethermind](https://github.com/NethermindEth/nethermind/pull/7879)

See also: [ethresear.ch](https://ethresear.ch/t/on-increasing-the-block-gas-limit-technical-considerations-path-forward/21225)

fixes #8245 for mainnet
