### PR TITLE
Turned PostMergeContext to be a regular class instead of a singleton.…

### DIFF
--- a/acceptance-tests/dsl/build.gradle
+++ b/acceptance-tests/dsl/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   implementation project(':config')
   implementation project(':consensus:clique')
   implementation project(':consensus:common')
+  implementation project(':consensus:merge')
   implementation project(':consensus:ibft')
   implementation project(':consensus:qbft')
   implementation project(':crypto:services')

--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/account/Account.java
@@ -78,7 +78,7 @@ public class Account {
     return new Account(eth, name, SIGNATURE_ALGORITHM.get().generateKeyPair());
   }
 
-  static Account fromPrivateKey(
+  public static Account fromPrivateKey(
       final EthTransactions eth, final String name, final String privateKey) {
     return new Account(
         eth,

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -89,6 +89,7 @@ import org.hyperledger.besu.config.CheckpointConfigOptions;
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.config.MergeConfiguration;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.controller.BesuControllerBuilder;
 import org.hyperledger.besu.crypto.Blake2bfMessageDigest;
@@ -1836,6 +1837,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
             .cacheLastBlocks(numberOfblocksToCache)
             .genesisStateHashCacheEnabled(genesisStateHashCacheEnabled)
             .apiConfiguration(apiConfigurationSupplier.get())
+            .postMergeContext(new PostMergeContext())
             .besuComponent(besuComponent);
     if (DataStorageFormat.BONSAI.equals(getDataStorageConfiguration().getDataStorageFormat())) {
       final DiffBasedSubStorageConfiguration subStorageConfiguration =

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.config.CheckpointConfigOptions;
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.consensus.merge.UnverifiedForkchoiceSupplier;
 import org.hyperledger.besu.consensus.qbft.BFTPivotSelectorFromPeers;
 import org.hyperledger.besu.cryptoservices.NodeKey;
@@ -221,6 +222,9 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
 
   /** When enabled, round changes on f+1 RC messages from higher rounds */
   protected boolean isEarlyRoundChangeEnabled = false;
+
+  /** PostMergeContext, responsible for managing the switch from pre-merge to post merge */
+  protected PostMergeContext postMergeContext;
 
   /** Instantiates a new Besu controller builder. */
   protected BesuControllerBuilder() {}
@@ -564,6 +568,17 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
    */
   public BesuControllerBuilder isEarlyRoundChangeEnabled(final boolean isEarlyRoundChangeEnabled) {
     this.isEarlyRoundChangeEnabled = isEarlyRoundChangeEnabled;
+    return this;
+  }
+
+  /**
+   * sets the postMergeContext in the builder
+   *
+   * @param postMergeContext the post merge context
+   * @return the besu controller builder
+   */
+  public BesuControllerBuilder postMergeContext(final PostMergeContext postMergeContext) {
+    this.postMergeContext = postMergeContext;
     return this;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/TransitionBesuControllerBuilder.java
@@ -147,7 +147,8 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
                 transitionMiningConfiguration,
                 syncState,
                 transitionBackwardsSyncContext,
-                ethProtocolManager.ethContext().getScheduler()));
+                ethProtocolManager.ethContext().getScheduler()),
+            preMergeBesuControllerBuilder.postMergeContext);
     initTransitionWatcher(protocolContext, composedCoordinator);
     return composedCoordinator;
   }
@@ -185,7 +186,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
         new TransitionProtocolSchedule(
             preMergeBesuControllerBuilder.createProtocolSchedule(),
             mergeBesuControllerBuilder.createProtocolSchedule(),
-            PostMergeContext.get());
+            postMergeContext);
     return transitionProtocolSchedule;
   }
 
@@ -205,6 +206,8 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
       final Blockchain blockchain,
       final WorldStateArchive worldStateArchive,
       final ProtocolSchedule protocolSchedule) {
+    preMergeBesuControllerBuilder.postMergeContext(postMergeContext);
+    mergeBesuControllerBuilder.postMergeContext(postMergeContext);
     return new TransitionContext(
         preMergeBesuControllerBuilder.createConsensusContext(
             blockchain, worldStateArchive, protocolSchedule),
@@ -290,7 +293,7 @@ public class TransitionBesuControllerBuilder extends BesuControllerBuilder {
   @Override
   public BesuController build() {
     final BesuController controller = super.build();
-    PostMergeContext.get().setSyncState(controller.getSyncState());
+    super.postMergeContext.setSyncState(controller.getSyncState());
     return controller;
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/FlexGroupPrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/FlexGroupPrivacyTest.java
@@ -23,6 +23,7 @@ import org.hyperledger.besu.components.MockBesuCommandModule;
 import org.hyperledger.besu.components.NoOpMetricsSystemModule;
 import org.hyperledger.besu.components.PrivacyTestModule;
 import org.hyperledger.besu.config.GenesisConfig;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
@@ -164,6 +165,7 @@ class FlexGroupPrivacyTest {
           .networkConfiguration(NetworkingConfiguration.create())
           .besuComponent(context)
           .apiConfiguration(ImmutableApiConfiguration.builder().build())
+          .postMergeContext(new PostMergeContext())
           .build();
     }
   }

--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.config.GenesisConfigOptions;
+import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.MergeProtocolSchedule;
 import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.consensus.merge.TransitionProtocolSchedule;
@@ -189,10 +190,8 @@ public class ForkIdsNetworkConfigTest {
                     new BadBlockManager(),
                     false,
                     new NoOpMetricsSystem()));
-    final MilestoneStreamingTransitionProtocolSchedule schedule =
-        new MilestoneStreamingTransitionProtocolSchedule(
-            preMergeProtocolSchedule, postMergeProtocolSchedule);
-    return schedule;
+    return new MilestoneStreamingTransitionProtocolSchedule(
+        preMergeProtocolSchedule, postMergeProtocolSchedule, new PostMergeContext());
   }
 
   public static class MilestoneStreamingTransitionProtocolSchedule
@@ -202,11 +201,11 @@ public class ForkIdsNetworkConfigTest {
 
     public MilestoneStreamingTransitionProtocolSchedule(
         final MilestoneStreamingProtocolSchedule preMergeProtocolSchedule,
-        final MilestoneStreamingProtocolSchedule postMergeProtocolSchedule) {
-      super(preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
+        final MilestoneStreamingProtocolSchedule postMergeProtocolSchedule,
+        final MergeContext mergeContext) {
+      super(preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext);
       transitionUtils =
-          new TransitionUtils<>(
-              preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
+          new TransitionUtils<>(preMergeProtocolSchedule, postMergeProtocolSchedule, mergeContext);
     }
 
     public Stream<Long> streamMilestoneBlocks() {

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -24,6 +24,7 @@ import org.hyperledger.besu.components.NoOpMetricsSystemModule;
 import org.hyperledger.besu.components.PrivacyParametersModule;
 import org.hyperledger.besu.components.PrivacyTestModule;
 import org.hyperledger.besu.config.GenesisConfig;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Address;
@@ -139,6 +140,7 @@ class PrivacyTest {
           .networkConfiguration(NetworkingConfiguration.create())
           .besuComponent(context)
           .apiConfiguration(ImmutableApiConfiguration.builder().build())
+          .postMergeContext(new PostMergeContext())
           .build();
     }
   }

--- a/besu/src/test/java/org/hyperledger/besu/chainexport/RlpBlockExporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainexport/RlpBlockExporterTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.chainimport.RlpBlockImporter;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.components.BesuComponent;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
@@ -107,6 +108,7 @@ public final class RlpBlockExporterTest {
         .networkConfiguration(NetworkingConfiguration.create())
         .besuComponent(mock(BesuComponent.class))
         .apiConfiguration(ImmutableApiConfiguration.builder().build())
+        .postMergeContext(new PostMergeContext())
         .build();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/chainimport/RlpBlockImporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainimport/RlpBlockImporterTest.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.components.BesuComponent;
 import org.hyperledger.besu.config.MergeConfiguration;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.ethereum.GasLimitCalculator;
@@ -82,6 +83,7 @@ public final class RlpBlockImporterTest {
             .networkConfiguration(NetworkingConfiguration.create())
             .besuComponent(mock(BesuComponent.class))
             .apiConfiguration(ImmutableApiConfiguration.builder().build())
+            .postMergeContext(new PostMergeContext())
             .build();
     final RlpBlockImporter.ImportResult result =
         rlpBlockImporter.importBlockchain(source, targetController, false);
@@ -117,6 +119,7 @@ public final class RlpBlockImporterTest {
             .networkConfiguration(NetworkingConfiguration.create())
             .besuComponent(mock(BesuComponent.class))
             .apiConfiguration(ImmutableApiConfiguration.builder().build())
+            .postMergeContext(new PostMergeContext())
             .build();
 
     assertThatThrownBy(
@@ -149,6 +152,7 @@ public final class RlpBlockImporterTest {
             .networkConfiguration(NetworkingConfiguration.create())
             .besuComponent(mock(BesuComponent.class))
             .apiConfiguration(ImmutableApiConfiguration.builder().build())
+            .postMergeContext(new PostMergeContext())
             .build();
 
     final RlpBlockImporter.ImportResult result =

--- a/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/CommandTestAbstract.java
@@ -299,6 +299,7 @@ public abstract class CommandTestAbstract {
     when(mockControllerBuilder.genesisStateHashCacheEnabled(any()))
         .thenReturn(mockControllerBuilder);
     when(mockControllerBuilder.apiConfiguration(any())).thenReturn(mockControllerBuilder);
+    when(mockControllerBuilder.postMergeContext(any())).thenReturn(mockControllerBuilder);
 
     when(mockControllerBuilder.build()).thenReturn(mockController);
     lenient().when(mockController.getProtocolManager()).thenReturn(mockEthProtocolManager);

--- a/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/controller/MergeBesuControllerBuilderTest.java
@@ -28,6 +28,7 @@ import org.hyperledger.besu.config.CheckpointConfigOptions;
 import org.hyperledger.besu.config.GenesisConfig;
 import org.hyperledger.besu.config.GenesisConfigOptions;
 import org.hyperledger.besu.consensus.merge.MergeContext;
+import org.hyperledger.besu.consensus.merge.PostMergeContext;
 import org.hyperledger.besu.cryptoservices.NodeKey;
 import org.hyperledger.besu.cryptoservices.NodeKeyUtils;
 import org.hyperledger.besu.datatypes.Hash;
@@ -193,7 +194,8 @@ public class MergeBesuControllerBuilderTest {
             .networkConfiguration(NetworkingConfiguration.create())
             .besuComponent(mock(BesuComponent.class))
             .networkId(networkId)
-            .apiConfiguration(ImmutableApiConfiguration.builder().build());
+            .apiConfiguration(ImmutableApiConfiguration.builder().build())
+            .postMergeContext(new PostMergeContext());
   }
 
   @Test

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/PostMergeContext.java
@@ -40,7 +40,6 @@ public class PostMergeContext implements MergeContext {
   /** The Max blocks in progress. */
   static final int MAX_BLOCKS_IN_PROGRESS = 12;
 
-  private static final AtomicReference<PostMergeContext> singleton = new AtomicReference<>();
   private final AtomicReference<SyncState> syncState;
   private final AtomicReference<Difficulty> terminalTotalDifficulty;
   // initial postMerge state is indeterminate until it is set:
@@ -62,8 +61,7 @@ public class PostMergeContext implements MergeContext {
   private boolean isPostMergeAtGenesis;
 
   /** Instantiates a new Post merge context. */
-  @VisibleForTesting
-  PostMergeContext() {
+  public PostMergeContext() {
     this(Difficulty.ZERO);
   }
 
@@ -76,18 +74,6 @@ public class PostMergeContext implements MergeContext {
   PostMergeContext(final Difficulty difficulty) {
     this.terminalTotalDifficulty = new AtomicReference<>(difficulty);
     this.syncState = new AtomicReference<>();
-  }
-
-  /**
-   * Get post merge context.
-   *
-   * @return the post merge context
-   */
-  public static PostMergeContext get() {
-    if (singleton.get() == null) {
-      singleton.compareAndSet(null, new PostMergeContext());
-    }
-    return singleton.get();
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/TransitionProtocolSchedule.java
@@ -61,41 +61,6 @@ public class TransitionProtocolSchedule implements ProtocolSchedule {
   }
 
   /**
-   * Create a Proof-of-Stake protocol schedule from a config object
-   *
-   * @param genesisConfigOptions {@link GenesisConfigOptions} containing the config options for the
-   *     milestone starting points
-   * @param miningConfiguration the mining parameters
-   * @param badBlockManager the cache to use to keep invalid blocks
-   * @param isParallelTxProcessingEnabled indicates whether parallel transaction is enabled.
-   * @return an initialised TransitionProtocolSchedule using post-merge defaults
-   */
-  public static TransitionProtocolSchedule fromConfig(
-      final GenesisConfigOptions genesisConfigOptions,
-      final MiningConfiguration miningConfiguration,
-      final BadBlockManager badBlockManager,
-      final boolean isParallelTxProcessingEnabled,
-      final MetricsSystem metricsSystem) {
-    ProtocolSchedule preMergeProtocolSchedule =
-        MainnetProtocolSchedule.fromConfig(
-            genesisConfigOptions,
-            miningConfiguration,
-            badBlockManager,
-            isParallelTxProcessingEnabled,
-            metricsSystem);
-    ProtocolSchedule postMergeProtocolSchedule =
-        MergeProtocolSchedule.create(
-            genesisConfigOptions,
-            false,
-            miningConfiguration,
-            badBlockManager,
-            isParallelTxProcessingEnabled,
-            metricsSystem);
-    return new TransitionProtocolSchedule(
-        preMergeProtocolSchedule, postMergeProtocolSchedule, PostMergeContext.get());
-  }
-
-  /**
    * Gets pre merge schedule.
    *
    * @return the pre merge schedule

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/TransitionCoordinator.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.consensus.merge.blockcreation;
 
-import org.hyperledger.besu.consensus.merge.PostMergeContext;
+import org.hyperledger.besu.consensus.merge.MergeContext;
 import org.hyperledger.besu.consensus.merge.TransitionUtils;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
@@ -47,10 +47,13 @@ public class TransitionCoordinator extends TransitionUtils<MiningCoordinator>
    *
    * @param miningCoordinator the mining coordinator
    * @param mergeCoordinator the merge coordinator
+   * @param mergeContext the merge context
    */
   public TransitionCoordinator(
-      final MiningCoordinator miningCoordinator, final MiningCoordinator mergeCoordinator) {
-    super(miningCoordinator, mergeCoordinator, PostMergeContext.get());
+      final MiningCoordinator miningCoordinator,
+      final MiningCoordinator mergeCoordinator,
+      final MergeContext mergeContext) {
+    super(miningCoordinator, mergeCoordinator, mergeContext);
     this.miningCoordinator = miningCoordinator;
     this.mergeCoordinator = (MergeMiningCoordinator) mergeCoordinator;
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeReorgTest.java
@@ -67,7 +67,7 @@ public class MergeReorgTest implements MergeGenesisConfigHelper {
 
   private MergeCoordinator coordinator;
 
-  private final MergeContext mergeContext = PostMergeContext.get();
+  private final MergeContext mergeContext = new PostMergeContext();
   private final ProtocolSchedule mockProtocolSchedule = getMergeProtocolSchedule();
   private final GenesisState genesisState =
       GenesisState.fromConfig(getPowGenesisConfig(), mockProtocolSchedule);


### PR DESCRIPTION
… Addded some other improvements to the acceptance tests DSL


## PR description

## Fixed Issue(s)
This fix allows `ThreadBesuNodeRunner` to spin up and tear down Besu instances multiple times during process's lifecycle.


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

