### PR TITLE
Use protocol schedule to determine mining beneficiary

### DIFF
--- a/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
+++ b/consensus/clique/src/main/java/org/hyperledger/besu/consensus/clique/blockcreation/CliqueBlockCreator.java
@@ -68,7 +68,7 @@ public class CliqueBlockCreator extends AbstractBlockCreator {
       final EthScheduler ethScheduler) {
     super(
         miningConfiguration,
-        __ -> Util.publicKeyToAddress(nodeKey.getPublicKey()),
+        (__, ___, ____) -> Util.publicKeyToAddress(nodeKey.getPublicKey()),
         extraDataCalculator,
         transactionPool,
         protocolContext,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftBlockCreator.java
@@ -68,7 +68,7 @@ public class BftBlockCreator extends AbstractBlockCreator {
       final EthScheduler ethScheduler) {
     super(
         miningConfiguration.setCoinbase(localAddress),
-        miningBeneficiaryCalculator(localAddress, forksSchedule),
+        miningBeneficiaryCalculator(protocolSchedule),
         extraDataCalculator,
         transactionPool,
         protocolContext,
@@ -91,9 +91,15 @@ public class BftBlockCreator extends AbstractBlockCreator {
   }
 
   private static MiningBeneficiaryCalculator miningBeneficiaryCalculator(
-      final Address localAddress, final ForksSchedule<? extends BftConfigOptions> forksSchedule) {
-    return blockNum ->
-        forksSchedule.getFork(blockNum).getValue().getMiningBeneficiary().orElse(localAddress);
+      final ProtocolSchedule protocolSchedule) {
+    return (blockNum, blockTimestamp, parentHeader) -> {
+      ProtocolSpec protocolSpec =
+          ((BftProtocolSchedule) protocolSchedule)
+              .getByBlockNumberOrTimestamp(parentHeader.getNumber() + 1, blockTimestamp);
+      Address theAddress =
+          protocolSpec.getMiningBeneficiaryCalculator().calculateBeneficiary(parentHeader);
+      return theAddress;
+    };
   }
 
   @Override

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeBlockCreator.java
@@ -56,7 +56,7 @@ class MergeBlockCreator extends AbstractBlockCreator {
       final EthScheduler ethScheduler) {
     super(
         miningConfiguration,
-        __ -> miningConfiguration.getCoinbase().orElseThrow(),
+        (__, ___, ____) -> miningConfiguration.getCoinbase().orElseThrow(),
         extraDataCalculator,
         transactionPool,
         protocolContext,

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/AbstractBlockCreator.java
@@ -205,7 +205,8 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
               .buildProcessableBlockHeader();
 
       final Address miningBeneficiary =
-          miningBeneficiaryCalculator.getMiningBeneficiary(processableBlockHeader.getNumber());
+          miningBeneficiaryCalculator.getMiningBeneficiary(
+              processableBlockHeader.getNumber(), timestamp, parentHeader);
 
       throwIfStopped();
 
@@ -495,6 +496,6 @@ public abstract class AbstractBlockCreator implements AsyncBlockCreator {
 
   @FunctionalInterface
   protected interface MiningBeneficiaryCalculator {
-    Address getMiningBeneficiary(long blockNumber);
+    Address getMiningBeneficiary(long blockNumber, long blockTimestamp, BlockHeader parentHeader);
   }
 }

--- a/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWBlockCreator.java
+++ b/ethereum/blockcreation/src/main/java/org/hyperledger/besu/ethereum/blockcreation/PoWBlockCreator.java
@@ -48,7 +48,7 @@ public class PoWBlockCreator extends AbstractBlockCreator {
       final EthScheduler ethScheduler) {
     super(
         miningConfiguration,
-        __ -> miningConfiguration.getCoinbase().orElseThrow(),
+        (__, ___, ____) -> miningConfiguration.getCoinbase().orElseThrow(),
         extraDataCalculator,
         transactionPool,
         protocolContext,


### PR DESCRIPTION
## PR description
Uses BFT protocol schedule correctly when calculating the mining beneficiary

## Fixed Issue(s)
Fixes https://github.com/hyperledger/besu/issues/8384
