### PR TITLE
Fix codehash removal upon account removal

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/LeafBuilder.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/LeafBuilder.java
@@ -49,9 +49,12 @@ public class LeafBuilder {
     keysForRemoval.add(trieKeyFactory.basicDataKey(address));
   }
 
-  public void generateCodeKeysForRemoval(final Address address, final Bytes code) {
-    keysForRemoval.add(trieKeyFactory.basicDataKey(address));
+  public void generateCodeHashKeyForRemoval(final Address address) {
     keysForRemoval.add(trieKeyFactory.codeHashKey(address));
+  }
+
+  public void generateCodeKeysForRemoval(final Address address, final Bytes code) {
+    generateCodeHashKeyForRemoval(address);
     List<UInt256> codeChunks = TrieKeyUtils.chunkifyCode(code);
     for (int i = 0; i < codeChunks.size(); i++) {
       keysForRemoval.add(trieKeyFactory.codeChunkKey(address, UInt256.valueOf(i)));

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/diffbased/verkle/worldview/VerkleWorldState.java
@@ -232,6 +232,7 @@ public class VerkleWorldState extends DiffBasedWorldState {
     }
     if (accountUpdate.getUpdated() == null) {
       leafBuilder.generateAccountKeyForRemoval(accountKey);
+      leafBuilder.generateCodeHashKeyForRemoval(accountKey);
       final Hash addressHash = hashAndSavePreImage(accountKey);
       maybeStateUpdater.ifPresent(
           verkleUpdater -> verkleUpdater.removeAccountInfoState(addressHash));
@@ -256,6 +257,8 @@ public class VerkleWorldState extends DiffBasedWorldState {
       final VerkleWorldStateUpdateAccumulator worldStateUpdater) {
     final VerkleAccount priorAccount = accountUpdate.getPrior();
     final VerkleAccount updatedAccount = accountUpdate.getUpdated();
+
+    // creating new account adds in codehash as well
     if (priorAccount == null) {
       leafBuilder.generateCodeHashKeyValueForUpdate(accountKey, updatedAccount.getCodeHash());
       return;


### PR DESCRIPTION
## PR description
The codehash should be removed when account is removed from the trie.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

