### PR TITLE
Fix: improve error message when data path is not writable

### DIFF
--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -73,13 +73,19 @@ public class VersionMetadata implements Comparable<VersionMetadata> {
     MAPPER.writeValue(getDefaultMetadataFile(dataDir), this);
   }
 
-  private static File getDefaultMetadataFile(final Path dataDir) {
+  private static File getDefaultMetadataFile(final Path dataDir) throws IOException {
     File metaDataFile = dataDir.resolve(METADATA_FILENAME).toFile();
 
     // Create the data dir here if it doesn't exist yet
     if (!metaDataFile.getParentFile().exists()) {
       LOG.info("Data directory {} does not exist - creating it", dataDir);
-      metaDataFile.getParentFile().mkdirs();
+      boolean created = metaDataFile.getParentFile().mkdirs();
+      if (!created) {
+        throw new IOException("Failed to create data directory: " + dataDir);
+      }
+    }
+    if (!metaDataFile.getParentFile().canWrite()) {
+      throw new IOException("Data directory is not writable: " + dataDir);
     }
     return metaDataFile;
   }


### PR DESCRIPTION
## PR description
This PR adds a check to verify whether the data path exists and is writable. If the directory does not exist or cannot be created, an exception is thrown to prevent misleading startup behaviour.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #8587 


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

