### PR TITLE
plugin-api: TrieLogAccumulator add lookups for account and storage

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/PathBasedWorldStateUpdateAccumulator.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/trie/pathbased/common/worldview/accumulator/PathBasedWorldStateUpdateAccumulator.java
@@ -250,6 +250,15 @@ public abstract class PathBasedWorldStateUpdateAccumulator<ACCOUNT extends PathB
     return super.getAccount(address);
   }
 
+  /**
+   * Note: PathBasedAccount implements both MutableAccount and AccountValue, so this cast is safe
+   * even though the compiler can't verify it.
+   */
+  @Override
+  public <T extends AccountValue> T getAccountValue(final Address address) {
+    return (T) getAccount(address);
+  }
+
   @Override
   public MutableAccount createAccount(final Address address, final long nonce, final Wei balance) {
     PathBasedValue<ACCOUNT> pathBasedValue = accountsToUpdate.get(address);

--- a/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/AccumulatorAccessTests.java
+++ b/ethereum/core/src/test/java/org/hyperledger/besu/ethereum/trie/pathbased/bonsai/worldview/AccumulatorAccessTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.hyperledger.besu.ethereum.trie.pathbased.bonsai.worldview;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hyperledger.besu.ethereum.trie.pathbased.common.provider.WorldStateQueryParams.withBlockHeaderAndNoUpdateNodeHead;
+
+import org.hyperledger.besu.ethereum.core.BlockchainSetupUtil;
+import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.AbstractIsolationTests;
+import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+
+import org.junit.jupiter.api.Test;
+
+public class AccumulatorAccessTests extends AbstractIsolationTests {
+
+  @Test
+  public void assertBonsaiAccumulatorCastIsSafe() {
+    var testChain = BlockchainSetupUtil.forTesting(DataStorageFormat.BONSAI);
+    var headHeader = testChain.getBlockchain().getChainHeadHeader();
+    var ws =
+        testChain
+            .getWorldArchive()
+            .getWorldState(withBlockHeaderAndNoUpdateNodeHead(headHeader))
+            .map(BonsaiWorldState.class::cast)
+            .orElseThrow();
+    var address = headHeader.getCoinbase();
+    // get as mutable account via WorldUpdater interface
+    var mutableAccount = ws.getAccumulator().getAccount(address);
+    // get as accountValue via TrieLogAccumulator interface
+    var accountVal = ws.getAccumulator().getAccountValue(address);
+    assertThat(accountVal).isEqualTo(mutableAccount);
+  }
+}

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = '/JSk28zZNkhV0ccft86fPaks1bBRg/tJ1ptlEHGuwqQ='
+  knownHash = '8J+8BvVtWtSa+iTB0A3w8cF7sABEcZIL8B3WN7+Jdag='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/build.gradle
+++ b/plugin-api/build.gradle
@@ -71,7 +71,7 @@ Calculated : ${currentHash}
 tasks.register('checkAPIChanges', FileStateChecker) {
   description = "Checks that the API for the Plugin-API project does not change without deliberate thought"
   files = sourceSets.main.allJava.files
-  knownHash = 'oLLEhw3aGJ8Q/yIJh8E2nQrRFprh9rGVYwag0qJY/Kk='
+  knownHash = '/JSk28zZNkhV0ccft86fPaks1bBRg/tJ1ptlEHGuwqQ='
 }
 check.dependsOn('checkAPIChanges')
 

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/trielogs/TrieLogAccumulator.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/trielogs/TrieLogAccumulator.java
@@ -19,6 +19,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -47,4 +48,19 @@ public interface TrieLogAccumulator {
    */
   Map<Address, ? extends Map<StorageSlotKey, ? extends TrieLog.LogTuple<UInt256>>>
       getStorageToUpdate();
+
+  /**
+   * Returns current account value
+   *
+   * @return the current AccountValue.
+   */
+  <T extends AccountValue> T getAccountValue(Address address);
+
+  /**
+   * Returns current account storage slot value
+   *
+   * @return the current storage slot value
+   */
+  Optional<UInt256> getStorageValueByStorageSlotKey(
+      final Address address, final StorageSlotKey storageSlotKey);
 }

--- a/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/trielogs/TrieLogAccumulator.java
+++ b/plugin-api/src/main/java/org/hyperledger/besu/plugin/services/trielogs/TrieLogAccumulator.java
@@ -52,6 +52,8 @@ public interface TrieLogAccumulator {
   /**
    * Returns current account value
    *
+   * @param <T> the specific storage subclass
+   * @param address the address to lookup
    * @return the current AccountValue.
    */
   <T extends AccountValue> T getAccountValue(Address address);
@@ -59,6 +61,8 @@ public interface TrieLogAccumulator {
   /**
    * Returns current account storage slot value
    *
+   * @param address the address to fetch storage from
+   * @param storageSlotKey the slot key for which to fetch storager
    * @return the current storage slot value
    */
   Optional<UInt256> getStorageValueByStorageSlotKey(


### PR DESCRIPTION
## PR description
Expose methods to lookup account and storage info in the accumulator plugin-api

Motivation: allow TrieLogFactory plugin to 'decorate' the accumulator maps prior to generating the trielog.  

In this instance we want Linea besu to be able to add state elements to the generated trielog for shomei


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [X] spotless: `./gradlew spotlessApply`
- [X] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

