### PR TITLE
Remove the deprecated `--tx-pool-disable-locals` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 ### Breaking Changes
 - Remove `MetricSystem::createLabelledGauge` deprecated since `24.12.0`, replace it with `MetricSystem::createLabelledSuppliedGauge` [#8299](https://github.com/hyperledger/besu/pull/8299)
+- Remove then deprecated `--tx-pool-disable-locals` option, use `--tx-pool-no-local-priority`, instead. [#8614](https://github.com/hyperledger/besu/pull/8614)
+
 ### Upcoming Breaking Changes
 ### Additions and Improvements
 
@@ -16,7 +18,6 @@
 - `--Xbonsai-trie-log-pruning-enabled` is deprecated, use `--bonsai-limit-trie-logs-enabled` instead.
 - `--Xbonsai-trie-logs-pruning-window-size` is deprecated, use `--bonsai-trie-logs-pruning-window-size` instead.
 - `--Xsnapsync-bft-enabled` is deprecated and will be removed in a future release. SNAP sync is supported for BFT networks.
-- `--tx-pool-disable-locals` has been deprecated, use `--tx-pool-no-local-priority`, instead.
 - Sunsetting features - for more context on the reasoning behind the deprecation of these features, including alternative options, read [this blog post](https://www.lfdecentralizedtrust.org/blog/sunsetting-tessera-and-simplifying-hyperledger-besu)
     - Tessera privacy
     - Smart-contract-based (onchain) permissioning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## Unreleased
 ### Breaking Changes
 - Remove `MetricSystem::createLabelledGauge` deprecated since `24.12.0`, replace it with `MetricSystem::createLabelledSuppliedGauge` [#8299](https://github.com/hyperledger/besu/pull/8299)
-- Remove then deprecated `--tx-pool-disable-locals` option, use `--tx-pool-no-local-priority`, instead. [#8614](https://github.com/hyperledger/besu/pull/8614)
+- Remove the deprecated `--tx-pool-disable-locals` option, use `--tx-pool-no-local-priority`, instead. [#8614](https://github.com/hyperledger/besu/pull/8614)
 
 ### Upcoming Breaking Changes
 ### Additions and Improvements

--- a/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/options/TransactionPoolOptions.java
@@ -47,11 +47,6 @@ import picocli.CommandLine;
 /** The Transaction pool Cli stable options. */
 public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfiguration> {
   private static final String TX_POOL_IMPLEMENTATION = "--tx-pool";
-
-  /** Use TX_POOL_NO_LOCAL_PRIORITY instead */
-  @Deprecated(forRemoval = true)
-  private static final String TX_POOL_DISABLE_LOCALS = "--tx-pool-disable-locals";
-
   private static final String TX_POOL_NO_LOCAL_PRIORITY = "--tx-pool-no-local-priority";
   private static final String TX_POOL_ENABLE_SAVE_RESTORE = "--tx-pool-enable-save-restore";
   private static final String TX_POOL_SAVE_FILE = "--tx-pool-save-file";
@@ -73,7 +68,7 @@ public class TransactionPoolOptions implements CLIOptions<TransactionPoolConfigu
   private TransactionPoolConfiguration.Implementation txPoolImplementation = LAYERED;
 
   @CommandLine.Option(
-      names = {TX_POOL_NO_LOCAL_PRIORITY, TX_POOL_DISABLE_LOCALS},
+      names = {TX_POOL_NO_LOCAL_PRIORITY},
       paramLabel = "<Boolean>",
       description =
           "Set to true if senders of transactions sent via RPC should not have priority (default: ${DEFAULT-VALUE})",

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/TransactionPoolOptionsTest.java
@@ -90,22 +90,22 @@ public class TransactionPoolOptionsTest
   }
 
   @Test
-  public void disableLocalsDefault() {
+  public void noLocalPriorityDefault() {
     internalTestSuccess(config -> assertThat(config.getNoLocalPriority()).isFalse());
   }
 
   @Test
-  public void disableLocalsOn() {
+  public void noLocalPriorityOn() {
     internalTestSuccess(
         config -> assertThat(config.getNoLocalPriority()).isTrue(),
-        "--tx-pool-disable-locals=true");
+        "--tx-pool-no-local-priority=true");
   }
 
   @Test
-  public void disableLocalsOff() {
+  public void noLocalPriorityOff() {
     internalTestSuccess(
         config -> assertThat(config.getNoLocalPriority()).isFalse(),
-        "--tx-pool-disable-locals=false");
+        "--tx-pool-no-local-priority=false");
   }
 
   @Test


### PR DESCRIPTION
## PR description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

