### PR TITLE
improve VersionedHash unit tests

### DIFF
--- a/datatypes/src/test/java/org/hyperledger/besu/datatypes/VersionedHashTest.java
+++ b/datatypes/src/test/java/org/hyperledger/besu/datatypes/VersionedHashTest.java
@@ -14,6 +14,7 @@
  */
 package org.hyperledger.besu.datatypes;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes32;
@@ -29,5 +30,24 @@ class VersionedHashTest {
   @Test
   public void throwsOnParsingUnsupportedHashType() {
     assertThrows(IllegalArgumentException.class, () -> new VersionedHash(Bytes32.ZERO));
+  }
+
+  @Test
+  public void parseValidVersionedHash() {
+    // Valid versioned hash: version byte = 0x01 followed by 31 bytes
+    String hex = "0x010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014";
+    VersionedHash vh = VersionedHash.fromHexString(hex);
+    assertEquals(VersionedHash.SHA256_VERSION_ID, vh.getVersionId(), "Version ID should be 1");
+    assertEquals(hex, vh.toString(), "toString should return the original hex string");
+  }
+
+  @Test
+  public void throwsOnParsingInvalidVersionedHash() {
+    // Invalid versioned hash: version byte = 0x00 not supported
+    String badHex = "0x000657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> VersionedHash.fromHexString(badHex),
+        "Parsing a hash with version byte 0x00 should throw IllegalArgumentException");
   }
 }


### PR DESCRIPTION
## PR description
Following this issue https://github.com/hyperledger/besu/issues/8624 I added two unit tests to make the case clear and covered by unit tests.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [x] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [x] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [x] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [x] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [x] spotless: `./gradlew spotlessApply`
- [x] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

