### PR TITLE
create access list - don't override gasPrice if not set

### DIFF
--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/EthCreateAccessList.java
@@ -15,7 +15,6 @@
 package org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods;
 
 import org.hyperledger.besu.datatypes.AccessListEntry;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.api.jsonrpc.RpcMethod;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.JsonRpcRequestContext;
 import org.hyperledger.besu.ethereum.api.jsonrpc.internal.response.RpcErrorType;
@@ -122,7 +121,7 @@ public class EthCreateAccessList extends AbstractEstimateGas {
         callParams.getFrom(),
         callParams.getTo(),
         gasLimit,
-        Optional.ofNullable(callParams.getGasPrice()).orElse(Wei.ZERO),
+        callParams.getGasPrice(),
         callParams.getMaxPriorityFeePerGas(),
         callParams.getMaxFeePerGas(),
         callParams.getValue(),

--- a/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_createAccessList_value_transfer.json
+++ b/ethereum/api/src/test/resources/org/hyperledger/besu/ethereum/api/jsonrpc/eth/eth_createAccessList_value_transfer.json
@@ -1,0 +1,24 @@
+{
+  "request": {
+    "id": 28,
+    "jsonrpc": "2.0",
+    "method": "eth_createAccessList",
+    "params": [
+      {
+        "from":"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+        "to":"0x0100000000000000000000000000000000000000",
+        "value":"0xa"
+      },
+      "latest"
+    ]
+  },
+  "response": {
+    "jsonrpc" : "2.0",
+    "id" : 28,
+    "result" : {
+      "gasUsed": "0x5208",
+      "accessList": []
+    }
+  },
+  "statusCode": 200
+}


### PR DESCRIPTION
## PR description
follow on from #8472 - this is the same fix for eth_createAccessList

If not set in call params, don't override gasPrice. TransactionSimulator does the work of deciding whether it is set and whether it needs overriding.

Also added a spec test for eth_createAccessList although it does duplicate a hive test so not strictly necessary just a faster feedback loop

##Fixed Issue(s)
This was discovered by looking at rpc-compat hive tests but doesn't actually fix any hive tests directly.
What is fixed by this is transactions will be detected as EIP1559 if no gas price set.

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

