### PR TITLE
Expose static method that can be used for qbft proposal selection

### DIFF
--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
@@ -103,6 +103,15 @@ public class ProposerSelector {
         roundIdentifier, prevBlockProposer, validatorsForRound, changeEachBlock);
   }
 
+  /**
+   * Determines which validator should be acting as the proposer for a given sequence/round.
+   *
+   * @param roundIdentifier The round for which a proposer is required.
+   * @param prevBlockProposer The proposer of the previous block.
+   * @param validatorsForRound The validators for the round.
+   * @param changeEachBlock Whether the proposer should change each block.
+   * @return The address of the node which is to propose a block for the provided Round.
+   */
   public static Address selectProposerForRound(
       final ConsensusRoundIdentifier roundIdentifier,
       final Address prevBlockProposer,

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
@@ -99,10 +99,20 @@ public class ProposerSelector {
     final Collection<Address> validatorsForRound =
         validatorProvider.getValidatorsAfterBlock(blockHeader);
 
+    return selectProposerForRound(
+        roundIdentifier, prevBlockProposer, validatorsForRound, changeEachBlock);
+  }
+
+  public static Address selectProposerForRound(
+      final ConsensusRoundIdentifier roundIdentifier,
+      final Address prevBlockProposer,
+      final Collection<Address> validatorsForRound,
+      final boolean changeEachBlock) {
     if (!validatorsForRound.contains(prevBlockProposer)) {
       return handleMissingProposer(prevBlockProposer, validatorsForRound, roundIdentifier);
     } else {
-      return handleWithExistingProposer(prevBlockProposer, validatorsForRound, roundIdentifier);
+      return handleWithExistingProposer(
+          prevBlockProposer, validatorsForRound, roundIdentifier, changeEachBlock);
     }
   }
 
@@ -112,7 +122,7 @@ public class ProposerSelector {
    *
    * <p>And validators will change from there.
    */
-  private Address handleMissingProposer(
+  private static Address handleMissingProposer(
       final Address prevBlockProposer,
       final Collection<Address> validatorsForRound,
       final ConsensusRoundIdentifier roundIdentifier) {
@@ -135,10 +145,11 @@ public class ProposerSelector {
    * If the previous Proposer is still a validator - determine what offset should be applied for the
    * given round - factoring in a proposer change on the new block.
    */
-  private Address handleWithExistingProposer(
+  private static Address handleWithExistingProposer(
       final Address prevBlockProposer,
       final Collection<Address> validatorsForRound,
-      final ConsensusRoundIdentifier roundIdentifier) {
+      final ConsensusRoundIdentifier roundIdentifier,
+      final boolean changeEachBlock) {
     int indexOffsetFromPrevBlock = roundIdentifier.getRoundNumber();
     if (changeEachBlock) {
       indexOffsetFromPrevBlock += 1;
@@ -151,7 +162,7 @@ public class ProposerSelector {
    * Given Round 0 of the given height should start from given proposer (baseProposer) - determine
    * which validator should be used given the indexOffset.
    */
-  private Address calculateRoundSpecificValidator(
+  private static Address calculateRoundSpecificValidator(
       final Address baseProposer,
       final Collection<Address> validatorsForRound,
       final int indexOffset) {


### PR DESCRIPTION
## PR description
Expose static method that can be used for qbft proposal selection without needing the blockchain, block interface or validator provider. This allows the logic to be reused in other projects without requiring a Besu block.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

