### PR TITLE
Modify besu plugin api for block added event

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
+++ b/besu/src/main/java/org/hyperledger/besu/services/BlockchainServiceImpl.java
@@ -82,6 +82,17 @@ public class BlockchainServiceImpl implements BlockchainService {
         .map(block -> blockContext(block::getHeader, block::getBody));
   }
 
+  /**
+   * Gets block header by hash
+   *
+   * @param hash the block hash
+   * @return the block header if block exists otherwise empty
+   */
+  @Override
+  public Optional<BlockHeader> getBlockHeaderByHash(final Hash hash) {
+    return blockchain.getBlockHeader(hash).map(BlockHeader.class::cast);
+  }
+
   @Override
   public Hash getChainHeadHash() {
     return blockchain.getChainHeadHash();

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/chain/DefaultBlockchain.java
@@ -736,10 +736,9 @@ public class DefaultBlockchain implements MutableBlockchain {
       final Block block = blockWithReceipts.getBlock();
 
       var reorgEvent = handleChainReorg(updater, blockWithReceipts);
+      updateCacheForNewCanonicalHead(block, calculateTotalDifficulty(block.getHeader()));
       updater.commit();
       blockAddedObservers.forEach(o -> o.onBlockAdded(reorgEvent));
-
-      updateCacheForNewCanonicalHead(block, calculateTotalDifficulty(block.getHeader()));
       return true;
     } catch (final NoSuchElementException e) {
       // Any Optional.get() calls in this block should be present, missing data means data

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/BlockchainService.java
@@ -46,6 +46,14 @@ public interface BlockchainService extends BesuService {
   Optional<BlockContext> getBlockByHash(final Hash hash);
 
   /**
+   * Gets block header by hash
+   *
+   * @param hash the block hash
+   * @return the block header if block exists otherwise empty
+   */
+  Optional<BlockHeader> getBlockHeaderByHash(final Hash hash);
+
+  /**
    * Get the hash of the chain head
    *
    * @return chain head hash


### PR DESCRIPTION
## PR description

This PR update some mechanism related to the besu plugin api 
- Add new block header by hash method in the besu plugin api
- Fix inconsistencies when we emit a block added event : we shoud update the chain head before sending the event

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

