### PR TITLE
Fix: Timeouts are now indexed by both request code and protocol.

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/PeerReputation.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nonnull;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,8 +41,8 @@ public class PeerReputation implements Comparable<PeerReputation> {
   public static final int TIMEOUT_THRESHOLD = 5;
   public static final int USELESS_RESPONSE_THRESHOLD = 5;
 
-  private final ConcurrentMap<Integer, AtomicInteger> timeoutCountByRequestType =
-      new ConcurrentHashMap<>();
+  private final ConcurrentMap<ImmutablePair<String, Integer>, AtomicInteger>
+      timeoutCountByRequestType = new ConcurrentHashMap<>();
   private final Queue<Long> uselessResponseTimes = new ConcurrentLinkedQueue<>();
 
   private static final int SMALL_ADJUSTMENT = 1;
@@ -63,12 +64,14 @@ public class PeerReputation implements Comparable<PeerReputation> {
   }
 
   public Optional<DisconnectReason> recordRequestTimeout(
-      final int requestCode, final EthPeer peer) {
-    final int newTimeoutCount = getOrCreateTimeoutCount(requestCode).incrementAndGet();
+      final String protocolName, final int requestCode, final EthPeer peer) {
+    final int newTimeoutCount =
+        getOrCreateTimeoutCount(protocolName, requestCode).incrementAndGet();
     if (newTimeoutCount >= TIMEOUT_THRESHOLD) {
       LOG.debug(
-          "Disconnection triggered by {} repeated timeouts for requestCode {} for peer {}",
+          "Disconnection triggered by {} repeated timeouts for protocol {} for requestCode {} for peer {}",
           newTimeoutCount,
+          protocolName,
           requestCode,
           peer.getLoggableId());
       score -= LARGE_ADJUSTMENT;
@@ -79,15 +82,16 @@ public class PeerReputation implements Comparable<PeerReputation> {
     }
   }
 
-  public void resetTimeoutCount(final int requestCode) {
-    timeoutCountByRequestType.remove(requestCode);
+  public void resetTimeoutCount(final String protocolName, final int requestCode) {
+    timeoutCountByRequestType.remove(new ImmutablePair<>(protocolName, requestCode));
   }
 
-  private AtomicInteger getOrCreateTimeoutCount(final int requestCode) {
-    return timeoutCountByRequestType.computeIfAbsent(requestCode, code -> new AtomicInteger());
+  private AtomicInteger getOrCreateTimeoutCount(final String protocolName, final int requestCode) {
+    return timeoutCountByRequestType.computeIfAbsent(
+        new ImmutablePair<>(protocolName, requestCode), code -> new AtomicInteger());
   }
 
-  public Map<Integer, AtomicInteger> timeoutCounts() {
+  public Map<ImmutablePair<String, Integer>, AtomicInteger> timeoutCounts() {
     return timeoutCountByRequestType;
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetAccountRangeFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetAccountRangeFromPeerTask.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager.snap;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
@@ -48,7 +49,7 @@ public class GetAccountRangeFromPeerTask
       final Bytes32 endKeyHash,
       final BlockHeader blockHeader,
       final MetricsSystem metricsSystem) {
-    super(ethContext, SnapV1.ACCOUNT_RANGE, metricsSystem);
+    super(ethContext, SnapProtocol.NAME, SnapV1.ACCOUNT_RANGE, metricsSystem);
     this.startKeyHash = startKeyHash;
     this.endKeyHash = endKeyHash;
     this.blockHeader = blockHeader;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBytecodeFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetBytecodeFromPeerTask.java
@@ -19,6 +19,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
@@ -53,7 +54,7 @@ public class GetBytecodeFromPeerTask extends AbstractPeerRequestTask<Map<Bytes32
       final List<Bytes32> codeHashes,
       final BlockHeader blockHeader,
       final MetricsSystem metricsSystem) {
-    super(ethContext, SnapV1.STORAGE_RANGE, metricsSystem);
+    super(ethContext, SnapProtocol.NAME, SnapV1.STORAGE_RANGE, metricsSystem);
     this.codeHashes = codeHashes;
     this.blockHeader = blockHeader;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetStorageRangeFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetStorageRangeFromPeerTask.java
@@ -15,6 +15,7 @@
 package org.hyperledger.besu.ethereum.eth.manager.snap;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
@@ -51,7 +52,7 @@ public class GetStorageRangeFromPeerTask
       final Bytes32 endKeyHash,
       final BlockHeader blockHeader,
       final MetricsSystem metricsSystem) {
-    super(ethContext, SnapV1.STORAGE_RANGE, metricsSystem);
+    super(ethContext, SnapProtocol.NAME, SnapV1.STORAGE_RANGE, metricsSystem);
     this.accountHashes = accountHashes;
     this.startKeyHash = startKeyHash;
     this.endKeyHash = endKeyHash;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetTrieNodeFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/snap/GetTrieNodeFromPeerTask.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyMap;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.SnapProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PeerRequest;
@@ -53,7 +54,7 @@ public class GetTrieNodeFromPeerTask extends AbstractPeerRequestTask<Map<Bytes, 
       final List<List<Bytes>> paths,
       final BlockHeader blockHeader,
       final MetricsSystem metricsSystem) {
-    super(ethContext, SnapV1.TRIE_NODES, metricsSystem);
+    super(ethContext, SnapProtocol.NAME, SnapV1.TRIE_NODES, metricsSystem);
     this.paths = paths;
     this.blockHeader = blockHeader;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractGetHeadersFromPeerTask.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.manager.task;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.messages.BlockHeadersMessage;
@@ -52,7 +53,7 @@ public abstract class AbstractGetHeadersFromPeerTask
       final int skip,
       final boolean reverse,
       final MetricsSystem metricsSystem) {
-    super(ethContext, EthProtocolMessages.GET_BLOCK_HEADERS, metricsSystem);
+    super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_BLOCK_HEADERS, metricsSystem);
     checkArgument(count > 0);
     this.protocolSchedule = protocolSchedule;
     this.count = count;

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/AbstractPeerRequestTask.java
@@ -39,12 +39,17 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
   private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
 
   private Duration timeout = DEFAULT_TIMEOUT;
+  private final String protocolName;
   private final int requestCode;
   private volatile PendingPeerRequest responseStream;
 
   protected AbstractPeerRequestTask(
-      final EthContext ethContext, final int requestCode, final MetricsSystem metricsSystem) {
+      final EthContext ethContext,
+      final String protocolName,
+      final int requestCode,
+      final MetricsSystem metricsSystem) {
     super(ethContext, metricsSystem);
+    this.protocolName = protocolName;
     this.requestCode = requestCode;
   }
 
@@ -75,7 +80,7 @@ public abstract class AbstractPeerRequestTask<R> extends AbstractPeerTask<R> {
           if (t != null) {
             t = ExceptionUtils.rootCause(t);
             if (t instanceof TimeoutException && responseStream.isPresent()) {
-              responseStream.get().getPeer().recordRequestTimeout(requestCode);
+              responseStream.get().getPeer().recordRequestTimeout(protocolName, requestCode);
             }
             result.completeExceptionally(t);
           } else if (r != null) {

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetBodiesFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetBodiesFromPeerTask.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.Withdrawal;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
@@ -58,7 +59,7 @@ public class GetBodiesFromPeerTask extends AbstractPeerRequestTask<List<Block>> 
       final EthContext ethContext,
       final List<BlockHeader> headers,
       final MetricsSystem metricsSystem) {
-    super(ethContext, EthProtocolMessages.GET_BLOCK_BODIES, metricsSystem);
+    super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_BLOCK_BODIES, metricsSystem);
     checkArgument(headers.size() > 0);
     this.protocolSchedule = protocolSchedule;
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetNodeDataFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetNodeDataFromPeerTask.java
@@ -17,6 +17,7 @@ package org.hyperledger.besu.ethereum.eth.manager.task;
 import static java.util.Collections.emptyMap;
 
 import org.hyperledger.besu.datatypes.Hash;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
@@ -49,7 +50,7 @@ public class GetNodeDataFromPeerTask extends AbstractPeerRequestTask<Map<Hash, B
       final Collection<Hash> hashes,
       final long pivotBlockNumber,
       final MetricsSystem metricsSystem) {
-    super(ethContext, EthProtocolMessages.GET_NODE_DATA, metricsSystem);
+    super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_NODE_DATA, metricsSystem);
     this.hashes = new HashSet<>(hashes);
     this.pivotBlockNumber = pivotBlockNumber;
   }

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetPooledTransactionsFromPeerTask.java
@@ -18,6 +18,7 @@ import static java.util.Collections.emptyList;
 
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.Transaction;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
@@ -44,7 +45,7 @@ public class GetPooledTransactionsFromPeerTask extends AbstractPeerRequestTask<L
 
   private GetPooledTransactionsFromPeerTask(
       final EthContext ethContext, final List<Hash> hashes, final MetricsSystem metricsSystem) {
-    super(ethContext, EthProtocolMessages.GET_POOLED_TRANSACTIONS, metricsSystem);
+    super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_POOLED_TRANSACTIONS, metricsSystem);
     this.hashes = new HashSet<>(hashes);
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetReceiptsFromPeerTask.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/task/GetReceiptsFromPeerTask.java
@@ -21,6 +21,7 @@ import static org.hyperledger.besu.ethereum.mainnet.BodyValidation.receiptsRoot;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
+import org.hyperledger.besu.ethereum.eth.EthProtocol;
 import org.hyperledger.besu.ethereum.eth.manager.EthContext;
 import org.hyperledger.besu.ethereum.eth.manager.EthPeer;
 import org.hyperledger.besu.ethereum.eth.manager.PendingPeerRequest;
@@ -50,7 +51,7 @@ public class GetReceiptsFromPeerTask
       final EthContext ethContext,
       final Collection<BlockHeader> blockHeaders,
       final MetricsSystem metricsSystem) {
-    super(ethContext, EthProtocolMessages.GET_RECEIPTS, metricsSystem);
+    super(ethContext, EthProtocol.NAME, EthProtocolMessages.GET_RECEIPTS, metricsSystem);
     this.blockHeaders = blockHeaders;
     blockHeaders.forEach(
         header ->

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutorTest.java
@@ -154,12 +154,13 @@ public class PeerTaskExecutorTest {
           InvalidPeerTaskResponseException {
     Object responseObject = new Object();
     int requestMessageDataCode = 123;
+    String protocolName = "snap";
 
     Mockito.when(peerTask.getRequestMessage()).thenReturn(requestMessageData);
     Mockito.when(peerTask.getRetriesWithSamePeer()).thenReturn(2);
 
     Mockito.when(peerTask.getSubProtocol()).thenReturn(subprotocol);
-    Mockito.when(subprotocol.getName()).thenReturn("subprotocol");
+    Mockito.when(subprotocol.getName()).thenReturn(protocolName);
     Mockito.when(requestSender.sendRequest(subprotocol, requestMessageData, ethPeer))
         .thenThrow(new TimeoutException())
         .thenReturn(responseMessageData);
@@ -170,7 +171,7 @@ public class PeerTaskExecutorTest {
 
     PeerTaskExecutorResult<Object> result = peerTaskExecutor.executeAgainstPeer(peerTask, ethPeer);
 
-    Mockito.verify(ethPeer).recordRequestTimeout(requestMessageDataCode);
+    Mockito.verify(ethPeer).recordRequestTimeout(protocolName, requestMessageDataCode);
     Mockito.verify(ethPeer).recordUsefulResponse();
 
     Assertions.assertNotNull(result);
@@ -207,18 +208,19 @@ public class PeerTaskExecutorTest {
           InterruptedException,
           TimeoutException {
     int requestMessageDataCode = 123;
+    String protocolName = "snap";
 
     Mockito.when(peerTask.getRequestMessage()).thenReturn(requestMessageData);
     Mockito.when(peerTask.getRetriesWithSamePeer()).thenReturn(0);
     Mockito.when(peerTask.getSubProtocol()).thenReturn(subprotocol);
-    Mockito.when(subprotocol.getName()).thenReturn("subprotocol");
+    Mockito.when(subprotocol.getName()).thenReturn(protocolName);
     Mockito.when(requestSender.sendRequest(subprotocol, requestMessageData, ethPeer))
         .thenThrow(new TimeoutException());
     Mockito.when(requestMessageData.getCode()).thenReturn(requestMessageDataCode);
 
     PeerTaskExecutorResult<Object> result = peerTaskExecutor.executeAgainstPeer(peerTask, ethPeer);
 
-    Mockito.verify(ethPeer).recordRequestTimeout(requestMessageDataCode);
+    Mockito.verify(ethPeer).recordRequestTimeout(protocolName, requestMessageDataCode);
 
     Assertions.assertNotNull(result);
     Assertions.assertTrue(result.result().isEmpty());
@@ -295,6 +297,7 @@ public class PeerTaskExecutorTest {
           InvalidPeerTaskResponseException {
     Object responseObject = new Object();
     int requestMessageDataCode = 123;
+    String protocolName = "snap";
     EthPeer peer2 = Mockito.mock(EthPeer.class);
 
     Mockito.when(peerSelector.getPeer(Mockito.any(Predicate.class)))
@@ -316,7 +319,7 @@ public class PeerTaskExecutorTest {
 
     PeerTaskExecutorResult<Object> result = peerTaskExecutor.execute(peerTask);
 
-    Mockito.verify(ethPeer).recordRequestTimeout(requestMessageDataCode);
+    Mockito.verify(ethPeer).recordRequestTimeout(protocolName, requestMessageDataCode);
     Mockito.verify(peer2).recordUsefulResponse();
 
     Assertions.assertNotNull(result);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutorTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/peertask/PeerTaskExecutorTest.java
@@ -308,6 +308,7 @@ public class PeerTaskExecutorTest {
     Mockito.when(peerTask.getRetriesWithOtherPeer()).thenReturn(2);
     Mockito.when(peerTask.getRetriesWithSamePeer()).thenReturn(0);
     Mockito.when(peerTask.getSubProtocol()).thenReturn(subprotocol);
+    Mockito.when(subprotocol.getName()).thenReturn(protocolName);
     Mockito.when(requestSender.sendRequest(subprotocol, requestMessageData, ethPeer))
         .thenThrow(new TimeoutException());
     Mockito.when(requestMessageData.getCode()).thenReturn(requestMessageDataCode);


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
fixes #6869


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [x] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

