### PR TITLE
Standardise log content in AbstractEngineNewPayload and AbstractEngineForkchoiceUpdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - update jc-kzg-4844 dependency from 2.0.0 to 2.1.1
 ### Bug fixes
 - fix block import tracing, refactor BlockProcessor interface [#8549](https://github.com/hyperledger/besu/pull/8549)
+- Shorten and standardise log labels in AbstractEngineNewPayload and AbstractEngineForkchoiceUpdated [#8568](https://github.com/hyperledger/besu/pull/8568)
 
 ## 25.4.1
 

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -384,7 +384,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
 
   // fcU calls are synchronous, no need to make volatile
   private long lastFcuInfoLog = System.currentTimeMillis();
-  private static final String logMessage = "FCU({}) | head: {} | finalized: {} | safeBlockHash: {}";
+  private static final String logMessage = "FCU({}) | head: {} | finalized: {} | safe: {}";
 
   private void logForkchoiceUpdatedCall(
       final EngineStatus status, final EngineForkchoiceUpdatedParameter forkChoice) {

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineForkchoiceUpdated.java
@@ -384,7 +384,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
 
   // fcU calls are synchronous, no need to make volatile
   private long lastFcuInfoLog = System.currentTimeMillis();
-  private static final String logMessage = "FCU({}) | head: {} | finalized: {} | safe: {}";
+  private static final String logMessage = "FCU({}) | head: {} | safe: {} | finalized: {}";
 
   private void logForkchoiceUpdatedCall(
       final EngineStatus status, final EngineForkchoiceUpdatedParameter forkChoice) {
@@ -408,8 +408,8 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
         logMessage,
         status.name(),
         forkChoice.getHeadBlockHash().toShortLogString(),
-        forkChoice.getFinalizedBlockHash().toShortLogString(),
-        forkChoice.getSafeBlockHash().toShortLogString());
+        forkChoice.getSafeBlockHash().toShortLogString(),
+        forkChoice.getFinalizedBlockHash().toShortLogString());
   }
 
   private void logAtDebug(
@@ -418,7 +418,7 @@ public abstract class AbstractEngineForkchoiceUpdated extends ExecutionEngineJso
         logMessage,
         status.name(),
         forkChoice.getHeadBlockHash(),
-        forkChoice.getFinalizedBlockHash(),
-        forkChoice.getSafeBlockHash());
+        forkChoice.getSafeBlockHash(),
+        forkChoice.getFinalizedBlockHash());
   }
 }

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -632,7 +632,7 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
     }
     double mgasPerSec = (timeInS != 0) ? block.getHeader().getGasUsed() / (timeInS * 1_000_000) : 0;
     message.append(
-        "| %d blobs| %s base| %,10d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
+        "| %2d blobs| %s bfee| %,11d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
     messageArgs.addAll(
         List.of(
             blobCount,

--- a/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
+++ b/ethereum/api/src/main/java/org/hyperledger/besu/ethereum/api/jsonrpc/internal/methods/engine/AbstractEngineNewPayload.java
@@ -615,18 +615,24 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
       final Optional<Integer> nbParallelizedTransactions) {
     final StringBuilder message = new StringBuilder();
     final int nbTransactions = block.getBody().getTransactions().size();
-    message.append("Imported #%,d  (%s)|%5d tx");
+    message.append("Imported #%,d  (%s)| %4d tx");
     final List<Object> messageArgs =
         new ArrayList<>(
             List.of(
                 block.getHeader().getNumber(), block.getHash().toShortLogString(), nbTransactions));
+    if (nbParallelizedTransactions.isPresent()) {
+      double parallelizedTxPercentage =
+          (double) (nbParallelizedTransactions.get() * 100) / nbTransactions;
+      message.append(" (%5.1f%% parallel)");
+      messageArgs.add(parallelizedTxPercentage);
+    }
     if (block.getBody().getWithdrawals().isPresent()) {
-      message.append("|%3d ws");
+      message.append("| %2d ws");
       messageArgs.add(block.getBody().getWithdrawals().get().size());
     }
     double mgasPerSec = (timeInS != 0) ? block.getHeader().getGasUsed() / (timeInS * 1_000_000) : 0;
     message.append(
-        "|%2d blobs| base fee %s| gas used %,11d (%5.1f%%)| exec time %01.3fs| mgas/s %6.2f");
+        "| %d blobs| %s base| %,10d (%5.1f%%) gas used| %01.3fs exec| %6.2f Mgas/s| %2d peers");
     messageArgs.addAll(
         List.of(
             blobCount,
@@ -634,15 +640,8 @@ public abstract class AbstractEngineNewPayload extends ExecutionEngineJsonRpcMet
             block.getHeader().getGasUsed(),
             (block.getHeader().getGasUsed() * 100.0) / block.getHeader().getGasLimit(),
             timeInS,
-            mgasPerSec));
-    if (nbParallelizedTransactions.isPresent()) {
-      double parallelizedTxPercentage =
-          (double) (nbParallelizedTransactions.get() * 100) / nbTransactions;
-      message.append("| parallel txs %5.1f%%");
-      messageArgs.add(parallelizedTxPercentage);
-    }
-    message.append("| peers: %2d");
-    messageArgs.add(ethPeers.peerCount());
+            mgasPerSec,
+            ethPeers.peerCount()));
     LOG.info(String.format(message.toString(), messageArgs.toArray()));
   }
 


### PR DESCRIPTION
## PR description
Further to PR #7961 the logs are now rather long (183 characters), requiring font size 9 to fit on one line within a Ubuntu console at its maximum size.

Moreover, the labels are now standardised to be appended instead of prepended to values, and block hash labels are standardised without the word `blockHash` 

```
printf 'Imported #21,293,789  (0xdcec.....503fa)|  212 tx| 16 ws| 2 blobs| base fee  13.78 gwei| gas used  19,512,289 ( 65.0%%)| exec time 0.249s| mgas/s  78.36| Parallel txs 36.8%%| peers: 25' | wc -c
183
```

This PR attempts to trim down log size.
```
printf 'Imported #22,300,103  (a8e1d.....b63b5)|   60 tx ( 65.0%% parallel)| 16 ws| 0 blobs| 355.69 mwei base|  4,087,850 ( 11.4%%) gas used| 0.083s exec|  49.25 Mgas/s|  7 peers' | wc -c
168
```

Sample log lines:
```
2025-04-19 19:52:31.676  INFO  AbstractEngineNewPayload - Imported #22,302,866  (744cf.....44361)|  184 tx ( 67.4% parallel)| 16 ws| 0 blobs| 314.58 mwei base| 35,919,031 (100.0%) gas used| 0.677s exec|  53.06 Mgas/s|  1 peers
2025-04-19 19:52:32.974  INFO  AbstractEngineNewPayload - Imported #22,302,867  (9a223.....88346)|  158 tx ( 66.5% parallel)| 16 ws| 5 blobs| 353.88 mwei base| 13,312,777 ( 37.0%) gas used| 0.350s exec|  38.04 Mgas/s|  1 peers
2025-04-19 19:52:33.667  INFO  AbstractEngineForkchoiceUpdated - FCU(VALID) | head: 9a223.....88346 | safe: 1c3ef.....57c2b | finalized: c290e.....c0239
2025-04-19 19:52:34.032  INFO  AbstractEngineNewPayload - Imported #22,302,868  (2f362.....7ab40)|  121 tx ( 67.8% parallel)| 16 ws| 3 blobs| 342.39 mwei base|  7,766,981 ( 21.6%) gas used| 0.347s exec|  22.38 Mgas/s|  1 peers
2025-04-19 19:52:36.378  INFO  AbstractEngineNewPayload - Imported #22,302,869  (569bf.....051bc)|   94 tx ( 75.5% parallel)| 16 ws| 6 blobs| 318.06 mwei base| 22,556,476 ( 62.7%) gas used| 0.601s exec|  37.53 Mgas/s|  1 peers
2025-04-19 19:52:37.892  INFO  AbstractEngineNewPayload - Imported #22,302,870  (7f815.....8933f)|  178 tx ( 62.9% parallel)| 16 ws| 3 blobs| 328.13 mwei base| 15,380,751 ( 42.7%) gas used| 0.453s exec|  33.95 Mgas/s|  1 peers
2025-04-19 19:52:38.595  INFO  AbstractEngineNewPayload - Imported #22,302,871  (2473d.....1771f)|   16 tx ( 56.3% parallel)| 16 ws| 0 blobs| 322.16 mwei base|  2,711,125 (  7.5%) gas used| 0.060s exec|  45.19 Mgas/s|  1 peers
2025-04-19 19:52:50.415  INFO  AbstractEngineNewPayload - Imported #22,302,872  (9d115.....a758b)|  283 tx ( 56.9% parallel)| 16 ws| 0 blobs| 287.95 mwei base| 28,756,687 ( 80.0%) gas used| 0.544s exec|  52.86 Mgas/s|  1 peers
```
Further trims would be most welcome.

Fork choice update block hashes are also listed in ascending order of finality (`head` → `safe` → `finalized`)

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

