### PR TITLE
Try to simplify the accumulator code 

### DIFF
--- a/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
+++ b/acceptance-tests/dsl/src/main/java/org/hyperledger/besu/tests/acceptance/dsl/node/ThreadBesuNodeRunner.java
@@ -49,7 +49,7 @@ import org.hyperledger.besu.ethereum.p2p.peers.EnodeURLImpl;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoaderModule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloaderModule;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateArchive;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
@@ -657,7 +657,7 @@ public class ThreadBesuNodeRunner implements BesuNodeRunner {
         ThreadBesuNodeRunner.MockBesuCommandModule.class,
         ThreadBesuNodeRunner.ObservableMetricsSystemModule.class,
         ThreadBesuNodeRunnerModule.class,
-        BonsaiCachedMerkleTrieLoaderModule.class,
+        BonsaiMerkleTriePreloaderModule.class,
         MetricsSystemModule.class,
         ThreadBesuNodeRunner.BesuNodeProviderModule.class,
         BlobCacheModule.class

--- a/besu/src/main/java/org/hyperledger/besu/components/BesuComponent.java
+++ b/besu/src/main/java/org/hyperledger/besu/components/BesuComponent.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.components;
 import org.hyperledger.besu.cli.BesuCommand;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCache;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCacheModule;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoaderModule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloaderModule;
 import org.hyperledger.besu.metrics.MetricsSystemModule;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
     modules = {
       BesuCommandModule.class,
       MetricsSystemModule.class,
-      BonsaiCachedMerkleTrieLoaderModule.class,
+      BonsaiMerkleTriePreloaderModule.class,
       BesuPluginContextModule.class,
       BlobCacheModule.class
     })
@@ -53,7 +53,7 @@ public interface BesuComponent {
    *
    * @return CachedMerkleTrieLoader
    */
-  BonsaiCachedMerkleTrieLoader getCachedMerkleTrieLoader();
+  BonsaiMerkleTriePreloader getCachedMerkleTrieLoader();
 
   /**
    * a metrics system that is observable by a Prometheus or OTEL metrics collection subsystem

--- a/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/BesuControllerBuilder.java
@@ -86,7 +86,7 @@ import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.transaction.TransactionSimulator;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogManager;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.TrieLogPruner;
@@ -604,10 +604,10 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
             reorgLoggingThreshold,
             dataDirectory.toString(),
             numberOfBlocksToCache);
-    final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader =
+    final BonsaiMerkleTriePreloader bonsaiCachedMerkleTrieLoader =
         besuComponent
             .map(BesuComponent::getCachedMerkleTrieLoader)
-            .orElseGet(() -> new BonsaiCachedMerkleTrieLoader(metricsSystem));
+            .orElseGet(() -> new BonsaiMerkleTriePreloader(metricsSystem));
 
     final var worldStateHealerSupplier = new AtomicReference<WorldStateHealer>();
 
@@ -1128,7 +1128,7 @@ public abstract class BesuControllerBuilder implements MiningParameterOverrides 
   WorldStateArchive createWorldStateArchive(
       final WorldStateStorageCoordinator worldStateStorageCoordinator,
       final Blockchain blockchain,
-      final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader,
+      final BonsaiMerkleTriePreloader bonsaiCachedMerkleTrieLoader,
       final Supplier<WorldStateHealer> worldStateHealerSupplier) {
     return switch (dataStorageConfiguration.getDataStorageFormat()) {
       case BONSAI -> {

--- a/besu/src/test/java/org/hyperledger/besu/FlexGroupPrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/FlexGroupPrivacyTest.java
@@ -40,7 +40,7 @@ import org.hyperledger.besu.ethereum.eth.transactions.BlobCacheModule;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivacyStorageProvider;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoaderModule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloaderModule;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
@@ -103,7 +103,7 @@ class FlexGroupPrivacyTest {
         FlexGroupPrivacyTest.PrivacyTestBesuControllerModule.class,
         PrivacyTestModule.class,
         MockBesuCommandModule.class,
-        BonsaiCachedMerkleTrieLoaderModule.class,
+        BonsaiMerkleTriePreloaderModule.class,
         NoOpMetricsSystemModule.class,
         BesuPluginContextModule.class,
         BlobCacheModule.class

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyReorgTest.java
@@ -64,7 +64,7 @@ import org.hyperledger.besu.ethereum.privacy.storage.PrivacyGroupHeadBlockMap;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivacyStorageProvider;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateStateStorage;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoaderModule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloaderModule;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -492,7 +492,7 @@ public class PrivacyReorgTest {
         PrivacyTestModule.class,
         MockBesuCommandModule.class,
         NoOpMetricsSystemModule.class,
-        BonsaiCachedMerkleTrieLoaderModule.class,
+        BonsaiMerkleTriePreloaderModule.class,
         BlobCacheModule.class,
         BesuPluginContextModule.class
       })

--- a/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/PrivacyTest.java
@@ -39,7 +39,7 @@ import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCacheModule;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoaderModule;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloaderModule;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.evm.precompile.PrecompiledContract;
@@ -97,7 +97,7 @@ class PrivacyTest {
         PrivacyTest.PrivacyTestBesuControllerModule.class,
         PrivacyTestModule.class,
         MockBesuCommandModule.class,
-        BonsaiCachedMerkleTrieLoaderModule.class,
+        BonsaiMerkleTriePreloaderModule.class,
         NoOpMetricsSystemModule.class,
         BesuPluginContextModule.class,
         BlobCacheModule.class

--- a/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/chainimport/JsonBlockImporterTest.java
@@ -44,7 +44,7 @@ import org.hyperledger.besu.ethereum.eth.sync.SynchronizerConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.BlobCacheModule;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.p2p.config.NetworkingConfiguration;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.metrics.MetricsSystemModule;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
@@ -482,8 +482,8 @@ public abstract class JsonBlockImporterTest {
   public static class JsonBlockImporterModule {
 
     @Provides
-    BonsaiCachedMerkleTrieLoader provideCachedMerkleTrieLoaderModule() {
-      return new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem());
+    BonsaiMerkleTriePreloader provideCachedMerkleTrieLoaderModule() {
+      return new BonsaiMerkleTriePreloader(new NoOpMetricsSystem());
     }
   }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -37,8 +37,8 @@ import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldState;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.DiffBasedWorldStateUpdateAccumulator;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
 import org.hyperledger.besu.evm.worldstate.WorldState;
@@ -192,8 +192,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
                 blockHeader.getHash().toHexString(),
                 transaction.getHash().toHexString());
         LOG.info(errorMessage);
-        if (worldState instanceof BonsaiWorldState) {
-          ((BonsaiWorldStateUpdateAccumulator) blockUpdater).reset();
+        if (worldState instanceof DiffBasedWorldState) {
+          ((DiffBasedWorldStateUpdateAccumulator<?>) blockUpdater).reset();
         }
         return new BlockProcessingResult(Optional.empty(), errorMessage);
       }
@@ -267,8 +267,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
 
     if (!rewardCoinbase(worldState, blockHeader, ommers, skipZeroBlockRewards)) {
       // no need to log, rewardCoinbase logs the error.
-      if (worldState instanceof BonsaiWorldState) {
-        ((BonsaiWorldStateUpdateAccumulator) worldState.updater()).reset();
+      if (worldState instanceof DiffBasedWorldState) {
+        ((DiffBasedWorldStateUpdateAccumulator<?>) worldState.updater()).reset();
       }
       return new BlockProcessingResult(Optional.empty(), "ommer too old");
     }
@@ -277,8 +277,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       worldState.persist(blockHeader);
     } catch (MerkleTrieException e) {
       LOG.trace("Merkle trie exception during Transaction processing ", e);
-      if (worldState instanceof BonsaiWorldState) {
-        ((BonsaiWorldStateUpdateAccumulator) worldState.updater()).reset();
+      if (worldState instanceof DiffBasedWorldState) {
+        ((DiffBasedWorldStateUpdateAccumulator<?>) worldState.updater()).reset();
       }
       throw e;
     } catch (Exception e) {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -332,7 +332,6 @@ public class MainnetTransactionProcessor {
         codeDelegationRefund =
             gasCalculator.calculateDelegateCodeGasRefund(
                 (codeDelegationResult.alreadyExistingDelegators()));
-
         evmWorldUpdater.commit();
       }
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/TransactionCollisionDetector.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/TransactionCollisionDetector.java
@@ -19,8 +19,8 @@ import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedAccount;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.StorageConsumingMap;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.DiffBasedWorldStateUpdateAccumulator;
-import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.preload.StorageConsumingMap;
 
 import java.util.HashSet;
 import java.util.Objects;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/GenesisWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/common/GenesisWorldStateProvider.java
@@ -19,8 +19,8 @@ import static org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.Worl
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.WorldStatePreimageKeyValueStorage;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.NoOpBonsaiCachedWorldStorageManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiNoOpCachedWorldStorageManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiNoOpMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.NoOpTrieLogManager;
@@ -59,8 +59,6 @@ public class GenesisWorldStateProvider {
    * @return a mutable world state for the Genesis block
    */
   private static MutableWorldState createGenesisBonsaiWorldState() {
-    final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader =
-        new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem());
     final BonsaiWorldStateKeyValueStorage bonsaiWorldStateKeyValueStorage =
         new BonsaiWorldStateKeyValueStorage(
             new KeyValueStorageProvider(
@@ -71,8 +69,8 @@ public class GenesisWorldStateProvider {
             DataStorageConfiguration.DEFAULT_BONSAI_CONFIG);
     return new BonsaiWorldState(
         bonsaiWorldStateKeyValueStorage,
-        bonsaiCachedMerkleTrieLoader,
-        new NoOpBonsaiCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage),
+        new BonsaiNoOpMerkleTriePreloader(),
+        new BonsaiNoOpCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage),
         new NoOpTrieLogManager(),
         EvmConfiguration.DEFAULT,
         createStatefulConfigWithTrie());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProvider.java
@@ -19,8 +19,8 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedWorldStorageManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.provider.DiffBasedWorldStateProvider;
@@ -43,19 +43,19 @@ import org.slf4j.LoggerFactory;
 public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
 
   private static final Logger LOG = LoggerFactory.getLogger(BonsaiWorldStateProvider.class);
-  private final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader;
+  private final BonsaiMerkleTriePreloader bonsaiMerkleTriePreloader;
   private final Supplier<WorldStateHealer> worldStateHealerSupplier;
 
   public BonsaiWorldStateProvider(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Blockchain blockchain,
       final Optional<Long> maxLayersToLoad,
-      final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader,
+      final BonsaiMerkleTriePreloader bonsaiMerkleTriePreloader,
       final ServiceManager pluginContext,
       final EvmConfiguration evmConfiguration,
       final Supplier<WorldStateHealer> worldStateHealerSupplier) {
     super(worldStateKeyValueStorage, blockchain, maxLayersToLoad, pluginContext);
-    this.bonsaiCachedMerkleTrieLoader = bonsaiCachedMerkleTrieLoader;
+    this.bonsaiMerkleTriePreloader = bonsaiMerkleTriePreloader;
     this.worldStateHealerSupplier = worldStateHealerSupplier;
     provideCachedWorldStorageManager(
         new BonsaiCachedWorldStorageManager(this, worldStateKeyValueStorage, worldStateConfig));
@@ -69,19 +69,19 @@ public class BonsaiWorldStateProvider extends DiffBasedWorldStateProvider {
       final TrieLogManager trieLogManager,
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Blockchain blockchain,
-      final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader,
+      final BonsaiMerkleTriePreloader bonsaiMerkleTriePreloader,
       final EvmConfiguration evmConfiguration,
       final Supplier<WorldStateHealer> worldStateHealerSupplier) {
     super(worldStateKeyValueStorage, blockchain, trieLogManager);
-    this.bonsaiCachedMerkleTrieLoader = bonsaiCachedMerkleTrieLoader;
+    this.bonsaiMerkleTriePreloader = bonsaiMerkleTriePreloader;
     this.worldStateHealerSupplier = worldStateHealerSupplier;
     provideCachedWorldStorageManager(bonsaiCachedWorldStorageManager);
     loadHeadWorldState(
         new BonsaiWorldState(this, worldStateKeyValueStorage, evmConfiguration, worldStateConfig));
   }
 
-  public BonsaiCachedMerkleTrieLoader getCachedMerkleTrieLoader() {
-    return bonsaiCachedMerkleTrieLoader;
+  public BonsaiMerkleTriePreloader getMerkleTriePreloader() {
+    return bonsaiMerkleTriePreloader;
   }
 
   private BonsaiWorldStateKeyValueStorage getBonsaiWorldStateKeyValueStorage() {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/cache/BonsaiNoOpCachedWorldStorageManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/cache/BonsaiNoOpCachedWorldStorageManager.java
@@ -23,9 +23,9 @@ import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.WorldStateC
 import java.util.Optional;
 import java.util.function.Function;
 
-public class NoOpBonsaiCachedWorldStorageManager extends BonsaiCachedWorldStorageManager {
+public class BonsaiNoOpCachedWorldStorageManager extends BonsaiCachedWorldStorageManager {
 
-  public NoOpBonsaiCachedWorldStorageManager(
+  public BonsaiNoOpCachedWorldStorageManager(
       final BonsaiWorldStateKeyValueStorage bonsaiWorldStateKeyValueStorage) {
     super(null, bonsaiWorldStateKeyValueStorage, WorldStateConfig.createStatefulConfigWithTrie());
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiMerkleTriePreloader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiMerkleTriePreloader.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache;
+package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload;
 
 import static org.hyperledger.besu.metrics.BesuMetricCategory.BLOCKCHAIN;
 
@@ -21,8 +21,13 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiAccount;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.StorageSubscriber;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.Consumer;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.PreloaderManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldState;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 
@@ -36,28 +41,40 @@ import com.google.common.cache.CacheBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 
-public class BonsaiCachedMerkleTrieLoader implements StorageSubscriber {
+/**
+ * BonsaiMerkleTriePreloader is responsible for preloading trie nodes for Bonsai accounts and
+ * storage slots. This preloader improves performance by preloading and caching frequently trie
+ * nodes of the touched data.
+ */
+public class BonsaiMerkleTriePreloader extends PreloaderManager<BonsaiAccount>
+    implements StorageSubscriber {
 
+  // Maximum cache sizes for accounts and storage nodes.
   private static final int ACCOUNT_CACHE_SIZE = 100_000;
   private static final int STORAGE_CACHE_SIZE = 200_000;
+
   private final Cache<Bytes, Bytes> accountNodes =
       CacheBuilder.newBuilder().recordStats().maximumSize(ACCOUNT_CACHE_SIZE).build();
   private final Cache<Bytes, Bytes> storageNodes =
       CacheBuilder.newBuilder().recordStats().maximumSize(STORAGE_CACHE_SIZE).build();
 
-  public BonsaiCachedMerkleTrieLoader(final ObservableMetricsSystem metricsSystem) {
+  /**
+   * Constructor that initializes the preloader and registers cache metrics with the metrics system.
+   *
+   * @param metricsSystem the metrics used to record cache statistics.
+   */
+  public BonsaiMerkleTriePreloader(final ObservableMetricsSystem metricsSystem) {
     metricsSystem.createGuavaCacheCollector(BLOCKCHAIN, "accountsNodes", accountNodes);
     metricsSystem.createGuavaCacheCollector(BLOCKCHAIN, "storageNodes", storageNodes);
   }
 
-  public void preLoadAccount(
-      final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
-      final Hash worldStateRootHash,
-      final Address account) {
-    CompletableFuture.runAsync(
-        () -> cacheAccountNodes(worldStateKeyValueStorage, worldStateRootHash, account));
-  }
-
+  /**
+   * Preloads and caches account trie nodes for a specific account.
+   *
+   * @param worldStateKeyValueStorage the key-value storage interface for the world state.
+   * @param worldStateRootHash the root hash of the world state trie.
+   * @param account the account whose trie nodes need to be cached.
+   */
   @VisibleForTesting
   public void cacheAccountNodes(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
@@ -84,14 +101,13 @@ public class BonsaiCachedMerkleTrieLoader implements StorageSubscriber {
     }
   }
 
-  public void preLoadStorageSlot(
-      final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
-      final Address account,
-      final StorageSlotKey slotKey) {
-    CompletableFuture.runAsync(
-        () -> cacheStorageNodes(worldStateKeyValueStorage, account, slotKey));
-  }
-
+  /**
+   * Preloads and caches storage trie nodes for a specific account and storage slot.
+   *
+   * @param worldStateKeyValueStorage the key-value storage interface for the world state.
+   * @param account the account for which storage nodes are to be cached.
+   * @param slotKey the specific storage slot key to preload.
+   */
   @VisibleForTesting
   public void cacheStorageNodes(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
@@ -127,31 +143,94 @@ public class BonsaiCachedMerkleTrieLoader implements StorageSubscriber {
     }
   }
 
+  /**
+   * Retrieves an account state trie node from the cache or storage.
+   *
+   * @param worldStateKeyValueStorage the world state key-value storage interface.
+   * @param location the location of the node within the trie.
+   * @param nodeHash the hash of the node to retrieve.
+   * @return an Optional containing the node bytes if found.
+   */
   public Optional<Bytes> getAccountStateTrieNode(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Bytes location,
       final Bytes32 nodeHash) {
+    // If the node hash represents an empty trie node, return the known empty node.
     if (nodeHash.equals(MerkleTrie.EMPTY_TRIE_NODE_HASH)) {
       return Optional.of(MerkleTrie.EMPTY_TRIE_NODE);
     } else {
+      // Otherwise, try to retrieve the node from the cache; if absent, load it from storage.
       return Optional.ofNullable(accountNodes.getIfPresent(nodeHash))
           .or(() -> worldStateKeyValueStorage.getAccountStateTrieNode(location, nodeHash));
     }
   }
 
+  /**
+   * Retrieves a storage trie node from the cache or storage.
+   *
+   * @param worldStateKeyValueStorage the world state key-value storage interface.
+   * @param accountHash the hash of the account.
+   * @param location the location of the node within the storage trie.
+   * @param nodeHash the hash of the node to retrieve.
+   * @return an Optional containing the node bytes if found.
+   */
   public Optional<Bytes> getAccountStorageTrieNode(
       final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
       final Hash accountHash,
       final Bytes location,
       final Bytes32 nodeHash) {
+    // If the node hash represents an empty trie node, return the known empty node.
     if (nodeHash.equals(MerkleTrie.EMPTY_TRIE_NODE_HASH)) {
       return Optional.of(MerkleTrie.EMPTY_TRIE_NODE);
     } else {
+      // Otherwise, try to retrieve the node from the storage cache; if absent, load it from
+      // storage.
       return Optional.ofNullable(storageNodes.getIfPresent(nodeHash))
           .or(
               () ->
                   worldStateKeyValueStorage.getAccountStorageTrieNode(
                       accountHash, location, nodeHash));
     }
+  }
+
+  /**
+   * Provides a consumer to asynchronously preload account trie nodes.
+   *
+   * <p>This method returns a Consumer that, when invoked, will asynchronously run the
+   * cacheAccountNodes method using the provided world state.
+   *
+   * @param worldState the diff-based world state.
+   * @return a Consumer that preloads account data.
+   */
+  @Override
+  public Consumer<DiffBasedValue<BonsaiAccount>> getAccountPreloader(
+      final DiffBasedWorldState worldState) {
+    return (address, value) ->
+        CompletableFuture.runAsync(
+            () ->
+                cacheAccountNodes(
+                    (BonsaiWorldStateKeyValueStorage) worldState.getWorldStateStorage(),
+                    worldState.getWorldStateRootHash(),
+                    address));
+  }
+
+  /**
+   * Provides a consumer to asynchronously preload storage trie nodes.
+   *
+   * <p>This method returns a Consumer that, when invoked, will asynchronously run the
+   * cacheStorageNodes method using the provided world state.
+   *
+   * @param worldState the diff-based world state.
+   * @return a Consumer that preloads storage slot data.
+   */
+  @Override
+  public Consumer<StorageSlotKey> getStoragePreloader(final DiffBasedWorldState worldState) {
+    return (address, slotKey) ->
+        CompletableFuture.runAsync(
+            () ->
+                cacheStorageNodes(
+                    (BonsaiWorldStateKeyValueStorage) worldState.getWorldStateStorage(),
+                    address,
+                    slotKey));
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiMerkleTriePreloaderModule.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiMerkleTriePreloaderModule.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache;
+package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload;
 
 import org.hyperledger.besu.metrics.ObservableMetricsSystem;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
@@ -21,11 +21,10 @@ import dagger.Module;
 import dagger.Provides;
 
 @Module
-public class BonsaiCachedMerkleTrieLoaderModule {
+public class BonsaiMerkleTriePreloaderModule {
 
   @Provides
-  BonsaiCachedMerkleTrieLoader provideCachedMerkleTrieLoaderModule(
-      final MetricsSystem metricsSystem) {
-    return new BonsaiCachedMerkleTrieLoader((ObservableMetricsSystem) metricsSystem);
+  BonsaiMerkleTriePreloader provideCachedMerkleTrieLoaderModule(final MetricsSystem metricsSystem) {
+    return new BonsaiMerkleTriePreloader((ObservableMetricsSystem) metricsSystem);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiNoOpMerkleTriePreloader.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/preload/BonsaiNoOpMerkleTriePreloader.java
@@ -12,33 +12,33 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache;
+package org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload;
 
-import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiAccount;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.Consumer;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldState;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
 
-public class NoopBonsaiCachedMerkleTrieLoader extends BonsaiCachedMerkleTrieLoader {
+public class BonsaiNoOpMerkleTriePreloader extends BonsaiMerkleTriePreloader {
 
-  public NoopBonsaiCachedMerkleTrieLoader() {
+  public BonsaiNoOpMerkleTriePreloader() {
     super(new NoOpMetricsSystem());
   }
 
   @Override
-  public void preLoadAccount(
-      final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
-      final Hash worldStateRootHash,
-      final Address account) {
-    // noop
+  public Consumer<DiffBasedValue<BonsaiAccount>> getAccountPreloader(
+      final DiffBasedWorldState worldState) {
+    return (address, value) -> {
+      // noop
+    };
   }
 
   @Override
-  public void preLoadStorageSlot(
-      final BonsaiWorldStateKeyValueStorage worldStateKeyValueStorage,
-      final Address account,
-      final StorageSlotKey slotKey) {
-    // noop
+  public Consumer<StorageSlotKey> getStoragePreloader(final DiffBasedWorldState worldState) {
+    return (address, value) -> {
+      // noop
+    };
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/AccountConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/AccountConsumingMap.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.preload;
+package org.hyperledger.besu.ethereum.trie.diffbased.common.preload;
 
 import org.hyperledger.besu.datatypes.Address;
 
@@ -22,32 +22,28 @@ import javax.annotation.Nonnull;
 
 import com.google.common.collect.ForwardingMap;
 
-public class StorageConsumingMap<K, T> extends ForwardingMap<K, T> {
+public class AccountConsumingMap<T> extends ForwardingMap<Address, T> {
 
-  private final Address address;
+  private final ConcurrentMap<Address, T> accounts;
+  private final Consumer<T> consumer;
 
-  private final ConcurrentMap<K, T> storages;
-  private final Consumer<K> consumer;
-
-  public StorageConsumingMap(
-      final Address address, final ConcurrentMap<K, T> storages, final Consumer<K> consumer) {
-    this.address = address;
-    this.storages = storages;
+  public AccountConsumingMap(final ConcurrentMap<Address, T> accounts, final Consumer<T> consumer) {
+    this.accounts = accounts;
     this.consumer = consumer;
   }
 
   @Override
-  public T put(@Nonnull final K slotKey, @Nonnull final T value) {
-    consumer.process(address, slotKey);
-    return storages.put(slotKey, value);
+  public T put(@Nonnull final Address address, @Nonnull final T value) {
+    consumer.process(address, value);
+    return accounts.put(address, value);
   }
 
-  public Consumer<K> getConsumer() {
+  public Consumer<T> getConsumer() {
     return consumer;
   }
 
   @Override
-  protected Map<K, T> delegate() {
-    return storages;
+  protected Map<Address, T> delegate() {
+    return accounts;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/Consumer.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/Consumer.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.preload;
+package org.hyperledger.besu.ethereum.trie.diffbased.common.preload;
 
 import org.hyperledger.besu.datatypes.Address;
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/PreloaderManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/PreloaderManager.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.diffbased.common.preload;
+
+import org.hyperledger.besu.datatypes.StorageSlotKey;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldState;
+
+/**
+ * PreloaderManager encapsulates the consumers used to preload account and storage data.
+ *
+ * <p>This abstract class defines the methods that need to be implemented in order to obtain
+ * consumers for preloading accounts and storage slot keys from the world state. The preloading
+ * mechanism is used to improve performance by loading required data before it is needed.
+ *
+ * @param <ACCOUNT> the type representing a diff-based account.
+ */
+public abstract class PreloaderManager<ACCOUNT> {
+
+  /**
+   * Returns a consumer responsible for preloading diff-based account values from the given world
+   * state.
+   *
+   * <p>This method should be implemented to supply a Consumer that handles the preloading of
+   * account data, ensuring that any necessary state is available when processing state transitions.
+   *
+   * @param worldState the diff-based world state from which to preload account data.
+   * @return a Consumer that preloads DiffBasedValue&lt;ACCOUNT&gt; instances.
+   */
+  public abstract Consumer<DiffBasedValue<ACCOUNT>> getAccountPreloader(
+      final DiffBasedWorldState worldState);
+
+  /**
+   * Returns a consumer responsible for preloading storage slot keys from the given world state.
+   *
+   * <p>This method should be implemented to supply a Consumer that handles the preloading of
+   * storage data. Preloading storage keys can help in optimizing state lookups and transitions.
+   *
+   * @param worldState the diff-based world state from which to preload storage slot keys.
+   * @return a Consumer that preloads StorageSlotKey instances.
+   */
+  public abstract Consumer<StorageSlotKey> getStoragePreloader(
+      final DiffBasedWorldState worldState);
+}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/StorageConsumingMap.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/preload/StorageConsumingMap.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.preload;
+package org.hyperledger.besu.ethereum.trie.diffbased.common.preload;
 
 import org.hyperledger.besu.datatypes.Address;
 
@@ -22,28 +22,32 @@ import javax.annotation.Nonnull;
 
 import com.google.common.collect.ForwardingMap;
 
-public class AccountConsumingMap<T> extends ForwardingMap<Address, T> {
+public class StorageConsumingMap<K, T> extends ForwardingMap<K, T> {
 
-  private final ConcurrentMap<Address, T> accounts;
-  private final Consumer<T> consumer;
+  private final Address address;
 
-  public AccountConsumingMap(final ConcurrentMap<Address, T> accounts, final Consumer<T> consumer) {
-    this.accounts = accounts;
+  private final ConcurrentMap<K, T> storages;
+  private final Consumer<K> consumer;
+
+  public StorageConsumingMap(
+      final Address address, final ConcurrentMap<K, T> storages, final Consumer<K> consumer) {
+    this.address = address;
+    this.storages = storages;
     this.consumer = consumer;
   }
 
   @Override
-  public T put(@Nonnull final Address address, @Nonnull final T value) {
-    consumer.process(address, value);
-    return accounts.put(address, value);
+  public T put(@Nonnull final K slotKey, @Nonnull final T value) {
+    consumer.process(address, slotKey);
+    return storages.put(slotKey, value);
   }
 
-  public Consumer<T> getConsumer() {
+  public Consumer<K> getConsumer() {
     return consumer;
   }
 
   @Override
-  protected Map<Address, T> delegate() {
-    return accounts;
+  protected Map<K, T> delegate() {
+    return storages;
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/provider/DiffBasedWorldStateProvider.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/provider/DiffBasedWorldStateProvider.java
@@ -313,7 +313,6 @@ public abstract class DiffBasedWorldStateProvider implements WorldStateArchive {
               .setMessage("State rolling failed on {} for block hash {}")
               .addArgument(mutableState.getWorldStateStorage().getClass().getSimpleName())
               .addArgument(blockHash)
-              .addArgument(e)
               .log();
 
           return Optional.empty();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/DiffBasedWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/DiffBasedWorldState.java
@@ -254,9 +254,8 @@ public abstract class DiffBasedWorldState
 
   @Override
   public Hash rootHash() {
-    if (isStorageFrozen && accumulator.isAccumulatorStateChanged()) {
+    if (isStorageFrozen) {
       worldStateRootHash = calculateRootHash(Optional.empty(), accumulator.copy());
-      accumulator.resetAccumulatorStateChanged();
     }
     return Hash.wrap(worldStateRootHash);
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/accumulator/AccumulatorUpdater.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/common/worldview/accumulator/AccumulatorUpdater.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright contributors to Hyperledger Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.datatypes.StorageSlotKey;
+import org.hyperledger.besu.ethereum.rlp.RLP;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedAccount;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.PreloaderManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.StorageConsumingMap;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.DiffBasedWorldView;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.internal.EvmConfiguration;
+import org.hyperledger.besu.evm.worldstate.AbstractWorldUpdater;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.units.bigints.UInt256;
+
+/**
+ * The AccumulatorUpdater is responsible for managing state transitions in the accumulator-based
+ * world view. It processes updates and deletions of accounts and their corresponding storage and
+ * code.
+ *
+ * @param <ACCOUNT> The type representing a diff-based account.
+ */
+@SuppressWarnings("unchecked")
+public class AccumulatorUpdater<ACCOUNT extends DiffBasedAccount>
+    extends AbstractWorldUpdater<DiffBasedWorldView, ACCOUNT> {
+
+  // Manager for preloading storage data into memory to optimize state access.
+  private final PreloaderManager<ACCOUNT> preloaderManager;
+
+  /**
+   * Instantiates a new world updater for the accumulator.
+   *
+   * @param world the world view update accumulator that holds pending state changes
+   * @param preloaderManager preloader of the trie nodes for efficient storage access
+   * @param evmConfiguration the EVM configuration parameters
+   */
+  protected AccumulatorUpdater(
+      final DiffBasedWorldStateUpdateAccumulator<ACCOUNT> world,
+      final PreloaderManager<ACCOUNT> preloaderManager,
+      final EvmConfiguration evmConfiguration) {
+    super(world, evmConfiguration);
+    this.preloaderManager = preloaderManager;
+  }
+
+  /**
+   * Loads or creates an account for mutation.
+   *
+   * @param address the address of the account
+   * @return the diff-based account to be mutated
+   */
+  @Override
+  protected ACCOUNT getForMutation(final Address address) {
+    return wrappedWorldView().loadAccount(address, DiffBasedValue::getUpdated);
+  }
+
+  /**
+   * Returns a collection of accounts that have been touched during the transaction.
+   *
+   * @return the collection of touched accounts
+   */
+  @Override
+  public Collection<? extends Account> getTouchedAccounts() {
+    return getUpdatedAccounts();
+  }
+
+  /**
+   * Returns the addresses of accounts that have been deleted during the transaction.
+   *
+   * @return the set of deleted account addresses
+   */
+  @Override
+  public Collection<Address> getDeletedAccountAddresses() {
+    return getDeletedAccounts();
+  }
+
+  /** Reverts all pending updates by clearing the tracked updates and deletions. */
+  @Override
+  public void revert() {
+    updatedAccounts.clear();
+    deletedAccounts.clear();
+  }
+
+  /**
+   * Commits the accumulated state changes into the world view. This method processes: This method
+   * ensures that all the changes from the current updater are merged into the underlying world
+   * view.
+   */
+  @Override
+  public void commit() {
+
+    final Map<Address, DiffBasedValue<ACCOUNT>> accountsToUpdate =
+        wrappedWorldView().getAccountsToUpdate();
+    final Map<Address, StorageConsumingMap<StorageSlotKey, DiffBasedValue<UInt256>>>
+        storageToUpdate = wrappedWorldView().getStorageToUpdate();
+    final Map<Address, DiffBasedValue<Bytes>> codeToUpdate = wrappedWorldView().getCodeToUpdate();
+    final Set<Address> storageToClear = wrappedWorldView().getStorageToClear();
+
+    // Process deleted accounts.
+    for (final Address deletedAddress : getDeletedAccounts()) {
+      final DiffBasedValue<ACCOUNT> accountValue =
+          accountsToUpdate.computeIfAbsent(
+              deletedAddress,
+              __ ->
+                  wrappedWorldView()
+                      .loadAccountFromParent(
+                          deletedAddress, new DiffBasedValue<>(null, null, true)));
+      storageToClear.add(deletedAddress);
+      final DiffBasedValue<Bytes> codeValue = codeToUpdate.get(deletedAddress);
+      if (codeValue != null) {
+        codeValue.setUpdated(null).setCleared();
+      } else {
+        wrappedWorldView()
+            .getCode(
+                deletedAddress,
+                Optional.ofNullable(accountValue)
+                    .map(DiffBasedValue::getPrior)
+                    .map(DiffBasedAccount::getCodeHash)
+                    .orElse(Hash.EMPTY))
+            .ifPresent(
+                deletedCode ->
+                    codeToUpdate.put(
+                        deletedAddress, new DiffBasedValue<>(deletedCode, null, true)));
+      }
+
+      // Mark storage changes for deletion.
+      final Map<StorageSlotKey, DiffBasedValue<UInt256>> deletedStorageUpdates =
+          storageToUpdate.computeIfAbsent(
+              deletedAddress,
+              k ->
+                  new StorageConsumingMap<>(
+                      deletedAddress,
+                      new ConcurrentHashMap<>(),
+                      preloaderManager.getStoragePreloader(
+                          wrappedWorldView().getParentWorldView())));
+      final Iterator<Map.Entry<StorageSlotKey, DiffBasedValue<UInt256>>> iter =
+          deletedStorageUpdates.entrySet().iterator();
+      while (iter.hasNext()) {
+        final Map.Entry<StorageSlotKey, DiffBasedValue<UInt256>> updateEntry = iter.next();
+        final DiffBasedValue<UInt256> updatedSlot = updateEntry.getValue();
+        if (updatedSlot.getPrior() == null || updatedSlot.getPrior().isZero()) {
+          iter.remove();
+        } else {
+          updatedSlot.setUpdated(null).setCleared();
+        }
+      }
+
+      final ACCOUNT originalValue = accountValue.getPrior();
+      if (originalValue != null) {
+        // Enumerate and delete addresses not updated
+        wrappedWorldView()
+            .getAllAccountStorage(deletedAddress, originalValue.getStorageRoot())
+            .forEach(
+                (keyHash, entryValue) -> {
+                  final StorageSlotKey storageSlotKey =
+                      new StorageSlotKey(Hash.wrap(keyHash), Optional.empty());
+                  if (!deletedStorageUpdates.containsKey(storageSlotKey)) {
+                    final UInt256 value = UInt256.fromBytes(RLP.decodeOne(entryValue));
+                    deletedStorageUpdates.put(
+                        storageSlotKey, new DiffBasedValue<>(value, null, true));
+                  }
+                });
+      }
+      if (deletedStorageUpdates.isEmpty()) {
+        storageToUpdate.remove(deletedAddress);
+      }
+      accountValue.setUpdated(null);
+    }
+
+    // Process updated accounts.
+    getUpdatedAccounts()
+        .forEach(
+            tracked -> {
+              final Address updatedAddress = tracked.getAddress();
+              System.out.println("commit " + updatedAddress);
+              final ACCOUNT updatedAccount;
+              final DiffBasedValue<ACCOUNT> updatedAccountValue =
+                  accountsToUpdate.get(updatedAddress);
+              final Map<StorageSlotKey, DiffBasedValue<UInt256>> pendingStorageUpdates =
+                  storageToUpdate.computeIfAbsent(
+                      updatedAddress,
+                      k ->
+                          new StorageConsumingMap<>(
+                              updatedAddress,
+                              new ConcurrentHashMap<>(),
+                              preloaderManager.getStoragePreloader(
+                                  wrappedWorldView().getParentWorldView())));
+
+              if (tracked.getWrappedAccount() == null) {
+                updatedAccount = wrappedWorldView().createAccount(tracked);
+                tracked.setWrappedAccount(updatedAccount);
+                if (updatedAccountValue == null) {
+                  accountsToUpdate.put(updatedAddress, new DiffBasedValue<>(null, updatedAccount));
+                  codeToUpdate.put(
+                      updatedAddress, new DiffBasedValue<>(null, updatedAccount.getCode()));
+                } else {
+                  updatedAccountValue.setUpdated(updatedAccount);
+                }
+              } else {
+                updatedAccount = tracked.getWrappedAccount();
+                updatedAccount.setBalance(tracked.getBalance());
+                updatedAccount.setNonce(tracked.getNonce());
+                if (tracked.codeWasUpdated()) {
+                  updatedAccount.setCode(tracked.getCode());
+                }
+                if (tracked.getStorageWasCleared()) {
+                  updatedAccount.clearStorage();
+                }
+                tracked.getUpdatedStorage().forEach(updatedAccount::setStorageValue);
+              }
+
+              if (tracked.codeWasUpdated()) {
+                final DiffBasedValue<Bytes> pendingCode =
+                    codeToUpdate.computeIfAbsent(
+                        updatedAddress,
+                        addr ->
+                            new DiffBasedValue<>(
+                                wrappedWorldView()
+                                    .getCode(
+                                        addr,
+                                        Optional.ofNullable(updatedAccountValue)
+                                            .map(DiffBasedValue::getPrior)
+                                            .map(DiffBasedAccount::getCodeHash)
+                                            .orElse(Hash.EMPTY))
+                                    .orElse(null),
+                                null));
+                pendingCode.setUpdated(updatedAccount.getCode());
+              }
+
+              if (tracked.getStorageWasCleared()) {
+                storageToClear.add(updatedAddress);
+                pendingStorageUpdates.clear();
+              }
+
+              // parallel stream here may cause database corruption
+              updatedAccount
+                  .getUpdatedStorage()
+                  .entrySet()
+                  .forEach(
+                      storageUpdate -> {
+                        final UInt256 keyUInt = storageUpdate.getKey();
+                        final StorageSlotKey slotKey =
+                            new StorageSlotKey(
+                                wrappedWorldView().hashAndSaveSlotPreImage(keyUInt),
+                                Optional.of(keyUInt));
+                        final UInt256 value = storageUpdate.getValue();
+                        final DiffBasedValue<UInt256> pendingValue =
+                            pendingStorageUpdates.get(slotKey);
+                        if (pendingValue == null) {
+                          pendingStorageUpdates.put(
+                              slotKey,
+                              new DiffBasedValue<>(
+                                  updatedAccount.getOriginalStorageValue(keyUInt), value));
+                        } else {
+                          pendingValue.setUpdated(value);
+                        }
+                      });
+
+              updatedAccount.getUpdatedStorage().clear();
+
+              if (pendingStorageUpdates.isEmpty()) {
+                storageToUpdate.remove(updatedAddress);
+              }
+
+              if (tracked.getStorageWasCleared()) {
+                tracked.setStorageWasCleared(false); // storage already cleared for this transaction
+              }
+            });
+  }
+
+  @Override
+  protected DiffBasedWorldStateUpdateAccumulator<ACCOUNT> wrappedWorldView() {
+    return (DiffBasedWorldStateUpdateAccumulator<ACCOUNT>) super.wrappedWorldView();
+  }
+}

--- a/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
+++ b/ethereum/core/src/test-support/java/org/hyperledger/besu/ethereum/core/InMemoryKeyValueStorageProvider.java
@@ -28,7 +28,7 @@ import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.VariablesKeyValueStorage;
 import org.hyperledger.besu.ethereum.storage.keyvalue.WorldStatePreimageKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiWorldStateProvider;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.forest.ForestWorldStateArchive;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
@@ -97,8 +97,8 @@ public class InMemoryKeyValueStorageProvider extends KeyValueStorageProvider {
       final Blockchain blockchain, final EvmConfiguration evmConfiguration) {
     final InMemoryKeyValueStorageProvider inMemoryKeyValueStorageProvider =
         new InMemoryKeyValueStorageProvider();
-    final BonsaiCachedMerkleTrieLoader bonsaiCachedMerkleTrieLoader =
-        new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem());
+    final BonsaiMerkleTriePreloader bonsaiCachedMerkleTrieLoader =
+        new BonsaiMerkleTriePreloader(new NoOpMetricsSystem());
     return new BonsaiWorldStateProvider(
         (BonsaiWorldStateKeyValueStorage)
             inMemoryKeyValueStorageProvider.createWorldStateStorage(

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
@@ -38,8 +38,8 @@ import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.NoOpBonsaiCachedWorldStorageManager;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.NoopBonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiNoOpCachedWorldStorageManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiNoOpMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.trielog.NoOpTrieLogManager;
@@ -90,8 +90,8 @@ class ParallelizedConcurrentTransactionProcessorTest {
     worldState =
         new BonsaiWorldState(
             bonsaiWorldStateKeyValueStorage,
-            new NoopBonsaiCachedMerkleTrieLoader(),
-            new NoOpBonsaiCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage),
+            new BonsaiNoOpMerkleTriePreloader(),
+            new BonsaiNoOpCachedWorldStorageManager(bonsaiWorldStateKeyValueStorage),
             new NoOpTrieLogManager(),
             EvmConfiguration.DEFAULT,
             createStatefulConfigWithTrie());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/TransactionCollisionDetectorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/TransactionCollisionDetectorTest.java
@@ -23,10 +23,11 @@ import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.BonsaiAccount;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiNoOpMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
 import org.hyperledger.besu.ethereum.trie.diffbased.common.DiffBasedValue;
-import org.hyperledger.besu.ethereum.trie.diffbased.common.worldview.accumulator.preload.StorageConsumingMap;
+import org.hyperledger.besu.ethereum.trie.diffbased.common.preload.StorageConsumingMap;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 
 import java.math.BigInteger;
@@ -53,10 +54,10 @@ class TransactionCollisionDetectorTest {
     collisionDetector = new TransactionCollisionDetector();
     bonsaiUpdater =
         new BonsaiWorldStateUpdateAccumulator(
-            worldState, (__, ___) -> {}, (__, ___) -> {}, EvmConfiguration.DEFAULT);
+            worldState, new BonsaiNoOpMerkleTriePreloader(), EvmConfiguration.DEFAULT);
     trxUpdater =
         new BonsaiWorldStateUpdateAccumulator(
-            worldState, (__, ___) -> {}, (__, ___) -> {}, EvmConfiguration.DEFAULT);
+            worldState, new BonsaiNoOpMerkleTriePreloader(), EvmConfiguration.DEFAULT);
   }
 
   private Transaction createTransaction(final Address sender, final Address to) {

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/AbstractIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/AbstractIsolationTests.java
@@ -67,7 +67,7 @@ import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueSegmentIdentifier;
 import org.hyperledger.besu.ethereum.storage.keyvalue.KeyValueStorageProviderBuilder;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
 import org.hyperledger.besu.ethereum.worldstate.WorldStateKeyValueStorage;
@@ -167,7 +167,7 @@ public abstract class AbstractIsolationTests {
             (BonsaiWorldStateKeyValueStorage) worldStateKeyValueStorage,
             blockchain,
             Optional.of(16L),
-            new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+            new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
             null,
             EvmConfiguration.DEFAULT,
             throwingWorldStateHealerSupplier());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiCachedMerkleTrieLoaderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiCachedMerkleTrieLoaderTest.java
@@ -26,7 +26,7 @@ import org.hyperledger.besu.ethereum.storage.StorageProvider;
 import org.hyperledger.besu.ethereum.trie.MerkleTrie;
 import org.hyperledger.besu.ethereum.trie.TrieIterator;
 import org.hyperledger.besu.ethereum.trie.common.PmtStateTrieAccountValue;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.patricia.StoredMerklePatriciaTrie;
 import org.hyperledger.besu.ethereum.worldstate.DataStorageConfiguration;
@@ -46,7 +46,7 @@ import org.mockito.Mockito;
 
 class BonsaiCachedMerkleTrieLoaderTest {
 
-  private BonsaiCachedMerkleTrieLoader merkleTrieLoader;
+  private BonsaiMerkleTriePreloader merkleTrieLoader;
   private final StorageProvider storageProvider = new InMemoryKeyValueStorageProvider();
   private final BonsaiWorldStateKeyValueStorage inMemoryWorldState =
       Mockito.spy(
@@ -68,7 +68,7 @@ class BonsaiCachedMerkleTrieLoaderTest {
         TrieGenerator.generateTrie(
             worldStateStorageCoordinator,
             accounts.stream().map(Address::addressHash).collect(Collectors.toList()));
-    merkleTrieLoader = new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem());
+    merkleTrieLoader = new BonsaiMerkleTriePreloader(new NoOpMetricsSystem());
   }
 
   @Test

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiSnapshotIsolationTests.java
@@ -97,6 +97,7 @@ public class BonsaiSnapshotIsolationTests extends AbstractIsolationTests {
     // assert we can roll a snapshot to a specific worldstate without mutating head
     Address testAddress = Address.fromHexString("0xdeadbeef");
 
+    System.out.println("start");
     var block1 = forTransactions(List.of(burnTransaction(sender1, 0L, testAddress)));
     var res = executeBlock(archive.getWorldState(), block1);
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProviderTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/BonsaiWorldStateProviderTest.java
@@ -39,8 +39,8 @@ import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
 import org.hyperledger.besu.ethereum.storage.StorageProvider;
-import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedMerkleTrieLoader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.cache.BonsaiCachedWorldStorageManager;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.trielog.TrieLogFactoryImpl;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
@@ -114,7 +114,7 @@ class BonsaiWorldStateProviderTest {
                 new NoOpMetricsSystem(),
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
             blockchain,
-            new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+            new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
             EvmConfiguration.DEFAULT,
             throwingWorldStateHealerSupplier());
 
@@ -132,7 +132,7 @@ class BonsaiWorldStateProviderTest {
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
             blockchain,
             Optional.of(512L),
-            new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+            new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
             null,
             EvmConfiguration.DEFAULT,
             throwingWorldStateHealerSupplier());
@@ -157,7 +157,7 @@ class BonsaiWorldStateProviderTest {
                 new NoOpMetricsSystem(),
                 DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
             blockchain,
-            new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+            new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
             EvmConfiguration.DEFAULT,
             throwingWorldStateHealerSupplier());
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
@@ -194,7 +194,7 @@ class BonsaiWorldStateProviderTest {
                 trieLogManager,
                 worldStateKeyValueStorage,
                 blockchain,
-                new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+                new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
                 EvmConfiguration.DEFAULT,
                 throwingWorldStateHealerSupplier()));
     final BlockHeader blockHeader = blockBuilder.number(0).buildHeader();
@@ -226,7 +226,7 @@ class BonsaiWorldStateProviderTest {
                 trieLogManager,
                 worldStateKeyValueStorage,
                 blockchain,
-                new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+                new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
                 EvmConfiguration.DEFAULT,
                 throwingWorldStateHealerSupplier()));
 
@@ -269,7 +269,7 @@ class BonsaiWorldStateProviderTest {
                 trieLogManager,
                 worldStateKeyValueStorage,
                 blockchain,
-                new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+                new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
                 EvmConfiguration.DEFAULT,
                 throwingWorldStateHealerSupplier()));
 
@@ -315,7 +315,7 @@ class BonsaiWorldStateProviderTest {
                     new NoOpMetricsSystem(),
                     DataStorageConfiguration.DEFAULT_BONSAI_CONFIG),
                 blockchain,
-                new BonsaiCachedMerkleTrieLoader(new NoOpMetricsSystem()),
+                new BonsaiMerkleTriePreloader(new NoOpMetricsSystem()),
                 EvmConfiguration.DEFAULT,
                 throwingWorldStateHealerSupplier()));
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogManagerTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/diffbased/bonsai/trielog/TrieLogManagerTests.java
@@ -21,6 +21,7 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
+import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.preload.BonsaiNoOpMerkleTriePreloader;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.storage.BonsaiWorldStateKeyValueStorage;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldState;
 import org.hyperledger.besu.ethereum.trie.diffbased.bonsai.worldview.BonsaiWorldStateUpdateAccumulator;
@@ -50,7 +51,7 @@ class TrieLogManagerTests {
   BonsaiWorldStateUpdateAccumulator bonsaiUpdater =
       spy(
           new BonsaiWorldStateUpdateAccumulator(
-              worldState, (__, ___) -> {}, (__, ___) -> {}, EvmConfiguration.DEFAULT));
+              worldState, new BonsaiNoOpMerkleTriePreloader(), EvmConfiguration.DEFAULT));
 
   TrieLogManager trieLogManager;
 

--- a/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
+++ b/evm/src/main/java/org/hyperledger/besu/evm/worldstate/AbstractWorldUpdater.java
@@ -75,7 +75,7 @@ public abstract class AbstractWorldUpdater<W extends WorldView, A extends Accoun
    * @param account the account
    * @return the update tracking account
    */
-  protected UpdateTrackingAccount<A> track(final UpdateTrackingAccount<A> account) {
+  public UpdateTrackingAccount<A> track(final UpdateTrackingAccount<A> account) {
     final Address address = account.getAddress();
     updatedAccounts.put(address, account);
     deletedAccounts.remove(address);


### PR DESCRIPTION
## PR description

Try to simplify the accumulator code by separating the different map levels that were causing confusion. Now I have added an additional updater level instead of merging the two directly into the accumulator. 

Also revising the preload manager in order to add more readability

BonsaiAccumulator
- updater() => AccumulatorUpdater

AccumulatorUpdater
- updater() => Stackedupdater

Stackedupdater
- updater() => Stackedupdater

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

