### PR TITLE
Add a method to get the encoded preimage of a transaction

### DIFF
--- a/datatypes/src/main/java/org/hyperledger/besu/datatypes/Transaction.java
+++ b/datatypes/src/main/java/org/hyperledger/besu/datatypes/Transaction.java
@@ -229,6 +229,13 @@ public interface Transaction {
   Bytes encoded();
 
   /**
+   * Returns the preimage of the transaction with the proper encoding
+   *
+   * @return the encoded preimage of the transaction as Bytes
+   */
+  Bytes encodedPreimage();
+
+  /**
    * Returns the size in bytes of the encoded transaction.
    *
    * @return the size in bytes of the encoded transaction.

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -728,6 +728,59 @@ public class Transaction
       checkArgument(chainId.isPresent(), "Transaction type %s requires chainId", transactionType);
     }
     final Bytes preimage =
+        getPreimage(
+            transactionType,
+            nonce,
+            gasPrice,
+            maxPriorityFeePerGas,
+            maxFeePerGas,
+            maxFeePerBlobGas,
+            gasLimit,
+            to,
+            value,
+            payload,
+            accessList,
+            versionedHashes,
+            codeDelegationList,
+            chainId);
+    return keccak256(preimage);
+  }
+
+  @Override
+  public Bytes encodedPreimage() {
+    return getPreimage(
+        transactionType,
+        nonce,
+        gasPrice.orElse(null),
+        maxPriorityFeePerGas.orElse(null),
+        maxFeePerGas.orElse(null),
+        maxFeePerBlobGas.orElse(null),
+        gasLimit,
+        to,
+        value,
+        payload,
+        maybeAccessList,
+        versionedHashes.orElse(null),
+        maybeCodeDelegationList,
+        chainId);
+  }
+
+  private static Bytes getPreimage(
+      final TransactionType transactionType,
+      final long nonce,
+      final Wei gasPrice,
+      final Wei maxPriorityFeePerGas,
+      final Wei maxFeePerGas,
+      final Wei maxFeePerBlobGas,
+      final long gasLimit,
+      final Optional<Address> to,
+      final Wei value,
+      final Bytes payload,
+      final Optional<List<AccessListEntry>> accessList,
+      final List<VersionedHash> versionedHashes,
+      final Optional<List<CodeDelegation>> codeDelegationList,
+      final Optional<BigInteger> chainId) {
+    final Bytes preimage =
         switch (transactionType) {
           case FRONTIER -> frontierPreimage(nonce, gasPrice, gasLimit, to, value, payload, chainId);
           case EIP1559 ->
@@ -783,7 +836,7 @@ public class Transaction
                           new IllegalStateException(
                               "Developer error: the transaction should be guaranteed to have a code delegations here")));
         };
-    return keccak256(preimage);
+    return preimage;
   }
 
   private static Bytes frontierPreimage(


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

