### PR TITLE
Add comment about relation of the evmtool version string and the execution spec test

### DIFF
--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/VersionProvider.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/VersionProvider.java
@@ -39,6 +39,9 @@ public class VersionProvider implements CommandLine.IVersionProvider {
    */
   @Override
   public String[] getVersion() {
+    // This version string is used in the execution spec tests to identify the client.
+    // If modified, update the `detect_binary_pattern` variable in the following repository:
+    // https://github.com/ethereum/execution-spec-tests/blob/main/src/ethereum_clis/clis/besu.py
     return new String[] {"Besu evm " + BesuInfo.shortVersion()};
   }
 }


### PR DESCRIPTION
## PR description

A recent change in the version string of `evmtool` has unexpectedly broken the [execution spec tests](https://github.com/ethereum/execution-spec-tests/). The reason being that this version string is used in the spec test to determine which client is used. I've added a comment to document this and where in the spec tests it needs to be updated.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

