### PR TITLE
Don't access state before OOG check for contract account proof of abs…

### DIFF
--- a/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/processor/ContractCreationProcessor.java
@@ -99,9 +99,7 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
 
       Address contractAddress = frame.getContractAddress();
 
-      final MutableAccount contract = frame.getWorldUpdater().getOrCreate(contractAddress);
-      long statelessGasCost =
-          evm.getGasCalculator().proofOfAbsenceCost(frame, contract.getAddress());
+      long statelessGasCost = evm.getGasCalculator().proofOfAbsenceCost(frame, contractAddress);
       if (handleInsufficientGas(
           frame,
           statelessGasCost,
@@ -112,6 +110,8 @@ public class ContractCreationProcessor extends AbstractMessageProcessor {
         return;
       }
       frame.decrementRemainingGas(statelessGasCost);
+
+      final MutableAccount contract = frame.getWorldUpdater().getOrCreate(contractAddress);
 
       if (accountExists(contract)) {
         LOG.trace(


### PR DESCRIPTION
## PR description
We were previously accessing the DB before checking for OOG and this could potentially be a DOS in verkle.

### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

