### PR TITLE
history-expiry: Prune fast by skipping pruning the transaction locations

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/PrunePreMergeBlockDataSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/PrunePreMergeBlockDataSubCommand.java
@@ -141,7 +141,6 @@ public class PrunePreMergeBlockDataSubCommand implements Runnable {
       }
       final Hash h = maybeBlockHash.get();
       updater.removeTransactionReceipts(h);
-      updater.removeTotalDifficulty(h);
       updater.removeBlockBody(h);
     } while (++headerNumber < endBlockNumber);
     updater.commit();

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/PrunePreMergeBlockDataSubCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/storage/PrunePreMergeBlockDataSubCommand.java
@@ -17,11 +17,12 @@ package org.hyperledger.besu.cli.subcommands.storage;
 import org.hyperledger.besu.cli.config.NetworkName;
 import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.controller.BesuController;
-import org.hyperledger.besu.datatypes.Transaction;
+import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.ethereum.chain.BlockchainStorage;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -45,7 +46,7 @@ public class PrunePreMergeBlockDataSubCommand implements Runnable {
   private static final long MAINNET_MERGE_BLOCK_NUMBER = 15_537_393;
   private static final long SEPOLIA_MERGE_BLOCK_NUMBER = 1_735_371;
 
-  private static final int DEFAULT_THREADS = 4;
+  private static final int DEFAULT_THREADS = Runtime.getRuntime().availableProcessors() - 1;
   private static final int DEFAULT_PRUNE_RANGE_SIZE = 10000;
 
   @SuppressWarnings("unused")
@@ -85,6 +86,9 @@ public class PrunePreMergeBlockDataSubCommand implements Runnable {
         network,
         dataPath);
     final long mergeBlockNumber = getMergeBlockNumber(network);
+    LOG.info("Parallelizing with number of threads: {}", threads);
+    LOG.info("Merge block number: {}", mergeBlockNumber);
+    LOG.info("Prune range size: {}", pruneRangeSize);
 
     try (BesuController besuController = storageSubCommand.besuCommand.buildController()) {
 
@@ -97,13 +101,22 @@ public class PrunePreMergeBlockDataSubCommand implements Runnable {
                   besuController.getDataStorageConfiguration());
 
       try (ExecutorService executor = Executors.newFixedThreadPool(threads)) {
+        // cannot prune genesis block so start at 1
         for (long i = 1; i < mergeBlockNumber; i += pruneRangeSize) {
-          final long headerNumber = i;
+          LOG.info(
+              "Starting pruning of block range {} to {}...",
+              i,
+              Math.min(i + pruneRangeSize, mergeBlockNumber));
+          final long startBlockNumber = i;
+          final long endBlockNumber = Math.min(startBlockNumber + pruneRangeSize, mergeBlockNumber);
           executor.submit(
-              () -> deleteBlockRange(headerNumber, mergeBlockNumber, blockchainStorage));
+              () ->
+                  deleteBlockRange(
+                      startBlockNumber, endBlockNumber, mergeBlockNumber, blockchainStorage));
         }
       }
     }
+    LOG.info("Pruning pre-merge blocks and transaction receipts completed");
   }
 
   private static long getMergeBlockNumber(final NetworkName network) {
@@ -116,31 +129,26 @@ public class PrunePreMergeBlockDataSubCommand implements Runnable {
 
   private void deleteBlockRange(
       final long startBlockNumber,
+      final long endBlockNumber,
       final long mergeBlockNumber,
       final BlockchainStorage blockchainStorage) {
     BlockchainStorage.Updater updater = blockchainStorage.updater();
     long headerNumber = startBlockNumber;
-    final long endBlockNumber = Math.min(startBlockNumber + pruneRangeSize, mergeBlockNumber);
     do {
-      blockchainStorage
-          .getBlockHash(headerNumber)
-          .filter((h) -> blockchainStorage.getBlockBody(h).isPresent())
-          .ifPresent(
-              (h) -> {
-                updater.removeTransactionReceipts(h);
-                updater.removeTotalDifficulty(h);
-                blockchainStorage
-                    .getBlockBody(h)
-                    .map((bb) -> bb.getTransactions())
-                    .ifPresent(
-                        (transactions) ->
-                            transactions.stream()
-                                .map(Transaction::getHash)
-                                .forEach((th) -> updater.removeTransactionLocation(th)));
-                updater.removeBlockBody(h);
-              });
+      final Optional<Hash> maybeBlockHash = blockchainStorage.getBlockHash(headerNumber);
+      if (maybeBlockHash.isEmpty()) {
+        continue;
+      }
+      final Hash h = maybeBlockHash.get();
+      updater.removeTransactionReceipts(h);
+      updater.removeTotalDifficulty(h);
+      updater.removeBlockBody(h);
     } while (++headerNumber < endBlockNumber);
     updater.commit();
-    LOG.info("Completed deletion of block range {} to {}", startBlockNumber, endBlockNumber);
+    LOG.info(
+        "...completed pruning of block range {} to {}; estimated {} blocks remaining",
+        startBlockNumber,
+        endBlockNumber,
+        mergeBlockNumber - endBlockNumber);
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/storage/keyvalue/KeyValueSegmentIdentifier.java
@@ -25,7 +25,7 @@ import java.util.EnumSet;
 
 public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
   DEFAULT("default".getBytes(StandardCharsets.UTF_8)),
-  BLOCKCHAIN(new byte[] {1}, true, true),
+  BLOCKCHAIN(new byte[] {1}, EnumSet.allOf(DataStorageFormat.class), true, true, false),
   WORLD_STATE(new byte[] {2}, EnumSet.of(FOREST), false, true, false),
   PRIVATE_TRANSACTIONS(new byte[] {3}),
   PRIVATE_STATE(new byte[] {4}),
@@ -56,16 +56,6 @@ public enum KeyValueSegmentIdentifier implements SegmentIdentifier {
 
   KeyValueSegmentIdentifier(final byte[] id) {
     this(id, EnumSet.allOf(DataStorageFormat.class));
-  }
-
-  KeyValueSegmentIdentifier(
-      final byte[] id, final boolean containsStaticData, final boolean eligibleToHighSpecFlag) {
-    this(
-        id,
-        EnumSet.allOf(DataStorageFormat.class),
-        containsStaticData,
-        eligibleToHighSpecFlag,
-        false);
   }
 
   KeyValueSegmentIdentifier(final byte[] id, final EnumSet<DataStorageFormat> formats) {


### PR DESCRIPTION
* Also skip pruning the totalDifficulty, for consistency with how the history expiry sync works as per https://github.com/hyperledger/besu/commit/1db03138508db8d630fc1aae74b7aff6f4926281
* Improve UX
  * more flexible number of threads default 
  * logging to show settings and remaining blocks estimate

Note, this PR does not enable BlobDB GC, that will be another PR.

Mainnet testing brings the prune time down from many days to ~5 minutes.

We can add back in the transaction location pruning once this PR is in https://github.com/hyperledger/besu/pull/8590

Example run using a dummy hoodi example, pruning the first 150,000 blocks:

```
➜  besu git:(improve-prune-ux) ✗ $BESU --data-path=/tmp/besu --network=hoodi storage x-prune-pre-merge-blocks

2025-05-08 12:40:23.786+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Pruning pre-merge blocks and transaction receipts, network=HOODI, data path=/tmp/besu
2025-05-08 12:40:23.787+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Parallelizing with number of threads: 9
2025-05-08 12:40:23.787+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Merge block number: 150000
2025-05-08 12:40:23.787+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Prune range size: 10000
2025-05-08 12:40:23.844+10:00 | main | INFO  | KeyPairUtil | Attempting to load public key from /tmp/besu/key
2025-05-08 12:40:23.864+10:00 | main | INFO  | KeyPairUtil | Loaded public key 0x2987b588eef8f25bc4dfeb97110568607ca8cdb1cfa4293ffa1c77a26ad81484d37f7e8c1230ea0afb79f9cce2b804155f98b9f3f3093a79a4b26084e95fcccd from /tmp/besu/key
2025-05-08 12:40:24.157+10:00 | main | INFO  | ProtocolScheduleBuilder | Protocol schedule created with milestones: [Cancun:0, Prague:1742999832]
2025-05-08 12:40:24.171+10:00 | main | INFO  | ProtocolScheduleBuilder | Protocol schedule created with milestones: [Cancun:0, Prague:1742999832]
2025-05-08 12:40:24.173+10:00 | main | INFO  | DatabaseMetadata | Lookup database metadata file in data directory: /tmp/besu
2025-05-08 12:40:24.207+10:00 | main | INFO  | RocksDBKeyValueStorageFactory | Existing database at /tmp/besu. Metadata versionedStorageFormat=BaseVersionedStorageFormat{format=BONSAI, version=3}. Processing WAL...
2025-05-08 12:40:24.629+10:00 | main | INFO  | FlatDbStrategyProvider | Flat db mode found FULL
2025-05-08 12:40:24.632+10:00 | main | INFO  | FlatDbStrategyProvider | DB mode with code stored using code hash enabled = true
2025-05-08 12:40:24.648+10:00 | main | INFO  | FlatDbStrategyProvider | Flat db mode found FULL
2025-05-08 12:40:24.648+10:00 | main | INFO  | FlatDbStrategyProvider | DB mode with code stored using code hash enabled = true
2025-05-08 12:40:24.837+10:00 | main | INFO  | TransactionPoolFactory | Enabling transaction pool
2025-05-08 12:40:24.844+10:00 | main | INFO  | EthPeers | Updating the default best peer comparator
2025-05-08 12:40:24.848+10:00 | main | INFO  | BesuControllerBuilder | TTD difficulty is present, creating initial sync for PoS
2025-05-08 12:40:24.855+10:00 | main | INFO  | TransitionBesuControllerBuilder | TTD present, creating DefaultSynchronizer that stops propagating after finalization
2025-05-08 12:40:24.871+10:00 | main | INFO  | TrieLogPruner | Trie log pruner queue preload starting...
2025-05-08 12:40:24.872+10:00 | main | INFO  | TrieLogPruner | Attempting to load first 5000 trie logs from database...
2025-05-08 12:40:24.873+10:00 | main | INFO  | TrieLogPruner | Trie log pruning will timeout after 30 seconds. If this is timing out, consider using `besu storage trie-log prune` subcommand, see https://besu.hyperledger.org/public-networks/how-to/bonsai-limit-trie-logs
2025-05-08 12:40:24.877+10:00 | pool-9-thread-1 | INFO  | TrieLogPruner | Added 57 trie logs to prune queue. Commencing pruning of eligible trie logs...
2025-05-08 12:40:24.882+10:00 | pool-9-thread-1 | INFO  | TrieLogPruner | Pruned 0 trie logs
2025-05-08 12:40:24.882+10:00 | main | INFO  | TrieLogPruner | Trie log pruner queue preload complete.
2025-05-08 12:40:24.883+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 1 to 10001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 10001 to 20001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 20001 to 30001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 30001 to 40001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 40001 to 50001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 50001 to 60001...
2025-05-08 12:40:24.884+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 60001 to 70001...
2025-05-08 12:40:24.885+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 70001 to 80001...
2025-05-08 12:40:24.885+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 80001 to 90001...
2025-05-08 12:40:24.885+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 90001 to 100001...
2025-05-08 12:40:24.885+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 100001 to 110001...
2025-05-08 12:40:24.885+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 110001 to 120001...
2025-05-08 12:40:24.886+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 120001 to 130001...
2025-05-08 12:40:24.886+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 130001 to 140001...
2025-05-08 12:40:24.886+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Starting pruning of block range 140001 to 150000...
2025-05-08 12:40:25.082+10:00 | pool-10-thread-2 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 10001 to 20001; estimated 129999 blocks remaining
2025-05-08 12:40:25.119+10:00 | pool-10-thread-9 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 80001 to 90001; estimated 59999 blocks remaining
2025-05-08 12:40:25.166+10:00 | pool-10-thread-1 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 1 to 10001; estimated 139999 blocks remaining
2025-05-08 12:40:25.221+10:00 | pool-10-thread-4 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 30001 to 40001; estimated 109999 blocks remaining
2025-05-08 12:40:25.285+10:00 | pool-10-thread-2 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 90001 to 100001; estimated 49999 blocks remaining
2025-05-08 12:40:25.353+10:00 | pool-10-thread-6 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 50001 to 60001; estimated 89999 blocks remaining
2025-05-08 12:40:25.415+10:00 | pool-10-thread-7 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 60001 to 70001; estimated 79999 blocks remaining
2025-05-08 12:40:25.481+10:00 | pool-10-thread-4 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 120001 to 130001; estimated 19999 blocks remaining
2025-05-08 12:40:25.554+10:00 | pool-10-thread-2 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 130001 to 140001; estimated 9999 blocks remaining
2025-05-08 12:40:25.637+10:00 | pool-10-thread-3 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 20001 to 30001; estimated 119999 blocks remaining
2025-05-08 12:40:25.713+10:00 | pool-10-thread-9 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 100001 to 110001; estimated 39999 blocks remaining
2025-05-08 12:40:25.792+10:00 | pool-10-thread-1 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 110001 to 120001; estimated 29999 blocks remaining
2025-05-08 12:40:25.870+10:00 | pool-10-thread-8 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 70001 to 80001; estimated 69999 blocks remaining
2025-05-08 12:40:25.957+10:00 | pool-10-thread-5 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 40001 to 50001; estimated 99999 blocks remaining
2025-05-08 12:40:26.041+10:00 | pool-10-thread-6 | INFO  | PrunePreMergeBlockDataSubCommand | ...completed pruning of block range 140001 to 150000; estimated 0 blocks remaining
2025-05-08 12:40:26.041+10:00 | main | INFO  | PrunePreMergeBlockDataSubCommand | Pruning pre-merge blocks and transaction receipts completed
```