### PR TITLE
Split long running DetermineCommonAncestorTaskParameterizedTest in 2 tests

### DIFF
--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskParameterizedTest1.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskParameterizedTest1.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.tasks;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+public class DetermineCommonAncestorTaskParameterizedTest1
+    extends AbstractDetermineCommonAncestorTaskParameterizedTest {
+
+  public static Stream<Arguments> parameters() {
+    final int[] requestSizes = {5, 12, chainHeight, chainHeight * 2};
+    final Stream.Builder<Arguments> builder = Stream.builder();
+    for (final int requestSize : requestSizes) {
+      for (int i = 0; i <= chainHeight; i++) {
+        builder.add(Arguments.of(requestSize, i, true));
+      }
+    }
+    return builder.build();
+  }
+}

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskParameterizedTest2.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/sync/tasks/DetermineCommonAncestorTaskParameterizedTest2.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.eth.sync.tasks;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+public class DetermineCommonAncestorTaskParameterizedTest2
+    extends AbstractDetermineCommonAncestorTaskParameterizedTest {
+
+  public static Stream<Arguments> parameters() {
+    final int[] requestSizes = {5, 12, chainHeight, chainHeight * 2};
+    final Stream.Builder<Arguments> builder = Stream.builder();
+    for (final int requestSize : requestSizes) {
+      for (int i = 0; i <= chainHeight; i++) {
+        builder.add(Arguments.of(requestSize, i, false));
+      }
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
## PR description

`DetermineCommonAncestorTaskParameterizedTest` is the test class that takes longer to execute on CI, to better leverage the parallel execution on different runners, it has been split in 2 test classes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

