### PR TITLE
Revert "Hotfix for gradle compile issue by locking in json-smart version (#8282)"

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -96,8 +96,6 @@ dependencies {
     api 'info.picocli:picocli-codegen:4.7.6'
 
     api 'io.kubernetes:client-java:21.0.1-legacy'
-    // Temporarily locking in to avoid https://github.com/netplex/json-smart-v2/issues/240
-    api 'net.minidev:json-smart:2.4.2'
 
     api 'io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:2.9.0-alpha'
     api 'io.opentelemetry.proto:opentelemetry-proto:1.3.2-alpha'


### PR DESCRIPTION
## PR description

This reverts commit 0ad85ecadafb8062ffdbea279f2f3dc266aa7ce0.

since the issue is solved

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

