### PR TITLE
Tune and make configurable the `PeerTransactionTracker` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - New metric `besu_peers_peer_count_by_client` to report the count of peers by client name [#8515](https://github.com/hyperledger/besu/pull/8515)- Add Prague fork time for mainnet. [#8521](https://github.com/hyperledger/besu/pull/8521)
 - Add Prague fork time for mainnet. [#8521](https://github.com/hyperledger/besu/pull/8521)
 - Add block import tracer plugin provider, used during block import [#8524](https://github.com/hyperledger/besu/pull/8534)
+- Tune and make configurable the PeerTransactionTracker [#8537](https://github.com/hyperledger/besu/pull/8537)
 #### Dependencies
 ### Bug fixes
 - Fix for storage proof key - if the key is zero use `0x0` not `0x` [#8499](https://github.com/hyperledger/besu/pull/8499)

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -296,7 +296,8 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         hidden = true,
         description =
             "Whether txs evicted due to the pool being full should be removed from peer tracker cache that checks for already known txs (default: false on layered and true on sequenced txpool)",
-        arity = "1")
+        arity = "0..1",
+        fallbackValue = "true")
     private Boolean peerTrackerForgetEvictedTxs;
   }
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -285,7 +285,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         paramLabel = "<LONG>",
         hidden = true,
         description =
-            "The number of exchanged txs that are remembered with each peer, to avoid broadcasting duplicates (default: ${DEFAULT-VALUE})",
+            "The number of exchanged txs that are remembered with each peer, to minimize broadcasting duplicates (default: ${DEFAULT-VALUE})",
         arity = "1")
     private int maxTrackedSeenTxsPerPeer =
         TransactionPoolConfiguration.Unstable.DEFAULT_MAX_TRACKED_SEEN_TXS_PER_PEER;

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import picocli.CommandLine;
@@ -247,15 +248,16 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
   }
 
   @CommandLine.ArgGroup(validate = false)
-  private final TransactionPoolOptions.Unstable unstableOptions =
-      new TransactionPoolOptions.Unstable();
+  private final Unstable unstableOptions = new Unstable();
 
   static class Unstable {
     private static final String TX_MESSAGE_KEEP_ALIVE_SEC_FLAG =
         "--Xincoming-tx-messages-keep-alive-seconds";
-
     private static final String ETH65_TX_ANNOUNCED_BUFFERING_PERIOD_FLAG =
         "--Xeth65-tx-announced-buffering-period-milliseconds";
+    private static final String MAX_TRACKED_SEEN_TXS_PER_PEER = "--Xmax-tracked-seen-txs-per-peer";
+    private static final String PEER_TRACKER_FORGET_EVICTED_TXS_FLAG =
+        "--Xpeer-tracker-forget-evicted-txs";
 
     @CommandLine.Option(
         names = {TX_MESSAGE_KEEP_ALIVE_SEC_FLAG},
@@ -277,6 +279,25 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         arity = "1")
     private Duration eth65TrxAnnouncedBufferingPeriod =
         TransactionPoolConfiguration.Unstable.ETH65_TRX_ANNOUNCED_BUFFERING_PERIOD;
+
+    @CommandLine.Option(
+        names = {MAX_TRACKED_SEEN_TXS_PER_PEER},
+        paramLabel = "<LONG>",
+        hidden = true,
+        description =
+            "The number of exchanged txs that are remembered with each peer, to avoid broadcasting duplicates (default: ${DEFAULT-VALUE})",
+        arity = "1")
+    private int maxTrackedSeenTxsPerPeer =
+        TransactionPoolConfiguration.Unstable.DEFAULT_MAX_TRACKED_SEEN_TXS_PER_PEER;
+
+    @CommandLine.Option(
+        names = {PEER_TRACKER_FORGET_EVICTED_TXS_FLAG},
+        paramLabel = "<BOOLEAN>",
+        hidden = true,
+        description =
+            "If txs evicted due to the pool being full should be removed from peer tracker cache that check for already known txs (default: false on layered and true on sequenced)",
+        arity = "1")
+    private Boolean peerTrackerForgetEvictedTxs;
   }
 
   private TransactionPoolOptions() {}
@@ -287,7 +308,10 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
    * @return the transaction pool options
    */
   public static TransactionPoolOptions create() {
-    return new TransactionPoolOptions();
+    final var txPoolOptions = new TransactionPoolOptions();
+    txPoolOptions.unstableOptions.peerTrackerForgetEvictedTxs =
+        deriveDefaultPeersTrackerForgetEvictedTxs(txPoolOptions.txPoolImplementation);
+    return txPoolOptions;
   }
 
   /**
@@ -334,7 +358,10 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         config.getUnstable().getTxMessageKeepAliveSeconds();
     options.unstableOptions.eth65TrxAnnouncedBufferingPeriod =
         config.getUnstable().getEth65TrxAnnouncedBufferingPeriod();
-
+    options.unstableOptions.maxTrackedSeenTxsPerPeer =
+        config.getUnstable().getMaxTrackedSeenTxsPerPeer();
+    options.unstableOptions.peerTrackerForgetEvictedTxs =
+        config.getUnstable().getPeerTrackerForgetEvictedTxs();
     return options;
   }
 
@@ -392,8 +419,20 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
             ImmutableTransactionPoolConfiguration.Unstable.builder()
                 .txMessageKeepAliveSeconds(unstableOptions.txMessageKeepAliveSeconds)
                 .eth65TrxAnnouncedBufferingPeriod(unstableOptions.eth65TrxAnnouncedBufferingPeriod)
+                .maxTrackedSeenTxsPerPeer(unstableOptions.maxTrackedSeenTxsPerPeer)
+                .peerTrackerForgetEvictedTxs(
+                    Optional.ofNullable(unstableOptions.peerTrackerForgetEvictedTxs)
+                        .orElse(deriveDefaultPeersTrackerForgetEvictedTxs(txPoolImplementation)))
                 .build())
         .build();
+  }
+
+  private static boolean deriveDefaultPeersTrackerForgetEvictedTxs(
+      final TransactionPoolConfiguration.Implementation txPoolImplementation) {
+    return switch (txPoolImplementation) {
+      case LEGACY, SEQUENCED -> true;
+      case LAYERED -> false;
+    };
   }
 
   @Override

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -295,7 +295,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
         paramLabel = "<BOOLEAN>",
         hidden = true,
         description =
-            "If txs evicted due to the pool being full should be removed from peer tracker cache that check for already known txs (default: false on layered and true on sequenced)",
+            "Whether txs evicted due to the pool being full should be removed from peer tracker cache that checks for already known txs (default: false on layered and true on sequenced txpool)",
         arity = "1")
     private Boolean peerTrackerForgetEvictedTxs;
   }

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.util.number.Percentage;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -452,6 +453,40 @@ public class TransactionPoolOptionsTest
         "Invalid value for option '--tx-pool-min-score': '" + overflowMinScore + "' is not a byte",
         "--tx-pool-min-score",
         overflowMinScore);
+  }
+
+  @Test
+  public void defaultForgetEvictedTxsWithSequencedIsTrue() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isTrue(),
+        "--tx-pool",
+        SEQUENCED.name().toLowerCase(Locale.ROOT));
+  }
+
+  @Test
+  public void explicitlyDisablingForgetEvictedTxsWithSequenced() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isFalse(),
+        "--tx-pool",
+        SEQUENCED.name().toLowerCase(Locale.ROOT),
+        "--Xpeer-tracker-forget-evicted-txs=false");
+  }
+
+  @Test
+  public void defaultForgetEvictedTxsWithLayeredIsFalse() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isFalse(),
+        "--tx-pool",
+        LAYERED.name().toLowerCase(Locale.ROOT));
+  }
+
+  @Test
+  public void explicitlyEnablingForgetEvictedTxsWithLayered() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isTrue(),
+        "--tx-pool",
+        LAYERED.name().toLowerCase(Locale.ROOT),
+        "--Xpeer-tracker-forget-evicted-txs=true");
   }
 
   @Override

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -473,6 +473,15 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
+  public void fallbackValueForgetEvictedTxsWithSequenced() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isTrue(),
+        "--tx-pool",
+        SEQUENCED.name().toLowerCase(Locale.ROOT),
+        "--Xpeer-tracker-forget-evicted-txs");
+  }
+
+  @Test
   public void defaultForgetEvictedTxsWithLayeredIsFalse() {
     internalTestSuccess(
         config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isFalse(),
@@ -487,6 +496,15 @@ public class TransactionPoolOptionsTest
         "--tx-pool",
         LAYERED.name().toLowerCase(Locale.ROOT),
         "--Xpeer-tracker-forget-evicted-txs=true");
+  }
+
+  @Test
+  public void fallbackValueForgetEvictedTxsWithLayered() {
+    internalTestSuccess(
+        config -> assertThat(config.getUnstable().getPeerTrackerForgetEvictedTxs()).isTrue(),
+        "--tx-pool",
+        LAYERED.name().toLowerCase(Locale.ROOT),
+        "--Xpeer-tracker-forget-evicted-txs");
   }
 
   @Override

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolConfiguration.java
@@ -40,6 +40,8 @@ public interface TransactionPoolConfiguration {
   interface Unstable {
     Duration ETH65_TRX_ANNOUNCED_BUFFERING_PERIOD = Duration.ofMillis(500);
     int DEFAULT_TX_MSG_KEEP_ALIVE = 60;
+    int DEFAULT_MAX_TRACKED_SEEN_TXS_PER_PEER = 200_000;
+    boolean DEFAULT_PEER_TRACKER_FORGET_EVICTED_TXS = false;
 
     TransactionPoolConfiguration.Unstable DEFAULT =
         ImmutableTransactionPoolConfiguration.Unstable.builder().build();
@@ -52,6 +54,16 @@ public interface TransactionPoolConfiguration {
     @Value.Default
     default int getTxMessageKeepAliveSeconds() {
       return DEFAULT_TX_MSG_KEEP_ALIVE;
+    }
+
+    @Value.Default
+    default int getMaxTrackedSeenTxsPerPeer() {
+      return DEFAULT_MAX_TRACKED_SEEN_TXS_PER_PEER;
+    }
+
+    @Value.Default
+    default boolean getPeerTrackerForgetEvictedTxs() {
+      return DEFAULT_PEER_TRACKER_FORGET_EVICTED_TXS;
     }
   }
 

--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionPoolFactory.java
@@ -61,7 +61,7 @@ public class TransactionPoolFactory {
     final TransactionPoolMetrics metrics = new TransactionPoolMetrics(metricsSystem);
 
     final PeerTransactionTracker transactionTracker =
-        new PeerTransactionTracker(ethContext.getEthPeers());
+        new PeerTransactionTracker(transactionPoolConfiguration, ethContext.getEthPeers());
     final TransactionsMessageSender transactionsMessageSender =
         new TransactionsMessageSender(transactionTracker);
 

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherTest.java
@@ -33,6 +33,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthPeers;
 import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.eth.transactions.PeerTransactionTracker;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
 import org.hyperledger.besu.metrics.StubMetricsSystem;
 
@@ -70,7 +71,7 @@ public class BufferedGetPooledTransactionsFromPeerFetcherTest {
   public void setup() {
     metricsSystem = new StubMetricsSystem();
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
-    transactionTracker = new PeerTransactionTracker(ethPeers);
+    transactionTracker = new PeerTransactionTracker(TransactionPoolConfiguration.DEFAULT, ethPeers);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
     ScheduledFuture<?> mock = mock(ScheduledFuture.class);
     fetcher =

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherUsingPeerTaskTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/manager/task/BufferedGetPooledTransactionsFromPeerFetcherUsingPeerTaskTest.java
@@ -37,6 +37,7 @@ import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorRespon
 import org.hyperledger.besu.ethereum.eth.manager.peertask.PeerTaskExecutorResult;
 import org.hyperledger.besu.ethereum.eth.transactions.PeerTransactionTracker;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPool;
+import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolMetrics;
 import org.hyperledger.besu.metrics.StubMetricsSystem;
 import org.hyperledger.besu.testutil.DeterministicEthScheduler;
@@ -77,7 +78,7 @@ public class BufferedGetPooledTransactionsFromPeerFetcherUsingPeerTaskTest {
   public void setup() {
     metricsSystem = new StubMetricsSystem();
     when(ethContext.getEthPeers()).thenReturn(ethPeers);
-    transactionTracker = new PeerTransactionTracker(ethPeers);
+    transactionTracker = new PeerTransactionTracker(TransactionPoolConfiguration.DEFAULT, ethPeers);
     when(ethContext.getScheduler()).thenReturn(ethScheduler);
     when(ethContext.getPeerTaskExecutor()).thenReturn(peerTaskExecutor);
     ScheduledFuture<?> mock = mock(ScheduledFuture.class);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/AbstractTransactionPoolTestBase.java
@@ -236,7 +236,8 @@ public abstract class AbstractTransactionPoolTestBase {
     doNothing().when(ethScheduler).scheduleSyncWorkerTask(syncTaskCapture.capture());
     doReturn(ethScheduler).when(ethContext).getScheduler();
 
-    peerTransactionTracker = new PeerTransactionTracker(ethContext.getEthPeers());
+    peerTransactionTracker =
+        new PeerTransactionTracker(TransactionPoolConfiguration.DEFAULT, ethContext.getEthPeers());
     transactionBroadcaster =
         spy(
             new TransactionBroadcaster(

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageSenderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/NewPooledTransactionHashesMessageSenderTest.java
@@ -65,7 +65,7 @@ public class NewPooledTransactionHashesMessageSenderTest {
 
   @BeforeEach
   public void setUp() {
-    transactionTracker = new PeerTransactionTracker(ethPeers);
+    transactionTracker = new PeerTransactionTracker(TransactionPoolConfiguration.DEFAULT, ethPeers);
     messageSender = new NewPooledTransactionHashesMessageSender(transactionTracker);
     final Transaction tx = mock(Transaction.class);
     pendingTransactions = mock(PendingTransactions.class);

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageSenderTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/TransactionsMessageSenderTest.java
@@ -48,7 +48,8 @@ public class TransactionsMessageSenderTest {
   private final Transaction transaction2 = generator.transaction();
   private final Transaction transaction3 = generator.transaction();
 
-  private final PeerTransactionTracker transactionTracker = new PeerTransactionTracker(ethPeers);
+  private final PeerTransactionTracker transactionTracker =
+      new PeerTransactionTracker(TransactionPoolConfiguration.DEFAULT, ethPeers);
   private final TransactionsMessageSender messageSender =
       new TransactionsMessageSender(transactionTracker);
 


### PR DESCRIPTION
## PR description

In PR #7755 the default behavior of the peer transaction tracker changed from always remember the txs exchanged with a peer (at least until they fits in the cache) to forget a txs has been already exchanged in case it is evicted from the pool for reason not related to the validity.

While the new default solves issues with re-broadcasting the same tx in small networks, it does not works well for public networks, where there are many thousands of pending txs and a lot of independent nodes, since it can cause the broadcast and the re-evaluation of already seen txs, with the waste of network and computation resources.

So this PR changes the current default based on the txpool implementation that is chosen:
* for Layered the default is to not forget on eviction (new behavior), since it is the implementation designed for public networks.
* for Sequencer the default is to forget on eviction (current behavior) since it is the implementation that is used in private/permissioned networks.

Moreover it is possible to overwrite the default behavior using the new experimental option `Xpeer-tracker-forget-evicted-txs`.

Another option has been added to customized the max size of the cache that keeps memory of the tx exchanged with each peers, so it can be tuned to adapt to increases in the pending txs number. The new option is `Xmax-tracked-seen-txs-per-peer` and by default is now `200_000` entries, double from the previous hard coded value.



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

