### PR TITLE
[build] evmtool Dockerfile - update apt-get packages

### DIFF
--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true
 RUN apt-get update $NO_PROXY_CACHE  && \
   # $NO_PROXY_CACHE must not be used here or otherwise will trigger a hadolint error
   apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
-    --no-install-recommends -q --assume-yes install ca-certificates-java=20190909*  && \
+    --no-install-recommends -q --assume-yes install ca-certificates-java=20240618*  && \
   apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
     --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21*  && \
   # Clean apt cache  \

--- a/ethereum/evmtool/src/main/docker/Dockerfile
+++ b/ethereum/evmtool/src/main/docker/Dockerfile
@@ -7,9 +7,7 @@ ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true
 RUN apt-get update $NO_PROXY_CACHE  && \
   # $NO_PROXY_CACHE must not be used here or otherwise will trigger a hadolint error
   apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
-    --no-install-recommends -q --assume-yes install ca-certificates-java=20240618*  && \
-  apt-get -o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0 \
-    --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21*  && \
+    --no-install-recommends -q --assume-yes install openjdk-21-jre-headless=21* adduser=3* && \
   # Clean apt cache  \
   apt-get clean  && \
   rm -rf /var/cache/apt/archives/* /var/cache/apt/archives/partial/*  && \


### PR DESCRIPTION
## PR description

Fixes this [build failure](https://github.com/hyperledger/besu/actions/runs/13381142166/job/37369815247) 
`#7 4.118 E: Version '20190909*' for 'ca-certificates-java' was not found`

could see the ca-certificates-java gets pulled in even without this explicit install.

```
#6 32.17 Setting up openjdk-21-jre-headless:arm64 (21.0.6+7-1~24.04.1) ...
#6 32.19 update-alternatives: using /usr/lib/jvm/java-21-openjdk-arm64/bin/java to provide /usr/bin/java (java) in auto mode
#6 32.19 update-alternatives: using /usr/lib/jvm/java-21-openjdk-arm64/bin/jpackage to provide /usr/bin/jpackage (jpackage) in auto mode
#6 32.19 update-alternatives: using /usr/lib/jvm/java-21-openjdk-arm64/bin/keytool to provide /usr/bin/keytool (keytool) in auto mode
#6 32.19 update-alternatives: using /usr/lib/jvm/java-21-openjdk-arm64/bin/rmiregistry to provide /usr/bin/rmiregistry (rmiregistry) in auto mode
#6 32.19 update-alternatives: using /usr/lib/jvm/java-21-openjdk-arm64/lib/jexec to provide /usr/bin/jexec (jexec) in auto mode
#6 32.20 Processing triggers for libc-bin (2.39-0ubuntu8.3) ...
#6 32.20 Processing triggers for ca-certificates (20240203) ...
#6 32.20 Updating certificates in /etc/ssl/certs...
#6 32.35 0 added, 0 removed; done.
#6 32.35 Running hooks in /etc/ca-certificates/update.d...
#6 32.35 done.
```

Had to explicitly install `adduser`

## Fixed Issue(s)
Fixes #8320 

Tested with 
```
gw ethereum:evmtool:distDocker
docker run  hyperledger/besu-evmtool:25.2-develop-3cd9384   --code=5B600080808060045AFA50600056
INSUFFICIENT_GAS
{"stateRoot":"0xa898ef8d5fb80ff2620fe4a6a6ba2379bec749406802bcf303a516b4e1cc2567","output":"0x","gasUsed":"0x2540be400","pass":false,"fork":"Prague","timens":70001025323,"time":70001025}
```

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

