### PR TITLE
Fix: javax.inject:javax.inject:1 entry in BOM

### DIFF
--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -32,7 +32,6 @@ dependencies {
   api platform('io.opentelemetry:opentelemetry-bom:1.47.0')
   api platform('io.prometheus:prometheus-metrics-bom:1.3.5')
   api platform('io.vertx:vertx-stack-depchain:4.5.13')
-  api platform('javax.inject:javax.inject:1')
   api platform('org.apache.logging.log4j:log4j-bom:2.24.3')
   api platform('org.assertj:assertj-bom:3.27.3')
   api platform('org.immutables:bom:2.10.1')
@@ -117,6 +116,8 @@ dependencies {
     api 'io.consensys.protocols:tuweni-rlp:2.6.0'
     api 'io.consensys.protocols:tuweni-toml:2.6.0'
     api 'io.consensys.protocols:tuweni-units:2.6.0'
+
+    api 'javax.inject:javax.inject:1'
 
     api 'net.java.dev.jna:jna:5.16.0'
 


### PR DESCRIPTION
## PR description

This is a constraint on a version and not a transitive dependency to another BOM/platform. If a Gradle projects depends on both `javax.inject:javax.inject` and `besu`, you currently can run into an error like this:

```
Cannot select module with conflict on capability '...' also provided by [javax.inject:javax.inject:1(platform-compile), javax.inject:javax.inject:1(compile)]
```

https://scans.gradle.com/s/f237bkq632kb4/failure#1

## Fixed Issue(s)

Discovered in https://github.com/hiero-ledger/hiero-gradle-conventions/pull/136


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- ~[ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).~
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- ~[ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests~

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

