### PR TITLE
increase Holesky and Sepolia default gas limit to 60M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add `--profile=PERFORMANCE` for high spec nodes: increases rocksdb cache and enables parallel transaction processing [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Add `--profile=PERFORMANCE_RPC` for high spec RPC nodes: increases rocksdb cache and caches last 2048 blocks [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Refine gas estimation algorithm for `eth_estimateGas` and `eth_createAccessList` [#8478](https://github.com/hyperledger/besu/pull/8478) including a new option to specify `--estimate-gas-tolerance-ratio`
-- Increase default target-gas-limit to 60M for Sepolia [#8594](https://github.com/hyperledger/besu/pull/8594)
+- Increase default target-gas-limit to 60M for Holesky and Sepolia [#8594](https://github.com/hyperledger/besu/pull/8594)
 
 #### Dependencies
 - update jc-kzg-4844 dependency from 2.0.0 to 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `--profile=PERFORMANCE` for high spec nodes: increases rocksdb cache and enables parallel transaction processing [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Add `--profile=PERFORMANCE_RPC` for high spec RPC nodes: increases rocksdb cache and caches last 2048 blocks [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Refine gas estimation algorithm for `eth_estimateGas` and `eth_createAccessList` [#8478](https://github.com/hyperledger/besu/pull/8478) including a new option to specify `--estimate-gas-tolerance-ratio`
+- Default target-gas-limit to 60M for sepolia
 
 #### Dependencies
 - update jc-kzg-4844 dependency from 2.0.0 to 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add `--profile=PERFORMANCE` for high spec nodes: increases rocksdb cache and enables parallel transaction processing [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Add `--profile=PERFORMANCE_RPC` for high spec RPC nodes: increases rocksdb cache and caches last 2048 blocks [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Refine gas estimation algorithm for `eth_estimateGas` and `eth_createAccessList` [#8478](https://github.com/hyperledger/besu/pull/8478) including a new option to specify `--estimate-gas-tolerance-ratio`
-- Default target-gas-limit to 60M for sepolia
+- Default target-gas-limit to 60M for sepolia and other testnets [#8594](https://github.com/hyperledger/besu/pull/8594)
 
 #### Dependencies
 - update jc-kzg-4844 dependency from 2.0.0 to 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add `--profile=PERFORMANCE` for high spec nodes: increases rocksdb cache and enables parallel transaction processing [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Add `--profile=PERFORMANCE_RPC` for high spec RPC nodes: increases rocksdb cache and caches last 2048 blocks [#8560](https://github.com/hyperledger/besu/pull/8560)
 - Refine gas estimation algorithm for `eth_estimateGas` and `eth_createAccessList` [#8478](https://github.com/hyperledger/besu/pull/8478) including a new option to specify `--estimate-gas-tolerance-ratio`
-- Default target-gas-limit to 60M for sepolia and other testnets [#8594](https://github.com/hyperledger/besu/pull/8594)
+- Increase default target-gas-limit to 60M for Sepolia [#8594](https://github.com/hyperledger/besu/pull/8594)
 
 #### Dependencies
 - update jc-kzg-4844 dependency from 2.0.0 to 2.1.1

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/MergeProtocolSchedule.java
@@ -144,8 +144,8 @@ public class MergeProtocolSchedule {
       final Map<Long, Function<ProtocolSpecBuilder, ProtocolSpecBuilder>> postMergeModifications) {
     // Any post-Paris fork can rely on the MainnetProtocolSpec definitions again
     // Must allow for config to skip Shanghai and go straight to a later fork.
-    if (config.getForkBlockTimestamps().size() > 0) {
-      postMergeModifications.put(config.getForkBlockTimestamps().get(0), Function.identity());
+    if (!config.getForkBlockTimestamps().isEmpty()) {
+      postMergeModifications.put(config.getForkBlockTimestamps().getFirst(), Function.identity());
     }
   }
 }

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -82,14 +82,14 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
   private static final long DEFAULT_TARGET_GAS_LIMIT = 36_000_000L;
   // testnets might have higher gas limits than mainnet
-  private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 36_000_000L;
+  private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 60_000_000L;
 
-  private static final Map<BigInteger, Long> TESTNET_CHAIN_IDS =
-      Map.of(
-          BigInteger.valueOf(11155111), 60_000_000L, // Sepolia
-          BigInteger.valueOf(17000), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Holesky
-          BigInteger.valueOf(560048), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Hoodi
-          BigInteger.valueOf(39438135), DEFAULT_TARGET_GAS_LIMIT_TESTNET // Ephemery
+  private static final List<BigInteger> TESTNET_CHAIN_IDS =
+      List.of(
+          BigInteger.valueOf(11155111), // Sepolia
+          BigInteger.valueOf(17000), // Holesky
+          BigInteger.valueOf(560048), // Hoodi
+          BigInteger.valueOf(39438135) // Ephemery
           );
 
   /** The Mining parameters. */
@@ -891,7 +891,8 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   private long getDefaultGasLimit(final ProtocolSchedule protocolSchedule) {
     return protocolSchedule
         .getChainId()
-        .map(TESTNET_CHAIN_IDS::get)
+        .filter(TESTNET_CHAIN_IDS::contains)
+        .map(id -> DEFAULT_TARGET_GAS_LIMIT_TESTNET)
         .orElse(DEFAULT_TARGET_GAS_LIMIT);
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -84,12 +84,12 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   // testnets might have higher gas limits than mainnet
   private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 36_000_000L;
 
-  private static final List<BigInteger> TESTNET_CHAIN_IDS =
-      List.of(
-          BigInteger.valueOf(11155111), // Sepolia
-          BigInteger.valueOf(17000), // Holesky
-          BigInteger.valueOf(560048), // Hoodi
-          BigInteger.valueOf(39438135) // Ephemery
+  private static final Map<BigInteger, Long> TESTNET_CHAIN_IDS =
+      Map.of(
+          BigInteger.valueOf(11155111), 60_000_000L, // Sepolia
+          BigInteger.valueOf(17000), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Holesky
+          BigInteger.valueOf(560048), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Hoodi
+          BigInteger.valueOf(39438135), DEFAULT_TARGET_GAS_LIMIT_TESTNET // Ephemery
           );
 
   /** The Mining parameters. */
@@ -889,12 +889,10 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   }
 
   private long getDefaultGasLimit(final ProtocolSchedule protocolSchedule) {
-    if (protocolSchedule.getChainId().isPresent()
-        && TESTNET_CHAIN_IDS.contains(protocolSchedule.getChainId().get())) {
-      return DEFAULT_TARGET_GAS_LIMIT_TESTNET;
-    }
-
-    return DEFAULT_TARGET_GAS_LIMIT;
+    return protocolSchedule
+        .getChainId()
+        .map(TESTNET_CHAIN_IDS::get)
+        .orElse(DEFAULT_TARGET_GAS_LIMIT);
   }
 
   private static class BlockCreationTask {

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -82,14 +82,14 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
 
   private static final long DEFAULT_TARGET_GAS_LIMIT = 36_000_000L;
   // testnets might have higher gas limits than mainnet
-  private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 60_000_000L;
+  private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 36_000_000L;
 
-  private static final List<BigInteger> TESTNET_CHAIN_IDS =
-      List.of(
-          BigInteger.valueOf(11155111), // Sepolia
-          BigInteger.valueOf(17000), // Holesky
-          BigInteger.valueOf(560048), // Hoodi
-          BigInteger.valueOf(39438135) // Ephemery
+  private static final Map<BigInteger, Long> TESTNET_CHAIN_IDS =
+      Map.of(
+          BigInteger.valueOf(11155111), 60_000_000L, // Sepolia
+          BigInteger.valueOf(17000), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Holesky
+          BigInteger.valueOf(560048), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Hoodi
+          BigInteger.valueOf(39438135), DEFAULT_TARGET_GAS_LIMIT_TESTNET // Ephemery
           );
 
   /** The Mining parameters. */
@@ -891,8 +891,7 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   private long getDefaultGasLimit(final ProtocolSchedule protocolSchedule) {
     return protocolSchedule
         .getChainId()
-        .filter(TESTNET_CHAIN_IDS::contains)
-        .map(id -> DEFAULT_TARGET_GAS_LIMIT_TESTNET)
+        .map(TESTNET_CHAIN_IDS::get)
         .orElse(DEFAULT_TARGET_GAS_LIMIT);
   }
 

--- a/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
+++ b/consensus/merge/src/main/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinator.java
@@ -81,13 +81,14 @@ public class MergeCoordinator implements MergeMiningCoordinator, BadChainListene
   private static final double TRY_FILL_BLOCK = 1.0;
 
   private static final long DEFAULT_TARGET_GAS_LIMIT = 36_000_000L;
-  // testnets might have higher gas limits than mainnet
+  // testnets might have higher gas limits than mainnet and are incrementally updated
   private static final long DEFAULT_TARGET_GAS_LIMIT_TESTNET = 36_000_000L;
+  private static final long NEXT_STEP_TARGET_GAS_LIMIT_TESTNET = 60_000_000L;
 
   private static final Map<BigInteger, Long> TESTNET_CHAIN_IDS =
       Map.of(
-          BigInteger.valueOf(11155111), 60_000_000L, // Sepolia
-          BigInteger.valueOf(17000), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Holesky
+          BigInteger.valueOf(11155111), NEXT_STEP_TARGET_GAS_LIMIT_TESTNET, // Sepolia
+          BigInteger.valueOf(17000), NEXT_STEP_TARGET_GAS_LIMIT_TESTNET, // Holesky
           BigInteger.valueOf(560048), DEFAULT_TARGET_GAS_LIMIT_TESTNET, // Hoodi
           BigInteger.valueOf(39438135), DEFAULT_TARGET_GAS_LIMIT_TESTNET // Ephemery
           );

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1012,7 +1012,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
     return Stream.of(
         Arguments.of("mainnet", 1L, 36_000_000L),
         Arguments.of("holesky", 17_000L, 36_000_000L),
-        Arguments.of("sepolia", 11_155_111L, 36_000_000L),
+        Arguments.of("sepolia", 11_155_111L, 60_000_000L),
         Arguments.of("hoodi", 560_048L, 36_000_000L),
         Arguments.of("ephemery", 39_438_135L, 36_000_000L));
   }

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1011,10 +1011,10 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public static Stream<Arguments> getGasLimits() {
     return Stream.of(
         Arguments.of("mainnet", 1L, 36_000_000L),
-        Arguments.of("holesky", 17_000L, 36_000_000L),
+        Arguments.of("holesky", 17_000L, 60_000_000L),
         Arguments.of("sepolia", 11_155_111L, 60_000_000L),
-        Arguments.of("hoodi", 560_048L, 36_000_000L),
-        Arguments.of("ephemery", 39_438_135L, 36_000_000L));
+        Arguments.of("hoodi", 560_048L, 60_000_000L),
+        Arguments.of("ephemery", 39_438_135L, 60_000_000L));
   }
 
   private void sendNewPayloadAndForkchoiceUpdate(

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1011,10 +1011,10 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public static Stream<Arguments> getGasLimits() {
     return Stream.of(
         Arguments.of("mainnet", 1L, 36_000_000L),
-        Arguments.of("holesky", 17_000L, 60_000_000L),
+        Arguments.of("holesky", 17_000L, 36_000_000L),
         Arguments.of("sepolia", 11_155_111L, 60_000_000L),
-        Arguments.of("hoodi", 560_048L, 60_000_000L),
-        Arguments.of("ephemery", 39_438_135L, 60_000_000L));
+        Arguments.of("hoodi", 560_048L, 36_000_000L),
+        Arguments.of("ephemery", 39_438_135L, 36_000_000L));
   }
 
   private void sendNewPayloadAndForkchoiceUpdate(

--- a/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
+++ b/consensus/merge/src/test/java/org/hyperledger/besu/consensus/merge/blockcreation/MergeCoordinatorTest.java
@@ -1011,7 +1011,7 @@ public class MergeCoordinatorTest implements MergeGenesisConfigHelper {
   public static Stream<Arguments> getGasLimits() {
     return Stream.of(
         Arguments.of("mainnet", 1L, 36_000_000L),
-        Arguments.of("holesky", 17_000L, 36_000_000L),
+        Arguments.of("holesky", 17_000L, 60_000_000L),
         Arguments.of("sepolia", 11_155_111L, 60_000_000L),
         Arguments.of("hoodi", 560_048L, 36_000_000L),
         Arguments.of("ephemery", 39_438_135L, 36_000_000L));


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <macfarla.github@gmail.com>## PR description

## Fixed Issue(s)
refs #8249 
Sepolia and Holesky now increasing to 60M


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [x] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

