### PR TITLE
Bft ProposerSelector interface

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/IbftBesuControllerBuilder.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.consensus.common.bft.RoundTimer;
 import org.hyperledger.besu.consensus.common.bft.UniqueMessageMulticaster;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftMiningCoordinator;
+import org.hyperledger.besu.consensus.common.bft.blockcreation.BftProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.ProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.network.ValidatorPeers;
 import org.hyperledger.besu.consensus.common.bft.protocol.BftProtocolManager;
@@ -162,7 +163,7 @@ public class IbftBesuControllerBuilder extends BesuControllerBuilder {
         protocolContext.getConsensusContext(BftContext.class).getValidatorProvider();
 
     final ProposerSelector proposerSelector =
-        new ProposerSelector(blockchain, bftBlockInterface, true, validatorProvider);
+        new BftProposerSelector(blockchain, bftBlockInterface, true, validatorProvider);
 
     // NOTE: peers should not be used for accessing the network as it does not enforce the
     // "only send once" filter applied by the UniqueMessageMulticaster.

--- a/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/controller/QbftBesuControllerBuilder.java
@@ -36,6 +36,7 @@ import org.hyperledger.besu.consensus.common.bft.MessageTracker;
 import org.hyperledger.besu.consensus.common.bft.RoundTimer;
 import org.hyperledger.besu.consensus.common.bft.UniqueMessageMulticaster;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftMiningCoordinator;
+import org.hyperledger.besu.consensus.common.bft.blockcreation.BftProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.ProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.network.ValidatorPeers;
 import org.hyperledger.besu.consensus.common.bft.protocol.BftProtocolManager;
@@ -236,7 +237,7 @@ public class QbftBesuControllerBuilder extends BesuControllerBuilder {
             protocolContext.getBadBlockManager());
 
     final ProposerSelector proposerSelector =
-        new ProposerSelector(blockchain, bftBlockInterface, true, validatorProvider);
+        new BftProposerSelector(blockchain, bftBlockInterface, true, validatorProvider);
 
     // NOTE: peers should not be used for accessing the network as it does not enforce the
     // "only send once" filter applied by the UniqueMessageMulticaster.

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftProposerSelector.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/BftProposerSelector.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.consensus.common.bft.blockcreation;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import org.hyperledger.besu.consensus.common.BlockInterface;
+import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
+import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.BlockHeader;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.TreeSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Responsible for determining which member of the validator pool should propose the next block
+ * (i.e. send the Proposal message).
+ *
+ * <p>It does this by extracting the previous block's proposer from the ProposerSeal (stored in the
+ * Blocks ExtraData) then iterating through the validator list (stored in {@link
+ * ValidatorProvider}*), such that each new round for the given height is serviced by a different
+ * validator.
+ */
+public class BftProposerSelector implements ProposerSelector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BftProposerSelector.class);
+
+  private final Blockchain blockchain;
+
+  /**
+   * If set, will cause the proposer to change on successful addition of a block. Otherwise, the
+   * previously successful proposer will propose the next block as well.
+   */
+  private final Boolean changeEachBlock;
+
+  private final ValidatorProvider validatorProvider;
+
+  private final BlockInterface blockInterface;
+
+  /**
+   * Instantiates a new Proposer selector.
+   *
+   * @param blockchain the blockchain
+   * @param blockInterface the block interface
+   * @param changeEachBlock the change each block
+   * @param validatorProvider the validator provider
+   */
+  public BftProposerSelector(
+      final Blockchain blockchain,
+      final BlockInterface blockInterface,
+      final boolean changeEachBlock,
+      final ValidatorProvider validatorProvider) {
+    this.blockchain = blockchain;
+    this.blockInterface = blockInterface;
+    this.changeEachBlock = changeEachBlock;
+    this.validatorProvider = validatorProvider;
+  }
+
+  /**
+   * Determines which validator should be acting as the proposer for a given sequence/round.
+   *
+   * @param roundIdentifier Identifies the chain height and proposal attempt number.
+   * @return The address of the node which is to propose a block for the provided Round.
+   */
+  @Override
+  public Address selectProposerForRound(final ConsensusRoundIdentifier roundIdentifier) {
+    checkArgument(roundIdentifier.getRoundNumber() >= 0);
+    checkArgument(roundIdentifier.getSequenceNumber() > 0);
+
+    final long prevBlockNumber = roundIdentifier.getSequenceNumber() - 1;
+    final Optional<BlockHeader> maybeParentHeader = blockchain.getBlockHeader(prevBlockNumber);
+    if (!maybeParentHeader.isPresent()) {
+      LOG.trace("Unable to determine proposer for requested block {}", prevBlockNumber);
+      throw new RuntimeException("Unable to determine past proposer");
+    }
+
+    final BlockHeader blockHeader = maybeParentHeader.get();
+    final Address prevBlockProposer = blockInterface.getProposerOfBlock(blockHeader);
+    final Collection<Address> validatorsForRound =
+        validatorProvider.getValidatorsAfterBlock(blockHeader);
+
+    return selectProposerForRound(
+        roundIdentifier, prevBlockProposer, validatorsForRound, changeEachBlock);
+  }
+
+  /**
+   * Determines which validator should be acting as the proposer for a given sequence/round.
+   *
+   * @param roundIdentifier The round for which a proposer is required.
+   * @param prevBlockProposer The proposer of the previous block.
+   * @param validatorsForRound The validators for the round.
+   * @param changeEachBlock Whether the proposer should change each block.
+   * @return The address of the node which is to propose a block for the provided Round.
+   */
+  public static Address selectProposerForRound(
+      final ConsensusRoundIdentifier roundIdentifier,
+      final Address prevBlockProposer,
+      final Collection<Address> validatorsForRound,
+      final boolean changeEachBlock) {
+    if (!validatorsForRound.contains(prevBlockProposer)) {
+      return handleMissingProposer(prevBlockProposer, validatorsForRound, roundIdentifier);
+    } else {
+      return handleWithExistingProposer(
+          prevBlockProposer, validatorsForRound, roundIdentifier, changeEachBlock);
+    }
+  }
+
+  /**
+   * If the proposer of the previous block is missing, the validator with an Address above the
+   * previous will become the next validator for the first round of the next block.
+   *
+   * <p>And validators will change from there.
+   */
+  private static Address handleMissingProposer(
+      final Address prevBlockProposer,
+      final Collection<Address> validatorsForRound,
+      final ConsensusRoundIdentifier roundIdentifier) {
+    final NavigableSet<Address> validatorSet = new TreeSet<>(validatorsForRound);
+    final NavigableSet<Address> latterValidators = validatorSet.tailSet(prevBlockProposer, false);
+    final Address nextProposer;
+    if (latterValidators.isEmpty()) {
+      // i.e. prevBlockProposer was at the end of the validator list, so the right validator for
+      // the start of this round is the first.
+      nextProposer = validatorSet.first();
+    } else {
+      // Else, use the first validator after the dropped entry.
+      nextProposer = latterValidators.first();
+    }
+    return calculateRoundSpecificValidator(
+        nextProposer, validatorsForRound, roundIdentifier.getRoundNumber());
+  }
+
+  /**
+   * If the previous Proposer is still a validator - determine what offset should be applied for the
+   * given round - factoring in a proposer change on the new block.
+   */
+  private static Address handleWithExistingProposer(
+      final Address prevBlockProposer,
+      final Collection<Address> validatorsForRound,
+      final ConsensusRoundIdentifier roundIdentifier,
+      final boolean changeEachBlock) {
+    int indexOffsetFromPrevBlock = roundIdentifier.getRoundNumber();
+    if (changeEachBlock) {
+      indexOffsetFromPrevBlock += 1;
+    }
+    return calculateRoundSpecificValidator(
+        prevBlockProposer, validatorsForRound, indexOffsetFromPrevBlock);
+  }
+
+  /**
+   * Given Round 0 of the given height should start from given proposer (baseProposer) - determine
+   * which validator should be used given the indexOffset.
+   */
+  private static Address calculateRoundSpecificValidator(
+      final Address baseProposer,
+      final Collection<Address> validatorsForRound,
+      final int indexOffset) {
+    final List<Address> currentValidatorList = new ArrayList<>(validatorsForRound);
+    final int prevProposerIndex = currentValidatorList.indexOf(baseProposer);
+    final int roundValidatorIndex = (prevProposerIndex + indexOffset) % currentValidatorList.size();
+    return currentValidatorList.get(roundValidatorIndex);
+  }
+}

--- a/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
+++ b/consensus/common/src/main/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -14,170 +14,19 @@
  */
 package org.hyperledger.besu.consensus.common.bft.blockcreation;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
-import org.hyperledger.besu.consensus.common.BlockInterface;
 import org.hyperledger.besu.consensus.common.bft.ConsensusRoundIdentifier;
-import org.hyperledger.besu.consensus.common.validator.ValidatorProvider;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.NavigableSet;
-import java.util.Optional;
-import java.util.TreeSet;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Responsible for determining which member of the validator pool should propose the next block
- * (i.e. send the Proposal message).
- *
- * <p>It does this by extracting the previous block's proposer from the ProposerSeal (stored in the
- * Blocks ExtraData) then iterating through the validator list (stored in {@link
- * ValidatorProvider}*), such that each new round for the given height is serviced by a different
- * validator.
+ * (i.e. send the Proposal message).*
  */
-public class ProposerSelector {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ProposerSelector.class);
-
-  private final Blockchain blockchain;
-
-  /**
-   * If set, will cause the proposer to change on successful addition of a block. Otherwise, the
-   * previously successful proposer will propose the next block as well.
-   */
-  private final Boolean changeEachBlock;
-
-  private final ValidatorProvider validatorProvider;
-
-  private final BlockInterface blockInterface;
-
-  /**
-   * Instantiates a new Proposer selector.
-   *
-   * @param blockchain the blockchain
-   * @param blockInterface the block interface
-   * @param changeEachBlock the change each block
-   * @param validatorProvider the validator provider
-   */
-  public ProposerSelector(
-      final Blockchain blockchain,
-      final BlockInterface blockInterface,
-      final boolean changeEachBlock,
-      final ValidatorProvider validatorProvider) {
-    this.blockchain = blockchain;
-    this.blockInterface = blockInterface;
-    this.changeEachBlock = changeEachBlock;
-    this.validatorProvider = validatorProvider;
-  }
-
+public interface ProposerSelector {
   /**
    * Determines which validator should be acting as the proposer for a given sequence/round.
    *
    * @param roundIdentifier Identifies the chain height and proposal attempt number.
    * @return The address of the node which is to propose a block for the provided Round.
    */
-  public Address selectProposerForRound(final ConsensusRoundIdentifier roundIdentifier) {
-    checkArgument(roundIdentifier.getRoundNumber() >= 0);
-    checkArgument(roundIdentifier.getSequenceNumber() > 0);
-
-    final long prevBlockNumber = roundIdentifier.getSequenceNumber() - 1;
-    final Optional<BlockHeader> maybeParentHeader = blockchain.getBlockHeader(prevBlockNumber);
-    if (!maybeParentHeader.isPresent()) {
-      LOG.trace("Unable to determine proposer for requested block {}", prevBlockNumber);
-      throw new RuntimeException("Unable to determine past proposer");
-    }
-
-    final BlockHeader blockHeader = maybeParentHeader.get();
-    final Address prevBlockProposer = blockInterface.getProposerOfBlock(blockHeader);
-    final Collection<Address> validatorsForRound =
-        validatorProvider.getValidatorsAfterBlock(blockHeader);
-
-    return selectProposerForRound(
-        roundIdentifier, prevBlockProposer, validatorsForRound, changeEachBlock);
-  }
-
-  /**
-   * Determines which validator should be acting as the proposer for a given sequence/round.
-   *
-   * @param roundIdentifier The round for which a proposer is required.
-   * @param prevBlockProposer The proposer of the previous block.
-   * @param validatorsForRound The validators for the round.
-   * @param changeEachBlock Whether the proposer should change each block.
-   * @return The address of the node which is to propose a block for the provided Round.
-   */
-  public static Address selectProposerForRound(
-      final ConsensusRoundIdentifier roundIdentifier,
-      final Address prevBlockProposer,
-      final Collection<Address> validatorsForRound,
-      final boolean changeEachBlock) {
-    if (!validatorsForRound.contains(prevBlockProposer)) {
-      return handleMissingProposer(prevBlockProposer, validatorsForRound, roundIdentifier);
-    } else {
-      return handleWithExistingProposer(
-          prevBlockProposer, validatorsForRound, roundIdentifier, changeEachBlock);
-    }
-  }
-
-  /**
-   * If the proposer of the previous block is missing, the validator with an Address above the
-   * previous will become the next validator for the first round of the next block.
-   *
-   * <p>And validators will change from there.
-   */
-  private static Address handleMissingProposer(
-      final Address prevBlockProposer,
-      final Collection<Address> validatorsForRound,
-      final ConsensusRoundIdentifier roundIdentifier) {
-    final NavigableSet<Address> validatorSet = new TreeSet<>(validatorsForRound);
-    final NavigableSet<Address> latterValidators = validatorSet.tailSet(prevBlockProposer, false);
-    final Address nextProposer;
-    if (latterValidators.isEmpty()) {
-      // i.e. prevBlockProposer was at the end of the validator list, so the right validator for
-      // the start of this round is the first.
-      nextProposer = validatorSet.first();
-    } else {
-      // Else, use the first validator after the dropped entry.
-      nextProposer = latterValidators.first();
-    }
-    return calculateRoundSpecificValidator(
-        nextProposer, validatorsForRound, roundIdentifier.getRoundNumber());
-  }
-
-  /**
-   * If the previous Proposer is still a validator - determine what offset should be applied for the
-   * given round - factoring in a proposer change on the new block.
-   */
-  private static Address handleWithExistingProposer(
-      final Address prevBlockProposer,
-      final Collection<Address> validatorsForRound,
-      final ConsensusRoundIdentifier roundIdentifier,
-      final boolean changeEachBlock) {
-    int indexOffsetFromPrevBlock = roundIdentifier.getRoundNumber();
-    if (changeEachBlock) {
-      indexOffsetFromPrevBlock += 1;
-    }
-    return calculateRoundSpecificValidator(
-        prevBlockProposer, validatorsForRound, indexOffsetFromPrevBlock);
-  }
-
-  /**
-   * Given Round 0 of the given height should start from given proposer (baseProposer) - determine
-   * which validator should be used given the indexOffset.
-   */
-  private static Address calculateRoundSpecificValidator(
-      final Address baseProposer,
-      final Collection<Address> validatorsForRound,
-      final int indexOffset) {
-    final List<Address> currentValidatorList = new ArrayList<>(validatorsForRound);
-    final int prevProposerIndex = currentValidatorList.indexOf(baseProposer);
-    final int roundValidatorIndex = (prevProposerIndex + indexOffset) % currentValidatorList.size();
-    return currentValidatorList.get(roundValidatorIndex);
-  }
+  Address selectProposerForRound(ConsensusRoundIdentifier roundIdentifier);
 }

--- a/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelectorTest.java
+++ b/consensus/common/src/test/java/org/hyperledger/besu/consensus/common/bft/blockcreation/ProposerSelectorTest.java
@@ -97,7 +97,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, true, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, true, validatorProvider);
 
     final ConsensusRoundIdentifier roundId = new ConsensusRoundIdentifier(PREV_BLOCK_NUMBER + 1, 0);
 
@@ -116,7 +116,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, true, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, true, validatorProvider);
 
     final ConsensusRoundIdentifier roundId = new ConsensusRoundIdentifier(PREV_BLOCK_NUMBER + 1, 0);
 
@@ -136,7 +136,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, false, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, false, validatorProvider);
     final Address nextProposer = uut.selectProposerForRound(roundId);
 
     assertThat(nextProposer).isEqualTo(localAddr);
@@ -154,7 +154,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, false, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, false, validatorProvider);
     assertThat(uut.selectProposerForRound(roundId)).isEqualTo(localAddr);
 
     roundId = new ConsensusRoundIdentifier(PREV_BLOCK_NUMBER + 1, 1);
@@ -181,7 +181,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, false, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, false, validatorProvider);
 
     assertThat(uut.selectProposerForRound(roundId)).isEqualTo(validatorList.get(2));
   }
@@ -202,7 +202,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, true, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, true, validatorProvider);
 
     assertThat(uut.selectProposerForRound(roundId)).isEqualTo(validatorList.get(2));
   }
@@ -224,7 +224,7 @@ public class ProposerSelectorTest {
         createMockedBlockChainWithHeadOf(PREV_BLOCK_NUMBER, localAddr, validatorList);
 
     final ProposerSelector uut =
-        new ProposerSelector(blockchain, blockInterface, false, validatorProvider);
+        new BftProposerSelector(blockchain, blockInterface, false, validatorProvider);
 
     assertThat(uut.selectProposerForRound(roundId)).isEqualTo(validatorList.get(0));
   }

--- a/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
+++ b/consensus/ibft/src/integration-test/java/org/hyperledger/besu/consensus/ibft/support/TestContextBuilder.java
@@ -43,6 +43,7 @@ import org.hyperledger.besu.consensus.common.bft.RoundTimer;
 import org.hyperledger.besu.consensus.common.bft.SynchronizerUpdater;
 import org.hyperledger.besu.consensus.common.bft.UniqueMessageMulticaster;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.BftBlockCreatorFactory;
+import org.hyperledger.besu.consensus.common.bft.blockcreation.BftProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.ProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.inttest.DefaultValidatorPeer;
 import org.hyperledger.besu.consensus.common.bft.inttest.NetworkLayout;
@@ -393,7 +394,7 @@ public class TestContextBuilder {
             ethScheduler);
 
     final ProposerSelector proposerSelector =
-        new ProposerSelector(blockChain, blockInterface, true, validatorProvider);
+        new BftProposerSelector(blockChain, blockInterface, true, validatorProvider);
 
     final BftExecutors bftExecutors =
         BftExecutors.create(new NoOpMetricsSystem(), BftExecutors.ConsensusType.IBFT);

--- a/consensus/qbft-core/src/integration-test/java/org/hyperledger/besu/consensus/qbft/core/support/TestContextBuilder.java
+++ b/consensus/qbft-core/src/integration-test/java/org/hyperledger/besu/consensus/qbft/core/support/TestContextBuilder.java
@@ -47,6 +47,7 @@ import org.hyperledger.besu.consensus.common.bft.MessageTracker;
 import org.hyperledger.besu.consensus.common.bft.RoundTimer;
 import org.hyperledger.besu.consensus.common.bft.SynchronizerUpdater;
 import org.hyperledger.besu.consensus.common.bft.UniqueMessageMulticaster;
+import org.hyperledger.besu.consensus.common.bft.blockcreation.BftProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.blockcreation.ProposerSelector;
 import org.hyperledger.besu.consensus.common.bft.inttest.DefaultValidatorPeer;
 import org.hyperledger.besu.consensus.common.bft.inttest.NetworkLayout;
@@ -527,7 +528,7 @@ public class TestContextBuilder {
             ethScheduler);
 
     final ProposerSelector proposerSelector =
-        new ProposerSelector(blockChain, bftBlockInterface, true, validatorProvider);
+        new BftProposerSelector(blockChain, bftBlockInterface, true, validatorProvider);
 
     final BftExecutors bftExecutors =
         BftExecutors.create(new NoOpMetricsSystem(), BftExecutors.ConsensusType.QBFT);


### PR DESCRIPTION
## PR description
Extract interface for the ProposerSelector so alternative implementations can be used that don't depend on the Besu blocks and headers.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

