### PR TITLE
Prague times for holesky and sepolia

### DIFF
--- a/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/ForkIdsNetworkConfigTest.java
@@ -63,18 +63,18 @@ public class ForkIdsNetworkConfigTest {
               new ForkId(Bytes.ofUnsignedInt(0xfe3366e7L), 1735371L),
               new ForkId(Bytes.ofUnsignedInt(0xb96cbd13L), 1677557088L),
               new ForkId(Bytes.ofUnsignedInt(0xf7f9bc08L), 1706655072L),
-              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 1739980128L),
-              new ForkId(Bytes.ofUnsignedInt(0xbafd09c3L), 0L),
-              new ForkId(Bytes.ofUnsignedInt(0xbafd09c3L), 0L))
+              new ForkId(Bytes.ofUnsignedInt(0x88cf81d9L), 1740471648L),
+              new ForkId(Bytes.ofUnsignedInt(0x8f6dc030L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0x8f6dc030L), 0L))
         },
         new Object[] {
           NetworkName.HOLESKY,
           List.of(
               new ForkId(Bytes.ofUnsignedInt(0xc61a6098L), 1696000704L),
               new ForkId(Bytes.ofUnsignedInt(0xfd4f016bL), 1707305664L),
-              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 1739352768L),
-              new ForkId(Bytes.ofUnsignedInt(0xf818a0d6L), 0L),
-              new ForkId(Bytes.ofUnsignedInt(0xf818a0d6L), 0L))
+              new ForkId(Bytes.ofUnsignedInt(0x9b192ad0L), 1739942592L),
+              new ForkId(Bytes.ofUnsignedInt(0xebef3829L), 0L),
+              new ForkId(Bytes.ofUnsignedInt(0xebef3829L), 0L))
         },
         new Object[] {
           NetworkName.MAINNET,

--- a/config/src/main/resources/holesky.json
+++ b/config/src/main/resources/holesky.json
@@ -15,7 +15,7 @@
     "terminalTotalDifficulty": 0,
     "shanghaiTime": 1696000704,
     "cancunTime": 1707305664,
-    "pragueTime": 1739352768,
+    "pragueTime": 1739942592,
     "blobSchedule": {
       "cancun": {
         "target": 3,

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -15,7 +15,7 @@
     "terminalTotalDifficulty": 17000000000000000,
     "shanghaiTime": 1677557088,
     "cancunTime": 1706655072,
-    "pragueTime": 1739980128,
+    "pragueTime": 1740471648,
     "blobSchedule": {
       "cancun": {
         "target": 3,


### PR DESCRIPTION
## PR description

https://github.com/ethereum/pm/issues/1265#issuecomment-2637778317

> Client testnet releases out by Feb 10
> Holesky slot: 3670016 (Wed, Feb 19 at 05:23:12 UTC)
> Sepolia slot: 7061504 (Tue, Feb 25 at 08:20:48 UTC)

Merging in the earliest times optimistically to allow a burn-in to start today and maximise soaking time, if Feb 10 becomes our target release date.
