### PR TITLE
Improve performance of LayeredKeyValueStorage.get method

### DIFF
--- a/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
+++ b/services/kvstore/src/main/java/org/hyperledger/besu/services/kvstore/SegmentedInMemoryKeyValueStorage.java
@@ -25,6 +25,7 @@ import org.hyperledger.besu.plugin.services.storage.SnappableKeyValueStorage;
 import org.hyperledger.besu.plugin.services.storage.SnappedKeyValueStorage;
 
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -75,10 +76,14 @@ public class SegmentedInMemoryKeyValueStorage
    * @return populated segment map
    */
   protected static NavigableMap<Bytes, Optional<byte[]>> newSegmentMap(
-      final Map<Bytes, Optional<byte[]>> sourceMap) {
-    // comparing by string to prevent Bytes comparator from collapsing zeroes
+          final Map<Bytes, Optional<byte[]>> sourceMap) {
+
+    Comparator<Bytes> byteWiseComparator =
+            Comparator.comparing(Bytes::toArrayUnsafe, Arrays::compare);
+
     NavigableMap<Bytes, Optional<byte[]>> segMap =
-        new ConcurrentSkipListMap<>(Comparator.comparing(Bytes::toHexString));
+            new ConcurrentSkipListMap<>(byteWiseComparator);
+
     segMap.putAll(sourceMap);
     return segMap;
   }


### PR DESCRIPTION
## PR description
When profiling big blocks on a devnet where besu is sync'ing with lock step, I noticed in the profiling that using Bytes.toHexString for comparaison is hurting the performances because of the usage of megamorphic methods in this method, like get method on Bytes implementations. The pink part of the profiling below corresponds to the cost of the get megamorphic call

<img width="1698" alt="image" src="https://github.com/user-attachments/assets/86861b4e-f877-49ac-9087-1c10d6e18308" />

This PR changes the way keys are compared by working on the underlying arrays and use Arrays.compare to do the comparaison. We can see below the new profiling following this optimization.

<img width="1698" alt="image" src="https://github.com/user-attachments/assets/0bd4465c-a8e3-4690-b324-b31b61dc6de3" />


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

