### PR TITLE
Update outdated link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# [Hyperledger Code of Conduct](https://wiki.hyperledger.org/community/hyperledger-project-code-of-conduct)
+# [Hyperledger Code of Conduct](https://lf-hyperledger.atlassian.net/wiki/spaces/HYP/pages/19595281/Hyperledger+Code+of+Conduct)
 
 Hyperledger is a collaborative project at The Linux Foundation. It is an open-source and open
 community project where participants choose to work together, and in that process experience


### PR DESCRIPTION
The original link to the Hyperledger Code of Conduct was outdated and no longer resolves correctly.
This update replaces it with the official and current link hosted on the LF Hyperledger Confluence site, ensuring contributors are directed to the most up-to-date and accurate code of conduct documentation.