### PR TITLE
[TEST] add pragueTime override in DifficultyCalculatorTest

### DIFF
--- a/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculatorTests.java
+++ b/ethereum/referencetests/src/reference-test/java/org/hyperledger/besu/ethereum/mainnet/DifficultyCalculatorTests.java
@@ -53,6 +53,7 @@ public class DifficultyCalculatorTests {
     Map<String, String> postMergeOverrides = new HashMap<>();
     postMergeOverrides.put("shanghaiTime", "999999999999");
     postMergeOverrides.put("cancunTime","999999999999");
+    postMergeOverrides.put("pragueTime","999999999999");
     return Stream.of(
         Arguments.of(
             "/BasicTests/difficultyMainNetwork.json",


### PR DESCRIPTION
## PR description

Fixes initialization error re prague time - required since #8521 

```
Genesis Config Error: 'Prague' is scheduled for milestone 1746612311 but it must be on or after milestone 999999999999.
java.lang.RuntimeException: Genesis Config Error: 'Prague' is scheduled for milestone 1746612311 but it must be on or after milestone 999999999999.
	at org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder.validateForkOrder(ProtocolScheduleBuilder.java:267)
	at org.hyperledger.besu.ethereum.mainnet.ProtocolScheduleBuilder.validateEthereumForkOrdering(ProtocolScheduleBuilder.java:233)
```

### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [x] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

