### PR TITLE
fix distDocker - revert gradle change to providers.exec

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -826,7 +826,7 @@ task distDocker {
       from file("${projectDir}/docker/Dockerfile")
       into(dockerBuildDir)
     }
-    providers.exec {
+    exec {
       def image = "${dockerImageName}:${dockerBuildVersion}"
       def dockerPlatform = ""
       if (project.hasProperty('docker-platform')){
@@ -850,7 +850,7 @@ task testDocker {
   }
 
   doLast {
-    providers.exec {
+    exec {
       def image = project.hasProperty('release.releaseVersion') ? "${dockerImageName}:" + project.property('release.releaseVersion') : "${dockerImageName}:${project.version}"
       workingDir "${projectDir}/docker"
       executable shell
@@ -874,7 +874,7 @@ task dockerUpload {
   }
 
   doLast {
-    providers.exec {
+    exec {
       def archVariantImage = "${image}-${architecture}"
       def cmd = "docker tag '${image}' '${archVariantImage}' && docker push '${archVariantImage}'"
       println "Executing '${cmd}'"
@@ -891,13 +891,13 @@ task dockerUploadRelease {
   doLast {
     for (def architecture in archs) {
 
-      providers.exec {
+      exec {
         def cmd = "docker pull '${image}-${architecture}' && docker tag '${image}-${architecture}' '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
         executable shell
         args "-c", cmd
       }
-      providers.exec {
+      exec {
         def cmd = "docker push '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
         executable shell
@@ -905,14 +905,14 @@ task dockerUploadRelease {
       }
 
 
-      providers.exec {
+      exec {
         def archImage = "${image}-${architecture}"
         def cmd = "docker pull '${archImage}' && docker tag ${archImage} '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
         executable shell
         args "-c", cmd
       }
-      providers.exec {
+      exec {
         def cmd = "docker push '${dockerImageName}:latest-${architecture}'"
         println "Executing '${cmd}'"
         executable shell
@@ -928,7 +928,7 @@ task manifestDocker {
     "arm64",
     "amd64"] //TODO: this assumes dockerUpload task has already been run on 2 different archs!
   doLast {
-    providers.exec {
+    exec {
       def targets = ""
       archs.forEach { arch -> targets += "'${image}-${arch}' " }
       def cmd = "docker manifest create '${image}' ${targets}"
@@ -936,7 +936,7 @@ task manifestDocker {
       executable shell
       args "-c", cmd
     }
-    providers.exec {
+    exec {
       def cmd = "docker manifest push '${image}'"
       println "Executing '${cmd}'"
       executable shell
@@ -951,7 +951,7 @@ task manifestDockerRelease {
 
   doLast {
 
-    providers.exec {
+    exec {
       def targets = ""
       archs.forEach { arch -> targets += "'${baseTag}-${arch}' " }
       def cmd = "docker manifest create '${baseTag}' ${targets} --amend"
@@ -959,7 +959,7 @@ task manifestDockerRelease {
       executable shell
       args "-c", cmd
     }
-    providers.exec {
+    exec {
       def cmd = "docker manifest push '${baseTag}'"
       println "Executing '${cmd}'"
       executable shell

--- a/ethereum/referencetests/build.gradle
+++ b/ethereum/referencetests/build.gradle
@@ -229,7 +229,7 @@ tasks.register('validateReferenceTestSubmodule') {
     def expectedHash = '9201075490807f58811078e9bb5ec895b4ac01a5'
     def submodulePath = java.nio.file.Path.of("${rootProject.projectDir}", "ethereum/referencetests/src/reference-test/external-resources").toAbsolutePath()
     try {
-      providers.exec {
+      exec {
         commandLine 'git', 'submodule', 'status', submodulePath
         standardOutput = result
         errorOutput = result


### PR DESCRIPTION
## PR description
distDocker was only creating evmtool docker not besu docker image

it affects CI as well - no longer publishing docker for besu: https://hub.docker.com/r/hyperledger/besu/tags (last develop was 5 days ago)

Seems to have been broken by this commit -
https://github.com/hyperledger/besu/commit/1508b5cba517f1a99f18c9232f14d987338cfe95#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7

This PR reverts one change from #8295 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

