### PR TITLE
Use existing HTTP timeout configuration instead of the hard coded value

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandler.java
@@ -24,7 +24,6 @@ import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
 import java.io.IOException;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.api.trace.Tracer;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
@@ -34,18 +33,7 @@ import org.slf4j.LoggerFactory;
 public class JsonRpcExecutorHandler {
   private static final Logger LOG = LoggerFactory.getLogger(JsonRpcExecutorHandler.class);
 
-  // Default timeout for RPC calls in seconds
-  private static final long DEFAULT_TIMEOUT_MILLISECONDS = 30_000L;
-
   private JsonRpcExecutorHandler() {}
-
-  public static Handler<RoutingContext> handler(
-      final ObjectMapper jsonObjectMapper,
-      final JsonRpcExecutor jsonRpcExecutor,
-      final Tracer tracer,
-      final JsonRpcConfiguration jsonRpcConfiguration) {
-    return handler(jsonRpcExecutor, tracer, jsonRpcConfiguration);
-  }
 
   public static Handler<RoutingContext> handler(
       final JsonRpcExecutor jsonRpcExecutor,
@@ -55,7 +43,7 @@ public class JsonRpcExecutorHandler {
       final long timerId =
           ctx.vertx()
               .setTimer(
-                  DEFAULT_TIMEOUT_MILLISECONDS,
+                  jsonRpcConfiguration.getHttpTimeoutSec() * 1000,
                   id -> {
                     final String method =
                         ctx.get(ContextKey.REQUEST_BODY_AS_JSON_OBJECT.name()).toString();

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutOptions.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/handlers/TimeoutOptions.java
@@ -21,7 +21,7 @@ public class TimeoutOptions {
 
   public static final int DEFAULT_ERROR_CODE = 504;
 
-  private static final long DEFAULT_TIMEOUT_SECONDS = Duration.ofMinutes(5).toSeconds();
+  private static final long DEFAULT_TIMEOUT_SECONDS = Duration.ofSeconds(30).toSeconds();
   private final long timeoutSec;
 
   private final int errorCode;

--- a/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandlerTest.java
+++ b/ethereum/api/src/test/java/org/hyperledger/besu/ethereum/api/handlers/JsonRpcExecutorHandlerTest.java
@@ -56,6 +56,7 @@ class JsonRpcExecutorHandlerTest {
     mockVertx = mock(Vertx.class);
     mockResponse = mock(HttpServerResponse.class);
 
+    when(mockConfig.getHttpTimeoutSec()).thenReturn(30L);
     when(mockContext.vertx()).thenReturn(mockVertx);
     when(mockContext.response()).thenReturn(mockResponse);
     when(mockResponse.ended()).thenReturn(false);


### PR DESCRIPTION
## PR description

I think there is some refactor to do around the HTTP timeout, because it seems to be enforced twice, but as quick fix we can just replace the hard coded 30 secs with the existing timeout configuration `Xhttp-timeout-seconds` and set the latter to 30 seconds instead of 5 minutes.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #7975
### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

