### PR TITLE
bonsai: commit trielog ahead of state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `eth_getLogs` - empty topic is a wildcard match [#8420](https://github.com/hyperledger/besu/pull/8420)
 - Upgrade spring-security-crypto to address CVE-2025-22228 [#8448](https://github.com/hyperledger/besu/pull/8448)
 - Fix restoring txpool from disk when blob transactions are present [#8481](https://github.com/hyperledger/besu/pull/8481)
+- Fix for bonsai db inconsistency on abnormal shutdown [#8500](https://github.com/hyperledger/besu/pull/8500)
 
 ## 25.3.0 
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/storage/BonsaiWorldStateKeyValueStorage.java
@@ -311,6 +311,16 @@ public class BonsaiWorldStateKeyValueStorage extends PathBasedWorldStateKeyValue
     }
 
     @Override
+    public void commitTrieLogOnly() {
+      trieLogStorageTransaction.commit();
+    }
+
+    @Override
+    public void commitComposedOnly() {
+      composedWorldStateTransaction.commit();
+    }
+
+    @Override
     public void rollback() {
       composedWorldStateTransaction.rollback();
       trieLogStorageTransaction.rollback();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/storage/PathBasedWorldStateKeyValueStorage.java
@@ -250,6 +250,10 @@ public abstract class PathBasedWorldStateKeyValueStorage
     @Override
     void commit();
 
+    void commitTrieLogOnly();
+
+    void commitComposedOnly();
+
     void rollback();
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/trielog/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/trielog/TrieLogManager.java
@@ -82,7 +82,7 @@ public class TrieLogManager {
         success = true;
       } finally {
         if (success) {
-          stateUpdater.commit();
+          stateUpdater.commitTrieLogOnly();
         } else {
           stateUpdater.rollback();
         }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/trielog/TrieLogManager.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/trielog/TrieLogManager.java
@@ -179,7 +179,7 @@ public class TrieLogManager {
         updater
             .getTrieLogStorageTransaction()
             .put(blockHash.toArrayUnsafe(), trieLog.toArrayUnsafe());
-        updater.commit();
+        updater.commitTrieLogOnly();
         // TODO maybe find a way to have a clean and complete trielog for observers
         trieLogObservers.forEach(
             o ->

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiSnapshotIsolationTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/BonsaiSnapshotIsolationTests.java
@@ -33,7 +33,6 @@ public class BonsaiSnapshotIsolationTests extends AbstractIsolationTests {
 
   @Test
   public void ensureTruncateDoesNotCauseSegfault() {
-
     var preTruncatedWorldState =
         archive.getWorldState(
             withBlockHeaderAndNoUpdateNodeHead(genesisState.getBlock().getHeader()));


### PR DESCRIPTION
## PR description

This PR addresses a regression where bonsai database can be left in a broken state on an abnormal shutdown.  

When besu commits a bonsai worldstate, it commits the trielog and the worldstate.  if the worldstate is committed first, and besu gets killed before it can commit the trielog, upon resuming operations besu will fail to create or import blocks, giving an error similar to: 
>Optional[Unable to process block because parent world state 0xcdee53accfeaa10680a304bc3ab3b721f15caeb61a4ede8ddde994f788892ced is not available]

The fix is to move the trielog commit ahead of the worldstate commit, and add the methods necessary to isolate the commit of both transactions.

Although this PR is very short, there is a lot of complexity hidden in it.  Several edge cases were discovered and addressed during testing:
* trie log manager inadvertently committing world state 
* composed worldstate commit inadvertently causing exceptions for closed trie log transactions
* block creation failure immediately after genesis caused  by caching worldstates at the wrong state of commitment


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #6569 

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

