### PR TITLE
Fix the version printed in the overview

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -309,7 +309,7 @@ public class ConfigurationOverviewBuilder {
    */
   public String build() {
     final List<String> lines = new ArrayList<>();
-    lines.add("Besu version " + BesuVersionUtils.version());
+    lines.add("Besu version " + BesuVersionUtils.shortVersion());
     lines.add("");
     lines.add("Configuration:");
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -2404,6 +2404,13 @@ public class BesuCommandTest extends CommandTestAbstract {
   }
 
   @Test
+  public void verifyVersionInTheConfigurationOverviewIsCorrect() {
+    parseCommand();
+    verify(mockLogger)
+        .info(argThat(arg -> arg.contains("# Besu version " + BesuVersionUtils.shortVersion())));
+  }
+
+  @Test
   public void checkpointPostMergeShouldFailWhenGenesisHasNoTTD() throws IOException {
     final String configText =
         Resources.toString(

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -46,7 +46,9 @@ public class VersionMetadata implements Comparable<VersionMetadata> {
    * @return the version of Besu
    */
   public static String getRuntimeVersionString() {
-    return BesuVersionUtils.version() == null ? BESU_VERSION_UNKNOWN : BesuVersionUtils.version();
+    return BesuVersionUtils.shortVersion() == null
+        ? BESU_VERSION_UNKNOWN
+        : BesuVersionUtils.shortVersion();
   }
 
   public static VersionMetadata getRuntimeVersion() {


### PR DESCRIPTION
## PR description

The refactor in https://github.com/hyperledger/besu/pull/8536 introduced a change in the version logged as part of the overview, instead of the short version `Besu version 25.4.1` the long version is used `Besu version besu/v25.4.1/linux-x86_64/openjdk-java-21`, this PR restore the previous behavior.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

