### PR TITLE
feature:Block Start/End tracing in AbstractBlockProcessor, refactor of BlockProcessor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Additions and Improvements
 #### Dependencies
 ### Bug fixes
+- fix block import tracing, refactor BlockProcessor interface [#8549](https://github.com/hyperledger/besu/pull/8549)
 
 ## 25.4.1
 

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -108,7 +108,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
               // if block import tracer provider is not specified by plugin, default to no tracing
               .orElse(
                   (__) -> {
-                    LOG.info("Block Import uses NO_TRACING");
+                    LOG.trace("Block Import uses NO_TRACING");
                     return BlockAwareOperationTracer.NO_TRACING;
                   });
     }
@@ -160,7 +160,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final BlockAwareOperationTracer blockTracer =
         getBlockImportTracer(protocolContext, blockHeader);
 
-    LOG.info("traceStartBlock for {}", blockHeader.getNumber());
+    LOG.trace("traceStartBlock for {}", blockHeader.getNumber());
     blockTracer.traceStartBlock(blockHeader, blockHeader.getCoinbase());
 
     final BlockProcessingContext blockProcessingContext =
@@ -307,7 +307,7 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
       return new BlockProcessingResult(Optional.empty(), "ommer too old");
     }
 
-    LOG.info("traceEndBlock for {}", blockHeader.getNumber());
+    LOG.trace("traceEndBlock for {}", blockHeader.getNumber());
     blockTracer.traceEndBlock(blockHeader, blockBody);
 
     try {

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessor.java
@@ -160,6 +160,8 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
     final BlockAwareOperationTracer blockTracer =
         getBlockImportTracer(protocolContext, blockHeader);
 
+    final Address miningBeneficiary = miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
+
     LOG.trace("traceStartBlock for {}", blockHeader.getNumber());
     blockTracer.traceStartBlock(blockHeader, blockHeader.getCoinbase());
 
@@ -167,8 +169,6 @@ public abstract class AbstractBlockProcessor implements BlockProcessor {
         new BlockProcessingContext(
             blockHeader, worldState, protocolSpec, blockHashLookup, blockTracer);
     protocolSpec.getBlockHashProcessor().process(blockProcessingContext);
-
-    final Address miningBeneficiary = miningBeneficiaryCalculator.calculateBeneficiary(blockHeader);
 
     Optional<BlockHeader> maybeParentHeader =
         blockchain.getBlockHeader(blockHeader.getParentHash());

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/BlockProcessor.java
@@ -19,11 +19,8 @@ import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
 import org.hyperledger.besu.ethereum.core.Block;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 
 import java.util.List;
@@ -75,95 +72,28 @@ public interface BlockProcessor {
    * @param block the block to process
    * @return the block processing result
    */
-  default BlockProcessingResult processBlock(
-      final ProtocolContext protocolContext,
-      final Blockchain blockchain,
-      final MutableWorldState worldState,
-      final Block block) {
-    return processBlock(
-        protocolContext,
-        blockchain,
-        worldState,
-        block.getHeader(),
-        block.getBody().getTransactions(),
-        block.getBody().getOmmers(),
-        block.getBody().getWithdrawals(),
-        null);
-  }
-
-  /**
-   * Processes the block.
-   *
-   * @param protocolContext the current context of the protocol
-   * @param blockchain the blockchain to append the block to
-   * @param worldState the world state to apply changes to
-   * @param blockHeader the block header for the block
-   * @param transactions the transactions in the block
-   * @param ommers the block ommers
-   * @return the block processing result
-   */
-  default BlockProcessingResult processBlock(
-      final ProtocolContext protocolContext,
-      final Blockchain blockchain,
-      final MutableWorldState worldState,
-      final BlockHeader blockHeader,
-      final List<Transaction> transactions,
-      final List<BlockHeader> ommers) {
-    return processBlock(
-        protocolContext,
-        blockchain,
-        worldState,
-        blockHeader,
-        transactions,
-        ommers,
-        Optional.empty(),
-        null);
-  }
-
-  /**
-   * Processes the block.
-   *
-   * @param protocolContext the current context of the protocol
-   * @param blockchain the blockchain to append the block to
-   * @param worldState the world state to apply changes to
-   * @param blockHeader the block header for the block
-   * @param transactions the transactions in the block
-   * @param ommers the block ommers
-   * @param withdrawals the withdrawals for the block
-   * @param privateMetadataUpdater the updater used to update the private metadata for the block
-   * @return the block processing result
-   */
   BlockProcessingResult processBlock(
-      ProtocolContext protocolContext,
-      Blockchain blockchain,
-      MutableWorldState worldState,
-      BlockHeader blockHeader,
-      List<Transaction> transactions,
-      List<BlockHeader> ommers,
-      Optional<List<Withdrawal>> withdrawals,
-      PrivateMetadataUpdater privateMetadataUpdater);
+      final ProtocolContext protocolContext,
+      final Blockchain blockchain,
+      final MutableWorldState worldState,
+      final Block block);
 
   /**
-   * Processes the block when running Besu in GoQuorum-compatible mode
+   * Processes the block.
    *
    * @param protocolContext the current context of the protocol
    * @param blockchain the blockchain to append the block to
-   * @param worldState the world state to apply public transactions to
-   * @param privateWorldState the private world state to apply private transaction to
+   * @param worldState the world state to apply changes to
    * @param block the block to process
    * @return the block processing result
    */
-  default BlockProcessingResult processBlock(
+  BlockProcessingResult processBlock(
       final ProtocolContext protocolContext,
       final Blockchain blockchain,
       final MutableWorldState worldState,
-      final MutableWorldState privateWorldState,
-      final Block block) {
-    /*
-     This method should never be executed. All GoQuorum processing must happen in the GoQuorumBlockProcessor.
-    */
-    throw new IllegalStateException("Tried to process GoQuorum block on AbstractBlockProcessor");
-  }
+      final Block block,
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
+      final AbstractBlockProcessor.PreprocessingFunction preprocessingBlockFunction);
 
   /**
    * Get ommer reward in ${@link Wei}

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetProtocolSpecs.java
@@ -28,12 +28,11 @@ import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.MainnetBlockValidator;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
-import org.hyperledger.besu.ethereum.core.Transaction;
 import org.hyperledger.besu.ethereum.core.TransactionReceipt;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
 import org.hyperledger.besu.ethereum.core.feemarket.CoinbaseFeePriceCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder.BlockValidatorBuilder;
 import org.hyperledger.besu.ethereum.mainnet.blockhash.CancunBlockHashProcessor;
@@ -1125,21 +1124,32 @@ public abstract class MainnetProtocolSpecs {
         final ProtocolContext protocolContext,
         final Blockchain blockchain,
         final MutableWorldState worldState,
-        final BlockHeader blockHeader,
-        final List<Transaction> transactions,
-        final List<BlockHeader> ommers,
-        final Optional<List<Withdrawal>> withdrawals,
-        final PrivateMetadataUpdater privateMetadataUpdater) {
+        final Block block) {
+      return processBlock(
+          protocolContext,
+          blockchain,
+          worldState,
+          block,
+          Optional.empty(),
+          new AbstractBlockProcessor.PreprocessingFunction.NoPreprocessing());
+    }
+
+    @Override
+    public BlockProcessingResult processBlock(
+        final ProtocolContext protocolContext,
+        final Blockchain blockchain,
+        final MutableWorldState worldState,
+        final Block block,
+        final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
+        final AbstractBlockProcessor.PreprocessingFunction preprocessingBlockFunction) {
       updateWorldStateForDao(worldState);
       return wrapped.processBlock(
           protocolContext,
           blockchain,
           worldState,
-          blockHeader,
-          transactions,
-          ommers,
-          withdrawals,
-          privateMetadataUpdater);
+          block,
+          privateMetadataUpdater,
+          preprocessingBlockFunction);
     }
 
     private static final Address DAO_REFUND_CONTRACT_ADDRESS =

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/MainnetTransactionProcessor.java
@@ -146,7 +146,7 @@ public class MainnetTransactionProcessor {
         blockHashLookup,
         isPersistingPrivateState,
         transactionValidationParams,
-        null,
+        Optional.empty(),
         blobGasPrice);
   }
 
@@ -185,7 +185,7 @@ public class MainnetTransactionProcessor {
         blockHashLookup,
         isPersistingPrivateState,
         transactionValidationParams,
-        null,
+        Optional.empty(),
         blobGasPrice);
   }
 
@@ -219,7 +219,7 @@ public class MainnetTransactionProcessor {
         blockHashLookup,
         isPersistingPrivateState,
         ImmutableTransactionValidationParams.builder().build(),
-        null,
+        Optional.empty(),
         blobGasPrice);
   }
 
@@ -255,7 +255,7 @@ public class MainnetTransactionProcessor {
         blockHashLookup,
         isPersistingPrivateState,
         transactionValidationParams,
-        null,
+        Optional.empty(),
         blobGasPrice);
   }
 
@@ -268,7 +268,7 @@ public class MainnetTransactionProcessor {
       final BlockHashLookup blockHashLookup,
       final Boolean isPersistingPrivateState,
       final TransactionValidationParams transactionValidationParams,
-      final PrivateMetadataUpdater privateMetadataUpdater,
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
       final Wei blobGasPrice) {
     try {
       final var transactionValidator = transactionValidatorFactory.get();
@@ -376,8 +376,8 @@ public class MainnetTransactionProcessor {
               .put(KEY_IS_PERSISTING_PRIVATE_STATE, isPersistingPrivateState)
               .put(KEY_TRANSACTION, transaction)
               .put(KEY_TRANSACTION_HASH, transaction.getHash());
-      if (privateMetadataUpdater != null) {
-        contextVariablesBuilder.put(KEY_PRIVATE_METADATA_UPDATER, privateMetadataUpdater);
+      if (privateMetadataUpdater.isPresent()) {
+        contextVariablesBuilder.put(KEY_PRIVATE_METADATA_UPDATER, privateMetadataUpdater.get());
       }
 
       operationTracer.traceStartTransaction(worldUpdater, transaction);

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/MainnetParallelBlockProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/MainnetParallelBlockProcessor.java
@@ -19,17 +19,16 @@ import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.BlockProcessingResult;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
-import org.hyperledger.besu.ethereum.core.BlockHeader;
+import org.hyperledger.besu.ethereum.core.Block;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.core.Withdrawal;
-import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor.PreprocessingFunction.NoPreprocessing;
 import org.hyperledger.besu.ethereum.mainnet.BlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MainnetTransactionProcessor;
 import org.hyperledger.besu.ethereum.mainnet.MiningBeneficiaryCalculator;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSchedule;
 import org.hyperledger.besu.ethereum.mainnet.ProtocolSpecBuilder;
+import org.hyperledger.besu.ethereum.mainnet.systemcall.BlockProcessingContext;
 import org.hyperledger.besu.ethereum.privacy.storage.PrivateMetadataUpdater;
 import org.hyperledger.besu.ethereum.processing.TransactionProcessingResult;
 import org.hyperledger.besu.evm.blockhash.BlockHashLookup;
@@ -38,7 +37,6 @@ import org.hyperledger.besu.metrics.BesuMetricCategory;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.hyperledger.besu.plugin.services.metrics.Counter;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -89,10 +87,9 @@ public class MainnetParallelBlockProcessor extends MainnetBlockProcessor {
   @Override
   protected TransactionProcessingResult getTransactionProcessingResult(
       final Optional<PreprocessingContext> preProcessingContext,
-      final MutableWorldState worldState,
+      final BlockProcessingContext blockProcessingContext,
       final WorldUpdater blockUpdater,
-      final PrivateMetadataUpdater privateMetadataUpdater,
-      final BlockHeader blockHeader,
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
       final Wei blobGasPrice,
       final Address miningBeneficiary,
       final Transaction transaction,
@@ -108,7 +105,7 @@ public class MainnetParallelBlockProcessor extends MainnetBlockProcessor {
           parallelizedPreProcessingContext
               .parallelizedConcurrentTransactionProcessor()
               .applyParallelizedTransactionResult(
-                  worldState,
+                  blockProcessingContext.getWorldState(),
                   miningBeneficiary,
                   transaction,
                   location,
@@ -120,10 +117,9 @@ public class MainnetParallelBlockProcessor extends MainnetBlockProcessor {
     if (transactionProcessingResult == null) {
       return super.getTransactionProcessingResult(
           preProcessingContext,
-          worldState,
+          blockProcessingContext,
           blockUpdater,
           privateMetadataUpdater,
-          blockHeader,
           blobGasPrice,
           miningBeneficiary,
           transaction,
@@ -139,39 +135,23 @@ public class MainnetParallelBlockProcessor extends MainnetBlockProcessor {
       final ProtocolContext protocolContext,
       final Blockchain blockchain,
       final MutableWorldState worldState,
-      final BlockHeader blockHeader,
-      final List<Transaction> transactions,
-      final List<BlockHeader> ommers,
-      final Optional<List<Withdrawal>> maybeWithdrawals,
-      final PrivateMetadataUpdater privateMetadataUpdater) {
+      final Block block) {
     final BlockProcessingResult blockProcessingResult =
         super.processBlock(
             protocolContext,
             blockchain,
             worldState,
-            blockHeader,
-            transactions,
-            ommers,
-            maybeWithdrawals,
-            privateMetadataUpdater,
+            block,
+            Optional.empty(),
             new ParallelTransactionPreprocessing(transactionProcessor, executor));
 
     if (blockProcessingResult.isFailed()) {
       // Fallback to non-parallel processing if there is a block processing exception .
       LOG.info(
           "Parallel transaction processing failure. Falling back to non-parallel processing for block #{} ({})",
-          blockHeader.getNumber(),
-          blockHeader.getBlockHash());
-      return super.processBlock(
-          protocolContext,
-          blockchain,
-          worldState,
-          blockHeader,
-          transactions,
-          ommers,
-          maybeWithdrawals,
-          privateMetadataUpdater,
-          new NoPreprocessing());
+          block.getHeader().getNumber(),
+          block.getHash());
+      return super.processBlock(protocolContext, blockchain, worldState, block);
     }
     return blockProcessingResult;
   }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelTransactionPreprocessing.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelTransactionPreprocessing.java
@@ -45,7 +45,7 @@ public class ParallelTransactionPreprocessing implements PreprocessingFunction {
   @Override
   public Optional<PreprocessingContext> run(
       final ProtocolContext protocolContext,
-      final PrivateMetadataUpdater privateMetadataUpdater,
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
       final BlockHeader blockHeader,
       final List<Transaction> transactions,
       final Address miningBeneficiary,

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessor.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessor.java
@@ -103,7 +103,7 @@ public class ParallelizedConcurrentTransactionProcessor {
       final Address miningBeneficiary,
       final BlockHashLookup blockHashLookup,
       final Wei blobGasPrice,
-      final PrivateMetadataUpdater privateMetadataUpdater,
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater,
       final Executor executor) {
 
     completableFuturesForBackgroundTransactions = new CompletableFuture[transactions.size()];
@@ -137,7 +137,7 @@ public class ParallelizedConcurrentTransactionProcessor {
       final Address miningBeneficiary,
       final BlockHashLookup blockHashLookup,
       final Wei blobGasPrice,
-      final PrivateMetadataUpdater privateMetadataUpdater) {
+      final Optional<PrivateMetadataUpdater> privateMetadataUpdater) {
     final BlockHeader chainHeadHeader = protocolContext.getBlockchain().getChainHeadHeader();
     if (chainHeadHeader.getHash().equals(blockHeader.getParentHash())) {
       try (BonsaiWorldState ws =

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/MainnetBlockValidatorTest.java
@@ -106,11 +106,7 @@ public class MainnetBlockValidatorTest {
     when(blockBodyValidator.validateBodyLight(any(), any(), any(), any())).thenReturn(true);
     when(blockProcessor.processBlock(eq(protocolContext), any(), any(), any()))
         .thenReturn(successfulProcessingResult);
-    when(blockProcessor.processBlock(any(), any(), any(), any()))
-        .thenReturn(successfulProcessingResult);
-    when(blockProcessor.processBlock(any(), any(), any(), any(), any()))
-        .thenReturn(successfulProcessingResult);
-    when(blockProcessor.processBlock(any(), any(), any(), any(), any(), any(), any(), any()))
+    when(blockProcessor.processBlock(eq(protocolContext), any(), any(), any(), any(), any()))
         .thenReturn(successfulProcessingResult);
 
     assertNoBadBlocks();

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/AbstractBlockProcessorIntegrationTest.java
@@ -36,7 +36,6 @@ import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.ExecutionContextTestFixture;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
 import org.hyperledger.besu.ethereum.core.Transaction;
-import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor.PreprocessingFunction.NoPreprocessing;
 import org.hyperledger.besu.ethereum.mainnet.AbstractBlockProcessor.TransactionReceiptFactory;
 import org.hyperledger.besu.ethereum.mainnet.parallelization.MainnetParallelBlockProcessor;
 import org.hyperledger.besu.ethereum.mainnet.parallelization.ParallelTransactionPreprocessing;
@@ -260,24 +259,12 @@ class AbstractBlockProcessorIntegrationTest {
             protocolContext,
             blockchain,
             worldStateParallel,
-            block.getHeader(),
-            List.of(transactions),
-            block.getBody().getOmmers(),
-            block.getBody().getWithdrawals(),
-            null,
+            block,
+            Optional.empty(),
             new ParallelTransactionPreprocessing(transactionProcessor, Runnable::run));
 
     BlockProcessingResult sequentialResult =
-        blockProcessor.processBlock(
-            protocolContext,
-            blockchain,
-            worldStateSequential,
-            block.getHeader(),
-            List.of(transactions),
-            block.getBody().getOmmers(),
-            block.getBody().getWithdrawals(),
-            null,
-            new NoPreprocessing());
+        blockProcessor.processBlock(protocolContext, blockchain, worldStateSequential, block);
 
     assertTrue(sequentialResult.isSuccessful());
     assertTrue(parallelResult.isSuccessful());

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/MainnetBlockProcessorTest.java
@@ -14,7 +14,6 @@
  */
 package org.hyperledger.besu.ethereum.mainnet;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +24,8 @@ import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.ethereum.ProtocolContext;
 import org.hyperledger.besu.ethereum.chain.Blockchain;
+import org.hyperledger.besu.ethereum.core.Block;
+import org.hyperledger.besu.ethereum.core.BlockBody;
 import org.hyperledger.besu.ethereum.core.BlockHeader;
 import org.hyperledger.besu.ethereum.core.BlockHeaderTestFixture;
 import org.hyperledger.besu.ethereum.core.MutableWorldState;
@@ -69,13 +70,14 @@ public class MainnetBlockProcessorTest extends AbstractBlockProcessorTest {
     final MutableWorldState worldState = ReferenceTestWorldState.create(emptyMap());
     final Hash initialHash = worldState.rootHash();
 
-    final BlockHeader emptyBlockHeader =
-        new BlockHeaderTestFixture()
-            .transactionsRoot(Hash.EMPTY_LIST_HASH)
-            .ommersHash(Hash.EMPTY_LIST_HASH)
-            .buildHeader();
-    blockProcessor.processBlock(
-        protocolContext, blockchain, worldState, emptyBlockHeader, emptyList(), emptyList());
+    final Block emptyBlock =
+        new Block(
+            new BlockHeaderTestFixture()
+                .transactionsRoot(Hash.EMPTY_LIST_HASH)
+                .ommersHash(Hash.EMPTY_LIST_HASH)
+                .buildHeader(),
+            BlockBody.empty());
+    blockProcessor.processBlock(protocolContext, blockchain, worldState, emptyBlock);
 
     // An empty block with 0 reward should not change the world state
     assertThat(worldState.rootHash()).isEqualTo(initialHash);
@@ -96,16 +98,17 @@ public class MainnetBlockProcessorTest extends AbstractBlockProcessorTest {
     final MutableWorldState worldState = ReferenceTestWorldState.create(emptyMap());
     final Hash initialHash = worldState.rootHash();
 
-    final BlockHeader emptyBlockHeader =
-        new BlockHeaderTestFixture()
-            .transactionsRoot(Hash.EMPTY_LIST_HASH)
-            .stateRoot(
-                Hash.fromHexString(
-                    "0xa6b5d50f7b3c39b969c2fe8fed091939c674fef49b4826309cb6994361e39b71"))
-            .ommersHash(Hash.EMPTY_LIST_HASH)
-            .buildHeader();
-    blockProcessor.processBlock(
-        protocolContext, blockchain, worldState, emptyBlockHeader, emptyList(), emptyList());
+    final Block emptyBlock =
+        new Block(
+            new BlockHeaderTestFixture()
+                .transactionsRoot(Hash.EMPTY_LIST_HASH)
+                .stateRoot(
+                    Hash.fromHexString(
+                        "0xa6b5d50f7b3c39b969c2fe8fed091939c674fef49b4826309cb6994361e39b71"))
+                .ommersHash(Hash.EMPTY_LIST_HASH)
+                .buildHeader(),
+            BlockBody.empty());
+    blockProcessor.processBlock(protocolContext, blockchain, worldState, emptyBlock);
 
     // An empty block with 0 reward should change the world state prior to EIP158
     assertThat(worldState.rootHash()).isNotEqualTo(initialHash);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/PrivacyBlockProcessorTest.java
@@ -117,20 +117,16 @@ class PrivacyBlockProcessorTest {
             eq(protocolContext),
             eq(blockchain),
             eq(mutableWorldState),
-            eq(firstBlock.getHeader()),
-            eq(firstBlock.getBody().getTransactions()),
-            eq(firstBlock.getBody().getOmmers()),
-            eq(Optional.empty()),
+            eq(firstBlock),
+            any(),
             any());
     verify(blockProcessor)
         .processBlock(
             eq(protocolContext),
             eq(blockchain),
             eq(mutableWorldState),
-            eq(secondBlock.getHeader()),
-            eq(secondBlock.getBody().getTransactions()),
-            eq(secondBlock.getBody().getOmmers()),
-            eq(Optional.empty()),
+            eq(secondBlock),
+            any(),
             any());
   }
 
@@ -183,10 +179,8 @@ class PrivacyBlockProcessorTest {
             eq(protocolContext),
             eq(blockchain),
             eq(mutableWorldState),
-            eq(secondBlock.getHeader()),
-            eq(secondBlock.getBody().getTransactions()),
-            eq(secondBlock.getBody().getOmmers()),
-            eq(Optional.empty()),
+            eq(secondBlock),
+            any(),
             any());
   }
 

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/mainnet/parallelization/ParallelizedConcurrentTransactionProcessorTest.java
@@ -70,15 +70,17 @@ class ParallelizedConcurrentTransactionProcessorTest {
   @Mock private BlockHeader blockHeader;
   @Mock ProtocolContext protocolContext;
   @Mock private Transaction transaction;
-  @Mock private PrivateMetadataUpdater privateMetadataUpdater;
+  @Mock private PrivateMetadataUpdater mockPrivateMetadataUpdater;
   @Mock private TransactionCollisionDetector transactionCollisionDetector;
 
   private BonsaiWorldState worldState;
+  private Optional<PrivateMetadataUpdater> privateMetadataUpdater;
 
   private ParallelizedConcurrentTransactionProcessor processor;
 
   @BeforeEach
   void setUp() {
+    privateMetadataUpdater = Optional.of(mockPrivateMetadataUpdater);
     processor =
         new ParallelizedConcurrentTransactionProcessor(
             transactionProcessor, transactionCollisionDetector);


### PR DESCRIPTION
## PR description

motivation: Block Import tracing needs to both start AND end block tracing.  

#8534 added block import tracing, but does not call block tracing end.  In order to have BlockBody available to call traceBlockEnd(), the BlockProcessor interface and implementations have to be refactored a bit.

The resulting interface is cleaner IMO, so that is a bonus



## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [X] spotless: `./gradlew spotlessApply`
- [X] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

