### PR TITLE
chore: update Sepolia checkpoint to merge block number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Upcoming Breaking Changes
 ### Additions and Improvements
+- Sepolia checkpoint block has been updated to the merge block [#8584](https://github.com/hyperledger/besu/pull/8584)
 - Add `--profile=PERFORMANCE` for high spec nodes: increases rocksdb cache and enables parallel transaction processing [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Add `--profile=PERFORMANCE_RPC` for high spec RPC nodes: increases rocksdb cache and caches last 2048 blocks [#8560](https://github.com/hyperledger/besu/pull/8560)
 #### Dependencies

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -44,7 +44,7 @@
     },
     "checkpoint": {
       "hash": "0x36fb89fba5b7857cf0ca78b5a9625b4043ff4555dfce9b7bcdcdd758a11eb946",
-      "number":  1735371,
+      "number": 1735371,
       "totalDifficulty": "0x3c656d23029ab0"
     }
   },

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -43,9 +43,9 @@
       ]
     },
     "checkpoint": {
-      "hash": "0x491ebac1b7f9c0eb426047a495dc577140cb3e09036cd3f7266eda86b635d9fa",
-      "number": 1273020,
-      "totalDifficulty": "0x13DE1653E7D280"
+      "hash": "0x36fb89fba5b7857cf0ca78b5a9625b4043ff4555dfce9b7bcdcdd758a11eb946",
+      "number":  1735371,
+      "totalDifficulty": "0x3c656d23029ab0"
     }
   },
   "alloc":{

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -45,7 +45,7 @@
     "checkpoint": {
       "hash": "0x36fb89fba5b7857cf0ca78b5a9625b4043ff4555dfce9b7bcdcdd758a11eb946",
       "number": 1735371,
-      "totalDifficulty": "0X3C656D23029AB0"
+      "totalDifficulty": "0x3c656d23029ab0"
     }
   },
   "alloc":{

--- a/config/src/main/resources/sepolia.json
+++ b/config/src/main/resources/sepolia.json
@@ -45,7 +45,7 @@
     "checkpoint": {
       "hash": "0x36fb89fba5b7857cf0ca78b5a9625b4043ff4555dfce9b7bcdcdd758a11eb946",
       "number": 1735371,
-      "totalDifficulty": "0x3c656d23029ab0"
+      "totalDifficulty": "0X3C656D23029AB0"
     }
   },
   "alloc":{


### PR DESCRIPTION
## PR description

With the history expiration approaching Sepolia on May 1st, nodes might encounter difficulties in checkpointing block bodies prior to the merge block. This PR updates the Sepolia checkpoint at genesis to align with the merge block.

