### PR TITLE
Fix restoring txpool from disk when blob transactions are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fix QBFT and IBFT transitions that change the mining beneficiary [#8387](https://github.com/hyperledger/besu/issues/8387)
 - `eth_getLogs` - empty topic is a wildcard match [#8420](https://github.com/hyperledger/besu/pull/8420)
 - Upgrade spring-security-crypto to address CVE-2025-22228 [#8448](https://github.com/hyperledger/besu/pull/8448)
+- Fix restoring txpool from disk when blob transactions are present [#8481](https://github.com/hyperledger/besu/pull/8481)
 
 ## 25.3.0 
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/Transaction.java
@@ -136,8 +136,25 @@ public class Transaction
     return readFrom(RLP.input(rlpBytes));
   }
 
+  /**
+   * Recreate a transaction from RLP serialized in the block body format
+   *
+   * @param rlpInput the RLP input in block body format
+   * @return the transaction
+   */
   public static Transaction readFrom(final RLPInput rlpInput) {
-    return TransactionDecoder.decodeRLP(rlpInput, EncodingContext.BLOCK_BODY);
+    return readFrom(rlpInput, EncodingContext.BLOCK_BODY);
+  }
+
+  /**
+   * Recreate a transaction from RLP serialized according to the specified format
+   *
+   * @param rlpInput the RLP input in block body format
+   * @param context specify in which format the RLP was serialized
+   * @return the transaction
+   */
+  public static Transaction readFrom(final RLPInput rlpInput, final EncodingContext context) {
+    return TransactionDecoder.decodeRLP(rlpInput, context);
   }
 
   /**
@@ -484,12 +501,22 @@ public class Transaction
   }
 
   /**
-   * Writes the transaction to RLP
+   * Writes the transaction to RLP using the block body format
    *
    * @param out the output to write the transaction to
    */
   public void writeTo(final RLPOutput out) {
-    TransactionEncoder.encodeRLP(this, out, EncodingContext.BLOCK_BODY);
+    writeTo(out, EncodingContext.BLOCK_BODY);
+  }
+
+  /**
+   * Writes the transaction to RLP using the specified format
+   *
+   * @param out the output to write the transaction to
+   * @param context the serialization format to use
+   */
+  public void writeTo(final RLPOutput out, final EncodingContext context) {
+    TransactionEncoder.encodeRLP(this, out, context);
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPool.java
@@ -34,7 +34,6 @@ import org.hyperledger.besu.ethereum.chain.MutableBlockchain;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.encoding.EncodingContext;
-import org.hyperledger.besu.ethereum.core.encoding.TransactionEncoder;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
@@ -44,6 +43,7 @@ import org.hyperledger.besu.ethereum.mainnet.TransactionValidator;
 import org.hyperledger.besu.ethereum.mainnet.ValidationResult;
 import org.hyperledger.besu.ethereum.mainnet.feemarket.FeeMarket;
 import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLP;
 import org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason;
 import org.hyperledger.besu.ethereum.trie.MerkleTrieException;
 import org.hyperledger.besu.evm.account.Account;
@@ -825,8 +825,7 @@ public class TransactionPool implements BlockAddedObserver {
                 .map(
                     ptx -> {
                       final BytesValueRLPOutput rlp = new BytesValueRLPOutput();
-                      TransactionEncoder.encodeRLP(
-                          ptx.getTransaction(), rlp, EncodingContext.POOLED_TRANSACTION);
+                      ptx.getTransaction().writeTo(rlp, EncodingContext.POOLED_TRANSACTION);
                       return ptx.getScore()
                           + (ptx.isReceivedFromLocalSource() ? "l" : "r")
                           + rlp.encoded().toBase64String();
@@ -881,7 +880,10 @@ public class TransactionPool implements BlockAddedObserver {
                           final boolean isLocal = line.charAt(scoreStr.length()) == 'l';
                           final Transaction tx =
                               Transaction.readFrom(
-                                  Bytes.fromBase64String(line.substring(scoreStr.length() + 1)));
+                                  RLP.input(
+                                      Bytes.fromBase64String(
+                                          line.substring(scoreStr.length() + 1))),
+                                  EncodingContext.POOLED_TRANSACTION);
 
                           final ValidationResult<TransactionInvalidReason> result =
                               addTransaction(tx, isLocal, score);
@@ -912,7 +914,7 @@ public class TransactionPool implements BlockAddedObserver {
               saveFile.delete();
             }
           } catch (IOException e) {
-            LOG.error("Error while saving txpool content to disk", e);
+            LOG.error("Error while loading txpool content from disk", e);
           }
         }
       }

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTest.java
@@ -25,11 +25,13 @@ import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.NONCE_TOO_FAR_IN_FUTURE_FOR_SENDER;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.NONCE_TOO_LOW;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.REPLAY_PROTECTED_SIGNATURE_REQUIRED;
+import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.TRANSACTION_ALREADY_KNOWN;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.TRANSACTION_REPLACEMENT_UNDERPRICED;
 import static org.hyperledger.besu.ethereum.transaction.TransactionInvalidReason.TX_FEECAP_EXCEEDED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -103,9 +105,9 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
     addAndAssertRemoteTransactionsValid(transaction0);
     addAndAssertRemoteTransactionsValid(transaction1);
 
-    assertThat(transactions.size()).isEqualTo(3);
-    assertThat(transactions.getLocalTransactions()).contains(localTransaction2);
-    assertThat(transactions.getPriorityTransactions()).hasSize(noLocalPriority ? 0 : 1);
+    assertThat(transactionPool.count()).isEqualTo(3);
+    assertThat(getLocalTransactions()).contains(localTransaction2);
+    assertThat(getPriorityTransactions()).hasSize(noLocalPriority ? 0 : 1);
   }
 
   @Test
@@ -131,7 +133,7 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
 
     assertTransactionNotPending(transaction0);
     assertTransactionNotPending(transaction1);
-    assertThat(transactions.size()).isZero();
+    assertThat(transactionPool.count()).isZero();
   }
 
   @Test
@@ -144,7 +146,7 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
 
     assertTransactionNotPending(transaction0);
     assertTransactionNotPending(transaction1);
-    assertThat(transactions.size()).isZero();
+    assertThat(transactionPool.count()).isZero();
   }
 
   @Test
@@ -197,19 +199,19 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
         appendBlock(Difficulty.ONE, originalFork1.getHeader(), transactionOtherSender);
     assertTransactionNotPending(transaction0);
     assertTransactionNotPending(transactionOtherSender);
-    assertThat(transactions.getLocalTransactions()).isEmpty();
+    assertThat(getLocalTransactions()).isEmpty();
 
     final Block reorgFork1 = appendBlock(Difficulty.ONE, commonParent);
     verifyChainHeadIs(originalFork2);
 
-    transactions.subscribePendingTransactions(listener);
+    transactionPool.subscribePendingTransactions(listener);
     final Block reorgFork2 = appendBlock(Difficulty.of(2000), reorgFork1.getHeader());
     verifyChainHeadIs(reorgFork2);
 
     assertTransactionPending(transaction0);
     assertTransactionPending(transactionOtherSender);
-    assertThat(transactions.getLocalTransactions()).contains(transaction0);
-    assertThat(transactions.getLocalTransactions()).doesNotContain(transactionOtherSender);
+    assertThat(getLocalTransactions()).contains(transaction0);
+    assertThat(getLocalTransactions()).doesNotContain(transactionOtherSender);
     verify(listener).onTransactionAdded(transaction0);
     verify(listener).onTransactionAdded(transactionOtherSender);
     verifyNoMoreInteractions(listener);
@@ -275,7 +277,7 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
     assertTransactionPending(transactionWithBlobs);
 
     Optional<Transaction> maybeBlob =
-        transactions.getTransactionByHash(transactionWithBlobs.getHash());
+        transactionPool.getTransactionByHash(transactionWithBlobs.getHash());
     assertThat(maybeBlob).isPresent();
     Transaction restoredBlob = maybeBlob.get();
     assertThat(restoredBlob).isEqualTo(transactionWithBlobs);
@@ -384,10 +386,19 @@ public abstract class AbstractTransactionPoolTest extends AbstractTransactionPoo
 
   @Test
   public void shouldDiscardRemoteTransactionThatAlreadyExistsBeforeValidation() {
-    doReturn(true).when(transactions).containsTransaction(transaction0);
-    transactionPool.addRemoteTransactions(singletonList(transaction0));
+    givenTransactionIsValid(transaction0);
+    addAndAssertRemoteTransactionsValid(transaction0);
 
-    verify(transactions).containsTransaction(transaction0);
+    verify(transactionValidatorFactory, atLeastOnce()).get();
+
+    clearInvocations(transactionValidatorFactory);
+
+    // trying to re-add the same tx should return transaction already known and no
+    // access to the transaction validator factory should be done
+    final var result = transactionPool.addRemoteTransactions(singletonList(transaction0));
+    assertThat(result.get(transaction0.getHash()))
+        .isEqualTo(ValidationResult.invalid(TRANSACTION_ALREADY_KNOWN));
+
     verifyNoInteractions(transactionValidatorFactory);
   }
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
@@ -126,7 +126,6 @@ public abstract class AbstractTransactionPoolTestBase {
   protected MutableBlockchain blockchain;
   protected TransactionBroadcaster transactionBroadcaster;
 
-  protected PendingTransactions transactions;
   protected final Transaction transaction0 = createTransaction(0);
   protected final Transaction transaction1 = createTransaction(1);
   protected final Transaction transactionWithBlobs = createBlobTransaction(2);
@@ -270,11 +269,9 @@ public abstract class AbstractTransactionPoolTestBase {
             transactionReplacementHandler.shouldReplace(
                 t1, t2, protocolContext.getBlockchain().getChainHeadHeader());
 
-    transactions = spy(createPendingTransactions(poolConfig, transactionReplacementTester));
-
     final TransactionPool txPool =
         new TransactionPool(
-            () -> transactions,
+            () -> createPendingTransactions(poolConfig, transactionReplacementTester),
             protocolSchedule,
             protocolContext,
             transactionBroadcaster,
@@ -310,7 +307,7 @@ public abstract class AbstractTransactionPoolTestBase {
   }
 
   protected void assertTransactionNotPending(final Transaction transaction) {
-    assertThat(transactions.getTransactionByHash(transaction.getHash())).isEmpty();
+    assertThat(transactionPool.getTransactionByHash(transaction.getHash())).isEmpty();
   }
 
   protected void addAndAssertRemoteTransactionInvalid(final Transaction tx) {
@@ -321,7 +318,7 @@ public abstract class AbstractTransactionPoolTestBase {
   }
 
   protected void assertTransactionPending(final Transaction t) {
-    assertThat(transactions.getTransactionByHash(t.getHash())).contains(t);
+    assertThat(transactionPool.getTransactionByHash(t.getHash())).contains(t);
   }
 
   protected void addAndAssertRemoteTransactionsValid(final Transaction... txs) {
@@ -340,9 +337,9 @@ public abstract class AbstractTransactionPoolTestBase {
         .onTransactionsAdded(
             argThat(btxs -> btxs.size() == txs.length && btxs.containsAll(List.of(txs))));
     Arrays.stream(txs).forEach(this::assertTransactionPending);
-    assertThat(transactions.getLocalTransactions()).doesNotContain(txs);
+    assertThat(getLocalTransactions()).doesNotContain(txs);
     if (hasPriority) {
-      assertThat(transactions.getPriorityTransactions()).contains(txs);
+      assertThat(getPriorityTransactions()).contains(txs);
     }
   }
 
@@ -354,11 +351,11 @@ public abstract class AbstractTransactionPoolTestBase {
     assertThat(result.isValid()).isTrue();
     assertTransactionPending(tx);
     verify(transactionBroadcaster).onTransactionsAdded(singletonList(tx));
-    assertThat(transactions.getLocalTransactions()).contains(tx);
+    assertThat(getLocalTransactions()).contains(tx);
     if (disableLocalPriority) {
-      assertThat(transactions.getPriorityTransactions()).doesNotContain(tx);
+      assertThat(getPriorityTransactions()).doesNotContain(tx);
     } else {
-      assertThat(transactions.getPriorityTransactions()).contains(tx);
+      assertThat(getPriorityTransactions()).contains(tx);
     }
   }
 
@@ -551,7 +548,7 @@ public abstract class AbstractTransactionPoolTestBase {
       transactionPool.addRemoteTransactions(List.of(transaction));
     }
 
-    return transactions.size();
+    return transactionPool.count();
   }
 
   protected Block appendBlockGasPriceMarket(
@@ -597,5 +594,19 @@ public abstract class AbstractTransactionPoolTestBase {
             .collect(toList());
     blockchain.appendBlock(block, transactionReceipts);
     return block;
+  }
+
+  protected List<Transaction> getPriorityTransactions() {
+    return transactionPool.getPendingTransactions().stream()
+        .filter(PendingTransaction::hasPriority)
+        .map(PendingTransaction::getTransaction)
+        .toList();
+  }
+
+  protected List<Transaction> getLocalTransactions() {
+    return transactionPool.getPendingTransactions().stream()
+        .filter(PendingTransaction::isReceivedFromLocalSource)
+        .map(PendingTransaction::getTransaction)
+        .toList();
   }
 }


### PR DESCRIPTION
## PR description

Fix to use the POOLED_TRANSACTION format also when reading from disk to fix the issue related to saving blob tx with that format but reading them with the BLOCK_BODY format.

Writing a test for this, I found that we where not correctly supporting the enable/disable feature in the unit tests, so that required a bit of refactoring on the test code.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #8449

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

