### PR TITLE
Remove unused method getValidatorsAtHead from QbftValidatorProvider

### DIFF
--- a/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/types/QbftValidatorProvider.java
+++ b/consensus/qbft-core/src/main/java/org/hyperledger/besu/consensus/qbft/core/types/QbftValidatorProvider.java
@@ -22,13 +22,6 @@ import java.util.Collection;
 public interface QbftValidatorProvider {
 
   /**
-   * Gets validators at head.
-   *
-   * @return the validators at head
-   */
-  Collection<Address> getValidatorsAtHead();
-
-  /**
    * Gets validators after block.
    *
    * @param header the header

--- a/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftValidatorProviderAdaptor.java
+++ b/consensus/qbft/src/main/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftValidatorProviderAdaptor.java
@@ -39,11 +39,6 @@ public class QbftValidatorProviderAdaptor implements QbftValidatorProvider {
   }
 
   @Override
-  public Collection<Address> getValidatorsAtHead() {
-    return validatorProvider.getValidatorsAtHead();
-  }
-
-  @Override
   public Collection<Address> getValidatorsAfterBlock(final QbftBlockHeader header) {
     return validatorProvider.getValidatorsAfterBlock(BlockUtil.toBesuBlockHeader(header));
   }

--- a/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftValidatorProviderAdaptorTest.java
+++ b/consensus/qbft/src/test/java/org/hyperledger/besu/consensus/qbft/adaptor/QbftValidatorProviderAdaptorTest.java
@@ -35,17 +35,6 @@ class QbftValidatorProviderAdaptorTest {
   @Mock private ValidatorProvider validatorProvider;
 
   @Test
-  void returnsValidatorsAtHead() {
-    List<Address> validatorsAtHead =
-        List.of(Address.fromHexString("0x095e7baea6a6c7c4c2dfeb977efac326af552d87"));
-    when(validatorProvider.getValidatorsAtHead()).thenReturn(validatorsAtHead);
-
-    QbftValidatorProviderAdaptor qbftValidatorProviderAdaptor =
-        new QbftValidatorProviderAdaptor(validatorProvider);
-    assertThat(qbftValidatorProviderAdaptor.getValidatorsAtHead()).isEqualTo(validatorsAtHead);
-  }
-
-  @Test
   void returnsValidatorsAfterBlock() {
     BlockHeader header = new BlockHeaderTestFixture().buildHeader();
     QbftBlockHeader qbftBlockHeader = new QbftBlockHeaderAdaptor(header);


### PR DESCRIPTION
## PR description
Remove unused method getValidatorsAtHead from QbftValidatorProvider

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

