### PR TITLE
Memoize the signature algorithm in Transaction

### DIFF
--- a/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransaction.java
+++ b/ethereum/eth/src/main/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransaction.java
@@ -429,8 +429,8 @@ public abstract class PendingTransaction
    * class changes its structure.
    */
   public interface MemorySize {
-    int FRONTIER_AND_ACCESS_LIST_SHALLOW_SIZE = 912;
-    int EIP1559_AND_EIP4844_SHALLOW_SIZE = 1024;
+    int FRONTIER_AND_ACCESS_LIST_SHALLOW_SIZE = 904;
+    int EIP1559_AND_EIP4844_SHALLOW_SIZE = 1016;
     int OPTIONAL_TO_SIZE = 112;
     int OPTIONAL_CHAIN_ID_SIZE = 80;
     int PAYLOAD_SHALLOW_SIZE = 32;

--- a/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionEstimatedMemorySizeTest.java
+++ b/ethereum/eth/src/test/java/org/hyperledger/besu/ethereum/eth/transactions/PendingTransactionEstimatedMemorySizeTest.java
@@ -96,7 +96,7 @@ import org.openjdk.jol.info.GraphWalker;
  * then complete the writing of the test that will verify the current amount of memory used by that
  * class.
  */
-@EnabledOnOs({OS.LINUX})
+@EnabledOnOs({OS.LINUX, OS.MAC})
 public class PendingTransactionEstimatedMemorySizeTest extends BaseTransactionPoolTest {
   /**
    * Classes that represent constant instances, across all pending transaction types, and are


### PR DESCRIPTION
## ** Testing ongoing **

Profiling the prune-pre-merge-blocks subcommand https://github.com/hyperledger/besu/commit/e255296f3988fb88916d95fd4f3b31a8c358edbb highlighted a performance issue during `getBlockBody -> TransactionDecoder.decodeRLP -> Transaction<init>`

The subcommand is loading (for mainnet 15million) block bodies and decoding their transactions in order to get the transactions hashes to prune.

You can see that nearly all the time spent in getBlockBody is loading the signature algorithm. Perhaps this impacts other Besu operations beyond the pruning subcommand.

<img width="1499" alt="Screenshot 2025-05-06 at 2 46 09 pm" src="https://github.com/user-attachments/assets/785b7e3f-f9df-4b6f-8cb2-74d30fa664a1" />


We also save 8 bytes of memory for every Transaction (4 bytes for the `signatureAlgorithm` object reference + 4 byte offset)

Previously:
```
org.hyperledger.besu.ethereum.core.Transaction object internals:
OFF  SZ                                             TYPE DESCRIPTION                           VALUE
  0   8                                                  (object header: mark)                 0x0000000000000001 (non-biasable; age: 0)
  8   4                                                  (object header: class)                0x001b6c98
 12   4                                              int Transaction.size                      101
 16   8                                             long Transaction.nonce                     1
 24   8                                             long Transaction.gasLimit                  5000
 32   4                               java.util.Optional Transaction.gasPrice                  (object)
 36   4                               java.util.Optional Transaction.maxPriorityFeePerGas      (object)
 40   4                               java.util.Optional Transaction.maxFeePerGas              (object)
 44   4                               java.util.Optional Transaction.maxFeePerBlobGas          (object)
 48   4                               java.util.Optional Transaction.to                        (object)
 52   4               org.hyperledger.besu.datatypes.Wei Transaction.value                     (object)
 56   4        org.hyperledger.besu.crypto.SECPSignature Transaction.signature                 (object)
 60   4       org.hyperledger.besu.ethereum.core.Payload Transaction.payload                   (object)
 64   4                               java.util.Optional Transaction.maybeAccessList           (object)
 68   4                               java.util.Optional Transaction.chainId                   (object)
 72   4                  org.apache.tuweni.bytes.Bytes32 Transaction.hashNoSignature           (object)
 76   4           org.hyperledger.besu.datatypes.Address Transaction.sender                    (object)
 80   4              org.hyperledger.besu.datatypes.Hash Transaction.hash                      (object)
 84   4   org.hyperledger.besu.datatypes.TransactionType Transaction.transactionType           (object)
 88   4   org.hyperledger.besu.crypto.SignatureAlgorithm Transaction.signatureAlgorithm        (object)
 92   4                               java.util.Optional Transaction.versionedHashes           (object)
 96   4                               java.util.Optional Transaction.blobsWithCommitments      (object)
100   4                               java.util.Optional Transaction.maybeCodeDelegationList   (object)
104   4                               java.util.Optional Transaction.rawRlp                    (object)
108   4                                                  (object alignment gap)
Instance size: 112 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

With this PR:
```
OFF  SZ                                             TYPE DESCRIPTION                           VALUE
  0   8                                                  (object header: mark)                 0x0000000000000001 (non-biasable; age: 0)
  8   4                                                  (object header: class)                0x001b70c0
 12   4                                              int Transaction.size                      101
 16   8                                             long Transaction.nonce                     1
 24   8                                             long Transaction.gasLimit                  5000
 32   4                               java.util.Optional Transaction.gasPrice                  (object)
 36   4                               java.util.Optional Transaction.maxPriorityFeePerGas      (object)
 40   4                               java.util.Optional Transaction.maxFeePerGas              (object)
 44   4                               java.util.Optional Transaction.maxFeePerBlobGas          (object)
 48   4                               java.util.Optional Transaction.to                        (object)
 52   4               org.hyperledger.besu.datatypes.Wei Transaction.value                     (object)
 56   4        org.hyperledger.besu.crypto.SECPSignature Transaction.signature                 (object)
 60   4       org.hyperledger.besu.ethereum.core.Payload Transaction.payload                   (object)
 64   4                               java.util.Optional Transaction.maybeAccessList           (object)
 68   4                               java.util.Optional Transaction.chainId                   (object)
 72   4                  org.apache.tuweni.bytes.Bytes32 Transaction.hashNoSignature           (object)
 76   4           org.hyperledger.besu.datatypes.Address Transaction.sender                    (object)
 80   4              org.hyperledger.besu.datatypes.Hash Transaction.hash                      (object)
 84   4   org.hyperledger.besu.datatypes.TransactionType Transaction.transactionType           (object)
 88   4                               java.util.Optional Transaction.versionedHashes           (object)
 92   4                               java.util.Optional Transaction.blobsWithCommitments      (object)
 96   4                               java.util.Optional Transaction.maybeCodeDelegationList   (object)
100   4                               java.util.Optional Transaction.rawRlp                    (object)
Instance size: 104 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```