### PR TITLE
Add metrics to report peer count by client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Upcoming Breaking Changes
 ### Additions and Improvements
 - Add support for `eth_simulateV1`. [#8406](https://github.com/hyperledger/besu/pull/8406)
-- New metric `besu_peers_peer_count_by_type` to report the count of peers by client type [#8515](https://github.com/hyperledger/besu/pull/8515)
+- New metric `besu_peers_peer_count_by_client` to report the count of peers by client name [#8515](https://github.com/hyperledger/besu/pull/8515)
 #### Dependencies
 ### Bug fixes
 - Fix for storage proof key - if the key is zero use `0x0` not `0x` [#8499](https://github.com/hyperledger/besu/pull/8499)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Upcoming Breaking Changes
 ### Additions and Improvements
-- Add support for `eth_simulateV1`. [#8406](https://github.com/hyperledger/besu/pull/8406) 
+- Add support for `eth_simulateV1`. [#8406](https://github.com/hyperledger/besu/pull/8406)
+- New metric `besu_peers_peer_count_by_type` to report the count of peers by client type [#8515](https://github.com/hyperledger/besu/pull/8515)
 #### Dependencies
 ### Bug fixes
 - Fix for storage proof key - if the key is zero use `0x0` not `0x` [#8499](https://github.com/hyperledger/besu/pull/8499)

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/manager/EthPeers.java
@@ -31,7 +31,7 @@ import org.hyperledger.besu.ethereum.p2p.peers.Peer;
 import org.hyperledger.besu.ethereum.p2p.peers.PeerId;
 import org.hyperledger.besu.ethereum.p2p.rlpx.RlpxAgent;
 import org.hyperledger.besu.ethereum.p2p.rlpx.connections.PeerConnection;
-import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerClientType;
+import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerClientName;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.PeerInfo;
 import org.hyperledger.besu.ethereum.p2p.rlpx.wire.messages.DisconnectMessage;
 import org.hyperledger.besu.metrics.BesuMetricCategory;
@@ -179,21 +179,21 @@ public class EthPeers implements PeerSelector {
     final LabelledSuppliedMetric peerClientLabelledGauge =
         metricsSystem.createLabelledSuppliedGauge(
             BesuMetricCategory.PEERS,
-            "peer_count_by_type",
-            "The number of clients connected by client type",
+            "peer_count_by_client",
+            "The number of clients connected by client",
             "client");
 
-    for (final var clientType : PeerClientType.values()) {
+    for (final var clientName : PeerClientName.values()) {
       peerClientLabelledGauge.labels(
-          () -> countConnectedPeersOfType(clientType), clientType.getDisplayName());
+          () -> countConnectedPeersByClientName(clientName), clientName.getDisplayName());
     }
   }
 
-  private double countConnectedPeersOfType(final PeerClientType clientType) {
+  private double countConnectedPeersByClientName(final PeerClientName clientName) {
     return streamAllActiveConnections()
         .map(PeerConnection::getPeerInfo)
-        .map(PeerInfo::getClientType)
-        .filter(clientType::equals)
+        .map(PeerInfo::getClientName)
+        .filter(clientName::equals)
         .count();
   }
 

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerClientName.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerClientName.java
@@ -18,7 +18,7 @@ import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 
-public enum PeerClientType {
+public enum PeerClientName {
   BESU("besu"),
   ERIGON("erigon"),
   GETH("Geth"),
@@ -30,7 +30,7 @@ public enum PeerClientType {
   private final String agentName;
   private final String displayName;
 
-  PeerClientType(final String agentName) {
+  PeerClientName(final String agentName) {
     this.agentName = agentName;
     this.displayName = StringUtils.capitalize(name().toLowerCase(Locale.ENGLISH));
   }
@@ -39,8 +39,8 @@ public enum PeerClientType {
     return displayName;
   }
 
-  public static PeerClientType fromAgentName(final String agentName) {
-    for (final var type : PeerClientType.values()) {
+  public static PeerClientName fromAgentName(final String agentName) {
+    for (final var type : PeerClientName.values()) {
       if (type != UNKNOWN && type.agentName.equals(agentName)) {
         return type;
       }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerClientType.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerClientType.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.p2p.rlpx.wire;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+public enum PeerClientType {
+  BESU("besu"),
+  ERIGON("erigon"),
+  GETH("Geth"),
+  NETHERMIND("Nethermind"),
+  NIMBUS("nimbus-eth1"),
+  RETH("reth"),
+  UNKNOWN(null);
+
+  private final String agentName;
+  private final String displayName;
+
+  PeerClientType(final String agentName) {
+    this.agentName = agentName;
+    this.displayName = StringUtils.capitalize(name().toLowerCase(Locale.ENGLISH));
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public static PeerClientType fromAgentName(final String agentName) {
+    for (final var type : PeerClientType.values()) {
+      if (type != UNKNOWN && type.agentName.equals(agentName)) {
+        return type;
+      }
+    }
+    return UNKNOWN;
+  }
+}

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
@@ -41,6 +41,7 @@ import org.owasp.encoder.Encode;
 public class PeerInfo implements Comparable<PeerInfo> {
   private final int version;
   private final String clientId;
+  private final PeerClientType clientType;
   private final List<Capability> capabilities;
   private final int port;
   private final Bytes nodeId;
@@ -57,6 +58,7 @@ public class PeerInfo implements Comparable<PeerInfo> {
     this.capabilities = capabilities;
     this.port = port;
     this.nodeId = nodeId;
+    this.clientType = detectClientType(clientId);
   }
 
   public static PeerInfo readFrom(final RLPInput in) {
@@ -107,6 +109,10 @@ public class PeerInfo implements Comparable<PeerInfo> {
     return address;
   }
 
+  public PeerClientType getClientType() {
+    return clientType;
+  }
+
   public void writeTo(final RLPOutput out) {
     out.startList();
     out.writeUnsignedByte(getVersion());
@@ -154,5 +160,11 @@ public class PeerInfo implements Comparable<PeerInfo> {
   @Override
   public int compareTo(final @Nonnull PeerInfo peerInfo) {
     return this.nodeId.compareTo(peerInfo.nodeId);
+  }
+
+  private static PeerClientType detectClientType(final String clientId) {
+    final var idxSeparator = clientId.indexOf('/');
+    final var agentName = idxSeparator == -1 ? clientId : clientId.substring(0, idxSeparator);
+    return PeerClientType.fromAgentName(agentName);
   }
 }

--- a/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
+++ b/ethereum/p2p/src/main/java/org/hyperledger/besu/ethereum/p2p/rlpx/wire/PeerInfo.java
@@ -41,7 +41,7 @@ import org.owasp.encoder.Encode;
 public class PeerInfo implements Comparable<PeerInfo> {
   private final int version;
   private final String clientId;
-  private final PeerClientType clientType;
+  private final PeerClientName clientName;
   private final List<Capability> capabilities;
   private final int port;
   private final Bytes nodeId;
@@ -58,7 +58,7 @@ public class PeerInfo implements Comparable<PeerInfo> {
     this.capabilities = capabilities;
     this.port = port;
     this.nodeId = nodeId;
-    this.clientType = detectClientType(clientId);
+    this.clientName = detectClientName(clientId);
   }
 
   public static PeerInfo readFrom(final RLPInput in) {
@@ -109,8 +109,8 @@ public class PeerInfo implements Comparable<PeerInfo> {
     return address;
   }
 
-  public PeerClientType getClientType() {
-    return clientType;
+  public PeerClientName getClientName() {
+    return clientName;
   }
 
   public void writeTo(final RLPOutput out) {
@@ -162,9 +162,9 @@ public class PeerInfo implements Comparable<PeerInfo> {
     return this.nodeId.compareTo(peerInfo.nodeId);
   }
 
-  private static PeerClientType detectClientType(final String clientId) {
+  private static PeerClientName detectClientName(final String clientId) {
     final var idxSeparator = clientId.indexOf('/');
     final var agentName = idxSeparator == -1 ? clientId : clientId.substring(0, idxSeparator);
-    return PeerClientType.fromAgentName(agentName);
+    return PeerClientName.fromAgentName(agentName);
   }
 }


### PR DESCRIPTION
## PR description

A new metric is exported with the count of peers by client type
```
# HELP besu_peers_peer_count_by_type The number of clients connected by client type
# TYPE besu_peers_peer_count_by_type gauge
besu_peers_peer_count_by_type{client="Besu"} 0.0
besu_peers_peer_count_by_type{client="Erigon"} 0.0
besu_peers_peer_count_by_type{client="Geth"} 5.0
besu_peers_peer_count_by_type{client="Nethermind"} 2.0
besu_peers_peer_count_by_type{client="Nimbus"} 0.0
besu_peers_peer_count_by_type{client="Reth"} 18.0
besu_peers_peer_count_by_type{client="Unknown"} 0.0
```

with it you can create graphs like this one 
![image](https://github.com/user-attachments/assets/3b15f2de-4bb0-4795-8d24-c81793b45ba2)


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

fixes #8439

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

